### PR TITLE
Twitter EmojiHelper fix

### DIFF
--- a/addons/MauticSocialBundle/Integration/TwitterIntegration.php
+++ b/addons/MauticSocialBundle/Integration/TwitterIntegration.php
@@ -9,7 +9,6 @@
 
 namespace MauticAddon\MauticSocialBundle\Integration;
 
-use Mautic\AddonBundle\Entity\Integration;
 use Mautic\CoreBundle\Helper\EmojiHelper;
 
 /**

--- a/addons/MauticSocialBundle/Integration/TwitterIntegration.php
+++ b/addons/MauticSocialBundle/Integration/TwitterIntegration.php
@@ -10,7 +10,7 @@
 namespace MauticAddon\MauticSocialBundle\Integration;
 
 use Mautic\AddonBundle\Entity\Integration;
-use Mautic\AddonBundle\Helper\EmojiHelper;
+use Mautic\CoreBundle\Helper\EmojiHelper;
 
 /**
  * Class TwitterIntegration


### PR DESCRIPTION
**Description**
Twitter still used the old namespace for the EmojiHelper causing an error when trying to load a lead with a twitter profile.  This fixes this.

**Testing**
Enable and auth the Twitter integration.  Create a lead with a twitter account.  And you'll encounter the issue.

