### PR TITLE
Added option to search any lead field by alias as a search command

### DIFF
--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -411,8 +411,18 @@ class Lead extends FormEntity
      */
     public function getName ($lastFirst = false)
     {
-        $firstName = (isset($this->fields['core']['firstname']['value'])) ? $this->fields['core']['firstname']['value'] : '';
-        $lastName  = (isset($this->fields['core']['lastname']['value'])) ? $this->fields['core']['lastname']['value'] : '';
+        if (isset($this->updatedFields['firstname'])) {
+            $firstName = $this->updatedFields['firstname'];
+        } else {
+            $firstName = (isset($this->fields['core']['firstname']['value'])) ? $this->fields['core']['firstname']['value'] : '';
+        }
+
+        if (isset($this->updatedFields['lastname'])) {
+            $lastName = $this->updatedFields['lastname'];
+        } else {
+            $lastName = (isset($this->fields['core']['lastname']['value'])) ? $this->fields['core']['lastname']['value'] : '';
+        }
+
         $fullName  = "";
         if ($lastFirst && !empty($firstName) && !empty($lastName)) {
             $fullName = $lastName.", ".$firstName;
@@ -434,6 +444,11 @@ class Lead extends FormEntity
      */
     public function getCompany()
     {
+        if (isset($this->updatedFields['company'])) {
+
+            return $this->updatedFields['company'];
+        }
+
         if (!empty($this->fields['core']['company']['value'])) {
 
             return $this->fields['core']['company']['value'];
@@ -443,18 +458,55 @@ class Lead extends FormEntity
     }
 
     /**
-     * Get company
+     * Get email
      *
      * @return string
      */
     public function getEmail()
     {
+        if (isset($this->updatedFields['email'])) {
+
+            return $this->updatedFields['email'];
+        }
+
         if (!empty($this->fields['core']['email']['value'])) {
 
             return $this->fields['core']['email']['value'];
         }
 
         return '';
+    }
+
+    /**
+     * Get lead field value
+     *
+     * @param      $field
+     * @param null $group
+     *
+     * @return bool
+     */
+    public function getFieldValue($field, $group = null)
+    {
+        if (isset($this->updatedFields[$field])) {
+
+            return $this->updatedFields[$field];
+        }
+
+        if (!empty($group) && isset($this->fields[$group][$field])) {
+
+            return $this->fields[$group][$field]['value'];
+        }
+
+        foreach ($this->fields as $group => $groupFields) {
+            foreach ($groupFields as $name => $details) {
+                if ($name == $field) {
+
+                    return $details['value'];
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/app/bundles/LeadBundle/Form/Type/LeadType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadType.php
@@ -13,6 +13,7 @@ use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Form\DataTransformer\StringToDatetimeTransformer;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
+use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Helper\FormFieldHelper;
 use Mautic\UserBundle\Form\DataTransformer as Transformers;
 use Symfony\Component\Form\AbstractType;
@@ -154,7 +155,7 @@ class LeadType extends AbstractType
             if ($type == 'number') {
                 if (empty($properties['precision'])) {
                     $properties['precision'] = null;
-                } //ensure deafult locale is used
+                } //ensure default locale is used
                 else {
                     $properties['precision'] = (int) $properties['precision'];
                 }
@@ -184,19 +185,25 @@ class LeadType extends AbstractType
                     'label_attr'  => array('class' => 'control-label'),
                     'widget'      => 'single_text',
                     'attr'        => $attr,
-                    'data'        => $value,
                     'mapped'      => false,
-                    'constraints' => $constraints,
-                    'input'       => 'string'
+                    'input'       => 'string',
+                    'html5'       => false,
+                    'constraints' => $constraints
                 );
 
-                if ($type == 'date' || $type == 'time') {
-                    $opts['input'] = 'string';
-                    $builder->add($alias, $type, $opts);
-                } else {
+                $dtHelper = new DateTimeHelper($value, null, 'local');
+
+                if ($type == 'datetime') {
                     $opts['model_timezone'] = 'UTC';
                     $opts['view_timezone']  = date_default_timezone_get();
                     $opts['format']         = 'yyyy-MM-dd HH:mm';
+                    $opts['with_seconds']   = false;
+
+                    $opts['data'] = $dtHelper->toLocalString('Y-m-d H:i:s');
+                } elseif ($type == 'date') {
+                    $opts['data'] = $dtHelper->toLocalString('Y-m-d');
+                } else {
+                    $opts['data'] = $dtHelper->toLocalString('H:i:s');
                 }
 
                 $builder->add($alias, $type, $opts);

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -400,6 +400,8 @@ class FieldModel extends FormModel
      *
      * @param       $group
      * @param array $filters
+     *
+     * @return array
      */
     public function getGroupFields($group, $filters = array('isPublished' => true))
     {

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -44,17 +44,28 @@ class LeadModel extends FormModel
      */
     public function getRepository()
     {
-        static $socialFieldsSet;
+        static $repoSetup;
 
         $repo = $this->em->getRepository('MauticLeadBundle:Lead');
 
-        if (!$socialFieldsSet) {
-            $fields = $this->factory->getModel('lead.field')->getGroupFields('social');
-            if (!empty($fields)) {
-                $socialFields = array_keys($fields);
-                $repo->setAvailableSocialFields($socialFields);
+        if (!$repoSetup) {
+            $repoSetup = true;
+
+            //set the point trigger model in order to get the color code for the lead
+            $repo->setTriggerModel($this->factory->getModel('point.trigger'));
+
+            /** @var FieldModel $fieldModel */
+            $fieldModel = $this->factory->getModel('lead.field');
+            $fields     = $fieldModel->getFieldList(true, false);
+
+            $socialFields = (!empty($fields['social'])) ? array_keys($fields['social']) : array();
+            $repo->setAvailableSocialFields($socialFields);
+
+            $searchFields = array();
+            foreach ($fields as $group => $groupFields) {
+                $searchFields = array_merge($searchFields, array_keys($groupFields));
             }
-            $socialFieldsSet = true;
+            $repo->setAvailableSearchFields($searchFields);
         }
 
         return $repo;
@@ -88,21 +99,6 @@ class LeadModel extends FormModel
     public function getNameGetter()
     {
         return "getPrimaryIdentifier";
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param array $args [start, limit, filter, orderBy, orderByDir]
-     * @return mixed
-     */
-    public function getEntities(array $args = array())
-    {
-        //set the point trigger model in order to get the color code for the lead
-        $repo = $this->getRepository();
-        $repo->setTriggerModel($this->factory->getModel('point.trigger'));
-
-        return parent::getEntities($args);
     }
 
     /**


### PR DESCRIPTION
**Description**
This adds support for using any lead field as a search command to filter leads.  I.e. firstname:alan, customfield:search, etc.

**Testing**
Apply the PR and try searching for leads using one of your custom fields/stock fields via the field_alias:value