### PR TITLE
EmojiHelper is in the CoreBundle, not AddonBundle

### DIFF
--- a/addons/MauticSocialBundle/Integration/TwitterIntegration.php
+++ b/addons/MauticSocialBundle/Integration/TwitterIntegration.php
@@ -10,7 +10,7 @@
 namespace MauticAddon\MauticSocialBundle\Integration;
 
 use Mautic\AddonBundle\Entity\Integration;
-use Mautic\AddonBundle\Helper\EmojiHelper;
+use Mautic\CoreBundle\Helper\EmojiHelper;
 
 /**
  * Class TwitterIntegration


### PR DESCRIPTION
Reported in https://www.mautic.org/community/index.php/597-unable-to-save-lead/0

#### How to test
1. Enable and configure Twitter inegration
2. Try to create a new lead with Twitter handle

It will fail with error 500
```
PHP Fatal error:  Class 'Mautic\\AddonBundle\\Helper\\EmojiHelper' not found in addons/MauticSocialBundle/Integration/TwitterIntegration.php on line 198
```

This PR fixes the use statement so the EmojiHelper will be loaded from the right bundle.