### PR TITLE
Campaign lead source UI fixes

### DIFF
--- a/app/bundles/CampaignBundle/Assets/js/campaign.js
+++ b/app/bundles/CampaignBundle/Assets/js/campaign.js
@@ -85,15 +85,7 @@ Mautic.campaignEventOnLoad = function (container, response) {
     Mautic.campaignBuilderUpdateLabel(domEventId);
 
     if (response.deleted) {
-        //remove the connections
-        Mautic.campaignBuilderInstance.detachAllConnections(document.getElementById(domEventId));
-
-        mQuery('.' + domEventId).each(function () {
-            mQuery(this).remove();
-        });
-
-        //remove the div
-        mQuery(eventId).remove();
+        Mautic.campaignBuilderInstance.remove(document.getElementById(domEventId));
     } else if (response.updateHtml) {
 
         mQuery(eventId + " .campaign-event-content").html(response.updateHtml);
@@ -174,11 +166,7 @@ Mautic.campaignSourceOnLoad = function (container, response) {
     var eventId = '#' + domEventId;
 
     if (response.deleted) {
-        //remove the connections
-        Mautic.campaignBuilderInstance.detachAllConnections(document.getElementById(domEventId));
-
-        //remove the div
-        mQuery(eventId).remove();
+        Mautic.campaignBuilderInstance.remove(document.getElementById(domEventId));
 
         mQuery('#campaignLeadSource_' + response.sourceType).removeClass('disabled');
     } else if (response.updateHtml) {
@@ -563,7 +551,7 @@ Mautic.launchCampaignEditor = function() {
 
         //enable drag and drop
         Mautic.campaignBuilderInstance.draggable(document.querySelectorAll("#CampaignCanvas .list-campaign-event"), Mautic.campaignDragOptions);
-        mQuery('#CampaignCanvas .list-campaign-source').draggable(Mautic.campaignDragOptions);
+        Mautic.campaignBuilderInstance.draggable(document.querySelectorAll("#CampaignCanvas .list-campaign-source"), Mautic.campaignDragOptions);
 
         //activate existing connections
         Mautic.campaignBuilderReconnectEndpoints();

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -674,7 +674,7 @@ class CampaignController extends FormController
 
                 if ($valid = $this->isFormValid($form)) {
                     //make sure that at least one field is selected
-                    if (empty($modifiedEvents)) {
+                    if (empty($campaignEvents)) {
                         //set the error
                         $form->addError(
                             new FormError(
@@ -1164,6 +1164,7 @@ class CampaignController extends FormController
 
         foreach ($sources as $type => &$typeSources) {
             $typeSources = array_keys($typeSources);
+            $typeSources = array_combine($typeSources, $typeSources);
         }
 
         $session->set('mautic.campaign.'.$id.'.leadsources.current', $sources);

--- a/app/bundles/CoreBundle/Assets/js/core.js
+++ b/app/bundles/CoreBundle/Assets/js/core.js
@@ -1523,7 +1523,7 @@ var Mautic = {
                 if (response.mauticContent) {
                     if (typeof Mautic[response.mauticContent + "OnLoad"] == 'function') {
                         Mautic[response.mauticContent + "OnLoad"](target, response);
-                        Mautic.loadedContent[contentSpecific] = true;
+                        Mautic.loadedContent[response.mauticContent] = true;
                     }
                 }
             } else {


### PR DESCRIPTION
**Description**
When editing a campaign, moving a lead source would disconnect the box from the anchor.  Also, when deleting a lead source then readding it to the canvas, the anchor would be in the wrong location.

**Testing**
Edit a campaign and attempt to drag a lead source.  It'll become disconnected from the anchor.  Delete the source, then readd it.  At first you won't see the anchor at all but drag it and it'll appear in the upper left hand corner.  Finally delete all the actions and decisions (leave at least one lead source) then try to save the campaign.  It should fail. Open the campaign builder and the text of the sources will be empty.

After the PR, these issues should be resolved.