### PR TITLE
Changing the webhook select type and data payload

### DIFF
--- a/app/bundles/WebhookBundle/Entity/Event.php
+++ b/app/bundles/WebhookBundle/Entity/Event.php
@@ -50,8 +50,8 @@ class Event
         // id columns
         $builder->addId();
         // M:1 for webhook
-        $builder->createManyToOne('webhook', 'Webhook')
-            ->inversedBy('events')
+        $builder->createOneToOne('webhook', 'Webhook')
+            ->inversedBy('event')
             ->addJoinColumn('webhook_id', 'id', false, false, 'CASCADE')
             ->build();
         // 1:M for queues

--- a/app/bundles/WebhookBundle/Entity/Webhook.php
+++ b/app/bundles/WebhookBundle/Entity/Webhook.php
@@ -46,7 +46,7 @@ class Webhook extends FormEntity
     /**
      * @var \Mautic\WebhookBundle\Entity\Event
      */
-    private $events;
+    private $event;
     /**
      * @var ArrayCollection
      */
@@ -56,12 +56,10 @@ class Webhook extends FormEntity
      */
     private $logs;
 
-    private $removedEvents = array();
     /*
      * Constructor
      */
     public function __construct() {
-        $this->events  = new ArrayCollection();
         $this->queues  = new ArrayCollection();
         $this->logs    = new ArrayCollection();
     }
@@ -77,10 +75,9 @@ class Webhook extends FormEntity
         $builder->addIdColumns();
         // categories
         $builder->addCategory();
-        // 1:M for events
-        $builder->createManyToOne('events', 'Event')
-            // ->orphanRemoval()
-            // ->setIndexBy('event_type')
+        // M:1 for events
+        $builder->createOneToOne('event', 'Event')
+            ->orphanRemoval()
             ->mappedBy('webhook')
             ->cascadePersist()
             ->build();
@@ -232,48 +229,36 @@ class Webhook extends FormEntity
     /**
      * @return mixed
      */
-    public function getEvents()
+    public function getEvent()
     {
-        return $this->events;
+        return $this->event;
     }
     /**
-     * @param mixed $events
+     * @param mixed $event
      */
     public function setEvent($event)
     {
-        $this->isChanged('events', $event);
-        $this->events = $event;
+        $this->isChanged('event', $event);
+        $this->event = $event;
 
         $event->setWebhook($this);
 
-        /**  @var \Mautic\WebhookBundle\Entity\Event $event */
-        // foreach ($events as $event) {
-        //     $event->setWebhook($this);
-        // }
         return $this;
     }
     public function addEvent(Event $event)
     {
-        $this->isChanged('events', $event);
-        $this->events[] = $event;
+        $this->isChanged('event', $event);
+        $this->event = $event;
 
         return $this;
     }
 
