### PR TITLE
Fix page builder tokens

### DIFF
--- a/app/bundles/CoreBundle/Event/BuilderEvent.php
+++ b/app/bundles/CoreBundle/Event/BuilderEvent.php
@@ -322,8 +322,13 @@ class BuilderEvent extends Event
         $allowVisualPlaceholder = false,
         $convertToLinks = false
     ) {
+    	$tokens = $this->getTokensFromHelper($tokenHelper, $tokens, $labelColumn, $valueColumn);
+		if ( $tokens == null ) {
+			$tokens = array();
+		}
+		
         $this->addTokens(
-            $this->getTokensFromHelper($tokenHelper, $tokens, $labelColumn, $valueColumn),
+        	$tokens,
             $allowVisualPlaceholder,
             $convertToLinks
         );

--- a/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
+++ b/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
@@ -73,7 +73,7 @@ class BuilderTokenHelper
         );
 
 
-        if (in_array(false, $permissions)) {
+        if (count(array_unique($permissions)) == 1 && end($permissions) == false) {
             return;
         }
 
@@ -169,7 +169,7 @@ class BuilderTokenHelper
             "RETURN_ARRAY"
         );
 
-        if (in_array(false, $permissions)) {
+        if (count(array_unique($permissions)) == 1 && end($permissions) == false) {
             return;
         }
 
@@ -186,7 +186,7 @@ class BuilderTokenHelper
 
         if (isset($permissions[$this->viewPermissionBase.':viewother']) && !$permissions[$this->viewPermissionBase.':viewother']) {
             $expr->add(
-                $exprBuilder->eq($prefix.'createdBy', $this->factory->getUser()->getId())
+                $exprBuilder->eq($prefix.'created_by', $this->factory->getUser()->getId())
             );
         }
 


### PR DESCRIPTION
This commit fixes a bug on landing page creation. 

This bug occures **only** after applying the fix in PR #612 . In landing page creation, select a theme and click on the *Builder* button. An exception will be thrown: *Internal Server Error - Catchable Fatal Error: Argument 1 passed to Mautic\CoreBundle\Event\BuilderEvent::addTokens() must be of the type array, null given, called in /var/www/clients/client21/web251/web/app/bundles/CoreBundle/Event/BuilderEvent.php on line 334 and defined in /var/www/clients/client21/web251/web/app/bundles/CoreBundle/Event/BuilderEvent.php line 175*. 
