### PR TITLE
Removed requirement for current password when updating profile

### DIFF
--- a/app/bundles/UserBundle/Controller/ProfileController.php
+++ b/app/bundles/UserBundle/Controller/ProfileController.php
@@ -122,17 +122,6 @@ class ProfileController extends FormController
             }
         }
 
-        //add an input to request the current password in order to change existing details
-        $form->add('currentPassword', 'password', array(
-            'label'      => 'mautic.user.account.form.password.current',
-            'label_attr' => array('class' => 'control-label'),
-            'attr'       => array(
-                'class'    => 'form-control',
-                'tooltip'  => 'mautic.user.account.form.help.password.current',
-                'preaddon' => 'fa fa-lock'
-            )
-        ));
-
         //Check for a submitted form and process it
         $submitted = $this->factory->getSession()->get('formProcessed', 0);
         if ($this->request->getMethod() == 'POST' && !$submitted) {

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -263,13 +263,6 @@ class User extends FormEntity implements AdvancedUserInterface, \Serializable
             )
         ));
 
-        $metadata->addPropertyConstraint('currentPassword', new SecurityAssert\UserPassword(
-            array(
-                'message' => 'mautic.user.account.password.userpassword',
-                'groups'  => array('Profile')
-            )
-        ));
-
         $metadata->setGroupSequence(array('User', 'SecondPass', 'CheckPassword'));
     }
 
@@ -286,11 +279,6 @@ class User extends FormEntity implements AdvancedUserInterface, \Serializable
         //check if creating a new user or editing an existing user and the password has been updated
         if (!$data->getId() || ($data->getId() && $data->getPlainPassword())) {
             $groups[] = 'CheckPassword';
-        }
-
-        //require current password if on profile page
-        if ($form->has('currentPassword')) {
-            $groups[] = 'Profile';
         }
 
         return $groups;

--- a/app/bundles/UserBundle/Translations/en_US/messages.ini
+++ b/app/bundles/UserBundle/Translations/en_US/messages.ini
@@ -1,5 +1,3 @@
-mautic.user.account.form.help.password.current="You must enter your current password in order to make changes to your profile."
-mautic.user.account.form.password.current="Current Password"
 mautic.user.account.header.authorizedclients="Authorized Applications"
 mautic.user.account.header.details="Account Details"
 mautic.user.account.permissions.editall="All"

--- a/app/bundles/UserBundle/Translations/en_US/validators.ini
+++ b/app/bundles/UserBundle/Translations/en_US/validators.ini
@@ -1,4 +1,3 @@
-mautic.user.account.password.userpassword="Current password is incorrect and is required to update your account."
 mautic.user.user.email.unique="Email is already in use. Please choose another."
 mautic.user.user.email.valid="The email entered is invalid."
 mautic.user.user.firstname.notblank="First name is required."

--- a/app/bundles/UserBundle/Views/Profile/index.html.php
+++ b/app/bundles/UserBundle/Views/Profile/index.html.php
@@ -71,7 +71,6 @@ $view['slots']->set("headerTitle", $view['translator']->trans('mautic.user.accou
                         <?php
                         echo $view['form']->row($userForm['timezone']);
                         echo $view['form']->row($userForm['locale']);
-                        echo $view['form']->row($userForm['currentPassword']);
                         echo $view['form']->row($userForm['plainPassword']['password']);
                         echo $view['form']->row($userForm['plainPassword']['confirm']);
                         ?>


### PR DESCRIPTION
**Description**
Whoops, got commits mixed up.  This PR removes the need to enter the current password when updating one's own profile.  It seemed that some long, complex passwords caused this to fail and it's annoying so just removed it.

**Testing**
After applying the PR, go to Account -> Profile and try updating fields, changing password, etc.  It should take and update without issue.