### PR TITLE
Prevented campaign event connections from being lost when form validation failed

### DIFF
--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -404,6 +404,9 @@ class CampaignController extends FormController
                             return $this->editAction($entity->getId(), true);
                         }
                     }
+                } else {
+                    $connections = $session->get('mautic.campaign.' . $sessionId . '.events.canvassettings');
+                    $model->setCanvasSettings($entity, $connections, false, $modifiedEvents);
                 }
             } else {
                 $viewParameters = array('page' => $page);
@@ -564,6 +567,12 @@ class CampaignController extends FormController
                             ))
                         ));
                     }
+                } else {
+                    $connections    = $session->get('mautic.campaign.' . $objectId . '.events.canvassettings');
+                    $campaignEvents = $modifiedEvents;
+                    if ($connections != null) {
+                        $model->setCanvasSettings($entity, $connections, false, $modifiedEvents);
+                    }
                 }
             } else {
                 //unlock the entity
@@ -586,9 +595,9 @@ class CampaignController extends FormController
                         'contentTemplate' => 'MauticCampaignBundle:Campaign:view'
                     ))
                 );
-            } elseif ($form->get('buttons')->get('apply')->isClicked()) {
-                //rebuild everything to include new ids
-                $cleanSlate = true;
+            } else {
+                //rebuild everything to include new ids if valid
+                $cleanSlate = $valid;
             }
         } else {
             $cleanSlate = true;

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -265,13 +265,20 @@ class CampaignModel extends CommonFormModel
      * @param $entity
      * @param $settings
      */
-    public function setCanvasSettings($entity, $settings, $persist = true)
+    public function setCanvasSettings($entity, $settings, $persist = true, $events = null)
     {
-        $events  = $entity->getEvents();
+        if ($events === null) {
+            $events = $entity->getEvents();
+        }
+
         $tempIds = array();
 
         foreach ($events as $e) {
-            $tempIds[$e->getTempId()] = $e->getId();
+            if ($e instanceof Event) {
+                $tempIds[$e->getTempId()] = $e->getId();
+            } else {
+                $tempIds[$e['tempId']] = $e['id'];
+            }
         }
 
         if (!isset($settings['nodes'])) {


### PR DESCRIPTION
Campaign event connections were not restored if validation failed after submitting the form. So this should fix that.