### PR TITLE
Removes iframe restriction from builders allowing Youtube, etc

### DIFF
--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -34,7 +34,7 @@ class InputHelper
                 'embed',
                 'frame',
                 'frameset',
-                'iframe',
+                //'iframe',
                 'ilayer',
                 'layer',
                 'object',

--- a/app/bundles/CoreBundle/Templating/Helper/SlotsHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/SlotsHelper.php
@@ -54,13 +54,13 @@ class SlotsHelper extends BaseSlotsHelper
             foreach ($names as $n) {
                 // strip tags used to ensure we don't have empty tags.
                 // Caused a bug with hasContent returning incorrectly. Whitelisted img to fix
-                $hasContent = (boolean) strip_tags(trim($this->slots[$n]), "<img>");
+                $hasContent = (boolean) strip_tags(trim($this->slots[$n]), "<img><iframe>");
                 if ($hasContent) {
                     return true;
                 }
             }
         }
-        
+
         return false;
     }
 }


### PR DESCRIPTION
**Description**
iFrames were stripped from HTML resulting in not being able to embed Youtube, etc.  This PR relaxes that restriction so that iframe can be uses. Fixes #418 and #64.

**Testing**
Before the PR, try to embed a youtube iframe widget.  It'll be wiped out on save.  Afterward, it should be allowed.
