### PR TITLE
Prevented a notice for when an event attempts to add or remove lead from a now non-existant lead list

### DIFF
--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -385,6 +385,11 @@ class ListModel extends FormModel
         $persistLists = array();
 
         foreach ($lists as $l) {
+            if (!isset($this->leadChangeLists[$l])) {
+                // List no longer exists in the DB so continue to the next
+                continue;
+            }
+
             $listLead = $this->getListLeadRepository()->findOneBy(array(
                 'lead' => $lead,
                 'list' => $this->leadChangeLists[$l]
@@ -477,6 +482,11 @@ class ListModel extends FormModel
 
         $persistLists = array();
         foreach ($lists as $l) {
+            if (!isset($this->leadChangeLists[$l])) {
+                // List no longer exists in the DB so continue to the next
+                continue;
+            }
+
             $dispatchEvent = false;
 
             $listLead = $this->getListLeadRepository()->findOneBy(array(


### PR DESCRIPTION
I believe this is should fix #255.

If a campaign event, form submit action or point trigger is configured to change a lead's list but that list has since been deleted, it would result in a PHP notice of undefined offset since the ID was not in the list of queried entities. So to prevent that, this commit adds a catch to check to see if the list was found before attempting to process it.