### PR TITLE
Removes the broken upload tab from ckeditor's image dialogue

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/config.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/config.js
@@ -14,7 +14,6 @@ CKEDITOR.editorConfig = function( config ) {
 
     config.enterMode = CKEDITOR.ENTER_P;
     config.filebrowserImageBrowseUrl = mauticBasePath + '/' + mauticAssetPrefix + 'app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/index.html?type=Images';
-    config.filebrowserImageUploadUrl = mauticBasePath + '/' + mauticAssetPrefix + 'app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/connectors/php/filemanager.php?command=QuickUpload&type;=Images';
 
     config.toolbar =
         [


### PR DESCRIPTION
This should fix #243. The Upload tab is not compatible with the filemanager we are using to integrate into CKEditor. Rather, the "Browser Server" button should be used to manage, upload, and insert images.  This PR removes the Upload tab from the dialogue. 

To test: edit an email or landing page and click the image button in the editor.  You'll see an Upload tab that breaks if you try to upload an image through it.  Apply the patch, clear your browser's cache, then try again.  The upload tab should no longer be available.