### PR TITLE
Ajax quick lead

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -180,6 +180,10 @@ class LeadController extends FormController
         ));
     }
 
+    /*
+     * Quick form controller route and view
+     */
+
     public function quickAddAction()
     {
         /** @var \Mautic\LeadBundle\Model\LeadModel $model */

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -101,29 +101,6 @@ class LeadController extends FormController
         $leads = $results['results'];
         unset($results);
 
-        // Get the quick add form
-        $action = $this->generateUrl('mautic_lead_action', array('objectAction' => 'new', 'qf' => 1));
-
-        $fields = $this->factory->getModel('lead.field')->getEntities(array(
-            'filter'         => array(
-                'force' => array(
-                    array(
-                        'column' => 'f.isPublished',
-                        'expr'   => 'eq',
-                        'value'  => true
-                    ),
-                    array(
-                        'column' => 'f.isShortVisible',
-                        'expr'   => 'eq',
-                        'value'  => true
-                    )
-                )
-            ),
-            'hydration_mode' => 'HYDRATE_ARRAY'
-        ));
-
-        $quickForm = $model->createForm($model->getEntity(), $this->get('form.factory'), $action, array('fields' => $fields, 'isShortForm' => true));
-
         if ($count && $count < ($start + 1)) {
             //the number of entities are now less then the current page so redirect to the last page
             if ($count === 1) {
@@ -192,7 +169,6 @@ class LeadController extends FormController
                 'currentList'   => $list,
                 'security'      => $this->factory->getSecurity(),
                 'inSingleList'  => $inSingleList,
-                'quickForm'     => $quickForm->createView(),
                 'noContactList' => $emailRepo->getDoNotEmailList()
             ),
             'contentTemplate' => "MauticLeadBundle:Lead:{$indexMode}.html.php",
@@ -202,6 +178,47 @@ class LeadController extends FormController
                 'route'         => $this->generateUrl('mautic_lead_index', array('page' => $page))
             )
         ));
+    }
+
+    public function quickAddAction()
+    {
+        /** @var \Mautic\LeadBundle\Model\LeadModel $model */
+        $model   = $this->factory->getModel('lead.lead');
+
+        // Get the quick add form
+        $action = $this->generateUrl('mautic_lead_action', array('objectAction' => 'new', 'qf' => 1));
+
+        $fields = $this->factory->getModel('lead.field')->getEntities(array(
+                'filter'         => array(
+                    'force' => array(
+                        array(
+                            'column' => 'f.isPublished',
+                            'expr'   => 'eq',
+                            'value'  => true
+                        ),
+                        array(
+                            'column' => 'f.isShortVisible',
+                            'expr'   => 'eq',
+                            'value'  => true
+                        )
+                    )
+                ),
+                'hydration_mode' => 'HYDRATE_ARRAY'
+            ));
+
+        $quickForm = $model->createForm($model->getEntity(), $this->get('form.factory'), $action, array('fields' => $fields, 'isShortForm' => true));
+
+        return $this->delegateView(array(
+                'viewParameters'  => array(
+                    'quickForm'     => $quickForm->createView()
+                ),
+                'contentTemplate' => "MauticLeadBundle:Lead:quickadd.html.php",
+                'passthroughVars' => array(
+                    'activeLink'    => '#mautic_lead_index',
+                    'mauticContent' => 'lead',
+                    'route'         => false
+                )
+            ));
     }
 
     /**

--- a/app/bundles/LeadBundle/Form/Type/LeadType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadType.php
@@ -222,6 +222,11 @@ class LeadType extends AbstractType
 
         if (!$options['isShortForm']) {
             $builder->add('buttons', 'form_buttons');
+        } else {
+            $builder->add('buttons', 'form_buttons', array(
+                    'apply_text' => false,
+                    'save_text'   => 'mautic.core.form.save'
+                ));
         }
 
         if (!empty($options["action"])) {

--- a/app/bundles/LeadBundle/Views/Lead/index.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/index.html.php
@@ -16,8 +16,9 @@ if ($permissions['lead:leads:create']) {
     $preButtons[] = array(
         'attr'      => array(
             'class'       => 'btn btn-default btn-nospin',
-            'data-toggle' => 'modal',
+            'data-toggle' => 'ajaxmodal',
             'data-target' => '#lead-quick-add',
+            'href'        => $view['router']->generate('mautic_lead_action', array('objectAction' => 'quickAdd')),
         ),
         'iconClass' => 'fa fa-bolt',
         'btnText'   => 'mautic.lead.lead.menu.quickadd'
@@ -42,11 +43,9 @@ button;
 $extraHtml .= "<div class=\"text-left\">\n" . $view->render('MauticCoreBundle:Helper:modal.html.php', array(
     'id'     => 'lead-quick-add',
     'header' => $view['translator']->trans('mautic.lead.lead.header.quick.add'),
-    'body'   => $view->render('MauticLeadBundle:Lead:quickadd.html.php', array('form' => $quickForm)),
+    'body'   => '',
     'size'   => 'sm',
-    'footer' =>
-        '<button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-times text-danger "></i> ' . $view["translator"]->trans("mautic.core.form.cancel") . '</button>' .
-        '<button id="save-quick-add" type="button" class="btn btn-default" onclick="Mautic.startModalLoadingBar(\'#lead-quick-add\'); mQuery(\'form[name=lead]\').submit();"><i class="fa fa-save"></i> ' . $view["translator"]->trans("mautic.core.form.save") . '</button>'
+    'footerButtons' => true
 )) . "\n</div>\n";
 
 $view['slots']->set('actions', $view->render('MauticCoreBundle:Helper:page_actions.html.php', array(

--- a/app/bundles/LeadBundle/Views/Lead/quickadd.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/quickadd.html.php
@@ -7,4 +7,4 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-echo $view['form']->form($form);
+echo $view['form']->form($quickForm);


### PR DESCRIPTION
This changes the quick lead form to use ajax loading, complete with a route action. 

How to test:
1) Apply patch
2) confirm that adding leads via quick lead button works without any broken behavior 