### PR TITLE
Small fixes for addon manager

### DIFF
--- a/app/bundles/AddonBundle/Bundle/AddonBundleBase.php
+++ b/app/bundles/AddonBundle/Bundle/AddonBundleBase.php
@@ -55,6 +55,8 @@ abstract class AddonBundleBase extends Bundle
     /**
      * Called by AddonController::reloadAction when an addon is uninstalled
      *
+     * @todo NOT IMPLEMENTED YET IN THE ADDON MANAGER
+     *
      * @param Addon         $addon
      * @param MauticFactory $factory
      */

--- a/app/bundles/AddonBundle/Controller/AddonController.php
+++ b/app/bundles/AddonBundle/Controller/AddonController.php
@@ -225,8 +225,8 @@ class AddonController extends FormController
             $model->saveEntities($persist);
         }
 
-        if ($updated) {
-            //clear the cache if addons were updated
+        if ($updated || $disabled) {
+            //clear the cache if addons were updated or disabled
             $this->clearCache();
         }
 

--- a/app/bundles/AddonBundle/Controller/AddonController.php
+++ b/app/bundles/AddonBundle/Controller/AddonController.php
@@ -43,7 +43,13 @@ class AddonController extends FormController
         $search = $this->request->get('search', $this->factory->getSession()->get('mautic.addon.filter', ''));
         $this->factory->getSession()->set('mautic.addon.filter', $search);
 
-        $filter = array('string' => $search, 'force' => array());
+        $filter = array('string' => $search, 'force' => array(
+            array(
+                'column' => 'i.isMissing',
+                'expr'   => 'eq',
+                'value'  => false
+            )
+        ));
 
         $orderBy    = $this->factory->getSession()->get('mautic.addon.orderby', 'i.name');
         $orderByDir = $this->factory->getSession()->get('mautic.addon.orderbydir', 'DESC');
@@ -115,6 +121,7 @@ class AddonController extends FormController
 
         /** @var \Mautic\AddonBundle\Model\AddonModel $model */
         $model  = $this->factory->getModel('addon');
+        /** @var \Mautic\AddonBundle\Entity\AddonRepository $repo */
         $repo   = $model->getRepository();
         $addons = $this->factory->getParameter('addon.bundles');
         $added  = $disabled = $updated = 0;
@@ -125,10 +132,12 @@ class AddonController extends FormController
         foreach ($installedAddons as $bundle => $addon) {
             $persistUpdate = false;
             if (!isset($addons[$bundle])) {
-                //files are no longer found
-                $addon->setIsEnabled(false);
-                $addon->setIsMissing(true);
-                $disabled++;
+                if (!$addon->getIsMissing()) {
+                    //files are no longer found
+                    $addon->setIsEnabled(false);
+                    $addon->setIsMissing(true);
+                    $disabled++;
+                }
             } else {
                 if ($addon->getIsMissing()) {
                     //was lost but now is found

--- a/app/bundles/AddonBundle/Helper/IntegrationHelper.php
+++ b/app/bundles/AddonBundle/Helper/IntegrationHelper.php
@@ -184,7 +184,9 @@ class IntegrationHelper
     {
         if (!is_array($addon)) {
             $addons = $this->factory->getParameter('addon.bundles');
-            $addon  = $addons[$addon];
+            if (array_key_exists($addon, $addons)) {
+                $addon = $addons[$addon];
+            }
         }
 
         if (is_dir($addon['directory'] . '/Integration')) {

--- a/app/bundles/AddonBundle/Helper/IntegrationHelper.php
+++ b/app/bundles/AddonBundle/Helper/IntegrationHelper.php
@@ -186,6 +186,10 @@ class IntegrationHelper
             $addons = $this->factory->getParameter('addon.bundles');
             if (array_key_exists($addon, $addons)) {
                 $addon = $addons[$addon];
+            } else {
+                // It doesn't exist so return 0
+
+                return 0;
             }
         }
 


### PR DESCRIPTION
If an addon's files were deleted, accessing the addon manager list threw a notice of a nonexistent key. This probably mainly affected dev environment since prod ignore notices.

Also, if an addon's files were deleted, the addon still displayed in the list so set a filter to only show addons with isMissing = false. (The addon entry remains in order to know what possible schema is in place if the user reinstalls an addon that manipulated the schema; this will likely change with upcoming addon manager changes).

To test, you'll need a test addon bundle. Ensure the system is recognizes the bundle then delete the files. Access the addon manager list in dev mode and should hit the notice. Hit up prod environment (to access the list) click the "Install/Upgrade Addons" button.  The addon remains in the list.

After the patch, no notice and the addon to disappear from the list.