### PR TITLE
Updated form view checks to not include featureSettings when not used

### DIFF
--- a/app/bundles/AddonBundle/Views/Integration/form.html.php
+++ b/app/bundles/AddonBundle/Views/Integration/form.html.php
@@ -9,7 +9,7 @@
 $formSettings  = $integration->getFormSettings();
 $hasFeatures   = (isset($form['supportedFeatures']) && count($form['supportedFeatures']));
 $hasFields     = (isset($form['featureSettings']) && count($form['featureSettings']['leadFields']));
-$fieldHtml     = (!empty($form['featureSettings']['leadFields'])) ? $view['form']->row($form['featureSettings']['leadFields'], array('integration' => $integration)) : '';
+$fieldHtml     = (isset($form['featureSettings']) && !empty($form['featureSettings']['leadFields'])) ? $view['form']->row($form['featureSettings']['leadFields'], array('integration' => $integration)) : '';
 
 $fieldTabClass = ($hasFields) ? '' : ' hide';
 ?>
@@ -70,9 +70,11 @@ $fieldTabClass = ($hasFields) ? '' : ' hide';
     </div>
     <?php endif; ?>
 
+    <?php if ($hasFeatures): ?>
     <div class="tab-pane fade bdr-w-0" id="fields-container">
         <h4 class="mb-sm"><?php echo $view['translator']->trans($form['featureSettings']['leadFields']->vars['label']); ?></h4>
         <?php echo $fieldHtml; ?>
     </div>
+    <?php endif; ?>
 </div>
 <?php echo $view['form']->end($form); ?>


### PR DESCRIPTION
**Problem**
Fixes problem with addon bundles of 'event' type throwing an unset array value when attempting to open their settings. 

**Testing**
1. Open an addon integration that does not have any extra form settings (featureSettings). The modal to enter the configuration details for that integration will fail to load.
2. Apply patch.
3. Re-open the modal and the API details will show correctly.