### PR TITLE
Fixes #96 where LeadMergeEvent did not use the correct namespace in Lead...

### DIFF
--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -250,7 +250,7 @@ class LeadSubscriber extends CommonSubscriber
     /**
      * @param LeadChangeEvent $event
      */
-    public function onLeadMerge(LeadMergeEvent $event)
+    public function onLeadMerge(Events\LeadMergeEvent $event)
     {
         $this->factory->getEntityManager()->getRepository('MauticLeadBundle:PointsChangeLog')->updateLead(
             $event->getLoser()->getId(),


### PR DESCRIPTION
...Bundle's LeadSubscriber::onLeadMerge