### PR TITLE
Fixed other instances related to #512

### DIFF
--- a/app/bundles/FormBundle/Views/SubscribedEvents/BuilderToken/list.html.php
+++ b/app/bundles/FormBundle/Views/SubscribedEvents/BuilderToken/list.html.php
@@ -12,10 +12,9 @@ if ($tmpl == 'index') {
 }
 ?>
 <div id="formPageTokens">
+    <?php if (count($items)): ?>
     <div class="list-group ma-5">
-        <?php
-        if (count($items)):
-        foreach ($items as $i):
+        <?php foreach ($items as $i):
         $token = $view->escape(\Mautic\CoreBundle\Helper\BuilderTokenHelper::getVisualTokenHtml('{form=' . $i[0]->getId() . '}', $i[0]->getName()))
         ?>
             <a href="#" class="list-group-item" data-token="<?php echo $token; ?>">

--- a/app/bundles/LeadBundle/Views/SubscribedEvents/BuilderToken/list.html.php
+++ b/app/bundles/LeadBundle/Views/SubscribedEvents/BuilderToken/list.html.php
@@ -12,9 +12,9 @@ if ($tmpl == 'index') {
 }
 ?>
 <div id="leadEmailTokens">
+    <?php if (count($items)): ?>
     <div class="list-group">
         <?php
-        if (count($items)):
         foreach ($items as $i):
         $token = $view->escape(\Mautic\CoreBundle\Helper\BuilderTokenHelper::getVisualTokenHtml('{leadfield=' . $i['alias'] . '}', $i['label']))
         ?>

--- a/app/bundles/PageBundle/Views/SubscribedEvents/BuilderToken/list.html.php
+++ b/app/bundles/PageBundle/Views/SubscribedEvents/BuilderToken/list.html.php
@@ -12,10 +12,9 @@ if ($tmpl == 'index') {
 }
 ?>
 <div id="pageBuilderTokens">
+    <?php if (count($items)): ?>
     <div class="list-group ma-5">
-        <?php
-        if (count($items)):
-        foreach ($items as $i):?>
+        <?php foreach ($items as $i): ?>
             <a href="#" class="list-group-item" data-token='<a href="%url={pagelink=<?php echo $i->getId(); ?>}%">%text=<?php echo $i->getName(); ?>%</a>' data-drop="showBuilderLinkModal">
                 <span><i class="fa fa-fw fa-file-text-o"></i><?php echo $i->getName() . ' (' . $i->getLanguage() . ')'; ?></span>
             </a>


### PR DESCRIPTION
Fixes same issue as #512 but in other places.  This only becomes apparent in the email form when there are no landing pages, assets, etc in the token lists which causes the type selection to not appear for a new email.