### PR TITLE
Update the Symfony Templating component to 2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/process": "2.5.*",
         "symfony/routing": "2.5.*",
         "symfony/security": "2.5.*",
-        "symfony/templating": "2.5.*",
+        "symfony/templating": "2.6.*",
         "symfony/translation": "2.5.*",
         "symfony/validator": "2.5.*",
         "symfony/yaml": "2.5.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bb2ff57ac7f1cdfd0b86b4da05c97210",
+    "hash": "9e0d6dcbf6d974d38d8bea0fed48a2af",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -4050,24 +4050,25 @@
         },
         {
             "name": "symfony/templating",
-            "version": "v2.5.10",
+            "version": "v2.6.10",
             "target-dir": "Symfony/Component/Templating",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Templating.git",
-                "reference": "b1d57353e696815ed1b42e90ac8e943668e59d5d"
+                "reference": "c952f520774000056a335486bc706909ce11f226"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Templating/zipball/b1d57353e696815ed1b42e90ac8e943668e59d5d",
-                "reference": "b1d57353e696815ed1b42e90ac8e943668e59d5d",
+                "url": "https://api.github.com/repos/symfony/Templating/zipball/c952f520774000056a335486bc706909ce11f226",
+                "reference": "c952f520774000056a335486bc706909ce11f226",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "psr/log": "~1.0"
+                "psr/log": "~1.0",
+                "symfony/phpunit-bridge": "~2.7"
             },
             "suggest": {
                 "psr/log": "For using debug logging in loaders"
@@ -4075,7 +4076,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -4089,17 +4090,17 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Templating Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-01-05 17:29:33"
+            "homepage": "https://symfony.com",
+            "time": "2015-06-25 11:21:15"
         },
         {
             "name": "symfony/translation",
@@ -4479,7 +4480,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liip/LiipFunctionalTestBundle/zipball/6142762ff5f3d8b8c0918c3866bf6b9111d5fce6",
+                "url": "https://api.github.com/repos/liip/LiipFunctionalTestBundle/zipball/e077720f49c50d38a8ff8a4ad04c3108c53e45a8",
                 "reference": "933cde549faae84d4e5ad2f59480f6de86deaaf0",
                 "shasum": ""
             },


### PR DESCRIPTION
Symfony's 2.5 branch reaches end of support this month.  This PR updates the Templating component to the 2.6 branch which has security support until January 2016.

Component Changes: https://github.com/symfony/Templating/compare/v2.5.10...v2.6.10