### PR TITLE
Fix of duplicated fields on field edit.

### DIFF
--- a/app/bundles/FormBundle/Views/Field/field_helper.php
+++ b/app/bundles/FormBundle/Views/Field/field_helper.php
@@ -67,7 +67,11 @@ if (!empty($inForm)) {
 }
 
 // Container
-$containerAttr         = 'id="mauticform_'.$formName.'_'.$id.'" '.htmlspecialchars_decode($field['containerAttributes']);
+if ($formName) {
+    $containerAttr = 'id="mauticform_'.$formName.'_'.$id.'" '.htmlspecialchars_decode($field['containerAttributes']);
+} else {
+    $containerAttr = 'id="mauticform_'.$id.'" '.htmlspecialchars_decode($field['containerAttributes']);
+}
 if (!isset($containerClass))
     $containerClass = $containerType;
 $defaultContainerClass = 'mauticform-row mauticform-'.$containerClass;


### PR DESCRIPTION
If you edit a Form field (FormBundle), the field get duplicated on edit modal open and than again on modal close. That was caused by duplicating of underscore "__" in id attribute.

### How to test
1. Edit or create a new form. The form must have some fields.
2. Try to edit a field.