### PR TITLE
Fixed issue where cleaner removed needed JS in generated forms' HTML

### DIFF
--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -242,8 +242,6 @@ class FormModel extends CommonFormModel
             'form' => $entity
         ));
 
-        $html = InputHelper::html($html);
-
         $style  = $templating->render('MauticFormBundle:Builder:style.html.php', array(
             'form' => $entity
         ));


### PR DESCRIPTION
HTML generated by the form builder was parsed through the InputHelper::html function which stripped the form's onsubmit function.

HTML should be already safe since there's no public user input in building the form.

To test before the patch, generate a form and view the preview.  The form tag will not have a onsubmit function.  After the patch, resave the form and then the function will remain.

Should fix #270 .