### PR TITLE
Prevented potential undefined notices when triggering campaigns from CLI

### DIFF
--- a/app/bundles/AddonBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/AddonBundle/Integration/AbstractIntegration.php
@@ -937,7 +937,8 @@ abstract class AbstractIntegration
      */
     protected function getRefererUrl ()
     {
-        return 'http' . (($_SERVER['SERVER_PORT'] == 443) ? 's://' : '://') . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+        $request = $this->factory->getRequest();
+        return $request->getRequestUri();
     }
 
     /**


### PR DESCRIPTION
In certain setups, triggering campaigns from cli could cause Php notices of undefined $_SERVER indexes as reported in #141.  Switched to using the request getRequestUri function instead which will avoid the need for the need for $_SERVER