### PR TITLE
Fixed lead date_identified lifecycle callback

### DIFF
--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -613,7 +613,15 @@ class Lead extends FormEntity
      */
     public function isAnonymous()
     {
-        if ($name = $this->getName() || !empty($this->fields['core']['company']['value']) || !empty($this->fields['core']['email']['value'])) {
+        if (
+        $name = $this->getName() ||
+            !empty($this->updatedFields['firstname']) ||
+            !empty($this->updatedFields['lastname']) ||
+            !empty($this->updatedFields['company']) ||
+            !empty($this->updatedFields['email']) ||
+            !empty($this->fields['core']['company']['value']) ||
+            !empty($this->fields['core']['email']['value'])
+        ) {
             return false;
         } else {
             return true;


### PR DESCRIPTION
**Description**
New leads were not marked as identified due to the isAnonymous check not looking at newly updated fields for the Lead entity.  This PR fixes that.

**Testing**
Import leads with at least a name. Check the date_identified field in the table.  It should be null.  Apply the PR, import some more leads and now they should have date_identified populated.