### PR TITLE
Begin Report API support

### DIFF
--- a/app/bundles/AssetBundle/Controller/Api/AssetApiController.php
+++ b/app/bundles/AssetBundle/Controller/Api/AssetApiController.php
@@ -42,7 +42,7 @@ class AssetApiController extends CommonApiController
             $this->listFilters[] = array(
                 'column' => 'a.createdBy',
                 'expr'   => 'eq',
-                'value'  => $this->factory->getUser()
+                'value'  => $this->factory->getUser()->getId()
             );
         }
 

--- a/app/bundles/AssetBundle/Controller/Api/AssetApiController.php
+++ b/app/bundles/AssetBundle/Controller/Api/AssetApiController.php
@@ -48,17 +48,4 @@ class AssetApiController extends CommonApiController
 
         return parent::getEntitiesAction();
     }
-
-    /**
-     * Obtains a specific asset
-     *
-     * @param int $id Asset ID
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
-    public function getEntityAction ($id)
-    {
-        return parent::getEntityAction($id);
-    }
 }

--- a/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
+++ b/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
@@ -33,29 +33,6 @@ class CampaignApiController extends CommonApiController
     }
 
     /**
-     * Obtains a list of campaigns
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    public function getEntitiesAction ()
-    {
-        return parent::getEntitiesAction();
-    }
-
-    /**
-     * Obtains a specific campaign
-     *
-     * @param int $id Campaign ID
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
-    public function getEntityAction ($id)
-    {
-        return parent::getEntityAction($id);
-    }
-
-    /**
      * Adds a lead to a campaign
      *
      * @param int $id     Campaign ID

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -59,19 +59,6 @@ class EmailApiController extends CommonApiController
     }
 
     /**
-     * Obtains a specific email
-     *
-     * @param int $id Email ID
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
-    public function getEntityAction ($id)
-    {
-        return parent::getEntityAction($id);
-    }
-
-    /**
      * Sends the email to it's assigned lists
      *
      * @param int $id Email ID

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -45,7 +45,7 @@ class EmailApiController extends CommonApiController
                 array(
                     'column' => 'e.createdBy',
                     'expr'   => 'eq',
-                    'value'  => $this->factory->getUser()
+                    'value'  => $this->factory->getUser()->getId()
                 );
         }
 

--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -43,7 +43,7 @@ class FormApiController extends CommonApiController
             $this->listFilters = array(
                 'column' => 'f.createdBy',
                 'expr'   => 'eq',
-                'value'  => $this->factory->getUser()
+                'value'  => $this->factory->getUser()->getId()
             );
         }
 

--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -51,19 +51,6 @@ class FormApiController extends CommonApiController
     }
 
     /**
-     * Obtains a specific form
-     *
-     * @param int $id Form ID
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
-    public function getEntityAction ($id)
-    {
-        return parent::getEntityAction($id);
-    }
-
-    /**
      * {@inheritdoc}
      */
     protected function preSerializeEntity (&$entity, $action = 'view')

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -35,41 +35,6 @@ class LeadApiController extends CommonApiController
     }
 
     /**
-     * Obtains a list of leads
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    public function getEntitiesAction ()
-    {
-        return parent::getEntitiesAction();
-    }
-
-    /**
-     * Obtains a specific lead
-     *
-     * @param int $id Lead ID
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
-    public function getEntityAction ($id)
-    {
-        return parent::getEntityAction($id);
-    }
-
-    /**
-     * Deletes a lead
-     *
-     * @param int $id Lead ID
-     *
-     * @return Response
-     */
-    public function deleteEntityAction ($id)
-    {
-        return parent::deleteEntityAction($id);
-    }
-
-    /**
      * Creates a new lead or edits if one is found with same email.  You should make a call to /api/leads/list/fields in order to get a list of custom fields that will be accepted. The key should be the alias of the custom field. You can also pass in a ipAddress parameter if the IP of the lead is different than that of the originating request.
      */
     public function newEntityAction ()
