### PR TITLE
Added campaign name for campaign events fired via CLI

### DIFF
--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -385,7 +385,8 @@ class EventModel extends CommonFormModel
     {
         defined('MAUTIC_CAMPAIGN_SYSTEM_TRIGGERED') or define('MAUTIC_CAMPAIGN_SYSTEM_TRIGGERED', 1);
 
-        $campaignId = $campaign->getId();
+        $campaignId   = $campaign->getId();
+        $campaignName = $campaign->getName();
 
         $logger = $this->factory->getLogger();
         $logger->debug('CAMPAIGN: Triggering starting events');
@@ -510,7 +511,10 @@ class EventModel extends CommonFormModel
                     }
 
                     // Set campaign ID
-                    $event['campaign'] = array('id' => $campaignId);
+                    $event['campaign'] = array(
+                        'id'   => $campaignId,
+                        'name' => $campaignName,
+                    );
 
                     $logger->debug('CAMPAIGN: Event ID# '.$event['id']);
 
@@ -621,7 +625,8 @@ class EventModel extends CommonFormModel
     {
         defined('MAUTIC_CAMPAIGN_SYSTEM_TRIGGERED') or define('MAUTIC_CAMPAIGN_SYSTEM_TRIGGERED', 1);
 
-        $campaignId = $campaign->getId();
+        $campaignId   = $campaign->getId();
+        $campaignName = $campaign->getName();
 
         $logger = $this->factory->getLogger();
         $logger->debug('CAMPAIGN: Triggering scheduled events');
@@ -719,7 +724,10 @@ class EventModel extends CommonFormModel
                     $event = $campaignEvents[$log['event_id']];
 
                     // Set campaign ID
-                    $event['campaign'] = array('id' => $campaignId);
+                    $event['campaign'] = array(
+                        'id'   => $campaignId,
+                        'name' => $campaignName
+                    );
 
                     if (!isset($eventSettings['action'][$event['type']])) {
                         unset($event);
@@ -820,7 +828,8 @@ class EventModel extends CommonFormModel
         $logger = $this->factory->getLogger();
         $logger->debug('CAMPAIGN: Triggering negative events');
 
-        $campaignId = $campaign->getId();
+        $campaignId   = $campaign->getId();
+        $campaignName = $campaign->getName();
 
         $repo         = $this->getRepository();
         $campaignRepo = $this->getCampaignRepository();
@@ -993,7 +1002,10 @@ class EventModel extends CommonFormModel
                             foreach ($eventTiming as $id => $timing) {
                                 // Set event
                                 $e             = $events[$id];
-                                $e['campaign'] = array('id' => $campaignId);
+                                $e['campaign'] = array(
+                                    'id'   => $campaignId,
+                                    'name' => $campaignName
+                                );
 
                                 // Set lead in case this is triggered by the system
                                 $leadModel->setSystemCurrentLead($l);


### PR DESCRIPTION
Fixes a notice related to adjusting a lead's points in a campaign flow when the event is triggered by CLI

See https://github.com/mautic/mautic/pull/439#issuecomment-105257066