### PR TITLE
Campaign event fix

### DIFF
--- a/app/bundles/CampaignBundle/Entity/EventRepository.php
+++ b/app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -129,7 +129,8 @@ class EventRepository extends CommonRepository
             ->where(
                 $q->expr()->andX(
                     $q->expr()->eq('IDENTITY(e.campaign)', (int) $id),
-                    $q->expr()->isNull('e.parent')
+                    $q->expr()->isNull('e.parent'),
+                    $q->expr()->eq('e.eventType', $q->expr()->literal('action'))
                 )
             );
 

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -160,19 +160,6 @@ class EventModel extends CommonFormModel
             return false;
         }
 
-        if ($typeId !== null && $this->factory->getEnvironment() == 'prod') {
-            //let's prevent some unnecessary DB calls
-            $session         = $this->factory->getSession();
-            $triggeredEvents = $session->get('mautic.triggered.campaign.events', array());
-            if (in_array($typeId, $triggeredEvents)) {
-                $logger->debug('CAMPAIGN: '.$typeId.' has already been processed.');
-
-                return false;
-            }
-            $triggeredEvents[] = $typeId;
-            $session->set('mautic.triggered.campaign.events', $triggeredEvents);
-        }
-
         //get the current lead
         /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
         $leadModel = $this->factory->getModel('lead');


### PR DESCRIPTION
This PR prevents root level decisions from being pulled when starting level actions are triggered.  

It also removes the session check that prevented the same browser session from executing the same event multiple times.

**Testing**

Add a decision at the root level of a campaign, such as downloads asset connected into a delayed send email action.  Configure a form to add a lead to a list associated with a campaign and downloads an asset.  Submit the form in an anonymous browser (one you're not logged into Mautic with) and make sure you were added to the campaign and the email is showing as scheduled in the lead profile.

Now run the mautic:campaign:trigger command. For the starting level events for this campaign, it should not show any but will because it's pulling the decision and likely auto logging it as completed.  Repeating the process after the PR should not include decisions in the starting level execution.