### PR TITLE
Clone Form and cancel fix

### DIFF
--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -28,7 +28,7 @@ class FormModel extends CommonModel
     public function lockEntity($entity)
     {
         //lock the row if applicable
-        if (method_exists($entity, 'setCheckedOut')) {
+        if (method_exists($entity, 'setCheckedOut') && method_exists($entity, 'getId') && $entity->getId()) {
             $user = $this->factory->getUser();
             if ($user->getId()) {
                 $entity->setCheckedOut(new \DateTime());
@@ -72,7 +72,7 @@ class FormModel extends CommonModel
     public function unlockEntity($entity, $extra = null)
     {
         //unlock the row if applicable
-        if (method_exists($entity, 'setCheckedOut')) {
+        if (method_exists($entity, 'setCheckedOut') && method_exists($entity, 'getId') && $entity->getId()) {
             //flush any potential changes
             $this->em->refresh($entity);
 

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -11,6 +11,7 @@ namespace Mautic\FormBundle\Controller;
 
 use Mautic\CoreBundle\Controller\FormController as CommonFormController;
 use Mautic\FormBundle\Entity\Field;
+use Mautic\FormBundle\Entity\Form;
 use Mautic\FormBundle\Helper\FormFieldHelper;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Response;
@@ -411,7 +412,21 @@ class FormController extends CommonFormController
     public function editAction($objectId, $ignorePost = false, $forceTypeSelection = false)
     {
         $model      = $this->factory->getModel('form.form');
-        $entity     = $model->getEntity($objectId);
+        $formData   = $this->request->request->get('mauticform');
+        $sessionId  = isset($formData['sessionId']) ? $formData['sessionId'] : null;
+
+        if ($objectId instanceof Form) {
+            $entity = $objectId;
+            $objectId = sha1(uniqid(mt_rand(), true));
+        } else {
+            $entity = $model->getEntity($objectId);
+
+            // Process submit of cloned form
+            if ($entity == null && $objectId == $sessionId) {
+                $entity = $model->getEntity();
+            }
+        }
+
         $session    = $this->factory->getSession();
         $cleanSlate = true;
 
@@ -491,6 +506,9 @@ class FormController extends CommonFormController
 
                         //save the form first so that new fields are available to actions
                         $model->saveEntity($entity, $form->get('buttons')->get('save')->isClicked());
+
+                        // Reset objectId to entity ID (can be session ID in case of cloned entity)
+                        $objectId = $entity->getId();
 
                         if ($entity->isStandalone()) {
                             //now set the actions
@@ -701,17 +719,17 @@ class FormController extends CommonFormController
                 return $this->accessDenied();
             }
 
-            $newForm = clone $entity;
-            $newForm->setIsPublished(false);
+            $entity = clone $entity;
+            $entity->setIsPublished(false);
 
             // Clone the forms's fields
             $fields = $entity->getFields();
             /** @var \Mautic\FormBundle\Entity\Field $field */
             foreach ($fields as $field) {
                 $fieldClone = clone $field;
-                $fieldClone->setForm($newForm);
+                $fieldClone->setForm($entity);
                 $fieldClone->setSessionId(null);
-                $newForm->addField($field->getId(), $fieldClone);
+                $entity->addField($field->getId(), $fieldClone);
             }
 
             // Clone the forms's actions
@@ -719,15 +737,12 @@ class FormController extends CommonFormController
             /** @var \Mautic\FormBundle\Entity\Action $action */
             foreach ($actions as $action) {
                 $actionClone = clone $action;
-                $actionClone->setForm($newForm);
-                $newForm->addAction($action->getId(), $actionClone);
+                $actionClone->setForm($entity);
+                $entity->addAction($action->getId(), $actionClone);
             }
-
-            $model->saveEntity($newForm);
-            $objectId = $newForm->getId();
         }
 
-        return $this->editAction($objectId, true, true);
+        return $this->editAction($entity, true, true);
     }
 
     /**


### PR DESCRIPTION
This is fix for https://github.com/mautic/mautic/issues/537

#### How to test
1. Create a form if you don't have any.
2. Clone the form.
3. The modal with "New Campaign Form" and "New Standalone Form" should appear.
4. Close the modal without selecting any of the options.

The result is that the new clone of the form was created (which is bad in this case). After this PR the clone is not created. The clone is created after the cloned form is saved. Make sure everything else still works. Fields and actions are cloned, do not link to the old form. The original results stay with the original form and new results are stored to the correct form.