### PR TITLE
Address a possible scenario in update script to cause an endless loop (Fix #340)

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -226,14 +226,14 @@ function move_mautic_bundles(array $status)
             $status['updateState']['completedBundles'] = array();
         }
 
-        $iterator = new DirectoryIterator(MAUTIC_UPGRADE_ROOT . '/app/bundles');
+        $completed = true;
+        $iterator  = new DirectoryIterator(MAUTIC_UPGRADE_ROOT . '/app/bundles');
 
         // Sanity check, make sure there are actually directories here to process
         $dirs = glob(MAUTIC_UPGRADE_ROOT . '/app/bundles/*', GLOB_ONLYDIR);
 
         if (count($dirs)) {
-            $count     = 0;
-            $completed = true;
+            $count = 0;
 
             /** @var DirectoryIterator $directory */
             foreach ($iterator as $directory) {
@@ -415,14 +415,14 @@ function move_mautic_vendors(array $status)
             $status['updateState']['completedSymfony'] = array();
         }
 
-        $iterator = new DirectoryIterator(MAUTIC_UPGRADE_ROOT . '/vendor/symfony');
+        $completed = true;
+        $iterator  = new DirectoryIterator(MAUTIC_UPGRADE_ROOT . '/vendor/symfony');
 
         // Sanity check, make sure there are actually directories here to process
         $dirs = glob(MAUTIC_UPGRADE_ROOT . '/vendor/symfony/*', GLOB_ONLYDIR);
 
         if (count($dirs)) {
-            $count     = 0;
-            $completed = true;
+            $count = 0;
 
             /** @var DirectoryIterator $directory */
             foreach ($iterator as $directory) {
@@ -487,14 +487,14 @@ function move_mautic_vendors(array $status)
     }
 
     // Once we've gotten here, we can safely iterate through the rest of the vendor directory; the rest of the contents are rather small in size
-    $iterator = new DirectoryIterator(MAUTIC_UPGRADE_ROOT . '/vendor');
+    $completed = true;
+    $iterator  = new DirectoryIterator(MAUTIC_UPGRADE_ROOT . '/vendor');
 
     // Sanity check, make sure there are actually directories here to process
     $dirs = glob(MAUTIC_UPGRADE_ROOT . '/vendor/*', GLOB_ONLYDIR);
 
     if (count($dirs)) {
-        $count     = 0;
-        $completed = true;
+        $count = 0;
 
         /** @var DirectoryIterator $directory */
         foreach ($iterator as $directory) {
@@ -575,8 +575,10 @@ function move_mautic_vendors(array $status)
 /**
  * Copy files from the directory
  *
- * @param $dir
- * @param $errorLog
+ * @param string $dir
+ * @param array  &$errorLog
+ *
+ * @return bool
  */
 function copy_files($dir, &$errorLog) {
     if (is_dir(MAUTIC_UPGRADE_ROOT . $dir)) {
@@ -596,18 +598,19 @@ function copy_files($dir, &$errorLog) {
         }
 
         return true;
-    } else {
-
-        return false;
     }
+
+    return false;
 }
 
 /**
  * Copy directories
  *
- * @param $dir
- * @param $errorLog
- * @param $createDest
+ * @param string $dir
+ * @param array  &$errorLog
+ * @param bool   $createDest
+ *
+ * @return bool|void
  */
 function copy_directories($dir, &$errorLog, $createDest = true) {
     // Ensure the destination directory exists


### PR DESCRIPTION
See https://github.com/mautic/mautic/issues/340#issuecomment-95575690 for full context.

Long and short, there exists a possibility in the standalone update script to enter into a recursive loop because of where in the script the `$completed` variable is set in a few locations.  This variable is used to instruct the updater whether a step has been completed or if it needs to be repeated in places we perform iterated batch operations.

This pull moves the location the variable is set to a place where it will always be defined which should resolve the potential endless loop scenario.

To test this, you'll need to test an update for Mautic in a scenario where a number of folders dividable by 5 is included in the bundles directory, vendor directory, or vendor/symfony directory (as was the case with 1.0.3).  At https://www.babdev.com/downloads/1.0.3-update-mod.zip I've packaged the 1.0.3-update ZIP with the modified upgrade.php file from this PR.  To further trick the app, you can use the following to place in your `app/cache/<env>/lastUpdateCheck.txt` file (adjust the checkedTime as needed):

```
{"error":false,"message":"mautic.core.updater.update.available","version":"1.0.3","announcement":"https:\/\/www.mautic.org\/community\/index.php\/278-1-0-3-released","package":"https:\/\/www.babdev.com\/downloads\/1.0.3-update-mod.zip","checkedTime":1429794700,"stability":"stable"}
```