### PR TITLE
Prevented white text on white inputs for Mauve templates with a form

### DIFF
--- a/themes/Mauve/css/mauve.css
+++ b/themes/Mauve/css/mauve.css
@@ -36,4 +36,9 @@ h1 {
 
 .mauticform-selectbox, .mauticform-input, .mauticform-textarea {
   width: 100% !important;
+  color: #000000;
+}
+
+.mauticform-button {
+  color: #000000;
 }


### PR DESCRIPTION
**Description**

If embedding a form in the bottom of the Mauve template, the input's would have a white color font on a white background and thus not visible.  This PR fixes that.

**Testing**
1. Create a new landing page using the Mauve theme and embed a form in the mautic blue area.  
2. View the preview of the landing page and attempt to type in the form.
3. The text should be white but after applying the PR, will be black and visible.