### PR TITLE
Removed break which caused some entities to be skipped on mapping

### DIFF
--- a/app/config/config.php
+++ b/app/config/config.php
@@ -63,13 +63,8 @@ $buildBundles = function($namespace, $bundle) use ($container, $paths, $root, &$
                         'mapping'   => true,
                         'is_bundle' => true
                     );
-                } else {
-                    // Use Symfony's auto mapping
-
-                    break;
                 }
             }
-
         }
 
         return array(


### PR DESCRIPTION
I had problems on my local that some entities were not mapped and I couldn't eve login to Mautic. I tried to re-install LAMP and do all sorts of crazy things. After many hours later I found out that this `break' is doing that. For example CoreBundle/CommonEntity does not have loadMetadata method and that caused that all CoreBundle entities were skipped.

#### How to test
1. Trigger `php app/console doctrine:mapping:info`. It will load a list of mapped entities.
2. Apply this PR
3. Clear cache
4. Trigger `php app/console doctrine:mapping:info` again

=> Both lists should be the same or in my case, the second one contains more (all) entities.