### PR TITLE
change permission compare to use and instead of or

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -42,7 +42,7 @@ class LeadController extends FormController
             'lead:leads:deleteother'
         ), "RETURN_ARRAY");
 
-        if (!$permissions['lead:leads:viewown'] || !$permissions['lead:leads:viewother']) {
+        if (!$permissions['lead:leads:viewown'] && !$permissions['lead:leads:viewother']) {
             return $this->accessDenied();
         }
 

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -36,7 +36,7 @@ class ListController extends FormController
         ), 'RETURN_ARRAY');
 
         //Lists can be managed by anyone who has access to leads
-        if (!$permissions['lead:leads:viewown'] || !$permissions['lead:leads:viewother']) {
+        if (!$permissions['lead:leads:viewown'] && !$permissions['lead:leads:viewother']) {
             return $this->accessDenied();
         }
 


### PR DESCRIPTION
Permissions for leads had a bug where the if statement was comparing with an `or` instead of `and`. This resolves the issue. Reported here:

https://www.mautic.org/community/index.php/258-mautic-for-multiple-business/p1#p1095

To test:
Create a role which has permissions only to create, edit own and view own leads. Before patch going to the the lead manager will throw a 403.

After patch the page will properly load and not 403 if you have the correct permissions. 