### PR TITLE
Prevented the "Could not set the preferred language. Using default language instead." message when unnecessary

### DIFF
--- a/app/bundles/UserBundle/Controller/ProfileController.php
+++ b/app/bundles/UserBundle/Controller/ProfileController.php
@@ -155,7 +155,7 @@ class ProfileController extends FormController
                     //check if the user's locale has been downloaded already, fetch it if not
                     $installedLanguages = $this->factory->getParameter('supported_languages');
 
-                    if (!array_key_exists($me->getLocale(), $installedLanguages)) {
+                    if ($me->getLocale() && !array_key_exists($me->getLocale(), $installedLanguages)) {
                         /** @var \Mautic\CoreBundle\Helper\LanguageHelper $languageHelper */
                         $languageHelper = $this->factory->getHelper('language');
 

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -158,7 +158,7 @@ class UserController extends FormController
                     //check if the user's locale has been downloaded already, fetch it if not
                     $installedLanguages = $this->factory->getParameter('supported_languages');
 
-                    if (!array_key_exists($user->getLocale(), $installedLanguages)) {
+                    if ($user->getLocale() && !array_key_exists($user->getLocale(), $installedLanguages)) {
                         /** @var \Mautic\CoreBundle\Helper\LanguageHelper $languageHelper */
                         $languageHelper = $this->factory->getHelper('language');
 
@@ -279,7 +279,7 @@ class UserController extends FormController
                     //check if the user's locale has been downloaded already, fetch it if not
                     $installedLanguages = $this->factory->getParameter('supported_languages');
 
-                    if (!array_key_exists($user->getLocale(), $installedLanguages)) {
+                    if ($user->getLocale() && !array_key_exists($user->getLocale(), $installedLanguages)) {
                         /** @var \Mautic\CoreBundle\Helper\LanguageHelper $languageHelper */
                         $languageHelper = $this->factory->getHelper('language');
 


### PR DESCRIPTION
If a user selected to use the system's default locale (which is an empty value), they received the notification "Could not set the preferred language. Using default language instead." which is exactly what they wanted :-) So this commit fixes that.