### PR TITLE
Lead fields could be saved only if a tag existed in the query - fixed

### DIFF
--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -538,10 +538,10 @@ class PageModel extends FormModel
                                     }
                                 }
                             }
+                        }
 
-                            if ($persistLead) {
-                                $leadModel->saveEntity($lead);
-                            }
+                        if ($persistLead) {
+                            $leadModel->saveEntity($lead);
                         }
                     }
                 }


### PR DESCRIPTION
A bug was added by adding the tag feature in 1.2.0. Now a lead field cannot be saved via tracking pixel URL query unless `tags` URL query param exists. This PR fixes it so both fields and tags can be saved.

Reported in the forum:
https://www.mautic.org/community/index.php/764-1-2-0-publicly-updatable-fields-not-working-anymore-with-mtrack/0#p2992

### How to test
1. Make an email field publicly accessible.
2. Trigger the tracking pixel with an email from a anonymous browser window.
```
http://yourmautic.com/mtracking.gif?email=user%40theirdomain.com
```

The lead with this email will not be saved. you can search for it in the Lead manager. Apply this PR and the lead will be saved.