### PR TITLE
Prevented a PHP notice if monitored_mail is not set

### DIFF
--- a/app/bundles/EmailBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ConfigSubscriber.php
@@ -55,24 +55,26 @@ class ConfigSubscriber extends CommonSubscriber
 
         // Get the original data so that passwords aren't lost
         $monitoredEmail = $this->factory->getParameter('monitored_email');
-        foreach ($data['monitored_email'] as $key => $monitor) {
-            if (empty($monitor['password']) && !empty($monitoredEmail[$key]['password'])) {
-                $data['monitored_email'][$key]['password'] = $monitoredEmail[$key]['password'];
-            }
+        if (isset($data['monitored_email'])) {
+            foreach ($data['monitored_email'] as $key => $monitor) {
+                if (empty($monitor['password']) && !empty($monitoredEmail[$key]['password'])) {
+                    $data['monitored_email'][$key]['password'] = $monitoredEmail[$key]['password'];
+                }
 
-            if ($key != 'general') {
-                if (empty($monitor['host']) || empty($monitor['address']) || empty($monitor['folder'])) {
-                    $data['monitored_email'][$key]['override_settings'] = '';
-                    $data['monitored_email'][$key]['address']           = '';
-                    $data['monitored_email'][$key]['host']              = '';
-                    $data['monitored_email'][$key]['user']              = '';
-                    $data['monitored_email'][$key]['password']          = '';
-                    $data['monitored_email'][$key]['ssl']               = '1';
-                    $data['monitored_email'][$key]['port']              = '993';
+                if ($key != 'general') {
+                    if (empty($monitor['host']) || empty($monitor['address']) || empty($monitor['folder'])) {
+                        $data['monitored_email'][$key]['override_settings'] = '';
+                        $data['monitored_email'][$key]['address']           = '';
+                        $data['monitored_email'][$key]['host']              = '';
+                        $data['monitored_email'][$key]['user']              = '';
+                        $data['monitored_email'][$key]['password']          = '';
+                        $data['monitored_email'][$key]['ssl']               = '1';
+                        $data['monitored_email'][$key]['port']              = '993';
+                    }
                 }
             }
-        }
 
-        $event->setConfig($data, 'emailconfig');
+            $event->setConfig($data, 'emailconfig');
+        }
     }
 }


### PR DESCRIPTION
**Description**

This simply prevents a PHP notice if `monitored_email` is not set when saving the local config in unique circumstances.    Testing requires those unique circumstances but the only code change was wrapping the foreach in a `if isset` check.