### PR TITLE
Fixed Postgres orderby/count issues

### DIFF
--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -344,7 +344,9 @@ class CampaignRepository extends CommonRepository
                 ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'll');
         } else {
             $q->select('distinct(ll.lead_id) as id')
-                ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'll');
+                ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'll')
+                ->orderBy('ll.lead_id', 'ASC');
+
         }
 
         $expr = $q->expr()->andX();
@@ -408,8 +410,6 @@ class CampaignRepository extends CommonRepository
 
         $q->andWhere('ll.lead_id NOT IN '.sprintf('(%s)', $dq->getSQL()));
 
-        $q->orderBy('ll.lead_id', 'ASC');
-
         $results = $q->execute()->fetchAll();
 
         foreach ($results as $r) {
@@ -453,7 +453,8 @@ class CampaignRepository extends CommonRepository
                 ->from(MAUTIC_TABLE_PREFIX.'campaign_leads', 'cl');
         } else {
             $q->select('distinct(cl.lead_id) as id')
-                ->from(MAUTIC_TABLE_PREFIX.'campaign_leads', 'cl');
+                ->from(MAUTIC_TABLE_PREFIX.'campaign_leads', 'cl')
+                ->orderBy('cl.lead_id', 'ASC');
         }
 
         $expr = $q->expr()->andX();
@@ -509,8 +510,6 @@ class CampaignRepository extends CommonRepository
         );
 
         $q->andWhere('cl.lead_id NOT IN ' . sprintf('(%s)', $dq->getSQL()));
-
-        $q->orderBy('cl.lead_id', 'ASC');
 
         $results = $q->execute()->fetchAll();
 

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -166,7 +166,8 @@ class EmailRepository extends CommonRepository
         if ($countOnly) {
             $q->select('count(l.id) as count');
         } else {
-            $q->select('l.*');
+            $q->select('l.*')
+                ->orderBy('l.id');
         }
         $q->from(MAUTIC_TABLE_PREFIX . 'leads', 'l')
             ->join('l', MAUTIC_TABLE_PREFIX . 'lead_lists_leads', 'll', 'l.id = ll.lead_id')
@@ -197,9 +198,6 @@ class EmailRepository extends CommonRepository
             $q->setFirstResult(0)
                 ->setMaxResults($limit);
         }
-
-        $q->groupBy('l.id')
-            ->orderBy('l.id');
 
         $results = $q->execute()->fetchAll();
 


### PR DESCRIPTION
A groupBy() clause was added in a recently merged PR to make postgres happy but it changed the count behavior for MySql resulting in an incorrect count of pending emails.  So this PR removes the groupBy and changes the query to only use the orderBy when getting rows and not just a count.

**Testing**
Under Mysql - create a list email and assign it to a list that has multiple leads.  The pending count should be the number of leads but will likely only show 1.  After the PR, it show the correct count.

Under Postgres - after the PR, ensure the Manage Email list is loaded without encountering a sql exception.