### PR TITLE
Fixed error when accessing public form URL for a nonexistent URL

### DIFF
--- a/app/bundles/FormBundle/Config/config.php
+++ b/app/bundles/FormBundle/Config/config.php
@@ -58,8 +58,11 @@ return array(
                 'controller' => 'MauticFormBundle:Public:submit'
             ),
             'mautic_form_preview'      => array(
-                'path'       => '/form',
-                'controller' => 'MauticFormBundle:Public:preview'
+                'path'       => '/form/{id}',
+                'controller' => 'MauticFormBundle:Public:preview',
+                'defaults'   => array(
+                    'id' => '0'
+                )
             ),
             'mautic_form_generateform' => array(
                 'path'       => '/form/generate.js',


### PR DESCRIPTION
To test:

Publish a form and access it via /form/ID or /form?id=ID.  The form should load (if it's published).  Then try to access with a nonexistent ID.  You should get a 404 message. 