### PR TITLE
Fixes the webview_url and unsubscribe_url tokens

### DIFF
--- a/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
@@ -62,16 +62,24 @@ class BuilderSubscriber extends CommonSubscriber
 
         $tokens = array(
             '{unsubscribe_text}' => $this->translator->trans('mautic.email.token.unsubscribe_text'),
-            '{unsubscribe_url}'  => $this->translator->trans('mautic.email.token.unsubscribe_url'),
-            '{webview_text}'     => $this->translator->trans('mautic.email.token.webview_text'),
-            '{webview_url}'      => $this->translator->trans('mautic.email.token.webview_url')
+            '{webview_text}'     => $this->translator->trans('mautic.email.token.webview_text')
         );
 
         if ($event->tokensRequested(array_keys($tokens))) {
-            unset($tokens['{leadfield}']);
             $event->addTokens(
                 $event->filterTokens($tokens),
                 true
+            );
+        }
+
+        // these should not allow visual tokens
+        $tokens = array(
+            '{unsubscribe_url}'  => $this->translator->trans('mautic.email.token.unsubscribe_url'),
+            '{webview_url}'      => $this->translator->trans('mautic.email.token.webview_url')
+        );
+        if ($event->tokensRequested(array_keys($tokens))) {
+            $event->addTokens(
+                $event->filterTokens($tokens)
             );
         }
     }


### PR DESCRIPTION
**Description**
The {webview_url} and {unsubscribe_url} tokens are used within links and thus cannot use the visual representations in the editor or it corrupts the links HTML.  This PR fixes it.

**Testing**
Insert {webview_url} into a link in the editor. Save and reopen.  The html will be corrupted.  Don't save again or else it'll be permanently corrupted.  Apply the PR and try again.  This time the html should be correctly reloaded. 