### PR TITLE
Fixed issue that prevented being able to edit the subject of the "send form results" submit action

### DIFF
--- a/app/bundles/FormBundle/Form/Type/SubmitActionEmailType.php
+++ b/app/bundles/FormBundle/Form/Type/SubmitActionEmailType.php
@@ -34,7 +34,7 @@ class SubmitActionEmailType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $data = (isset($options['subject'])) ? $options['subject'] : $this->factory->getTranslator()->trans('mautic.form.action.sendemail.subject.default');
+        $data = (isset($options['data']['subject'])) ? $options['data']['subject'] : $this->factory->getTranslator()->trans('mautic.form.action.sendemail.subject.default');
         $builder->add('subject', 'text', array(
             'label'      => 'mautic.form.action.sendemail.subject',
             'label_attr' => array('class' => 'control-label'),


### PR DESCRIPTION
To test:  Create/edit a form and add the "send form results" submit action.  Edit the subject, save, double click to open again, the custom subject should be repopulated.  

Should fix #219.