### PR TITLE
UX improvements for app/console

### DIFF
--- a/app/console
+++ b/app/console
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
 
 $input = new ArgvInput();
-$env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
+$env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'prod');
 $debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(array('--no-debug', '')) && $env !== 'prod';
 
 if ($debug) {
@@ -29,4 +29,6 @@ if ($debug) {
 
 $kernel = new AppKernel($env, $debug);
 $application = new Application($kernel);
+$application->setName('Mautic');
+$application->setVersion($kernel->getVersion().' - '.$kernel->getName().'/'.$kernel->getEnvironment().($kernel->isDebug() ? '/debug' : ''));
 $application->run($input);


### PR DESCRIPTION
This PR makes some user experience improvements to the `app/console` shell script entry point:

- Defaults the environment to `prod` versus `dev`
- Changes the application name and version number to use Mautic's versus the Symfony core (this shows up in some of the help screen outputs)

```sh
Michaels-MacBook-Pro:mautic mbabker$ php app/console
Mautic version 1.1.3-dev - app/prod

Usage:
  [options] command [arguments]

[...]
```