-    public function removeEvent(Event $event)
-    {
-        $this->isChanged('events', $event);
-        $this->removedEvents[] = $event;
-        $this->events->removeElement($event);
-
-        return $this;
-    }
     public function getQueues()
     {
         return $this->queues;
     }
     /**
-     * @param mixed $events
+     * @param mixed $event
      */
     public function addQueues($queues)
     {
@@ -305,7 +290,7 @@ class Webhook extends FormEntity
         return $this->logs;
     }
     /**
-     * @param mixed $events
+     * @param mixed $event
      */
     public function addLogs($logs)
     {
@@ -344,7 +329,7 @@ class Webhook extends FormEntity
             if ($currentId != $newId) {
                 $this->changes[$prop] = array($currentId, $newId);
             }
-        } elseif ($prop == 'events') {
+        } elseif ($prop == 'event') {
             $this->changes[$prop] = array();
         } elseif ($current != $val) {
             $this->changes[$prop] = array($current, $val);

--- a/app/bundles/WebhookBundle/Entity/Webhook.php
+++ b/app/bundles/WebhookBundle/Entity/Webhook.php
@@ -44,7 +44,7 @@ class Webhook extends FormEntity
      **/
     private $category;
     /**
-     * @var ArrayCollection
+     * @var \Mautic\WebhookBundle\Entity\Event
      */
     private $events;
     /**
@@ -78,9 +78,9 @@ class Webhook extends FormEntity
         // categories
         $builder->addCategory();
         // 1:M for events
-        $builder->createOneToMany('events', 'Event')
-            ->orphanRemoval()
-            ->setIndexBy('event_type')
+        $builder->createManyToOne('events', 'Event')
+            // ->orphanRemoval()
+            // ->setIndexBy('event_type')
             ->mappedBy('webhook')
             ->cascadePersist()
             ->build();
@@ -239,14 +239,17 @@ class Webhook extends FormEntity
     /**
      * @param mixed $events
      */
-    public function setEvents($events)
+    public function setEvent($event)
     {
-        $this->isChanged('events', $events);
-        $this->events = $events;
+        $this->isChanged('events', $event);
+        $this->events = $event;
+
+        $event->setWebhook($this);
+
         /**  @var \Mautic\WebhookBundle\Entity\Event $event */
-        foreach ($events as $event) {
-            $event->setWebhook($this);
-        }
+        // foreach ($events as $event) {
+        //     $event->setWebhook($this);
+        // }
         return $this;
     }
     public function addEvent(Event $event)

--- a/app/bundles/WebhookBundle/Form/DataTransformer/EventsToArrayTransformer.php
+++ b/app/bundles/WebhookBundle/Form/DataTransformer/EventsToArrayTransformer.php
@@ -33,12 +33,7 @@ class EventsToArrayTransformer implements DataTransformerInterface
      */
     public function transform($event)
     {
-        // $eventArray = array();
-        // foreach ($events as $event) {
-        //     $eventArray[] = $event->getEventType();
-        // }
         return $event->getEventType();
-        //return 'tst';
     }
 
     /**
@@ -48,38 +43,10 @@ class EventsToArrayTransformer implements DataTransformerInterface
      */
     public function reverseTransform($submittedArray)
     {
-        // Get a list of existing events and types
-
-        /** @var PersistentCollection $events */
-        $events     = $this->webhook->getEvents();
-        //$eventTypes = $events->getKeys();
-        
-        print_r($submittedArray);
-        
+        // Set the webhoook and event type, basically update the selected event   
         $event = new Event();
         $event->setWebhook($this->webhook)->setEventType($submittedArray);
         $this->webhook->setEvent($event);
-
-        // // Check to see what events have been removed
-        // $removed = array_diff($eventTypes, $submittedArray);
-        // if ($removed) {
-        //     foreach ($removed as $type) {
-        //         $this->webhook->removeEvent($events[$type]);
-        //     }
-        // }
-
-        // // Now check to see what events have been added
-        // $added = array_diff($submittedArray, $eventTypes);
-        // if ($added) {
-        //     foreach ($added as $type) {
-        //         // Create a new entity
-        //         $event = new Event();
-        //         $event->setWebhook($this->webhook)->setEventType($type);
-        //         $events[] = $event;
-        //     }
-        // }
-
-       // $this->webhook->setEvent($event);
 
         return $event;
     }

--- a/app/bundles/WebhookBundle/Form/DataTransformer/EventsToArrayTransformer.php
+++ b/app/bundles/WebhookBundle/Form/DataTransformer/EventsToArrayTransformer.php
@@ -31,13 +31,14 @@ class EventsToArrayTransformer implements DataTransformerInterface
      *
      * @return array
      */
-    public function transform($events)
+    public function transform($event)
     {
-        $eventArray = array();
-        foreach ($events as $event) {
-            $eventArray[] = $event->getEventType();
-        }
-        return $eventArray;
+        // $eventArray = array();
+        // foreach ($events as $event) {
+        //     $eventArray[] = $event->getEventType();
+        // }
+        return $event->getEventType();
+        //return 'tst';
     }
 
     /**
@@ -51,29 +52,35 @@ class EventsToArrayTransformer implements DataTransformerInterface
 
         /** @var PersistentCollection $events */
         $events     = $this->webhook->getEvents();
-        $eventTypes = $events->getKeys();
+        //$eventTypes = $events->getKeys();
+        
+        print_r($submittedArray);
+        
+        $event = new Event();
+        $event->setWebhook($this->webhook)->setEventType($submittedArray);
+        $this->webhook->setEvent($event);
 
-        // Check to see what events have been removed
-        $removed = array_diff($eventTypes, $submittedArray);
-        if ($removed) {
-            foreach ($removed as $type) {
-                $this->webhook->removeEvent($events[$type]);
-            }
-        }
+        // // Check to see what events have been removed
+        // $removed = array_diff($eventTypes, $submittedArray);
+        // if ($removed) {
+        //     foreach ($removed as $type) {
+        //         $this->webhook->removeEvent($events[$type]);
+        //     }
+        // }
 
-        // Now check to see what events have been added
-        $added = array_diff($submittedArray, $eventTypes);
-        if ($added) {
-            foreach ($added as $type) {
-                // Create a new entity
-                $event = new Event();
-                $event->setWebhook($this->webhook)->setEventType($type);
-                $events[] = $event;
-            }
-        }
+        // // Now check to see what events have been added
+        // $added = array_diff($submittedArray, $eventTypes);
+        // if ($added) {
+        //     foreach ($added as $type) {
+        //         // Create a new entity
+        //         $event = new Event();
+        //         $event->setWebhook($this->webhook)->setEventType($type);
+        //         $events[] = $event;
+        //     }
+        // }
 
-        $this->webhook->setEvents($events);
+       // $this->webhook->setEvent($event);
 
-        return $events;
+        return $event;
     }
 }

