### PR TITLE
add setting to allow parameters to be stringified before being posted in curl

### DIFF
--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -520,6 +520,10 @@ abstract class AbstractIntegration
                 }
             }
 
+            if (isset($settings['stringify_params'])) {
+                $parameters = http_build_query($parameters);
+            }
+
             curl_setopt($ch, CURLOPT_POSTFIELDS, $parameters);
         }
 


### PR DESCRIPTION
This PR changes makeRequest slightly to allow for a new setting to be passed:
```
$setting['stringify_params'] = true
```

When this is set, the $parameters sent to makeRequest will be converted to a string using `http_build_query`. This helps us use makeRequest for certain APIs that require that. 

How to test:
Easiest way to test is to edit an integration where the API calls are made, and add the key to the $settings variable, then just var_dump the $parameters and exit before the curl request goes out, and make sure the params all get squashed to a string.