### PR TITLE
Fixes being able to send test email through Configuration for Mandrill

### DIFF
--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -636,6 +636,10 @@ class AjaxController extends CommonController
                     break;
             }
 
+            if (method_exists($mailer, 'setMauticFactory')) {
+                $mailer->setMauticFactory($this->factory);
+            }
+
             if (!empty($mailer)) {
                 if (empty($settings['password'])) {
                     $settings['password'] = $this->factory->getParameter('mailer_password');


### PR DESCRIPTION
**Description**
Trying to use the "Send Test Email" button in the Configuration would fail for Mandrill due to trying to use a non-object.  This PR sets MauticFactory if required which fixes the problem. 

**Testing**
Choose Mandrill as the mail transport and click the send test email button.  It should just spin and spin. The PR will fix that and send the test email.