### PR TITLE
Fixes issue with addons and clearing Symfony's cache from command line

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -63,11 +63,6 @@ class AppKernel extends Kernel
 
         if (strpos($request->getRequestUri(), 'installer') !== false || !$this->isInstalled()) {
             define('MAUTIC_INSTALLER', 1);
-        } else {
-            //set the table prefix before boot
-            $localParams = $this->getLocalParams();
-            $prefix      = isset($localParams['db_table_prefix']) ? $localParams['db_table_prefix'] : '';
-            define('MAUTIC_TABLE_PREFIX', $prefix);
         }
 
         if (false === $this->booted) {
@@ -106,9 +101,9 @@ class AppKernel extends Kernel
                 error_log($e);
                 throw new \Mautic\CoreBundle\Exception\DatabaseConnectionException(
                     $this->getContainer()->get('translator')->trans('mautic.core.db.connection.error', array(
-                        '%code%' => $e->getCode()
-                    )
-                ));
+                            '%code%' => $e->getCode()
+                        )
+                    ));
             }
         }
 
@@ -209,6 +204,13 @@ class AppKernel extends Kernel
             return;
         }
 
+        if (!defined('MAUTIC_INSTALLER') && !defined('MAUTIC_TABLE_PREFIX')) {
+            //set the table prefix before boot
+            $localParams = $this->getLocalParams();
+            $prefix      = isset($localParams['db_table_prefix']) ? $localParams['db_table_prefix'] : '';
+            define('MAUTIC_TABLE_PREFIX', $prefix);
+        }
+
         if ($this->loadClassCache) {
             $this->doLoadClassCache($this->loadClassCache[0], $this->loadClassCache[1]);
         }
@@ -218,6 +220,13 @@ class AppKernel extends Kernel
 
         // init container
         $this->initializeContainer();
+
+        // If in console, set the table prefix since handle() is not executed
+        if (defined('IN_MAUTIC_CONSOLE') && !defined('MAUTIC_TABLE_PREFIX')) {
+            $localParams = $this->getLocalParams();
+            $prefix      = isset($localParams['db_table_prefix']) ? $localParams['db_table_prefix'] : '';
+            define('MAUTIC_TABLE_PREFIX', $prefix);
+        }
 
         $registeredAddonBundles = $this->container->getParameter('mautic.addon.bundles');
 
@@ -338,7 +347,7 @@ class AppKernel extends Kernel
      * @throws Exception
      * @throws \Doctrine\DBAL\DBALException
      */
-    private function getDatabaseConnection($params = array())
+    public function getDatabaseConnection($params = array())
     {
         if (empty($params)) {
             $params = $this->getLocalParams();
@@ -402,7 +411,7 @@ class AppKernel extends Kernel
      *
      * @return array
      */
-    private function getLocalParams()
+    public function getLocalParams()
     {
         static $localParameters;
 


### PR DESCRIPTION
**Description**
If using addons that register services, etc and if Symfony's cache is cleared through the command line, the addon's services, routes, menu etc were not rebuilt into the cache resulting in exceptions.  The reason is that the table prefix constant was defined in the kernel's handle() function which is only used through the request scope (web UI) and thus Mautic did not find any enabled addons due to not finding the addon table.  This PR moves it to the kernel's boot() method instead so that it's set for both cli and web.

**Testing**
Somewhat tricky unless you have a publicly available addon that uses menu, routes, etc.  But, you can try to add a bogus menu item to one of the included addon's Config/config.php file.  Add a table prefix to Mautic's config.  Enable the addon.  Then run `php app/console cache:clear` from the command line.  The menu item should not be loaded or maybe even result in errors.  After the PR, the menu item should be found even after clearing the cache from the command line.  