### PR TITLE
Long page names were destroying A/B test chart. Fixed.

### DIFF
--- a/app/bundles/CoreBundle/Helper/GraphHelper.php
+++ b/app/bundles/CoreBundle/Helper/GraphHelper.php
@@ -219,13 +219,18 @@ class GraphHelper
     /**
      * Prepares data structure for basic count based line graphs
      *
-     * @param array $labels       array of labels
-     * @param array $datasets     array array(label => array of values in order of $labels)
+     * @param array   $labels       array of labels
+     * @param array   $datasets     array array(label => array of values in order of $labels)
+     * @param integer $labelsLength truncate labels to this char length
      *
      * @return array
      */
-    public static function prepareBarGraphData($labels, $datasets)
+    public static function prepareBarGraphData(array $labels, array $datasets, $labelsLength = 30)
     {
+        foreach ($labels as $key => $lab) {
+            $labels[$key] = self::truncate($lab, $labelsLength);
+        }
+
         $data = array();
         $data['labels'] = $labels;
         $j = 0;
@@ -367,5 +372,27 @@ class GraphHelper
         }
 
         return $graphData;
+    }
+
+    /**
+     * Helper function to shorten/truncate a string
+     *
+     * @param string  $string
+     * @param integer $length
+     * @param string  $append
+     *
+     * @return string
+     */
+    public static function truncate($string, $length = 100, $append = "...")
+    {
+        $string = trim($string);
+
+        if (strlen($string) > $length) {
+            $string = wordwrap($string, $length);
+            $string = explode("\n", $string, 2);
+            $string = $string[0] . $append;
+        }
+
+        return $string;
     }
 }


### PR DESCRIPTION
Problem described in https://github.com/mautic/mautic/issues/493

#### How to test
- Create a Landing Page with a long title. (more than 100 chars)
- Create an A/B test page.
- Click on A/B test stats button.

The long chart label (page title) is moving the whole chart up and the bars are not visible. This PR limits labels to 30 characters.