### PR TITLE
Editor token fixes

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/plugins/tokens/plugin.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/plugins/tokens/plugin.js
@@ -175,8 +175,9 @@ CKEDITOR_tokens.prototype.timeout_callback = function (args) {
     var startOffset = parseInt(range.startOffset - str.length) || 0;
     var element = range.startContainer.$;
     var tokenAction = $('#' + element_id).data('token-callback');
+    var tokenVisual = $('#' + element_id).data('token-visual');
 
-    $.get(CKEDITOR_tokens.ajaxUrl + '?action=' + tokenAction, {query: str}, function (rsp) {
+    $.get(CKEDITOR_tokens.ajaxUrl + '?action=' + tokenAction, {query: str, visual: tokenVisual}, function (rsp) {
         var ckel = $('#' + element_id);
         var par  = ckel.parent();
 
@@ -327,6 +328,18 @@ CKEDITOR_tokens.prototype.timeout_callback = function (args) {
             } else {
                 var tokenContent = document.createTextNode($(this).data('token'));
             }
+
+            tokenContent.addEventListener("dblclick", function(event) {
+                var selEl = new CKEDITOR.dom.element( event.target );
+                var rangeObjForSelection = new CKEDITOR.dom.range( editor.document );
+                rangeObjForSelection.selectNodeContents( selEl );
+                editor.getSelection().selectRanges( [ rangeObjForSelection ] );
+
+                // Remove contenteditable=false to make it deletable
+                mQuery(event.target).prop('contenteditable', true);
+
+                editor.focus();
+            });
 
             // Insert link after text node
             // this is used when the link is inserted not at the end of the text

--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -742,11 +742,13 @@ class AjaxController extends CommonController
 
         if (method_exists($this, 'getBuilderTokens')) {
             $query = $request->get('query');
+            $visual = $request->get('visual');
+
             if ($query && $query !== '{' && $query !== '{@') {
                 $tokenList = $this->getBuilderTokens($query);
 
                 $tokens       = (isset($tokenList['tokens'])) ? $tokenList['tokens'] : array();
-                $visualTokens = (isset($tokenList['visualTokens'])) ? $tokenList['visualTokens'] : array();
+                $visualTokens = ($visual !== 'false' && isset($tokenList['visualTokens'])) ? $tokenList['visualTokens'] : array();
 
                 if (!empty($tokens)) {
                     asort($tokens);

--- a/app/bundles/EmailBundle/Assets/builder/builder.js
+++ b/app/bundles/EmailBundle/Assets/builder/builder.js
@@ -4,29 +4,32 @@ mQuery(document).ready( function() {
     mQuery("div[contenteditable='true']").each(function (index) {
         var content_id = mQuery(this).attr('id');
         var that       = this;
+
+        var editorEvents = Mautic.getGlobalEditorEvents();
+
+        // Remove inserted <p /> tag if empty to allow the CSS3 placeholder to display
+        editorEvents['blur'] = function( event ) {
+            mQuery('.token-suggestions').remove();
+
+            var data = event.editor.getData();
+            if (!data) {
+                mQuery(that).html('');
+            }
+        };
+        editorEvents['instanceReady'] = function( event ) {
+            var data = event.editor.getData();
+            if (!data) {
+                mQuery(that).html('');
+            }
+        };
+
         CKEDITOR.inline(content_id, {
             extraPlugins: 'tokens,sourcedialog',
             toolbar: 'advanced',
             // Inline mode seems to ignore this but leaving anyway
             allowedContent: true,
             // Allow any attributes and prevent conversion of height/width attributes to styles
-            on: {
-                // Remove inserted <p /> tag if empty to allow the CSS3 placeholder to display
-                blur: function( event ) {
-                    mQuery('.token-suggestions').remove();
-
-                    var data = event.editor.getData();
-                    if (!data) {
-                        mQuery(that).html('');
-                    }
-                },
-                instanceReady: function( event ) {
-                    var data = event.editor.getData();
-                    if (!data) {
-                        mQuery(that).html('');
-                    }
-                }
-            }
+            on: editorEvents
         });
 
         mQuery(this).data('token-callback', 'email:getBuilderTokens');

--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -72,16 +72,17 @@ Mautic.emailOnLoad = function (container, response) {
         // Now empty it so that ckeditor doesn't load it as html
         mQuery('#emailform_plainText').val('');
 
+        var events = Mautic.getGlobalEditorEvents();
+        events.instanceReady = function( event ) {
+            event.editor.insertText(plainText);
+        };
+
         mQuery('#emailform_plainText').ckeditor({
             removePlugins: 'elementspath,toolbar',
             extraPlugins: 'tokens',
             autoParagraph: false,
             height: "235px",
-            on: {
-                instanceReady: function( event ) {
-                    event.editor.insertText(plainText);
-                }
-            }
+            on: events
         });
 
         if (mQuery('#emailform_emailType').val() == '') {

--- a/app/bundles/EmailBundle/Controller/AjaxController.php
+++ b/app/bundles/EmailBundle/Controller/AjaxController.php
@@ -231,12 +231,8 @@ class AjaxController extends CommonAjaxController
             // Convert placeholders into raw tokens
             BuilderTokenHelper::replaceVisualPlaceholdersWithTokens($content);
 
-            $parsed = array();
-            foreach ($content as $html) {
-                $parsed[] = $parser->setHtml($html)->getText();
-            }
-
-            $dataArray['text'] = implode("\n\n", $parsed);
+            $content           = implode("<br /><br />", $content);
+            $dataArray['text'] = $parser->setHtml($content)->getText();
         }
 
         return $this->sendJsonResponse($dataArray);

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -98,7 +98,6 @@ class EmailRepository extends CommonRepository
             ->createQueryBuilder()
             ->select('e')
             ->from('MauticEmailBundle:Email', 'e', 'e.id');
-
         if (empty($args['iterator_mode'])) {
             $q->leftJoin('e.category', 'c');
 

--- a/app/bundles/EmailBundle/Form/Type/EmailType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailType.php
@@ -200,7 +200,8 @@ class EmailType extends AbstractType
                     'class'                => 'form-control',
                     'rows'                 => '15',
                     'data-token-callback'  => 'email:getBuilderTokens',
-                    'data-token-activator' => '{'
+                    'data-token-activator' => '{',
+                    'data-token-visual'    => 'false'
                 ),
                 'required'   => false
             )
@@ -218,8 +219,8 @@ class EmailType extends AbstractType
 
                 $data = $event->getData();
 
+                // Then strip out HTML
                 $data['plainText'] = $parser->setHtml($data['plainText'])->getText();
-
                 $event->setData($data);
             }
         );

--- a/app/bundles/EmailBundle/Helper/PlainTextHelper.php
+++ b/app/bundles/EmailBundle/Helper/PlainTextHelper.php
@@ -304,7 +304,7 @@ class PlainTextHelper
         $text = ltrim($text, "\n");
 
         if ($this->options['width'] > 0) {
-            $text = wordwrap($text, $this->options['width']);
+            $text = $this->linewrap($text, $this->options['width']);
         }
     }
 
@@ -525,5 +525,25 @@ class PlainTextHelper
         $str = htmlspecialchars($str, ENT_COMPAT, self::ENCODING);
 
         return $str;
+    }
+
+    /**
+     * @param            $text
+     * @param            $width
+     * @param string     $breakline
+     * @param bool|false $cut
+     *
+     * @return string
+     */
+    private function linewrap($text, $width, $breakline = "\n", $cut = false)
+    {
+        $lines = explode("\n", $text);
+        $text  = '';
+        foreach ($lines as $line) {
+            $text .= trim(wordwrap(trim($line), $width, $breakline, $cut));
+            $text .= "\n";
+        }
+
+        return $text;
     }
 }

--- a/app/bundles/PageBundle/Assets/builder/builder.js
+++ b/app/bundles/PageBundle/Assets/builder/builder.js
@@ -13,9 +13,28 @@ mQuery(document).ready(function () {
     });
 
     CKEDITOR.disableAutoInline = true;
+
     mQuery("div[contenteditable='true']").each(function (index) {
         var content_id = mQuery(this).attr('id');
         var that = this;
+
+        var editorEvents = Mautic.getGlobalEditorEvents();
+        // Remove inserted <p /> tag if empty to allow the CSS3 placeholder to display
+        editorEvents['blur'] = function( event ) {
+            mQuery('.token-suggestions').remove();
+
+            var data = event.editor.getData();
+            if (!data) {
+                mQuery(that).html('');
+            }
+        };
+        editorEvents['instanceReady'] = function( event ) {
+            var data = event.editor.getData();
+            if (!data) {
+                mQuery(that).html('');
+            }
+        };
+
         CKEDITOR.inline(content_id, {
             extraPlugins: 'tokens,sourcedialog',
             toolbar: 'advanced',
@@ -23,23 +42,7 @@ mQuery(document).ready(function () {
             allowedContent: true,
             // Allow any attributes and prevent conversion of height/width attributes to styles
             extraAllowedContent: '*{*}; img[height,width]; table[height,width]',
-            on: {
-                // Remove inserted <p /> tag if empty to allow the CSS3 placeholder to display
-                blur: function( event ) {
-                    mQuery('.token-suggestions').remove();
-
-                    var data = event.editor.getData();
-                    if (!data) {
-                        mQuery(that).html('');
-                    }
-                },
-                instanceReady: function( event ) {
-                    var data = event.editor.getData();
-                    if (!data) {
-                        mQuery(that).html('');
-                    }
-                }
-            }
+            on: editorEvents
         });
 
         mQuery(this).data('token-callback', 'page:getBuilderTokens');
@@ -169,9 +172,9 @@ SlideshowManager.BrowseServer = function(obj)
 {
     SlideshowManager.urlobj = obj;
     SlideshowManager.OpenServerBrowser(
-    mauticBasePath + '/' + mauticAssetPrefix + 'app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/index.html?type=images',
-    screen.width * 0.7,
-    screen.height * 0.7 ) ;
+        mauticBasePath + '/' + mauticAssetPrefix + 'app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/index.html?type=images',
+        screen.width * 0.7,
+        screen.height * 0.7 ) ;
 }
 
 SlideshowManager.OpenServerBrowser = function( url, width, height )


### PR DESCRIPTION
**Description**
This PR fixes a formatting issue for the plain text email editor due to the use of PHP's wordwrap that left a space in front of the lines.  

It also improves selecting the visual tokens for deletion.  Firefox appropriately highlighted on click.  Chrome would not.  This PR allows a double click of a token and allows backspace to delete the token.

**Testing**
Copy and paste text into the plain text box (around 195 characters).  Save.  Open again and the formatting should be off as there will be one or two characters are on it's own line.

Also after applying the PR, insert a leadfield token into one of the editors (not the email plain text). Double click the token and it should be selected then hit backspace to delete. 

