### PR TITLE
Fixes case mismatch with translated search string commands

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -504,16 +504,16 @@ class CommonRepository extends EntityRepository
         foreach ($commands as $k => $c) {
             if (is_array($c)) {
                 //subcommands
-                if ($this->translator->trans($k) == $command) {
+                if (strtolower($this->translator->trans($k)) == $command) {
                     foreach ($c as $subc) {
-                        if ($this->translator->trans($subc) == $subcommand) {
+                        if (strtolower($this->translator->trans($subc)) == $subcommand) {
                             return true;
                         }
                     }
                 }
-            } elseif ($this->translator->trans($c) == $command) {
+            } elseif (strtolower($this->translator->trans($c)) == $command) {
                 return true;
-            } elseif ($this->translator->trans($c) == "{$command}:{$subcommand}") {
+            } elseif (strtolower($this->translator->trans($c)) == "{$command}:{$subcommand}") {
                 $command    = "{$command}:{$subcommand}";
                 $subcommand = '';
 


### PR DESCRIPTION
**Description**
Fixes #690.  The German translation had the search command "Liste" but the filter parser transforms the case to "liste" so the isSupportedSearchCommand failed to find a match.  This PR ensures same case.

**Testing**
See #690.