### PR TITLE
Fixes 500 errors during the database upgrade step and when saving configuration

### DIFF
--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -19,6 +19,7 @@ use Mautic\CoreBundle\Swiftmailer\Transport\PostmarkTransport;
 use Mautic\CoreBundle\Swiftmailer\Transport\SendgridTransport;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -500,7 +501,8 @@ class AjaxController extends CommonController
             $input       = new ArgvInput($args);
             $application = new Application($this->get('kernel'));
             $application->setAutoExit(false);
-            $result = $application->run($input);
+            $output      = new NullOutput();
+            $result      = $application->run($input, $output);
         }
 
         if ($result !== 0) {

--- a/app/bundles/CoreBundle/Helper/CacheHelper.php
+++ b/app/bundles/CoreBundle/Helper/CacheHelper.php
@@ -12,6 +12,7 @@ namespace Mautic\CoreBundle\Helper;
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\NullOutput;
 
 /**
  * Class CacheHelper
@@ -64,7 +65,8 @@ class CacheHelper
         $input       = new ArgvInput($args);
         $application = new Application($this->factory->getKernel());
         $application->setAutoExit(false);
-        $application->run($input);
+        $output      = new NullOutput();
+        $application->run($input, $output);
 
         if (ob_get_length() > 0) {
             ob_end_clean();


### PR DESCRIPTION
This PR fixes issues on some servers where the database migration step during upgrades and saving the configuration resulted in unexplained 500 errors. The issue didn't seem to affect all servers but is reproducible.  It seemed to be an issue related to calling a Symfony command from within the code rather than from CLI while not passing in an OutputInterface object.

This should fix #188.