### PR TITLE
Set Mailchimp list limit to 100

### DIFF
--- a/addons/MauticEmailMarketingBundle/Api/MailchimpApi.php
+++ b/addons/MauticEmailMarketingBundle/Api/MailchimpApi.php
@@ -39,7 +39,7 @@ class MailchimpApi extends EmailMarketingApi{
 
     public function getLists()
     {
-        return $this->request('lists/list');
+        return $this->request('lists/list', array('limit' => 100));
     }
 
     /**


### PR DESCRIPTION
**Description**

As noted in #415, Mailchimp defaults it's list limit to 25.  So if the account has more than 25 lists, some will not show in the push to integration lists.  This PR sets the limit to 100 which is Mandrill's max.  Eventually this will likely need to be changed to support paginated calls.

**Testing**
Hard to test unless you have more than 25 mail chimp lists. But can see the details on limit in https://apidocs.mailchimp.com/api/2.0/lists/list.php.