### PR TITLE
Fixed lookup and select lead field on save error

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -173,7 +173,11 @@ class FieldType extends AbstractType
             $type = (is_array($data)) ? (isset($data['type']) ? $data['type'] : null) : $data->getType();
 
             if ($type == 'select' || $type == 'lookup') {
-                $properties = $data->getProperties();
+                if (is_array($data) && isset($data['properties'])) {
+                    $properties = $data['properties'];
+                } else {
+                    $properties = $data->getProperties();
+                }
 
                 if (isset($properties['list']) && is_string($properties['list'])) {
                     $properties['list'] = array_map('trim', explode('|', $properties['list']));


### PR DESCRIPTION
There was an error message on saving the select or lookup lead field. `$data` variable is sometimes an array and sometimes object.

Reported in https://github.com/mautic/mautic/issues/891 and more places.