### PR TITLE
Prevents botched upgrades if the session is lost after cache is cleared

### DIFF
--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -325,7 +325,7 @@ class AjaxController extends CommonController
         // the cache is cleared by upgrade.php
         /** @var \Mautic\CoreBundle\Helper\CookieHelper $cookieHelper */
         $cookieHelper = $this->factory->getHelper('cookie');
-        $cookieHelper->setCookie('mautic_update', 'setup', 300);
+        $cookieHelper->setCookie('mautic_update', 'setupUpdate', 300);
 
         return $this->sendJsonResponse($dataArray);
     }
@@ -352,11 +352,24 @@ class AjaxController extends CommonController
         if ($package['error']) {
             $dataArray['stepStatus'] = $translator->trans('mautic.core.update.step.failed');
             $dataArray['message']    = $translator->trans('mautic.core.update.error', array('%error%' => $translator->trans($package['message'])));
+
+            // A way to keep the upgrade from failing if the session is lost after
+            // the cache is cleared by upgrade.php
+            /** @var \Mautic\CoreBundle\Helper\CookieHelper $cookieHelper */
+            $cookieHelper = $this->factory->getHelper('cookie');
+            $cookieHelper->deleteCookie('mautic_update');
         } else {
             $dataArray['success']        = 1;
             $dataArray['stepStatus']     = $translator->trans('mautic.core.update.step.success');
             $dataArray['nextStep']       = $translator->trans('mautic.core.update.step.extracting.package');
             $dataArray['nextStepStatus'] = $translator->trans('mautic.core.update.step.in.progress');
+
+            // A way to keep the upgrade from failing if the session is lost after
+            // the cache is cleared by upgrade.php
+            /** @var \Mautic\CoreBundle\Helper\CookieHelper $cookieHelper */
+            $cookieHelper = $this->factory->getHelper('cookie');
+            $cookieHelper->setCookie('mautic_update', 'downloadPackage', 300);
+
         }
 
         return $this->sendJsonResponse($dataArray);
@@ -411,6 +424,12 @@ class AjaxController extends CommonController
 
             $dataArray['stepStatus'] = $translator->trans('mautic.core.update.step.failed');
             $dataArray['message']    = $translator->trans('mautic.core.update.error', array('%error%' => $translator->trans($error)));
+
+            // A way to keep the upgrade from failing if the session is lost after
+            // the cache is cleared by upgrade.php
+            /** @var \Mautic\CoreBundle\Helper\CookieHelper $cookieHelper */
+            $cookieHelper = $this->factory->getHelper('cookie');
+            $cookieHelper->delete('mautic_update');
         } else {
             // Extract the archive file now
             $zipper->extractTo(dirname($this->container->getParameter('kernel.root_dir')) . '/upgrade');
@@ -420,6 +439,12 @@ class AjaxController extends CommonController
             $dataArray['stepStatus']     = $translator->trans('mautic.core.update.step.success');
             $dataArray['nextStep']       = $translator->trans('mautic.core.update.step.moving.package');
             $dataArray['nextStepStatus'] = $translator->trans('mautic.core.update.step.in.progress');
+
+            // A way to keep the upgrade from failing if the session is lost after
+            // the cache is cleared by upgrade.php
+            /** @var \Mautic\CoreBundle\Helper\CookieHelper $cookieHelper */
+            $cookieHelper = $this->factory->getHelper('cookie');
+            $cookieHelper->setCookie('mautic_update', 'extractPackage', 300);
         }
 
         return $this->sendJsonResponse($dataArray);
@@ -514,13 +539,20 @@ class AjaxController extends CommonController
         if ($result !== 0) {
             $dataArray['stepStatus'] = $translator->trans('mautic.core.update.step.failed');
             $dataArray['message']    = $translator->trans('mautic.core.update.error', array('%error%' => $translator->trans('mautic.core.update.error_performing_migration')));
+
+            // A way to keep the upgrade from failing if the session is lost after
+            // the cache is cleared by upgrade.php
+            /** @var \Mautic\CoreBundle\Helper\CookieHelper $cookieHelper */
+            $cookieHelper = $this->factory->getHelper('cookie');
+            $cookieHelper->deleteCookie('mautic_update');
+
         } else {
 
             // A way to keep the upgrade from failing if the session is lost after
             // the cache is cleared by upgrade.php
             /** @var \Mautic\CoreBundle\Helper\CookieHelper $cookieHelper */
             $cookieHelper = $this->factory->getHelper('cookie');
-            $cookieHelper->setCookie('mautic_update', 'schema', 300);
+            $cookieHelper->setCookie('mautic_update', 'schemaMigration', 300);
 
             if ($request->get('finalize', false)) {
                 // Go to the finalize step

--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -321,6 +321,12 @@ class AjaxController extends CommonController
             'content' => $this->renderView('MauticCoreBundle:Update:update.html.php')
         );
 
+        // A way to keep the upgrade from failing if the session is lost after
+        // the cache is cleared by upgrade.php
+        /** @var \Mautic\CoreBundle\Helper\CookieHelper $cookieHelper */
+        $cookieHelper = $this->factory->getHelper('cookie');
+        $cookieHelper->setCookie('mautic_update', 'setup', 300);
+
         return $this->sendJsonResponse($dataArray);
     }
 
