### PR TITLE
Fixes email tokens when duplicate tokens are used

### DIFF
--- a/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
+++ b/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
@@ -250,21 +250,26 @@ class BuilderTokenHelper
         } else {
             if (isset($tokens['visualTokens'])) {
                 // Get all the tokens in the content
+                $replacedTokens = array();
                 if (preg_match_all('/{(.*?)}/', $content, $matches)) {
                     $search = $replace = array();
 
                     foreach ($matches[0] as $tokenMatch) {
-                        if (strstr($tokenMatch, '|')) {
-                            // This token has been customized
-                            $tokenParts = explode('|', $tokenMatch);
-                            $token = $tokenParts[0] . '}';
-                        } else {
-                            $token = $tokenMatch;
-                        }
+                        if (!in_array($tokenMatch, $replacedTokens)) {
+                            $replacedTokens[] = $tokenMatch;
 
-                        if (in_array($token, $tokens['visualTokens'])) {
-                            $search[]  = $tokenMatch;
-                            $replace[] = self::getVisualTokenHtml($tokenMatch, $tokens['tokens'][$token]);
+                            if (strstr($tokenMatch, '|')) {
+                                // This token has been customized
+                                $tokenParts = explode('|', $tokenMatch);
+                                $token      = $tokenParts[0].'}';
+                            } else {
+                                $token = $tokenMatch;
+                            }
+
+                            if (in_array($token, $tokens['visualTokens'])) {
+                                $search[]  = $tokenMatch;
+                                $replace[] = self::getVisualTokenHtml($tokenMatch, $tokens['tokens'][$token]);
+                            }
                         }
                     }
 


### PR DESCRIPTION
**Description**
When duplicate tokens are used in a single email body, the first token is replaced correctly with the visual representation but the others are corrupted due to the data attribute being replaced.  

**Testing**
Create an email and add a couple of the same leadfield tokens.  Save and edit.  The second token will be corrupted.  Apply the PR and repeat, and now all tokens should be correctly parsed.