### PR TITLE
Fixes campaign emails that only recognized a lead's first and last name tokens

### DIFF
--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -550,9 +550,7 @@ class CampaignRepository extends CommonRepository
                     $q->expr()->eq('cl.manually_removed', ':false')
                 )
             )
-            ->setParameter('false', false, 'boolean')
-            ->groupBy('cl.lead_id')
-            ->orderBy('cl.lead_id', 'ASC');
+            ->setParameter('false', false, 'boolean');
 
         if (!empty($ignoreLeads)) {
             $q->andWhere(

--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -435,7 +435,7 @@ class CampaignRepository extends CommonRepository
      * @param array $lists
      * @param array $args
      *
-     * @return array|int\
+     * @return array|int
      */
     public function getCampaignOrphanLeads($id, array $lists, $args = array())
     {
@@ -551,6 +551,7 @@ class CampaignRepository extends CommonRepository
                 )
             )
             ->setParameter('false', false, 'boolean')
+            ->groupBy('cl.lead_id')
             ->orderBy('cl.lead_id', 'ASC');
 
         if (!empty($ignoreLeads)) {

--- a/app/bundles/EmailBundle/Helper/CampaignEventHelper.php
+++ b/app/bundles/EmailBundle/Helper/CampaignEventHelper.php
@@ -43,7 +43,7 @@ class CampaignEventHelper
      * @param               $lead
      * @param               $event
      *
-     * @throws \Doctrine\ORM\ORMException
+     * @return bool|mixed
      */
     public static function sendEmailAction(MauticFactory $factory, $lead, $event)
     {
@@ -52,12 +52,10 @@ class CampaignEventHelper
         if ($lead instanceof Lead) {
             $fields = $lead->getFields();
 
-            $leadCredentials = array(
-                'id'        => $lead->getId(),
-                'email'     => $fields['core']['email']['value'],
-                'firstname' => $fields['core']['firstname']['value'],
-                'lastname'  => $fields['core']['lastname']['value']
-            );
+            /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
+            $leadModel             = $factory->getModel('lead');
+            $leadCredentials       = $leadModel->flattenFields($fields);
+            $leadCredentials['id'] = $lead->getId();
         } else {
             $leadCredentials = $lead;
         }

--- a/app/bundles/EmailBundle/Helper/PointEventHelper.php
+++ b/app/bundles/EmailBundle/Helper/PointEventHelper.php
@@ -55,12 +55,11 @@ class PointEventHelper
         if ($email != null && $email->isPublished()) {
             $leadFields = $lead->getFields();
             if (isset($leadFields['core']['email']['value']) && $leadFields['core']['email']['value']) {
-                $leadCredentials = array(
-                    'email'     => $leadFields['core']['email']['value'],
-                    'id'        => $lead->getId(),
-                    'firstname' => $leadFields['core']['firstname']['value'],
-                    'lastname'  => $leadFields['core']['lastname']['value']
-                );
+                /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
+                $leadModel             = $factory->getModel('lead');
+                $leadCredentials       = $leadModel->flattenFields($leadFields);
+                $leadCredentials['id'] = $lead->getId();
+
                 $options = array('source' => array('trigger', $event['id']));
                 $model->sendEmail($email, $leadCredentials, $options);
             }

--- a/app/bundles/LeadBundle/EventListener/EmailSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/EmailSubscriber.php
@@ -97,7 +97,8 @@ class EmailSubscriber extends CommonSubscriber
                 }
 
                 $fallbackCheck = explode('|', $match);
-                $fallback      = $urlencode = false;
+                $urlencode     = false;
+                $fallback      = '';
 
                 if (isset($fallbackCheck[1])) {
                     // There is a fallback or to be urlencoded


### PR DESCRIPTION
**Description**
Emails sent through a campaign would not populate lead fields other than first and last name. This PR fixes it.

**Testing**
Add an email to a campaign dropflow.  In that email add a token for the {leadfield=company} and {leadfield=firstname}.  Create/edit a lead to have both filled in.  Add the lead to the campaign then execute the mautic:campaign:trigger command. The email that arrives will have the first name but not the company populated.  Apply the PR, repeat and this time all the lead's fields should be available.