### PR TITLE
Added an offline static page for runtime exceptions and database connection errors

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -60,6 +60,7 @@ class AppKernel extends Kernel
      */
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
+
         if (strpos($request->getRequestUri(), 'installer') !== false || !$this->isInstalled()) {
             define('MAUTIC_INSTALLER', 1);
         } else {
@@ -72,6 +73,7 @@ class AppKernel extends Kernel
         if (false === $this->booted) {
             $this->boot();
         }
+
         //the context is not populated at this point so have to do it manually
         $router = $this->getContainer()->get('router');
         $requestContext = new \Symfony\Component\Routing\RequestContext();
@@ -102,9 +104,11 @@ class AppKernel extends Kernel
                 $db->connect();
             } catch (\Exception $e) {
                 error_log($e);
-                die($this->getContainer()->get('translator')->trans('mautic.core.db.connection.error', array(
-                    '%code%' => $e->getCode()
-                )));
+                throw new \Mautic\CoreBundle\Exception\DatabaseConnectionException(
+                    $this->getContainer()->get('translator')->trans('mautic.core.db.connection.error', array(
+                        '%code%' => $e->getCode()
+                    )
+                ));
             }
         }
 

--- a/app/bundles/CoreBundle/Exception/DatabaseConnectionException.php
+++ b/app/bundles/CoreBundle/Exception/DatabaseConnectionException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2014 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Exception;
+
+
+class DatabaseConnectionException extends \Exception
+{
+    public function __construct($message = 'Unable to connect to the database.', $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/index.php
+++ b/index.php
@@ -27,13 +27,27 @@ $apcLoader->register(true);
 require_once __DIR__ . '/app/AppKernel.php';
 //require_once __DIR__.'/mautic/app/AppCache.php';
 
-$kernel = new AppKernel('prod', false);
-$kernel->loadClassCache();
-//$kernel = new AppCache($kernel);
+try {
+    $kernel = new AppKernel('prod', false);
+    $kernel->loadClassCache();
+    //$kernel = new AppCache($kernel);
 
-// When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter
-//Request::enableHttpMethodParameterOverride();
-$request  = Request::createFromGlobals();
-$response = $kernel->handle($request);
-$response->send();
-$kernel->terminate($request, $response);
+    // When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter
+    //Request::enableHttpMethodParameterOverride();
+    $request  = Request::createFromGlobals();
+    $response = $kernel->handle($request);
+    $response->send();
+    $kernel->terminate($request, $response);
+
+} catch (\Mautic\CoreBundle\Exception\DatabaseConnectionException $e) {
+    define('MAUTIC_OFFLINE', 1);
+    $message = $e->getMessage();
+    include __DIR__ . '/offline.php';
+} catch (\Exception $e) {
+    error_log($e);
+
+    define('MAUTIC_OFFLINE', 1);
+    $message    = 'The site is currently offline due to encountering an error. If the problem persists, please contact the system administrator.';
+    $submessage = 'System administrators, check server logs for errors.';
+    include __DIR__ . '/offline.php';
+}

--- a/offline.php
+++ b/offline.php
@@ -1,0 +1,49 @@
+<?php
+defined('MAUTIC_OFFLINE') or die('access denied');
+
+// Get the URLs base path
+$base = str_replace('index.php', '', $_SERVER['SCRIPT_NAME']);
+
+// Determine if there is an asset prefix
+$root = __DIR__;
+include $root . '/app/config/paths.php';
+$assetPrefix = $paths['asset_prefix'];
+if (!empty($assetPrefix)) {
+    if (substr($assetPrefix, -1) == '/') {
+        $assetPrefix = substr($assetPrefix, 0, -1);
+    }
+}
+$assetBase = $assetPrefix . $base . $paths['assets'];
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <title><?php echo $_SERVER['HTTP_HOST']; ?></title>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <link rel="icon" type="image/x-icon" href="<?php echo $assetBase . '/images/favicon.ico'; ?>" />
+    <link rel="stylesheet" href="<?php echo $assetBase . '/css/libraries.css'; ?>" />
+    <link rel="stylesheet" href="<?php echo $assetBase . '/css/app.css'; ?>" />
+</head>
+
+<body>
+    <div class="container">
+        <div class="row">
+            <div class="col-sm-offset-3 col-sm-6">
+                <div class="bg-white pa-lg text-center" style="margin-top:100px;">
+                    <i class="fa fa-warning fa-5x"></i>
+                    <h2><?php echo $message; ?></h2>
+                    <?php if (!empty($submessage)): ?>
+                    <h4 class="mt-15"><?php echo $submessage; ?></h4>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/offline.php
+++ b/offline.php
@@ -14,6 +14,13 @@ if (!empty($assetPrefix)) {
     }
 }
 $assetBase = $assetPrefix . $base . $paths['assets'];
+
+// Allow a custom error page
+if (file_exists(__DIR__ . '/custom_offline.php')) {
+    include __DIR__ . '/custom_offline.php';
+    exit;
+}
+
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -23,7 +30,7 @@ $assetBase = $assetPrefix . $base . $paths['assets'];
     <meta name="description" content="">
     <meta name="author" content="">
 
-    <title><?php echo $_SERVER['HTTP_HOST']; ?></title>
+    <title>Site is offline</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <link rel="icon" type="image/x-icon" href="<?php echo $assetBase . '/images/favicon.ico'; ?>" />


### PR DESCRIPTION
This adds a static offline page for when a runtime exception occurs or if the database is not accessible. The error page can be override by adding a root level custom_offline.php file. 