### PR TITLE
update common repository query to use andWhere

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -285,7 +285,7 @@ class CommonRepository extends EntityRepository
                 $filterCount = ($expressions instanceof \Countable) ? count($expressions) : count($expressions->getParts());
 
                 if (!empty($filterCount)) {
-                    $q->where($expressions);
+                    $q->andWhere($expressions);
                     foreach ($parameters as $k => $v) {
                         if ($v === true || $v === false) {
                             $q->setParameter($k, $v, 'boolean');


### PR DESCRIPTION
This allows the filters to be appended rather than replaced in the buildWhereClause function. Makes getEntities more reusable. 