### PR TITLE
Prevents bad email addresses from killing campaign/batch email sends

### DIFF
--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -618,15 +618,16 @@ class AjaxController extends CommonController
                     $mailer->start();
                     $translator = $this->factory->getTranslator();
 
-                    if (!empty($settings['send_test'])) {
+                    if ($settings['send_test'] == 'true') {
                         $message = new \Swift_Message(
                             $translator->trans('mautic.core.config.form.mailer.transport.test_send.subject'),
                             $translator->trans('mautic.core.config.form.mailer.transport.test_send.body')
                         );
 
                         $user = $this->factory->getUser();
+
                         $message->setFrom(array($settings['from_email'] => $settings['from_name']));
-                        $message->setTo(array($user->getEmail() => $user->getFirstName() . ' ' . $user->getLastName()));
+                        $message->setTo(array($user->getEmail() => $user->getFirstName().' '.$user->getLastName()));
 
                         $mailer->send($message);
                     }

--- a/app/bundles/CoreBundle/Helper/MailHelper.php
+++ b/app/bundles/CoreBundle/Helper/MailHelper.php
@@ -287,6 +287,21 @@ class MailHelper
         }
     }
 
+    /**
+     * Set from address (defaults to system)
+     *
+     * @param $address
+     * @param $name
+     */
+    public function setFrom($address, $name = null)
+    {
+        try {
+            $this->message->setFrom($address, $name);
+        } catch (\Exception $e) {
+            $this->errors[] = $e->getMessage();
+            $this->factory->getLogger()->log('error', '[MAIL ERROR] ' . $e->getMessage());
+        }
+    }
 
     /**
      * @return null

--- a/app/bundles/CoreBundle/Helper/MailHelper.php
+++ b/app/bundles/CoreBundle/Helper/MailHelper.php
@@ -210,6 +210,26 @@ class MailHelper
     }
 
     /**
+     * Set subject
+     *
+     * @param $subject
+     */
+    public function setSubject($subject)
+    {
+        $this->message->setSubject($subject);
+    }
+
+    /**
+     * Set a plain text part
+     *
+     * @param $content
+     */
+    public function setPlainText($content)
+    {
+        $this->message->addPart($content, 'text/plain');
+    }
+
+    /**
      * @param        $content
      * @param string $contentType
      * @param null   $charset
@@ -217,6 +237,25 @@ class MailHelper
     public function setBody($content, $contentType = 'text/html', $charset = null)
     {
         $this->message->setBody($content, $contentType, $charset);
+    }
+
+    /**
+     * Set the to address (includes exception catching)
+     *
+     * @param $addresses
+     */
+    public function setTo($addresses)
+    {
+        if (!is_array($addresses)) {
+            $addresses = array($addresses);
+        }
+
+        try {
+            $this->message->setTo($addresses);
+        } catch (\Exception $e) {
+            $this->errors[] = $e->getMessage();
+            $this->factory->getLogger()->log('error', '[MAIL ERROR] ' . $e->getMessage());
+        }
     }
 
     /**
@@ -233,6 +272,9 @@ class MailHelper
     public function setIdHash ($idHash)
     {
         $this->idHash = $idHash;
+
+        // Add the trackingID to the $message object in order to update the stats if the email failed to send
+        $this->message->leadIdHash = $idHash;
     }
 
     /**

--- a/app/bundles/CoreBundle/Helper/MailHelper.php
+++ b/app/bundles/CoreBundle/Helper/MailHelper.php
@@ -240,23 +240,53 @@ class MailHelper
     }
 
     /**
-     * Set the to address (includes exception catching)
+     * Set to address(es)
      *
      * @param $addresses
+     * @param $name
      */
-    public function setTo($addresses)
+    public function setTo($addresses, $name = null)
     {
-        if (!is_array($addresses)) {
-            $addresses = array($addresses);
-        }
-
         try {
-            $this->message->setTo($addresses);
+            $this->message->setTo($addresses, $name);
         } catch (\Exception $e) {
             $this->errors[] = $e->getMessage();
             $this->factory->getLogger()->log('error', '[MAIL ERROR] ' . $e->getMessage());
         }
     }
