### PR TITLE
Dispatch an event when a campaign action is triggered

### DIFF
--- a/app/bundles/CampaignBundle/CampaignEvents.php
+++ b/app/bundles/CampaignBundle/CampaignEvents.php
@@ -76,4 +76,14 @@ final class CampaignEvents
      * @var string
      */
     const CAMPAIGN_ON_LEADCHANGE  = 'mautic.campaign_on_leadchange';
+
+    /**
+     * The mautic.campaign_on_event_execution event is dispatched when a campaign event is executed
+     *
+     * The event listener receives a
+     * Mautic\CampaignBundle\Event\CampaignExecutionEvent instance.
+     *
+     * @var string
+     */
+    const ON_EVENT_EXECUTION = 'mautic.campaign_on_event_execution';
 }

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -1094,11 +1094,15 @@ class CampaignController extends FormController
         $currentSources  = $session->get('mautic.campaign.'.$id.'.leadsources.current', array());
         $modifiedSources = $session->get('mautic.campaign.'.$id.'.leadsources.modified', array());
 
+        if ($currentSources === $modifiedSources) {
+            return array(array(), array(), $currentSources);
+        }
+
         // Deleted sources
         $deletedSources = array();
         foreach ($currentSources as $type => $sources) {
             if (isset($modifiedSources[$type])) {
-                $deletedSources[$type] = array_diff_key($sources, array_flip($modifiedSources[$type]));
+                $deletedSources[$type] = array_diff($sources, $modifiedSources[$type]);
             } else {
                 $deletedSources[$type] = $sources;
             }
@@ -1108,7 +1112,7 @@ class CampaignController extends FormController
         $addedSources = array();
         foreach ($modifiedSources as $type => $sources) {
             if (isset($currentSources[$type])) {
-                $addedSources[$type] = array_diff_key($sources, array_flip($currentSources[$type]));
+                $addedSources[$type] = array_diff($sources, $currentSources[$type]);
             } else {
                 $addedSources[$type] = $sources;
             }

--- a/app/bundles/CampaignBundle/Event/CampaignExecutionEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignExecutionEvent.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2015 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CampaignBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class CampaignEvent
+ *
+ * @package Mautic\CampaignBundle\Event
+ */
+class CampaignExecutionEvent extends Event
+{
+    protected $lead;
+    protected $event;
+    protected $config;
+    protected $eventDetails;
+    protected $systemTriggered;
+    protected $result;
+
+    public function __construct($args, $result)
+    {
+        $this->lead            = $args['lead'];
+        $this->event           = $args['event'];
+        $this->config          = $args['config'];
+        $this->eventDetails    = $args['eventDetails'];
+        $this->systemTriggered = $args['systemTriggered'];
+        $this->result          = $result;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLead()
+    {
+        return $this->lead;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getEvent()
+    {
+        return $this->event;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getEventDetails()
+    {
+        return $this->eventDetails;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getSystemTriggered()
+    {
+        return $this->systemTriggered;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getResult()
+    {
+        return $this->result;
+    }
+}

--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -81,7 +81,7 @@ class LeadSubscriber extends CommonSubscriber
                     $removeLeads = array();
                     foreach ($leads as $l) {
                         $lists = (isset($leadLists[$l])) ? $leadLists[$l] : array();
-                        if (array_intersect($lists, $campaignLists[$c['id']])) {
+                        if (array_intersect(array_keys($lists), $campaignLists[$c['id']])) {
                             continue;
                         } else {
                             $removeLeads[] = $l;

--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -321,14 +321,18 @@ class FormModel extends CommonModel
     /**
      * Dispatches events for child classes
      *
-     * @param string $action
-     * @param object $entity
-     * @param bool   $isNew
-     * @param Event  $event
+     * @param       $action
+     * @param       $entity
+     * @param bool  $isNew
+     * @param Event $event
+     *
+     * @return Event|null
      */
     protected function dispatchEvent($action, &$entity, $isNew = false, Event $event = null)
     {
         //...
+
+        return $event;
     }
 
     /**


### PR DESCRIPTION
This adds a new event that is dispatched when a campaign event is triggered allowing listeners to take action based on what happened.

It also prevents a PHP notice and false campaign source change records.