### PR TITLE
Prevented sql error if validation constraints fail using Apply and the newStandard() function

### DIFF
--- a/app/bundles/CoreBundle/Controller/FormController.php
+++ b/app/bundles/CoreBundle/Controller/FormController.php
@@ -509,7 +509,7 @@ class FormController extends CommonController
                         )
                     )
                 );
-            } elseif ($this->isFormApplied($form)) {
+            } elseif ($valid && $this->isFormApplied($form)) {
                 return $this->editAction($entity->getId(), true);
             }
         }


### PR DESCRIPTION
**Description**

For bundles and plugins that leverage the newStandard() function, using Apply when validation constraints fail would lead to a SQL error at worst, at best it goes into the /edit route, because editAction would be called prematurely.  This PR fixes this by ensuring that the editAction function is only called if $valid is true.

**Testing**
Create a new webhook and click apply without filling anything in.  Notice that you're taken to /edit and there is no validation feedback.