### PR TITLE
Uses the extension if known rather than re-analyzing the file each time.

### DIFF
--- a/app/bundles/AssetBundle/Entity/Asset.php
+++ b/app/bundles/AssetBundle/Entity/Asset.php
@@ -876,6 +876,10 @@ class Asset extends FormEntity
      */
     public function getFileType()
     {
+        if (!empty($this->extension)) {
+            return $this->extension;
+        }
+
         if ($this->getStorageLocation() == 'remote') {
             return pathinfo(parse_url($this->getRemotePath(), PHP_URL_PATH), PATHINFO_EXTENSION);
         }


### PR DESCRIPTION
**Description**

Sometimes the extension failed to load leading to the assets not showing  a preview.  Instead of reanalyzing each time to obtain the extension, used what's saved to the DB if already known.