### PR TITLE
Removes form name and description from generated HTML

### DIFF
--- a/app/bundles/FormBundle/Views/Builder/form.html.php
+++ b/app/bundles/FormBundle/Views/Builder/form.html.php
@@ -12,14 +12,6 @@ $fields   = $form->getFields();
 $required = array();
 ?>
 
-<div class="mauticform-name">
-	<?php echo $form->getName(); ?>
-</div>
-
-<?php if ($description = $form->getDescription()): ?>
-	<div class="mauticform-description"><?php echo $description; ?></div>
-<?php endif; ?>
-
 <form autocomplete="off" role="form" method="post" action="<?php echo $view['router']->generate('mautic_form_postresults', array('formId' => $form->getId()), true); ?>" id="mauticform_<?php echo $formName ?>" onsubmit="return MauticForm_<?php echo $formName; ?>.validateForm();">
 	<div class="mauticform-error" id="mauticform_<?php echo $formName ?>_error"></div>
 	<div class="mauticform-message" id="mauticform_<?php echo $formName ?>_message"></div>

--- a/app/bundles/FormBundle/Views/Field/country.html.php
+++ b/app/bundles/FormBundle/Views/Field/country.html.php
@@ -13,5 +13,5 @@ echo $view->render('MauticFormBundle:Field:select.html.php', array(
     'list'    => \Symfony\Component\Intl\Intl::getRegionBundle()->getCountryNames(),
     'id'      => $id,
     'deleted' => (!empty($deleted)) ? true : false,
-    'formId'  => $formId
+    'formId'  => (isset($formId)) ? $formId : 0
 ));

--- a/app/bundles/FormBundle/Views/Field/select.html.php
+++ b/app/bundles/FormBundle/Views/Field/select.html.php
@@ -11,8 +11,11 @@ if (strpos($labelAttr, 'class') === false)
     $labelAttr .= ' class="mauticform-label"';
 
 $inputAttr = 'id="mauticform_input_' . $field['alias'] . '" '. $field['inputAttributes'];
-if (strpos($inputAttr, 'class') === false)
-    $inputAttr .= ' class="mauticform-selectbox"';
+if (strpos($inputAttr, 'class') === false) {
+    $inputAttr .= ' class="mauticform-selectbox' . (!empty($inForm) ? ' not-chosen' : '') . '"';
+} elseif ((!empty($inForm))) {
+    $inputAttr = str_replace('class="', 'class="not-chosen ', $labelAttr);
+}
 
 if (!empty($inForm))
     $inputAttr .= ' disabled="disabled"';
@@ -43,7 +46,7 @@ if ($field['isRequired']) {
 }
 ?>
 
-<div class="mauticform-row mauticform-select<?php echo $containerClass; ?> mauticform-row-<?php echo $field['alias']; ?>" id="mauticform_<?php echo $id; ?>">
+<div class="mauticform-row mauticform-select<?php echo $containerClass . ($inForm ? ' not-chosen' : ''); ?> mauticform-row-<?php echo $field['alias']; ?>" id="mauticform_<?php echo $id; ?>">
     <?php
     if (!empty($inForm))
         echo $view->render('MauticFormBundle:Builder:actions.html.php', array(


### PR DESCRIPTION
This removes the form name and description from the HTML generated for the public which typically is used for internal purposes only.  Should resolve #121.