@@ -426,7 +432,7 @@ class AjaxController extends CommonController
      *
      * @return JsonResponse
      */
-    protected function updateDatabaseMigrationAction(Request $request)
+    public function updateDatabaseMigrationAction(Request $request)
     {
         $dataArray  = array('success' => 0);
         $translator = $this->factory->getTranslator();
@@ -509,6 +515,13 @@ class AjaxController extends CommonController
             $dataArray['stepStatus'] = $translator->trans('mautic.core.update.step.failed');
             $dataArray['message']    = $translator->trans('mautic.core.update.error', array('%error%' => $translator->trans('mautic.core.update.error_performing_migration')));
         } else {
+
+            // A way to keep the upgrade from failing if the session is lost after
+            // the cache is cleared by upgrade.php
+            /** @var \Mautic\CoreBundle\Helper\CookieHelper $cookieHelper */
+            $cookieHelper = $this->factory->getHelper('cookie');
+            $cookieHelper->setCookie('mautic_update', 'schema', 300);
+
             if ($request->get('finalize', false)) {
                 // Go to the finalize step
                 $dataArray['success']        = 1;
@@ -532,7 +545,7 @@ class AjaxController extends CommonController
      *
      * @return JsonResponse
      */
-    protected function updateFinalizationAction(Request $request)
+    public function updateFinalizationAction(Request $request)
     {
         $dataArray  = array('success' => 0);
         $translator = $this->factory->getTranslator();
@@ -540,6 +553,12 @@ class AjaxController extends CommonController
         // Here as a just in case it's needed for a future upgrade
         $dataArray['success'] = 1;
         $dataArray['message'] = $translator->trans('mautic.core.update.update_successful', array('%version%' => $this->factory->getVersion()));
+
+        // A way to keep the upgrade from failing if the session is lost after
+        // the cache is cleared by upgrade.php
+        /** @var \Mautic\CoreBundle\Helper\CookieHelper $cookieHelper */
+        $cookieHelper = $this->factory->getHelper('cookie');
+        $cookieHelper->deleteCookie('mautic_update');
 
         return $this->sendJsonResponse($dataArray);
     }

--- a/app/bundles/CoreBundle/Helper/CookieHelper.php
+++ b/app/bundles/CoreBundle/Helper/CookieHelper.php
@@ -60,4 +60,18 @@ class CookieHelper
             ($httponly == null) ? $this->httponly : $httponly
         );
     }
+
+    /**
+     * Deletes a cookie by expiring it
+     *
+     * @param           $name
+     * @param null      $path
+     * @param null      $domain
+     * @param null      $secure
+     * @param bool|true $httponly
+     */
+    public function deleteCookie($name, $path = null, $domain = null, $secure = null, $httponly = true)
+    {
+        $this->setCookie($name, '', time() - 3600, $path, $domain, $secure, $httponly);
+    }
 }

