### PR TITLE
Fixes js error and addon asset loading

### DIFF
--- a/app/bundles/CoreBundle/Templating/Helper/AssetsHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/AssetsHelper.php
@@ -11,7 +11,6 @@ namespace Mautic\CoreBundle\Templating\Helper;
 
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Helper\AssetGenerationHelper;
-use Symfony\Component\Finder\Finder;
 use Symfony\Component\Templating\Helper\CoreAssetsHelper;
 
 /**
@@ -210,7 +209,7 @@ class AssetsHelper extends CoreAssetsHelper
 
     public function includeScript($assetFilePath)
     {
-        return  '<script type="text/javascript">Mautic.loadScript(\'' . $this->getUrl($assetFilePath) . '\');</script>';
+        return  '<script async="async" type="text/javascript">Mautic.loadScript(\'' . $this->getUrl($assetFilePath) . '\');</script>';
     }
 
     /*
@@ -221,7 +220,7 @@ class AssetsHelper extends CoreAssetsHelper
 
     public function includeStylesheet($assetFilePath)
     {
-        return  '<script type="text/javascript">Mautic.loadStylesheet(\'' . $this->getUrl($assetFilePath) . '\');</script>';
+        return  '<script async="async" type="text/javascript">Mautic.loadStylesheet(\'' . $this->getUrl($assetFilePath) . '\');</script>';
     }
 
     /**
@@ -434,7 +433,6 @@ class AssetsHelper extends CoreAssetsHelper
      * @param string $text
      * @param array  $protocols  http/https, ftp, mail, twitter
      * @param array  $attributes
-     * @param string $mode       normal or all
      * @return string
      */
     public function makeLinks($text, $protocols = array('http', 'mail'), array $attributes = array())
@@ -464,12 +462,12 @@ class AssetsHelper extends CoreAssetsHelper
                             $link = $match[2] ?: $match[3];
                             return '<' . array_push($links, "<a $attr href=\"$protocol://$link\">$link</a>") . '>';
                         }, $text);
-                    break;
+                        break;
                     case 'mail':
                         $text = preg_replace_callback('~([^\s<]+?@[^\s<]+?\.[^\s<]+)(?<![\.,:])~', function ($match) use (&$links, $attr) {
                             return '<' . array_push($links, "<a $attr href=\"mailto:{$match[1]}\">{$match[1]}</a>") . '>';
                         }, $text);
-                    break;
+                        break;
                     case 'twitter':
                         $text = preg_replace_callback('~(?<!\w)[@#](\w++)~', function ($match) use (&$links, $attr) {
                             return '<' . array_push($links, "<a $attr href=\"https://twitter.com/" . ($match[0][0] == '@' ? '' : 'search/%23') . $match[1]  . "\">{$match[0]}</a>") . '>';
@@ -548,7 +546,11 @@ class AssetsHelper extends CoreAssetsHelper
     }
 
     /**
-     * @param $country
+     * @param           $country
+     * @param bool|true $urlOnly
+     * @param string    $class
+     *
+     * @return string
      */
     public function getCountryFlag($country, $urlOnly = true, $class = '')
     {

--- a/app/bundles/PageBundle/Assets/builder/builder.js
+++ b/app/bundles/PageBundle/Assets/builder/builder.js
@@ -1,9 +1,8 @@
 mQuery(document).ready(function () {
     mQuery('.dropdown-toggle').dropdown();
     mQuery('[data-toggle="tooltip"]').tooltip();
-    mQuery('input[data-toggle="color"]').pickAColor({
-        fadeMenuToggle: false,
-        inlineDropdown: true
+    mQuery('input[data-toggle="color"]').each(function() {
+        Mautic.activateColorPicker(this);
     });
     mQuery('*[data-toggle="sortablelist"]').sortable({
         placeholder: 'list-group-item ui-placeholder-highlight',


### PR DESCRIPTION
**Description**
This PR fixes an issue where a missed pickAColor reference caused the builders to break.

It also fixes a scenario where a page refresh would not execute an addon's onLoad method if the asset is loaded using $view['asset']->loadScript();  Clicking to the addon's URL (content loaded via ajax) would work.  But if refeshing the page would not.  This is done by converting to JQuery's $.getScript and using the callback to then manually execute the addon's onLoad method.  Checks were put in place so that the method is not called twice in the case of ajax use.

**Testing**
Before the PR, open a page builder and try to drag and drop a token into an editor.  Then browse the source.  The token should be missing.  If you view the browser's console, there will be an error about the pickAColor not being a function.  After the PR, the builder should work.

Testing the asset fix requires access to a 3rd party addon that utilizes it.  The big thing is to just test that Mautic's core stuff still works.  For example on the lead's details page.  The graph, initiated by the bundle's onLoad method, should populate on both browsing to the URL and a page refresh.