### PR TITLE
Fix for CLI generated routes

### DIFF
--- a/app/bundles/CoreBundle/Model/CommonModel.php
+++ b/app/bundles/CoreBundle/Model/CommonModel.php
@@ -156,14 +156,7 @@ class CommonModel
      */
     public function buildUrl($route, $routeParams = array(), $absolute = true, $clickthrough = array())
     {
-        if ($absolute && php_sapi_name() == 'cli') {
-            $siteUrl = $this->factory->getParameter('site_url');
-            $baseUrl = $this->factory->getRouter()->generate($route, $routeParams);
-            $url     = $siteUrl . $baseUrl;
-        } else {
-            $url = $this->factory->getRouter()->generate($route, $routeParams, $absolute);
-        }
-
+        $url  = $this->factory->getRouter()->generate($route, $routeParams, $absolute);
         $url .= (!empty($clickthrough)) ? '?ct=' . $this->encodeArrayForUrl($clickthrough) : '';
 
         return $url;

--- a/app/config/parameters.php
+++ b/app/config/parameters.php
@@ -104,4 +104,13 @@ foreach ($mauticParams as $k => &$v) {
 // Used for passing params into factory/services
 $container->setParameter('mautic.parameters', $mauticParams);
 
+// Set the router URI for CLI
+if (isset($mauticParams['site_url'])) {
+    $parts = parse_url($mauticParams['site_url']);
+
+    $container->setParameter('router.request_context.host', $parts['host']);
+    $container->setParameter('router.request_context.scheme', $parts['scheme']);
+    $container->setParameter('router.request_context.base_url', $parts['path']);
+}
+
 unset($mauticParams, $replaceRootPlaceholder, $bundles);

--- a/app/config/parameters.php
+++ b/app/config/parameters.php
@@ -108,9 +108,11 @@ $container->setParameter('mautic.parameters', $mauticParams);
 if (isset($mauticParams['site_url'])) {
     $parts = parse_url($mauticParams['site_url']);
 
-    $container->setParameter('router.request_context.host', $parts['host']);
-    $container->setParameter('router.request_context.scheme', $parts['scheme']);
-    $container->setParameter('router.request_context.base_url', $parts['path']);
+    if (!empty($parts['host'])) {
+        $container->setParameter('router.request_context.host', $parts['host']);
+        $container->setParameter('router.request_context.scheme', (!empty($parts['scheme']) ? $parts['scheme'] : 'http'));
+        $container->setParameter('router.request_context.base_url', (!empty($parts['path']) ? $parts['path'] : '/'));
+    }
 }
 
 unset($mauticParams, $replaceRootPlaceholder, $bundles);


### PR DESCRIPTION
Leveraged Symfony's built in support for forcing a route context to properly generate absolute URLs for all links when using from CLI