### PR TITLE
Fixed issue with the CSS driven placeholders not showing in the builders

### DIFF
--- a/app/bundles/EmailBundle/Assets/builder/builder.js
+++ b/app/bundles/EmailBundle/Assets/builder/builder.js
@@ -16,6 +16,12 @@ mQuery(document).ready( function() {
                     if (!data) {
                         mQuery(that).html('');
                     }
+                },
+                instanceReady: function( event ) {
+                    var data = event.editor.getData();
+                    if (!data) {
+                        mQuery(that).html('');
+                    }
                 }
             }
         });

--- a/app/bundles/PageBundle/Assets/builder/builder.js
+++ b/app/bundles/PageBundle/Assets/builder/builder.js
@@ -30,6 +30,12 @@ mQuery(document).ready(function () {
                     if (!data) {
                         mQuery(that).html('');
                     }
+                },
+                instanceReady: function( event ) {
+                    var data = event.editor.getData();
+                    if (!data) {
+                        mQuery(that).html('');
+                    }
                 }
             }
         });


### PR DESCRIPTION
With the upgrade of CKEditor, it now inserted blank P tags automatically in new inline instances which caused the CSS driven placeholders to not show up.  This removes those so the placeholder is displayed.