### PR TITLE
Fixed issue with re-importing lead's "do not contact" status

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -774,7 +774,7 @@ class LeadModel extends FormModel
      * @param string    $reason
      * @param bool|true $persist
      *
-     * @return DoNotEmail|void
+     * @return DoNotEmail|bool
      * @throws \Doctrine\DBAL\DBALException
      */
     public function setDoNotContact(Lead $lead, $emailAddress = '', $reason = '', $persist = true)
@@ -784,9 +784,10 @@ class LeadModel extends FormModel
             $emailAddress = $fields['core']['email']['value'];
 
             if (empty($emailAddress)) {
-                return;
+                return false;
             }
         }
+
         $em   = $this->factory->getEntityManager();
         $repo = $em->getRepository('MauticEmailBundle:Email');
         if (!$repo->checkDoNotEmail($emailAddress)) {
@@ -800,10 +801,13 @@ class LeadModel extends FormModel
             if ($persist) {
                 $repo->saveEntity($dnc);
             } else {
+                $lead->addDoNotEmailEntry($dnc);
 
                 return $dnc;
             }
         }
+
+        return false;
     }
 
     /**
@@ -910,8 +914,8 @@ class LeadModel extends FormModel
                 $reason = $this->factory->getTranslator()->trans('mautic.lead.import.by.user', array(
                     "%user%" => $this->factory->getUser()->getUsername()
                 ));
-                $dnc = $this->setDoNotContact($lead, $data[$fields['email']], $reason, false);
-                $lead->addDoNotEmailEntry($dnc);
+
+                $this->setDoNotContact($lead, $data[$fields['email']], $reason, false);
             }
         }
         unset($fields['doNotEmail']);


### PR DESCRIPTION
**Description**
When doing a lead import, if a lead already has an do not contact entry and the do not contact field is matched up during the import configuration, this error may be thrown

<b>Catchable fatal error</b>:  Argument 1 passed to Proxies\__CG__\Mautic\LeadBundle\Entity\Lead::addDoNotEmailEntry() must be an instance of Mautic\EmailBundle\Entity\DoNotEmail, null given, called in /home/user/public_html/mautic/app/bundles/LeadBundle/Model/LeadModel.php on line 914 and defined in <b>/home/user/public_html/mautic/app/cache/prod/doctrine/orm/Proxies/__CG__MauticLeadBundleEntityLead.php</b> on line <b>416</b><br />

This PR fixes that.

**Testing**
Import a lead list with "do not contact" column set to 1 for each email.  Then try to reimport the same list. It should fail the second time with the error above.  After the PR is applied; then it will make it through.