### PR TITLE
PHP function strtoupper does not work with non ASCII chars. CSS does.

### DIFF
--- a/app/bundles/CoreBundle/Views/Helper/publishstatus_badge.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/publishstatus_badge.html.php
@@ -19,5 +19,5 @@
         $labelColor = "warning";
         break;
 } ?>
-<?php $labelText = strtoupper($view['translator']->trans('mautic.core.form.' . $entity->getPublishStatus())); ?>
-<h4 class="fw-sb"><span class="label label-<?php echo $labelColor; ?>"><?php echo $labelText; ?></span></h4>
+<?php $labelText = $view['translator']->trans('mautic.core.form.' . $entity->getPublishStatus()); ?>
+<h4 class="fw-sb"><span class="tt-u label label-<?php echo $labelColor; ?>"><?php echo $labelText; ?></span></h4>


### PR DESCRIPTION
Tested with Czech language on Published label at Email detail.

### Before
![mautic-uppercase-non-ascii-error](https://cloud.githubusercontent.com/assets/1235442/7628736/2725b262-fa27-11e4-8071-51d8c4fc453c.png)

### After
![mautic-uppercase-non-ascii-fix](https://cloud.githubusercontent.com/assets/1235442/7628739/35709f44-fa27-11e4-8424-7faf9360d3fa.png)
