### PR TITLE
Leadtoken fix

### DIFF
--- a/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
+++ b/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
@@ -252,10 +252,8 @@ class BuilderTokenHelper
      */
     static public function encodeUrlTokens(&$content, array $tokenKeys)
     {
-        // Special handling for leadfield tokens in URLs
-        $foundMatches = preg_match_all('/<a.*?href=["\'].*?=({['.implode('|', $tokenKeys).'].*?}).*?["\']/i', $content, $matches);
-        if ($foundMatches) {
-            foreach ($matches[0] as $link) {
+        $processMatches = function($matches) use (&$content, $tokenKeys) {
+            foreach ($matches as $link) {
                 // There may be more than one leadfield token in the URL
                 preg_match_all('/{['.implode('|', $tokenKeys).'].*?}/i', $link, $tokens);
                 $newLink = $link;
@@ -266,6 +264,18 @@ class BuilderTokenHelper
                 }
                 $content = str_replace($link, $newLink, $content);
             }
+        };
+
+        // Special handling for leadfield tokens in URLs
+        $foundMatches = preg_match_all('/<a.*?href=["\'].*?=({['.implode('|', $tokenKeys).'].*?}).*?["\']/i', $content, $matches);
+        if ($foundMatches) {
+            $processMatches($matches[0]);
+        }
+
+        // Special handling for leadfield tokens in image src
+        $foundMatches = preg_match_all('/<img.*?src=["\'].*?=({['.implode('|', $tokenKeys).'].*?}).*?["\']/i', $content, $matches);
+        if ($foundMatches) {
+            $processMatches($matches[0]);
         }
     }
 

--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -203,6 +203,34 @@ class EmailSendEvent extends CommonEvent
     }
 
     /**
+     * @return string
+     */
+    public function getSubject()
+    {
+        if ($this->helper !== null) {
+
+            return $this->helper->getSubject();
+        } else {
+
+            return $this->subject;
+        }
+    }
+
+    /**
+     * @param string $subject
+     *
+     * @return EmailSendEvent
+     */
+    public function setSubject($subject)
+    {
+        if ($this->helper !== null) {
+            $this->helper->setSubject($subject);
+        } else {
+            $this->subject = $subject;
+        }
+    }
+
+    /**
      * Get the MailHelper object
      *
      * @return MailHelper

--- a/app/bundles/LeadBundle/EventListener/EmailSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/EmailSubscriber.php
@@ -88,8 +88,11 @@ class EmailSubscriber extends CommonSubscriber
      */
     public function onEmailGenerate(EmailSendEvent $event)
     {
-        $content = $event->getContent();
-        $lead    = $event->getLead();
+        // Combine all possible content to find tokens across them
+        $content  = $event->getSubject();
+        $content .= $event->getContent();
+        $content .= $event->getPlainText();
+        $lead     = $event->getLead();
 
         $tokenList = self::findLeadTokens($content, $lead);
         if (count($tokenList)) {


### PR DESCRIPTION
**Description**
1.1.3 fixed the issue with visual tokens inside a tags but the issue remained for use within img src tags.  This PR fixes that plus an issue lead field tokens were not replaced if used only in the subject.  This fixes #697.

**Testing**
Add an image to an email and view the source.  Append {leadfield=email} to the image's src tag.  Save the email and edit.  The source will be broken. 

Add a lead field token to the subject but don't include it in the body and send a lead a test email.  That token will not be found and replaced.

After the PR, both of those should now work.