### PR TITLE
Triggering campaign events

### DIFF
--- a/app/bundles/CampaignBundle/Assets/css/campaign.css
+++ b/app/bundles/CampaignBundle/Assets/css/campaign.css
@@ -80,12 +80,6 @@
     border: solid 1px #00b49d;
 }
 
-.list-campaign-systemaction, a.list-campaign-systemaction {
-    /*background-color: #8393a2;*/
-    border: solid 1px #8393a2;
-    /*color: #fff;*/
-}
-
 .list-campaign-action, a.list-campaign-action {
     /*background-color: #47558f;*/
     border: solid 1px #4e5e9e;

--- a/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
@@ -52,6 +52,11 @@ class TriggerCampaignCommand extends ContainerAwareCommand
         $scheduleOnly = $input->getOption('scheduled-only');
         $negativeOnly = $input->getOption('negative-only');
 
+        if (!$negativeOnly && !$scheduleOnly) {
+            //trigger starting action events for newly added leads
+            $model->triggerStartingEvents($campaignId);
+        }
+
         if (!$negativeOnly) {
             //trigger scheduled events
             $model->triggerScheduledEvents($campaignId);

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -364,7 +364,6 @@ class CampaignController extends FormController
                         $valid = false;
                     } else {
                         $connections     = $session->get('mautic.campaign.' . $sessionId . '.events.canvassettings');
-                        $processedEvents = $model->setEvents($entity, $events, $connections, $deletedEvents);
 
                         //form is valid so process the data
                         $model->saveEntity($entity);
@@ -372,17 +371,6 @@ class CampaignController extends FormController
                         //update canvas settings with new event IDs then save
                         $model->setCanvasSettings($entity, $connections);
 
-                        //trigger the first action in dripflow if published and first event is an action
-                        if ($entity->isPublished()) {
-                            //check for top level action events
-                            foreach ($processedEvents as $id => $e) {
-                                $parent = $e->getParent();
-                                if ($e->getEventType() == 'action' && $parent === null) {
-                                    //check the callback function for the event to make sure it even applies based on its settings
-                                    $eventModel->triggerCampaignStartingAction($entity, $e, $eventSettings['action'][$e->getType()]);
-                                }
-                            }
-                        }
                         $this->addFlash('mautic.core.notice.created', array(
                             '%name%'      => $entity->getName(),
                             '%menu_link%' => 'mautic_campaign_index',
@@ -531,7 +519,6 @@ class CampaignController extends FormController
                     } else {
                         $connections = $session->get('mautic.campaign.' . $objectId . '.events.canvassettings');
                         if ($connections != null) {
-                            $processedEvents = $model->setEvents($entity, $events, $connections, $deletedEvents);
 
                             //form is valid so process the data
                             $model->saveEntity($entity, $form->get('buttons')->get('save')->isClicked());
@@ -544,19 +531,6 @@ class CampaignController extends FormController
                             }
                         } else {
                             $model->saveEntity($entity, $form->get('buttons')->get('save')->isClicked());
-                            $processedEvents = $entity->getEvents();
-                        }
-
-                        //trigger the first action in dripflow if published and first event is an action
-                        if ($entity->isPublished()) {
-                            //check for top level action events
-                            foreach ($processedEvents as $id => $e) {
-                                $parent = $e->getParent();
-                                if ($e->getEventType() == 'action' && $parent === null) {
-                                    //check the callback function for the event to make sure it even applies based on its settings
-                                    $eventModel->triggerCampaignStartingAction($entity, $e, $eventSettings['action'][$e->getType()]);
-                                }
-                            }
                         }
 
                         $this->addFlash('mautic.core.notice.updated', array(

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -363,7 +363,8 @@ class CampaignController extends FormController
                         ));
                         $valid = false;
                     } else {
-                        $connections     = $session->get('mautic.campaign.' . $sessionId . '.events.canvassettings');
+                        $connections = $session->get('mautic.campaign.' . $sessionId . '.events.canvassettings');
+                        $model->setEvents($entity, $events, $connections, $deletedEvents);
 
                         //form is valid so process the data
                         $model->saveEntity($entity);
@@ -519,6 +520,7 @@ class CampaignController extends FormController
                     } else {
                         $connections = $session->get('mautic.campaign.' . $objectId . '.events.canvassettings');
                         if ($connections != null) {
+                            $model->setEvents($entity, $events, $connections, $deletedEvents);
 
                             //form is valid so process the data
                             $model->saveEntity($entity, $form->get('buttons')->get('save')->isClicked());

--- a/app/bundles/CampaignBundle/Controller/EventController.php
+++ b/app/bundles/CampaignBundle/Controller/EventController.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 class EventController extends CommonFormController
 {
-    private $supportedEventTypes = array('decision', 'systemaction', 'action');
+    private $supportedEventTypes = array('decision', 'action');
 
     /**
      * Generates new form and processes post data

--- a/app/bundles/CampaignBundle/Entity/EventRepository.php
+++ b/app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -333,7 +333,7 @@ class EventRepository extends CommonRepository
 
         $expr = $this->getPublishedByDateExpression($q, 'c', false);
         $expr->add(
-            $q->expr()->eq('o.isScheduled', 1)
+            $q->expr()->eq('o.isScheduled', ':true')
         );
 
         $expr->add(

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -97,7 +97,7 @@ class LeadEventLogRepository extends EntityRepository
 
         if (isset($options['scheduled'])) {
             $query->andWhere('ll.isScheduled = :scheduled')
-                ->setParameter('scheduled', $options['scheduled']);
+                ->setParameter('scheduled', $options['scheduled'], 'boolean');
         }
 
         if (isset($options['eventType'])) {

--- a/app/bundles/CampaignBundle/Event/CampaignBuilderEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignBuilderEvent.php
@@ -28,11 +28,6 @@ class CampaignBuilderEvent extends Event
     /**
      * @var array
      */
-    private $systemChanges = array();
-
-    /**
-     * @var array
-     */
     private $actions      = array();
 
     /**
@@ -104,65 +99,6 @@ class CampaignBuilderEvent extends Event
         }
 
         return $this->leadDecisions;
-    }
-
-
-    /**
-     * Add an system action to the list of available .
-     *
-     * @param string $key    - a unique identifier; it is recommended that it be namespaced i.e. lead.mytrigger
-     * @param array  $action - can contain the following keys:
-     *                        'label'       => (required) what to display in the list
-     *                        'description' => (optional) short description of event
-     *                        'formType'    => (optional) name of the form type SERVICE for the action
-     *                        'formTypeOptions' => (optional) array of options to pass to the formType service
-     *                        'formTheme'   => (optional) form theme
-     *                        'callback'    => (optional) callback function that will be passed when the event is triggered
-     *                            The callback function should return a bool to determine if the trigger's actions
-     *                            should be executed.  For example, only trigger actions for specific entities.
-     *                            it can can receive the following arguments by name (via ReflectionMethod::invokeArgs())
-     *                              mixed $eventDetails Whatever the bundle passes when triggering the event
-     *                              Mautic\CoreBundle\Factory\MauticFactory $factory
-     *                              Mautic\SystemBundle\Entity\System $lead
-     *                              array $event
-     */
-    public function addSystemChange ($key, array $action)
-    {
-        if (array_key_exists($key, $this->leadDecisions)) {
-            throw new InvalidArgumentException("The key, '$key' is already used by another system action. Please use a different key.");
-        }
-
-        //check for required keys and that given functions are callable
-        $this->verifyComponent(
-            array('label'),
-            array('callback'),
-            $action
-        );
-
-        $action['label']       = $this->translator->trans($action['label']);
-        $action['description'] = (isset($action['description'])) ? $this->translator->trans($action['description']) : '';
-
-        $this->systemChanges[$key] = $action;
-    }
-
-    /**
-     * Get lead actions
-     *
-     * @return array
-     */
-    public function getSystemChanges ()
-    {
-        static $sorted = false;
-
-        if (empty($sorted)) {
-            uasort($this->systemChanges, function ($a, $b) {
-                return strnatcasecmp(
-                    $a['label'], $b['label']);
-            });
-            $sorted = true;
-        }
-
-        return $this->systemChanges;
     }
 
     /**

--- a/app/bundles/CampaignBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignSubscriber.php
@@ -118,13 +118,6 @@ class CampaignSubscriber extends CommonSubscriber
         $lead     = $event->getLead();
         $campaign = $event->getCampaign();
 
-        if ($event->getAction() == 'added' && !$this->security->isAnonymous()) {
-
-            /** @var \Mautic\CampaignBundle\Model\EventModel $eventModel */
-            $eventModel = $this->factory->getModel('campaign.event');
-            $eventModel->triggerCampaignStartingActionsForLead($campaign, $lead);
-        }
-
         // Trigger a lead change event
         $model->triggerEvent('campaign.leadchange', $event, 'campaign.leadchange.'.$lead->getId() . '.' . $campaign->getId());
     }

--- a/app/bundles/CampaignBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignSubscriber.php
@@ -29,8 +29,7 @@ class CampaignSubscriber extends CommonSubscriber
         return array(
             CampaignEvents::CAMPAIGN_POST_SAVE     => array('onCampaignPostSave', 0),
             CampaignEvents::CAMPAIGN_POST_DELETE   => array('onCampaignDelete', 0),
-            CampaignEvents::CAMPAIGN_ON_BUILD      => array('onCampaignBuild', 0),
-            CampaignEvents::CAMPAIGN_ON_LEADCHANGE => array('onCampaignLeadChange', 0)
+            CampaignEvents::CAMPAIGN_ON_BUILD      => array('onCampaignBuild', 0)
         );
     }
 
@@ -86,15 +85,6 @@ class CampaignSubscriber extends CommonSubscriber
      */
     public function onCampaignBuild(Events\CampaignBuilderEvent $event)
     {
-        //Add trigger
-        $leadChangeTrigger = array(
-            'label'       => 'mautic.campaign.event.leadchange',
-            'description' => 'mautic.campaign.event.leadchange_descr',
-            'formType'    => 'campaignevent_leadchange',
-            'callback'    => '\Mautic\CampaignBundle\Helper\CampaignEventHelper::validateLeadChangeTrigger'
-        );
-        $event->addSystemChange('campaign.leadchange', $leadChangeTrigger);
-
         //Add action to actually add/remove lead to a specific lists
         $addRemoveLeadAction = array(
             'label'           => 'mautic.campaign.event.addremovelead',
@@ -106,19 +96,5 @@ class CampaignSubscriber extends CommonSubscriber
             'callback'        => '\Mautic\CampaignBundle\Helper\CampaignEventHelper::addRemoveLead'
         );
         $event->addAction('campaign.addremovelead', $addRemoveLeadAction);
-    }
-
-    /**
-     * @param Events\CampaignLeadChangeEvent $event
-     */
-    public function onCampaignLeadChange(Events\CampaignLeadChangeEvent $event)
-    {
-        /** @var \Mautic\CampaignBundle\Model\CampaignModel $model */
-        $model    = $this->factory->getModel('campaign');
-        $lead     = $event->getLead();
-        $campaign = $event->getCampaign();
-
-        // Trigger a lead change event
-        $model->triggerEvent('campaign.leadchange', $event, 'campaign.leadchange.'.$lead->getId() . '.' . $campaign->getId());
     }
 }

--- a/app/bundles/CampaignBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignSubscriber.php
@@ -118,13 +118,7 @@ class CampaignSubscriber extends CommonSubscriber
         $lead     = $event->getLead();
         $campaign = $event->getCampaign();
 
-        if ($event->getAction() == 'added') {
-            // Trigger first action(s) if applicable
-
-            if (!$this->security->isAnonymous()) {
-                // Force actions
-                defined('MAUTIC_CAMPAIGN_SYSTEM_TRIGGERED') or define('MAUTIC_CAMPAIGN_SYSTEM_TRIGGERED', 1);
-            }
+        if ($event->getAction() == 'added' && !$this->security->isAnonymous()) {
 
             /** @var \Mautic\CampaignBundle\Model\EventModel $eventModel */
             $eventModel = $this->factory->getModel('campaign.event');

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -539,12 +539,12 @@ class CampaignModel extends CommonFormModel
                 // Manually added and manually removed so chuck it
                 $dispatchEvent   = true;
 
-                $this->getRepository()->deleteEntity($campaignLead);
+                $this->getEventRepository()->deleteEntity($campaignLead);
             } elseif ($manuallyRemoved) {
                 $dispatchEvent = true;
 
                 $campaignLead->setManuallyRemoved(true);
-                $this->getRepository()->saveEntity($campaignLead);
+                $this->getEventRepository()->saveEntity($campaignLead);
             }
 
             if ($dispatchEvent) {

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -234,7 +234,7 @@ class CampaignModel extends CommonFormModel
             } elseif ($events[$id]->getParent()) {
                 // No longer has a parent so null it out
 
-                // Remove decision
+                // Remove decision so that it doesn't affect execution
                 $events[$id]->setDecisionPath(null);
 
                 // Remove child from parent
@@ -248,6 +248,7 @@ class CampaignModel extends CommonFormModel
                 // Is a parent
                 $hierarchy[$id] = 'null';
 
+                // Remove decision so that it doesn't affect execution
                 $events[$id]->setDecisionPath(null);
             }
         }

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -234,6 +234,9 @@ class CampaignModel extends CommonFormModel
             } elseif ($events[$id]->getParent()) {
                 // No longer has a parent so null it out
 
+                // Remove decision
+                $events[$id]->setDecisionPath(null);
+
                 // Remove child from parent
                 $parent = $events[$id]->getParent();
                 $parent->removeChild($events[$id]);
@@ -244,6 +247,8 @@ class CampaignModel extends CommonFormModel
             } else {
                 // Is a parent
                 $hierarchy[$id] = 'null';
+
+                $events[$id]->setDecisionPath(null);
             }
         }
 

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -375,7 +375,6 @@ class CampaignModel extends CommonFormModel
             $event  = new Events\CampaignBuilderEvent($this->translator);
             $this->dispatcher->dispatch(CampaignEvents::CAMPAIGN_ON_BUILD, $event);
             $events['decision']     = $event->getLeadDecisions();
