### PR TITLE
Changed order of form buttons

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/core.js
+++ b/app/bundles/CoreBundle/Assets/js/core.js
@@ -360,6 +360,7 @@ var Mautic = {
                     mQuery(container + ' .toolbar-form-buttons .hidden-xs').html('');
                     mQuery(container + ' .toolbar-form-buttons .hidden-md .drop-menu').html('');
 
+                    var lastIndex = mQuery(buttons).filter("button").length - 1;
                     mQuery(buttons).filter("button").each(function (i, v) {
                         //get the ID
                         var id = mQuery(this).attr('id');
@@ -383,7 +384,7 @@ var Mautic = {
                             .on('click.ajaxform', buttonClick)
                             .appendTo('.toolbar-form-buttons .hidden-sm');
 
-                        if (i === 0) {
+                        if (i === lastIndex) {
                             mQuery(".toolbar-form-buttons .hidden-md .btn-main")
                                 .off('.ajaxform')
                                 .attr('id', mQuery(this).attr('id') + '_toolbar_mobile')
@@ -394,7 +395,7 @@ var Mautic = {
                                 .attr('id', mQuery(this).attr('id') + '_toolbar_mobile')
                                 .html(mQuery(this).html())
                                 .on('click.ajaxform', buttonClick)
-                                .appendTo(mQuery('<li />').appendTo('.toolbar-form-buttons .hidden-md .dropdown-menu'))
+                                .appendTo(mQuery('<li />').prependTo('.toolbar-form-buttons .hidden-md .dropdown-menu'))
                         }
 
                     });

--- a/app/bundles/CoreBundle/Form/Type/FormButtonsType.php
+++ b/app/bundles/CoreBundle/Form/Type/FormButtonsType.php
@@ -34,13 +34,13 @@ class FormButtonsType extends AbstractType
             ));
         }
 
-        if (!empty($options['apply_text'])) {
-            $builder->add('apply', 'submit', array(
-                'label' => $options['apply_text'],
+        if (!empty($options['cancel_text'])) {
+            $builder->add('cancel', 'submit', array(
+                'label' => $options['cancel_text'],
                 'attr'  => array(
-                    'class'   => $options['apply_class'],
-                    'icon'    => $options['apply_icon'],
-                    'onclick' => $options['apply_onclick']
+                    'class'   => $options['cancel_class'],
+                    'icon'    => $options['cancel_icon'],
+                    'onclick' => $options['cancel_onclick']
                 )
             ));
         }
@@ -56,13 +56,13 @@ class FormButtonsType extends AbstractType
             ));
         }
 
-        if (!empty($options['cancel_text'])) {
-            $builder->add('cancel', 'submit', array(
-                'label' => $options['cancel_text'],
+        if (!empty($options['apply_text'])) {
+            $builder->add('apply', 'submit', array(
+                'label' => $options['apply_text'],
                 'attr'  => array(
-                    'class'   => $options['cancel_class'],
-                    'icon'    => $options['cancel_icon'],
-                    'onclick' => $options['cancel_onclick']
+                    'class'   => $options['apply_class'],
+                    'icon'    => $options['apply_icon'],
+                    'onclick' => $options['apply_onclick']
                 )
             ));
         }


### PR DESCRIPTION
As it was, the positive buttons were to the far left for forms.  This PR changes that to have the positive button on the right.  For the dropdown (small screen), it lists the positive button as the main button and the negative as last in the list. 

This has to be ran in dev mode as generating prod assets as part of the PR may cause conflicts.  Or delete media/js/app.js to have it dynamically regenerated on page load then revert change if necessary for git purposes.