### PR TITLE
Added support for leadfield token fall backs

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/plugins/tokens/plugin.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/plugins/tokens/plugin.js
@@ -313,14 +313,12 @@ CKEDITOR_tokens.prototype.timeout_callback = function (args) {
             if ($(this).data('visual')) {
                 // Placeholder
                 var tokenContent = document.createElement('strong');
-                var em = document.createElement('em');
-                tokenContent.appendChild(em);
 
                 tokenContent.setAttribute('data-token', $(this).data('token'));
                 tokenContent.setAttribute('contenteditable', 'false');
 
                 var description = document.createTextNode('**' + $(this).data('description') + '**');
-                em.appendChild(description);
+                tokenContent.appendChild(description);
             } else if ($(this).data('link')) {
                 var tokenContent = document.createElement('a');
                 tokenContent.setAttribute('href', $(this).data('token'));

--- a/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
+++ b/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
@@ -249,13 +249,27 @@ class BuilderTokenHelper
             }
         } else {
             if (isset($tokens['visualTokens'])) {
-                $search = $replace = array();
-                foreach ($tokens['visualTokens'] as $token) {
-                    $search[]  = $token;
-                    $replace[] = self::getVisualTokenHtml($token, $tokens['tokens'][$token]);
-                }
+                // Get all the tokens in the content
+                if (preg_match_all('/{(.*?)}/', $content, $matches)) {
+                    $search = $replace = array();
 
-                $content = str_ireplace($search, $replace, $content);
+                    foreach ($matches[0] as $tokenMatch) {
+                        if (strstr($tokenMatch, '|')) {
+                            // This token has been customized
+                            $tokenParts = explode('|', $tokenMatch);
+                            $token = $tokenParts[0] . '}';
+                        } else {
+                            $token = $tokenMatch;
+                        }
+
+                        if (in_array($token, $tokens['visualTokens'])) {
+                            $search[]  = $tokenMatch;
+                            $replace[] = self::getVisualTokenHtml($tokenMatch, $tokens['tokens'][$token]);
+                        }
+                    }
+
+                    $content = str_ireplace($search, $replace, $content);
+                }
             }
         }
     }
@@ -270,10 +284,10 @@ class BuilderTokenHelper
     static public function getVisualTokenHtml($token, $description, $forPregReplace = false)
     {
         if ($forPregReplace) {
-            return preg_quote('<strong contenteditable="false" data-token="', '/').'(.*?)'.preg_quote('"><em>**', '/')
-            .'(.*?)'.preg_quote('**</em></strong>', '/');
+            return preg_quote('<strong contenteditable="false" data-token="', '/').'(.*?)'.preg_quote('">**', '/')
+            .'(.*?)'.preg_quote('**</strong>', '/');
         }
 
-        return '<strong contenteditable="false" data-token="'.$token.'"><em>**'.$description.'**</em></strong>';
+        return '<strong contenteditable="false" data-token="'.$token.'">**'.$description.'**</strong>';
     }
 }

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -474,7 +474,7 @@ class EmailController extends FormController
                     } else {
                         $entity->setCustomHtml($content);
                     }
-
+                    
                     //form is valid so process the data
                     $model->saveEntity($entity);
 

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -69,6 +69,12 @@ class EmailModel extends FormModel
     {
         $now = new \DateTime();
 
+        $type = $entity->getEmailType();
+        if (empty($type)) {
+            // Just in case JS failed
+            $entity->setEmailType('template');
+        }
+
         //set the author for new pages
         if (!$entity->isNew()) {
             //increase the revision

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -14,6 +14,9 @@ $view['slots']->set("headerTitle", $email->getName());
 $isVariant    = $email->isVariant(true);
 $showVariants = count($variants['children']);
 $emailType    = $email->getEmailType();
+if (empty($emailType)) {
+    $emailType = 'template';
+}
 $sentCount    = $email->getSentCount();
 
 $edit = ($emailType == 'template' || empty($sentCount)) && $security->hasEntityAccess($permissions['email:emails:editown'], $permissions['email:emails:editother'], $email->getCreatedBy());

--- a/app/bundles/LeadBundle/EventListener/EmailSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/EmailSubscriber.php
@@ -96,10 +96,22 @@ class EmailSubscriber extends CommonSubscriber
                     continue;
                 }
 
-                $urlencode = (strpos($match, '|true') !== false);
-                $alias     = ($urlencode) ? str_replace('|true', '', $match) : $match;
-                $value     = (isset($lead[$alias])) ? $lead[$alias] : '';
+                $fallbackCheck = explode('|', $match);
+                $fallback      = $urlencode = false;
 
+                if (isset($fallbackCheck[1])) {
+                    // There is a fallback or to be urlencoded
+                    $alias = $fallbackCheck[0];
+
+                    if ($fallbackCheck[1] === 'true') {
+                        $urlencode = true;
+                        $fallback  = '';
+                    } else {
+                        $fallback = $fallbackCheck[1];
+                    }
+                }
+
+                $value             = (!empty($lead[$alias])) ? $lead[$alias] : $fallback;
                 $tokenList[$token] = ($urlencode) ? urlencode($value) : $value;
             }
 


### PR DESCRIPTION
Editing the source in an email editor and adjusting {leadfield=alias|custom fallback} will populate the token with the fallback if the lead doesn't have anything for the alias.