### PR TITLE
Fixes issue with form results export for fields not saved to the DB

### DIFF
--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -518,7 +518,7 @@ class SubmissionModel extends CommonFormModel
                         $translator->trans('mautic.form.result.thead.referrer')
                     );
                     foreach ($fields as $f) {
-                        if (in_array($f->getType(), array('button', 'freetext')))
+                        if (in_array($f->getType(), array('button', 'freetext')) || $f->getSaveResult() === false)
                             continue;
                         $header[] = $f->getLabel();
                     }
@@ -589,7 +589,7 @@ class SubmissionModel extends CommonFormModel
                             $translator->trans('mautic.form.result.thead.referrer')
                         );
                         foreach ($fields as $f) {
-                            if (in_array($f->getType(), array('button', 'freetext')))
+                            if (in_array($f->getType(), array('button', 'freetext')) || $f->getSaveResult() === false)
                                 continue;
                             $header[] = $f->getLabel();
                         }

--- a/app/bundles/FormBundle/Views/Result/export.html.php
+++ b/app/bundles/FormBundle/Views/Result/export.html.php
@@ -24,7 +24,7 @@ $view['slots']->set("headerTitle", $view['translator']->trans('mautic.form.resul
             <?php
             $fields = $form->getFields();
             foreach ($fields as $f):
-            if (in_array($f->getType(), array('button', 'freetext'))) continue;
+            if (in_array($f->getType(), array('button', 'freetext')) || $f->getSaveResult() === false) continue;
             ?>
             <th class="col-formresult-field col-formresult-<?php echo $f->getType(); ?> col-formresult-field<?php echo $f->getId(); ?>"><?php echo $f->getLabel(); ?></th>
             <?php endforeach; ?>


### PR DESCRIPTION
**Description**

1.2.0 fixed some issues related to form fields that were set to not be saved to the database.  A similar error occurred when attempting to export the results since the headers mismatched the data.  This PR fixes that.

**Testing**
To reproduce the issue,

1. Create a new form with at least one field set to not save to the database
2. Submit the form
3. View the form results and export to csv, excel or HTML and the headers will mismatch the result data

After the patch is applied, headers should match the data.

