### PR TITLE
Inserts analytics for custom HTML landing pages and email web views

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -64,7 +64,17 @@ class PublicController extends CommonFormController
                 //replace tokens
                 $content = $response->getContent();
             } else {
-                $content = $entity->getCustomHtml();
+                $content   = $entity->getCustomHtml();
+                $analytics = htmlspecialchars_decode($this->factory->getParameter('google_analytics', ''));
+
+                // Check for html doc
+                if (strpos($content, '<html>') === false) {
+                    $content = "<html>\n<head>{$analytics}</head>\n<body>{$content}</body>\n</html>";
+                } elseif (strpos($content, '<head>') === false) {
+                    $content = str_replace('<html>', "<html>\n<head>\n{$analytics}\n</head>", $content);
+                } elseif (!empty($analytics)) {
+                    $content = str_replace('</head>', $analytics . "\n</head>", $content);
+                }
             }
 
             $dispatcher = $this->get('event_dispatcher');

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -242,6 +242,10 @@ class PublicController extends CommonFormController
                 $content = $response->getContent();
             } else {
                 $content = $entity->getCustomHtml();
+                $analytics = $this->factory->getParameter('google_analytics');
+                if (!empty($analytics)) {
+                    $content = str_replace('</head>', htmlspecialchars_decode($analytics) . "\n</head>", $content);
+                }
             }
 
             $dispatcher = $this->get('event_dispatcher');


### PR DESCRIPTION
**Description**
The analytics code will display for template based landing pages and emails (web view) but it will not show for the custom HTML option. Fixes #364 

**Testing**
Create a landing page using custom HTML. Go into configuration and insert the analytics code into the landing page tab. Browse to the landing page public URL and view the source.  Before the PR, the analytics code will not be inserted.  Afterward, it should.