### PR TITLE
Added better logging for the Mandrill API transport

### DIFF
--- a/app/bundles/CoreBundle/Helper/MailHelper.php
+++ b/app/bundles/CoreBundle/Helper/MailHelper.php
@@ -269,6 +269,13 @@ class MailHelper
                 $this->logger->clear();
             } catch (\Exception $e) {
                 $this->logError($e);
+
+                // Exception encountered when sending so all recipients are considered failures
+                $this->errors['failures'] = array_merge(
+                    array_keys((array) $this->message->getTo()),
+                    array_keys((array) $this->message->getCc()),
+                    array_keys((array) $this->message->getBcc())
+                );
             }
         }
 
@@ -1207,8 +1214,8 @@ class MailHelper
         }
 
         $logDump = $this->logger->dump();
-        if (!empty($logDump)) {
-            $error .= "; $logDump";
+        if (!empty($logDump) && strpos($error, $logDump) === false) {
+            $error .= " Log data: $logDump";
         }
 
         $this->errors[] = $error;

--- a/app/bundles/CoreBundle/Swiftmailer/Transport/AbstractTokenArrayTransport.php
+++ b/app/bundles/CoreBundle/Swiftmailer/Transport/AbstractTokenArrayTransport.php
@@ -200,4 +200,25 @@ abstract class AbstractTokenArrayTransport implements InterfaceTokenTransport
     {
         $this->factory = $factory;
     }
+
+    /**
+     * @param \Exception|string $exception
+     *
+     * @throws \Exception
+     */
+    protected function throwException($exception)
+    {
+        if (!$exception instanceof \Exception) {
+            $exception = new \Swift_TransportException($exception);
+        }
+
+        if ($evt = $this->getDispatcher()->createTransportExceptionEvent($this, $exception)) {
+            $this->getDispatcher()->dispatchEvent($evt, 'exceptionThrown');
+            if (!$evt->bubbleCancelled()) {
+                throw $exception;
+            }
+        } else {
+            throw $exception;
+        }
+    }
 }

--- a/app/bundles/CoreBundle/Swiftmailer/Transport/AbstractTokenHttpTransport.php
+++ b/app/bundles/CoreBundle/Swiftmailer/Transport/AbstractTokenHttpTransport.php
@@ -160,7 +160,7 @@ abstract class AbstractTokenHttpTransport extends AbstractTokenArrayTransport im
         $info     = curl_getinfo($ch);
 
         if(curl_error($ch)) {
-            throw new \Swift_TransportException("API call to $endpoint failed: " . curl_error($ch));
+            $this->throwException("API call to $endpoint failed: " . curl_error($ch));
         }
 
         curl_close($ch);


### PR DESCRIPTION
**Description**
If a mail send failed to communicate to Mandrill's API for unknown reasons such as a HTTP communication issue, a generic MAIL ERROR hit the log but nothing to accompany it.  This PR attempts to add more feedback from the Mautic -> Mandrill communication process to the log if an error is encountered.

It also adds the recipients to the failed email list if an exception is encountered when attempting to send (such as failing to communicated with Mandrill) which resulted in Mautic assuming a successful send for those emails.

The logging was inspired by #642 and the send error encountered while testing.

**Testing**
Configure Mautic with Mandrill but use an invalid key.  Send an email to a list. Before the PR, nothing will be logged about the invalid api key and Mautic will display the emails as a successful send.  

Apply the PR, delete the entries in the email_stats table, then try to send again.  This time the emails should be noted as failed and if looking at Mautic's log, an entry will include the invalid api key error. 