### PR TITLE
Fixes issue with decoding the tracking pixel's d parameter

### DIFF
--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -384,10 +384,13 @@ class PageModel extends FormModel
                 // if additional data were sent with the tracking pixel
                 if ($request->server->get('QUERY_STRING')) {
                     parse_str($request->server->get('QUERY_STRING'), $query);
-                    // URL attr 'd' is decoded. Encode it first.
+
+                    // URL attr 'd' is encoded so let's decode it first.
+
                     $decoded = false;
                     if (isset($query['d'])) {
-                        $query   = unserialize(base64_decode(urldecode($query['d'])));
+                        // parse_str auto urldecodes
+                        $query   = unserialize(base64_decode($query['d']));
                         $decoded = true;
                     }
 


### PR DESCRIPTION
When the encoded tracking pixel's d query parameter contained a + sign and possibly other encoded characters from base64 encoding, decoding the parameter failed.  Apparently parse_str auto url decodes the string (https://php.net/parse_str#82675) thus when urldecode() was applied again, the base64 encoding became corrupt.

This fixes the issue by removing urlencode().