### PR TITLE
Lead Timeline: display only fields with a value

### DIFF
--- a/app/bundles/FormBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/FormBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -51,7 +51,7 @@ if ($page->getId()) {
 					<dd class="ellipsis"><?php echo $view['assets']->makeLinks($submission->getReferer()); ?></dd>
 				<?php if (is_array($results)) : ?>
 					<?php foreach ($form->getFields() as $field) : ?>
-						<?php if (array_key_exists($field->getAlias(), $results) && !empty($results[$field->getAlias()])) : ?>
+						<?php if (array_key_exists($field->getAlias(), $results) && $results[$field->getAlias()] != '' && $results[$field->getAlias()] != null && $results[$field->getAlias()] != array()) : ?>
 							<dt><?php echo $field->getLabel(); ?></dt>
 							<dd class="ellipsis"><?php echo $results[$field->getAlias()]; ?></dd>
 						<?php endif; ?>

--- a/app/bundles/FormBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/FormBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -53,7 +53,7 @@ if ($page->getId()) {
 					<?php foreach ($form->getFields() as $field) : ?>
 						<?php if (array_key_exists($field->getAlias(), $results)) : ?>
 							<dt><?php echo $field->getLabel(); ?></dt>
-							<dd class="ellipsis"><?php echo $results[$field->getAlias()]; ?></dd>
+							<dd class="ellipsis"><?php echo empty($results[$field->getAlias()]) ? '&nbsp;' : $results[$field->getAlias()]; ?></dd>
 						<?php endif; ?>
 					<?php endforeach; ?>
 				<?php endif; ?>

--- a/app/bundles/FormBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/FormBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -51,9 +51,9 @@ if ($page->getId()) {
 					<dd class="ellipsis"><?php echo $view['assets']->makeLinks($submission->getReferer()); ?></dd>
 				<?php if (is_array($results)) : ?>
 					<?php foreach ($form->getFields() as $field) : ?>
-						<?php if (array_key_exists($field->getAlias(), $results)) : ?>
+						<?php if (array_key_exists($field->getAlias(), $results) && !empty($results[$field->getAlias()])) : ?>
 							<dt><?php echo $field->getLabel(); ?></dt>
-							<dd class="ellipsis"><?php echo empty($results[$field->getAlias()]) ? '&nbsp;' : $results[$field->getAlias()]; ?></dd>
+							<dd class="ellipsis"><?php echo $results[$field->getAlias()]; ?></dd>
 						<?php endif; ?>
 					<?php endforeach; ?>
 				<?php endif; ?>


### PR DESCRIPTION
The problem is outlined in https://github.com/mautic/mautic/issues/773

It was actually caused by form values being moved to the top. So if one value in the middle of the form was empty, all values from below was moved one field up and didn't match the labels.

~~This PR adds an empty space HTML entity when a value is empty.~~ *(edited according to comments)*
This PR displays only fields which has a non-empty value