### PR TITLE
Support for click tracking with extra query parameters

### DIFF
--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -342,6 +342,20 @@ class PublicController extends CommonFormController
 
         $this->factory->getModel('page')->hitPage($redirect, $this->request);
 
-        return $this->redirect($redirect->getUrl());
+        $url = $redirect->getUrl();
+
+        // Get query string
+        $query = $this->request->query->all();
+
+        // Unset the clickthrough
+        unset($query['ct']);
+
+        // Tak on anything left to the URL
+        if (count($query)) {
+            $url .= (strpos($url, '?') !== false) ? '&' : '?';
+            $url .= http_build_query($query);
+        }
+
+        return $this->redirect($url);
     }
 }


### PR DESCRIPTION
**Description**
Hopefully fixes #643 

Using a link like `{pagelink=1}&email={leadfield=email|true}` would at best create a trackable link for the landing page but the &email query would not be fowarded on to the final page.  Also, when editing the email, the visual token for the leadfield breaks the link (as a span is inserted inside the link's href tag).  

So this PR adds support to Mautic's redirect links to forward extra query parameters on to the final destination (it removes the ct query param of course).  

It also prevents the editor from corrupting the HTML on edit when a leadfield token is used inside a link.  This is only for edited emails so any existing email with this problem will have to be cleaned up and resaved (the problem only becomes an issue when editing the content of the email as the original content saved to the database is fine _the first time_).

**Testing**
Create a new email and add various types of urls and tokens. For example,
```
Hi {leadfield=firstname}, 
<br/ ><br />
Check out these links: <br />
<a href="{pagelink=1}&email={leadfield=email|true}">Landing page token with lead field as query param</a><br />
<a href="{pagelink=1}">Landing page</a><br />
<a href="https://github.com?email={leadfield=email|true}">General link with lead field as query param</a><br />
<a href="https://github.com">Normal external link</a>
```
Before the PR, clicking on the landing page token with lead field as query param will land on the landing page but without the email query.  Editing the email will result in broken HTML.

After the PR, editing the content should be as expected (although the brackets for the leadfield token in the query param are encoded which is how they are preserved).  Sending the email should result in all working links and the email query params should make it to the final destination.