### PR TITLE
Fixed issue that calculated an incorrect pending count for mass emails

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -140,7 +140,12 @@ class EmailRepository extends CommonRepository
         $sq2 = $this->_em->getConnection()->createQueryBuilder();
         $sq2->select('stat.lead_id')
             ->from(MAUTIC_TABLE_PREFIX.'email_stats', 'stat')
-            ->where('stat.email_id = el.email_id');
+            ->where(
+                $sq2->expr()->andX(
+                    $sq2->expr()->isNotNull('stat.lead_id'),
+                    $sq2->expr()->eq('stat.email_id', 'el.email_id')
+                )
+            );
 
         if ($countOnly) {
             $q->select('count(l.id) as count');

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -135,7 +135,11 @@ class EmailRepository extends CommonRepository
         $q = $this->_em->getConnection()->createQueryBuilder();
 
         $sq = $this->_em->getConnection()->createQueryBuilder();
-        $sq->select('dne.lead_id')->from(MAUTIC_TABLE_PREFIX.'email_donotemail', 'dne');
+        $sq->select('dne.lead_id')
+            ->from(MAUTIC_TABLE_PREFIX.'email_donotemail', 'dne')
+            ->where(
+                $sq->expr()->isNotNull('dne.lead_id')
+            );
 
         $sq2 = $this->_em->getConnection()->createQueryBuilder();
         $sq2->select('stat.lead_id')


### PR DESCRIPTION
**Description**
Pending leads for mass emails were incorrectly counted if the email_stats table had a null value for lead_id (lead was deleted).  This PR fixes that query to show the correct count.

**Testing**
Create a new email and assign it to a small lead list.  Send the email to the list.  Create a new lead, assign it to the list. Either delete one of the leads the email was already sent to, or manipulate the database to change lead_id to NULL for one of the stats for this email.  Before the PR, the new lead won't be counted.  Afterward, it should be.