### PR TITLE
Prevented dashboard from crashing if a route was not found in the recent activity

### DIFF
--- a/app/bundles/DashboardBundle/Controller/DefaultController.php
+++ b/app/bundles/DashboardBundle/Controller/DefaultController.php
@@ -74,6 +74,7 @@ class DefaultController extends CommonController
         $logs = $this->factory->getModel('core.auditLog')->getLogForObject(null, null, 10);
 
         // Get names of log's items
+        $router = $this->factory->getRouter();
         foreach ($logs as &$log) {
             if (!empty($log['bundle']) && !empty($log['object']) && !empty($log['objectId'])) {
                 $model = $this->factory->getModel($log['bundle'] . '.' . $log['object']);
@@ -82,6 +83,13 @@ class DefaultController extends CommonController
                     $log['objectName'] = $item->{$model->getNameGetter()}();
                 } else {
                     $log['objectName'] = '';
+                }
+
+                $routeName = 'mautic_' . $log['bundle'] . '_action';
+                if ($router->getRouteCollection()->get($routeName) !== null) {
+                    $log['route'] = $router->generate('mautic_' . $log['bundle'] . '_action', array('objectAction' => 'view', 'objectId' => $log['objectId']));
+                } else {
+                    $log['route'] = false;
                 }
             }
         }

--- a/app/bundles/DashboardBundle/Views/Default/recentactivity.html.php
+++ b/app/bundles/DashboardBundle/Views/Default/recentactivity.html.php
@@ -31,9 +31,14 @@
                         <?php echo $log['userName']; ?>
                     <?php endif; ?>
                     <?php echo $view['translator']->trans('mautic.dashboard.' . $log['action'] . '.past.tense'); ?>
-                    <a href="<?php echo $view['router']->generate('mautic_' . $log['bundle'] . '_action', array('objectAction' => 'view', 'objectId' => $log['objectId'])); ?>" data-toggle="ajax">
+
+                    <?php if (!empty($log['route'])): ?>
+                    <a href="<?php echo $log['route']; ?>" data-toggle="ajax">
                         <?php echo $log['objectName']; ?>
                     </a>
+                    <?php else: ?>
+                    <?php echo $log['objectName']; ?>
+                    <?php endif; ?>
                     <?php echo $log['object']; ?>
                     <p class="fs-12 dark-sm"><small> <?php echo $view['date']->toFull($log['dateAdded']); ?></small></p>
                 </div>


### PR DESCRIPTION
The recent activity of a dashboard assumes view routes are 
```
'mautic_' . $log['bundle'] . '_action'
```
This is not always the case.  For example, creating a new API client will cause the dashboard to crash with a 500 because it uses mautic_client_action as the route name. 

This PR adds a check to see if the route exists before pushing through the generator to prevent the dashboard from crashing.

To test, enable the API and create a new api client then go to the dashboard.  The recent activity should have a 500 in it.  Apply the patch and then the 500 should no longer be there. 