### PR TITLE
Change the new user to default to system's default for timezone and locale

### DIFF
--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -113,7 +113,7 @@ class User extends FormEntity implements AdvancedUserInterface, \Serializable
      * @Serializer\Since("1.0")
      * @Serializer\Groups({"userDetails"})
      */
-    private $timezone = 'UTC';
+    private $timezone = '';
 
     /**
      * @ORM\Column(type="text", nullable=true)
@@ -121,7 +121,7 @@ class User extends FormEntity implements AdvancedUserInterface, \Serializable
      * @Serializer\Since("1.0")
      * @Serializer\Groups({"userDetails"})
      */
-    private $locale   = 'en_US';
+    private $locale   = '';
 
     /**
      * @ORM\Column(type="datetime", name="last_login", nullable=true)


### PR DESCRIPTION
The new user was coded to default to UTC and en_US instead of being empty so that it uses the "System Default Timezone" and the "System Default Locale."