### PR TITLE
Fixed error when fitlering report data by multiple table column filters

### DIFF
--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -433,7 +433,7 @@ class ReportModel extends FormModel
                 }
             }
             $query->andWhere($filterExpressions);
-            $query->setParameters($parameters);
+            $query->setParameters($filterParameters);
         }
         $contentTemplate = $reportGenerator->getContentTemplate();
 


### PR DESCRIPTION
**Description**
If applying more than one filter to report data using the table header filters would result in a DQL error that specific parameters could not be found.  This PR fixes the issue.

**Testing**
Go to Reports and select any report.  Add values to two of the table header filters which should result in an uh oh or DQL exception.  After applying the PR, the report filters should work.
