### PR TITLE
Fixed issue where asset file upload size limit did not honor PHP limits

### DIFF
--- a/app/bundles/AssetBundle/Controller/AssetController.php
+++ b/app/bundles/AssetBundle/Controller/AssetController.php
@@ -267,7 +267,7 @@ class AssetController extends FormController
             return $this->accessDenied();
         }
 
-        $maxSize    = $this->factory->getParameter('max_size');
+        $maxSize    =  $model->getMaxUploadSize();
         $extensions = '.' . implode(', .', $this->factory->getParameter('allowed_extensions'));
 
         $maxSizeError = $this->get('translator')->trans('mautic.asset.asset.error.file.size', array(
@@ -399,7 +399,7 @@ class AssetController extends FormController
         $session    = $this->factory->getSession();
         $page       = $this->factory->getSession()->get('mautic.asset.page', 1);
         $method     = $this->request->getMethod();
-        $maxSize    = $this->factory->getParameter('max_size');
+        $maxSize    = $model->getMaxUploadSize();
         $extensions = '.' . implode(', .', $this->factory->getParameter('allowed_extensions'));
 
         $maxSizeError = $this->get('translator')->trans('mautic.asset.asset.error.file.size', array(

--- a/app/bundles/AssetBundle/EventListener/UploadSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/UploadSubscriber.php
@@ -89,7 +89,8 @@ class UploadSubscriber extends CommonSubscriber
     {
         $file       = $event->getFile();
         $extensions = $this->factory->getParameter('allowed_extensions');
-        $maxSize    = Asset::convertSizeToBytes($this->factory->getParameter('max_size') . 'M'); // max size is set in MB
+        $maxAllowed = $this->factory->getModel('asset')->getMaxUploadSize();
+        $maxSize    = Asset::convertSizeToBytes($maxAllowed . 'M'); // max size is set in MB
 
         if ($file !== null) {
             if ($file->getSize() > $maxSize) {


### PR DESCRIPTION
**Description**
If the mautic configured max_asset parameter was bigger than PHP's limits, Mautic would try to upload the asset but would ultimately fail once the PHP limit is hit.  This PR ensures Dropzone uses the max size supported by the system.

**Testing**
Set PHP upload_max_filesize to something lower than what's configured in Mautic' config as max asset size.  Then try to upload a file that is bigger than upload_max_filesize but smaller than Mautic's configured asset size.  Dropzone will attempt to upload it but fail.  

Apply the PR and now Dropzone should not allow the file to even start uploading.