### PR TITLE
Fixes issues related to merging leads

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -241,7 +241,9 @@ class LeadRepository extends CommonRepository
         $results = $this->_em->getConnection()->createQueryBuilder()
             ->select('cl.campaign_id')
             ->from(MAUTIC_TABLE_PREFIX . 'campaign_leads', 'cl')
-            ->where('cl.lead_id = ' . $toLeadId);
+            ->where('cl.lead_id = ' . $toLeadId)
+            ->execute()
+            ->fetchAll();
         $campaigns = array();
         foreach ($results as $r) {
             $campaigns[] = $r['campaign_id'];

--- a/app/bundles/LeadBundle/Entity/LeadNoteRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadNoteRepository.php
@@ -160,4 +160,18 @@ class LeadNoteRepository extends CommonRepository
         );
     }
 
+    /**
+     * Updates lead ID (e.g. after a lead merge)
+     *
+     * @param $fromLeadId
+     * @param $toLeadId
+     */
+    public function updateLead($fromLeadId, $toLeadId)
+    {
+        $this->_em->getConnection()->createQueryBuilder()
+            ->update(MAUTIC_TABLE_PREFIX . 'lead_notes')
+            ->set('lead_id', (int)$toLeadId)
+            ->where('lead_id = ' . (int)$fromLeadId)
+            ->execute();
+    }
 }

--- a/app/bundles/LeadBundle/Entity/ListLeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/ListLeadRepository.php
@@ -19,4 +19,41 @@ use Mautic\CoreBundle\Entity\CommonRepository;
 class ListLeadRepository extends CommonRepository
 {
 
+    /**
+     * Updates lead ID (e.g. after a lead merge)
+     *
+     * @param $fromLeadId
+     * @param $toLeadId
+     */
+    public function updateLead($fromLeadId, $toLeadId)
+    {
+        // First check to ensure the $toLead doesn't already exist
+        $results = $this->_em->getConnection()->createQueryBuilder()
+            ->select('l.leadlist_id')
+            ->from(MAUTIC_TABLE_PREFIX . 'lead_lists_leads', 'l')
+            ->where('l.lead_id = ' . $toLeadId);
+        $lists = array();
+        foreach ($results as $r) {
+            $lists[] = $r['leadlist_id'];
+        }
+
+        $q = $this->_em->getConnection()->createQueryBuilder();
+        $q->update(MAUTIC_TABLE_PREFIX . 'lead_lists_leads')
+            ->set('lead_id', (int)$toLeadId)
+            ->where('lead_id = ' . (int)$fromLeadId);
+
+        if (!empty($lists)) {
+            $q->andWhere(
+                $q->expr()->notIn('leadlist_id', $lists)
+            )->execute();
+
+            // Delete remaining leads as the new lead already belongs
+            $this->_em->getConnection()->createQueryBuilder()
+                ->delete(MAUTIC_TABLE_PREFIX . 'lead_lists_leads')
+                ->where('lead_id = ' . (int)$fromLeadId)
+                ->execute();
+        } else {
+            $q->execute();
+        }
+    }
 }

--- a/app/bundles/LeadBundle/Entity/ListLeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/ListLeadRepository.php
@@ -31,7 +31,9 @@ class ListLeadRepository extends CommonRepository
         $results = $this->_em->getConnection()->createQueryBuilder()
             ->select('l.leadlist_id')
             ->from(MAUTIC_TABLE_PREFIX . 'lead_lists_leads', 'l')
-            ->where('l.lead_id = ' . $toLeadId);
+            ->where('l.lead_id = ' . $toLeadId)
+            ->execute()
+            ->fetchAll();
         $lists = array();
         foreach ($results as $r) {
             $lists[] = $r['leadlist_id'];

--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -257,6 +257,16 @@ class LeadSubscriber extends CommonSubscriber
             $event->getVictor()->getId()
         );
 
+        $this->factory->getEntityManager()->getRepository('MauticLeadBundle:ListLead')->updateLead(
+            $event->getLoser()->getId(),
+            $event->getVictor()->getId()
+        );
+
+        $this->factory->getEntityManager()->getRepository('MauticLeadBundle:LeadNote')->updateLead(
+            $event->getLoser()->getId(),
+            $event->getVictor()->getId()
+        );
+
         $log = array(
             "bundle"     => "lead",
             "object"     => "lead",


### PR DESCRIPTION
This fixes issue related to attempting to add a merged lead to a campaign or lead list that it was already part of (i.e. after a repeat form submission).

