### PR TITLE
Fixed auth issue with integrating with SugarCRM OnDemand (7.x)

### DIFF
--- a/plugins/MauticCrmBundle/Api/SugarcrmApi.php
+++ b/plugins/MauticCrmBundle/Api/SugarcrmApi.php
@@ -7,6 +7,14 @@ class SugarcrmApi extends CrmApi
 {
     private $module = 'Leads';
 
+    /**
+     * @param        $sMethod
+     * @param array  $data
+     * @param string $method
+     *
+     * @return mixed|string
+     * @throws ApiErrorException
+     */
     public function request($sMethod, $data = array(), $method = 'GET')
     {
         $tokenData = $this->integration->getKeys();
@@ -46,9 +54,8 @@ class SugarcrmApi extends CrmApi
     }
 
     /**
-     * @param $Object
-     *
-     * @return mixed
+     * @return mixed|string
+     * @throws ApiErrorException
      */
     public function getLeadFields ()
     {
@@ -64,6 +71,7 @@ class SugarcrmApi extends CrmApi
             );
 
             $response = $this->request('metadata', $parameters);
+
             return $response['modules']['Leads'];
         }
     }
@@ -92,7 +100,8 @@ class SugarcrmApi extends CrmApi
 
             return $this->request('set_entry', $parameters, 'POST');
         } else {
-            return $this->request('Lead', $fields, 'POST');
+
+            return $this->request('Leads', $fields, 'POST');
         }
     }
 }

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -185,7 +185,9 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                         //7.x
                         foreach ($leadObject['fields'] as $fieldInfo) {
                             if (isset($fieldInfo['name']) && empty($fieldInfo['readonly']) && !empty($fieldInfo['comment']) && !in_array($fieldInfo['type'], array('id', 'team_list', 'bool', 'link', 'relate'))) {
-                                $sugarFields[$fieldInfo['name']] = array(
+                                $fieldName = (strpos($fieldInfo['name'], 'webtolead_email') === false) ? $fieldInfo['name'] : str_replace('webtolead_', '', $fieldInfo['name']);
+
+                                $sugarFields[$fieldName] = array(
                                     'type'     => 'string',
                                     'label'    => $fieldInfo['comment'],
                                     'required' => !empty($fieldInfo['required'])
@@ -302,6 +304,11 @@ class SugarcrmIntegration extends CrmAbstractIntegration
 
             return (empty($error));
         } else {
+            if ($this->isConfigured()) {
+                // SugarCRM 7 uses password grant type so login each time to ensure session is valid
+                $this->authCallback();
+            }
+
             return parent::isAuthorized();
         }
     }
@@ -351,7 +358,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
     public function getFormSettings()
     {
         return array(
-            'requires_callback'      => true,
+            'requires_callback'      => false,
             'requires_authorization' => true
         );
     }

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -11,7 +11,6 @@ namespace MauticPlugin\MauticCrmBundle\Integration;
 
 use Mautic\PluginBundle\Exception\ApiErrorException;
 use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\Form;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
@@ -158,7 +157,10 @@ class SugarcrmIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @return array|mixed
+     * @param array $settings
+     *
+     * @return array
+     * @throws \Exception
      */
     public function getAvailableLeadFields($settings = array())
     {
@@ -235,6 +237,31 @@ class SugarcrmIntegration extends CrmAbstractIntegration
     }
 
     /**
+     * @param $url
+     * @param $parameters
+     * @param $method
+     * @param $settings
+     * @param $authType
+     *
+     * @return array
+     */
+    public function prepareRequest($url, $parameters, $method, $settings, $authType)
+    {
+        if ($authType == 'oauth2' && empty($settings['authorize_session'])) {
+
+            // Append the access token as the oauth-token header
+            $headers                   = array(
+                "oauth-token: {$this->keys['access_token']}"
+            );
+
+            return array($parameters, $headers);
+        } else {
+
+            return parent::prepareRequest($url, $parameters, $method, $settings, $authType);
+        }
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @return bool
@@ -295,7 +322,9 @@ class SugarcrmIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param FormBuilder|Form $builder
+     * @param \Mautic\PluginBundle\Integration\Form|FormBuilder $builder
+     * @param array                                             $data
+     * @param string                                            $formArea
      */
     public function appendToForm(&$builder, $data, $formArea)
     {


### PR DESCRIPTION
**Description**
Setting up the SugarCRM integration with Sugar OnDemand (7.x) would authenticate successfully but then failed when communicating with the rest api with a "access token is invalid" error.  This PR corrects the API auth header for Sugar OnDemand.

Because Sugar OnDemand also used password grant type, the token became invalid as soon as someone logged in through the browser.  So this PR changes it to force a fresh login each time Mautic communicates with SugarCRM.

It also fixes an issue that prevented creating new leads in Sugar OnDemand due to an invalid module name and a stupid issue where SugarCRM returned webtolead_email1 as the email field but accepted email1 when creating the lead.

**Testing**
This requires access to a Sugar OnDemand (7.x) account (demo should work).  Create the oauth 2 credentials in SugarCRM, then configure Mautic's integration.  You should be successful in authenticating but will receive the error right after.  Once the PR is applied, SugarCRM's lead fields should be listed on the lead field tab and of course no access token error.