### PR TITLE
Fixes issues with sending emails to users

### DIFF
--- a/app/bundles/AssetBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/BuilderSubscriber.php
@@ -106,18 +106,22 @@ class BuilderSubscriber extends CommonSubscriber
     private function generateTokensFromContent($event, $leadId, $source = array(), $emailId = null)
     {
         $content       = $event->getContent();
-        $pagelinkRegex = '/' . $this->assetToken . '/';
+        $pagelinkRegex = '/'.$this->assetToken.'/';
 
         /** @var \Mautic\AssetBundle\Model\AssetModel $model */
-        $model        = $this->factory->getModel('asset');
-        $clickthrough = array('source' => $source);
+        $model = $this->factory->getModel('asset');
 
-        if ($leadId !== null) {
-            $clickthrough['lead'] = $leadId;
-        }
+        $clickthrough = array();
+        if ($event instanceof PageDisplayEvent || ($event instanceof EmailSendEvent && !$event->isInternalSend())) {
+            $clickthrough = array('source' => $source);
 
-        if (!empty($emailId)) {
-            $clickthrough['email'] = $emailId;
+            if ($leadId !== null) {
+                $clickthrough['lead'] = $leadId;
+            }
+
+            if (!empty($emailId)) {
+                $clickthrough['email'] = $emailId;
+            }
         }
 
         $tokens = array();

--- a/app/bundles/CoreBundle/Helper/MailHelper.php
+++ b/app/bundles/CoreBundle/Helper/MailHelper.php
@@ -884,6 +884,16 @@ class MailHelper
     }
 
     /**
+     * Check if this is not being send directly to the lead
+     *
+     * @return bool
+     */
+    public function isInternalSend()
+    {
+        return $this->internalSend;
+    }
+
+    /**
      * @return array
      */
     public function getSource()

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1212,7 +1212,7 @@ class EmailController extends FormController
         $lead = $this->factory->getModel('lead')->getRepository()->getRandomLead();
 
         // Send to current user
-        $model->sendEmailToUser($entity, $this->factory->getUser()->getId(), $lead);
+        $model->sendEmailToUser($entity, $this->factory->getUser()->getId(), $lead, array(), array(), false);
 
         $this->addFlash('mautic.email.notice.test_sent.success');
 
@@ -1240,7 +1240,7 @@ class EmailController extends FormController
 
         $template = $entity->getTemplate();
         if (!empty($template)) {
-            $slots    = $this->factory->getTheme($template)->getSlots('email');
+            $slots = $this->factory->getTheme($template)->getSlots('email');
 
             $response = $this->render(
                 'MauticEmailBundle::public.html.php',
@@ -1264,12 +1264,15 @@ class EmailController extends FormController
         $tokens = array('{tracking_pixel}' => '');
 
         // Generate and replace tokens
-        $event = new EmailSendEvent(null, array(
-            'content' => $content,
-            'email'   => $entity,
-            'idHash'  => $idHash,
-            'tokens'  => $tokens
-        ));
+        $event = new EmailSendEvent(
+            null, array(
+            'content'      => $content,
+            'email'        => $entity,
+            'idHash'       => $idHash,
+            'tokens'       => $tokens,
+            'internalSend' => true
+        )
+        );
         $this->factory->getDispatcher()->dispatch(EmailEvents::EMAIL_ON_DISPLAY, $event);
         $content = $event->getContent();
 

--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -63,9 +63,9 @@ class EmailSendEvent extends CommonEvent
     private $tokens = array();
 
     /**
-     * @var array
+     * @var internalSend
      */
-    private $foundTokens = array();
+    private $internalSend = false;
 
     /**
      * @param MailHelper $helper
@@ -102,6 +102,23 @@ class EmailSendEvent extends CommonEvent
         if (isset($args['tokens'])) {
             $this->tokens = $args['tokens'];
         }
+
+        if (isset($args['internalSend'])) {
+            $this->internalSend = $args['internalSend'];
+        } elseif ($helper !== null) {
+            $this->internalSend = $helper->isInternalSend();
+        }
+    }
+
+
+    /**
+     * Check if this email is an internal send or to the lead; if an internal send, don't append lead tracking
+     *
+     * @return internalSend
+     */
+    public function isInternalSend()
+    {
+        return $this->internalSend;
     }
 
     /**

--- a/app/bundles/EmailBundle/Helper/FormSubmitHelper.php
+++ b/app/bundles/EmailBundle/Helper/FormSubmitHelper.php
@@ -15,10 +15,11 @@ use Mautic\LeadBundle\Entity\Lead;
 
 class FormSubmitHelper
 {
-	/**
-     * @param       $action
-     *
-     * @return array
+    /**
+     * @param               $tokens
+     * @param Action        $action
+     * @param MauticFactory $factory
+     * @param               $feedback
      */
     public static function sendEmail($tokens, Action $action, MauticFactory $factory, $feedback)
     {

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -326,11 +326,29 @@ class EmailModel extends FormModel
         $readDateTime = $this->factory->getDate();
         $stat->setLastOpened($readDateTime->getDateTime());
 
+        $lead = $stat->getLead();
+        if ($lead !== null) {
+            /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
+            $leadModel = $this->factory->getModel('lead');
+
+            /*
+            // @todo too many webmail clients mask IP address
+            if (!$lead->getIpAddresses()->contains($ipAddress)) {
+                $lead->addIpAddress($ipAddress);
+                $leadModel->saveEntity($lead, true);
+            }
+            */
+
+            // Set the lead as current lead
+            $leadModel->setCurrentLead($lead);
+        }
+
         if (!$stat->getIsRead()) {
             $stat->setIsRead(true);
             $stat->setDateRead($readDateTime->getDateTime());
 
-            if ($email) {
+            // Only up counts if associated with both an email and lead
+            if ($email && $lead) {
                 $readCount = $email->getReadCount();
                 $readCount++;
                 $email->setReadCount($readCount);
@@ -356,25 +374,6 @@ class EmailModel extends FormModel
         //check for existing IP
         $ipAddress = $this->factory->getIpAddress();
         $stat->setIpAddress($ipAddress);
-
-        //save the IP to the lead
-        $lead = $stat->getLead();
-
-        if ($lead !== null) {
-            /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
-            $leadModel = $this->factory->getModel('lead');
-
-            /*
-            // @todo too many webmail clients mask IP address
-            if (!$lead->getIpAddresses()->contains($ipAddress)) {
-                $lead->addIpAddress($ipAddress);
-                $leadModel->saveEntity($lead, true);
-            }
-            */
-
-            // Set the lead as current lead
-            $leadModel->setCurrentLead($lead);
-        }
 
         if ($email) {
             if ($this->dispatcher->hasListeners(EmailEvents::EMAIL_ON_OPEN)) {
@@ -1030,11 +1029,12 @@ class EmailModel extends FormModel
      * @param mixed $lead
      * @param array $tokens
      * @param array $assetAttachments
+     * @param bool  $saveStat
      *
      * @return mixed
      * @throws \Doctrine\ORM\ORMException
      */
-    public function sendEmailToUser ($email, $users, $lead = null, $tokens = array(), $assetAttachments = array())
+    public function sendEmailToUser ($email, $users, $lead = null, $tokens = array(), $assetAttachments = array(), $saveStat = true)
     {
         if (!$emailId = $email->getId()) {
             return false;
@@ -1056,7 +1056,7 @@ class EmailModel extends FormModel
         $mailer = $this->factory->getMailer();
         $mailer->setLead($lead, true);
         $mailer->setTokens($tokens);
-        $mailer->setEmail($email, false, $emailSettings[$emailId]['slots'], $assetAttachments);
+        $mailer->setEmail($email, false, $emailSettings[$emailId]['slots'], $assetAttachments, (!$saveStat));
 
         $mailer->useMailerTokenization();
 
@@ -1082,22 +1082,23 @@ class EmailModel extends FormModel
 
             $mailer->setTo($user['email'], $user['firstname'] . ' ' . $user['lastname']);
 
-            $mailer->queue();
+            $mailer->queue(true);
 
-            //create a stat
-            $stat = new Stat();
-            $stat->setDateSent(new \DateTime());
-            $stat->setEmail($email);
-            $stat->setEmailAddress($user['email']);
-            $stat->setTrackingHash($idHash);
-            if (!empty($source)) {
-                $stat->setSource($source[0]);
-                $stat->setSourceId($source[1]);
+            if ($saveStat) {
+                //create a stat
+                $stat = new Stat();
+                $stat->setDateSent(new \DateTime());
+                $stat->setEmailAddress($user['email']);
+                $stat->setTrackingHash($idHash);
+                if (!empty($source)) {
+                    $stat->setSource($source[0]);
+                    $stat->setSourceId($source[1]);
+                }
+                $stat->setCopy($mailer->getBody());
+                $stat->setTokens($mailer->getTokens());
+
+                $saveEntities[] = $stat;
             }
-            $stat->setCopy($mailer->getBody());
-            $stat->setTokens($mailer->getTokens());
-
-            $saveEntities[] = $stat;
         }
 
         //flush the message


### PR DESCRIPTION
**Description**
Emails sent to users, including sending email previews, did not have tokens replaced.  Also, they were tracked as part of the email stats.  This PR fixes both.

It fixes #557 and fixes #538.

**Testing**
First, test sending an email preview with tokens. The received email should have tokens replaced (uses a random lead) but links should be the original and without the ct= links meaning they should not be trackable (to prevent false stats or lead tracking).   After reading the email, check the email stats.  This email should not be counted in either the send or read counts.

Create a standalone form with actions to send the same email to the lead and then one to a user.  The lead one should be have all trackable links.  The user one, should have lead details populated and the links should be raw.  The lead one should be counted in the email stats.  The user one should not.  