### PR TITLE
Updated dashboard timeline to use 'System' if no user executed the action

### DIFF
--- a/app/bundles/DashboardBundle/Views/Default/recentactivity.html.php
+++ b/app/bundles/DashboardBundle/Views/Default/recentactivity.html.php
@@ -27,8 +27,10 @@
                         <a href="<?php echo $view['router']->generate('mautic_user_action', array('objectAction' => 'edit', 'objectId' => $log['userId'])); ?>" data-toggle="ajax">
                             <?php echo $log['userName']; ?>
                         </a>
-                    <?php else : ?>
+                    <?php elseif ($log['userName']) : ?>
                         <?php echo $log['userName']; ?>
+                    <?php else: ?>
+                        <?php echo $view['translator']->trans('mautic.core.system'); ?>
                     <?php endif; ?>
                     <?php echo $view['translator']->trans('mautic.dashboard.' . $log['action'] . '.past.tense'); ?>
 

--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -166,7 +166,9 @@ class SubmissionRepository extends CommonRepository
                 ->setParameter('id', $id);
             $results = $q->execute()->fetchAll();
             unset($results[0]['submission_id']);
-            $entity->setResults($results[0]);
+            if (isset($results[0])) {
+                $entity->setResults($results[0]);
+            }
         }
 
         return $entity;


### PR DESCRIPTION
**Description**
Just a UI fix.  If they system executed an action (such as creating the lead), the text in the timeline would simply be "created X..." This updates it to be "System created X".

Accidentally committed a bit of code to prevent a PHP notice in some rare cases of viewing a lead timeline due to form submissions.