### PR TITLE
Fixed pagination for lead grid view

### DIFF
--- a/app/bundles/LeadBundle/Views/Lead/grid.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/grid.html.php
@@ -110,7 +110,7 @@ if ($tmpl == 'index')
             "baseUrl"         => (isset($objectId)) ? $view['router']->generate($link, array('objectId' => $objectId)) : $view['router']->generate($link),
             "tmpl"            => (!in_array($tmpl, array('grid', 'index'))) ? $tmpl : $indexMode,
             'sessionVar'      => (isset($sessionVar)) ? $sessionVar : 'lead',
-            'target'          => (isset($target)) ? $target : 'page-list'
+            'target'          => (isset($target)) ? $target : '.page-list'
         ));
         ?>
     </div>


### PR DESCRIPTION
**Description** 
Using pagination for the lead grid view failed because of an incorrect selector. This PR fixes that.

**Testing**
Before the PR, change to the grid view for leads then try to navigate to the second page.  It'll fail.  After the PR, it should show the new page.