### PR TITLE
OAuth changes to allow iOS scheme callbacks

### DIFF
--- a/app/bundles/ApiBundle/Config/config.php
+++ b/app/bundles/ApiBundle/Config/config.php
@@ -143,7 +143,13 @@ return array(
             'bazinga.oauth.security.authentication.provider.class'    => 'Mautic\ApiBundle\Security\OAuth1\Authentication\Provider\OAuthProvider',
             'bazinga.oauth.security.authentication.listener.class'    => 'Mautic\ApiBundle\Security\OAuth1\Firewall\OAuthListener',
             'bazinga.oauth.event_listener.request.class'              => 'Mautic\ApiBundle\EventListener\OAuth1\OAuthRequestListener',
-            'fos_oauth_server.security.authentication.listener.class' => 'Mautic\ApiBundle\Security\OAuth2\Firewall\OAuthListener'
+            'fos_oauth_server.security.authentication.listener.class' => 'Mautic\ApiBundle\Security\OAuth2\Firewall\OAuthListener',
+
+            'mautic.validator.oauthcallback' => array(
+                'class'     => 'Mautic\ApiBundle\Form\Validator\Constraints\OAuthCallbackValidator',
+                'tag'       => 'validator.constraint_validator',
+                'alias'     => 'oauth_callback'
+            )
         )
     ),
 

--- a/app/bundles/ApiBundle/Entity/oAuth1/Consumer.php
+++ b/app/bundles/ApiBundle/Entity/oAuth1/Consumer.php
@@ -63,10 +63,6 @@ class Consumer implements ConsumerInterface
         $metadata->addPropertyConstraint('name', new Assert\NotBlank(
             array('message' => 'mautic.core.name.required')
         ));
-
-        $metadata->addPropertyConstraint('callback', new Assert\NotBlank(
-            array('message' => 'mautic.api.client.callback.notblank')
-        ));
     }
 
     /**
@@ -119,7 +115,6 @@ class Consumer implements ConsumerInterface
     {
         return array($this->callback);
     }
-
 
     /**
      * {@inheritDoc}

--- a/app/bundles/ApiBundle/Form/Type/ClientType.php
+++ b/app/bundles/ApiBundle/Form/Type/ClientType.php
@@ -9,6 +9,7 @@
 
 namespace Mautic\ApiBundle\Form\Type;
 
+use Mautic\ApiBundle\Form\Validator\Constraints\OAuthCallback;
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
@@ -108,9 +109,7 @@ class ClientType extends AbstractType
 
                 if ($form->has('redirectUris')) {
                     foreach ($data->getRedirectUris() as $uri) {
-                        $urlConstraint = new Assert\Url(array(
-                            'protocols' => array('http','https')
-                        ));
+                        $urlConstraint = new OAuthCallback();
                         $urlConstraint->message = $translator->trans('mautic.api.client.redirecturl.invalid', array('%url%' => $uri), 'validators');
 
                         $errors = $validator->validateValue(
@@ -127,14 +126,16 @@ class ClientType extends AbstractType
                 }
             });
         } else {
-            $builder->add('callback', 'text', array(
+            $builder->add(
+                $builder->create('callback', 'text', array(
                 'label'      => 'mautic.api.client.form.callback',
                 'label_attr' => array('class' => 'control-label'),
                 'attr'       => array(
                     'class'   => 'form-control',
                     'tooltip' => 'mautic.api.client.form.help.callback',
-                )
-            ));
+                ),
+                'required'   => false
+            ))->addModelTransformer(new Transformers\NullToEmptyTransformer()));
 
             $builder->add('consumerKey', 'text', array(
                 'label'      => 'mautic.api.client.form.consumerkey',
@@ -163,9 +164,7 @@ class ClientType extends AbstractType
 
                 if ($form->has('callback')) {
                     $uri           = $data->getCallback();
-                    $urlConstraint = new Assert\Url(array(
-                        'protocols' => array('http','https')
-                    ));
+                    $urlConstraint = new OAuthCallback();
                     $urlConstraint->message = $translator->trans('mautic.api.client.redirecturl.invalid', array('%url%' => $uri), 'validators');
 
                     $errors = $validator->validateValue(

--- a/app/bundles/ApiBundle/Form/Validator/Constraints/OAuthCallback.php
+++ b/app/bundles/ApiBundle/Form/Validator/Constraints/OAuthCallback.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2014 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\ApiBundle\Form\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class OAuthCallback extends Constraint
+{
+    public $message = 'The callback URL is invalid.';
+
+    public function validatedBy()
+    {
+        return 'oauth_callback';
+    }
+}

--- a/app/bundles/ApiBundle/Form/Validator/Constraints/OAuthCallbackValidator.php
+++ b/app/bundles/ApiBundle/Form/Validator/Constraints/OAuthCallbackValidator.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Modified from \Symfony\Component\Validator\Constraints\UrlValidator
+ *
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ *
+ * @package     Mautic
+ * @copyright   2014 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\ApiBundle\Form\Validator\Constraints;
+
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class OAuthCallbackValidator extends ConstraintValidator
+{
+    const PATTERN = '~^[0-9a-z].*://(.*?)(:[0-9]+)?(/?|/\S+)$~ixu';
+
+    /**
+     * @param mixed      $value
+     * @param Constraint $constraint
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof OAuthCallback) {
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\OAuthCallback');
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        $value = (string) $value;
+        if (!preg_match(static::PATTERN, $value)) {
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->addViolation();
+        }
+    }
+}

--- a/app/bundles/CoreBundle/Form/DataTransformer/NullToEmptyTransformer.php
+++ b/app/bundles/CoreBundle/Form/DataTransformer/NullToEmptyTransformer.php
@@ -1,0 +1,42 @@
+<?php /**
+ * @package     Mautic
+ * @copyright   2015 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Form\DataTransformer;
+
+use Symfony\Component\Form\DataTransformerInterface;
+
+class NullToEmptyTransformer implements DataTransformerInterface
+{
+    /**
+     * Does not transform anything
+     *
+     * @param  string|null $value
+     *
+     * @return string
+     */
+    public function transform($value)
+    {
+        return $value;
+    }
+
+    /**
+     * Transforms a null to an empty string.
+     *
+     * @param  string $value
+     *
+     * @return string
+     */
+    public function reverseTransform($value)
+    {
+        if (is_null($value)) {
+            return '';
+        }
+
+        return $value;
+    }
+}


### PR DESCRIPTION
**Background**
OAuth callbacks had validators that restricted the URL to http:// or https://. The problem is that callbacks generated for iOS apps was not allowed since the iOS scheme is something like myapp://oauth/callback.  

Also, as noted in and fixes #343, the OAuth 1a callback's tooltip states that the callback isn't required but the UI did require it.

**Testing**
 Before applying the PR, try creating a client or consumer with a callback of myapp://oauth/callback and it should return a validation error.  After applying the PR, that type of URL should be allowed.

Also in partnership with https://github.com/mautic/api-library/pull/10, the OAuth1a consumer callback is now not required and will return to the given callback if one is not specified.  However, if one is specified in the consumer, the consumer's callback URL must be the root of the sent callback.