### PR TITLE
Fix forms list for users with restricted access

### DIFF
--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -66,7 +66,7 @@ class FormController extends CommonFormController
 
 
         if (!$permissions['form:forms:viewother']) {
-            $filter['force'] = array('column' => 'f.createdBy', 'expr' => 'eq', 'value' => $this->factory->getUser()->getId());
+            $filter['force'][] = array('column' => 'f.createdBy', 'expr' => 'eq', 'value' => $this->factory->getUser()->getId());
         }
 
         $orderBy    = $session->get('mautic.form.orderby', 'f.name');


### PR DESCRIPTION
This PR fixes a bug on Forms list. This bug occures when an user has privileges only on his own forms.

Steps to reproduce bug:
- Create an user with a custom role and these permissions on forms: View own - Edit own - Create - Delete own - Publish own.
- Login with this new user.
- Create a form.
- Go to forms list: you cannot see the form you have just created.

The problem is an incorrect setting in the filters array.