### PR TITLE
Check if a column name is an integer or reserved word (Fix #596)

### DIFF
--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -34,7 +34,17 @@ class SubmissionRepository extends CommonRepository
         $results['form_id']       = $form->getId();
         $tableName                = MAUTIC_TABLE_PREFIX . 'form_results_' . $form->getId() . '_' . $form->getAlias();
         if (!empty($results)) {
-            $this->_em->getConnection()->insert($tableName, $results);
+            // Make sure the column names are all SQL safe
+            $data = array();
+            $databasePlatform = $this->_em->getConnection()->getDatabasePlatform();
+            $reservedWords = $databasePlatform->getReservedKeywordsList();
+
+            foreach ($results as $name => $value) {
+                $columnName = ($reservedWords->isKeyword($name) || is_numeric($name)) ? $databasePlatform->quoteIdentifier($name) : $name;
+                $data[$columnName] = $value;
+            }
+
+            $this->_em->getConnection()->insert($tableName, $data);
         }
     }
 

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -357,6 +357,8 @@ class FormModel extends CommonFormModel
     public function generateFieldColumns(Form $form)
     {
         $fields = $form->getFields();
+        $databasePlatform = $this->factory->getDatabase()->getDatabasePlatform();
+        $reservedWords = $databasePlatform->getReservedKeywordsList();
 
         $columns = array(
             array(
@@ -372,7 +374,7 @@ class FormModel extends CommonFormModel
         foreach ($fields as $f) {
             if (!in_array($f->getType(), $ignoreTypes) && $f->getSaveResult() !== false) {
                 $columns[] = array(
-                    'name'    => $f->getAlias(),
+                    'name'    => ($reservedWords->isKeyword($f->getAlias()) || is_numeric($f->getAlias())) ? $databasePlatform->quoteIdentifier($f->getAlias()) : $f->getAlias(),
                     'type'    => 'text',
                     'options' => array(
                         'notnull' => false


### PR DESCRIPTION
This PR adds checks to places where `form_results` tables are written to (either created or rows inserted) and ensures the column names are SQL safe.  We use the database platform's reserved keyword list and a check if the string is numeric and the values are quoted if so.

```sh
doctrine.DEBUG: CREATE TABLE mautic_form_results_12_asdfasdfas (submission_id INT NOT NULL, form_id INT NOT NULL, `42` LONGTEXT DEFAULT NULL, UNIQUE INDEX UNIQ_48FC6D4BE1FD49335FF69B7D (submission_id, form_id), PRIMARY KEY(submission_id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB [] []
doctrine.DEBUG: INSERT INTO mautic_form_results_12_asdfasdfas (`42`, submission_id, form_id) VALUES (?, ?, ?) ["asdf",7,12] []
doctrine.DEBUG: CREATE TABLE mautic_form_results_13_wegotthis (submission_id INT NOT NULL, form_id INT NOT NULL, `select` LONGTEXT DEFAULT NULL, UNIQUE INDEX UNIQ_BBBA5398E1FD49335FF69B7D (submission_id, form_id), PRIMARY KEY(submission_id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB [] []
doctrine.DEBUG: INSERT INTO mautic_form_results_13_wegotthis (`select`, submission_id, form_id) VALUES (?, ?, ?) ["asdf",8,13] []
```