### PR TITLE
Lead timeline fixes

### DIFF
--- a/app/bundles/CoreBundle/EventListener/AuditLogSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/AuditLogSubscriber.php
@@ -9,6 +9,7 @@
 
 namespace Mautic\CoreBundle\EventListener;
 
+use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\LeadBundle\Event\LeadTimelineEvent;
 use Mautic\LeadBundle\LeadEvents;
 
@@ -94,7 +95,7 @@ class AuditLogSubscriber extends CommonSubscriber
             } elseif (isset($details[1])) {
                 $ipAddress = $details[1];
             } else {
-                continue;
+                $row->getIpAddress();
             }
 
             $event->addEvent(array(

--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -369,27 +369,6 @@ class SubmissionRepository extends CommonRepository
     }
 
     /**
-     * @param $leadId
-     * @param $newTrackingId
-     * @param $oldTrackingId
-     */
-    public function updateLeadByTrackingId($leadId, $newTrackingId, $oldTrackingId)
-    {
-        $q = $this->_em->getConnection()->createQueryBuilder();
-        $q->update(MAUTIC_TABLE_PREFIX . 'form_submissions')
-            ->set('lead_id', (int) $leadId)
-            ->set('tracking_id', ':newTrackingId')
-            ->where(
-                $q->expr()->eq('tracking_id', ':oldTrackingId')
-            )
-            ->setParameters(array(
-                'newTrackingId' => $newTrackingId,
-                'oldTrackingId' => $oldTrackingId
-            ))
-            ->execute();
-    }
-
-    /**
      * Updates lead ID (e.g. after a lead merge)
      *
      * @param $fromLeadId

--- a/app/bundles/FormBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/LeadSubscriber.php
@@ -29,7 +29,6 @@ class LeadSubscriber extends CommonSubscriber
     {
         return array(
             LeadEvents::TIMELINE_ON_GENERATE => array('onTimelineGenerate', 0),
-            LeadEvents::CURRENT_LEAD_CHANGED => array('onLeadChange', 0),
             LeadEvents::LEAD_POST_MERGE      => array('onLeadMerge', 0)
         );
     }
@@ -85,14 +84,6 @@ class LeadSubscriber extends CommonSubscriber
                 'contentTemplate' => 'MauticFormBundle:SubscribedEvents\Timeline:index.html.php'
             ));
         }
-    }
-
-    /**
-     * @param LeadChangeEvent $event
-     */
-    public function onLeadChange(LeadChangeEvent $event)
-    {
-        $this->factory->getModel('form.submission')->getRepository()->updateLeadByTrackingId($event->getNewLead()->getId(), $event->getNewTrackingId(), $event->getOldTrackingId());
     }
 
     /**

--- a/app/bundles/FormBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/LeadSubscriber.php
@@ -71,11 +71,14 @@ class LeadSubscriber extends CommonSubscriber
 
         // Add the submissions to the event array
         foreach ($rows as $row) {
+            // Convert to local from UTC
+            $dtHelper = $this->factory->getDate($row['dateSubmitted'], 'Y-m-d H:i:s', 'UTC');
+
             $submission = $submissionRepository->getEntity($row['id']);
             $event->addEvent(array(
                 'event'     => $eventTypeKey,
-                'eventLabel' => $eventTypeName,
-                'timestamp' => new \DateTime($row['dateSubmitted']),
+                'eventLabel'=> $eventTypeName,
+                'timestamp' => $dtHelper->getLocalDateTime(),
                 'extra'     => array(
                     'submission' => $submission,
                     'form'  => $formModel->getEntity($row['form_id']),

--- a/app/bundles/FormBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/FormBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -36,11 +36,11 @@ if ($page->getId()) {
 	        	<dl class="dl-horizontal">
         		<?php if (isset($link)) : ?>
 					<dt><?php echo $view['translator']->trans('mautic.core.source'); ?></dt>
-					<dd><?php echo $link; ?></dd>
+					<dd class="ellipsis"><?php echo $link; ?></dd>
 				<?php endif; ?>
 				<?php if ($form->getDescription()) : ?>
 					<dt><?php echo $view['translator']->trans('mautic.core.description'); ?></dt>
-					<dd><?php echo $form->getDescription(); ?></dd>
+					<dd class="ellipsis"><?php echo $form->getDescription(); ?></dd>
 				    <?php if (isset($event['extra'])) : ?>
                         <?php if ($descr = $form->getDescription()): ?>
 	                    <p><?php echo $descr; ?></p>
@@ -48,12 +48,12 @@ if ($page->getId()) {
                     <?php endif; ?>
 				<?php endif; ?>
 					<dt><?php echo $view['translator']->trans('mautic.form.result.thead.referrer'); ?></dt>
-					<dd><?php echo $view['assets']->makeLinks($submission->getReferer()); ?></dd>
+					<dd class="ellipsis"><?php echo $view['assets']->makeLinks($submission->getReferer()); ?></dd>
 				<?php if (is_array($results)) : ?>
 					<?php foreach ($form->getFields() as $field) : ?>
 						<?php if (array_key_exists($field->getAlias(), $results)) : ?>
 							<dt><?php echo $field->getLabel(); ?></dt>
-							<dd><?php echo $results[$field->getAlias()]; ?></dd>
+							<dd class="ellipsis"><?php echo $results[$field->getAlias()]; ?></dd>
 						<?php endif; ?>
 					<?php endforeach; ?>
 				<?php endif; ?>

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -294,8 +294,8 @@ class LeadController extends FormController
         $event      = new LeadTimelineEvent($lead, $filters);
         $dispatcher->dispatch(LeadEvents::TIMELINE_ON_GENERATE, $event);
 
-        $events     = $event->getEvents();
-        $eventTypes = $event->getEventTypes();
+        $eventsByDate = $event->getEvents(true);
+        $eventTypes   = $event->getEventTypes();
 
         // Get an engagement count
         $translator = $this->factory->getTranslator();
@@ -303,14 +303,18 @@ class LeadController extends FormController
         $fromDate = $graphData['fromDate'];
         $allEngagements = array();
         $total          = 0;
-        foreach ($events as $e) {
-            if ($e['timestamp'] < $fromDate) {
+
+        $events = array();
+        foreach ($eventsByDate as $eventDate => $dateEvents) {
+            $datetime = \DateTime::createFromFormat('Y-m-d H:i:s', $eventDate);
+            if ($datetime > $fromDate) {
                 $total++;
                 $allEngagements[] = array(
-                    'date'  => $e['timestamp'],
-                    'data'  => 1
+                    'date' => $datetime,
+                    'data' => 1
                 );
             }
+            $events = array_merge($events, array_reverse($dateEvents));
         }
 
         $graphData = GraphHelper::mergeLineGraphData($graphData, $allEngagements, 'M', 0, 'date', 'data', false, false);

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -60,7 +60,7 @@ class Lead extends FormEntity
     private $pointsChangeLog;
 
     /**
-     * @ORM\ManyToMany(targetEntity="Mautic\CoreBundle\Entity\IpAddress", cascade={"merge", "persist"}, fetch="EXTRA_LAZY", indexBy="ipAddress")
+     * @ORM\ManyToMany(targetEntity="Mautic\CoreBundle\Entity\IpAddress", cascade={"merge", "persist"}, indexBy="ipAddress")
      * @ORM\JoinTable(name="lead_ips_xref",
      *   joinColumns={@ORM\JoinColumn(name="lead_id", referencedColumnName="id")},
      *   inverseJoinColumns={@ORM\JoinColumn(name="ip_id", referencedColumnName="id")}
@@ -402,6 +402,12 @@ class Lead extends FormEntity
      */
     public function addPointsChangeLogEntry($type, $name, $action, $pointsDelta, IpAddress $ip)
     {
+        if ($pointsDelta <= 0) {
+            // No need to record this
+
+            return;
+        }
+
         //create a new points change event
         $event = new PointsChangeLog();
         $event->setType($type);

--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -104,6 +104,8 @@ class LeadTimelineEvent extends Event
 
         // Sort by certain event actions
         $order = array(
+            'page.hit',
+            'asset.download',
             'form.submitted',
             'lead.merge',
             'lead.create',

--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -83,19 +83,57 @@ class LeadTimelineEvent extends Event
      *
      * @return array Events sorted by timestamp with most recent event first
      */
-    public function getEvents()
+    public function getEvents($returnGrouped = false)
     {
         $events = $this->events;
 
-        usort($events, function($a, $b) {
-            if ($a['timestamp'] == $b['timestamp']) {
-                return 0;
+        $byDate = array();
+
+        // Group by date
+        foreach ($events as $e) {
+            $dateString = $e['timestamp']->format('Y-m-d H:i:s');
+            if (!isset($byDate[$dateString])) {
+                $byDate[$dateString] = array();
             }
 
-            return ($a['timestamp'] > $b['timestamp']) ? -1 : 1;
-        });
+            $byDate[$dateString][] = $e;
+        }
 
-        return $events;
+        // Sort by date
+        krsort($byDate);
+
+        // Sort by certain event actions
+        $order = array(
+            'form.submitted',
+            'lead.merge',
+            'lead.create',
+            'lead.ipadded',
+            'lead.identified'
+        );
+
+        $events = array();
+        foreach ($byDate as $date => $dateEvents) {
+            usort(
+                $dateEvents,
+                function ($a, $b) use ($order) {
+                    if (!in_array($a['event'], $order) || !in_array($b['event'], $order)) {
+                        // No specific order so push to the end
+
+                        return 1;
+                    }
+
+                    $pos_a = array_search($a['event'], $order);
+                    $pos_b = array_search($b['event'], $order);
+
+                    return $pos_a - $pos_b;
+                }
+            );
+
+            $byDate[$date] = $dateEvents;
+            $events = array_merge($events, array_reverse($dateEvents));
+        }
+
+        return ($returnGrouped) ? $byDate : $events;
     }
 
     /**

--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -70,21 +70,6 @@ class LeadSubscriber extends CommonSubscriber
                 );
                 $this->factory->getModel('core.auditLog')->writeToLog($log);
 
-                //trigger the points change event
-                if (!$lead->imported && isset($details["points"])) {
-                    if (!$event->isNew() && $this->dispatcher->hasListeners(LeadEvents::LEAD_POINTS_CHANGE)) {
-                        $pointsEvent = new Events\PointsChangeEvent($lead, $details['points'][0], $details['points'][1]);
-                        $this->dispatcher->dispatch(LeadEvents::LEAD_POINTS_CHANGE, $pointsEvent);
-                    }
-                }
-
-                //regenerate the lists leads if there are changes AND the lead wasn't created by getCurrentLead
-                if (!$lead->imported && !$lead->isNewlyCreated()) {
-                    /** @var \Mautic\LeadBundle\Model\LeadModel $model */
-                    $model = $this->factory->getModel('lead');
-                    $model->regenerateLeadLists($lead);
-                }
-
                 if (isset($details['dateIdentified'])) {
                     //log the day lead was identified
                     $log = array(
@@ -92,7 +77,7 @@ class LeadSubscriber extends CommonSubscriber
                         "object"    => "lead",
                         "objectId"  => $lead->getId(),
                         "action"    => "identified",
-                        "details"   => $details,
+                        "details"   => array(),
                         "ipAddress" => $this->factory->getIpAddressFromRequest()
                     );
                     $this->factory->getModel('core.auditLog')->writeToLog($log);
@@ -114,6 +99,21 @@ class LeadSubscriber extends CommonSubscriber
                         "ipAddress" => $this->request->server->get('REMOTE_ADDR')
                     );
                     $this->factory->getModel('core.auditLog')->writeToLog($log);
+                }
+
+                //trigger the points change event
+                if (!$lead->imported && isset($details["points"]) || (int) $details["points"][1] > 0) {
+                    if (!$event->isNew() && $this->dispatcher->hasListeners(LeadEvents::LEAD_POINTS_CHANGE)) {
+                        $pointsEvent = new Events\PointsChangeEvent($lead, $details['points'][0], $details['points'][1]);
+                        $this->dispatcher->dispatch(LeadEvents::LEAD_POINTS_CHANGE, $pointsEvent);
+                    }
+                }
+
+                //regenerate the lists leads if there are changes AND the lead wasn't created by getCurrentLead
+                if (!$lead->imported && !$lead->isNewlyCreated()) {
+                    /** @var \Mautic\LeadBundle\Model\LeadModel $model */
+                    $model = $this->factory->getModel('lead');
+                    $model->regenerateLeadLists($lead);
                 }
             }
         }

