### PR TITLE
Fixes ckeditor dialogue fields not working when the editor is inside bootstrap modal

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/3b.bootstrap-ckeditor-fix.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/3b.bootstrap-ckeditor-fix.js
@@ -1,0 +1,11 @@
+jQuery.fn.modal.Constructor.prototype.enforceFocus = function() {
+    var $modalElement = this.$element;
+    jQuery(document).on('focusin.modal',function(e) {
+        var $parent = jQuery(e.target.parentNode);
+        if ($modalElement[0] !== e.target
+            && !$modalElement.has(e.target).length
+            && jQuery(e.target).parentsUntil('*[role="dialog"]').length === 0) {
+            $modalElement.focus();
+        }
+    });
+};


### PR DESCRIPTION
**Description**

Apparently ckeditor dialogues have an incompatibility with bootstrap modals.  If opening a dialogue (link insert, source, etc) when the editor is inside a bootstrap modal, you cannot focus on inputs.  There is a bug report with ckeditor that states that it's a bootstrap issue and gave a workaround code.  This PR implements that fix.

** Testing **
Create a new form with a downloads asset form submit action and click on the insert link button in the download message editor. You should not be able to click inside the inputs.  After applying the PR, you will.

Note that if applying the fix to the prod environment, you must delete media/js/libraries.js in order for the file to be regenerated to include the fix. If in dev environment, the file will automatically load.

This should fix #374 