### PR TITLE
Change getDrivers to account for cases where PDO may not be installed

### DIFF
--- a/app/bundles/InstallBundle/Configurator/Step/DoctrineStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/DoctrineStep.php
@@ -178,9 +178,9 @@ class DoctrineStep implements StepInterface
         $mauticSupported = array(
             'pdo_mysql'  => 'MySQL PDO (Recommended)',
             'mysqli'     => 'MySQLi',
-            'pdo_pgsql'  => 'PosgreSQL',
+            'pdo_pgsql'  => 'PostgreSQL',
             //'pdo_sqlite' => 'SQLite',
-            'pdo_sqlsrv' => 'SQLServer',
+            'pdo_sqlsrv' => 'SQL Server',
             //'pdo_oci'    => 'Oracle (PDO)',
             //'pdo_ibm'    => 'IBM DB2 (PDO)',
             //'oci8'       => 'Oracle (native)',

--- a/app/bundles/InstallBundle/Configurator/Step/DoctrineStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/DoctrineStep.php
@@ -175,7 +175,7 @@ class DoctrineStep implements StepInterface
      */
     public static function getDrivers()
     {
-        $supported = array(
+        $mauticSupported = array(
             'pdo_mysql'  => 'MySQL PDO (Recommended)',
             'mysqli'     => 'MySQLi',
             'pdo_pgsql'  => 'PosgreSQL',
@@ -187,17 +187,22 @@ class DoctrineStep implements StepInterface
             //'ibm_db2'    => 'IBM DB2 (native)',
         );
 
-        // Add PDO drivers if they're supported
-        $pdoDrivers = \PDO::getAvailableDrivers();
-        foreach ($pdoDrivers as $driver) {
-            if (!array_key_exists('pdo_' . $driver, $supported)) {
-                unset($supported[$driver]);
+        $supported = array();
+
+        // Add PDO drivers if supported
+        if (class_exists('\PDO')) {
+            $pdoDrivers = \PDO::getAvailableDrivers();
+
+            foreach ($pdoDrivers as $driver) {
+                if (array_key_exists('pdo_' . $driver, $mauticSupported)) {
+                    $supported['pdo_' . $driver] = $mauticSupported['pdo_' . $driver];
+                }
             }
         }
 
         // Add MySQLi if available
-        if (!function_exists('mysqli_connect')) {
-            unset($supported['mysqli']);
+        if (function_exists('mysqli_connect')) {
+            $supported['mysqli'] = $mauticSupported['mysqli'];
         }
 
         return $supported;


### PR DESCRIPTION
There are some web hosts which do not have PHP's PDO extension installed (see https://www.mautic.org/community/index.php/235-received-this-error-on-installation for an example).  This PR change the code in the InstallBundle that checks for supported database drivers to account for this.

- The supported database array is now an inclusive list by only adding supported platforms versus exclusive and removing unsupported platforms
- Calling `PDO::getAvailableDrivers()` is wrapped in a `class_exists('PDO')` check for platforms where this may not be installed

Note that PDO is still checked as a mandatory requirement in the `checkRequirements()` method in this class.  In theory as we support the non-PDO based MySQLi extension we could relax this requirement.  It should also be possible to add the non-PDO based SQL Server driver to our supported list as Doctrine has a compatible class for this.  But, both of those changes are outside scope of this PR.