+
+    /**
+     * Set CC address(es)
+     *
+     * @param $addresses
+     * @param $name
+     */
+    public function setCc($addresses, $name = null)
+    {
+        try {
+            $this->message->setCc($addresses, $name);
+        } catch (\Exception $e) {
+            $this->errors[] = $e->getMessage();
+            $this->factory->getLogger()->log('error', '[MAIL ERROR] ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Set BCC address(es)
+     *
+     * @param $addresses
+     * @param $name
+     */
+    public function setBcc($addresses, $name = null)
+    {
+        try {
+            $this->message->setBcc($addresses, $name);
+        } catch (\Exception $e) {
+            $this->errors[] = $e->getMessage();
+            $this->factory->getLogger()->log('error', '[MAIL ERROR] ' . $e->getMessage());
+        }
+    }
+
 
     /**
      * @return null

--- a/app/bundles/EmailBundle/Form/Type/EmailListType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailListType.php
@@ -31,7 +31,7 @@ class EmailListType extends AbstractType
         $choices = $factory->getModel('email')->getRepository()
             ->getEmailList('', 0, 0, $viewOther, true);
         foreach ($choices as $email) {
-            $this->choices[$email['language']][$email['id']] = $email['id'] . ':' . $email['subject'];
+            $this->choices[$email['language']][$email['id']] = $email['subject'] . " ({$email['id']})";
         }
 
         //sort by language

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -820,15 +820,12 @@ class EmailModel extends FormModel
                 $mailer->setBody($customHtml);
             }
 
-            $mailer->message->setTo(array($lead['email'] => $lead['firstname'] . ' ' . $lead['lastname']));
-            $mailer->message->setSubject($useEmail['entity']->getSubject());
+            $mailer->setTo(array($lead['email'] => $lead['firstname'] . ' ' . $lead['lastname']));
+            $mailer->setSubject($useEmail['entity']->getSubject());
 
             if ($plaintext = $useEmail['entity']->getPlainText()) {
-                $mailer->message->addPart($plaintext, 'text/plain');
+                $mailer->setPlainText($plaintext);
             }
-
-            //add the trackingID to the $message object in order to update the stats if the email failed to send
-            $mailer->message->leadIdHash = $idHash;
 
             //queue the message
             $mailer->send(true);
@@ -942,11 +939,11 @@ class EmailModel extends FormModel
                 $mailer->setBody($email->getCustomHtml());
             }
 
-            $mailer->message->setTo(array($user['email'] => $user['firstname'] . ' ' . $user['lastname']));
-            $mailer->message->setSubject($email->getSubject());
+            $mailer->setTo(array($user['email'] => $user['firstname'] . ' ' . $user['lastname']));
+            $mailer->setSubject($email->getSubject());
 
             if ($plaintext = $email->getPlainText()) {
-                $mailer->message->addPart($plaintext, 'text/plain');
+                $mailer->setPlainText($plaintext);
             }
 
             //queue the message

--- a/app/bundles/EmailBundle/Views/Email/list.html.php
+++ b/app/bundles/EmailBundle/Views/Email/list.html.php
@@ -114,7 +114,7 @@ if ($tmpl == 'index') {
                 </td>
                 <td class="visible-md visible-lg"><?php echo $item->getSentCount(); ?></td>
                 <td class="visible-md visible-lg"><?php echo $item->getReadCount(); ?></td>
-                <td class="visible-md visible-lg">~<?php echo $model->getPendingLeads($item, null, true); ?></td>
+                <td class="visible-md visible-lg"><?php echo $model->getPendingLeads($item, null, true); ?></td>
                 <td class="visible-md visible-lg"><?php echo $item->getId(); ?></td>
             </tr>
         <?php endforeach; ?>

--- a/app/bundles/UserBundle/Model/UserModel.php
+++ b/app/bundles/UserBundle/Model/UserModel.php
@@ -208,11 +208,11 @@ class UserModel extends FormModel
         // Email the user
         $mailer = $this->factory->getMailer();
 
-        $mailer->message->setTo(array($user->getEmail() => $user->getName()));
-        $mailer->message->setSubject($this->translator->trans('mautic.user.user.passwordreset.subject'));
+        $mailer->setTo(array($user->getEmail() => $user->getName()));
+        $mailer->setSubject($this->translator->trans('mautic.user.user.passwordreset.subject'));
         $body = $this->translator->trans('mautic.user.user.passwordreset.body', array('%name%' => $user->getFirstName(), '%password%' => $newPassword));
         $body = str_replace('\\n', "\n", $body);
-        $mailer->message->setBody($body);
+        $mailer->setBody($body);
 
         //queue the message
         $mailer->send();


### PR DESCRIPTION
In relation to #329, if an email address is invalid, campaign processing and/or email batch sending will fail due to an uncaught exception. This PR adds helper functions that will catch and handle the exceptions so that processing should continue.

To test, create a lead with a bad email address then add them to a campaign that has a send email action and/or list and send an email to the list. An exception (see #329) will be thrown.  Apply the patch and then no exception should be thrown and all should continue working.

Also moved setSubject and addPart (for plainText) into MailHelper functions rather than having to mix between using $MailHelperObject directly and $MailHelperObject->message for basic email setup.

Also added a couple very minor UI tweaks (removed tilde from pending column and moved the ID of a emails in the email dropdown lists to be after the subject).