### PR TITLE
Fix lead list like/notLike filters

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -469,14 +469,18 @@ class LeadListRepository extends CommonRepository
         $useExpr     =& $expr;
 
         foreach ($filters as $k => $details) {
-            $uniqueFilter              = $this->generateRandomParameterName();
-            $parameters[$uniqueFilter] = $details['filter'];
-
-            $uniqueFilter              = ":$uniqueFilter";
             //DQL does not have a not() function so we have to use the opposite
             $func                      = (!$not) ? $options[$details['operator']]['func'] :
                 $options[$details['operator']]['oFunc'];
             $field                     = "l.{$details['field']}";
+            $uniqueFilter              = $this->generateRandomParameterName();
+            $parameters[$uniqueFilter] = $details['filter'];
+
+            if ($func == 'like' || $func == 'notLike') {
+                $parameters[$uniqueFilter] = '%' . $parameters[$uniqueFilter] . '%';
+            }
+
+            $uniqueFilter              = ":$uniqueFilter";
 
             //the next one will determine the group
             $glue = (isset($filters[$k + 1])) ? $filters[$k + 1]['glue'] : $details['glue'];


### PR DESCRIPTION
Lead list filters using like or notLike failed because the the search term was not wrapped in the % wildcard. 

To test, try applying a filter that should match existing leads using like or not like and it should fail to find the leads.  Apply the fix, edit and save the filter and now the leads should be assigned to it.