### PR TITLE
Line chart label must be unique or it will display data wrong

### DIFF
--- a/app/bundles/CoreBundle/Helper/GraphHelper.php
+++ b/app/bundles/CoreBundle/Helper/GraphHelper.php
@@ -115,7 +115,7 @@ class GraphHelper
         } elseif ($unit == 'W') {
             $format = 'W';
         } elseif ($unit == 'M') {
-            $format = 'F';
+            $format = 'F y';
         } elseif ($unit == 'Y') {
             $format = 'Y';
         }


### PR DESCRIPTION
When the line chart was set to monthly view, it displayed form submissions in the right month, but the wrong year. So I added the year into the label.

### Before
![mautic-monthly-wrong-year](https://cloud.githubusercontent.com/assets/1235442/6963670/2bd068bc-d942-11e4-9c27-7583aaf5bdf1.png)

### After
![mautic-monthly-right-year](https://cloud.githubusercontent.com/assets/1235442/6963673/33253df4-d942-11e4-8046-9f9b58719e31.png)
