### PR TITLE
Fixed page hit based reports

### DIFF
--- a/app/bundles/PageBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/ReportSubscriber.php
@@ -238,7 +238,7 @@ class ReportSubscriber extends CommonSubscriber
             $qb = $this->factory->getEntityManager()->getConnection()->createQueryBuilder();
 
             $qb->from(MAUTIC_TABLE_PREFIX . 'page_hits', 'ph')
-                ->leftJoin('ph', MAUTIC_TABLE_PREFIX . 'pages', 'p', 'ph.id = p.id')
+                ->leftJoin('ph', MAUTIC_TABLE_PREFIX . 'pages', 'p', 'ph.page_id = p.id')
                 ->leftJoin('p', MAUTIC_TABLE_PREFIX . 'pages', 'tp', 'p.id = tp.id')
                 ->leftJoin('p', MAUTIC_TABLE_PREFIX . 'pages', 'vp', 'p.id = vp.id')
                 ->leftJoin('ph', MAUTIC_TABLE_PREFIX . 'emails', 'e', 'e.id = ph.email_id')


### PR DESCRIPTION
Page hit based reports was not returning data due to a bad join statement. 

To test, create a landing page and hit up the public URL a time or two.  Check the Visits published Pages report which should have no data.

Apply the patch then check the report again.  This time the data should show.