### PR TITLE
Enable the DoctrineCacheBundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -121,6 +121,7 @@ class AppKernel extends Kernel
             new Symfony\Bundle\MonologBundle\MonologBundle(),
             new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+            new Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle(),
             new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
             new Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle(),
             new Knp\Bundle\MenuBundle\KnpMenuBundle(),

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "doctrine/migrations": "dev-master",
         "doctrine/orm": "2.4.*,>=2.4.8",
         "doctrine/doctrine-bundle": "~1.2",
+        "doctrine/doctrine-cache-bundle": "~1.0",
         "doctrine/doctrine-fixtures-bundle": "2.2.*@dev",
         "doctrine/doctrine-migrations-bundle": "~1.0",
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a4ae82061c303bf011ecdd80618287df",
+    "hash": "48ef35a464de5399c31ddf014992f383",
     "packages": [
         {
             "name": "aws/aws-sdk-php",


### PR DESCRIPTION
This PR enables the `DoctrineCacheBundle` which is already included in the distributed package as a dependency of the `DoctrineBundle`.  Enabling the bundle allows site admins to implement the bundle's features for caching Doctrine activities.  No UI is presently provided for this; one would need to utilize Mautic's configuration override system to add the desired services.