### PR TITLE
Run PHP version checks before booting the app

### DIFF
--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -87,10 +87,6 @@ class CheckStep implements StepInterface
     {
         $messages = array();
 
-        if (version_compare(PHP_VERSION, '5.3.7', '<')) {
-            $messages[] = 'mautic.install.minimum.php.version';
-        }
-
         if (version_compare(PHP_VERSION, '5.3.16', '==')) {
             $messages[] = 'mautic.install.buggy.php.version';
         }
@@ -111,17 +107,16 @@ class CheckStep implements StepInterface
             $messages[] = 'mautic.install.logs.unwritable';
         }
 
-        if (version_compare(PHP_VERSION, '5.3.7', '>=')) {
-            $timezones = array();
-            foreach (\DateTimeZone::listAbbreviations() as $abbreviations) {
-                foreach ($abbreviations as $abbreviation) {
-                    $timezones[$abbreviation['timezone_id']] = true;
-                }
-            }
+        $timezones = array();
 
-            if (!isset($timezones[date_default_timezone_get()])) {
-                $messages[] = 'mautic.install.timezone.not.supported';
+        foreach (\DateTimeZone::listAbbreviations() as $abbreviations) {
+            foreach ($abbreviations as $abbreviation) {
+                $timezones[$abbreviation['timezone_id']] = true;
             }
+        }
+
+        if (!isset($timezones[date_default_timezone_get()])) {
+            $messages[] = 'mautic.install.timezone.not.supported';
         }
 
         if (get_magic_quotes_gpc()) {

--- a/app/bundles/InstallBundle/Views/Install/check.html.php
+++ b/app/bundles/InstallBundle/Views/Install/check.html.php
@@ -31,9 +31,6 @@ if ($tmpl == 'index') {
             <ul class="list-group">
                 <?php foreach ($majors as $message) : ?>
                     <?php switch ($message) :
-                        case 'mautic.install.minimum.php.version': ?>
-                            <li class="list-group-item"> <?php echo $view['translator']->trans($message, array('%minimum%' => '5.3.7', '%installed' => PHP_VERSION)); ?></li>
-                            <?php break;
                         case 'mautic.install.cache.unwritable': ?>
                             <li class="list-group-item"><?php echo $view['translator']->trans('mautic.install.directory.unwritable', array('%path%' => $appRoot . '/cache')); ?></li>
                             <?php break;

--- a/index.php
+++ b/index.php
@@ -7,6 +7,24 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
+// Define Mautic's supported PHP versions
+define('MAUTIC_MINIMUM_PHP', '5.3.7');
+define('MAUTIC_MAXIMUM_PHP', '5.6.999');
+
+// Are we running the minimum version?
+if (version_compare(PHP_VERSION, MAUTIC_MINIMUM_PHP, '<')) {
+    echo 'Your server does not meet the minimum PHP requirements. Mautic requires PHP version '.MAUTIC_MINIMUM_PHP.' while your server has '.PHP_VERSION.'. Please contact your host to update your PHP installation.';
+
+    exit;
+}
+
+// Are we running a version newer than what Mautic supports?
+if (version_compare(PHP_VERSION, MAUTIC_MAXIMUM_PHP, '>')) {
+    echo 'Mautic does not support PHP version '.PHP_VERSION.' at this time. To use Mautic, you will need to downgrade to an earlier version.';
+
+    exit;
+}
+
 // Fix for hosts that do not have date.timezone set, it will be reset based on users settings
 date_default_timezone_set ('UTC');
 

--- a/index_dev.php
+++ b/index_dev.php
@@ -6,6 +6,24 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
+// Define Mautic's supported PHP versions
+define('MAUTIC_MINIMUM_PHP', '5.3.7');
+define('MAUTIC_MAXIMUM_PHP', '5.6.999');
+
+// Are we running the minimum version?
+if (version_compare(PHP_VERSION, MAUTIC_MINIMUM_PHP, '<')) {
+    echo 'Your server does not meet the minimum PHP requirements. Mautic requires PHP version '.MAUTIC_MINIMUM_PHP.' while your server has '.PHP_VERSION.'. Please contact your host to update your PHP installation.';
+
+    exit;
+}
+
+// Are we running a version newer than what Mautic supports?
+if (version_compare(PHP_VERSION, MAUTIC_MAXIMUM_PHP, '>')) {
+    echo 'Mautic does not support PHP version '.PHP_VERSION.' at this time. To use Mautic, you will need to downgrade to an earlier version.';
+
+    exit;
+}
+
 // Fix for hosts that do not have date.timezone set, it will be reset based on users settings
 date_default_timezone_set ('UTC');
 


### PR DESCRIPTION
This PR moves the minimum supported PHP version check from the installer to the index(_dev).php file so that the app does not have to be fully booted to determine whether the version is supported.  This also adds a check for the maximum supported version and will block bootup for new PHP versions that aren't supported (this blocks PHP 7 entirely right now).