### PR TITLE
fix bug where page event listener tried to execute a method on a null object

### DIFF
--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -304,7 +304,11 @@ class BuilderSubscriber extends CommonSubscriber
     protected function generateUrlTokens($content, $clickthrough, $emailId = null, Email $email = null, EmailSendEvent $event = null)
     {
         $tokens                    = array();
-        $this->emailIsInternalSend = $event->isInternalSend();
+
+        // check we have a complete event property before trying to use it's methods
+        if ($event !== null) {
+            $this->emailIsInternalSend = $event->isInternalSend();
+        }
 
         if ($emailId !== null && isset($this->emailTrackedLinks[$emailId])) {
             // Tokenization is supported and the links have already been parsed so rebuild tokens from saved links


### PR DESCRIPTION
Fixes issue with landing pages.

How to test:
- create a landing page
- visit the page url
- you will probably get a fatal error saying there's no method on this event
- checkout the PR
- the error should go away