### PR TITLE
Fixes email send issue related to bad emails

### DIFF
--- a/app/bundles/CoreBundle/Helper/MailHelper.php
+++ b/app/bundles/CoreBundle/Helper/MailHelper.php
@@ -260,8 +260,12 @@ class MailHelper
 
                 if (!empty($failures)) {
                     $this->errors['failures'] = $failures;
-                    $this->factory->getLogger()->log('error', '[MAIL ERROR] '.$this->logger->dump());
+
+                    $this->logError('Sending failed for one or more recipients');
                 }
+
+                // Clear the log so that previous output is not associated with new errors
+                $this->logger->clear();
             } catch (\Exception $e) {
                 $this->logError($e);
             }
@@ -278,11 +282,20 @@ class MailHelper
      * If batching is supported and enabled, the message will be queued and will on be sent upon flushQueue().
      * Otherwise, the message will be sent to the transport immediately
      *
-     * @param bool $dispatchSendEvent
+     * @param bool   $dispatchSendEvent
+     * @param string $immediateSendMessageHandling If tokenization is not supported by the mailer, this argument determines
+     *                                             what should happen to $this->message after the email send is attempted.
+     *                                             Options are:
+     *                                             RESET_TO           resets the to recipients and resets errors
+     *                                             FULL_RESET         creates a new MauticMessage instance and resets errors
+     *                                             DO_NOTHING         leaves the current errors array and MauticMessage instance intact
+     *                                             NOTHING_IF_FAILED  leaves the current errors array MauticMessage instance intact if it fails, otherwise reset_to
+     *
+     *
      *
      * @return bool
      */
-    public function queue($dispatchSendEvent = false)
+    public function queue($dispatchSendEvent = false, $immediateSendMessageHandling = 'RESET_TO')
     {
         if ($this->tokenizationEnabled) {
 
@@ -317,7 +330,30 @@ class MailHelper
 
             // Reset the message for the next
             $this->queuedRecipients = array();
-            $this->message          = $this->getMessageInstance();
+
+            // Reset message
+            switch (ucwords($immediateSendMessageHandling)) {
+                case 'RESET_TO':
+                    $this->message->setTo(array());
+                    $this->clearErrors();
+                    break;
+                case 'NOTHING_IF_FAILED':
+                    if ($success) {
+                        $this->message->setTo(array());
+                        $this->clearErrors();
+                    }
+
+                    break;
+                case 'FULL_RESET':
+                    $this->message = $this->getMessageInstance();
+                    $this->clearErrors();
+                    break;
+                case 'DO_NOTHING':
+                default:
+                    // Nada
+
+                    break;
+            }
 
             return $success;
         }
@@ -522,14 +558,6 @@ class MailHelper
     }
 
     /**
-     * @return array
-     */
-    public function getErrors()
-    {
-        return $this->errors;
-    }
-
-    /**
      * Add an attachment to email
      *
      * @param string $filePath
@@ -683,6 +711,8 @@ class MailHelper
      *
      * @param $addresses
      * @param $name
+     *
+     * @return bool
      */
     public function setTo($addresses, $name = null)
     {
@@ -695,8 +725,12 @@ class MailHelper
         try {
             $this->message->setTo($addresses);
             $this->queuedRecipients = array_merge($this->queuedRecipients, $addresses);
+
+            return true;
         } catch (\Exception $e) {
             $this->logError($e);
+
+            return false;
         }
     }
 
@@ -705,6 +739,8 @@ class MailHelper
      *
      * @param      $address
      * @param null $name
+     *
+     * @return bool
      */
     public function addTo($address, $name = null)
     {
@@ -713,8 +749,12 @@ class MailHelper
         try {
             $this->message->addTo($address, $name);
             $this->queuedRecipients[$address] = $name;
+
+            return true;
         } catch (\Exception $e) {
             $this->logError($e);
+
+            return false;
         }
     }
 
@@ -723,6 +763,8 @@ class MailHelper
      *
      * @param $addresses
      * @param $name
+     *
+     * @return bool
      */
     public function setCc($addresses, $name = null)
     {
@@ -730,8 +772,12 @@ class MailHelper
 
         try {
             $this->message->setCc($addresses, $name);
+
+            return true;
         } catch (\Exception $e) {
             $this->logError($e);
+
+            return false;
         }
     }
 
