### PR TITLE
Ensure that a form's cached html exists

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -160,9 +160,10 @@ class PublicController extends CommonFormController
             /** @var \Mautic\FormBundle\Entity\Form $unsubscribeForm */
             $unsubscribeForm = $email->getUnsubscribeForm();
 
-            if ($unsubscribeForm != null) {
+            if ($unsubscribeForm != null && $unsubscribeForm->isPublished()) {
                 $formTemplate = $unsubscribeForm->getTemplate();
-                $formContent  = '<div class="mautic-unsubscribeform">' . $unsubscribeForm->getCachedHtml() . '</div>';
+                $formModel    = $this->factory->getModel('form');
+                $formContent  = '<div class="mautic-unsubscribeform">' . $formModel->getContent($unsubscribeForm) . '</div>';
             }
         } else {
             $email = $lead = false;

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -225,7 +225,8 @@ class FormController extends CommonFormController
                     'submissionsInTime' => $timeStats,
                 ),
                 'activeFormActions' => $activeFormActions,
-                'activeFormFields'  => $activeFormFields
+                'activeFormFields'  => $activeFormFields,
+                'formContent'  => htmlspecialchars($model->getContent($activeForm), ENT_QUOTES, "UTF-8")
             ),
             'contentTemplate' => 'MauticFormBundle:Form:details.html.php',
             'passthroughVars' => array(
@@ -751,11 +752,8 @@ class FormController extends CommonFormController
         ))  {
             $html = '<h1>' . $this->get('translator')->trans('mautic.core.error.accessdenied', array(), 'flashes') . '</h1>';
         } else {
-            $html = $form->getCachedHtml();
+            $html = $model->getContent($form);
         }
-
-        $model->populateValuesWithGetParameters($form, $html);
-        $html = $form->getCachedHtml();
 
         $model->populateValuesWithGetParameters($form, $html);
 

--- a/app/bundles/FormBundle/Controller/PublicController.php
+++ b/app/bundles/FormBundle/Controller/PublicController.php
@@ -241,7 +241,7 @@ class PublicController extends CommonFormController
             throw $this->createNotFoundException($this->factory->getTranslator()->trans('mautic.core.url.error.404'));
 
         } else {
-            $html = $form->getCachedHtml();
+            $html = $model->getContent($form);
 
             $model->populateValuesWithGetParameters($form, $html);
 

--- a/app/bundles/FormBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/PageSubscriber.php
@@ -86,7 +86,7 @@ class PageSubscriber extends CommonSubscriber
                         )
                     )
                 ) {
-                    $formHtml = ($form->isPublished()) ? $form->getCachedHtml() :
+                    $formHtml = ($form->isPublished()) ? $model->getContent($form) :
                         '<div class="mauticform-error">' .
                         $this->translator->trans('mautic.form.form.pagetoken.notpublished') .
                         '</div>';

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -160,6 +160,7 @@ class FormModel extends CommonFormModel
     /**
      * @param Form $entity
      * @param      $sessionActions
+     * @param      $sessionFields
      */
     public function setActions(Form &$entity, $sessionActions, $sessionFields)
     {
@@ -228,10 +229,30 @@ class FormModel extends CommonFormModel
     }
 
     /**
+     * Obtains the cached HTML of a form and generates it if missing
+     *
+     * @param Form $form
+     *
+     * @return string
+     */
+    public function getContent(Form $form)
+    {
+        $cachedHtml = $form->getCachedHtml();
+
+        if (empty($cachedHtml)) {
+            $cachedHtml = $this->generateHtml($form);
+        }
+
+        return $cachedHtml;
+    }
+
+    /**
      * Generate the form's html
      *
      * @param Form $entity
      * @param bool $persist
+     *
+     * @return string
      */
     public function generateHtml(Form $entity, $persist = true)
     {
@@ -257,6 +278,8 @@ class FormModel extends CommonFormModel
             //bypass model function as events aren't needed for this
             $this->getRepository()->saveEntity($entity);
         }
+
+        return $html;
     }
 
     /**
@@ -389,7 +412,7 @@ class FormModel extends CommonFormModel
      */
     public function getAutomaticJavascript(Form $form)
     {
-        $html = $form->getCachedHtml();
+        $html = $this->getContent($form);
 
         //replace line breaks with literal symbol and escape quotations
         $search  = array("\n", '"');

--- a/app/bundles/FormBundle/Views/Form/details.html.php
+++ b/app/bundles/FormBundle/Views/Form/details.html.php
@@ -256,7 +256,7 @@ $isStandalone = $activeForm->isStandalone();
                   </div>
                   <div class="panel-body">
                       <p><?php echo $view['translator']->trans('mautic.form.form.help.manualcopy'); ?></p>
-                      <textarea class="form-html form-control" readonly onclick="this.setSelectionRange(0, this.value.length);"><?php echo htmlspecialchars($activeForm->getCachedHtml(), ENT_QUOTES, "UTF-8"); ?></textarea>
+                      <textarea class="form-html form-control" readonly onclick="this.setSelectionRange(0, this.value.length);"><?php echo $formContent; ?></textarea>
                   </div>
                   <div class="panel-footer text-right">
                       <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>


### PR DESCRIPTION
**Description**
This PR changes the use of $form->getCachedHtml() to use a model function instead that checks that the content of cached html is not empty then caches if it is.

**Testing**
Create a form, manually empty the cached_html column in the forms table then view the form.  The content should have been regenerated.