### PR TITLE
Fixes issue with social profile fetching and prevent lead from being anonymous if they have a social identity

### DIFF
--- a/addons/MauticSocialBundle/Integration/TwitterIntegration.php
+++ b/addons/MauticSocialBundle/Integration/TwitterIntegration.php
@@ -76,7 +76,9 @@ class TwitterIntegration extends SocialIntegration
         // Get request token
         $requestToken = $this->getRequestToken();
 
-        $url .= '?oauth_token=' . $requestToken['oauth_token'];
+        if (isset($requestToken['oauth_token'])) {
+            $url .= '?oauth_token='.$requestToken['oauth_token'];
+        }
 
         return $url;
     }

--- a/app/bundles/AddonBundle/Helper/IntegrationHelper.php
+++ b/app/bundles/AddonBundle/Helper/IntegrationHelper.php
@@ -346,6 +346,8 @@ class IntegrationHelper
     /**
      * @param      $lead
      * @param bool $integration
+     *
+     * @return array
      */
     public function clearIntegrationCache ($lead, $integration = false)
     {
@@ -431,7 +433,9 @@ class IntegrationHelper
             }
         };
 
-        if (isset($fields['core'])) {
+        $groups = array('core', 'social', 'professional', 'personal');
+        $keys   = array_keys($fields);
+        if (count(array_intersect($groups, $keys)) !== 0 && count($keys) <= 4) {
             //fields are group
             foreach ($fields as $group => $groupFields) {
                 $availableFields = array_keys($groupFields);

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -548,9 +548,12 @@ class LeadController extends FormController
     }
 
     /**
-     * Generates edit form and processes post data
+     * Generates edit form
      *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     * @param            $objectId
+     * @param bool|false $ignorePost
+     *
+     * @return array|JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      */
     public function editAction($objectId, $ignorePost = false)
     {

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -132,6 +132,11 @@ class LeadRepository extends CommonRepository
             ->setParameter('ids', $ids)
             ->orderBy('l.dateAdded', 'DESC');
             $results = $q->getQuery()->getResult();
+
+            /** @var Lead $lead */
+            foreach ($results as $lead) {
+                $lead->setAvailableSocialFields($this->availableSocialFields);
+            }
         }
 
         return $results;
@@ -176,6 +181,11 @@ class LeadRepository extends CommonRepository
             ->orderBy('l.dateAdded', 'DESC');
 
         $results = $q->getQuery()->getResult();
+
+        /** @var Lead $lead */
+        foreach ($results as $lead) {
+            $lead->setAvailableSocialFields($this->availableSocialFields);
+        }
 
         return $results;
     }
@@ -250,6 +260,11 @@ class LeadRepository extends CommonRepository
             ->setParameter('ip', $ip)
             ->orderBy('l.dateAdded', 'DESC');
         $results = $q->getQuery()->getResult();
+
+        /** @var Lead $lead */
+        foreach ($results as $lead) {
+            $lead->setAvailableSocialFields($this->availableSocialFields);
+        }
 
         return $results;
     }

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -677,6 +677,17 @@ class LeadRepository extends CommonRepository
                         $q->expr()->$nullFunc("l.email")
                     )
                 );
+
+                if (!empty($this->availableSocialFields)) {
+                    foreach ($this->availableSocialFields as $field) {
+                        $expr->add(
+                            $q->expr()->$xSubFunc(
+                                $q->expr()->$eqFunc("l.$field", $q->expr()->literal('')),
+                                $q->expr()->$nullFunc("l.$field")
+                            )
+                        );
+                    }
+                }
                 $returnParameter = false;
                 break;
             case $this->translator->trans('mautic.core.searchcommand.ismine'):

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -342,8 +342,9 @@ class FieldModel extends FormModel
     }
 
     /**
-     * @param bool $byGroup
-     * @param bool $alphabetical
+     * @param bool|true $byGroup
+     * @param bool|true $alphabetical
+     * @param array     $filters
      *
      * @return array
      */
@@ -393,6 +394,46 @@ class FieldModel extends FormModel
         return $leadFields;
     }
 
+    /**
+     * Get the fields for a specific group
+     *
+     * @param       $group
+     * @param array $filters
+     */
+    public function getGroupFields($group, $filters = array('isPublished' => true))
+    {
+        $forceFilters = array(
+            array(
+                'column' => 'f.group',
+                'expr'   => 'eq',
+                'value'  => $group
+            )
+        );
+        foreach ($filters as $col => $val) {
+            $forceFilters[] = array(
+                'column' => "f.{$col}",
+                'expr'   => 'eq',
+                'value'  => $val
+            );
+        }
+        // Get a list of custom form fields
+        $fields = $this->getEntities(array(
+            'filter'     => array(
+                'force' => $forceFilters
+            ),
+            'orderBy'    => 'f.order',
+            'orderByDir' => 'asc'
+        ));
+
+        $leadFields = array();
+
+        foreach ($fields as $f) {
+            $leadFields[$f->getAlias()] = $f->getLabel();
+        }
+
+        return $leadFields;
+    }
+
     /*
      * Retrieves a list of published fields that are unique identifers
      *
@@ -402,7 +443,7 @@ class FieldModel extends FormModel
     {
         $filters = array ('isPublished' => true, 'isUniqueIdentifer' => true);
 
-        $fields = $this->getFieldList(false, true,  $filters);
+        $fields = $this->getFieldList(false, true, $filters);
 
         return $fields;
     }

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -40,11 +40,24 @@ class LeadModel extends FormModel
     /**
      * {@inheritdoc}
      *
-     * @return string
+     * @return \Mautic\LeadBundle\Entity\LeadRepository
      */
     public function getRepository()
     {
-        return $this->em->getRepository('MauticLeadBundle:Lead');
+        static $socialFieldsSet;
+
+        $repo = $this->em->getRepository('MauticLeadBundle:Lead');
+
+        if (!$socialFieldsSet) {
+            $fields = $this->factory->getModel('lead.field')->getGroupFields('social');
+            if (!empty($fields)) {
+                $socialFields = array_keys($fields);
+                $repo->setAvailableSocialFields($socialFields);
+            }
+            $socialFieldsSet = true;
+        }
+
+        return $repo;
     }
 
     /**


### PR DESCRIPTION
**Description**

If a lead did not have any vales for the core group, social profile fetching would fail due to an if statement that checked for the core group existence.  This PR should fix that.

Also this PR will consider leads with a social identity as NOT anonymous. The lead list is also searchable by social profile handles.

**Testing**
Setup Twitter integration. Create a new lead with only a twitter handle.  The twitter profile will not be found.  Apply the PR and repeat and this time it should fetch.