### PR TITLE
Prevented a duplicate <html> tag for certain email documents

### DIFF
--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -352,14 +352,20 @@ class InputHelper
      */
     public static function html($value)
     {
-        // Specially handling for doctype
-        $doctypeFound = preg_match("/(<!DOCTYPE(.*?)>)/is", $value, $doctype);
+        if (is_array($value)) {
+            foreach ($value as &$val) {
+                $val = self::html($val);
+            }
+        } else {
+            // Specially handling for doctype
+            $doctypeFound = preg_match("/(<!DOCTYPE(.*?)>)/is", $value, $doctype);
 
-        $value = self::getFilter()->clean($value, 'html');
+            $value = self::getFilter()->clean($value, 'html');
 
-        // Was a doctype found?
-        if ($doctypeFound) {
-            $value = "$doctype[0]\n$value";
+            // Was a doctype found?
+            if ($doctypeFound) {
+                $value = "$doctype[0]\n$value";
+            }
         }
 
         return $value;

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -353,7 +353,7 @@ class InputHelper
     public static function html($value)
     {
         // Specially handling for doctype
-        $doctypeFound = preg_match("~<(?:!DOCTYPE|/?(?:html|body))[^>]*>\s*~i", $value, $doctype);
+        $doctypeFound = preg_match("/(<!DOCTYPE(.*?)>)/is", $value, $doctype);
 
         $value = self::getFilter()->clean($value, 'html');
 

--- a/app/bundles/FormBundle/Controller/FieldController.php
+++ b/app/bundles/FormBundle/Controller/FieldController.php
@@ -215,7 +215,7 @@ class FieldController extends CommonFormController
             // Only show the lead fields not already used
             $usedLeadFields = $session->get('mautic.form.'.$formId.'.fields.leadfields', array());
             $testLeadFields = array_flip($usedLeadFields);
-            $currentLeadField = $formField['leadField'];
+            $currentLeadField = (isset($formField['leadField'])) ? $formField['leadField'] : null;
             if (!empty($currentLeadField) && isset($testLeadFields[$currentLeadField])) {
                 unset($testLeadFields[$currentLeadField]);
             }

--- a/app/bundles/FormBundle/Views/Field/field_helper.php
+++ b/app/bundles/FormBundle/Views/Field/field_helper.php
@@ -68,7 +68,7 @@ if (!isset($containerClass))
     $containerClass = $containerType;
 $defaultContainerClass = 'mauticform-row mauticform-'.$containerClass;
 $validationMessage     = '';
-if ($field['isRequired']) {
+if (isset($field['isRequired']) && $field['isRequired']) {
     $defaultContainerClass .= ' mauticform-required';
     $validationMessage = $field['validationMessage'];
     if (empty($validationMessage)) {


### PR DESCRIPTION
**Description**
This fixes an issue where a duplicate opening html tag was added to custom html emails.  It also fixes InputHelper::html when $value is an array and prevented a couple stumbled upon PHP notices.

**Testing**
Create a custom html email without a doctype.  Save and open again then view the source.  It should have a two opening html tags.  Apply the PR and save and now all should be good.  Also test content with a doctype to ensure it remains after the email is saved.