### PR TITLE
Fixes bad query when adding owner as a lead list filter

### DIFF
--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -58,7 +58,7 @@ class AjaxController extends CommonAjaxController
         $filter    = InputHelper::clean($request->query->get('filter'));
         $field     = InputHelper::clean($request->query->get('field'));
         if (!empty($field)) {
-            if ($field == "owner") {
+            if ($field == "owner_id") {
                 $results = $this->factory->getModel('lead.lead')->getLookupResults('user', $filter);
                 foreach ($results as $r) {
                     $name        = $r['firstName'] . ' ' . $r['lastName'];

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -255,7 +255,7 @@ class ListModel extends FormModel
                 'label'       => $this->translator->trans('mautic.core.date.added'),
                 'properties'  => array('type' => 'date')
             ),
-            'owner'     => array(
+            'owner_id'     => array(
                 'label'      => $this->translator->trans('mautic.lead.list.filter.owner'),
                 'properties' => array(
                     'type'     => 'lookup_id',


### PR DESCRIPTION
Should fix #245.

To test, create a new lead list and add "owner" as the filter.  Try to save and you should get a 500 error.

Apply the patch and try again.  This time it should save and leads assigned to the selected owner should be assigned to the list.