### PR TITLE
Fixes page/email builder URL modal populating last used URL

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/core.js
+++ b/app/bundles/CoreBundle/Assets/js/core.js
@@ -2923,7 +2923,7 @@ var Mautic = {
 
         mQuery('#BuilderLinkModal').modal('hide');
         mQuery('#BuilderLinkModal input[name="editor"]').val('');
-        mQuery('#BuilderLinkModal input[name="link"]').val('');
+        mQuery('#BuilderLinkModal input[name="url"]').val('');
         mQuery('#BuilderLinkModal input[name="text"]').val('');
         mQuery('#BuilderLinkModal input[name="text"]').parent().removeClass('hide');
     },


### PR DESCRIPTION
**Description**

The builder modal used to insert URLs left the last URL after it was inserted into an editor.  This PR fixes it. Fixes #402

**Testing**
Use a builder and drag and drop a landing page int an editor.  A modal will appear with the page token and name of the landing page auto populated.  Insert then drag and drop the external URL token (soon to be obsolete but demonstrates the issue).  The last used landing page token will be in the URL input.  After the PR, repeating the process should result in a inputs with nothing.