### PR TITLE
Client secret fix

### DIFF
--- a/app/bundles/ApiBundle/Controller/ClientController.php
+++ b/app/bundles/ApiBundle/Controller/ClientController.php
@@ -217,7 +217,7 @@ class ClientController extends FormController
                     )
                 ));
             } elseif ($valid && !$cancelled) {
-                return $this->editAction($client->getId(), false);
+                return $this->editAction($client->getId(), true);
             }
         }
 

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -504,16 +504,16 @@ class CommonRepository extends EntityRepository
         foreach ($commands as $k => $c) {
             if (is_array($c)) {
                 //subcommands
-                if ($this->translator->trans($k) == $command) {
+                if (strtolower($this->translator->trans($k)) == $command) {
                     foreach ($c as $subc) {
-                        if ($this->translator->trans($subc) == $subcommand) {
+                        if (strtolower($this->translator->trans($subc)) == $subcommand) {
                             return true;
                         }
                     }
                 }
-            } elseif ($this->translator->trans($c) == $command) {
+            } elseif (strtolower($this->translator->trans($c)) == $command) {
                 return true;
-            } elseif ($this->translator->trans($c) == "{$command}:{$subcommand}") {
+            } elseif (strtolower($this->translator->trans($c)) == "{$command}:{$subcommand}") {
                 $command    = "{$command}:{$subcommand}";
                 $subcommand = '';
 


### PR DESCRIPTION
**Description**
Clicking Apply when creating an OAuth1 credential would wipe out the secret key due to the newACtion forwarding to the editAction while setting the $ingorePost to false so a double save resulted. This PR fixes that.

**Testing**
Create a new OAuth1 credential and click apply.  No secret will display.  After the PR, it'll be there.