### PR TITLE
Reduced the need to query for the user when sending an example email

### DIFF
--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1219,7 +1219,16 @@ class EmailController extends FormController
         $lead = $this->factory->getModel('lead')->getRepository()->getRandomLead();
 
         // Send to current user
-        $model->sendEmailToUser($entity, $this->factory->getUser()->getId(), $lead, array(), array(), false);
+        $user  = $this->factory->getUser();
+        $users = array(
+            array(
+                'id'        => $user->getId(),
+                'firstname' => $user->getFirstName(),
+                'lastname'  => $user->getLastName(),
+                'email'     => $user->getEmail()
+            )
+        );
+        $model->sendEmailToUser($entity, $users, $lead, array(), array(), false);
 
         $this->addFlash('mautic.email.notice.test_sent.success');
 


### PR DESCRIPTION
**Description**
When sending an example email to a user, the user ID was obtained from the logged in user which required EmailModel's sendEmailToUser to query for the email, etc.  This is not needed since all that information is already available in the session.

**Testing**
Apply the PR and use the Send Example button to send an email.  It should arrive to the configured inbox.