### PR TITLE
Fixed namespace issue with a caught exception in config

### DIFF
--- a/app/bundles/ConfigBundle/Controller/ConfigController.php
+++ b/app/bundles/ConfigBundle/Controller/ConfigController.php
@@ -104,7 +104,7 @@ class ConfigController extends FormController
                         /** @var \Mautic\CoreBundle\Helper\CacheHelper $cacheHelper */
                         $cacheHelper = $this->factory->getHelper('cache');
                         $cacheHelper->clearCache(false, true);
-                    } catch (RuntimeException $exception) {
+                    } catch (\RuntimeException $exception) {
                         $this->addFlash('mautic.config.config.error.not.updated', array('%exception%' => $exception->getMessage()), 'error');
                     }
                 } elseif (!$isWritabale) {


### PR DESCRIPTION
**Description**

The config bundle was set to catch a RuntimeException however it was not namespaced or used.  This PR adds a prefixing \ to use the global RuntimeException.