### PR TITLE
Fixed installer when PDO is not available

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -368,7 +368,7 @@ return array(
         'log_path'                     => '%kernel.root_dir%/logs',
         'image_path'                   => 'media/images',
         'theme'                        => 'Mauve',
-        'db_driver'                    => 'pdo_mysql',
+        'db_driver'                    => 'mysqli',
         'db_host'                      => 'localhost',
         'db_port'                      => 3306,
         'db_name'                      => '',


### PR DESCRIPTION
**Description**
If the PDO extension is not installed on the web server, the installer will fail due to the default being pdo_mysql which forces Doctrine to attempt use of the functions.  This PR changes it to mysqli so that PDO is not used during the installer boot. 

**Testing**
Disable PDO and attempt to run the installer for a clean install (cleared cache, no local.php, etc). It should give a fatal error about PDO not being available.  After the PR, the installer should boot and only show mysqli as a driver option.