### PR TITLE
Fixes issue with getting IP address from proxies that include multiple IPs

### DIFF
--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -554,11 +554,19 @@ class MauticFactory
 
         foreach ($ipHolders as $key) {
             if ($request->server->get($key)) {
-                return $request->server->get($key);
+                $ip = $request->server->get($key);
+
+                if (strpos($ip, ',') !== false) {
+                    // Multiple IPs are present so use the last IP which should be the most reliable IP that last connected to the proxy
+                    $ips = explode(',', $ip);
+                    $ip  = end($ips);
+                }
+
+                return trim($ip);
             }
         }
 
-        // if everything else failes
+        // if everything else fails
         return '127.0.0.1';
     }
 


### PR DESCRIPTION
Some proxy servers have multiple IPs delimited with a comma in the HTTP_X_FORWARDED_FOR header that needs to be accounted for when determining the client's IP.  This is the cause for the errors in #314. According to various docs, the last IP in that header should be the most reliable IP for the request thus this PR checks for comma delimited IP addresses and uses the last listed.

Testing is tricky as I don't have access to a proxy server that forces multiple ip addresses.