### PR TITLE
Set UTF8 charset for the DB connection in the installer

### DIFF
--- a/app/bundles/InstallBundle/Controller/InstallController.php
+++ b/app/bundles/InstallBundle/Controller/InstallController.php
@@ -421,8 +421,9 @@ class InstallController extends CommonController
      */
     private function performDatabaseInstallation ($dbParams)
     {
-        $dbName             = $dbParams['dbname'];
-        $dbParams['dbname'] = null;
+        $dbName              = $dbParams['dbname'];
+        $dbParams['dbname']  = null;
+        $dbParams['charset'] = 'UTF8';
 
         //suppress display of errors as we know its going to happen while testing the connection
         ini_set('display_errors', 0);
@@ -872,6 +873,9 @@ class InstallController extends CommonController
                 $dbParams['dbname'] = $dbParams['name'];
                 unset($dbParams['name']);
             }
+
+            // Ensure UTF8 charset
+            $dbParams['charset'] = 'UTF8';
 
             $paths = $namespaces = array();
 


### PR DESCRIPTION
As reported in #325, the installer will not save UTF8 characters to the database correctly.  This was because the installer makes a dynamic connection to the database and did not set the charset. This resulted in corrupt UTF8 characters in usernames, surnames, etc.  

**Testing**

To test, go through the installer and insert a UTF8 character in the first or last name of the admin user (i.e. ě).  After going through the installer and logging in, ě will be corrupted in the user's name in the upper right hand side (or in the user's profile).  After the patch, go through the installer again and this time, ě should be correctly saved to the database.

Fixes #325.