--- a/app/bundles/LeadBundle/Views/SubscribedEvents/Timeline/ipadded.html.php
+++ b/app/bundles/LeadBundle/Views/SubscribedEvents/Timeline/ipadded.html.php
@@ -6,7 +6,14 @@
  * @link        http://mautic.org
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
-$ip      = $event['extra']['ipDetails'];
+$ip = $event['extra']['ipDetails'];
+
+if (!is_object($ip)) {
+    // Somehow the IP entity wasn't found
+
+    return;
+}
+
 $details = $ip->getIpDetails();
 $ipAddress = $ip->getIpAddress();
 
@@ -40,6 +47,6 @@ $ipAddress = $ip->getIpAddress();
             if (!empty($location)): ?>
             <i class="fa fa-map-marker"></i> <?php echo $location; ?> </span>
             <?php endif; ?>
-	    </div>
-	</div>
+        </div>
+    </div>
 </li>

--- a/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -27,7 +27,7 @@ if ($event['extra']['hit']['dateLeft']) {
 	<div class="figure"><span class="fa <?php echo isset($icons['page']) ? $icons['page'] : '' ?>"></span></div>
 	<div class="panel">
 	    <div class="panel-body">
-	    	<h3>
+	    	<h3 class="ellipsis">
 		    	<?php if ($event['extra']['hit']['page_id']) : ?>
 		    		<a href="<?php echo $view['router']->generate('mautic_page_action',
 					    array("objectAction" => "view", "objectId" => $item->getId())); ?>"
