### PR TITLE
Fixed FormController viewStandard helper and Dashboard timeline fix

### DIFF
--- a/app/bundles/CoreBundle/Controller/FormController.php
+++ b/app/bundles/CoreBundle/Controller/FormController.php
@@ -336,12 +336,13 @@ class FormController extends CommonController
     /**
      * Individual item's details page
      *
-     * @param     $objectId
-     * @param int $listPage
+     * @param      $objectId
+     * @param null $logObject
+     * @param int  $listPage
      *
      * @return array|\Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      */
-    protected function viewStandard($objectId, $listPage = 1)
+    protected function viewStandard($objectId, $logObject= null, $listPage = 1)
     {
         $model    = $this->factory->getModel($this->modelName);
         $entity   = $model->getEntity($objectId);
@@ -377,8 +378,13 @@ class FormController extends CommonController
             $this->setListFilters();
         }
 
+        // Audit log entries
+        $logs = ($logObject) ? $this->factory->getModel('core.auditLog')->getLogForObject($logObject, $objectId, $entity->getDateAdded()) : array();
+
         $delegateArgs = array(
             'viewParameters'  => array(
+                'item'        => $entity,
+                'logs'        => $logs,
                 'tmpl'        => $this->request->isXmlHttpRequest() ? $this->request->get('tmpl', 'index') : 'index',
                 'permissions' => $security->isGranted(
                     array(
@@ -406,10 +412,11 @@ class FormController extends CommonController
                 'activeLink'    => $this->activeLink,
                 'mauticContent' => $this->mauticContent,
                 'route'         => $this->generateUrl(
-                    $this->routeBase.'_view',
+                    $this->routeBase.'_action',
                     array(
-                        'objectId' => $entity->getId(),
-                        'listPage' => $listPage
+                        'objectAction' => 'view',
+                        'objectId'     => $entity->getId(),
+                        'listPage'     => $listPage
                     )
                 )
             )

--- a/app/bundles/CoreBundle/Controller/FormController.php
+++ b/app/bundles/CoreBundle/Controller/FormController.php
@@ -320,7 +320,7 @@ class FormController extends CommonController
             'contentTemplate' => $this->templateBase.':list.html.php',
             'passthroughVars' => array(
                 'activeLink'    => $this->activeLink,
-                'mauticContent' => 'form',
+                'mauticContent' => $this->mauticContent,
                 'route'         => $this->generateUrl($this->routeBase.'_index', array('page' => $page))
             )
         );
@@ -338,11 +338,12 @@ class FormController extends CommonController
      *
      * @param      $objectId
      * @param null $logObject
-     * @param int  $listPage
+     * @param null $logBundle
+     * @param null $listPage
      *
      * @return array|\Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      */
-    protected function viewStandard($objectId, $logObject= null, $listPage = 1)
+    protected function viewStandard($objectId, $logObject= null, $logBundle =  null, $listPage = null)
     {
         $model    = $this->factory->getModel($this->modelName);
         $entity   = $model->getEntity($objectId);
@@ -379,7 +380,20 @@ class FormController extends CommonController
         }
 
         // Audit log entries
-        $logs = ($logObject) ? $this->factory->getModel('core.auditLog')->getLogForObject($logObject, $objectId, $entity->getDateAdded()) : array();
+        $logs = ($logObject) ? $this->factory->getModel('core.auditLog')->getLogForObject($logObject, $objectId, $entity->getDateAdded(), 10, $logBundle) : array();
+
+        // Generate route
+        $routeVars = array(
+            'objectAction' => 'view',
+            'objectId'     => $entity->getId()
+        );
+        if ($listPage !== null) {
+            $routeVars['listPage'] = $listPage;
+        }
+        $route = $this->generateUrl(
+            $this->routeBase.'_action',
+            $routeVars
+        );
 
         $delegateArgs = array(
             'viewParameters'  => array(
@@ -411,14 +425,7 @@ class FormController extends CommonController
             'passthroughVars' => array(
                 'activeLink'    => $this->activeLink,
                 'mauticContent' => $this->mauticContent,
-                'route'         => $this->generateUrl(
-                    $this->routeBase.'_action',
-                    array(
-                        'objectAction' => 'view',
-                        'objectId'     => $entity->getId(),
-                        'listPage'     => $listPage
-                    )
-                )
+                'route'         => $route
             )
         );
 

--- a/app/bundles/CoreBundle/Entity/AuditLogRepository.php
+++ b/app/bundles/CoreBundle/Entity/AuditLogRepository.php
@@ -14,18 +14,18 @@ namespace Mautic\CoreBundle\Entity;
  */
 class AuditLogRepository extends CommonRepository
 {
-	/**
+    /**
      * Get array of objects which belongs to the object
      *
-     * @param string    $object
-     * @param integer   $id
-     * @param integer   $limit of items
-     * @param \DateTime $afterDate
+     * @param null $object
+     * @param null $id
+     * @param int  $limit
+     * @param null $afterDate
+     * @param null $bundle
+     *
      * @return array
-     * @throws \Doctrine\ORM\NoResultException
-     * @throws \Doctrine\ORM\NonUniqueResultException
      */
-    public function getLogForObject($object = null, $id = null, $limit = 10, $afterDate = null)
+    public function getLogForObject($object = null, $id = null, $limit = 10, $afterDate = null, $bundle = null)
     {
         $query = $this->createQueryBuilder('al')
             ->select('al.userName, al.userId, al.bundle, al.object, al.objectId, al.action, al.details, al.dateAdded, al.ipAddress')
@@ -38,6 +38,11 @@ class AuditLogRepository extends CommonRepository
                 ->andWhere('al.objectId = :id')
                 ->setParameter('object', $object)
                 ->setParameter('id', $id);
+        }
+
+        if ($bundle) {
+            $query->andWhere('al.bundle = :bundle')
+                ->setParameter('bundle', $bundle);
         }
 
         // Prevent InnoDB shared IDs

--- a/app/bundles/CoreBundle/Model/AuditLogModel.php
+++ b/app/bundles/CoreBundle/Model/AuditLogModel.php
@@ -35,12 +35,12 @@ class AuditLogModel extends CommonModel
      */
     public function writeToLog(array $args)
     {
-        $bundle     = (isset($args["bundle"])) ? $args["bundle"] : "";
-        $object     = (isset($args["object"])) ? $args["object"] : "";
-        $objectId   = (isset($args["objectId"])) ? $args["objectId"] : "";
-        $action     = (isset($args["action"])) ? $args["action"] : "";
-        $details    = (isset($args["details"])) ? $args["details"] : "";
-        $ipAddress  = (isset($args["ipAddress"])) ? $args["ipAddress"] : "";
+        $bundle    = (isset($args["bundle"])) ? $args["bundle"] : "";
+        $object    = (isset($args["object"])) ? $args["object"] : "";
+        $objectId  = (isset($args["objectId"])) ? $args["objectId"] : "";
+        $action    = (isset($args["action"])) ? $args["action"] : "";
+        $details   = (isset($args["details"])) ? $args["details"] : "";
+        $ipAddress = (isset($args["ipAddress"])) ? $args["ipAddress"] : "";
 
         $log = new AuditLog();
         $log->setBundle($bundle);
@@ -51,14 +51,14 @@ class AuditLogModel extends CommonModel
         $log->setIpAddress($ipAddress);
         $log->setDateAdded(new \DateTime());
 
-        $user   = (!defined('MAUTIC_IGNORE_AUDITLOG_USER')) ? $this->factory->getUser() : null;
-        $userId = 0;
+        $user     = (!defined('MAUTIC_IGNORE_AUDITLOG_USER')) ? $this->factory->getUser() : null;
+        $userId   = 0;
         $userName = '';
         if (!$user instanceof User) {
-            $userId = 0;
+            $userId   = 0;
             $userName = $this->translator->trans('mautic.core.system');
         } elseif ($user->getId()) {
-            $userId = $user->getId();
+            $userId   = $user->getId();
             $userName = $user->getName();
         }
         $log->setUserId($userId);
@@ -70,15 +70,16 @@ class AuditLogModel extends CommonModel
     /**
      * Get the audit log for specific object
      *
-     * @param string $object type
-     * @param integer $id of the object
-     * @param \DateTime $afterDate
-     * @param integer $limit of items
+     * @param      $object
+     * @param      $id
+     * @param null $afterDate
+     * @param int  $limit
+     * @param null $bundle
      *
-     * @return array of logs
+     * @return mixed
      */
-    public function getLogForObject($object, $id, $afterDate = null, $limit = 10)
+    public function getLogForObject($object, $id, $afterDate = null, $limit = 10, $bundle = null)
     {
-        return $this->em->getRepository("MauticCoreBundle:AuditLog")->getLogForObject($object, $id, $limit, $afterDate);
+        return $this->em->getRepository("MauticCoreBundle:AuditLog")->getLogForObject($object, $id, $limit, $afterDate, $bundle);
     }
 }

--- a/app/bundles/CoreBundle/Templating/Helper/AssetsHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/AssetsHelper.php
@@ -59,14 +59,15 @@ class AssetsHelper extends CoreAssetsHelper
     /**
      * Set asset url path
      *
-     * @param string $path
-     * @param null   $packageName
-     * @param null   $version
-     * @param bool   $absolute
+     * @param string     $path
+     * @param null       $packageName
+     * @param null       $version
+     * @param bool|false $absolute
+     * @param bool|false $ignorePrefix
      *
      * @return string
      */
-    public function getUrl($path, $packageName = null, $version = null, $absolute = false)
+    public function getUrl($path, $packageName = null, $version = null, $absolute = false, $ignorePrefix = false)
     {
         // if we have http in the url it is absolute and we can just return it
         if (strpos($path, 'http') === 0) {
@@ -74,8 +75,10 @@ class AssetsHelper extends CoreAssetsHelper
         }
 
         // otherwise build the complete path
-        $assetPrefix = $this->getAssetPrefix(strpos($path, '/') !== 0);
-        $path        = $assetPrefix . $path;
+        if (!$ignorePrefix) {
+            $assetPrefix = $this->getAssetPrefix(strpos($path, '/') !== 0);
+            $path        = $assetPrefix.$path;
+        }
 
         $url = parent::getUrl($path, $packageName, $version);
 
@@ -210,7 +213,7 @@ class AssetsHelper extends CoreAssetsHelper
 
     public function includeScript($assetFilePath)
     {
-        return  '<script type="text/javascript">Mautic.loadScript(\'' . $this->getUrl($assetFilePath) . '\');</script>';
+        return  '<script async="async" type="text/javascript">Mautic.loadScript(\'' . $this->getUrl($assetFilePath) . '\');</script>';
     }
 
     /*
@@ -221,7 +224,7 @@ class AssetsHelper extends CoreAssetsHelper
 
     public function includeStylesheet($assetFilePath)
     {
-        return  '<script type="text/javascript">Mautic.loadStylesheet(\'' . $this->getUrl($assetFilePath) . '\');</script>';
+        return  '<script async="async" type="text/javascript">Mautic.loadStylesheet(\'' . $this->getUrl($assetFilePath) . '\');</script>';
     }
 
     /**
@@ -464,12 +467,12 @@ class AssetsHelper extends CoreAssetsHelper
                             $link = $match[2] ?: $match[3];
                             return '<' . array_push($links, "<a $attr href=\"$protocol://$link\">$link</a>") . '>';
                         }, $text);
-                    break;
+                        break;
                     case 'mail':
                         $text = preg_replace_callback('~([^\s<]+?@[^\s<]+?\.[^\s<]+)(?<![\.,:])~', function ($match) use (&$links, $attr) {
                             return '<' . array_push($links, "<a $attr href=\"mailto:{$match[1]}\">{$match[1]}</a>") . '>';
                         }, $text);
-                    break;
+                        break;
                     case 'twitter':
                         $text = preg_replace_callback('~(?<!\w)[@#](\w++)~', function ($match) use (&$links, $attr) {
                             return '<' . array_push($links, "<a $attr href=\"https://twitter.com/" . ($match[0][0] == '@' ? '' : 'search/%23') . $match[1]  . "\">{$match[0]}</a>") . '>';
@@ -548,7 +551,11 @@ class AssetsHelper extends CoreAssetsHelper
     }
 
     /**
-     * @param $country
+     * @param           $country
+     * @param bool|true $urlOnly
+     * @param string    $class
+     *
+     * @return string
      */
     public function getCountryFlag($country, $urlOnly = true, $class = '')
     {

--- a/app/bundles/DashboardBundle/Controller/DefaultController.php
+++ b/app/bundles/DashboardBundle/Controller/DefaultController.php
@@ -74,21 +74,28 @@ class DefaultController extends CommonController
 
         // Get names of log's items
         $router = $this->factory->getRouter();
-        foreach ($logs as &$log) {
+        foreach ($logs as $key => &$log) {
             if (!empty($log['bundle']) && !empty($log['object']) && !empty($log['objectId'])) {
-                $model = $this->factory->getModel($log['bundle'] . '.' . $log['object']);
-                $item = $model->getEntity($log['objectId']);
-                if (method_exists($item, $model->getNameGetter())) {
-                    $log['objectName'] = $item->{$model->getNameGetter()}();
-                } else {
-                    $log['objectName'] = '';
-                }
+                try {
+                    $model = $this->factory->getModel($log['bundle'].'.'.$log['object']);
+                    $item  = $model->getEntity($log['objectId']);
+                    if (method_exists($item, $model->getNameGetter())) {
+                        $log['objectName'] = $item->{$model->getNameGetter()}();
+                    } else {
+                        $log['objectName'] = '';
+                    }
 
-                $routeName = 'mautic_' . $log['bundle'] . '_action';
-                if ($router->getRouteCollection()->get($routeName) !== null) {
-                    $log['route'] = $router->generate('mautic_' . $log['bundle'] . '_action', array('objectAction' => 'view', 'objectId' => $log['objectId']));
-                } else {
-                    $log['route'] = false;
+                    $routeName = 'mautic_'.$log['bundle'].'_action';
+                    if ($router->getRouteCollection()->get($routeName) !== null) {
+                        $log['route'] = $router->generate(
+                            'mautic_'.$log['bundle'].'_action',
+                            array('objectAction' => 'view', 'objectId' => $log['objectId'])
+                        );
+                    } else {
+                        $log['route'] = false;
+                    }
+                } catch (\Exception $e) {
+                    unset($logs[$key]);
                 }
             }
         }


### PR DESCRIPTION
**Descrption**
This fixes several issues with utilizing the newly added viewStandard helper function for 3rd party addons. 

It also fixed an issue with the Dashboard when the audit log entries weren't uniform leading to uncaught exceptions when generating the recent events timeline (mainly when 3rd party addons utilize the table).

**Testing**
Mostly code review and to ensure the dashboard still loads correctly.