### PR TITLE
en_US catalogue is not generated after a cache clear when another locale is selected

### DIFF
--- a/app/bundles/CoreBundle/Translation/Translator.php
+++ b/app/bundles/CoreBundle/Translation/Translator.php
@@ -49,6 +49,11 @@ class Translator extends BaseTranslator
      */
     protected function loadCatalogue($locale)
     {
+        if ($locale != 'en_US') {
+            // Always force en_US so that it's available for fallback
+            $this->addResource('mautic', null, 'en_US', 'messages');
+        }
+
         $this->addResource('mautic', null, $locale, 'messages');
 
         parent::loadCatalogue($locale);


### PR DESCRIPTION
When the system is set to a locale other than en_US and the cache gets cleared, the en_US catalogue is not rebuilt so any language string missing in the translation will show the translation key instead.

To fix this, I added a catch to always load the en_US catalogue when building so that it's available for fallback.

To test, select a locale in your configuration other than English (preferably one that is not complete such as Portuguese).  Also make sure your current user's profile is set to use the system's default locale.  Clear your cache and refresh.  The page should have the translation keys throughout other than the ones included in the translation.

Now apply the patch and repeat.  This time, English string should show for those missing strings.