### PR TITLE
Added a check to the 1.0.2 migration script to prevent being double applied

### DIFF
--- a/app/migrations/Version20150402000000.php
+++ b/app/migrations/Version20150402000000.php
@@ -9,6 +9,7 @@
 
 namespace Mautic\Migrations;
 
+use Doctrine\DBAL\Migrations\SkipMigrationException;
 use Doctrine\DBAL\Schema\Schema;
 use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
 
@@ -17,6 +18,22 @@ use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
  */
 class Version20150402000000 extends AbstractMauticMigration
 {
+
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        // Test to see if this migration has already been applied
+        $formTable = $schema->getTable($this->prefix . 'forms');
+        if ($formTable->hasColumn('in_kiosk_mode')) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
     /**
      * @param Schema $schema
      */


### PR DESCRIPTION
This shouldn't become an issue until the next version is released, but added a catch to check to see if the schema is already applied and prevents the attempt to reapply if it has. 

To test, if you an up-to-date schema, remove 20150402000000 from your migrations table then run `php app/console doctrine:migrations:migrate` You should get a message that the schema has already been applied and no errors.