### PR TITLE
Fixed an email pending count error

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -165,7 +165,9 @@ class EmailRepository extends CommonRepository
                 $sq->expr()->in('stat.email_id', $variantIds)
             );
         } else {
-            $sq->expr()->eq('stat.email_id', $emailId);
+            $sqExpr->add(
+                $sq->expr()->eq('stat.email_id', $emailId)
+            );
         }
 
         $sq2->select('stat.lead_id')


### PR DESCRIPTION
**Description**
The pending count was off for list based emails if the leads had received any other email.  This was due to a query expression that wasn't actually getting added to the query. 

**Testing**
Setup two list based emails assigned to the same lead group and send the first email to the leads.  Now the second email will have 0.  Apply the PR and the correct Pending count should be displayed. 