### PR TITLE
Fixes finding landing pages when the category is appended to the URL

### DIFF
--- a/app/bundles/CoreBundle/Model/CommonModel.php
+++ b/app/bundles/CoreBundle/Model/CommonModel.php
@@ -172,9 +172,8 @@ class CommonModel
     public function getEntityBySlugs($slug)
     {
         $slugs = explode('/', $slug);
-        if (!empty($slugs[0])) {
-            $idSlug = $slugs[0];
-        } elseif (!empty($slugs[1])) {
+
+        if (!empty($slugs[1])) {
             $idSlug = $slugs[1];
         } else {
             $idSlug = $slugs[0];


### PR DESCRIPTION
This PR fixes the issue for when Mautic is configured to include the category alias in the URL, landing pages were returning 404s. 

To test, go to Configuration -> Landing Page Settings and enable including the category in the URL. Then  go to a landing page and click the button to preview the live URL.  It should return a 404.  After applying the patch, it should then find the landing page.

Note that the same code affects finding assets so also test that the public asset download URL still works after applying the patch.