### PR TITLE
Fixes issue when merging leads that resulted from recent api changes

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -203,7 +203,7 @@ class LeadApiController extends CommonApiController
                 return $this->accessDenied();
             }
 
-            $lists = $this->model->getLists($entity, true);
+            $lists = $this->model->getLists($entity, true, true);
 
             $view = $this->view(
                 array(

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -111,12 +111,13 @@ class LeadListRepository extends CommonRepository
     /**
      * Get lists for a specific lead
      *
-     * @param      $lead
-     * @param bool $forList
+     * @param       $lead
+     * @param bool  $forList
+     * @param bool  $singleArrayHydration
      *
      * @return mixed
      */
-    public function getLeadLists($lead, $forList = false)
+    public function getLeadLists($lead, $forList = false, $singleArrayHydration = false)
     {
         static $return = array();
 
@@ -148,7 +149,9 @@ class LeadListRepository extends CommonRepository
 
             return $return;
         } else {
-            if (empty($return[$lead])) {
+            $typeKey = $singleArrayHydration ? 'array' : 'object';
+
+            if (empty($return[$lead][$typeKey])) {
                 $q = $this->_em->createQueryBuilder()
                     ->from('MauticLeadBundle:LeadList', 'l', 'l.id');
 
@@ -164,10 +167,10 @@ class LeadListRepository extends CommonRepository
                     $q->expr()->eq('IDENTITY(il.lead)', (int) $lead)
                 );
 
-                $return[$lead] = $q->getQuery()->getArrayResult();
+                $return[$lead][$typeKey] = ($singleArrayHydration) ? $q->getQuery()->getArrayResult() : $q->getQuery()->getResult();
             }
 
-            return $return[$lead];
+            return $return[$lead][$typeKey];
         }
     }
 

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -561,15 +561,16 @@ class LeadModel extends FormModel
     /**
      * Get a list of lists this lead belongs to
      *
-     * @param $lead
-     * @param bool $forLists
+     * @param Lead  $lead
+     * @param bool  $forLists
+     * @param boole $arrayHydration
      *
      * @return mixed
      */
-    public function getLists(Lead $lead, $forLists = false)
+    public function getLists(Lead $lead, $forLists = false, $arrayHydration = false)
     {
         $repo = $this->em->getRepository('MauticLeadBundle:LeadList');
-        return $repo->getLeadLists($lead->getId(), $forLists);
+        return $repo->getLeadLists($lead->getId(), $forLists, $arrayHydration);
     }
 
     /**


### PR DESCRIPTION
This should fix #272.

To test, create a form, map a create/update lead action, and submit with an email from an existing lead.  Also test the /leads/{id}/lists api endpoint.  Both should be successful without hitting the error in #272.