### PR TITLE
Fixes double // in URLs generated from CLI when the config's site_url

### DIFF
--- a/app/config/parameters.php
+++ b/app/config/parameters.php
@@ -109,9 +109,19 @@ if (isset($mauticParams['site_url'])) {
     $parts = parse_url($mauticParams['site_url']);
 
     if (!empty($parts['host'])) {
+        $path = '';
+
+        if (!empty($parts['path'])) {
+            // Check and remove trailing slash to prevent double // in Symfony cli generated URLs
+            $path = $parts['path'];
+            if (substr($path, -1) == '/') {
+                $path = substr($path, 0, -1);
+            }
+        }
+
         $container->setParameter('router.request_context.host', $parts['host']);
         $container->setParameter('router.request_context.scheme', (!empty($parts['scheme']) ? $parts['scheme'] : 'http'));
-        $container->setParameter('router.request_context.base_url', (!empty($parts['path']) ? $parts['path'] : '/'));
+        $container->setParameter('router.request_context.base_url', $path);
     }
 }
 


### PR DESCRIPTION
This should fix #267 and assist with #264.

The problem is that configs that had site_url set with an ending slash, and/or no end path at all (root domain), ended up with // in the URLs leading to open decisions failing.

This adds a catch to remove ending / from the path which resolves the issue.

Testing requires that an email be sent from cli via a campaign. Create a campaign with a send email starting action with a 1 minute delay. Add a lead to the campaign then a minute later, run the command `php app/console mautic:campaigns:trigger` and the email should be sent. View the original source and the tracking image will have something like //email/ in it. After the patch, (clear the cache!), the URL should be correct with /email/ in it instead.