### PR TITLE
Fixes issue where campaigns could not be deleted due to event constraints

### DIFF
--- a/app/bundles/CampaignBundle/Entity/EventRepository.php
+++ b/app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -41,11 +41,11 @@ class EventRepository extends CommonRepository
 
     /**
      * Get array of published events based on type
+     * @param       $type
+     * @param array $campaigns
+     * @param null  $leadId             If included, only events that have not been triggered by the lead yet will be included
+     * @param bool  $positivePathOnly   If negative, all events including those with a negative path will be returned
      *
-     * @param $type
-     * @param $campaigns
-     * @param $leadId           If included, only events that have not been triggered by the lead yet will be included
-     * @param $positivePathOnly If negative, all events including those with a negative path will be returned
      * @return array
      */
     public function getPublishedByType($type, array $campaigns = null, $leadId = null, $positivePathOnly = true)
@@ -92,7 +92,8 @@ class EventRepository extends CommonRepository
         if ($positivePathOnly) {
             $q->andWhere(
                 $q->expr()->orX(
-                    $q->expr()->neq('e.decisionPath',
+                    $q->expr()->neq(
+                        'e.decisionPath',
                         $q->expr()->literal('no')
                     ),
                     $q->expr()->isNull('e.decisionPath')
@@ -170,7 +171,6 @@ class EventRepository extends CommonRepository
     /**
      * Get an array of events that have been triggered by this lead
      *
-     * @param $type
      * @param $leadId
      *
      * @return array
@@ -199,10 +199,11 @@ class EventRepository extends CommonRepository
     /**
      * Get a list of scheduled events
      *
-     * @param mixed $campaignId
-     * @param \DateTime $date   Defaults to events scheduled before now
+     * @param      $campaignId
+     * @param bool $count
+     * @param int  $limit
      *
-     * @return array
+     * @return array|bool
      */
     public function getScheduledEvents($campaignId, $count = false, $limit = 0)
     {
@@ -252,6 +253,8 @@ class EventRepository extends CommonRepository
 
     /**
      * @param $campaignId
+     *
+     * @return array
      */
     public function getCampaignEvents($campaignId)
     {
@@ -269,7 +272,7 @@ class EventRepository extends CommonRepository
         $events = array();
         foreach ($results as $id => $r) {
             $r[0]['parent_id'] = $r[1];
-            $events[$id] = $r[0];
+            $events[$id]       = $r[0];
         }
         unset($results);
 
@@ -280,6 +283,7 @@ class EventRepository extends CommonRepository
      * Get array of events with stats
      *
      * @param array $args
+     *
      * @return array
      */
     public function getEvents($args = array())
@@ -299,7 +303,8 @@ class EventRepository extends CommonRepository
         if (isset($args['positivePathOnly'])) {
             $q->andWhere(
                 $q->expr()->orX(
-                    $q->expr()->neq('e.decisionPath',
+                    $q->expr()->neq(
+                        'e.decisionPath',
                         $q->expr()->literal('no')
                     ),
                     $q->expr()->isNull('e.decisionPath')
@@ -315,6 +320,8 @@ class EventRepository extends CommonRepository
 
     /**
      * @param $campaignId
+     *
+     * @return array
      */
     public function getCampaignActionEvents($campaignId)
     {
@@ -334,9 +341,12 @@ class EventRepository extends CommonRepository
     /**
      * Get the non-action log
      *
-     * @param $events
+     * @param       $campaignId
+     * @param array $leads
+     * @param array $havingEvents
+     * @param array $excludeEvents
      *
-     * @return mixed
+     * @return array
      */
     public function getEventLog($campaignId, $leads = array(), $havingEvents = array(), $excludeEvents = array())
     {
@@ -400,5 +410,19 @@ class EventRepository extends CommonRepository
         unset($results);
 
         return $log;
+    }
+
+    /**
+     * Null event parents in preparation for deleting a campaign
+     *
+     * @param $campaignId
+     */
+    public function nullEventParents($campaignId)
+    {
+        $this->_em->getConnection()->update(
+            MAUTIC_TABLE_PREFIX.'campaign_events',
+            array('parent_id' => null),
+            array('campaign_id' => (int) $campaignId)
+        );
     }
 }

--- a/app/bundles/CampaignBundle/Entity/LeadEventLog.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLog.php
@@ -37,7 +37,6 @@ class LeadEventLog
 
     /**
      * @ORM\ManyToOne(targetEntity="Campaign")
-     * @ORM\JoinColumn(onDelete="CASCADE")
      **/
     private $campaign;
 

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -105,6 +105,17 @@ class CampaignModel extends CommonFormModel
     }
 
     /**
+     * @param object $entity
+     */
+    public function deleteEntity($entity)
+    {
+        // Null all the event parents for this campaign to avoid database constraints
+        $this->getEventRepository()->nullEventParents($entity->getId());
+
+        parent::deleteEntity($entity);
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @param $action
@@ -159,6 +170,8 @@ class CampaignModel extends CommonFormModel
      * @param          $sessionEvents
      * @param          $sessionConnections
      * @param          $deletedEvents
+     *
+     * @return array
      */
     public function setEvents (Campaign &$entity, $sessionEvents, $sessionConnections, $deletedEvents)
     {
@@ -853,6 +866,8 @@ class CampaignModel extends CommonFormModel
 
     /**
      * @param $id
+     *
+     * @return array
      */
     public function getCampaignListIds($id)
     {


### PR DESCRIPTION
**Description** 
I couldn't consistently reproduce this but it definitely was a problem.  If campaign events had parents (connected into other events), they sometimes prevented the campaign from being deleted because of foreign constraints.  This PR works around it by nulling the parents before deleting the campaign.

**Testing**
Mainly, after the PR, delete a campaign that has a decent branching drip flow structure. 