### PR TITLE
Block update to doctrine/orm 2.5+ due to PHP minimum bump

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "sensio/distribution-bundle": "~2.3",
         "sensio/framework-extra-bundle": "~3.0",
 
-        "doctrine/orm": "~2.3",
+        "doctrine/orm": "~2.3,<2.5",
         "doctrine/dbal": "2.4.*",
         "doctrine/doctrine-bundle": "~1.2",
         "doctrine/doctrine-fixtures-bundle": "2.2.*@dev",


### PR DESCRIPTION
Doctrine ORM 2.5 requires PHP 5.4 minimum.  Block Composer allowing updates to it while we support PHP 5.3.