### PR TITLE
Prevents PHP warning in dev mode when trying to save form fields. 

### DIFF
--- a/app/bundles/FormBundle/Controller/ActionController.php
+++ b/app/bundles/FormBundle/Controller/ActionController.php
@@ -72,7 +72,7 @@ class ActionController extends CommonFormController
                     $keyId = 'new' . hash('sha1', uniqid(mt_rand()));
 
                     //save the properties to session
-                    $actions          = $session->get('mautic.form.'.$formId.'.actions.modified');
+                    $actions          = $session->get('mautic.form.'.$formId.'.actions.modified', array());
                     $formData         = $form->getData();
                     $formAction       = array_merge($formAction, $formData);
                     $formAction['id'] = $keyId;

--- a/app/bundles/FormBundle/Controller/FieldController.php
+++ b/app/bundles/FormBundle/Controller/FieldController.php
@@ -78,7 +78,7 @@ class FieldController extends CommonFormController
                     $keyId = 'new' . hash('sha1', uniqid(mt_rand()));
 
                     //save the properties to session
-                    $fields          = $session->get('mautic.form.'.$formId.'.fields.modified');
+                    $fields          = $session->get('mautic.form.'.$formId.'.fields.modified', array());
                     $formData        = $form->getData();
                     $formField       = array_merge($formField, $formData);
                     $formField['id'] = $keyId;


### PR DESCRIPTION
This prevents a warning in dev mode when trying to save form fields.  Doesn't seem to affect production though although the warning is likely logged.