### PR TITLE
Add clone link to Email details page

### DIFF
--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -43,6 +43,15 @@ $customButtons[] = array(
     'btnText'   => 'mautic.email.send.example'
 );
 
+$customButtons[] = array(
+    'attr' => array(
+        'data-toggle' => 'ajax',
+        'href'        => $view['router']->generate('mautic_email_action', array("objectAction" => "clone", "objectId" => $email->getId())),
+        ),
+        'iconClass' => 'fa fa-copy',
+        'btnText'   => 'mautic.core.form.clone'
+);
+
 $view['slots']->set('actions', $view->render('MauticCoreBundle:Helper:page_actions.html.php', array(
     'item'       => $email,
     'templateButtons' => array(


### PR DESCRIPTION
Fixes #747 adds clone button to email details page. 

**Testing**
1. Apply PR
2. Clear cache
3. Open an email overview page (Email Details)
4. Find and click on new "Clone Email" button
5. Verify email is cloned.
