### PR TITLE
Restores lost lead list/card view buttons

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/core.js
+++ b/app/bundles/CoreBundle/Assets/js/core.js
@@ -102,6 +102,10 @@ var Mautic = {
             mQuery('#mautic_dashboard_index').click();
         });
 
+        Mousetrap.bind('shift+l', function(e) {
+            mQuery('#menu_lead_parent_child > li:first > a').click();
+        });
+
         Mousetrap.bind('shift+right', function (e) {
             mQuery('.navbar-right > button.navbar-toggle').click();
         });

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -1,9 +1,5 @@
 //LeadBundle
 Mautic.leadOnLoad = function (container) {
-    Mousetrap.bind('shift+l', function(e) {
-        mQuery('#menu_lead_parent_child > li:first > a').click();
-    });
-
     Mousetrap.bind('a', function(e) {
         if(mQuery('#lead-quick-add').length) {
             mQuery('#lead-quick-add').modal();

--- a/app/bundles/LeadBundle/Views/Lead/index.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/index.html.php
@@ -48,7 +48,8 @@ $view['slots']->set('actions', $view->render('MauticCoreBundle:Helper:page_actio
     'routeBase' => 'lead',
     'langVar'   => 'lead.lead',
     'preCustomButtons' => $preButtons,
-    'customButtons'    => $buttons
+    'customButtons'    => $buttons,
+    'extraHtml'        => $extraHtml
 )));
 ?>
 


### PR DESCRIPTION
This restores the lost lead list/card view buttons on the /leads page.

Before:
![](http://dvkrd.co/drop/2015-04-14_16-32-59.png)

After:
![](http://dvkrd.co/drop/2015-04-14_16-30-59.png)

Also fixed keyboard shortcut shift+l which is supposed to go to the /leads page but was only bound when already on the lead list page, so it was pretty much useless.

