### PR TITLE
Restricted objectId route parameter to alphanumeric or underscore.

### DIFF
--- a/app/bundles/CoreBundle/EventListener/CommonSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CommonSubscriber.php
@@ -247,7 +247,12 @@ class CommonSubscriber implements EventSubscriberInterface
                     }
                     if (strpos($details['path'], '{objectId}') !== false) {
                         if (!isset($defaults['objectId'])) {
+                            // Set default to 0 for the "new" actions
                             $defaults['objectId'] = 0;
+                        }
+                        if (!isset($requirements['objectId'])) {
+                            // Only allow alphanumeric for objectId
+                            $requirements['objectId'] = "[a-zA-Z0-9_]+";
                         }
                     }
                     if ($type == 'api' && strpos($details['path'], '{id}') !== false) {


### PR DESCRIPTION
**Description**
Probably related to the issue fixed by #719 and mentioned in #697, somehow lead token visual representation HTML is getting appended to an email and loaded leading to a logging of broken HTML in the notifications.  This then leads to a broken layout. This PR adds a requirement to the objectId route placeholder so that only alphanumeric and the underscore is recognized for the route to prevent broken HTML from triggering the route.  This should prevent it from being logged in notifications as it would just be a 404 instead.

**Testing**
Load the route `/emails/view/<strong` and it'll redirect back to the list with a message that the email was not found with an ID of.  Now the layout is possibly broken as well (if not, try refreshing).  If broken, purge the notifications table.  After the PR, that same route should take you to a 404.