### PR TITLE
Fixed an issue with CSV lead imports

### DIFF
--- a/app/bundles/CoreBundle/Helper/MailHelper.php
+++ b/app/bundles/CoreBundle/Helper/MailHelper.php
@@ -839,6 +839,30 @@ class MailHelper
     }
 
     /**
+     * Validates a given address to ensure RFC 2822, 3.6.2 specs
+     *
+     * @param $address
+     *
+     * @throws \Swift_RfcComplianceException
+     */
+    static public function validateEmail($address)
+    {
+        static $grammer;
+
+        if ($grammer === null) {
+            $grammer = new \Swift_Mime_Grammar();
+        }
+
+        if (!preg_match('/^'.$grammer->getDefinition('addr-spec').'$/D',
+            $address)) {
+            throw new \Swift_RfcComplianceException(
+                'Address in mailbox given ['.$address.
+                '] does not comply with RFC 2822, 3.6.2.'
+            );
+        }
+    }
+
+    /**
      * @return null
      */
     public function getIdHash()

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -9,6 +9,7 @@
 
 namespace Mautic\LeadBundle\Model;
 
+use Mautic\CoreBundle\Helper\MailHelper;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Entity\IpAddress;
@@ -772,16 +773,21 @@ class LeadModel extends FormModel
      * @param      $fields
      * @param      $data
      * @param null $owner
+     * @param null $list
      * @param bool $persist Persist to the database; otherwise return entity
      *
-     * @return Lead
+     * @return bool
      * @throws \Doctrine\ORM\ORMException
+     * @throws \Swift_RfcComplianceException
      */
     public function importLead($fields, $data, $owner = null, $list = null, $persist = true)
     {
         // Let's check for an existing lead by email
         $hasEmail = (!empty($fields['email']) && !empty($data[$fields['email']]));
         if ($hasEmail) {
+            // Validate the email
+            MailHelper::validateEmail($data[$fields['email']]);
+
             $leadFound = $this->getRepository()->getLeadByEmail($data[$fields['email']]);
             $lead      = ($leadFound) ? $this->em->getReference('MauticLeadBundle:Lead', $leadFound['id']) : new Lead();
             $merged    = $leadFound;
@@ -892,8 +898,8 @@ class LeadModel extends FormModel
             if ($list !== null) {
                 $this->addToLists($lead, array($list));
             }
-
-            return $merged;
         }
+
+        return $merged;
     }
 }

--- a/app/bundles/LeadBundle/Views/Import/progress.html.php
+++ b/app/bundles/LeadBundle/Views/Import/progress.html.php
@@ -25,26 +25,37 @@ $header   = ($complete) ? 'mautic.lead.import.success': 'mautic.lead.import.dono
             </div>
             <div class="panel-body">
                 <?php if (!$complete): ?>
-                <h4><?php echo $view['translator']->trans('mautic.lead.import.inprogress'); ?></h4>
+                    <h4><?php echo $view['translator']->trans('mautic.lead.import.inprogress'); ?></h4>
                 <?php else: ?>
-                <h4><?php echo $view['translator']->trans('mautic.lead.import.stats', array('%merged%' => $stats['merged'], '%created%' => $stats['created'], '%ignored%' => $stats['ignored'])); ?></h4>
+                    <h4><?php echo $view['translator']->trans('mautic.lead.import.stats', array('%merged%' => $stats['merged'], '%created%' => $stats['created'], '%ignored%' => $stats['ignored'])); ?></h4>
                 <?php endif; ?>
                 <div class="progress mt-md" style="height:50px;">
-                    <div class="progress-bar progress-bar-striped<?php if (!$complete) echo ' active'; ?>" role="progressbar" aria-valuenow="<?php echo $progress[0]; ?>" aria-valuemin="0" aria-valuemax="<?php echo $progress[1]; ?>" style="width: <?php echo $percent; ?>%; height: 50px;">
+                    <div class="progress-bar-import progress-bar progress-bar-striped<?php if (!$complete) echo ' active'; ?>" role="progressbar" aria-valuenow="<?php echo $progress[0]; ?>" aria-valuemin="0" aria-valuemax="<?php echo $progress[1]; ?>" style="width: <?php echo $percent; ?>%; height: 50px;">
                         <span class="sr-only"><?php echo $percent; ?>%</span>
                     </div>
                 </div>
             </div>
+            <?php if (!empty($stats['failures'])): ?>
+                <ul class="list-group">
+                    <?php foreach ($stats['failures'] as $failure): ?>
+                        <li class="list-group-item text-left">
+                            <a target="_new" class="text-danger">
+                                <?php echo $failure; ?>
+                            </a>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif; ?>
             <div class="panel-footer">
                 <p class="small"><span class="imported-count"><?php echo $progress[0]; ?></span> / <span class="total-count"><?php echo $progress[1]; ?></span></p>
                 <?php if (!$complete): ?>
-                <div>
-                    <a class="text-danger mt-md" href="<?php echo $view['router']->generate('mautic_lead_action', array('objectAction' => 'import', 'cancel' => 1)); ?>" data-toggle="ajax"><?php echo $view['translator']->trans('mautic.core.form.cancel'); ?></a>
-                </div>
+                    <div>
+                        <a class="text-danger mt-md" href="<?php echo $view['router']->generate('mautic_lead_action', array('objectAction' => 'import', 'cancel' => 1)); ?>" data-toggle="ajax"><?php echo $view['translator']->trans('mautic.core.form.cancel'); ?></a>
+                    </div>
                 <?php else: ?>
-                <div>
-                    <a class="btn btn-success" href="<?php echo $view['router']->generate('mautic_lead_index'); ?>" data-toggle="ajax"><?php echo $view['translator']->trans('mautic.lead.list.view_leads'); ?></a>
-                </div>
+                    <div>
+                        <a class="btn btn-success" href="<?php echo $view['router']->generate('mautic_lead_index'); ?>" data-toggle="ajax"><?php echo $view['translator']->trans('mautic.lead.list.view_leads'); ?></a>
+                    </div>
                 <?php endif; ?>
             </div>
         </div>


### PR DESCRIPTION
**Descriptions**

Some CSV files accounted for empty columns at the end of a row and some seem not to.  Or maybe this is how CSV specs allow I dunno but there was an issue that if the header count did not match the data row count, the lead was ignored.  This PR fills in the data array up to the header count to ensure the lead imports.  

For example, a csv file might be something like
```
firstname,email,note
jerry,jerry@email.com,
george,george.@email.com
kramer,kramer@email.com,I'm out there Jerry and loving every minute of it.
```
Notice the first ended in a comma which would result in a count of 3.  But the second did not resulting in a count of 2.  

Also, this PR adds email validation on lead imports.

**Testing**
Import the CSV file above.  Only the two will be imported and the third will not be accounted for.  Apply the PR and all three will be imported and accounted for.

Before the PR, George's email will import.  After the PR, it will be noted as ignored and an error displayed.