### PR TITLE
Fixed issue that caused the publish switches to be too small after toggling

### DIFF
--- a/app/bundles/CoreBundle/Views/Helper/publishstatus_icon.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/publishstatus_icon.html.php
@@ -9,7 +9,7 @@
 
 $query  = (!isset($query)) ? '' : $query;
 $status = $item->getPublishStatus();
-$size   = (!isset($size)) ? 'fa-lg' : $size;
+$size   = (empty($size)) ? 'fa-lg' : $size;
 switch ($status) {
     case 'published':
         $icon = " fa-toggle-on text-success";


### PR DESCRIPTION
**Description** 

Before the PR, clicking a publish switch in a list (email, campaigns, etc) would cause the button to switch to a smaller version.

**Testing**

Toggle the publish status of an entity in a list (email,form, etc).  The reverse switch will appear smaller than originally.