### PR TITLE
Fixed a dashboard issue that caused a query error for postgres

### DIFF
--- a/app/bundles/DashboardBundle/Controller/DefaultController.php
+++ b/app/bundles/DashboardBundle/Controller/DefaultController.php
@@ -71,7 +71,7 @@ class DefaultController extends CommonController
         }
 
         // Audit Log
-        $logs = $this->factory->getModel('core.auditLog')->getLogForObject(null, null, 10);
+        $logs = $this->factory->getModel('core.auditLog')->getLogForObject(null, null);
 
         // Get names of log's items
         $router = $this->factory->getRouter();


### PR DESCRIPTION
This fixes ```500 Internal Server Error - An exception occurred while executing 'SELECT m0_.user_name AS user_name0, m0_.user_id AS user_id1, m0_.bundle AS bundle2, m0_.object AS object3, m0_.object_id AS object_id4, m0_.action AS action5, m0_.details AS details6, m0_.date_added AS date_added7, m0_.ip_address AS ip_address8 FROM mau_audit_log m0_ WHERE m0_.object <> ? AND m0_.date_added >= ? ORDER BY m0_.date_added DESC LIMIT 10' with params ["category", 10]: SQLSTATE[22007]: Invalid datetime format: 7 ERROR: invalid input syntax for type timestamp: "10"```

When viewing the dashboard under postgres.