### PR TITLE
Bugfix: Remove unnecessary wrong data options condition

### DIFF
--- a/app/bundles/FormBundle/Form/Type/FormType.php
+++ b/app/bundles/FormBundle/Form/Type/FormType.php
@@ -108,7 +108,6 @@ class FormType extends AbstractType
 
         $builder->add('renderStyle', 'yesno_button_group', array(
             'label'       => 'mautic.form.form.renderstyle',
-            'data'       => (array_key_exists('renderstyle', $options['data']) && empty($options['data']['renderstyle'])) ? false : true,
             'attr'        => array(
                 'tooltip' => 'mautic.form.form.renderstyle.tooltip'
             )


### PR DESCRIPTION
DESCRIPTION

Render Style switch was still disable in Forms.
This PR remove line with wrong condition. This line is not necessary.
Version 1.2. 