### PR TITLE
Fixes some issues related to triggers and leads

### DIFF
--- a/app/bundles/LeadBundle/Helper/FormEventHelper.php
+++ b/app/bundles/LeadBundle/Helper/FormEventHelper.php
@@ -42,6 +42,7 @@ class FormEventHelper
             array('filter' => array('isPublished' => true))
         );
         $data = array();
+
         $lead = $model->getCurrentLead();
         $currentFields = $lead->getFields();
 
@@ -87,6 +88,7 @@ class FormEventHelper
         //no lead was found by a mapped email field so create a new one
         if ($lead->isNewlyCreated()) {
             $lead->setPoints($properties['points']);
+            $lead->addIpAddress($ipAddress);
 
             //create a new points change event
             $lead->addPointsChangeLogEntry(
@@ -96,6 +98,11 @@ class FormEventHelper
                 $properties['points'],
                 $ipAddress
             );
+        } else {
+            $leadIpAddresses = $lead->getIpAddresses();
+            if (!$leadIpAddresses->contains($ipAddress)) {
+                $lead->addIpAddress($ipAddress);
+            }
         }
 
         //set the mapped fields

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -432,6 +432,7 @@ class LeadModel extends FormModel
         if (empty($this->currentLead)) {
             $leadId = $cookies->get($trackingId);
             $ip     = $this->factory->getIpAddress();
+
             if (empty($leadId)) {
                 //this lead is not tracked yet so get leads by IP and track that lead or create a new one
                 $leads = $this->getLeadsByIp($ip->getIpAddress());
@@ -445,7 +446,11 @@ class LeadModel extends FormModel
                     $lead = new Lead();
                     $lead->addIpAddress($ip);
                     $lead->setNewlyCreated(true);
-                    $this->saveEntity($lead);
+
+                    // Set to prevent loops
+                    $this->currentLead = $lead;
+
+                    $this->saveEntity($lead, false);
                     $leadId = $lead->getId();
                 }
 
@@ -453,12 +458,17 @@ class LeadModel extends FormModel
                 $lead->setFields($fields);
             } else {
                 $lead = $this->getEntity($leadId);
+
                 if ($lead === null) {
                     //let's create a lead
                     $lead = new Lead();
                     $lead->addIpAddress($ip);
                     $lead->setNewlyCreated(true);
-                    $this->saveEntity($lead);
+
+                    // Set to prevent loops
+                    $this->currentLead = $lead;
+
+                    $this->saveEntity($lead, false);
                     $leadId = $lead->getId();
 
                     $fields = $this->getLeadDetails($lead);

--- a/app/bundles/PointBundle/Entity/TriggerEventRepository.php
+++ b/app/bundles/PointBundle/Entity/TriggerEventRepository.php
@@ -20,11 +20,11 @@ class TriggerEventRepository extends CommonRepository
     /**
      * Get array of published triggers based on point total
      *
-     * @param int $points
+     * @param int      $points
      *
      * @return array
      */
-    public function getPublishedByPointTotal($points = 0)
+    public function getPublishedByPointTotal($points)
     {
         $q = $this->createQueryBuilder('a')
             ->select('partial a.{id, type, name, properties}, partial r.{id, name, points, color}')
@@ -33,9 +33,11 @@ class TriggerEventRepository extends CommonRepository
 
         //make sure the published up and down dates are good
         $expr = $this->getPublishedByDateExpression($q, 'r');
+
         $expr->add(
-            $q->expr()->gte('r.points', $points)
+            $q->expr()->lte('r.points', (int) $points)
         );
+
         $q->where($expr);
 
         return $q->getQuery()->getArrayResult();


### PR DESCRIPTION
This fixes several issues with leads and triggers.  

One, it prevents a scenario where an anonymous lead is created over and over and over.  This only seemed to happen when the lead identified by a cookie no longer existed.

Second, it fixed an issue where triggers were prematurely firing due to a bad query.

And third, ensured the IP address is added at the time the form submit action created the lead to prevent unnecessary update hits to the audit table.