### PR TITLE
Fixes conflict with lead field "title" and tracking pixel's "title" for the page hit

### DIFF
--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -397,7 +397,6 @@ class PageModel extends FormModel
                     parse_str($request->server->get('QUERY_STRING'), $query);
 
                     // URL attr 'd' is encoded so let's decode it first.
-
                     $decoded = false;
                     if (isset($query['d'])) {
                         // parse_str auto urldecodes
@@ -405,28 +404,48 @@ class PageModel extends FormModel
                         $decoded = true;
                     }
 
-                    if (isset($query['url'])) {
+                    if (isset($query['page_url'])) {
+                        $pageURL = $query['page_url'];
+                        if (!$decoded) {
+                            $pageURL = urldecode($pageURL);
+                        }
+                    } elseif (isset($query['url'])) {
                         $pageURL = $query['url'];
                         if (!$decoded) {
                             $pageURL = urldecode($pageURL);
                         }
                     }
 
-                    if (isset($query['referrer'])) {
+                    if (isset($query['page_referrer'])) {
+                        if (!$decoded) {
+                            $query['page_referrer'] = urldecode($query['page_referrer']);
+                        }
+                        $hit->setReferer($query['page_referrer']);
+                    } elseif (isset($query['referrer'])) {
                         if (!$decoded) {
                             $query['referrer'] = urldecode($query['referrer']);
                         }
                         $hit->setReferer($query['referrer']);
                     }
 
-                    if (isset($query['language'])) {
+                    if (isset($query['page_language'])) {
+                        if (!$decoded) {
+                            $query['page_language'] = urldecode($query['page_language']);
+                        }
+                        $hit->setPageLanguage($query['page_language']);
+                    } elseif (isset($query['language'])) {
                         if (!$decoded) {
                             $query['language'] = urldecode($query['language']);
                         }
                         $hit->setPageLanguage($query['language']);
                     }
 
-                    if (isset($query['title'])) {
+                    if (isset($query['page_title'])) {
+                        if (!$decoded) {
+                            $query['page_title'] = urldecode($query['page_title']);
+                        }
+                        $hit->setUrlTitle($query['page_title']);
+                    } elseif (isset($query['title'])) {
                         if (!$decoded) {
                             $query['title'] = urldecode($query['title']);
                         }


### PR DESCRIPTION
**Description**
See #649. The default lead field for "title" conflicts with the tracking pixel's page "title."  This PR changes the behavior to first check for a "page_title" with a fallback to "title" if it doesn't exist for BC support.  Eventually the CMS plugins will need to be updated if we allow custom lead field data through them.

**Testing**
From a coding standpoint, you can't have two keys in the same array:
```
$query = array(
    'url'             => $_SERVER['REQUEST_URI'],
    'title'           => 'The Page Title',
    'title'           => 'Mr',
    'firstname' => 'Jack'
);
$encoded = urlencode(base64_encode(serialize($query)));
$trackingPixel = 'http://mautic.mysite.com/p/mtracking.gif?d=' . $encoded;
```
This PR adds support for 
```
$query = array(
    'page_url'    => $_SERVER['REQUEST_URI'],
    'page_title'  => 'The Page Title',
    'title'            => 'Mr',
    'firstname'  => 'Jack'
);
$encoded = urlencode(base64_encode(serialize($query)));
$trackingPixel = 'http://mautic.mysite.com/p/mtracking.gif?d=' . $encoded;
```

While keeping BC support for 
```
$query = array(
    'url'    => $_SERVER['REQUEST_URI'],
    'title'  => 'The Page Title',
    'firstname'  => 'Jack'
);
$encoded = urlencode(base64_encode(serialize($query)));
$trackingPixel = 'http://mautic.mysite.com/p/mtracking.gif?d=' . $encoded;
```