### PR TITLE
Fixed not being able to use batch actions with the lead grid view

### DIFF
--- a/app/bundles/LeadBundle/Views/Lead/grid_cards.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/grid_cards.html.php
@@ -32,7 +32,7 @@
                                 <div class="pull-right">
                                     <div class="checkbox-inline custom-primary mnr-10">
                                         <label class="mb-0">
-                                            <input type="checkbox" value="1">
+                                            <input class="list-checkbox" type="checkbox" value="<?php echo $item->getId(); ?>">
                                             <span></span>
                                         </label>
                                     </div>


### PR DESCRIPTION
**Description**
Trying to batch delete leads in grid view would do nothing.  This PR fixes it.

To reproduce the issue:
1. Go to manage leads
2. Change to grid view
3. Check a lead or two
4. Click the batch/bulk delete button and nothing happens

**Testing**
Apply the PR and repeat the steps above.  This time you should get a successfully deleted message.