### PR TITLE
Adds install_source to config for anonymous stats

### DIFF
--- a/app/bundles/CoreBundle/Helper/UpdateHelper.php
+++ b/app/bundles/CoreBundle/Helper/UpdateHelper.php
@@ -113,12 +113,13 @@ class UpdateHelper
             $instanceId = hash('sha1', $this->factory->getParameter('secret_key') . 'Mautic' . $this->factory->getParameter('db_driver'));
 
             $data = array(
-                'application' => 'Mautic',
-                'version'     => $this->factory->getVersion(),
-                'phpVersion'  => PHP_VERSION,
-                'dbDriver'    => $this->factory->getParameter('db_driver'),
-                'serverOs'    => php_uname('s') . ' ' . php_uname('r'),
-                'instanceId'  => $instanceId
+                'application'   => 'Mautic',
+                'version'       => $this->factory->getVersion(),
+                'phpVersion'    => PHP_VERSION,
+                'dbDriver'      => $this->factory->getParameter('db_driver'),
+                'serverOs'      => php_uname('s') . ' ' . php_uname('r'),
+                'instanceId'    => $instanceId,
+                'installSource' => $this->factory->getParameter('install_source', 'Mautic')
             );
 
             $this->connector->post('https://updates.mautic.org/stats/send', $data);

--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -53,6 +53,13 @@ class CheckStep implements StepInterface
     public $site_url;
 
     /**
+     * Set the name of the source that installed Mautic
+     *
+     * @var string
+     */
+    public $install_source = 'Mautic';
+
+    /**
      * Constructor
      *
      * @param boolean $configIsWritable Flag if the configuration file is writable


### PR DESCRIPTION
Added a install_source to the config file that is fed to the anonymous stats URL as installSource. It defaults to 'Mautic' i.e. the Mautic installer. Sources that install Mautic outside of the web installer should set this value to something that identifies them.