### PR TITLE
Prevented a lead's social cache from being emptied when inappropriate

### DIFF
--- a/app/bundles/AddonBundle/Helper/IntegrationHelper.php
+++ b/app/bundles/AddonBundle/Helper/IntegrationHelper.php
@@ -316,8 +316,6 @@ class IntegrationHelper
                         $socialCache[$integration]['profile']     = (!empty($profile['profile'])) ? $profile['profile'] : array();
                         $socialCache[$integration]['activity']    = (!empty($profile['activity'])) ? $profile['activity'] : array();
                         $socialCache[$integration]['lastRefresh'] = $now->toUtcString();
-                    } else {
-                        unset($socialCache[$integration]);
                     }
                 } elseif (isset($socialCache[$integration])) {
                     //integration is now not applicable
@@ -325,7 +323,7 @@ class IntegrationHelper
                 }
             }
 
-            if ($persistLead) {
+            if ($persistLead && !empty($socialCache)) {
                 $lead->setSocialCache($socialCache);
                 $this->factory->getEntityManager()->getRepository('MauticLeadBundle:Lead')->saveEntity($lead);
             }

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -208,7 +208,9 @@ class LeadModel extends FormModel
         list($socialCache, $socialFeatureSettings) = $this->factory->getHelper('integration')->getUserProfiles($lead, $data, true, null, false, true);
 
         //set the social cache while we have it
-        $lead->setSocialCache($socialCache);
+        if (!empty($socialCache)) {
+            $lead->setSocialCache($socialCache);
+        }
 
         //save the field values
         $fieldValues = $lead->getFields();


### PR DESCRIPTION
**Description**

When one integration is configured (such as Twitter) and there is a temporary issue with connecting to the service, a lead's social cache would be emptied. This PR prevents that.

**Testing**

Difficult to reproduce as it requires the right circumstances or hacked code to prevent a successful API call after the cache has already been built the first time.  The PR basically adds some checks to ensure the cache has content before persisting to the lead.