### PR TITLE
Lead modal HTML was missing - added

### DIFF
--- a/app/bundles/LeadBundle/Views/Note/index.html.php
+++ b/app/bundles/LeadBundle/Views/Note/index.html.php
@@ -29,7 +29,7 @@
         </form>
 	</div>
 	<div class="col-xs-2 va-t">
-		<a class="btn btn-primary btn-leadnote-add pull-right" href="<?php echo $view['router']->generate('mautic_leadnote_action', array('leadId' => $lead->getId(), 'objectAction' => 'new')); ?>" data-toggle="ajaxmodal" data-target="#leadModal" data-header="<?php echo $view['translator']->trans('mautic.lead.note.header.new'); ?>"><i class="fa fa-plus fa-lg"></i> <?php echo $view['translator']->trans('mautic.lead.add.note'); ?></a>
+		<a class="btn btn-primary btn-leadnote-add pull-right" href="<?php echo $view['router']->generate('mautic_leadnote_action', array('leadId' => $lead->getId(), 'objectAction' => 'new')); ?>" data-toggle="ajaxmodal" data-target="#MauticSharedModal" data-header="<?php echo $view['translator']->trans('mautic.lead.note.header.new'); ?>"><i class="fa fa-plus fa-lg"></i> <?php echo $view['translator']->trans('mautic.lead.add.note'); ?></a>
 	</div>
 </div>
 

--- a/app/bundles/LeadBundle/Views/Note/list.html.php
+++ b/app/bundles/LeadBundle/Views/Note/list.html.php
@@ -33,6 +33,3 @@ if ($tmpl == 'index') {
         'sessionVar'      => 'leadnote'
     )); ?>
 </div>
-<?php echo $view->render('MauticCoreBundle:Helper:modal.html.php', array(
-    'id'     => 'leadModal'
-)); ?>

--- a/app/bundles/LeadBundle/Views/Note/list.html.php
+++ b/app/bundles/LeadBundle/Views/Note/list.html.php
@@ -33,3 +33,6 @@ if ($tmpl == 'index') {
         'sessionVar'      => 'leadnote'
     )); ?>
 </div>
+<?php echo $view->render('MauticCoreBundle:Helper:modal.html.php', array(
+    'id'     => 'leadModal'
+)); ?>

--- a/app/bundles/LeadBundle/Views/Note/note.html.php
+++ b/app/bundles/LeadBundle/Views/Note/note.html.php
@@ -47,7 +47,7 @@ switch ($type) {
             <div class="media-body col-xs-11 pa-10">
                 <div class="pull-right btn-group">
                     <?php if ($permissions['edit']): ?>
-                        <a class="btn btn-default btn-xs" href="<?php echo $this->container->get('router')->generate('mautic_leadnote_action', array('leadId' => $lead->getId(), 'objectAction' => 'edit', 'objectId' => $id)); ?>" data-toggle="ajaxmodal" data-target="#leadModal" data-header="<?php echo $view['translator']->trans('mautic.lead.note.header.edit'); ?>"><i class="fa fa-pencil"></i></a>
+                        <a class="btn btn-default btn-xs" href="<?php echo $this->container->get('router')->generate('mautic_leadnote_action', array('leadId' => $lead->getId(), 'objectAction' => 'edit', 'objectId' => $id)); ?>" data-toggle="ajaxmodal" data-target="#MauticSharedModal" data-header="<?php echo $view['translator']->trans('mautic.lead.note.header.edit'); ?>"><i class="fa fa-pencil"></i></a>
                     <?php endif; ?>
                      <?php if ($permissions['delete']): ?>
                          <a class="btn btn-default btn-xs"


### PR DESCRIPTION
It's impossible to create or edit a Lead Note. Reported in https://github.com/mautic/mautic/issues/875

### How to test
1. Go to a lead detal
2. Select the Notes tab
3. Click on Add Note button

The view become un-scrollable, the AJAX call successfully retrieves the response, but the modal doesn't snow up. I added a modal HTML and the Notes are working. Not sure if that's the best solution. I wonder how could the Note modal HTML could disappear in the first place...