### PR TITLE
MySQL migration fixes

### DIFF
--- a/app/migrations/Version20150724000000.php
+++ b/app/migrations/Version20150724000000.php
@@ -9,6 +9,7 @@
 
 namespace Mautic\Migrations;
 
+use Doctrine\DBAL\Migrations\SkipMigrationException;
 use Doctrine\DBAL\Schema\Schema;
 use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
 
@@ -40,8 +41,20 @@ class Version20150724000000 extends AbstractMauticMigration
     public function mysqlUp(Schema $schema)
     {
         $this->addSql('ALTER TABLE ' . $this->prefix . 'oauth1_consumers CHANGE consumerKey consumer_key VARCHAR(255) NOT NULL, CHANGE consumerSecret consumer_secret VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE ' . $this->prefix . 'oauth1_access_tokens DROP FOREIGN KEY ' . $this->findPropertyName('oauth1_access_tokens', 'fk', '37FDBD6D'));
+        $this->addSql('DROP INDEX ' . $this->findPropertyName('oauth1_access_tokens', 'idx', '37FDBD6D') . ' ON ' . $this->prefix . 'oauth1_access_tokens');
+        $this->addSql('ALTER TABLE ' . $this->prefix . 'oauth1_access_tokens DROP FOREIGN KEY ' . $this->findPropertyName('oauth1_access_tokens', 'fk', 'A76ED395'));
+        $this->addSql('DROP INDEX ' . $this->findPropertyName('oauth1_access_tokens', 'idx', 'A76ED395') . ' ON ' . $this->prefix . 'oauth1_access_tokens');
         $this->addSql('ALTER TABLE ' . $this->prefix . 'oauth1_access_tokens CHANGE consumer_id consumer_id INT NOT NULL, CHANGE user_id user_id INT NOT NULL, CHANGE expiresat expires_at BIGINT DEFAULT NULL');
+        $this->addSql('ALTER TABLE ' . $this->prefix . 'oauth1_access_tokens ADD CONSTRAINT ' . $this->generatePropertyName('oauth1_access_tokens', 'fk', array('consumer_id')) . ' FOREIGN KEY (consumer_id) REFERENCES ' . $this->prefix . 'oauth1_access_tokens (id)');
+        $this->addSql('CREATE INDEX ' . $this->generatePropertyName('oauth1_access_tokens', 'idx', array('consumer_id')) . ' ON ' . $this->prefix . 'oauth1_consumers (id)');
+        $this->addSql('ALTER TABLE ' . $this->prefix . 'oauth1_access_tokens ADD CONSTRAINT ' . $this->generatePropertyName('oauth1_access_tokens', 'fk', array('user_id')) . ' FOREIGN KEY (consumer_id) REFERENCES ' . $this->prefix . 'users (id)');
+        $this->addSql('CREATE INDEX ' . $this->generatePropertyName('oauth1_access_tokens', 'idx', array('user_id')) . ' ON ' . $this->prefix . 'oauth1_access_tokens (user_id)');
+        $this->addSql('ALTER TABLE ' . $this->prefix . 'oauth1_request_tokens DROP FOREIGN KEY ' . $this->findPropertyName('oauth1_request_tokens', 'fk', '37FDBD6D'));
+        $this->addSql('DROP INDEX ' . $this->findPropertyName('oauth1_request_tokens', 'idx', '37FDBD6D') . ' ON ' . $this->prefix . 'oauth1_request_tokens');
         $this->addSql('ALTER TABLE ' . $this->prefix . 'oauth1_request_tokens CHANGE consumer_id consumer_id INT NOT NULL, CHANGE expiresat expires_at BIGINT NOT NULL');
+        $this->addSql('ALTER TABLE ' . $this->prefix . 'oauth1_request_tokens ADD CONSTRAINT ' . $this->generatePropertyName('oauth1_request_tokens', 'fk', array('consumer_id')) . ' FOREIGN KEY (consumer_id) REFERENCES ' . $this->prefix . 'oauth1_request_tokens (id)');
+        $this->addSql('CREATE INDEX ' . $this->generatePropertyName('oauth1_request_tokens', 'idx', array('consumer_id')) . ' ON ' . $this->prefix . 'oauth1_consumers (id)');
 
         $this->addSql('ALTER TABLE ' . $this->prefix . 'oauth2_clients CHANGE name name VARCHAR(255) NOT NULL');
         $this->addSql('ALTER TABLE ' . $this->prefix . 'oauth2_accesstokens CHANGE expires_at expires_at BIGINT DEFAULT NULL');
@@ -68,7 +81,11 @@ class Version20150724000000 extends AbstractMauticMigration
         $this->addSql('ALTER TABLE ' . $this->prefix . 'form_fields CHANGE form_id form_id INT NOT NULL');
         $this->addSql('ALTER TABLE ' . $this->prefix . 'lead_ips_xref DROP FOREIGN KEY ' . $this->findPropertyName('lead_ips_xref', 'fk', '0655458D'));
         $this->addSql('ALTER TABLE ' . $this->prefix . 'lead_ips_xref ADD CONSTRAINT ' . $this->generatePropertyName('lead_ips_xref', 'fk', array('lead_id')) . ' FOREIGN KEY (lead_id) REFERENCES ' . $this->prefix . 'leads (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE ' . $this->prefix . 'lead_notes DROP FOREIGN KEY ' . $this->findPropertyName('lead_notes', 'fk', '1755458D'));
+        $this->addSql('DROP INDEX ' . $this->findPropertyName('lead_notes', 'idx', '1755458D') . ' ON ' . $this->prefix . 'lead_notes');
         $this->addSql('ALTER TABLE ' . $this->prefix . 'lead_notes CHANGE lead_id lead_id INT NOT NULL, CHANGE text text LONGTEXT NOT NULL');
+        $this->addSql('ALTER TABLE ' . $this->prefix . 'lead_notes ADD CONSTRAINT ' . $this->generatePropertyName('lead_notes', 'fk', array('lead_id')) . ' FOREIGN KEY (lead_id) REFERENCES ' . $this->prefix . 'leads (id)');
+        $this->addSql('CREATE INDEX ' . $this->generatePropertyName('lead_notes', 'idx', array('lead_id')) . ' ON ' . $this->prefix . 'leads (id)');
         $this->addSql('ALTER TABLE ' . $this->prefix . 'lead_points_change_log DROP FOREIGN KEY ' . $this->findPropertyName('lead_points_change_log', 'fk', '6955458D'));
         $this->addSql('ALTER TABLE ' . $this->prefix . 'lead_points_change_log CHANGE event_name event_name VARCHAR(255) NOT NULL, CHANGE action_name action_name VARCHAR(255) NOT NULL');
         $this->addSql('ALTER TABLE ' . $this->prefix . 'lead_points_change_log ADD CONSTRAINT ' . $this->generatePropertyName('lead_points_change_log', 'fk', array('lead_id')) . ' FOREIGN KEY (lead_id) REFERENCES ' . $this->prefix . 'leads (id) ON DELETE CASCADE');
@@ -90,7 +107,11 @@ class Version20150724000000 extends AbstractMauticMigration
         $this->addSql('ALTER TABLE ' . $this->prefix . 'points CHANGE name name VARCHAR(255) NOT NULL');
         $this->addSql('ALTER TABLE ' . $this->prefix . 'point_triggers CHANGE name name VARCHAR(255) NOT NULL');
         $this->addSql('ALTER TABLE ' . $this->prefix . 'point_trigger_events CHANGE name name VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE ' . $this->prefix . 'users DROP FOREIGN KEY ' . $this->findPropertyName('users', 'fk', 'D60322AC'));
+        $this->addSql('DROP INDEX ' . $this->findPropertyName('users', 'idx', 'D60322AC') . ' ON ' . $this->prefix . 'users');
         $this->addSql('ALTER TABLE ' . $this->prefix . 'users CHANGE role_id role_id INT NOT NULL, CHANGE username username VARCHAR(255) NOT NULL, CHANGE first_name first_name VARCHAR(255) NOT NULL, CHANGE last_name last_name VARCHAR(255) NOT NULL, CHANGE email email VARCHAR(255) NOT NULL, CHANGE position position VARCHAR(255) DEFAULT NULL, CHANGE timezone timezone VARCHAR(255) DEFAULT NULL, CHANGE locale locale VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE ' . $this->prefix . 'users ADD CONSTRAINT ' . $this->generatePropertyName('users', 'fk', array('role_id')) . ' FOREIGN KEY (role_id) REFERENCES ' . $this->prefix . 'roles (id)');
+        $this->addSql('CREATE INDEX ' . $this->generatePropertyName('users', 'idx', array('role_id')) . ' ON ' . $this->prefix . 'roles (id)');
         $this->addSql('ALTER TABLE ' . $this->prefix . 'permissions DROP FOREIGN KEY ' . $this->findPropertyName('permissions', 'fk', 'D60322AC'));
         $this->addSql('ALTER TABLE ' . $this->prefix . 'permissions CHANGE role_id role_id INT NOT NULL');
         $this->addSql('ALTER TABLE ' . $this->prefix . 'permissions ADD CONSTRAINT ' . $this->generatePropertyName('permissions', 'fk', array('role_id')) . ' FOREIGN KEY (role_id) REFERENCES ' . $this->prefix . 'roles (id) ON DELETE CASCADE');


### PR DESCRIPTION
This PR adds some queries to the 1.1.4 migration class I needed to run the migration successfully.  All of the errors I got were related to changing columns which had indexes so the indexes had to be deleted and recreated.  Also, the use statement for the `SkipMigrationException` was missing.

@alanhartless You might want to go through this with a fine toothed comb, I hand jammed these changes together so I hope I didn't break too much :laughing: 