-            $events['systemaction'] = $event->getSystemChanges();
             $events['action']       = $event->getActions();
         }
 

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -175,6 +175,12 @@ class EventModel extends CommonFormModel
             $leadCampaigns[$leadId] = $campaignModel->getLeadCampaigns($lead, true);
         }
 
+        if (empty($leadCampaigns[$leadId] )) {
+            $logger->debug('CAMPAIGN: no campaigns found so abort');
+
+            return false;
+        }
+
         //get the list of events that match the triggering event and is in the campaigns this lead belongs to
         /** @var \Mautic\CampaignBundle\Entity\EventRepository $eventRepo */
         $eventRepo = $this->getRepository();
@@ -642,12 +648,6 @@ class EventModel extends CommonFormModel
             'systemTriggered' => $systemTriggered,
             'config'          => $event['properties']
         );
-
-        if ($lead instanceof Lead) {
-            /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
-            $leadModel = $this->factory->getModel('lead');
-            $lead->setFields($leadModel->getLeadDetails($lead));
-        }
 
         if (is_callable($settings['callback'])) {
             if (is_array($settings['callback'])) {

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -335,6 +335,8 @@ class EventModel extends CommonFormModel
                         //a child of this event was triggered or scheduled so make not of the triggering event in the log
                         $persist[] = $this->getLogEntity($event['id'], $event['campaign']['id'], $lead, $ipAddress, $systemTriggered);
                     }
+                } else {
+                    $logger->debug('CAMPAIGN: No children for this event.');
                 }
             }
         }

