### PR TITLE
Prevents fatal error when submitting forms

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -431,7 +431,7 @@ class LeadModel extends FormModel
      */
     public function getCurrentLead($returnTracking = false)
     {
-        if ($this->systemCurrentLead) {
+        if (!$returnTracking && $this->systemCurrentLead) {
             // Just return the system set lead
             return $this->systemCurrentLead;
         }


### PR DESCRIPTION
This should fix #311.

Due to a change made in 1.0.3 fixing campaigns, getCurrentLead's behavior was inadvertently changed for when the current lead's tracking information was requested. Thus honored the flag for this even when setSystemLead is used as if $returnTracking is only true when tracking a lead via a cookie (and thus the actions are taking place directly by the lead).

#311, #315, and #272 mention this issue.

To replicate, create form with "create/update lead" and "modify lead's lists" actions then submit the form.  Before the fix, 
```
500 Internal Server Error - Error: Cannot use object of type Mautic\LeadBundle\Entity\Lead as array in /app/bundles/FormBundle/Model/SubmissionModel.php line 281
```

After, no error and the lead should be added to the list.