@@ -48,14 +48,14 @@ if ($event['extra']['hit']['dateLeft']) {
 	        <div class="panel-footer">
 	            <dl class="dl-horizontal">
 					<dt><?php echo $view['translator']->trans('mautic.page.time.on.page'); ?>:</dt>
-					<dd><?php echo $timeOnPage; ?></dd>
+					<dd class="ellipsis"><?php echo $timeOnPage; ?></dd>
 					<dt><?php echo $view['translator']->trans('mautic.page.referrer'); ?>:</dt>
-					<dd><?php echo $event['extra']['hit']['referer'] ? $view['assets']->makeLinks($event['extra']['hit']['referer']) : $view['translator']->trans('mautic.core.unknown'); ?></dd>
+					<dd class="ellipsis"><?php echo $event['extra']['hit']['referer'] ? $view['assets']->makeLinks($event['extra']['hit']['referer']) : $view['translator']->trans('mautic.core.unknown'); ?></dd>
 					<dt><?php echo $view['translator']->trans('mautic.page.url'); ?>:</dt>
-					<dd><?php echo $event['extra']['hit']['url'] ? $view['assets']->makeLinks($event['extra']['hit']['url']) : $view['translator']->trans('mautic.core.unknown'); ?></dd>
+					<dd class="ellipsis"><?php echo $event['extra']['hit']['url'] ? $view['assets']->makeLinks($event['extra']['hit']['url']) : $view['translator']->trans('mautic.core.unknown'); ?></dd>
 					<?php if (isset($event['extra']['hit']['sourceName'])) : ?>
 					<dt><?php echo $view['translator']->trans('mautic.core.source'); ?>:</dt>
-					<dd>
+					<dd class="ellipsis">
 						<a href="<?php echo $view['router']->generate('mautic_' . $event['extra']['hit']['source'] . '_action',
 						    array("objectAction" => "view", "objectId" => $event['extra']['hit']['sourceId'])); ?>"
 						   data-toggle="ajax">


### PR DESCRIPTION
While working on campaigns, I came across a number of issues with the lead timeline so decided to fix them.

1) When a form was submitted back to back with different IP addresses, the submission was getting associated with the wrong lead and thus displayed incorrectly in the lead's timeline.

2) A lot of useless ip added and 0 point entries were displaying in the timeline so added catches to prevent logging already known IPs for the lead and 0 point log entries.

3) Added ellipsis classes to some of the titles and details of the lead timeline boxes to keep long URLs, for example, from breaking the layout

4) Forced an order of events that happened at the same time so that it looks to the user to be the order that was executed.  For example, form submission -> lead created -> lead identified, etc. Before it looked all out of order because they were sorted by just date.

5) Fixed the engagement graph to only show unique engagements, not each event.  A single form submit could have resulted in 4-6 entries to the timeline (leads created, emails sent, etc) but they all took place during a single engagement.