### PR TITLE
fix bug where publish up and down expressions were reversed 

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -646,11 +646,11 @@ class CommonRepository extends EntityRepository
             $q->expr()->eq("$alias.isPublished", ':true'),
             $q->expr()->orX(
                 $q->expr()->isNull("$alias.publishUp"),
-                $q->expr()->gte("$alias.publishUp", ':now')
+                $q->expr()->lte("$alias.publishUp", ':now')
             ),
             $q->expr()->orX(
                 $q->expr()->isNull("$alias.publishDown"),
-                $q->expr()->lte("$alias.publishDown", ':now')
+                $q->expr()->gte("$alias.publishDown", ':now')
             )
         );
 


### PR DESCRIPTION
The getPublishedbyDateExpression function had the date functions to build the query reversed, resulting in the list of returned entities not being correct. 