### PR TITLE
Added one unit in the future for linegraphs

### DIFF
--- a/app/bundles/CoreBundle/Helper/GraphHelper.php
+++ b/app/bundles/CoreBundle/Helper/GraphHelper.php
@@ -144,6 +144,10 @@ class GraphHelper
 
         $date    = new \DateTime();
         $oneUnit = new \DateInterval('P' . $isTime . '1' . $unit);
+
+        // Start with the next unit
+        $date->add($oneUnit);
+
         $data    = array('labels' => array(), 'datasets' => array());
         $j       = 0;
 


### PR DESCRIPTION
**Description**
Line graphs seemed to act funny or hide some of the information due to it stopping at today's date.  This PR adds tomorrow to the graph so that it displays a little better with a full curve.

Before:
![Before](http://dvkrd.co/drop/2015-07-14_15-21-38.png)

After:
![After](http://dvkrd.co/drop/2015-07-14_15-20-49.png)