@@ -88,19 +53,6 @@ class LeadApiController extends CommonApiController
         }
 
         return parent::newEntityAction();
-    }
-
-    /**
-     * Edits an existing lead or creates a new one on PUT if not found.  You should make a call to /api/leads/list/fields in order to get a list of custom fields that will be accepted. The key should be the alias of the custom field. You can also pass in a ipAddress parameter if the IP of the lead is different than that of the originating request.
-     *
-     * @param int $id Lead ID
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     * @throws NotFoundHttpException
-     */
-    public function editEntityAction ($id)
-    {
-        return parent::editEntityAction($id);
     }
 
     /**

--- a/app/bundles/PageBundle/Controller/Api/PageApiController.php
+++ b/app/bundles/PageBundle/Controller/Api/PageApiController.php
@@ -62,19 +62,6 @@ class PageApiController extends CommonApiController
     }
 
     /**
-     * Obtains a specific page
-     *
-     * @param int $id Page ID
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
-    public function getEntityAction ($id)
-    {
-        return parent::getEntityAction($id);
-    }
-
-    /**
      * {@inheritdoc}
      */
     protected function preSerializeEntity (&$entity, $action = 'view')

--- a/app/bundles/PageBundle/Controller/Api/PageApiController.php
+++ b/app/bundles/PageBundle/Controller/Api/PageApiController.php
@@ -43,7 +43,7 @@ class PageApiController extends CommonApiController
             $this->listFilters = array(
                 'column' => 'p.createdBy',
                 'expr'   => 'eq',
-                'value'  => $this->factory->getUser()
+                'value'  => $this->factory->getUser()->getId()
             );
         }
 

--- a/app/bundles/PointBundle/Controller/Api/PointApiController.php
+++ b/app/bundles/PointBundle/Controller/Api/PointApiController.php
@@ -31,27 +31,4 @@ class PointApiController extends CommonApiController
         $this->permissionBase   = 'point:points';
         $this->serializerGroups = array('pointDetails', 'categoryList', 'publishDetails');
     }
