### PR TITLE
Fixed issue with A/B testing theme based emails

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -809,7 +809,7 @@ class EmailModel extends FormModel
                             if (isset($slots[$template])) {
                                 $useSlots = $slots[$template];
                             } else {
-                                $slots[$template] = $this->factory->getTheme($template())->getSlots('email');
+                                $slots[$template] = $this->factory->getTheme($template)->getSlots('email');
                                 $useSlots         = $slots[$template];
                             }
                             $variantSettings = $child->getVariantSettings();


### PR DESCRIPTION
**Description**
See https://www.mautic.org/community/index.php/614-cannot-trigger-campaigns-function-name-must-be-a-string/0#p2428.  When an A/B test is based on a theme rather than custom HTML, an error occurred to the typo this PR fixes.

**Testing**
Create an email that uses a theme.  Then create an a/b test for it.  Assign the email to a campaign send email action and try to process the campaign through the `mautic:campaign:trigger` command.  It should result in the fatal error as noted in the above forum post.  The PR should result in a successful email send.