### PR TITLE
Fix of JS validation when the form name starts with a number

### DIFF
--- a/app/bundles/FormBundle/Views/Builder/script.html.php
+++ b/app/bundles/FormBundle/Views/Builder/script.html.php
@@ -31,7 +31,7 @@ $fields   = $form->getFields();
     }
 
     /** This is needed for each form **/
-    MauticFormValidations.<?php echo $formName; ?> = {
+    MauticFormValidations['<?php echo $formName; ?>'] = {
 <?php
 foreach($fields as $f):
 if (!$f->isRequired()) continue;


### PR DESCRIPTION
Problem described in https://github.com/mautic/mautic/issues/545

#### How to test
- Create a form with name starting with a number. For example `66 Cute Cats`.
- Create a form field which is required.
- Open the form from the public.
- Open the JS console

You should see a JS error. Apply this PR and the error should be gone and the form should work.