### PR TITLE
Fixes error when saving new lead lists under postgreSQL

### DIFF
--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -120,22 +120,21 @@ class ListModel extends FormModel
      */
     public function regenerateListLeads(LeadList $entity, $isNew = false, $persist = true)
     {
+        $id          = $entity->getId();
+        $newLeadList = $this->getLeadsByList(array('id' => $id, 'filters' => $entity->getFilters()), true, true);
+
         if (!$isNew) {
-            $id = $entity->getId();
-
             $oldLeadList = $this->getLeadsByList(array('id' => $id), true);
-            $newLeadList = $this->getLeadsByList(array('id' => $id, 'filters' => $entity->getFilters()), true, true);
 
-            $addLeads     = array_diff($newLeadList[$id], $oldLeadList[$id]);
-            $removeLeads  = array_diff($oldLeadList[$id], $newLeadList[$id]);
+            $addLeads    = array_diff($newLeadList[$id], $oldLeadList[$id]);
+            $removeLeads = array_diff($oldLeadList[$id], $newLeadList[$id]);
         } else {
-            $newLeadList = $this->getLeadsByList(array('id' => 'new', 'filters' => $entity->getFilters()), true, true);
-            $addLeads    = $newLeadList['new'];
+            $addLeads    = $newLeadList[$id];
             $removeLeads = array();
         }
 
         foreach ($addLeads as $l) {
-           $this->addLead($l, $entity);
+            $this->addLead($l, $entity);
         }
 
         if (isset($manuallyAdded)) {
@@ -145,7 +144,7 @@ class ListModel extends FormModel
         }
 
         foreach ($removeLeads as $l) {
-           $this->removeLead($l, $entity);
+            $this->removeLead($l, $entity);
         }
 
         if ($persist) {


### PR DESCRIPTION
As reported in https://github.com/mautic/mautic/pull/268#issuecomment-92466581, saving new lists resulted in a sql error under postgreSQL.  This prevents the type mismatch error and also fixes building lead lists on save.

To test, under postgreSQL, try to create a new lead list and should hit the sql error.  Patch it and then it should save a new list without the error.