### PR TITLE
Urlencoded oauth_callback if used for oauth1a integrations

### DIFF
--- a/app/bundles/AddonBundle/Helper/oAuthHelper.php
+++ b/app/bundles/AddonBundle/Helper/oAuthHelper.php
@@ -122,7 +122,7 @@ class oAuthHelper
         }
 
         if (!empty($this->settings['append_callback']) && !empty($this->callback)) {
-            $oauth['oauth_callback'] = $this->callback;
+            $oauth['oauth_callback'] = urlencode($this->callback);
         }
 
         return $oauth;
@@ -198,6 +198,8 @@ class oAuthHelper
      * Returns an encoded string according to the RFC3986.
      *
      * @param $string
+     *
+     * @return string
      */
     public function encode ($string)
     {


### PR DESCRIPTION
**Description**
Addons with integrations that use oauth1a and oauth_callback failed because oauth_callback wasn't urlencoded. This PR fixes that.

**Testing**
Tricky to do without a publicly available addon that leverages oauth1a and oauth_callback.