### PR TITLE
Forms: Render Style switch never show false value

### DIFF
--- a/app/bundles/FormBundle/Form/Type/FormType.php
+++ b/app/bundles/FormBundle/Form/Type/FormType.php
@@ -106,8 +106,15 @@ class FormType extends AbstractType
             )
         ));
 
+        // Render style for new form by default
+        if ($options['data']->getId() === null) {
+            $options['data']->setRenderStyle(true);
+        }
+
         $builder->add('renderStyle', 'yesno_button_group', array(
             'label'       => 'mautic.form.form.renderstyle',
+            'data'        => ($options['data']->getRenderStyle() === null) ? true : $options['data']->getRenderStyle(),
+            'empty_data'  => true,
             'attr'        => array(
                 'tooltip' => 'mautic.form.form.renderstyle.tooltip'
             )

--- a/app/bundles/FormBundle/Form/Type/FormType.php
+++ b/app/bundles/FormBundle/Form/Type/FormType.php
@@ -108,7 +108,6 @@ class FormType extends AbstractType
 
         $builder->add('renderStyle', 'yesno_button_group', array(
             'label'       => 'mautic.form.form.renderstyle',
-            'data'       => (array_key_exists('renderstyle', $options['data']) && empty($options['data']['renderstyle'])) ? false : true,
             'attr'        => array(
                 'tooltip' => 'mautic.form.form.renderstyle.tooltip'
             )


### PR DESCRIPTION
In the Form edit form: **Render Style** option was always true. The false value was saved correctly, but it didn't display correctly. Reported in
https://www.mautic.org/community/index.php/754-form-css-in-wordpress/0#p3014

### How to test
1. Create/Edit a form.
2. Switch the Render Style option to No.
3. Save & close
4. Edit the form again

The Render Style option is set to Yes again. After the PR, the option stays to the value you saved it with.