### PR TITLE
Fix unsubscribe action

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -981,15 +981,6 @@ class EmailModel extends FormModel
             $em = $this->factory->getEntityManager();
             $em->persist($dnc);
 
-            //update stats
-            $stat->setIsFailed(true);
-            $em->persist($stat);
-
-            if ($email !== null) {
-                $email->downSentCounts();
-                $em->persist($email);
-            }
-
             $em->flush();
         }
     }

--- a/app/bundles/EmailBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/EmailBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -41,9 +41,6 @@ $item = $event['extra']['stats'];
 	            <?php if (!empty($item['list_name'])) : ?>
 	            	<?php echo $view['translator']->trans('mautic.email.timeline.event.list', array('%list%' => $item['list_name'])); ?>
 	            <?php endif; ?>
-	            <?php if (!empty($item['isFailed'])) : ?>
-	            	<?php echo $view['translator']->trans('mautic.email.timeline.event.failed'); ?>
-	            <?php endif; ?>
 	            </p>
 	        </div>
 	    <?php endif; ?>


### PR DESCRIPTION
To test:

Send email to a lead. Open email. Review the lead in Mautic to see that it successfully shows on the timeline as opened. Return to the email and unsubscribe via the unsubscribe link. Mautic will show incorrectly on the timeline that the email bounced ("sending email failed"). 

Apply patch and re-test. The timeline should not show a failed email send after unsubscribing. 