### PR TITLE
Removes the all option from pagination limit list

### DIFF
--- a/app/bundles/CoreBundle/Form/Type/ConfigType.php
+++ b/app/bundles/CoreBundle/Form/Type/ConfigType.php
@@ -475,8 +475,7 @@ class ConfigType extends AbstractType
                 25  => 'mautic.core.pagination.25',
                 30  => 'mautic.core.pagination.30',
                 50  => 'mautic.core.pagination.50',
-                100 => 'mautic.core.pagination.100',
-                0   => 'mautic.core.pagination.all'
+                100 => 'mautic.core.pagination.100'
             ),
             'expanded'    => false,
             'multiple'    => false,

--- a/app/bundles/CoreBundle/Views/Helper/pagination.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/pagination.html.php
@@ -38,8 +38,7 @@ $limitOptions = array(
     25  => '25',
     30  => '30',
     50  => '50',
-    100 => '100',
-    0   => 'all'
+    100 => '100'
 );
 
 $formExit = (!empty($ignoreFormExit)) ? ' data-ignore-formexit="true"' : '';


### PR DESCRIPTION
**Description**
Just removes the "all" option from the pagination limit lists since the system can't support loading thousands of items in a single page view (what web ui could?) :-)