### PR TITLE
Factory get bundle config

### DIFF
--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -671,7 +671,7 @@ class MauticFactory
     /**
      * Gets an array of a specific bundle's config settings
      *
-     * @return array
+     * @return mixed array | string
      */
     public function getBundleConfig($bundleName, $keyName = '', $includeAddons = false)
     {

--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -669,6 +669,47 @@ class MauticFactory
     }
 
     /**
+     * Gets an array of a specific bundle's config settings
+     *
+     * @return array
+     */
+    public function getBundleConfig($bundleName, $keyName = '', $includeAddons = false)
+    {
+        // get the configs
+        $configFiles = $this->getMauticBundles($includeAddons);
+
+        // if no bundle name specified we throw
+        if (! $bundleName)
+        {
+           throw new \Exception('Bundle name not supplied');
+        }
+
+        // check for the bundle config requested actually exists
+        if (! array_key_exists($bundleName, $configFiles))
+        {
+            throw new \Exception('Bundle ' . $bundleName . ' does not exist');
+        }
+
+        // no config key supplied so just return the bundle's config
+        if (! $keyName)
+        {
+            return $configFiles[$bundleName];
+        }
+
+        // get the specific bundle's config
+        $bundleConfig = $configFiles[$bundleName];
+
+        // check that the key exists
+        if (!array_key_exists($keyName, $bundleConfig))
+        {
+            throw new \Exception('Key ' . $keyName . 'does not exist in bundle ' . $bundleName);
+        }
+
+        // we didn't throw so we can send the key value
+        return $bundleConfig[$keyName];
+    }
+
+    /**
      * Get's an array of details for enabled Mautic addons
      *
      * @return array

--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -702,7 +702,7 @@ class MauticFactory
         // check that the key exists
         if (!array_key_exists($configKey, $bundleConfig))
         {
-            throw new \Exception('Key ' . $configKey . 'does not exist in bundle ' . $bundleName);
+            throw new \Exception('Key ' . $configKey . ' does not exist in bundle ' . $bundleName);
         }
 
         // we didn't throw so we can send the key value

--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -673,7 +673,7 @@ class MauticFactory
      *
      * @return mixed array | string
      */
-    public function getBundleConfig($bundleName, $keyName = '', $includeAddons = false)
+    public function getBundleConfig($bundleName, $configKey = '', $includeAddons = false)
     {
         // get the configs
         $configFiles = $this->getMauticBundles($includeAddons);
@@ -690,23 +690,23 @@ class MauticFactory
             throw new \Exception('Bundle ' . $bundleName . ' does not exist');
         }
 
+        // get the specific bundle's configurations
+        $bundleConfig = $configFiles[$bundleName]['config'];
+
         // no config key supplied so just return the bundle's config
-        if (! $keyName)
+        if (! $configKey)
         {
-            return $configFiles[$bundleName];
+            return $bundleConfig;
         }
 
-        // get the specific bundle's config
-        $bundleConfig = $configFiles[$bundleName];
-
         // check that the key exists
-        if (!array_key_exists($keyName, $bundleConfig))
+        if (!array_key_exists($configKey, $bundleConfig))
         {
-            throw new \Exception('Key ' . $keyName . 'does not exist in bundle ' . $bundleName);
+            throw new \Exception('Key ' . $configKey . 'does not exist in bundle ' . $bundleName);
         }
 
         // we didn't throw so we can send the key value
-        return $bundleConfig[$keyName];
+        return $bundleConfig[$configKey];
     }
 
     /**


### PR DESCRIPTION
How to test:

You can use this method to access any bundle's config settings. Use by accessing the factory:

```
$this->factory->getBundleConfig('BundleName', 'configKey'));
```

Note that `configKey` is optional. 

For example:
```
var_dump($this->factory->getBundleConfig('MauticCampaignBundle'));
```

Will give you:

```
 array (size=2)
      'events' => 
        array (size=5)
          'mautic.campaign.subscriber' => 
            array (size=1)
      'forms' => 
        array (size=6)
          'mautic.campaign.type.form' => 
            array (size=3)
```

If you specify a specific config group you want:

```
var_dump($this->factory->getBundleConfig('MauticCampaignBundle', 'services'));
```

Which will give you that bundle's config subset of values:

```
array (size=2)
  'events' => 
    array (size=5)
      'mautic.campaign.subscriber' => 
        array (size=1)
          'class' => string 'Mautic\CampaignBundle\EventListener\CampaignSubscriber' (length=54)
  'forms' => 
    array (size=6)
      'mautic.campaign.type.form' => 
        array (size=3)
          'class' => string 'Mautic\CampaignBundle\Form\Type\CampaignType' (length=44)
          'arguments' => string 'mautic.factory' (length=14)
          'alias' => string 'campaign' (length=8)
```

Last thing to test is there is an option for Addons, if you're accessing an addon's config you must include 'true' as the final parameter:

```
var_dump($this->factory->getBundleConfig('MauticCampaignBundle', 'services', true));
```