### PR TITLE
Alias as SQL reserved words or numeric

### DIFF
--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -34,17 +34,7 @@ class SubmissionRepository extends CommonRepository
         $results['form_id']       = $form->getId();
         $tableName                = MAUTIC_TABLE_PREFIX . 'form_results_' . $form->getId() . '_' . $form->getAlias();
         if (!empty($results)) {
-            // Make sure the column names are all SQL safe
-            $data = array();
-            $databasePlatform = $this->_em->getConnection()->getDatabasePlatform();
-            $reservedWords = $databasePlatform->getReservedKeywordsList();
-
-            foreach ($results as $name => $value) {
-                $columnName = ($reservedWords->isKeyword($name) || is_numeric($name)) ? $databasePlatform->quoteIdentifier($name) : $name;
-                $data[$columnName] = $value;
-            }
-
-            $this->_em->getConnection()->insert($tableName, $data);
+            $this->_em->getConnection()->insert($tableName, $results);
         }
     }
 

--- a/app/bundles/FormBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/ReportSubscriber.php
@@ -132,9 +132,7 @@ class ReportSubscriber extends CommonSubscriber
     /**
      * Initialize the QueryBuilder object to generate reports from
      *
-     * @param ReportGeneratorEvent $event
-     *
-     * @return void
+     * @param ReportGraphEvent $event
      */
     public function onReportGraphGenerate (ReportGraphEvent $event)
     {

--- a/app/bundles/FormBundle/Model/FieldModel.php
+++ b/app/bundles/FormBundle/Model/FieldModel.php
@@ -52,6 +52,8 @@ class FieldModel extends CommonFormModel
     /**
      * Get the fields saved in session
      *
+     * @param $formId
+     *
      * @return array
      */
     public function getSessionFields($formId)
@@ -63,17 +65,14 @@ class FieldModel extends CommonFormModel
     }
 
     /**
-     * @param $formId
      * @param $label
+     * @param $aliases
+     *
+     * @return string
      */
     public function generateAlias($label, &$aliases)
     {
-        // Some labels are quite long if a question so cut this short
-        $alias = substr(strtolower(InputHelper::alphanum($label, false, '_')), 0, 25);
-
-        if (substr($alias, -1) == '_') {
-            $alias = substr($alias, 0, -1);
-        }
+        $alias = $this->cleanAlias($label);
 
         //make sure alias is not already taken
         $testAlias = $alias;

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -122,7 +122,7 @@ class FormModel extends CommonFormModel
      * @param Form $entity
      * @param      $sessionFields
      */
-    public function setFields(Form &$entity, $sessionFields)
+    public function setFields(Form $entity, $sessionFields)
     {
         $order          = 1;
         $existingFields = $entity->getFields();
@@ -161,7 +161,7 @@ class FormModel extends CommonFormModel
      * @param Form $entity
      * @param      $sessionFields
      */
-    public function deleteFields(Form &$entity, $sessionFields)
+    public function deleteFields(Form $entity, $sessionFields)
     {
         if (empty($sessionFields)) {
             return;
@@ -177,9 +177,8 @@ class FormModel extends CommonFormModel
     /**
      * @param Form $entity
      * @param      $sessionActions
-     * @param      $sessionFields
      */
-    public function setActions(Form &$entity, $sessionActions, $sessionFields)
+    public function setActions(Form $entity, $sessionActions)
     {
         $order   = 1;
         $existingActions = $entity->getActions();
@@ -374,8 +373,6 @@ class FormModel extends CommonFormModel
     public function generateFieldColumns(Form $form)
     {
         $fields = $form->getFields();
-        $databasePlatform = $this->factory->getDatabase()->getDatabasePlatform();
-        $reservedWords = $databasePlatform->getReservedKeywordsList();
 
         $columns = array(
             array(
@@ -391,7 +388,7 @@ class FormModel extends CommonFormModel
         foreach ($fields as $f) {
             if (!in_array($f->getType(), $ignoreTypes) && $f->getSaveResult() !== false) {
                 $columns[] = array(
-                    'name'    => ($reservedWords->isKeyword($f->getAlias()) || is_numeric($f->getAlias())) ? $databasePlatform->quoteIdentifier($f->getAlias()) : $f->getAlias(),
+                    'name'    => $f->getAlias(),
                     'type'    => 'text',
                     'options' => array(
                         'notnull' => false

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -69,7 +69,6 @@ class SubmissionModel extends CommonFormModel
         $submission->setReferer($referer);
 
         $fields           = $form->getFields();
-        $errors           = array();
         $fieldArray       = array();
         $results          = array();
         $tokens           = array();

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -96,11 +96,12 @@ class FieldModel extends FormModel
         if ($isNew) {
             if (empty($alias)) {
                 $alias = strtolower(InputHelper::alphanum($entity->getName()));
-            } else {
-                $alias = strtolower(InputHelper::alphanum($alias));
             }
 
-            //make sure alias is not already taken
+            // clean the alias
+            $alias = $this->cleanAlias($alias);
+
+            // make sure alias is not already taken
             $repo      = $this->getRepository();
             $testAlias = $alias;
             $aliases   = $repo->getAliases($entity->getId());

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -409,6 +409,8 @@ class LeadModel extends FormModel
      * Takes leads organized by group and flattens them into just alias => value
      *
      * @param $fields
+     *
+     * @return array
      */
     public function flattenFields($fields)
     {
@@ -421,7 +423,6 @@ class LeadModel extends FormModel
 
         return $flat;
     }
-
 
     /**
      * Returns flat array for single lead
@@ -566,9 +567,9 @@ class LeadModel extends FormModel
     /**
      * Get a list of lists this lead belongs to
      *
-     * @param Lead  $lead
-     * @param bool  $forLists
-     * @param boole $arrayHydration
+     * @param Lead       $lead
+     * @param bool|false $forLists
+     * @param bool|false $arrayHydration
      *
      * @return mixed
      */
@@ -666,6 +667,8 @@ class LeadModel extends FormModel
      *
      * @param Lead $lead
      * @param Lead $lead2
+     *
+     * @return Lead
      */
     public function mergeLeads(Lead $lead, Lead $lead2)
     {
@@ -735,10 +738,13 @@ class LeadModel extends FormModel
     /**
      * Add a do not contact entry for the lead
      *
-     * @param Lead   $lead
-     * @param string $emailAddress
-     * @param string $reason
-     * @param bool   $persist
+     * @param Lead      $lead
+     * @param string    $emailAddress
+     * @param string    $reason
+     * @param bool|true $persist
+     *
+     * @return DoNotEmail|void
+     * @throws \Doctrine\DBAL\DBALException
      */
     public function setDoNotContact(Lead $lead, $emailAddress = '', $reason = '', $persist = true)
     {


### PR DESCRIPTION
**Description**
Piggy backing on #621, the same issue has been found to affect viewing form results, API result filtering, reports, and lead fields. This PR changes the technique to prefix the alias (which is used as the column name) instead, preventing the need to escape every query use case for form fields and lead fields.

(Refer to #596)

This PR will not fix existing fields but existing fields shouldn't be working anyway so no data lost.

**Testing**
1) Create a form field as an integer or as a SQL keyword such as "select" or "use." With #621 merged, the field will save and you can submit to it.  But browse to the form's Results, and the same SQL error will appear.  After the PR, the alias/column will be prefixed with f_ and thus should work in any query scenario. 

2) Create a lead field the same way.  If it is a reserved word or integer, you will not be able to save a lead that has a value assigned to that field.  After the PR, it prefixes the alias/column with f_ and thus should not cause query issues.