### PR TITLE
Fixed issue where all pre-installed fields were set as "fixed"

### DIFF
--- a/app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
+++ b/app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
@@ -90,7 +90,25 @@ class LeadFieldData extends AbstractFixture implements OrderedFixtureInterface, 
                 $entity->setProperties(array("list" =>"|Mr|Mrs|Miss"));
             }
             $entity->setType($type);
-            $entity->setIsFixed(true);
+
+            $fixed = in_array($name, array(
+                'title',
+                'firstname',
+                'lastname',
+                'position',
+                'company',
+                'email',
+                'phone',
+                'mobile',
+                'address1',
+                'address2',
+                'country',
+                'city',
+                'state',
+                'zipcode'
+            )) ? true : false;
+            $entity->setIsFixed($fixed);
+
             $entity->setOrder(($key+1));
             $entity->setAlias($name);
             $listable    = in_array($name, array(

--- a/app/migrations/Version20150310000000.php
+++ b/app/migrations/Version20150310000000.php
@@ -23,6 +23,38 @@ class Version20150310000000 extends AbstractMauticMigration
     public function preUp(Schema $schema)
     {
         $this->connection->delete(MAUTIC_TABLE_PREFIX . 'addons', array('bundle' => 'MauticChatBundle'));
+
+
+        $qb = $this->connection->createQueryBuilder();
+        $qb->update(MAUTIC_TABLE_PREFIX . 'lead_fields')
+            ->set('is_fixed', ':false')
+            ->where(
+                $qb->expr()->notIn('alias',
+                    array_map(
+                        function($v) use ($qb) {
+                            return $qb->expr()->literal($v);
+                        },
+                        array(
+                            'title',
+                            'firstname',
+                            'lastname',
+                            'position',
+                            'company',
+                            'email',
+                            'phone',
+                            'mobile',
+                            'address1',
+                            'address2',
+                            'country',
+                            'city',
+                            'state',
+                            'zipcode'
+                        )
+                    )
+                )
+            )
+            ->setParameter('false', false, 'boolean')
+            ->execute();
     }
 
     /**


### PR DESCRIPTION
Upon install, all lead fields were set as fixed rather than the list of truly "fixed" fields such as company, email, etc.  This correctly sets the flag for the pre installed lead fields and fixes existing installations when upgraded.