### PR TITLE
Add Send Test and Send buttons to the email editing page

### DIFF
--- a/app/bundles/EmailBundle/Views/Email/form.html.php
+++ b/app/bundles/EmailBundle/Views/Email/form.html.php
@@ -29,6 +29,34 @@ $emailType = $form['emailType']->vars['data'];
 if (!isset($attachmentSize)) {
     $attachmentSize = 0;
 }
+
+$customButtons = array();
+if ($emailType == 'list') {
+    $customButtons[] = array(
+        'attr' => array(
+            'data-toggle' => 'ajax',
+            'href'        => $view['router']->generate('mautic_email_action', array('objectAction' => 'send', 'objectId'
+ => $email->getId())),
+        ),
+        'iconClass' => 'fa fa-send-o',
+        'btnText'   => 'mautic.email.send'
+    );
+}
+$customButtons[] = array(
+    'attr' => array(
+        'data-toggle' => 'ajax',
+        'href'        => $view['router']->generate('mautic_email_action', array('objectAction' => 'example', 'objectId'
+=> $email->getId())),
+    ),
+    'iconClass' => 'fa fa-send',
+    'btnText'   => 'mautic.email.send.example'
+);
+$view['slots']->set('actions', $view->render('MauticCoreBundle:Helper:page_actions.html.php', array(
+    'item'       => $email,
+    'routeBase'  => 'email',
+    'customButtons' => $customButtons
+)));
+
 ?>
 
 


### PR DESCRIPTION
Working on adding these buttons to the email edit page.  Some obvious issues I still need to resolve, tips appreciated. I'm pretty new to the Mautic Form system.

* Doesn't save the email; ideally it either would save the form, or do nothing if there are unsaved changes.  Changes are easily lost.
* After a "Send Test" it drops you onto the "view" page, I'd rather it returned to page I was already on (the edit page).

