### PR TITLE
Fix wrong page repository query

### DIFF
--- a/app/bundles/PageBundle/Entity/PageRepository.php
+++ b/app/bundles/PageBundle/Entity/PageRepository.php
@@ -149,7 +149,7 @@ class PageRepository extends CommonRepository
         }
 
         if (!$viewOther) {
-            $q->andWhere($q->expr()->eq('IDENTITY(p.createdBy)', ':id'))
+            $q->andWhere($q->expr()->eq('p.createdBy', ':id'))
                 ->setParameter('id', $this->currentUser->getId());
         }
 

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -33,7 +33,11 @@ class PageModel extends FormModel
      */
     public function getRepository ()
     {
-        return $this->em->getRepository('MauticPageBundle:Page');
+        $repo = $this->em->getRepository('MauticPageBundle:Page');
+        $repo->setCurrentUser(
+            $this->factory->getUser()
+        );
+        return $repo;
     }
 
     /**


### PR DESCRIPTION
This commit fixes a bug on landing page creation. This bug occures when an user has privileges only on his own pages because the field *created_by* isn't a foreign key.

Step to reproduce bug:
- Create a user with a custom role and these permissions on landing pages: *View own - Edit own - Create - Delete own - Publish own*.
- Login with this new user.
- Try to create a new landing page. An exception will be thrown: *Internal Server Error - [Semantical Error] line 0, col 100 near 'createdBy) =': Error: Invalid PathExpression. Must be a SingleValuedAssociationField.*.