### PR TITLE
Fixed issue where campaign labels were not removed when the interval was removed

### DIFF
--- a/app/bundles/CampaignBundle/Assets/js/campaign.js
+++ b/app/bundles/CampaignBundle/Assets/js/campaign.js
@@ -76,10 +76,8 @@ Mautic.campaignEventOnLoad = function (container, response) {
     var domEventId = 'CampaignEvent_' + response.eventId;
     var eventId = '#' + domEventId;
 
-    if (response.label) {
-        Mautic.campaignBuilderLabels[domEventId] = response.label;
-        Mautic.campaignBuilderUpdateLabel(domEventId);
-    }
+    Mautic.campaignBuilderLabels[domEventId] = (response.label) ? response.label : '';
+    Mautic.campaignBuilderUpdateLabel(domEventId);
 
     if (response.deleted) {
         //remove the connections


### PR DESCRIPTION
The labels that note the interval/delay of an event were not removed when the event was changed to remove the set interval.  This fixes that. 

To test, create a campaign, connecting an event into a decision and set a delay.  Then edit the event and remove the delay (immediate). Before the patch, the old label remains.  After the patch, the label will be removed.

This works in dev environment unless prod assets are rebuilt (which will happen with the release).