### PR TITLE
Fixes not being able to delete lead lists associated with an email stat

### DIFF
--- a/app/bundles/EmailBundle/Entity/Stat.php
+++ b/app/bundles/EmailBundle/Entity/Stat.php
@@ -47,9 +47,10 @@ class Stat
      * @ORM\Column(name="email_address", type="string")
      */
     private $emailAddress;
+
     /**
      * @ORM\ManyToOne(targetEntity="Mautic\LeadBundle\Entity\LeadList")
-     * @ORM\JoinColumn(name="list_id", referencedColumnName="id", nullable=true)
+     * @ORM\JoinColumn(name="list_id", referencedColumnName="id", nullable=true, onDelete="SET NULL")
      **/
     private $list;
 


### PR DESCRIPTION
Email stats had a foreign constraint to a list if the email was sent to specific lead lists. That foreign constraint prevented being able to delete lead lists if an email had already been sent to it.

This PR fixes that by changing the constraint to set the list ID to null in the email stat upon deleting the list.

To test: Create a lead list and assign at least one lead to it.  Create an email and assign the lead list to it. Send the email to the list then try to delete the list. You should get the 500 error reported in #213. 

Apply the patch and run `php app/console doctrine:schema:update --force` to apply the schema change (you may want to use `--dump-sql` first if you have other potential pending schema changes just to see what Doctrine plans to do).  (This will need to be included in a migration script for the next release.)

Now deleting the list should be successful.
