### PR TITLE
Allows overriding Mautic views from a themes/system folder

### DIFF
--- a/app/bundles/CoreBundle/Templating/TemplateReference.php
+++ b/app/bundles/CoreBundle/Templating/TemplateReference.php
@@ -47,11 +47,19 @@ class TemplateReference extends BaseTemplateReference
             preg_match('/Mautic(.*?)Bundle/', $this->parameters['bundle'], $match);
 
             if (!empty($match[1])) {
-                $theme = $this->factory->getTheme();
-                //check for an override and load it if there is
-                $themeDir = $theme->getThemePath();
-                if (!file_exists($template = $themeDir . '/html/' . $this->parameters['bundle'] . '/' . $path)) {
-                    $template = '@' . $this->get('bundle') . '/Views/' . $path;
+                // Check for a system-wide override
+                $themePath      = $this->factory->getSystemPath('themes', true);
+                $systemTemplate = $themePath . '/system/' . $this->parameters['bundle'] . '/' . $path;
+                if (file_exists($systemTemplate)) {
+                    $template = $systemTemplate;
+                } else {
+                    $theme = $this->factory->getTheme();
+                    //check for an override and load it if there is
+                    $themeDir = $theme->getThemePath();
+                    $template = $themeDir . '/html/' . $this->parameters['bundle'] . '/' . $path;
+                    if (!file_exists($template)) {
+                        $template = '@' . $this->get('bundle') . '/Views/' . $path;
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
Currently views can be overridden from the configured default theme's HTML folder. But if the config changes, the overrides no longer apply. So added option to check for an override in a themes/system folder so that changing the configuration will not affect the view.

To test, create a themes/system/MauticLeadBundle/Lead/list.html.php file with a die statement.  Then browse directly to /s/leads/ (to avoid ajax) and the page to should show your die statement.

Delete the system folder, and the default list.html.php view should show.