### PR TITLE
Adds support for 0 point triggers

### DIFF
--- a/app/bundles/PointBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/LeadSubscriber.php
@@ -10,6 +10,7 @@
 namespace Mautic\PointBundle\EventListener;
 
 use Mautic\CoreBundle\EventListener\CommonSubscriber;
+use Mautic\LeadBundle\Event\LeadEvent;
 use Mautic\LeadBundle\Event\LeadMergeEvent;
 use Mautic\LeadBundle\Event\LeadTimelineEvent;
 use Mautic\LeadBundle\Event\PointsChangeEvent;
@@ -29,7 +30,8 @@ class LeadSubscriber extends CommonSubscriber
         return array(
             LeadEvents::LEAD_POINTS_CHANGE   => array('onLeadPointsChange', 0),
             LeadEvents::TIMELINE_ON_GENERATE => array('onTimelineGenerate', 0),
-            LeadEvents::LEAD_POST_MERGE      => array('onLeadMerge', 0)
+            LeadEvents::LEAD_POST_MERGE      => array('onLeadMerge', 0),
+            LeadEvents::LEAD_POST_SAVE       => array('onLeadSave', -1)
         );
     }
 
@@ -43,6 +45,20 @@ class LeadSubscriber extends CommonSubscriber
         /** @var \Mautic\PointBundle\Model\TriggerModel */
         $model = $this->factory->getModel('point.trigger');
         $model->triggerEvents($event->getLead());
+    }
+
+    /**
+     * Handle point triggers for new leads (including 0 point triggers)
+     *
+     * @param LeadEvent $event
+     */
+    public function onLeadSave(LeadEvent $event)
+    {
+        if ($event->isNew()) {
+            /** @var \Mautic\PointBundle\Model\TriggerModel */
+            $model = $this->factory->getModel('point.trigger');
+            $model->triggerEvents($event->getLead());
+        }
     }
 
     /**


### PR DESCRIPTION
Currently, point triggers are executed only when a lead's points change. This means that triggers set to 0 points purposively will not execute. This PR changes that to execute point triggers for new leads so that it catches the 0 point triggers (applicable for scenarios where a trigger is desired for all newly added leads).

Easiest way to test is to lead list. Then create a point trigger, set points to 0, add an adjust lead lists event and set it to add the lead to the created list. Create a new lead. Before the patch, the lead should not be auto-added to the list.  After the patch, new leads should be added.

Try editing a lead with 0 points. That lead should not be auto-added to the list as 0 point triggers should only apply to newly added leads.