### PR TITLE
Fixed a couple PHP notices related to custom lead avatars.

### DIFF
--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -394,7 +394,9 @@ class MauticFactory
                 $imageDir = substr($imageDir, 0, -1);
             }
 
+            // Use local root if set if different than the system's root (for symlinked scenarios)
             $root = (isset($paths['local_root'])) ? $paths['local_root'] : $paths['root'];
+
             return ($fullPath)  ? $root  . '/' . $imageDir : $imageDir;
         } elseif (isset($paths[$name])) {
             $path = $paths[$name];

--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -394,7 +394,8 @@ class MauticFactory
                 $imageDir = substr($imageDir, 0, -1);
             }
 
-            return ($fullPath)  ? $paths['local_root'] . '/' . $imageDir : $imageDir;
+            $root = (isset($paths['local_root'])) ? $paths['local_root'] : $paths['root'];
+            return ($fullPath)  ? $root  . '/' . $imageDir : $imageDir;
         } elseif (isset($paths[$name])) {
             $path = $paths[$name];
         } else {

--- a/app/bundles/LeadBundle/Views/Lead/grid.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/grid.html.php
@@ -18,8 +18,7 @@ if ($tmpl == 'index')
             'security'      => $security,
             'currentList'   => $currentList,
             'permissions'   => $permissions,
-            'noContactList' => $noContactList,
-            'avatarPath'    => $avatarPath
+            'noContactList' => $noContactList
         )); ?>
     </div>
     <?php else: ?>


### PR DESCRIPTION
**Description**

When viewing the grid view of leads, there is a PHP noticed recorded regarding undefined $avatarPath variable and undefined local_root key.  This PR fixes it.

**Testing**
If display errors are on, visit the lead grid view and should see the notices.  If not, they should be recorded in the servers logs.  After the PR, this should go away.