--- a/app/bundles/CampaignBundle/Views/Campaign/builder.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/builder.html.php
@@ -24,26 +24,6 @@
 
         <div><em><?php echo $view['translator']->trans('mautic.campaign.event.drag.help'); ?></em></div>
         <div class="panel-group margin-sm-top" id="CampaignEventPanel">
-            <?php /*
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h4 class="panel-title">
-                            <a href="#CampaignEventSystemActions">
-                                <?php echo $view['translator']->trans('mautic.campaign.event.systemchanges.header'); ?>
-                            </a>
-                        </h4>
-                    </div>
-                    <div class="panel-body">
-                        <?php foreach ($eventSettings['systemaction'] as $k => $e): ?>
-                            <a id="campaignEvent_<?php echo str_replace('.', '', $k); ?>" data-toggle="ajaxmodal" data-target="#CampaignEventModal" class="list-group-item list-campaign-systemaction" href="<?php echo $view['router']->generate('mautic_campaignevent_action', array('objectAction' => 'new', 'type' => $k, 'eventType'=> 'systemaction')); ?>">
-                                <div class="padding-sm" data-toggle="tooltip" title="<?php echo $e['description']; ?>">
-                                    <span><?php echo $e['label']; ?></span>
-                                </div>
-                            </a>
-                        <?php endforeach; ?>
-                    </div>
-                </div>
-                */ ?>
             <div class="panel panel-default">
                 <div class="panel-heading">
                     <h4 class="panel-title">

