### PR TITLE
Fixed the user form to show firstname and lastname validation errors

### DIFF
--- a/app/bundles/UserBundle/Views/User/form.html.php
+++ b/app/bundles/UserBundle/Views/User/form.html.php
@@ -27,11 +27,13 @@ $view['slots']->set("headerTitle", $header);
 			<div class="form-group mb-0">
 			    <label class="control-label mb-xs"><?php echo $view['translator']->trans('mautic.core.name'); ?></label>
 			    <div class="row">
-			        <div class="col-sm-6">
+                    <div class="col-sm-6<?php echo (count($form['firstName']->vars['errors'])) ? ' has-error' : ''; ?>">
 			            <?php echo $view['form']->widget($form['firstName'], array('attr' => array('placeholder' => $form['firstName']->vars['label']))); ?>
+                        <?php echo $view['form']->errors($form['firstName']); ?>
 			        </div>
-			        <div class="col-sm-6">
+                    <div class="col-sm-6<?php echo (count($form['lastName']->vars['errors'])) ? ' has-error' : ''; ?>">
 			            <?php echo $view['form']->widget($form['lastName'], array('attr' => array('placeholder' => $form['lastName']->vars['label']))); ?>
+                        <?php echo $view['form']->errors($form['lastName']); ?>
 			        </div>
 			    </div>
 			</div>


### PR DESCRIPTION
Saving a user form without filling in the first name and last name would not allow saving but would not display the errors either because the form errors were not rendered for first name or last name.

To test, try to save a new user without filling in the first name and/or last name; it should fail without giving any kind of reason as to why.

Apply the patch, try again, and this time first name and/or last name should show the validation errors.

Fixes #240.