### PR TITLE
Removed the read only attribute for the remote file input in asset form

### DIFF
--- a/app/bundles/AssetBundle/Form/Type/AssetType.php
+++ b/app/bundles/AssetBundle/Form/Type/AssetType.php
@@ -73,7 +73,6 @@ class AssetType extends AbstractType
             'label'      => 'mautic.asset.asset.form.remotePath',
             'label_attr' => array('class' => 'control-label'),
             'attr'       => array('class' => 'form-control'),
-            'read_only'  => true,
             'required'   => false
         ));
 


### PR DESCRIPTION
If one is not using a cloud storage integration, the remote option still shows in the asset forms but is totally useless since the remote URL input is set to readonly. Removed the readonly attribute so that any remote URL can be used but will continue to auto populate if selecting a file from an integrated cloud storage.

Refer to #278.