### PR TITLE
Fixed instances where generic use of .progress-bar

### DIFF
--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -254,13 +254,13 @@ Mautic.emailSendOnUnload = function () {
 };
 
 Mautic.sendEmailBatch = function () {
-    var data = 'id=' + mQuery('.progress-bar').data('email') + '&pending=' + mQuery('.progress-bar').attr('aria-valuemax') + '&batchlimit=' + mQuery('.progress-bar').data('batchlimit');
+    var data = 'id=' + mQuery('.progress-bar-send').data('email') + '&pending=' + mQuery('.progress-bar-send').attr('aria-valuemax') + '&batchlimit=' + mQuery('.progress-bar-send').data('batchlimit');
     Mautic.sendEmailBatchXhr = Mautic.ajaxActionRequest('email:sendBatch', data, function (response) {
         if (response.progress) {
             if (response.progress[0] > 0) {
                 mQuery('.imported-count').html(response.progress[0]);
-                mQuery('.progress-bar').attr('aria-valuenow', response.progress[0]).css('width', response.percent + '%');
-                mQuery('.progress-bar span.sr-only').html(response.percent + '%');
+                mQuery('.progress-bar-send').attr('aria-valuenow', response.progress[0]).css('width', response.percent + '%');
+                mQuery('.progress-bar-send span.sr-only').html(response.percent + '%');
             }
 
             if (response.progress[0] >= response.progress[1]) {

--- a/app/bundles/EmailBundle/Views/Send/progress.html.php
+++ b/app/bundles/EmailBundle/Views/Send/progress.html.php
@@ -26,7 +26,7 @@ $id       = ($status != 'inprogress') ? 'emailSendProgressComplete' : 'emailSend
                 <h4><?php echo $view['translator']->trans('mautic.email.send.stats', array('%sent%' => $stats['sent'], '%failed%' => $stats['failed'])); ?></h4>
                 <?php endif; ?>
                 <div class="progress mt-md" style="height:50px;">
-                    <div class="progress-bar progress-bar-striped<?php if ($status == 'inprogress') echo ' active'; ?>" role="progressbar" aria-valuenow="<?php echo $progress[0]; ?>" aria-valuemin="0" aria-valuemax="<?php echo $progress[1]; ?>" style="width: <?php echo $percent; ?>%; height: 50px;" data-batchlimit="<?php echo $batchlimit; ?>" data-email="<?php echo $email->getId(); ?>">
+                    <div class="progress-bar-send progress-bar progress-bar-striped<?php if ($status == 'inprogress') echo ' active'; ?>" role="progressbar" aria-valuenow="<?php echo $progress[0]; ?>" aria-valuemin="0" aria-valuemax="<?php echo $progress[1]; ?>" style="width: <?php echo $percent; ?>%; height: 50px;" data-batchlimit="<?php echo $batchlimit; ?>" data-email="<?php echo $email->getId(); ?>">
                         <span class="sr-only"><?php echo $percent; ?>%</span>
                     </div>
                 </div>

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -555,8 +555,8 @@ Mautic.reloadLeadImportProgress = function() {
             if (response.progress) {
                 if (response.progress[0] > 0) {
                     mQuery('.imported-count').html(response.progress[0]);
-                    mQuery('.progress-bar').attr('aria-valuenow', response.progress[0]).css('width', response.percent + '%');
-                    mQuery('.progress-bar span.sr-only').html(response.percent + '%');
+                    mQuery('.progress-bar-import').attr('aria-valuenow', response.progress[0]).css('width', response.percent + '%');
+                    mQuery('.progress-bar-import span.sr-only').html(response.percent + '%');
                 }
             }
         });

--- a/app/bundles/LeadBundle/Views/Import/progress.html.php
+++ b/app/bundles/LeadBundle/Views/Import/progress.html.php
@@ -30,7 +30,7 @@ $header   = ($complete) ? 'mautic.lead.import.success': 'mautic.lead.import.dono
                 <h4><?php echo $view['translator']->trans('mautic.lead.import.stats', array('%merged%' => $stats['merged'], '%created%' => $stats['created'], '%ignored%' => $stats['ignored'])); ?></h4>
                 <?php endif; ?>
                 <div class="progress mt-md" style="height:50px;">
-                    <div class="progress-bar progress-bar-striped<?php if (!$complete) echo ' active'; ?>" role="progressbar" aria-valuenow="<?php echo $progress[0]; ?>" aria-valuemin="0" aria-valuemax="<?php echo $progress[1]; ?>" style="width: <?php echo $percent; ?>%; height: 50px;">
+                    <div class="progress-bar-import progress-bar progress-bar-striped<?php if (!$complete) echo ' active'; ?>" role="progressbar" aria-valuenow="<?php echo $progress[0]; ?>" aria-valuemin="0" aria-valuemax="<?php echo $progress[1]; ?>" style="width: <?php echo $percent; ?>%; height: 50px;">
                         <span class="sr-only"><?php echo $percent; ?>%</span>
                     </div>
                 </div>


### PR DESCRIPTION
**Description**
With email sends and with lead imports, the generic use of .progress-bar in it's JS resulted in manipulation of other progress bars that may be in the UI from addons, etc.  

**Testing**
Using dev environment (or compile the assets for prod), just make sure lead import and email list sends still work and the progress bar progresses.