### PR TITLE
Removed dependency on php_sapi_name() due to server inconsistencies

### DIFF
--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -245,7 +245,7 @@ class MauticFactory
      */
     public function getTemplating()
     {
-        if (php_sapi_name() == 'cli') {
+        if (defined('IN_MAUTIC_CONSOLE')) {
             //enter the request scope in order to be use the templating.helper.assets service
             $this->container->enterScope('request');
             $this->container->set('request', new Request(), 'request');

--- a/app/console
+++ b/app/console
@@ -7,6 +7,8 @@
 
 set_time_limit(0);
 
+defined('IN_MAUTIC_CONSOLE') or define('IN_MAUTIC_CONSOLE', 1);
+
 require_once __DIR__.'/bootstrap.php.cache';
 require_once __DIR__.'/AppKernel.php';
 


### PR DESCRIPTION
**Background**
Generating emails from templates requires the templating service which in turn required Symfony's AssetHelper (for asset url generation). The AssetHelper requires the container to be in the "request" scope which it is not when using Symfony's console. (Symfony assumes the request is not needed). This is a problem because emails generated from the campaign trigger command depend on this.

To prevent Symfony from throwing an error, Mautic checked php_sapi_name() when retrieving the templating service and entered the "request" scope if it equaled cli.  On some servers this is fine and all worked as it should.  But php_sapi_name() returned cgi-fcgi, as it would if the script is served by apache, when calling the script via a cronjob on many cPanel servers; which then resulted in a fatal error.

**Resolution**
Using `/usr/local/bin/php` usually  returned the expected sapi name but is inconsistent as well (some servers required the `-f` argument). So, to prevent all these inconsistencies, this PR sets a constant in app/console that MauticFactory::getTemplating() checks instead of relying on php_sapi_name(). 

**Testing**
Using a cPanel server, setup a basic campaign with a send email action. Make sure the email sent uses a template rather than custom HTML.  Add a lead to the campaign. Create a cronjob that calls `php /path/to/mautic/app/console mautic:campaign:trigger -e prod` Either leave off  `> /dev/null 2>&1` so that cron emails the output or write the output to a file. The cron job will likely result in a PHP error regarding the request scope.

After applying the PR, add a new lead to the campaign, then wait for the cron to fire again. No error should be generated and the email should be successfully sent.

Note that not all cPanel servers seem to have this issue so if the email sends both before and after the PR, consider it a win.