### PR TITLE
Developer helpers

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -189,6 +189,11 @@ return array(
                 'class'     => 'Mautic\CoreBundle\Templating\Helper\FormatterHelper',
                 'arguments' => 'mautic.factory',
                 'alias'     => 'formatter'
+            ),
+            'mautic.helper.template.security' => array(
+                'class'     => 'Mautic\CoreBundle\Templating\Helper\SecurityHelper',
+                'arguments' => 'mautic.factory',
+                'alias'     => 'security'
             )
         ),
         'other'   => array(

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -56,6 +56,8 @@ class CommonController extends Controller implements MauticController
 
     /**
      * @param FilterControllerEvent $event
+     *
+     * @return void
      */
     public function initialize(FilterControllerEvent $event)
     {
@@ -98,6 +100,8 @@ class CommonController extends Controller implements MauticController
      * refresh
      *
      * @param $url
+     *
+     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
      */
     public function delegateRedirect($url)
     {
@@ -456,7 +460,9 @@ class CommonController extends Controller implements MauticController
     /**
      * Renders notification info for ajax
      *
-     * @return string
+     * @param Request $request
+     *
+     * @return array
      */
     protected function getNotificationContent(Request $request = null)
     {

--- a/app/bundles/CoreBundle/Controller/FormController.php
+++ b/app/bundles/CoreBundle/Controller/FormController.php
@@ -16,6 +16,15 @@ use Symfony\Component\Form\Form;
  */
 class FormController extends CommonController
 {
+    // Used for the standard template functions
+    protected $modelName;
+    protected $permissionBase;
+    protected $routeBase;
+    protected $sessionBase;
+    protected $langStringBase;
+    protected $activeLink;
+    protected $mauticContent;
+    protected $templateBase;
 
     /**
      * Checks to see if the form was cancelled
@@ -24,11 +33,11 @@ class FormController extends CommonController
      *
      * @return int
      */
-    protected function isFormCancelled (Form &$form)
+    protected function isFormCancelled(Form &$form)
     {
         $name = $form->getName();
 
-        return $this->request->request->get($name . '[buttons][cancel]', false, true) !== false;
+        return $this->request->request->get($name.'[buttons][cancel]', false, true) !== false;
     }
 
     /**
@@ -36,11 +45,11 @@ class FormController extends CommonController
      *
      * @return bool
      */
-    protected function isFormApplied ($form)
+    protected function isFormApplied($form)
     {
         $name = $form->getName();
 
-        return $this->request->request->get($name . '[buttons][apply]', false, true) !== false;
+        return $this->request->request->get($name.'[buttons][apply]', false, true) !== false;
     }
 
     /**
@@ -50,7 +59,7 @@ class FormController extends CommonController
      *
      * @return int
      */
-    protected function isFormValid (Form &$form)
+    protected function isFormValid(Form &$form)
     {
         //bind request to the form
         $form->handleRequest($this->request);
@@ -68,11 +77,13 @@ class FormController extends CommonController
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|array
      */
-    protected function isLocked ($postActionVars, $entity, $model, $batch = false)
+    protected function isLocked($postActionVars, $entity, $model, $batch = false)
     {
         $date      = $entity->getCheckedOut();
-        $returnUrl = !empty($postActionVars['returnUrl']) ?
-            urlencode($postActionVars['returnUrl']) :
+        $returnUrl = !empty($postActionVars['returnUrl'])
+            ?
+            urlencode($postActionVars['returnUrl'])
+            :
             urlencode($this->generateUrl('mautic_dashboard_index'));
         $override  = '';
 
@@ -80,16 +91,21 @@ class FormController extends CommonController
         $nameFunction = $modelClass->getNameGetter();
 
         if ($this->factory->getUser()->isAdmin()) {
-            $override = $this->get('translator')->trans('mautic.core.override.lock', array(
-                '%url%' => $this->generateUrl('mautic_core_form_action', array(
-                        'objectAction' => 'unlock',
-                        'objectModel'  => $model,
-                        'objectId'     => $entity->getId(),
-                        'returnUrl'    => $returnUrl,
-                        'name'         => urlencode($entity->$nameFunction())
+            $override = $this->get('translator')->trans(
+                'mautic.core.override.lock',
+                array(
+                    '%url%' => $this->generateUrl(
+                        'mautic_core_form_action',
+                        array(
+                            'objectAction' => 'unlock',
+                            'objectModel'  => $model,
+                            'objectId'     => $entity->getId(),
+                            'returnUrl'    => $returnUrl,
+                            'name'         => urlencode($entity->$nameFunction())
+                        )
                     )
                 )
-            ));
+            );
         }
 
         $flash = array(
@@ -98,7 +114,8 @@ class FormController extends CommonController
             'msgVars' => array(
                 "%name%"       => $entity->$nameFunction(),
                 "%user%"       => $entity->getCheckedOutByUser(),
-                '%contactUrl%' => $this->generateUrl('mautic_user_action',
+                '%contactUrl%' => $this->generateUrl(
+                    'mautic_user_action',
                     array(
                         'objectAction' => 'contact',
                         'objectId'     => $entity->getCheckedOutBy(),
@@ -119,9 +136,12 @@ class FormController extends CommonController
         }
 
         return $this->postActionRedirect(
-            array_merge($postActionVars, array(
-                'flashes' => array($flash)
-            ))
+            array_merge(
+                $postActionVars,
+                array(
+                    'flashes' => array($flash)
+                )
+            )
         );
     }
 
@@ -131,7 +151,7 @@ class FormController extends CommonController
      *
      * @return array|\Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function unlockAction ($id, $modelName)
+    public function unlockAction($id, $modelName)
     {
         if ($this->factory->getUser()->isAdmin()) {
             $model = $this->factory->getModel($modelName);
@@ -145,13 +165,685 @@ class FormController extends CommonController
                 $returnUrl = $this->generateUrl('mautic_dashboard_index');
             }
 
-            $this->addFlash('mautic.core.action.entity.unlocked',
-                array('%name%' => urldecode($this->request->get('name'))
-                ));
+            $this->addFlash(
+                'mautic.core.action.entity.unlocked',
+                array(
+                    '%name%' => urldecode($this->request->get('name'))
+                )
+            );
 
             return $this->redirect($returnUrl);
         }
 
         return $this->accessDenied();
+    }
+
+    /**
+     * @param string $modelName      The model for this controller
+     * @param string $permissionBase Permission base for the model (i.e. form.forms or addon.yourAddon.items)
+     * @param string $routeBase      Route base for the controller routes (i.e. mautic_form or custom_addon)
+     * @param string $sessionBase    Session name base for items saved to session such as filters, page, etc
+     * @param string $langStringBase Language string base for the shared strings
+     * @param string $templateBase   Template base (i.e. YourController:Default) for the view/controller
+     * @param string $activeLink     Link ID to return via ajax response
+     * @param string $mauticContent  Mautic content string to return via ajax response for onLoad functions
+     */
+    protected function setStandardParameters(
+        $modelName,
+        $permissionBase,
+        $routeBase,
+        $sessionBase,
+        $langStringBase,
+        $templateBase,
+        $activeLink = null,
+        $mauticContent = null
+    ) {
+        $this->modelName      = $modelName;
+        $this->permissionBase = $permissionBase;
+        $this->sessionBase    = $sessionBase;
+        $this->routeBase      = $routeBase;
+        $this->langStringBase = $langStringBase;
+        $this->templateBase   = $templateBase;
+        $this->activeLink     = $activeLink;
+        $this->mauticContent  = $mauticContent;
+    }
+
+    /**
+     * @param int $page
+     *
+     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
+     */
+    protected function indexStandard($page = 1)
+    {
+        //set some permissions
+        $permissions = $this->factory->getSecurity()->isGranted(
+            array(
+                $this->permissionBase.':view',
+                $this->permissionBase.':viewown',
+                $this->permissionBase.':viewother',
+                $this->permissionBase.':create',
+                $this->permissionBase.':edit',
+                $this->permissionBase.':editown',
+                $this->permissionBase.':editother',
+                $this->permissionBase.':delete',
+                $this->permissionBase.':deleteown',
+                $this->permissionBase.':deleteother',
+                $this->permissionBase.':publish',
+                $this->permissionBase.':publishown',
+                $this->permissionBase.':publishother'
+            ),
+            "RETURN_ARRAY",
+            null,
+            true
+        );
+
+        if (!$permissions[$this->permissionBase.':viewown'] && !$permissions[$this->permissionBase.':viewother']) {
+            return $this->accessDenied();
+        }
+
+        if ($this->request->getMethod() == 'POST') {
+            $this->setListFilters();
+        }
+
+        $session = $this->factory->getSession();
+
+        //set limits
+        $limit = $session->get($this->sessionBase.'.limit', $this->factory->getParameter('default_pagelimit'));
+        $start = ($page === 1) ? 0 : (($page - 1) * $limit);
+        if ($start < 0) {
+            $start = 0;
+        }
+
+        $search = $this->request->get('search', $session->get($this->sessionBase.'.filter', ''));
+        $session->set($this->sessionBase.'.filter', $search);
+
+        $filter = array('string' => $search, 'force' => array());
+
+        $model = $this->factory->getModel($this->modelName);
+        $repo  = $model->getRepository();
+
+        if (!$permissions[$this->permissionBase.':viewother']) {
+            $filter['force'] = array('column' => $repo->getTableAlias().'.createdBy', 'expr' => 'eq', 'value' => $this->factory->getUser()->getId());
+        }
+
+        $orderBy    = $session->get($this->sessionBase.'.orderby', $repo->getTableAlias().'.name');
+        $orderByDir = $session->get($this->sessionBase.'.orderbydir', 'ASC');
+
+        $items = $model->getEntities(
+            array(
+                'start'      => $start,
+                'limit'      => $limit,
+                'filter'     => $filter,
+                'orderBy'    => $orderBy,
+                'orderByDir' => $orderByDir
+            )
+        );
+
+        $count = count($items);
+
+        if ($count && $count < ($start + 1)) {
+            //the number of entities are now less then the current page so redirect to the last page
+            $lastPage = ($count === 1) ? 1 : ((ceil($count / $limit)) ?: 1) ?: 1;
+
+            $session->set($this->sessionBase.'.page', $lastPage);
+            $returnUrl = $this->generateUrl($this->routeBase.'_index', array('page' => $lastPage));
+
+            return $this->postActionRedirect(
+                array(
+                    'returnUrl'       => $returnUrl,
+                    'viewParameters'  => array('page' => $lastPage),
+                    'contentTemplate' => $this->templateBase.':index',
+                    'passthroughVars' => array(
+                        'activeLink'    => $this->activeLink,
+                        'mauticContent' => $this->mauticContent
+                    )
+                )
+            );
+        }
+
+        //set what page currently on so that we can return here after form submission/cancellation
+        $session->set($this->sessionBase.'.page', $page);
+
+        $viewParameters = array(
+            'searchValue' => $search,
+            'items'       => $items,
+            'totalItems'  => $count,
+            'page'        => $page,
+            'limit'       => $limit,
+            'permissions' => $permissions,
+            'security'    => $this->factory->getSecurity(),
+            'tmpl'        => $this->request->get('tmpl', 'index')
+        );
+
+        $delegateArgs = array(
+            'viewParameters'  => $viewParameters,
+            'contentTemplate' => $this->templateBase.':list.html.php',
+            'passthroughVars' => array(
+                'activeLink'    => $this->activeLink,
+                'mauticContent' => 'form',
+                'route'         => $this->generateUrl($this->routeBase.'_index', array('page' => $page))
+            )
+        );
+
+        // Allow inherited class to adjust
+        if (method_exists($this, 'customizeViewArguments')) {
+            $delegateArgs = $this->customizeViewArguments($delegateArgs, 'index');
+        }
+
+        return $this->delegateView($delegateArgs);
+    }
+
+    /**
+     * Individual item's details page
+     *
+     * @param     $objectId
+     * @param int $listPage
+     *
+     * @return array|\Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     */
+    protected function viewStandard($objectId, $listPage = 1)
+    {
+        $model    = $this->factory->getModel($this->modelName);
+        $entity   = $model->getEntity($objectId);
+        $security = $this->factory->getSecurity();
+
+        if ($entity === null) {
+            $page = $this->factory->getSession()->get($this->sessionBase.'.page', 1);
+
+            return $this->postActionRedirect(
+                array(
+                    'returnUrl'       => $this->generateUrl($this->routeBase.'_index', array('page' => $page)),
+                    'viewParameters'  => array('page' => $page),
+                    'contentTemplate' => $this->templateBase.':index',
+                    'passthroughVars' => array(
+                        'activeLink'    => $this->activeLink,
+                        'mauticContent' => $this->mauticContent
+                    ),
+                    'flashes'         => array(
+                        array(
+                            'type'    => 'error',
+                            'msg'     => $this->langStringBase.'.error.notfound',
+                            'msgVars' => array('%id%' => $objectId)
+                        )
+                    )
+                )
+            );
+        } elseif (!$security->hasEntityAccess($this->permissionBase.':viewown', $this->permissionBase.':viewother', $entity->getCreatedBy())) {
+            return $this->accessDenied();
+        }
+
+        // Set filters
+        if ($this->request->getMethod() == 'POST') {
+            $this->setListFilters();
+        }
+
+        $delegateArgs = array(
+            'viewParameters'  => array(
+                'tmpl'        => $this->request->isXmlHttpRequest() ? $this->request->get('tmpl', 'index') : 'index',
+                'permissions' => $security->isGranted(
+                    array(
+                        $this->permissionBase.':view',
+                        $this->permissionBase.':viewown',
+                        $this->permissionBase.':viewother',
+                        $this->permissionBase.':create',
+                        $this->permissionBase.':edit',
+                        $this->permissionBase.':editown',
+                        $this->permissionBase.':editother',
+                        $this->permissionBase.':delete',
+                        $this->permissionBase.':deleteown',
+                        $this->permissionBase.':deleteother',
+                        $this->permissionBase.':publish',
+                        $this->permissionBase.':publishown',
+                        $this->permissionBase.':publishother'
+                    ),
+                    "RETURN_ARRAY",
+                    null,
+                    true
+                ),
+            ),
+            'contentTemplate' => $this->templateBase.':details.html.php',
+            'passthroughVars' => array(
+                'activeLink'    => $this->activeLink,
+                'mauticContent' => $this->mauticContent,
+                'route'         => $this->generateUrl(
+                    $this->routeBase.'_view',
+                    array(
+                        'objectId' => $entity->getId(),
+                        'listPage' => $listPage
+                    )
+                )
+            )
+        );
+
+        // Allow inherited class to adjust
+        if (method_exists($this, 'customizeViewArguments')) {
+            $delegateArgs = $this->customizeViewArguments($delegateArgs, 'view');
+        }
+
+        return $this->delegateView($delegateArgs);
+    }
+
+    /**
+     * Generates new form and processes post data
+     *
+     * @return \Symfony\Component\HttpFoundation\JsonResponse|Response
+     */
+    protected function newStandard()
+    {
+        $model  = $this->factory->getModel($this->modelName);
+        $entity = $model->getEntity();
+
+        if (!$this->factory->getSecurity()->isGranted($this->permissionBase.':create')) {
+            return $this->accessDenied();
+        }
+
+        //set the page we came from
+        $page = $this->factory->getSession()->get($this->sessionBase.'.page', 1);
+
+        $action = $this->generateUrl($this->routeBase.'_action', array('objectAction' => 'new'));
+        $form   = $model->createForm($entity, $this->get('form.factory'), $action);
+
+        ///Check for a submitted form and process it
+        if ($this->request->getMethod() == 'POST') {
+            $valid = false;
+            if (!$cancelled = $this->isFormCancelled($form)) {
+                if ($valid = $this->isFormValid($form)) {
+                    // Allow inherited class to adjust
+                    if (method_exists($this, 'beforeSaveEntity')) {
+                        $valid = $this->beforeSaveEntity($entity, $form, 'new');
+                    }
+
+                    if ($valid) {
+                        $model->saveEntity($entity);
+
+                        // Allow inherited class to adjust
+                        if (method_exists($this, 'afterSaveEntity')) {
+                            $this->afterSaveEntity($entity, $form, 'new');
+                        }
+                    }
+                }
+            } else {
+                $viewParameters = array('page' => $page);
+                $returnUrl      = $this->generateUrl($this->routeBase.'_index', $viewParameters);
+                $template       = $this->templateBase.':index';
+            }
+
+            if ($cancelled || ($valid && $form->get('buttons')->get('save')->isClicked())) {
+
+                return $this->postActionRedirect(
+                    array(
+                        'returnUrl'       => $returnUrl,
+                        'viewParameters'  => $viewParameters,
+                        'contentTemplate' => $template,
+                        'passthroughVars' => array(
+                            'activeLink'    => $this->activeLink,
+                            'mauticContent' => $this->mauticContent
+                        )
+                    )
+                );
+            }
+        }
+
+        $delegateArgs = array(
+            'viewParameters'  => array(
+                'tmpl'  => $this->request->isXmlHttpRequest() ? $this->request->get('tmpl', 'index') : 'index',
+                'entity' => $entity,
+                'form'  => $form->createView()
+            ),
+            'contentTemplate' => $this->templateBase.':form.html.php',
+            'passthroughVars' => array(
+                'activeLink'    => $this->activeLink,
+                'mauticContent' => $this->mauticContent,
+                'route'         => $this->generateUrl(
+                    $this->routeBase.'_action',
+                    array(
+                        'objectAction' => (!empty($valid) ? 'edit' : 'new'), //valid means a new form was applied
+                        'objectId'     => $entity->getId()
+                    )
+                )
+            )
+        );
+
+        // Allow inherited class to adjust
+        if (method_exists($this, 'customizeViewArguments')) {
+            $delegateArgs = $this->customizeViewArguments($delegateArgs, 'new');
+        }
+
+        return $this->delegateView($delegateArgs);
+    }
+
+    /**
+     * Generates edit form and processes post data
+     *
+     * @param int  $objectId
+     * @param bool $ignorePost
+     *
+     * @return \Symfony\Component\HttpFoundation\JsonResponse|Response
+     */
+    protected function editStandard($objectId, $ignorePost = false)
+    {
+        $model  = $this->factory->getModel($this->modelName);
+        $entity = $model->getEntity($objectId);
+
+        //set the page we came from
+        $page = $this->factory->getSession()->get($this->sessionBase.'.page', 1);
+
+        //set the return URL
+        $returnUrl = $this->generateUrl($this->routeBase.'_index', array('page' => $page));
+
+        $postActionVars = array(
+            'returnUrl'       => $returnUrl,
+            'viewParameters'  => array('page' => $page),
+            'contentTemplate' => $this->templateBase.':index',
+            'passthroughVars' => array(
+                'activeLink'    => $this->activeLink,
+                'mauticContent' => $this->mauticContent
+            )
+        );
+
+        //form not found
+        if ($entity === null) {
+            return $this->postActionRedirect(
+                array_merge(
+                    $postActionVars,
+                    array(
+                        'flashes' => array(
+                            array(
+                                'type'    => 'error',
+                                'msg'     => $this->langStringBase.'.error.notfound',
+                                'msgVars' => array('%id%' => $objectId)
+                            )
+                        )
+                    )
+                )
+            );
+        } elseif (!$this->factory->getSecurity()->hasEntityAccess(
+            $this->permissionBase.':editown',
+            $this->permissionBase.':editother',
+            $entity->getCreatedBy()
+        )
+        ) {
+            return $this->accessDenied();
+        } elseif ($model->isLocked($entity)) {
+            //deny access if the entity is locked
+            return $this->isLocked($postActionVars, $entity, $this->modelName);
+        }
+
+        $action = $this->generateUrl($this->routeBase.'_action', array('objectAction' => 'edit', 'objectId' => $objectId));
+        $form   = $model->createForm($entity, $this->get('form.factory'), $action);
+
+        ///Check for a submitted form and process it
+        if (!$ignorePost && $this->request->getMethod() == 'POST') {
+            $valid = false;
+            if (!$cancelled = $this->isFormCancelled($form)) {
+                // Allow inherited class to adjust
+                if (method_exists($this, 'beforeSaveEntity')) {
+                    $valid = $this->beforeSaveEntity($entity, $form, 'new');
+                }
+
+                if ($valid) {
+                    $model->saveEntity($entity, $form->get('buttons')->get('save')->isClicked());
+
+                    // Allow inherited class to adjust
+                    if (method_exists($this, 'afterSaveEntity')) {
+                        $this->afterSaveEntity($entity, $form, 'new');
+                    }
+
+                    $this->addFlash(
+                        'mautic.core.notice.updated',
+                        array(
+                            '%name%'      => $entity->getName(),
+                            '%menu_link%' => $this->routeBase.'_index',
+                            '%url%'       => $this->generateUrl(
+                                $this->routeBase.'_action',
+                                array(
+                                    'objectAction' => 'edit',
+                                    'objectId'     => $entity->getId()
+                                )
+                            )
+                        )
+                    );
+
+                    if ($form->get('buttons')->get('save')->isClicked()) {
+                        $viewParameters = array(
+                            'objectAction' => 'view',
+                            'objectId'     => $entity->getId()
+                        );
+                        $returnUrl      = $this->generateUrl($this->routeBase.'_action', $viewParameters);
+                        $template       = $this->templateBase.':view';
+                    }
+                }
+            } else {
+                //unlock the entity
+                $model->unlockEntity($entity);
+
+                $viewParameters = array('page' => $page);
+                $returnUrl      = $this->generateUrl($this->routeBase.'_index', $viewParameters);
+                $template       = $this->templateBase.':index';
+            }
+
+            if ($cancelled || ($valid && $form->get('buttons')->get('save')->isClicked())) {
+                return $this->postActionRedirect(
+                    array_merge(
+                        $postActionVars,
+                        array(
+                            'returnUrl'       => $returnUrl,
+                            'viewParameters'  => $viewParameters,
+                            'contentTemplate' => $template
+                        )
+                    )
+                );
+            }
+        } else {
+            $model->lockEntity($entity);
+        }
+
+        $delegateArgs = array(
+            'viewParameters'  => array(
+                'tmpl'  => $this->request->isXmlHttpRequest() ? $this->request->get('tmpl', 'index') : 'index',
+                'entity'  => $entity,
+                'form'  => $form->createView()
+            ),
+            'contentTemplate' => $this->templateBase.':index.html.php',
+            'passthroughVars' => array(
+                'activeLink'    => $this->activeLink,
+                'mauticContent' => $this->mauticContent,
+                'route'         => $this->generateUrl(
+                    $this->routeBase.'_action',
+                    array(
+                        'objectAction' => 'edit',
+                        'objectId'     => $entity->getId()
+                    )
+                )
+            )
+        );
+
+        // Allow inherited class to adjust
+        if (method_exists($this, 'customizeViewArguments')) {
+            $delegateArgs = $this->customizeViewArguments($delegateArgs, 'edit');
+        }
+
+        return $this->delegateView($delegateArgs);
+    }
+
+    /**
+     * Clone an entity
+     *
+     * @param int $objectId
+     *
+     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
+     */
+    protected function cloneStandard($objectId)
+    {
+        $model  = $this->factory->getModel($this->modelName);
+        $entity = $model->getEntity($objectId);
+
+        if ($entity != null) {
+            if (!$this->factory->getSecurity()->isGranted($this->permissionBase.':create')
+                || !$this->factory->getSecurity()->hasEntityAccess(
+                    $this->permissionBase.':viewown',
+                    $this->permissionBase.':viewother',
+                    $entity->getCreatedBy()
+                )
+            ) {
+                return $this->accessDenied();
+            }
+
+            $newEntity = clone $entity;
+            if (method_exists($newEntity, 'setIsPublished')) {
+                $newEntity->setIsPublished(false);
+            }
+
+            // Allow inherited class to adjust
+            if (method_exists($this, 'afterCloneEntity')) {
+                $this->afterCloneEntity($newEntity, $entity);
+            }
+
+            $model->saveEntity($newEntity);
+            $objectId = $newEntity->getId();
+        }
+
+        return $this->editAction($objectId, true, true);
+    }
+
+    /**
+     * Deletes the entity
+     *
+     * @param int $objectId
+     *
+     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
+     */
+    protected function deleteStandard($objectId)
+    {
+        $page      = $this->factory->getSession()->get($this->sessionBase.'.page', 1);
+        $returnUrl = $this->generateUrl($this->routeBase.'_index', array('page' => $page));
+        $flashes   = array();
+
+        $postActionVars = array(
+            'returnUrl'       => $returnUrl,
+            'viewParameters'  => array('page' => $page),
+            'contentTemplate' => $this->templateBase.':index',
+            'passthroughVars' => array(
+                'activeLink'    => $this->activeLink,
+                'mauticContent' => $this->mauticContent
+            )
+        );
+
+        if ($this->request->getMethod() == 'POST') {
+            $model  = $this->factory->getModel($this->modelName);
+            $entity = $model->getEntity($objectId);
+
+            if ($entity === null) {
+                $flashes[] = array(
+                    'type'    => 'error',
+                    'msg'     => $this->langStringBase.'.error.notfound',
+                    'msgVars' => array('%id%' => $objectId)
+                );
+            } elseif (!$this->factory->getSecurity()->hasEntityAccess(
+                $this->permissionBase.':deleteown',
+                $this->permissionBase.':deleteother',
+                $entity->getCreatedBy()
+            )
+            ) {
+                return $this->accessDenied();
+            } elseif ($model->isLocked($entity)) {
+                return $this->isLocked($postActionVars, $entity, $this->modelName);
+            }
+
+            $model->deleteEntity($entity);
+
+            $identifier = $this->get('translator')->trans($entity->getName());
+            $flashes[]  = array(
+                'type'    => 'notice',
+                'msg'     => 'mautic.core.notice.deleted',
+                'msgVars' => array(
+                    '%name%' => $identifier,
+                    '%id%'   => $objectId
+                )
+            );
+        } //else don't do anything
+
+        return $this->postActionRedirect(
+            array_merge(
+                $postActionVars,
+                array(
+                    'flashes' => $flashes
+                )
+            )
+        );
+    }
+
+    /**
+     * Deletes a group of entities
+     *
+     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
+     */
+    protected function batchDeleteStandard()
+    {
+        $page      = $this->factory->getSession()->get($this->sessionBase.'.page', 1);
+        $returnUrl = $this->generateUrl($this->routeBase.'_index', array('page' => $page));
+        $flashes   = array();
+
+        $postActionVars = array(
+            'returnUrl'       => $returnUrl,
+            'viewParameters'  => array('page' => $page),
+            'contentTemplate' => $this->templateBase.':index',
+            'passthroughVars' => array(
+                'activeLink'    => $this->activeLink,
+                'mauticContent' => $this->mauticContent
+            )
+        );
+
+        if ($this->request->getMethod() == 'POST') {
+            $model     = $this->factory->getModel($this->modelName);
+            $ids       = json_decode($this->request->query->get('ids', ''));
+            $deleteIds = array();
+
+            // Loop over the IDs to perform access checks pre-delete
+            foreach ($ids as $objectId) {
+                $entity = $model->getEntity($objectId);
+
+                if ($entity === null) {
+                    $flashes[] = array(
+                        'type'    => 'error',
+                        'msg'     => $this->langStringBase.'.error.notfound',
+                        'msgVars' => array('%id%' => $objectId)
+                    );
+                } elseif (!$this->factory->getSecurity()->hasEntityAccess(
+                    $this->permissionBase.':deleteown',
+                    $this->permissionBase.':deleteother',
+                    $entity->getCreatedBy()
+                )
+                ) {
+                    $flashes[] = $this->accessDenied(true);
+                } elseif ($model->isLocked($entity)) {
+                    $flashes[] = $this->isLocked($postActionVars, $entity, $this->modelName, true);
+                } else {
+                    $deleteIds[] = $objectId;
+                }
+            }
+
+            // Delete everything we are able to
+            if (!empty($deleteIds)) {
+                $entities = $model->deleteEntities($deleteIds);
+
+                $flashes[] = array(
+                    'type'    => 'notice',
+                    'msg'     => $this->langStringBase.'.notice.batch_deleted',
+                    'msgVars' => array(
+                        '%count%' => count($entities)
+                    )
+                );
+            }
+        } //else don't do anything
+
+        return $this->postActionRedirect(
+            array_merge(
+                $postActionVars,
+                array(
+                    'flashes' => $flashes
+                )
+            )
+        );
     }
 }

--- a/app/bundles/CoreBundle/Model/CommonModel.php
+++ b/app/bundles/CoreBundle/Model/CommonModel.php
@@ -9,6 +9,7 @@
 
 namespace Mautic\CoreBundle\Model;
 
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Mautic\CoreBundle\Entity\CommonRepository;
 use Mautic\CoreBundle\Factory\MauticFactory;
@@ -87,7 +88,13 @@ class CommonModel
      */
     public function getRepository()
     {
-        return false;
+        static $commonRepo;
+
+        if ($commonRepo === null) {
+            $commonRepo = new CommonRepository($this->em, new ClassMetadata('MauticCoreBundle:FormEntity'));
+        }
+
+        return $commonRepo;
     }
 
     /**
@@ -125,6 +132,27 @@ class CommonModel
     }
 
     /**
+     * Get a specific entity
+     *
+     * @param $id
+     *
+     * @return null|object
+     */
+    public function getEntity($id = null)
+    {
+        if (null !== $id) {
+            $repo = $this->getRepository();
+            if (method_exists($repo, 'getEntity')) {
+                return $repo->getEntity($id);
+            }
+
+            return $repo->find($id);
+        }
+
+        return null;
+    }
+
+    /**
      * Encode an array to append to a URL
      *
      * @param $array
@@ -153,6 +181,8 @@ class CommonModel
      * @param array $routeParams
      * @param bool  $absolute
      * @param array $clickthrough
+     *
+     * @return string
      */
     public function buildUrl($route, $routeParams = array(), $absolute = true, $clickthrough = array())
     {
@@ -201,6 +231,8 @@ class CommonModel
 
     /**
      * @param $alias
+     *
+     * @return null|object
      */
     public function getEntityByAlias($alias)
     {

--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -18,28 +18,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class FormModel extends CommonModel
 {
-
-    /**
-     * Get a specific entity
-     *
-     * @param $id
-     *
-     * @return null|object
-     */
-    public function getEntity($id = null)
-    {
-        if (null !== $id) {
-            $repo = $this->getRepository();
-            if (method_exists($repo, 'getEntity')) {
-                return $repo->getEntity($id);
-            }
-
-            return $repo->find($id);
-        }
-
-        return null;
-    }
-
     /**
      * Lock an entity to prevent multiple people from editing
      *

--- a/app/bundles/CoreBundle/Security/Permissions/AbstractPermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/AbstractPermissions.php
@@ -164,17 +164,33 @@ abstract class AbstractPermissions
             if (isset($this->permissions[$name]['view'])) {
                 $level = 'view';
             }
+        } elseif ($level == 'view') {
+            if (isset($this->permissions[$name]['viewown'])) {
+                $level = 'viewown';
+            }
         } elseif (in_array($level, array('editown', 'editother'))) {
             if (isset($this->permissions[$name]['edit'])) {
                 $level = 'edit';
+            }
+        } elseif ($level == 'edit') {
+            if (isset($this->permissions[$name]['editown'])) {
+                $level = 'editown';
             }
         } elseif (in_array($level, array('deleteown', 'deleteother'))) {
             if (isset($this->permissions[$name]['delete'])) {
                 $level = 'delete';
             }
+        }  elseif ($level == 'delete') {
+            if (isset($this->permissions[$name]['deleteown'])) {
+                $level = 'deleteown';
+            }
         } elseif (in_array($level, array('publishown', 'publishother'))) {
             if (isset($this->permissions[$name]['publish'])) {
                 $level = 'publish';
+            }
+        } elseif ($level == 'publish') {
+            if (isset($this->permissions[$name]['publishown'])) {
+                $level = 'publishown';
             }
         }
 
@@ -380,7 +396,6 @@ abstract class AbstractPermissions
      * Add a single full permission
      *
      * @param array $permissionNames
-     * @param bool  $includePublish
      *
      * @return void
      */
@@ -404,7 +419,6 @@ abstract class AbstractPermissions
      * @param string               $level
      * @param FormBuilderInterface $builder
      * @param array                $data
-     * @param bool                 $includePublish
      */
     protected function addManageFormFields($bundle, $level, &$builder, $data)
     {

--- a/app/bundles/CoreBundle/Templating/Helper/SecurityHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/SecurityHelper.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2014 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Templating\Helper;
+
+use Mautic\CoreBundle\Factory\MauticFactory;
+use Symfony\Component\Templating\Helper\Helper;
+
+/**
+ * Class SecurityHelper
+ */
+class SecurityHelper extends Helper
+{
+    /**
+     * @var MauticFactory
+     */
+    private $factory;
+
+    /**
+     * @param MauticFactory $factory
+     */
+    public function __construct(MauticFactory $factory)
+    {
+        $this->factory = $factory;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'security';
+    }
+
+    /**
+     * Helper function to check if the logged in user has access to an entity
+     *
+     * @param $ownPermission
+     * @param $otherPermission
+     * @param $ownerId
+     *
+     * @return bool
+     */
+    public function hasEntityAccess($ownPermission, $otherPermission, $ownerId)
+    {
+        return $this->factory->getSecurity()->hasEntityAccess($ownPermission, $otherPermission, $ownerId);
+    }
+
+    /**
+     * @param $permission
+     *
+     * @return mixed
+     */
+    public function isGranted($permission)
+    {
+        return $this->factory->getSecurity()->isGranted($permission);
+    }
+}


### PR DESCRIPTION
**Description**
As I'm working on addons, there's a lot of duplicate code required for the controllers for the common UI used throughout Mautic :-) So this is mainly a developer helper PR.  

It adds helper code to FormController.php to easily add common usages of index (list), edit, new, clone, delete, and batchDelete actions without requiring duplicate code.  

It adds access to $view['security'] to templates and adds synonym support for view, edit, delete, and publish when the bundle uses extended permissions (viewown, etc).  And adds support to isGranted to return false for unknown permissions rather than throwing an exception to support the shared controller functions.

**Testing**
Nothing that can really be tested right now unless you write code that leverages the new helper code.