### PR TITLE
Fixed role permissions not being editable after using Apply

### DIFF
--- a/app/bundles/UserBundle/Controller/RoleController.php
+++ b/app/bundles/UserBundle/Controller/RoleController.php
@@ -272,7 +272,8 @@ class RoleController extends FormController
                 return $this->postActionRedirect($postActionVars);
             } else {
                 //the form has to be rebuilt because the permissions were updated
-                $form = $model->createForm($entity, $this->get('form.factory'), $action);
+                $permissionsConfig = $this->getPermissionsConfig($entity);
+                $form              = $model->createForm($entity, $this->get('form.factory'), $action, array('permissionsConfig' => $permissionsConfig['config']));
             }
         } else {
             //lock the entity

--- a/app/bundles/UserBundle/Entity/PermissionRepository.php
+++ b/app/bundles/UserBundle/Entity/PermissionRepository.php
@@ -48,6 +48,7 @@ class PermissionRepository extends CommonRepository
             ->orderBy('p.bundle')
             ->setParameter(':role', $role)
             ->getQuery()
+            ->useResultCache(false)
             ->getResult(Query::HYDRATE_ARRAY);
 
         //rearrange the array to meet needs


### PR DESCRIPTION
**Description**
Edit a role and click Apply.  Go to the permissions tab and you'll find the tabs don't work.  This PR fixes that. Fixes #332.

**Testing**
Create/edit a role that is not an admin.  Adjust the permissions then click apply.  The permissions tabs no longer work.  After the PR, all should work.