### PR TITLE
Fixed issue that prevented the validation for the "return" URL

### DIFF
--- a/app/bundles/FormBundle/Entity/Form.php
+++ b/app/bundles/FormBundle/Entity/Form.php
@@ -205,11 +205,12 @@ class Form extends FormEntity
         $groups = array('form');
 
         $postAction = $data->getPostAction();
+
         if ($postAction == 'message') {
             $groups[] = 'messageRequired';
         } elseif ($postAction == 'redirect') {
-            $groups['urlRequired'];
-            $groups['urlRequiredPassTwo'];
+            $groups[] = 'urlRequired';
+            $groups[] = 'urlRequiredPassTwo';
         }
 
         return $groups;


### PR DESCRIPTION
Fixes an exception caused when using the "return to URL" post form submit which also prevented validating the return URL.