### PR TITLE
Prevented bad query if the translation had a search command with a case mismatch

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -795,7 +795,9 @@ class LeadRepository extends CommonRepository
                 $expr = $q->expr()->$likeFunc('LOWER(l.company)', ":$unique");
                 break;
             default:
-                $expr = $q->expr()->$likeFunc('LOWER(l.' . $command .')', ":$unique");
+                if (in_array($command, $this->availableSearchFields)) {
+                    $expr = $q->expr()->$likeFunc('LOWER(l.'.$command.')', ":$unique");
+                }
                 break;
         }
 


### PR DESCRIPTION
**Description**

The German translation had "Liste" for the list search command which resulted in the search command not getting caught by the switch/case statement and land in the filter that assumed the command as lead column.  This lead to an error since the leads table did not have a "liste" column.  This PR added a catch to fix it (and the translation has been fixed in Transifex).

**Testing**
Will likely need to modify the mautic.lead.lead.searchcommand.list translation key to start with a capital letter like "List" or "Liste".  Then try to filter leads with "Liste:some-list-alias" and you should get the query error that l.liste doesn't exist.  After the PR, it should be filterable although search commands should use lower case until we implement a better case matching fix.