### PR TITLE
Prevented a PHP notice due to recent PR merge

### DIFF
--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -102,7 +102,7 @@ class LeadSubscriber extends CommonSubscriber
                 }
 
                 //trigger the points change event
-                if (!$lead->imported && isset($details["points"]) || (int) $details["points"][1] > 0) {
+                if (!$lead->imported && isset($details["points"]) && (int) $details["points"][1] > 0) {
                     if (!$event->isNew() && $this->dispatcher->hasListeners(LeadEvents::LEAD_POINTS_CHANGE)) {
                         $pointsEvent = new Events\PointsChangeEvent($lead, $details['points'][0], $details['points'][1]);
                         $this->dispatcher->dispatch(LeadEvents::LEAD_POINTS_CHANGE, $pointsEvent);


### PR DESCRIPTION
Recent PR merge caused ```500 Internal Server Error - Notice: Undefined index: points in app/bundles/LeadBundle/EventListener/LeadSubscriber.php line 105``` 

This fixes a bad if statement that used || instead of && leading to the notice.

To test, try to use the quick add form to create a new lead while in dev mode and you should hit the notice.  After the patch, the notice should not longer happen.