### PR TITLE
Added linked title to form actions (edit page)

### DIFF
--- a/app/bundles/FormBundle/Views/Action/generic.html.php
+++ b/app/bundles/FormBundle/Views/Action/generic.html.php
@@ -20,7 +20,7 @@ $containerClass = (!empty($deleted)) ? ' bg-danger' : '';
             'formId'     => $formId
         ));
     ?>
-    <span class="action-label"><?php echo $action['name']; ?></span>
+    <a data-toggle="ajaxmodal" data-target="#formComponentModal" href="<?php echo $view['router']->generate('mautic_formaction_action', array('objectAction' => 'edit', 'objectId' => $id, 'formId' => $formId)); ?>"><span class="action-label"><?php echo $action['name']; ?></span></a>
     <?php if (!empty($action['description'])): ?>
     <span class="action-descr"><?php echo $action['description']; ?></span>
     <?php endif; ?>


### PR DESCRIPTION
**Description**
This PR changes the title on Form Actions in the Edit Mode to be clickable links to edit the action. 

**Testing Steps**
Apply the PR. 
Edit a form. 
View the list of actions. 
Verify clicking a title loads the modal window.