@@ -740,6 +786,8 @@ class MailHelper
      *
      * @param      $address
      * @param null $name
+     *
+     * @return bool
      */
     public function addCc($address, $name = null)
     {
@@ -747,8 +795,12 @@ class MailHelper
 
         try {
             $this->message->addCc($address, $name);
+
+            return true;
         } catch (\Exception $e) {
             $this->logError($e);
+
+            return false;
         }
     }
 
@@ -757,6 +809,8 @@ class MailHelper
      *
      * @param $addresses
      * @param $name
+     *
+     * @return bool
      */
     public function setBcc($addresses, $name = null)
     {
@@ -764,8 +818,12 @@ class MailHelper
 
         try {
             $this->message->setBcc($addresses, $name);
+
+            return true;
         } catch (\Exception $e) {
             $this->logError($e);
+
+            return false;
         }
     }
 
@@ -774,6 +832,8 @@ class MailHelper
      *
      * @param      $address
      * @param null $name
+     *
+     * @return bool
      */
     public function addBcc($address, $name = null)
     {
@@ -781,8 +841,12 @@ class MailHelper
 
         try {
             $this->message->addBcc($address, $name);
+
+            return true;
         } catch (\Exception $e) {
             $this->logError($e);
+
+            return false;
         }
     }
 
@@ -1117,16 +1181,42 @@ class MailHelper
             $this->fatal = true;
         }
 
-        $this->errors[] = $error;
-
         $logDump = $this->logger->dump();
-
         if (!empty($logDump)) {
             $error .= "; $logDump";
-            $this->logger->clear();
         }
 
+        $this->errors[] = $error;
+
+        $this->logger->clear();
+
         $this->factory->getLogger()->log('error', '[MAIL ERROR] ' . $error);
+    }
+
+    /**
+     * Get list of errors
+     *
+     * @param bool $reset Resets the error array in preparation for the next mail send or else it'll fail
+     *
+     * @return array
+     */
+    public function getErrors($reset = true)
+    {
+        $errors = $this->errors;
+
+        if ($reset) {
+            $this->clearErrors();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Clears the errors from a previous send
+     */
+    public function clearErrors()
+    {
+        $this->errors = array();
     }
 
     /**

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -198,6 +198,7 @@ class EmailRepository extends CommonRepository
                 ->setMaxResults($limit);
         }
 
+        $q->orderBy('l.id');
         $results = $q->execute()->fetchAll();
 
         if ($countOnly) {

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -198,7 +198,9 @@ class EmailRepository extends CommonRepository
                 ->setMaxResults($limit);
         }
 
-        $q->orderBy('l.id');
+        $q->groupBy('l.id')
+            ->orderBy('l.id');
+
         $results = $q->execute()->fetchAll();
 
         if ($countOnly) {

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -949,7 +949,15 @@ class EmailModel extends FormModel
             $mailer->setIdHash($idHash);
 
             try {
-                $mailer->addTo($lead['email'], $lead['firstname'] . ' ' . $lead['lastname']);
+                if (!$mailer->addTo($lead['email'], $lead['firstname'] . ' ' . $lead['lastname'])) {
+                    // Clear the errors so it doesn't stop the next send
+                    $mailer->clearErrors();
+
+                    // Bad email so note and continue
+                    $errors[$lead['id']] = $lead['email'];
+
+                    continue;
+                }
             } catch (BatchQueueMaxException $e) {
                 // Queue full so flush then try again
                 $flushQueue(false);


### PR DESCRIPTION
**Description**
See #582.  When a bad email is encountered during a batch email send, subsequent email sends failed due to Mautic retaining the previous error.  This PR fixes the issue so that the process is not stopped.

**Testing**
Create several leads.  The first, use a bad email such as `bad.@gmail.com`.  The others, use a good email.  Add the three leads to a clean lead list.  Create a new list based email and associate that list to the email.  Send to the leads.  If the bad email is encountered before the others, the rest will fail.

Apply the PR and all the good ones should still send and thus only the bad emails listed as failed.