### PR TITLE
Lead import upload field filters only csv files

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/LeadImportType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadImportType.php
@@ -29,6 +29,7 @@ class LeadImportType extends AbstractType
         $builder->add('file', 'file', array(
             'label' => 'mautic.lead.import.file',
             'attr'  => array(
+                'accept' => '.csv',
                 'class' => 'form-control'
             )
         ));


### PR DESCRIPTION
I found it hard to search for csv files I want to upload. This change displays only CSV files for upload.

### How to test
1. Go to Import Leads section.
2. Click to **Choose File** button

-> You should see all types of files.

After this PR, you should see only folders and CSV files