--- a/app/bundles/UserBundle/Controller/SecurityController.php
+++ b/app/bundles/UserBundle/Controller/SecurityController.php
@@ -51,7 +51,7 @@ class SecurityController extends CommonController
         // the cache is cleared by upgrade.php
         if ($this->request->cookies->has('mautic_update')) {
             $step = $this->request->cookies->get('mautic_update');
-            if ($step == 'setup') {
+            if ($step == 'clearCache') {
                 // Run migrations
                 $this->request->query->set('finalize', 1);
                 return $this->forward('MauticCoreBundle:Ajax:updateDatabaseMigration',
@@ -59,7 +59,7 @@ class SecurityController extends CommonController
                         'request'  => $this->request
                     )
                 );
-            } elseif ($step == 'schema') {
+            } elseif ($step == 'schemaMigration') {
                 // Done so finalize
                 return $this->forward('MauticCoreBundle:Ajax:updateFinalization',
                     array(

--- a/app/bundles/UserBundle/Controller/SecurityController.php
+++ b/app/bundles/UserBundle/Controller/SecurityController.php
@@ -47,6 +47,30 @@ class SecurityController extends CommonController
      */
     public function loginAction ()
     {
+        // A way to keep the upgrade from failing if the session is lost after
+        // the cache is cleared by upgrade.php
+        if ($this->request->cookies->has('mautic_update')) {
+            $step = $this->request->cookies->get('mautic_update');
+            if ($step == 'setup') {
+                // Run migrations
+                $this->request->query->set('finalize', 1);
+                return $this->forward('MauticCoreBundle:Ajax:updateDatabaseMigration',
+                    array(
+                        'request'  => $this->request
+                    )
+                );
+            } elseif ($step == 'schema') {
+                // Done so finalize
+                return $this->forward('MauticCoreBundle:Ajax:updateFinalization',
+                    array(
+                        'request'  => $this->request
+                    ));
+            }
+
+            /** @var \Mautic\CoreBundle\Helper\CookieHelper $cookieHelper */
+            $cookieHelper = $this->factory->getHelper('cookie');
+            $cookieHelper->deleteCookie('mautic_update');
+        }
 
         $session = $this->request->getSession();
 

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -87,11 +87,19 @@ $container->setParameter('mautic.bundles', $setBundles);
 $container->setParameter('mautic.addon.bundles', $setAddonBundles);
 unset($setBundles, $setAddonBundles);
 
-
 $loader->import('parameters.php');
 $container->loadFromExtension('mautic_core');
 
 $engines = ($container->getParameter('kernel.environment') == 'dev') ? array('php', 'twig') : array('php');
+
+if (isset($_COOKIE['mautic_session_name'])) {
+    // Attempt to keep from losing sessions if cache is cleared through UI
+    $sessionName = $_COOKIE['mautic_session_name'];
+} else {
+    $paths       = $container->getParameter('mautic.paths');
+    $sessionName = md5($paths['local_config']);
+}
+
 $container->loadFromExtension('framework', array(
     'secret'               => '%mautic.secret_key%',
     'router'               => array(
@@ -120,7 +128,7 @@ $container->loadFromExtension('framework', array(
     'trusted_proxies'      => '%mautic.trusted_proxies%',
     'session'              => array( //handler_id set to null will use default session handler from php.ini
         'handler_id' => null,
-        'name'       => md5(dirname($_SERVER['SCRIPT_NAME'])),
+        'name'       => $sessionName,
     ),
     'fragments'            => null,
     'http_method_override' => true,

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -97,7 +97,8 @@ if (isset($_COOKIE['mautic_session_name'])) {
     $sessionName = $_COOKIE['mautic_session_name'];
 } else {
     $paths       = $container->getParameter('mautic.paths');
-    $sessionName = md5($paths['local_config']);
+    $key         = $container->hasParameter('mautic.secret_key') ? $container->getParameter('mautic.secret_key') : uniqid();
+    $sessionName = md5(md5($paths['local_config']).$key);
 }
 
 $container->loadFromExtension('framework', array(

--- a/build/package_devhead.php
+++ b/build/package_devhead.php
@@ -38,4 +38,11 @@ include_once __DIR__ . '/processfiles.php';
 echo "Packaging Mautic\n";
 chdir(__DIR__ . '/packaging');
 
-system('zip -r ../packages/mautic-head.zip . -x@../excludefiles.txt > /dev/null');
+system('zip -r ../packages/mautic-head.zip . > /dev/null');
+
+// Copy over upgrade.php
+system('cp ' . __DIR__ . '/../upgrade.php ' . __DIR__ . '/packaging');
+
+chdir(__DIR__ . '/packaging');
+echo "Packaging Mautic Update Package\n";
+system('zip -r ../packages/mautic-head-update.zip . > /dev/null');

--- a/upgrade.php
+++ b/upgrade.php
@@ -845,6 +845,16 @@ switch ($task) {
         break;
 }
 
+// A way to keep the upgrade from failing if the session is lost after
+// the cache is cleared by upgrade.php
+$isSSL           = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off');
+$cookie_path     = (isset($localParameters['cookie_path'])) ? $localParameters['cookie_path'] : '/';
+$cookie_domain   = (isset($localParameters['cookie_domain'])) ? $localParameters['cookie_domain'] : '';
+$cookie_secure   = (isset($localParameters['cookie_secure'])) ? $localParameters['cookie_secure'] : $isSSL;
+$cookie_httponly = (isset($localParameters['cookie_httponly'])) ? $localParameters['cookie_httponly'] : false;
+
+setcookie('mautic_update', $task, time() + 300, $cookie_path, $cookie_domain, $cookie_secure, $cookie_httponly);
+
 // Encode the state for the next request
 $status['updateState'] = base64_encode(json_encode($status['updateState']));
 


### PR DESCRIPTION
**Description**
For some people, it seems that upgrades fail because they lose the session after the cache is cleared and so the next ajax call (the migrations call) failed. 

Attempting to use a means that doesn't require JS changes and thus wouldn't catch the next upgrade, this is done by adding a cookie when an upgrade starts.  If the login controller is hit, it checks for the cookie and forwards the controller to the database migrations step then to the finalization step where the cookie is deleted.  This allows the upgrade to finish and then require a login (if the session is lost) on a refresh.

**Testing**
Using a clean 1.1.2 install (do not use a git repository), add `'update_stability' => 'dev'` to the config/local.php file and delete the cache. Log out and back in and an update should be available.  Open the browsers console and view the cookies. Note the value of the mautic_session_name cookie and find the cookie that matches. Start the update. Once it hits the extracting package step, delete that cookie which will in effect kill the session. Before the PR, this will cause a failed update (no migration step).  After the PR, repeating these steps should result in a successful upgrade.