### PR TITLE
Added support  for an app/config/bundles_local.php file

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -192,6 +192,11 @@ class AppKernel extends Kernel
             $bundles[] = new Liip\FunctionalTestBundle\LiipFunctionalTestBundle();
         }
 
+        // Check for local bundle inclusion
+        if (file_exists(__DIR__ .'/config/bundles_local.php')) {
+            include __DIR__ . '/config/bundles_local.php';
+        }
+
         return $bundles;
     }
 
@@ -329,7 +334,9 @@ class AppKernel extends Kernel
     /**
      * @param array $params
      *
-     * @return bool|\Doctrine\DBAL\Connection
+     * @return \Doctrine\DBAL\Connection
+     * @throws Exception
+     * @throws \Doctrine\DBAL\DBALException
      */
     private function getDatabaseConnection($params = array())
     {
@@ -426,7 +433,7 @@ class AppKernel extends Kernel
     /**
      * Get local config file
      *
-     * @param $checkExists If true, then return false if the file doesn't exist
+     * @param bool $checkExists If true, then return false if the file doesn't exist
      *
      * @return bool
      */


### PR DESCRIPTION
**Description**

This is a dev/customization PR. It adds support to create a local app/config/bundles_local.php file to include 3rd party Symfony bundles without the need to maintain a hacked AppKernel.php.
