### PR TITLE
Update Symfony Translation component to 2.6

### DIFF
--- a/app/bundles/CoreBundle/Translation/Translator.php
+++ b/app/bundles/CoreBundle/Translation/Translator.php
@@ -41,7 +41,7 @@ class Translator extends BaseTranslator
             $this->loadCatalogue($locale);
         }
 
-        return $this->catalogues[$locale]->has((string) $id, $domain);
+        return $this->getCatalogue($locale)->has((string) $id, $domain);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/routing": "2.5.*",
         "symfony/security": "2.5.*",
         "symfony/templating": "2.5.*",
-        "symfony/translation": "2.5.*",
+        "symfony/translation": "2.6.*",
         "symfony/validator": "2.5.*",
         "symfony/yaml": "2.5.*",
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bb2ff57ac7f1cdfd0b86b4da05c97210",
+    "hash": "4fbc3be0f0f56c5a35118ac5cfe9612d",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -4103,35 +4103,38 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v2.5.10",
+            "version": "v2.6.10",
             "target-dir": "Symfony/Component/Translation",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Translation.git",
-                "reference": "165b5348cd20f8c4b2fcf1097c9c8300d1093b90"
+                "reference": "d84291215b5892834dd8ca8ee52f9cbdb8274904"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Translation/zipball/165b5348cd20f8c4b2fcf1097c9c8300d1093b90",
-                "reference": "165b5348cd20f8c4b2fcf1097c9c8300d1093b90",
+                "url": "https://api.github.com/repos/symfony/Translation/zipball/d84291215b5892834dd8ca8ee52f9cbdb8274904",
+                "reference": "d84291215b5892834dd8ca8ee52f9cbdb8274904",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
+                "psr/log": "~1.0",
                 "symfony/config": "~2.3,>=2.3.12",
                 "symfony/intl": "~2.3",
+                "symfony/phpunit-bridge": "~2.7",
                 "symfony/yaml": "~2.2"
             },
             "suggest": {
+                "psr/log": "To use logging capability in translator",
                 "symfony/config": "",
                 "symfony/yaml": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -4145,17 +4148,17 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Translation Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-01-03 15:23:51"
+            "homepage": "https://symfony.com",
+            "time": "2015-07-08 05:59:48"
         },
         {
             "name": "symfony/validator",
@@ -4479,7 +4482,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liip/LiipFunctionalTestBundle/zipball/6142762ff5f3d8b8c0918c3866bf6b9111d5fce6",
+                "url": "https://api.github.com/repos/liip/LiipFunctionalTestBundle/zipball/e077720f49c50d38a8ff8a4ad04c3108c53e45a8",
                 "reference": "933cde549faae84d4e5ad2f59480f6de86deaaf0",
                 "shasum": ""
             },


### PR DESCRIPTION
Symfony's 2.5 branch reaches end of support this month.  This PR updates the Translation component to the 2.6 branch which has security support until January 2016.

Component Changes: https://github.com/symfony/Translation/compare/v2.5.10...v2.6.10