### PR TITLE
Fixes email unsubscribe and resubscribe pages for templates with folders that mismatch their names

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -148,8 +148,8 @@ class PublicController extends CommonFormController
             $template = $formTemplate;
         }
         $theme  = $this->factory->getTheme($template);
-        if ($theme->getName() != $template) {
-            $template = $theme->getName();
+        if ($theme->getTheme() != $template) {
+            $template = $theme->getTheme();
         }
         $config = $theme->getConfig();
 
@@ -204,13 +204,13 @@ class PublicController extends CommonFormController
         }
 
         $theme  = $this->factory->getTheme($template);
-        if ($theme->getName() != $template) {
-            $template = $theme->getName();
+        if ($theme->getTheme() != $template) {
+            $template = $theme->getTheme();
         }
 
         // Ensure template still exists
         $theme = $this->factory->getTheme($template);
-        if (empty($theme) || $theme->getName() !== $template) {
+        if (empty($theme) || $theme->getTheme() !== $template) {
             $template = $this->factory->getParameter('theme');
         }
 


### PR DESCRIPTION
If attempting to view an unsubscribe link for an email that is based on a template other than Mauve, an error will be thrown due to the template not being found. This PR fixes this by using the correct function.

To reproduce, build an email with {unsubscribe_text} token using a template other than Mauve. Send the email then click on the link and you should get the error before the patch, and a success after.