### PR TITLE
Prevented a redirect URL from being saved to the database with encoded ampersands

### DIFF
--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -351,6 +351,9 @@ class PublicController extends CommonFormController
 
         $url = $redirect->getUrl();
 
+        // Ensure the URL does not have encoded ampersands
+        $url = str_replace('&amp;', '&', $url);
+
         // Get query string
         $query = $this->request->query->all();
 

--- a/app/bundles/PageBundle/Model/RedirectModel.php
+++ b/app/bundles/PageBundle/Model/RedirectModel.php
@@ -50,6 +50,9 @@ class RedirectModel extends FormModel
      */
     public function getRedirectByUrl($url, $forEmail = null, $createEntity = true)
     {
+        // Ensure the URL saved to the database does not have encoded ampersands
+        $url = str_replace('&amp;', '&', $url);
+
         $repo     = $this->getRepository();
         $criteria = array('url' => $url);
 


### PR DESCRIPTION
**Description**

If a redirect URL has an encoded ampersand in it, it's saved to the database as so and thus redirected with the encoded ampersand. See #880.

**Testing**
Add a URL to an email that includes a query string with an ampersand, save and send. The redirect URL will be saved with the encoded ampersand. After the PR, links should be saved with decoded ampersands and ensure they are decoded at the time of being redirected as well. 