### PR TITLE
Set MauticFactory via a methodCall for the Mandrill transport

### DIFF
--- a/app/bundles/CoreBundle/Command/ProcessEmailQueueCommand.php
+++ b/app/bundles/CoreBundle/Command/ProcessEmailQueueCommand.php
@@ -66,6 +66,15 @@ EOT
         $quiet      = $input->getOption('quiet');
         $timeout    = $input->getOption('clear-timeout');
 
+        $factory    = $container->get('mautic.factory');
+        $queueMode  = $factory->getParameter('mailer_spool_type');
+
+        if ($queueMode != 'file') {
+            $output->writeln('Mautic is not set to queue email.');
+
+            return 0;
+        }
+
         if (empty($timeout)) {
             $timeout = $container->getParameter('mautic.mailer_spool_clear_timeout');
         }

--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -296,8 +296,9 @@ return array(
                 'class'        => 'Mautic\CoreBundle\Swiftmailer\Transport\MandrillTransport',
                 'serviceAlias' => 'swiftmailer.mailer.transport.%s',
                 'methodCalls'  => array(
-                    'setUsername'   => array('%mautic.mailer_user%'),
-                    'setPassword'   => array('%mautic.mailer_password%')
+                    'setUsername'      => array('%mautic.mailer_user%'),
+                    'setPassword'      => array('%mautic.mailer_password%'),
+                    'setMauticFactory' => array('mautic.factory')
                 )
             ),
             'mautic.transport.sendgrid'          => array(

--- a/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php
+++ b/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php
@@ -154,7 +154,28 @@ class MauticCoreExtension extends Extension
                         // Set method calls
                         if (!empty($details['methodCalls'])) {
                             foreach ($details['methodCalls'] as $method => $methodArguments) {
-                                $definition->addMethodCall($method, $methodArguments);
+                                $methodCallArguments = array();
+                                foreach ($methodArguments as $argument) {
+                                    if (is_array($argument) || is_object($argument)) {
+                                        foreach ($argument as $k => &$v) {
+                                            if (strpos($v, '%') === 0) {
+                                                $v = $container->getParameter(substr($v, 1, -1));
+                                            }
+                                        }
+                                        $methodCallArguments[] = $argument;
+                                    } elseif (is_bool($argument) || strpos($argument, '%') === 0 || strpos($argument, '\\') !== false) {
+                                        // Parameter or Class
+                                        $methodCallArguments[] = $argument;
+                                    } elseif (strpos($argument, '"') === 0) {
+                                        // String
+                                        $methodCallArguments[] = substr($argument, 1, -1);
+                                    } else {
+                                        // Reference
+                                        $methodCallArguments[] = new Reference($argument);
+                                    }
+                                }
+
+                                $definition->addMethodCall($method, $methodCallArguments);
                             }
                         }
 


### PR DESCRIPTION
**Description**
When using Mandrill and the Mautic's queue means of handling mail, the CLI command to process the queue may result in an error due to working outside the MailHelper class.  This fixes that by configuring Symfony to use a method call to set MauticFactory so that it's always set for the service. (Had to adjust the service configuration code to support services as arguments for methodCalls).

**Testing**
Apply PR, configure Mandrill as the mailer then try to send an email.  It should be successful (an unsuccessful test will be an error related to the mandrill transport service).