### PR TITLE
Fixed mix-match of headers and data form results when the form fields have been reordered

### DIFF
--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -55,7 +55,8 @@ class SubmissionRepository extends CommonRepository
             ->where('f.form_id = ' . $form->getId())
             ->andWhere(
                 $fq->expr()->notIn('f.type', array("'button'", "'freetext'"))
-            );
+            )
+            ->orderBy('f.field_order', 'ASC');
         $results = $fq->execute()->fetchAll();
 
         $fields = array();

--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -122,9 +122,10 @@ class SubmissionRepository extends CommonRepository
             //ORM - generates lead entities
             $q = $this
                 ->createQueryBuilder('s');
-            $q->select('s, p, i,' . $order)
+            $q->select('s, partial l.{id}, p, i,' . $order)
                 ->leftJoin('s.ipAddress', 'i')
-                ->leftJoin('s.page', 'p');
+                ->leftJoin('s.page', 'p')
+                ->leftJoin('s.lead', 'l');
 
             //only pull the submissions as filtered via DBAL
             $q->where(

--- a/app/bundles/FormBundle/Views/Result/list.html.php
+++ b/app/bundles/FormBundle/Views/Result/list.html.php
@@ -58,7 +58,15 @@ $formId = $form->getId();
         <?php foreach ($items as $item):?>
             <tr>
                 <td><?php echo $item['id']; ?></td>
-                <td><?php echo $view['date']->toFull($item['dateSubmitted']); ?></td>
+                <td>
+                    <?php if (!empty($item['lead']['id'])): ?>
+                    <a href="<?php echo $view['router']->generate('mautic_lead_action', array('objectAction' => 'view', 'objectId' => $item['lead']['id'])); ?>" data-toggle="ajax">
+                        <?php echo $view['date']->toFull($item['dateSubmitted']); ?>
+                    </a>
+                    <?php else: ?>
+                    <?php echo $view['date']->toFull($item['dateSubmitted']); ?>
+                    <?php endif; ?>
+                </td>
                 <td><?php echo $item['ipAddress']['ipAddress']; ?></td>
                 <?php foreach($item['results'] as $r):?>
                     <td><?php echo $r['value']; ?></td>


### PR DESCRIPTION
Should fix #271.

To replicate, create a form with a couple text fields and submit a few results.

Then edit the form and change the order of the form fields.  When viewing the data, the headers will not match the data. After applying the patch, it will.

This also makes the result date clickable through to the lead that submitted the form.