--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -15,6 +15,7 @@ use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Event\EmailEvent;
 use Mautic\EmailBundle\Event\EmailOpenEvent;
 use Mautic\EmailBundle\Event\EmailSendEvent;
+use Mautic\LeadBundle\Entity\Lead;
 
 /**
  * Class CampaignSubscriber
@@ -73,8 +74,11 @@ class CampaignSubscriber extends CommonSubscriber
      */
     public function onEmailSend(EmailSendEvent $event)
     {
-        $email = $event->getEmail();
-        $this->factory->getModel('campaign')->triggerEvent('email.send', $email);
+        $email  = $event->getEmail();
+        $lead   = $event->getLead();
+        $leadId = ($lead instanceof Lead) ? $lead->getId() : $lead['id'];
+
+        $this->factory->getModel('campaign')->triggerEvent('email.send', $email, 'email.send.'.$leadId.'.'.$email->getId());
     }
 
     /**

--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -32,7 +32,6 @@ class CampaignSubscriber extends CommonSubscriber
     {
         return array(
             CampaignEvents::CAMPAIGN_ON_BUILD => array('onCampaignBuild', 0),
-            EmailEvents::EMAIL_ON_SEND        => array('onEmailSend', 0),
             EmailEvents::EMAIL_ON_OPEN        => array('onEmailOpen', 0)
         );
     }
@@ -65,20 +64,6 @@ class CampaignSubscriber extends CommonSubscriber
             'formTheme'       => 'MauticEmailBundle:FormTheme\EmailSendList'
         );
         $event->addAction('email.send', $action);
-    }
-
-    /**
-     * Trigger campaign event for sending of an email
-     *
-     * @param EmailSendEvent $event
-     */
-    public function onEmailSend(EmailSendEvent $event)
-    {
-        $email  = $event->getEmail();
-        $lead   = $event->getLead();
-        $leadId = ($lead instanceof Lead) ? $lead->getId() : $lead['id'];
-
-        $this->factory->getModel('campaign')->triggerEvent('email.send', $email, 'email.send.'.$leadId.'.'.$email->getId());
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -327,7 +327,7 @@ class LeadModel extends FormModel
     }
 
     /**
-     * Gets the details of a lead
+     * Gets the details of a lead if not already set
      *
      * @param $lead
      *
@@ -337,13 +337,17 @@ class LeadModel extends FormModel
     {
         static $details = array();
 
-        $leadId = ($lead instanceof Lead) ? $lead->getId() : (int) $lead;
+        if ($lead instanceof Lead) {
+            $fields = $lead->getFields();
+            if (!empty($fields)) {
 
-        if (!isset($details[$leadId])) {
-            $details[$leadId] = $this->getRepository()->getFieldValues($leadId);
+                return $fields;
+            }
         }
 
-        return $details[$leadId];
+        $leadId = ($lead instanceof Lead) ? $lead->getId() : (int) $lead;
+
+        return $this->getRepository()->getFieldValues($leadId);
     }
 
     /**
@@ -541,6 +545,11 @@ class LeadModel extends FormModel
      */
     function setSystemCurrentLead(Lead $lead = null)
     {
+        $fields = $lead->getFields();
+        if (empty($fields)) {
+            $lead->setFields($this->getLeadDetails($lead));
+        }
+
         $this->systemCurrentLead = $lead;
     }
 

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -345,7 +345,7 @@ class ListModel extends FormModel
 
         if (!$lead instanceof Lead) {
             $leadId = (is_array($lead) && isset($lead['id'])) ? $lead['id'] : $lead;
-            $lead   = $leadModel->getEntities($leadId);
+            $lead   = $leadModel->getEntity($leadId);
         }
 
         if (!$lists instanceof LeadList) {
@@ -443,7 +443,7 @@ class ListModel extends FormModel
 
         if (!$lead instanceof Lead) {
             $leadId = (is_array($lead) && isset($lead['id'])) ? $lead['id'] : $lead;
-            $lead   = $leadModel->getEntities($leadId);
+            $lead   = $leadModel->getEntity($leadId);
         }
 
         if (!$lists instanceof LeadList) {

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -340,9 +340,12 @@ class ListModel extends FormModel
      */
     public function addLead($lead, $lists, $manuallyAdded = false)
     {
+        /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
+        $leadModel = $this->factory->getModel('lead');
+
         if (!$lead instanceof Lead) {
             $leadId = (is_array($lead) && isset($lead['id'])) ? $lead['id'] : $lead;
-            $lead = $this->em->getReference('MauticLeadBundle:Lead', $leadId);
+            $lead   = $leadModel->getEntities($leadId);
         }
 
         if (!$lists instanceof LeadList) {
@@ -411,6 +414,9 @@ class ListModel extends FormModel
             }
 
             if ($this->dispatcher->hasListeners(LeadEvents::LEAD_LIST_CHANGE)) {
+                // Force system lead for actions that use getCurrentLead
+                $leadModel->setSystemCurrentLead($lead);
+
                 $event = new ListChangeEvent($lead, $this->leadChangeLists[$l], true);
                 $this->dispatcher->dispatch(LeadEvents::LEAD_LIST_CHANGE, $event);
             }
@@ -432,9 +438,12 @@ class ListModel extends FormModel
      */
     public function removeLead($lead, $lists, $manuallyRemoved = false)
     {
+        /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
+        $leadModel = $this->factory->getModel('lead');
+
         if (!$lead instanceof Lead) {
             $leadId = (is_array($lead) && isset($lead['id'])) ? $lead['id'] : $lead;
-            $lead = $this->em->getReference('MauticLeadBundle:Lead', $leadId);
+            $lead   = $leadModel->getEntities($leadId);
         }
 
         if (!$lists instanceof LeadList) {
@@ -505,6 +514,9 @@ class ListModel extends FormModel
             }
 
             if ($dispatchEvent && $this->dispatcher->hasListeners(LeadEvents::LEAD_LIST_CHANGE)) {
+                // Force system lead for actions that use getCurrentLead
+                $leadModel->setSystemCurrentLead($lead);
+
                 $event = new ListChangeEvent($lead, $this->leadChangeLists[$l], false);
                 $this->dispatcher->dispatch(LeadEvents::LEAD_LIST_CHANGE, $event);
             }


### PR DESCRIPTION
So this PR changes one behavior and one issue with campaign events.

1) There is a bug where actions connected into a "no" decision point would be executed for all leads within a campaign when at least one lead fit criteria (even though the others did not). There was a problem with the DQL statement when querying the leads which was changed so that now only appropriate leads should be affected.

Testing this fix comes with a bit of setup. First create three test emails. Then, create a new campaign that has something like 

send email A -> open email -> YES -> send email B (2 minute delay)
                                             -> NO   -> send email C (3 minute delay)

Now add two leads to the campaign and execute the campaign trigger command (see 2 below for a note on this) which should send email A to each lead. Now, open only one of the emails (you should get email B for that lead).  Wait 3 or 4 minutes then run the command again. Before the patch, you should get email C for both leads. After the patch, only the lead that didn't open the email should get email C. (If testing against the same leads, truncate email_stats and campaign_lead_event_log tables between tests).

2) When saving a campaign associated with a lead list that has a large number of leads, saving a campaign took a long time and/or timed out leading to a slow UI experience (due to all the processes happening behind the scenes). The process of adding leads to a campaign really needs to be batched but that will have to eventually come with another PR.  The process change is that the root level actions (first listed actions in a campaign) are not executed at the time a lead is added to a campaign through the UI of Mautic (it will if it happens by something the lead does). But for the logged in Mautic user, the first actions will be executed for applicable leads when the mautic:campaigns:trigger command is executed via a cron job. 

3) Found an issue related to remnant code for a system based campaign trigger that resulted in actions being prematurely triggered and all at once. This really only became visible as an issue when you have multiple starting actions in a campaign. For example, have two or three send email actions to start with only one to send immediately and the others at an interval.  Add a lead to the campaign and all three emails will be sent plus the two get scheduled.

4) Fixes a bug where a lead created by a form submission and added to a lead list and thus a campaign may not have the email sent because the lead's details were lost along the way.