### PR TITLE
Fixed a few more instances where a lead was removed from a list when regenerated based on filters

### DIFF
--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -251,8 +251,8 @@ class AjaxController extends CommonAjaxController
             $list = $listModel->getEntity($listId);
 
             if ($lead !== null && $list !== null) {
-                $class = "{$action}Lead";
-                $listModel->$class($lead, $list, true);
+                $class = $action == 'add' ? 'addToLists' : 'removeFromLists';
+                $leadModel->$class($lead, $list);
                 $dataArray['success'] = 1;
             }
         }

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -424,7 +424,7 @@ class ListController extends FormController
      *
      * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function removeleadAction($objectId)
+    public function removeLeadAction($objectId)
     {
         return $this->changeList($objectId, 'remove');
     }
@@ -434,7 +434,7 @@ class ListController extends FormController
      *
      * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function addLeadDecision($objectId)
+    public function addLeadAction($objectId)
     {
         return $this->changeList($objectId, 'add');
     }
@@ -494,7 +494,7 @@ class ListController extends FormController
                 return $this->isLocked($postActionVars, $lead, 'lead');
             } else {
                 $function = ($action == 'remove') ? 'removeLead' : 'addLead';
-                $model->$function($lead, $list);
+                $model->$function($lead, $list, true);
 
                 $identifier = $this->get('translator')->trans($lead->getPrimaryIdentifier());
                 $flashes[]  = array(

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -629,7 +629,7 @@ class LeadModel extends FormModel
      * @param      $lists
      * @param bool $manuallyAdded
      */
-    public function addToLists($lead, $lists, $manuallyAdded = false)
+    public function addToLists($lead, $lists, $manuallyAdded = true)
     {
         $this->factory->getModel('lead.list')->addLead($lead, $lists, $manuallyAdded);
     }
@@ -641,7 +641,7 @@ class LeadModel extends FormModel
      * @param      $lists
      * @param bool $manuallyRemoved
      */
-    public function removeFromLists($lead, $lists, $manuallyRemoved = false)
+    public function removeFromLists($lead, $lists, $manuallyRemoved = true)
     {
         $this->factory->getModel('lead.list')->removeLead($lead, $lists, $manuallyRemoved);
     }

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -389,9 +389,9 @@ class ListModel extends FormModel
                 'list' => $this->leadChangeLists[$l]
             ));
             if ($listLead != null) {
-                if ($manuallyAdded && ($listLead->wasManuallyRemoved() || !$listLead->wasManuallyAdded())) {
+                if ($listLead->wasManuallyRemoved()) {
                     $listLead->setManuallyRemoved(false);
-                    $listLead->setManuallyAdded(true);
+                    $listLead->setManuallyAdded($manuallyAdded);
 
                     $this->leadChangeLists[$l]->addLead($lead->getId(), $listLead);
                     $persistLists[] = $this->leadChangeLists[$l];

--- a/app/bundles/LeadBundle/Views/Lead/list.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/list.html.php
@@ -79,7 +79,7 @@ if ($tmpl == 'index')
                         $custom[] = array(
                             'attr' => array(
                                 'href' => $view['router']->generate('mautic_leadlist_action', array(
-                                    "objectAction" => "removelead",
+                                    "objectAction" => "removeLead",
                                     "objectId" => $currentList['id'],
                                     "leadId"   => $item->getId()
                                 )),


### PR DESCRIPTION
Easiest way to test:

Create a point action that adds one point when they open an email (any email)
Create a lead list and a lead, add the lead to the list
Create email and assign list to the email then send it
Open the email and one point should be given to the lead and they should still be in the list

Should fix #150  and fix #54.