### PR TITLE
Removed secondary menu from Addons on right sidebar

### DIFF
--- a/app/bundles/AddonBundle/Config/config.php
+++ b/app/bundles/AddonBundle/Config/config.php
@@ -45,14 +45,7 @@ return array(
                     'id'        => 'mautic_addon_root',
                     'iconClass' => 'fa-plus-circle',
                     'access'    => 'addon:addons:manage',
-                    'children'  => array(
-                        'mautic.addon.manage.addons'       => array(
-                            'route' => 'mautic_addon_index',
-                        ),
-                        'mautic.addon.manage.integrations' => array(
-                            'route' => 'mautic_addon_integration_index'
-                        ),
-                    )
+                    'route'     => 'mautic_addon_index'
                 )
             )
         )

--- a/app/bundles/CoreBundle/EventListener/CommonSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CommonSubscriber.php
@@ -138,11 +138,6 @@ class CommonSubscriber implements EventSubscriberInterface
 
             $allItems[$name] = $event->getMenuItems();
 
-            // Only store in session for prod
-            if ($this->factory->getEnvironment() == 'prod') {
-                $session->set('mautic.menu.items', $allItems);
-            }
-
             unset($bundles, $menuItems);
         } else {
             $event->setMenuItems($allItems[$name]);


### PR DESCRIPTION
**Test:** Apply PR, clear session cache, open righthand menu. Verify Addons is a single menu with no sub-navigation.