### PR TITLE
Fixed issue with populating and repopulating lead fields

### DIFF
--- a/app/bundles/FormBundle/Controller/FieldController.php
+++ b/app/bundles/FormBundle/Controller/FieldController.php
@@ -215,6 +215,10 @@ class FieldController extends CommonFormController
             // Only show the lead fields not already used
             $usedLeadFields = $session->get('mautic.form.'.$formId.'.fields.leadfields', array());
             $testLeadFields = array_flip($usedLeadFields);
+            $currentLeadField = $formField['leadField'];
+            if (!empty($currentLeadField) && isset($testLeadFields[$currentLeadField])) {
+                unset($testLeadFields[$currentLeadField]);
+            }
             $leadFields     = $this->factory->getModel('lead.field')->getFieldList();
             foreach ($leadFields as &$group) {
                 $group = array_diff_key($group, $testLeadFields);

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -603,6 +603,9 @@ class FormController extends CommonFormController
                     $usedLeadFields[$id] = $field['leadField'];
                 }
             }
+
+            $session->set('mautic.form.'.$objectId.'.fields.leadfields', $usedLeadFields);
+
             if (!empty($reorder)) {
                 uasort(
                     $modifiedFields,


### PR DESCRIPTION
**Description**
This PR fixes issues with editing form fields which wouldn't re-populate the lead field correctly.

**Testing**
Create a form, add a form field and assign it a lead field.  Save then edit the field again and you'll see the lead field is no longer assigned and not available to be assigned.  After the PR, these should be fixed.