### PR TITLE
Add a check for the zip extension to the installer

### DIFF
--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -268,6 +268,10 @@ class CheckStep implements StepInterface
             }
         }
 
+        if (!extension_loaded('zip')) {
+            $messages[] = 'mautic.install.extension.zip';
+        }
+
         // We set a default timezone in the app bootstrap, but advise the user if their PHP config is missing it
         if (!ini_get('date.timezone')) {
             $messages[] = 'mautic.install.date.timezone.not.set';

--- a/app/bundles/InstallBundle/Translations/en_US/messages.ini
+++ b/app/bundles/InstallBundle/Translations/en_US/messages.ini
@@ -16,6 +16,7 @@ mautic.install.email.subheader.spooler="Email can either be sent immediately or 
 mautic.install.extension.fileinfo="Install and enable the <strong>fileinfo</strong> extension."
 mautic.install.extension.imap="Install and enable the <strong>imap</strong> extension to support monitored email."
 mautic.install.extension.mcrypt="Install and enable the <strong>mcrypt</strong> extension."
+mautic.install.extension.zip="Install and enable the <strong>zip</strong> extension. This is required to allow Mautic to install language packages and perform updates within the application."
 mautic.install.final.step="Finish"
 mautic.install.finalizing="Finalizing the installation. This may take a few seconds."
 mautic.install.form.backup_prefix="Prefix for backup tables"


### PR DESCRIPTION
This adds a check for PHP's zip extension to be present as a recommendation.  It's required to be able to install language packages and run updates within Mautic.  I don't have it as a requirement as the actual application can function without this extension but it not being present makes updates require a bit more effort.