### PR TITLE
Fixes overlay issue when there is a validation error with the Configuration form

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/core.js
+++ b/app/bundles/CoreBundle/Assets/js/core.js
@@ -1070,6 +1070,15 @@ var Mautic = {
     },
 
     /**
+     * Deactivates backdrop
+     */
+    deactivateBackgroup: function() {
+        if (mQuery('#mautic-backdrop').length) {
+            mQuery('#mautic-backdrop').remove();
+        }
+    },
+
+    /**
      * Posts a form and returns the output.
      * Uses jQuery form plugin so it handles files as well.
      *
@@ -1135,6 +1144,8 @@ var Mautic = {
      */
     processPageContent: function (response) {
         if (response) {
+            Mautic.deactivateBackgroup();
+
             if (!response.target) {
                 response.target = '#app-content';
             }


### PR DESCRIPTION
**Description**
If there is a validation error with the Configuration, the overlay is not removed.  This PR fixes that.

**Testing**
In dev mode, remove the site URL from the configuration and save.  The validation error will appear but the overlay is still there.  After the PR, the overlay should be dismissed.