### PR TITLE
Fixes fatal error caused by submitting a form with a change lead points submit action

### DIFF
--- a/app/bundles/LeadBundle/Helper/FormEventHelper.php
+++ b/app/bundles/LeadBundle/Helper/FormEventHelper.php
@@ -140,8 +140,8 @@ class FormEventHelper
                 $model = $factory->getModel('lead.lead');
                 $em    = $factory->getEntityManager();
                 $leads = $em->getRepository('MauticLeadBundle:Lead')->getLeadsByFieldValue(
-                    $properties['leadField'],
-                    $fieldName
+                    $fieldName,
+                    $post[$fieldName]
                 );
 
                 //check for existing IP address or add one if not exist


### PR DESCRIPTION
The function used to search for a lead passed in the wrong variables leading to a bad query that caused a 500 error.  

To test, create a form with a create/update lead action then a change points form submit action.  Open the form in a different browser via its public url (/form?id=ID) and submit. 