### PR TITLE
Fixed report filter issue with postgres and integer columns

### DIFF
--- a/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
@@ -184,7 +184,7 @@ class ReportSubscriber extends CommonSubscriber
     /**
      * Initialize the QueryBuilder object to generate reports from
      *
-     * @param ReportGeneratorEvent $event
+     * @param ReportGraphEvent $event
      *
      * @return void
      */


### PR DESCRIPTION
**Description**

This fixes #904. It seems that Postgres doesn't like to use LIKE with integer columns.  This is a "hack" until we can revamp our report bundle to properly handle type casting, etc.  It simply checks to see if a value is_numeric then uses eq or neq instead of like or notLike.

**Testing**
See #904.  Using postgres, create a lead point log report and add at least the point change column to columns of the report and save.  Then try to filter the point change column which should report in the sql error reported.  After the PR, the report should filter without error.  Also, of course filtering should work for other columns and under MySQL as well.