### PR TITLE
Fixed not being able to batch delete point triggers.  

### DIFF
--- a/app/bundles/PointBundle/Controller/TriggerController.php
+++ b/app/bundles/PointBundle/Controller/TriggerController.php
@@ -573,7 +573,7 @@ class TriggerController extends FormController
         );
 
         if ($this->request->getMethod() == 'POST') {
-            $model     = $this->factory->getModel('lead');
+            $model     = $this->factory->getModel('point.trigger');
             $ids       = json_decode($this->request->query->get('ids', array()));
             $deleteIds = array();
 


### PR DESCRIPTION
**Description**

Fixes #419. Point triggers was using the lead model when trying to bulk delete which could lead to deleting a lead and/or giving an error that the trigger doesn't exist. This PR fixes that.

**Testing**

Create, select in list, then try to delete using the bulk delete button. If a lead with the same ID existed.  It may have been deleted.  Otherwise, an message that the trigger does not exist will likely show.  After the PR, you should be able to successfully delete the point trigger.