### PR TITLE
Fixes an issue that resulted in duplicate campaign events triggering

### DIFF
--- a/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
@@ -136,6 +136,12 @@ class CampaignSubscriber extends CommonSubscriber
         $list   = $event->getList();
         $action = $event->wasAdded() ? 'added' : 'removed';
         $name   = 'lead.listchange.' . $lead->getId() . '.' . $list->getId() . '.' . $action;
+
+        if (!$this->security->isAnonymous()) {
+            // Force actions
+            defined('MAUTIC_CAMPAIGN_SYSTEM_TRIGGERED') or define('MAUTIC_CAMPAIGN_SYSTEM_TRIGGERED', 1);
+        }
+
         $model->triggerEvent('lead.listchange', $event, $name);
     }
 }


### PR DESCRIPTION
When a lead is added to a lead list by the Mautic user, it was possible that a starting action campaign event would be duplicated that led to duplicate emails being sent for example.

To test: Email needs to work on your machine.

Prep: create a campaign that simply has a send email action with an email selected and assign a lead list to it.

Before patch, go to a lead with an email, view the details page, and click on the Lists button.  Add the lead to the list by toggling the switch.  You should get two emails.

After the patch, you should only get one email.