### PR TITLE
Fixes tracking links with & in the URL

### DIFF
--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -616,8 +616,11 @@ class BuilderSubscriber extends CommonSubscriber
         foreach ($links as $link) {
             $url = $link->getAttribute('href');
 
+            // The editor will have converted & to &amp; but DOMDocument will have converted them back so this must be accounted for
+            $url = str_replace('&', '&amp;', $url);
+
             // Ensure a valid URL
-            if (substr($url, 0, 4) !== 'http' && substr($url, 0, 3) !== 'ftp' && !in_array($url, $foundLinks) && !in_array($url, $trackedLinks)) {
+            if ((substr($url, 0, 4) !== 'http' && substr($url, 0, 3) !== 'ftp') || in_array($url, $foundLinks) || in_array($url, $trackedLinks)) {
                 continue;
             }
 


### PR DESCRIPTION
**Description**
CKEditor correctly converts & in links to &amp; but this is not accounted for when search/replacing links because DOMDocument decodes them which leads to the URLs not being found. This PR converts them back so that search/replace should work.

**Testing**
Create a new email and include a link that includes an ampersand.  Send the email to a lead (not through the Send Example option).  The URL will arrive without being converted to a trackable. After the PR, it should be converted correctly.