### PR TITLE
Fixed redirect issue when creating categories from within other forms

### DIFF
--- a/app/bundles/CategoryBundle/Controller/CategoryController.php
+++ b/app/bundles/CategoryBundle/Controller/CategoryController.php
@@ -248,6 +248,8 @@ class CategoryController extends FormController
         $entity    = $model->getEntity($objectId);
         $success   = $closeModal = 0;
         $cancelled = $valid = false;
+        $method    = $this->request->getMethod();
+        $inForm    = ($method == 'POST') ? $this->request->request->get('category_form[inForm]', 0, true) : $this->request->get('inForm', 0);
 
         //not found
         if ($entity === null) {
@@ -265,9 +267,10 @@ class CategoryController extends FormController
             'bundle'       => $bundle
         ));
         $form   = $model->createForm($entity, $this->get('form.factory'), $action, array('bundle' => $bundle));
+        $form['inForm']->setData($inForm);
 
         ///Check for a submitted form and process it
-        if (!$ignorePost && $this->request->getMethod() == 'POST') {
+        if (!$ignorePost && $method == 'POST') {
             $valid = false;
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($valid = $this->isFormValid($form)) {
@@ -294,6 +297,16 @@ class CategoryController extends FormController
         $closeModal = ($closeModal || $cancelled || ($valid && $form->get('buttons')->get('save')->isClicked()));
 
         if ($closeModal) {
+            if ($inForm) {
+                return new JsonResponse(array(
+                    'mauticContent' => 'category',
+                    'closeModal'    => 1,
+                    'inForm'        => 1,
+                    'categoryName'  => $entity->getName(),
+                    'categoryId'    => $entity->getId()
+                ));
+            }
+
             $viewParameters = array(
                 'page'   => $session->get('mautic.category.page'),
                 'bundle' => $bundle


### PR DESCRIPTION
When selecting "Create new category..." from the Category dropdown of a form (email, landing page, campaign, etc), clicking Apply first then Save and Exit would redirect to the category list rather than exiting back to the form. 

To test:

Create a new email, form, campaign, etc.  In the Category dropdown, click "Create new category..."  Enter a name then click Apply.  The modal should remain open.  Now click Save and Exit and you should be redirected to the category list losing the form.

Apply the patch then repeat.  This time the modal should close allowing you to continue manipulating the form.

This should resolve #242 