### PR TITLE
Fixed double url encoding of Google+ and Instagram people search paramet...

### DIFF
--- a/addons/MauticSocialBundle/Integration/GooglePlusIntegration.php
+++ b/addons/MauticSocialBundle/Integration/GooglePlusIntegration.php
@@ -367,13 +367,11 @@ class GooglePlusIntegration extends SocialIntegration
             return false;
         }
 
-        $cleaned = $this->cleanIdentifier($identifier);
-
-        if (!is_array($cleaned)) {
-            $cleaned = array($cleaned);
+        if (!is_array($identifier)) {
+            $identifier = array($identifier);
         }
 
-        foreach ($cleaned as $type => $id) {
+        foreach ($identifier as $type => $id) {
             if (empty($id)) {
                 continue;
             }

--- a/addons/MauticSocialBundle/Integration/InstagramIntegration.php
+++ b/addons/MauticSocialBundle/Integration/InstagramIntegration.php
@@ -145,8 +145,6 @@ class InstagramIntegration extends SocialIntegration
             return false;
         }
 
-        $identifier = $this->cleanIdentifier($identifier);
-
         $data = $this->makeRequest($this->getApiUrl('users/search'), array('q' => $identifier));
 
         if (!empty($data->data)) {


### PR DESCRIPTION
This should fix the issue #76 where Mautic was failing to find users on Google+ when using the email due to the Integration url encoding the parameters then the makeRequest function also url encoding via http_build_query()