### PR TITLE
Minor UI fixes

### DIFF
--- a/app/bundles/CoreBundle/Views/Helper/confirm.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/confirm.html.php
@@ -86,6 +86,6 @@ if (!isset($precheck)) {
 }
 
 ?>
-<?php echo $wrapOpeningTag; ?><<?php echo $tag; ?><?php echo $buttonType; ?> class="<?php echo $btnClass; ?>" href="<?php echo $confirmAction; ?>" data-toggle="confirmation" data-precheck="<?php echo $precheck; ?>" data-message="<?php echo $view->escape($message); ?>" data-confirm-text="<?php echo $view->escape($confirmText); ?>"<?php echo implode(" " , $attr); ?>>
+<?php echo $wrapOpeningTag; ?><<?php echo $tag; ?><?php echo $buttonType; ?> class="<?php echo $btnClass; ?>" href="<?php echo $confirmAction; ?>" data-toggle="confirmation" data-precheck="<?php echo $precheck; ?>" data-message="<?php echo $view->escape($message); ?>" data-confirm-text="<?php echo $view->escape($confirmText); ?>" <?php echo implode(" " , $attr); ?>>
 <span<?php echo $tooltipAttr; ?>><?php if (isset($iconClass)):?><i class="<?php echo $iconClass; ?>"></i> <?php endif; ?><?php if (isset($btnText)):?><span class="<?php echo $btnTextClass; ?>"><?php echo $btnText; ?></span><?php endif; ?></span>
 </<?php echo $tag; ?>><?php echo $wrapClosingTag; ?>

--- a/app/bundles/CoreBundle/Views/Helper/noresults.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/noresults.html.php
@@ -18,3 +18,4 @@
         </div>
     </div>
 <?php endif; ?>
+<div class="clearfix"></div>


### PR DESCRIPTION
**Description**
There was a space missing between attributes for the confirm.html.php helper and thus broke some confirmation windows.

Also added a clearfix div after the "noresults" div so that it displays properly in empty tabs.