### PR TITLE
fix issue where reusing a passed-by-ref variable resulted in repeating IDs

### DIFF
--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -595,8 +595,8 @@ class ListModel extends FormModel
 
         $persistLists = array();
 
-        foreach ($lists as $l) {
-            if (!isset($this->leadChangeLists[$l])) {
+        foreach ($lists as $listid) {
+            if (!isset($this->leadChangeLists[$listid])) {
                 // List no longer exists in the DB so continue to the next
                 continue;
             }
@@ -607,14 +607,14 @@ class ListModel extends FormModel
                 $listLead = $this->getListLeadRepository()->findOneBy(
                     array(
                         'lead' => $lead,
-                        'list' => $this->leadChangeLists[$l]
+                        'list' => $this->leadChangeLists[$listid]
                     )
                 );
             } else {
                 $listLead = $this->em->getReference('MauticLeadBundle:ListLead',
                     array(
                         'lead' => $leadId,
-                        'list' => $l
+                        'list' => $listid
                     )
                 );
             }
@@ -633,7 +633,7 @@ class ListModel extends FormModel
                 }
             } else {
                 $listLead = new ListLead();
-                $listLead->setList($this->leadChangeLists[$l]);
+                $listLead->setList($this->leadChangeLists[$listid]);
                 $listLead->setLead($lead);
                 $listLead->setManuallyAdded($manuallyAdded);
                 $listLead->setDateAdded(new \DateTime());
@@ -642,7 +642,7 @@ class ListModel extends FormModel
             }
 
             if (!$batchProcess && $this->dispatcher->hasListeners(LeadEvents::LEAD_LIST_CHANGE)) {
-                $event = new ListChangeEvent($lead, $this->leadChangeLists[$l], true);
+                $event = new ListChangeEvent($lead, $this->leadChangeLists[$listid], true);
                 $this->dispatcher->dispatch(LeadEvents::LEAD_LIST_CHANGE, $event);
 
                 unset($event);
@@ -653,9 +653,9 @@ class ListModel extends FormModel
             $this->getRepository()->saveEntities($persistLists);
 
             // Detach the entities to save memory
-            foreach ($persistLists as $l) {
-                $this->em->detach($l);
-                unset($l);
+            foreach ($persistLists as $listEntity) {
+                $this->em->detach($listEntity);
+                unset($listEntity);
             }
         }
 
@@ -728,8 +728,8 @@ class ListModel extends FormModel
         }
 
         $persistLists = $deleteLists = array();
-        foreach ($lists as $l) {
-            if (!isset($this->leadChangeLists[$l])) {
+        foreach ($lists as $listid) {
+            if (!isset($this->leadChangeLists[$listid])) {
                 // List no longer exists in the DB so continue to the next
                 continue;
             }
@@ -739,11 +739,11 @@ class ListModel extends FormModel
             $listLead = (!$skipFindOne) ?
                 $this->getListLeadRepository()->findOneBy(array(
                     'lead' => $lead,
-                    'list' => $this->leadChangeLists[$l]
+                    'list' => $this->leadChangeLists[$listid]
                 )) :
                 $this->em->getReference('MauticLeadBundle:ListLead', array(
                     'lead' => $leadId,
-                    'list' => $l
+                    'list' => $listid
                 ));
 
             if ($listLead == null) {
@@ -767,7 +767,7 @@ class ListModel extends FormModel
             unset($listLead);
 
             if (!$batchProcess && $dispatchEvent && $this->dispatcher->hasListeners(LeadEvents::LEAD_LIST_CHANGE)) {
-                $event = new ListChangeEvent($lead, $this->leadChangeLists[$l], false);
+                $event = new ListChangeEvent($lead, $this->leadChangeLists[$listid], false);
                 $this->dispatcher->dispatch(LeadEvents::LEAD_LIST_CHANGE, $event);
 
                 unset($event);
@@ -778,9 +778,9 @@ class ListModel extends FormModel
             $this->getRepository()->saveEntities($persistLists);
 
             // Detach the entities to save memory
-            foreach ($persistLists as $l) {
-                $this->em->detach($l);
-                unset($l);
+            foreach ($persistLists as $listEntity) {
+                $this->em->detach($listEntity);
+                unset($listEntity);
             }
         }
 


### PR DESCRIPTION
This was a fun bug to find ;)

This issue was a variable declared as pass by reference was then being used in an for loop. The loop would then change the IDs to all be the same as the first value in the array. 

This meant doctrine would create a transaction for the IDs, but since they were both the same mysql would error out because it tried to insert duplicate records for the list-leads table. 