-
-    /**
-     * Obtains a list of points
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    public function getEntitiesAction ()
-    {
-        return parent::getEntitiesAction();
-    }
-
-    /**
-     * Obtains a specific point
-     *
-     * @param int $id Point ID
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
-    public function getEntityAction ($id)
-    {
-        return parent::getEntityAction($id);
-    }
 }

--- a/app/bundles/PointBundle/Controller/Api/TriggerApiController.php
+++ b/app/bundles/PointBundle/Controller/Api/TriggerApiController.php
@@ -31,27 +31,4 @@ class TriggerApiController extends CommonApiController
         $this->permissionBase   = 'point:triggers';
         $this->serializerGroups = array('triggerDetails', 'categoryList', 'publishDetails');
     }
-
-    /**
-     * Obtains a list of triggers
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    public function getEntitiesAction ()
-    {
-        return parent::getEntitiesAction();
-    }
-
-    /**
-     * Obtains a specific trigger
-     *
-     * @param int $id Point ID
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
-    public function getEntityAction ($id)
-    {
-        return parent::getEntityAction($id);
-    }
 }

--- a/app/bundles/ReportBundle/Config/config.php
+++ b/app/bundles/ReportBundle/Config/config.php
@@ -35,6 +35,16 @@ return array(
                 'path'         => '/reports/{objectAction}/{objectId}',
                 'controller'   => 'MauticReportBundle:Report:execute'
             )
+        ),
+        'api'  => array(
+            'mautic_api_getreports'   => array(
+                'path'       => '/reports',
+                'controller' => 'MauticReportBundle:Api\ReportApi:getEntities'
+            ),
+            'mautic_api_getreport'    => array(
+                'path'       => '/reports/{id}',
+                'controller' => 'MauticReportBundle:Api\ReportApi:getReport'
+            )
         )
     ),
 

--- a/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
+++ b/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2014 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\ReportBundle\Controller\Api;
+
+use FOS\RestBundle\Util\Codes;
+use JMS\Serializer\SerializationContext;
+use Mautic\ApiBundle\Controller\CommonApiController;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+
+/**
+ * Class ReportApiController
+ */
+class ReportApiController extends CommonApiController
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize(FilterControllerEvent $event)
+    {
+        parent::initialize($event);
+        $this->model            = $this->factory->getModel('report');
+        $this->entityClass      = 'Mautic\ReportBundle\Entity\Report';
+        $this->entityNameOne    = 'report';
+        $this->entityNameMulti  = 'reports';
+        $this->permissionBase   = 'report:reports';
+        $this->serializerGroups = array('reportList', 'reportDetails');
+    }
+
+    /**
+     * Obtains a list of reports
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function getEntitiesAction()
+    {
+        if (!$this->security->isGranted('report:reports:viewother')) {
+            $this->listFilters = array(
+                'column' => 'r.createdBy',
+                'expr'   => 'eq',
+                'value'  => $this->factory->getUser()
+            );
+        }
+
+        return parent::getEntitiesAction();
+    }
+
+    /**
+     * Obtains a compiled report
+     *
+     * @param int $id Report ID
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function getReportAction($id)
+    {
+        $entity = $this->model->getEntity($id);
+
+        if (!$entity instanceof $this->entityClass) {
+            return $this->notFound();
+        }
+
+        $reportData = $this->model->getReportData($entity, $this->container->get('form.factory'), array('paginate' => false, 'ignoreGraphData' => true));
+
+        $view = $this->view($reportData, Codes::HTTP_OK);
+        $context = SerializationContext::create()->setGroups(array('reportDetails'));
+        $view->setSerializationContext($context);
+
+        return $this->handleView($view);
+    }
+}

--- a/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
+++ b/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
@@ -45,7 +45,7 @@ class ReportApiController extends CommonApiController
             $this->listFilters = array(
                 'column' => 'r.createdBy',
                 'expr'   => 'eq',
-                'value'  => $this->factory->getUser()
+                'value'  => $this->factory->getUser()->getId()
             );
         }
 
@@ -70,8 +70,6 @@ class ReportApiController extends CommonApiController
         $reportData = $this->model->getReportData($entity, $this->container->get('form.factory'), array('paginate' => false, 'ignoreGraphData' => true));
 
         $view = $this->view($reportData, Codes::HTTP_OK);
-        $context = SerializationContext::create()->setGroups(array('reportDetails'));
-        $view->setSerializationContext($context);
 
         return $this->handleView($view);
     }

--- a/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
+++ b/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
@@ -69,6 +69,11 @@ class ReportApiController extends CommonApiController
 
         $reportData = $this->model->getReportData($entity, $this->container->get('form.factory'), array('paginate' => false, 'ignoreGraphData' => true));
 
+        // Unset keys that we don't need to send back
+        foreach (array('graphs', 'contentTemplate', 'columns', 'limit') as $key) {
+            unset($reportData[$key]);
+        }
+
         $view = $this->view($reportData, Codes::HTTP_OK);
 
         return $this->handleView($view);

--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -46,7 +46,7 @@ class Report extends FormEntity
      * @ORM\Column(type="text", nullable=true)
      * @Serializer\Expose
      * @Serializer\Since("1.0")
-     * @Serializer\Groups({"reportDetails"})
+     * @Serializer\Groups({"reportList", "reportDetails"})
      */
     private $description;
 


### PR DESCRIPTION
Begins support for pulling report data via the API.  Two endpoints are available:

- `GET /reports` to pull the list of reports
- `GET /reports/{id}` to compile the given report without the graph data

Also as a bit of cleanup, all API controllers have had methods which only call their respective parent methods deleted.  If extended functionality is needed, then implement these methods.