### PR TITLE
Update the Symfony Security component and bundle to 2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/options-resolver": "2.5.*",
         "symfony/process": "2.5.*",
         "symfony/routing": "2.5.*",
-        "symfony/security": "2.5.*",
+        "symfony/security": "2.6.*",
         "symfony/templating": "2.5.*",
         "symfony/translation": "2.5.*",
         "symfony/validator": "2.5.*",
@@ -34,7 +34,7 @@
 
         "symfony/framework-bundle": "2.5.*",
         "symfony/monolog-bundle": "~2.4",
-        "symfony/security-bundle": "2.5.*",
+        "symfony/security-bundle": "2.6.*",
         "symfony/swiftmailer-bundle": "~2.3",
 
         "symfony/doctrine-bridge": "2.5.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bb2ff57ac7f1cdfd0b86b4da05c97210",
+    "hash": "9517c9222cd082d74ebdf532e107b934",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -3748,17 +3748,17 @@
         },
         {
             "name": "symfony/security",
-            "version": "v2.5.10",
+            "version": "v2.6.10",
             "target-dir": "Symfony/Component/Security",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Security.git",
-                "reference": "4cf41cef4ad7377ea89fb3856e2b07b925aa15cf"
+                "reference": "bc07ab0b812567146980e40ab3987aa46a3f95a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Security/zipball/4cf41cef4ad7377ea89fb3856e2b07b925aa15cf",
-                "reference": "4cf41cef4ad7377ea89fb3856e2b07b925aa15cf",
+                "url": "https://api.github.com/repos/symfony/Security/zipball/bc07ab0b812567146980e40ab3987aa46a3f95a1",
+                "reference": "bc07ab0b812567146980e40ab3987aa46a3f95a1",
                 "shasum": ""
             },
             "require": {
@@ -3778,8 +3778,9 @@
                 "doctrine/dbal": "~2.2",
                 "ircmaxell/password-compat": "~1.0",
                 "psr/log": "~1.0",
-                "symfony/expression-language": "~2.4",
+                "symfony/expression-language": "~2.6",
                 "symfony/intl": "~2.3",
+                "symfony/phpunit-bridge": "~2.7",
                 "symfony/routing": "~2.2",
                 "symfony/translation": "~2.0,>=2.0.5",
                 "symfony/validator": "~2.5,>=2.5.5"
@@ -3796,7 +3797,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -3810,58 +3811,61 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Security Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-01-25 04:37:39"
+            "homepage": "https://symfony.com",
+            "time": "2015-07-08 05:59:48"
         },
         {
             "name": "symfony/security-bundle",
-            "version": "v2.5.10",
+            "version": "v2.6.10",
             "target-dir": "Symfony/Bundle/SecurityBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/SecurityBundle.git",
-                "reference": "007ebe3a30f093a650167d2bf435aab7bd794919"
+                "reference": "6adb8e508e9ed21abaa6b01184beef91ece8c8ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/SecurityBundle/zipball/007ebe3a30f093a650167d2bf435aab7bd794919",
-                "reference": "007ebe3a30f093a650167d2bf435aab7bd794919",
+                "url": "https://api.github.com/repos/symfony/SecurityBundle/zipball/6adb8e508e9ed21abaa6b01184beef91ece8c8ba",
+                "reference": "6adb8e508e9ed21abaa6b01184beef91ece8c8ba",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "symfony/http-kernel": "~2.2",
-                "symfony/security": "~2.5"
+                "symfony/security": "~2.6"
             },
             "require-dev": {
+                "doctrine/doctrine-bundle": "~1.2",
                 "symfony/browser-kit": "~2.4",
+                "symfony/console": "~2.3",
                 "symfony/css-selector": "~2.0,>=2.0.5",
                 "symfony/dependency-injection": "~2.3",
                 "symfony/dom-crawler": "~2.0,>=2.0.5",
-                "symfony/expression-language": "~2.4",
+                "symfony/expression-language": "~2.6",
                 "symfony/form": "~2.4",
-                "symfony/framework-bundle": "~2.4",
+                "symfony/framework-bundle": "~2.6",
                 "symfony/http-foundation": "~2.3",
+                "symfony/phpunit-bridge": "~2.7",
                 "symfony/process": "~2.0,>=2.0.5",
                 "symfony/twig-bridge": "~2.2,>=2.2.6",
                 "symfony/twig-bundle": "~2.2",
-                "symfony/validator": "~2.2",
+                "symfony/validator": "~2.5",
                 "symfony/yaml": "~2.0,>=2.0.5",
                 "twig/twig": "~1.12"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -3875,17 +3879,17 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony SecurityBundle",
-            "homepage": "http://symfony.com",
-            "time": "2015-01-13 07:22:00"
+            "homepage": "https://symfony.com",
+            "time": "2015-07-09 16:02:48"
         },
         {
             "name": "symfony/stopwatch",
@@ -4479,7 +4483,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liip/LiipFunctionalTestBundle/zipball/6142762ff5f3d8b8c0918c3866bf6b9111d5fce6",
+                "url": "https://api.github.com/repos/liip/LiipFunctionalTestBundle/zipball/e077720f49c50d38a8ff8a4ad04c3108c53e45a8",
                 "reference": "933cde549faae84d4e5ad2f59480f6de86deaaf0",
                 "shasum": ""
             },


### PR DESCRIPTION
Symfony's 2.5 branch reaches end of support this month.  This PR updates the Security component and bundle to the 2.6 branch which has security support until January 2016.

Component Changes: https://github.com/symfony/Security/compare/v2.5.10...v2.6.10
Bundle Changes: https://github.com/symfony/SecurityBundle/compare/v2.5.10...v2.6.10