### PR TITLE
Email unsubscribe fix

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -842,7 +842,7 @@ class EmailModel extends FormModel
             $sendTo = $leads;
         }
 
-        if ($ignoreDNC) {
+        if (!$ignoreDNC) {
             //get the list of do not contacts
             static $dnc;
             if (!is_array($dnc)) {
@@ -1126,7 +1126,9 @@ class EmailModel extends FormModel
         $repo = $this->getRepository();
         if (!$repo->checkDoNotEmail($address)) {
             $dnc = new DoNotEmail();
-            $dnc->setEmail($email);
+            if ($email != null) {
+                $dnc->setEmail($email);
+            }
             $dnc->setLead($lead);
             $dnc->setEmailAddress($address);
             $dnc->setDateAdded(new \DateTime());


### PR DESCRIPTION
**Description**
If clicking an unsubcribe link form an email sent directly to a lead's profile, a blank page or exception will occur due to the system trying to associate with a specific email ID. This PR should fix that so that unsubscribe links should work even if not associated with a specific email ID.

This also fixes an issue where the system would continue sending emails to those marked as do not contact :-/ 

**Testing**
Add an {unsubscribe_url} token to a template email, go to a lead's profile, Send Email, select the email from the dropdown list to have the content populated.  Send.  Click on the unsubscribe link in the email, should hit white page or error depending on the environment used.

Apply the PR, the lead should not get error and is registered as do not contact.