### PR TITLE
Fixed dispatching lead lists and api client post save events

### DIFF
--- a/app/bundles/ApiBundle/Model/ClientModel.php
+++ b/app/bundles/ApiBundle/Model/ClientModel.php
@@ -116,7 +116,7 @@ class ClientModel extends FormModel
                 $event = new ClientEvent($entity, $isNew);
                 $event->setEntityManager($this->em);
             }
-            $this->dispatcher->dispatch(ApiEvents::CLIENT_POST_SAVE, $event);
+            $this->dispatcher->dispatch($name, $event);
             return $event;
         }
 

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -184,7 +184,7 @@ class ListModel extends FormModel
                 $event = new LeadListEvent($entity, $isNew);
                 $event->setEntityManager($this->em);
             }
-            $this->dispatcher->dispatch(LeadEvents::LIST_PRE_SAVE, $event);
+            $this->dispatcher->dispatch($name, $event);
 
             return $event;
         } else {
@@ -289,11 +289,12 @@ class ListModel extends FormModel
     /**
      * Rebuild lead lists
      *
-     * @param LeadList $entity
-     * @param          $limit
-     * @param          $batchsize
+     * @param LeadList        $entity
+     * @param int             $limit
+     * @param bool            $maxLeads
+     * @param OutputInterface $output
      *
-     * @throws \Doctrine\ORM\ORMException
+     * @return int
      */
     public function rebuildListLeads(LeadList $entity, $limit = 1000, $maxLeads = false, OutputInterface $output = null)
     {


### PR DESCRIPTION
**Description**
Event dispatching for post save events for lead lists and api clients failed due to the dynamic name not used.
