### PR TITLE
Addon and budle folders can be symlinks and Mautic will see them now.

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -141,16 +141,15 @@ class AppKernel extends Kernel
         $searchPath = __DIR__ . '/bundles';
         $finder     = new \Symfony\Component\Finder\Finder();
         $finder->files()
+            ->followLinks()
             ->in($searchPath)
             ->depth('1')
             ->name('*Bundle.php');
 
         foreach ($finder as $file) {
-            $path      = substr($file->getRealPath(), strlen($searchPath) + 1, -4);
-            $parts     = explode(DIRECTORY_SEPARATOR, $path);
-            $class     = array_pop($parts);
-            $namespace = "Mautic\\" . implode('\\', $parts);
-            $class     = $namespace . '\\' . $class;
+            $dirname  = basename($file->getRelativePath());
+            $filename = substr($file->getFilename(), 0, -4);
+            $class    = '\\Mautic' . '\\' . $dirname . '\\' . $filename;
             if (class_exists($class)) {
                 $bundleInstance = new $class();
                 if (method_exists($bundleInstance, 'isEnabled')) {
@@ -167,16 +166,15 @@ class AppKernel extends Kernel
         $searchPath = dirname(__DIR__) . '/addons';
         $finder     = new \Symfony\Component\Finder\Finder();
         $finder->files()
+            ->followLinks()
             ->depth('1')
             ->in($searchPath)
             ->name('*Bundle.php');
 
         foreach ($finder as $file) {
-            $path      = substr($file->getRealPath(), strlen($searchPath) + 1, -4);
-            $parts     = explode(DIRECTORY_SEPARATOR, $path);
-            $class     = array_pop($parts);
-            $namespace = "MauticAddon\\" . implode('\\', $parts);
-            $class     = $namespace . '\\' . $class;
+            $dirname  = basename($file->getRelativePath());
+            $filename = substr($file->getFilename(), 0, -4);
+            $class    = '\\MauticAddon' . '\\' . $dirname . '\\' . $filename;
             if (class_exists($class)) {
                 $bundles[] = new $class();
             }

--- a/app/bundles/PageBundle/Assets/builder/builder.js
+++ b/app/bundles/PageBundle/Assets/builder/builder.js
@@ -48,8 +48,8 @@ mQuery(document).ready(function () {
 
 var SlideshowManager = {};
 
-SlideshowManager.toggleFileOpened = false;
 SlideshowManager.slotConfigs = {};
+SlideshowManager.urlobj;
 
 // add newProp (dot separated string) to obj with new value
 SlideshowManager.addValueToObj = function (obj, newProp, value) {
@@ -124,51 +124,6 @@ SlideshowManager.saveConfigObject = function (slot) {
     });
 }
 
-SlideshowManager.toggleFileManager = function () {
-    var listOfSlides = mQuery('.modal.slides-config .list-of-slides li:not(.active)');
-    var activeSlide = mQuery('.modal.slides-config .list-of-slides li.active');
-    var configFields = mQuery('.modal.slides-config .config-fields .row:not(:last-child)');
-    var fileManager = mQuery('#fileManager');
-    var newSlideBtn = mQuery('.btn.new-slide');
-    var handle = mQuery('.list-of-slides .ui-sortable-handle');
-
-    listOfSlides.animate({
-        opacity: "toggle",
-        padding: "toggle",
-        height: "toggle"
-    }, 300);
-    configFields.animate({
-        opacity: "toggle",
-        padding: "toggle",
-        height: "toggle"
-    }, 300);
-    fileManager.animate({
-        height: "toggle",
-        opacity: "toggle"
-    }, 300);
-    newSlideBtn.animate({
-        height: "toggle",
-        opacity: "toggle"
-    }, 300);
-    handle.animate({
-        opacity: "toggle"
-    }, 300);
-
-    if (SlideshowManager.toggleFileOpened) {
-        activeSlide.animate({
-            borderRadius: "0px"
-        }, 500, function () {
-            activeSlide.removeAttr('style');
-        });
-    } else {
-        activeSlide.animate({
-            borderRadius: "21px"
-        }, 500);
-    }
-
-    SlideshowManager.toggleFileOpened = !SlideshowManager.toggleFileOpened;
-}
-
 SlideshowManager.newSlide = function () {
     var tabPaneExisting = mQuery('.config-fields .tab-pane').first();
 
@@ -205,17 +160,29 @@ SlideshowManager.newSlide = function () {
     listGroupItemExisting.parent().append(listGroupItemNew);
 }
 
-SlideshowManager.preloadFileManager = function () {
-    filebrowserImageBrowseUrl = mauticBasePath + '/' + mauticAssetPrefix + 'app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/index.html?type=images';
-    var iframe = mQuery("<iframe id='filemanager_iframe' />").attr({src: filebrowserImageBrowseUrl});
-    mQuery("#fileManager").hide().append(iframe);
-    iframe.load(function () {
-        var fileManager = mQuery('#filemanager_iframe').contents().find('body');
-        fileManager.click(function () {
-            var copyBtn = fileManager.find('#copy-button');
-            if (copyBtn.length) {
-                mQuery('.tab-pane.active.in input.background-image').val(copyBtn.attr('data-clipboard-text'));
-            }
-        });
-    });
+SlideshowManager.BrowseServer = function(obj)
+{
+    SlideshowManager.urlobj = obj;
+    SlideshowManager.OpenServerBrowser(
+    mauticBasePath + '/' + mauticAssetPrefix + 'app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/index.html?type=images',
+    screen.width * 0.7,
+    screen.height * 0.7 ) ;
+}
+
+SlideshowManager.OpenServerBrowser = function( url, width, height )
+{
+    var iLeft = (screen.width - width) / 2 ;
+    var iTop = (screen.height - height) / 2 ;
+    var sOptions = "toolbar=no,status=no,resizable=yes,dependent=yes" ;
+    sOptions += ",width=" + width ;
+    sOptions += ",height=" + height ;
+    sOptions += ",left=" + iLeft ;
+    sOptions += ",top=" + iTop ;
+    var oWindow = window.open( url, "BrowseWindow", sOptions ) ;
+}
+
+function SetUrl( url, width, height, alt )
+{
+    document.getElementById(SlideshowManager.urlobj).value = url ;
+    oWindow = null;
 }

--- a/app/bundles/PageBundle/Views/Page/Slots/slideshow.html.php
+++ b/app/bundles/PageBundle/Views/Page/Slots/slideshow.html.php
@@ -112,7 +112,7 @@ $view['assets']->addStyleDeclaration($css);
 				</a>
 			</li>
 			<li role="presentation">
-				<a role="menuitem" tabindex="-1" href="#" data-toggle="modal" data-target=".slideshow-slides-config<?php echo $slot ?>" onclick="SlideshowManager.preloadFileManager();">
+				<a role="menuitem" tabindex="-1" href="#" data-toggle="modal" data-target=".slideshow-slides-config<?php echo $slot ?>">
 					<i class="fa fa-bars"></i> Edit Slides
 				</a>
 			</li>
@@ -188,7 +188,7 @@ $view['assets']->addStyleDeclaration($css);
 								<?php echo $view['form']->row($slide['form']['slides:' . $key . ':background-image']); ?>
 							</div>
 							<div class="col-md-3">
-								<button type="button" onclick="SlideshowManager.toggleFileManager();" class="btn button-default file-manager-toggle">
+								<button type="button" onclick="SlideshowManager.BrowseServer('slides:<?php echo $key; ?>:background-image');" class="btn button-default file-manager-toggle">
 									<i class="fa fa-folder-open-o"></i> File Manager
 								</button>
 							</div>


### PR DESCRIPTION
Can be tested with Chad's https://github.com/drmmr763/TestAddonBundle.

Steps:
1. Clone Chad's Test Addon Bundle somewhere,
2. Create the symlink of the TestAddonBundle folder and add it to the /addon folder.
3. Go to Mautic / Addons / Manage Addons and hit the Install / Upgrade button.

Success result: The Test Addon should appear in the Addons table.

It should work the same way with Mautic core bundles.

Plus (forgot to create new branch so it is in this PR, sorry for that): File manager in the Pages/Slideshow Manager changed from iframe to new browser window. Image select was not working.

Steps:
1. Go to Landing Pages, create new, theme must be Mauve
2. Open Page builder. At the top-right corner is slideshow configuration.
3. Try to change background image of a slide. 

Before this PR the file manager was opened in the iframe, but the image select was not working. It didn't prefill the image url to the input. This PR change this and the file manager is opened in a new window as in other places of Mautic administration. Image selection works.