--- a/app/bundles/WebhookBundle/Form/Type/WebhookType.php
+++ b/app/bundles/WebhookBundle/Form/Type/WebhookType.php
@@ -92,7 +92,7 @@ class WebhookType extends AbstractType
             $choices[$type] = $event['label'];
         }
 
-        $builder->add('events', 'choice',  array(
+        $builder->add('event', 'choice',  array(
                 'choices' => $choices,
                 'multiple' => false,
                 'expanded' => false,
@@ -102,7 +102,7 @@ class WebhookType extends AbstractType
             )
         );
 
-        $builder->get('events')->addModelTransformer(new EventsToArrayTransformer($options['data']));
+        $builder->get('event')->addModelTransformer(new EventsToArrayTransformer($options['data']));
 
         $builder->add('buttons', 'form_buttons');
 

--- a/app/bundles/WebhookBundle/Form/Type/WebhookType.php
+++ b/app/bundles/WebhookBundle/Form/Type/WebhookType.php
@@ -94,8 +94,8 @@ class WebhookType extends AbstractType
 
         $builder->add('events', 'choice',  array(
                 'choices' => $choices,
-                'multiple' => true,
-                'expanded' => true,
+                'multiple' => false,
+                'expanded' => false,
                 'label'      => 'mautic.webhook.form.webhook.events',
                 'label_attr' => array('class' => 'control-label'),
                 'attr'       => array('class' => ''),

--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -326,18 +326,12 @@ class WebhookModel extends FormModel
 
                 /** @var \Mautic\WebhookBundle\Entity\Event $event */
                 $event = $queue->getEvent();
-                $type  = $event->getEventType();
-
-                // create new array level for each unique event type
-                if (!isset($payload[$type])) {
-                    $payload[$type] = array();
-                }
 
                 $queuePayload = json_decode($queue->getPayload(), true);
                 $queuePayload['timestamp'] = $queue->getDateAdded()->format('c');
 
                 // its important to decode the payload form the DB as we re-encode it with the
-                $payload[$type][] = $queuePayload;
+                $payload = $queuePayload;
 
                 $this->webhookQueueIdList[] = $queue->getId();
                 $this->em->clear($queue);

--- a/app/bundles/WebhookBundle/Views/Webhook/form.html.php
+++ b/app/bundles/WebhookBundle/Views/Webhook/form.html.php
@@ -44,7 +44,7 @@ $view['slots']->set("headerTitle", $header);
 
                 </div>
                 <div class="col-md-6" id="event-types">
-                    <?php echo $view['form']->row($form['events']); ?>
+                    <?php echo $view['form']->row($form['event']); ?>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Changes the selection type to not having multiple and not expanded so only one event can be selected at a time.

The webhook payload is also now isn't wrapped in a JSON array

Is raised for discussion in #834

To test:

1. Create a new webhook, only one should be selecteable
2. When a webhook is triggered the payload returned should be a simple JSON object with the data underneath without a parent type JSON array