### PR TITLE
Form preview on Nature theme fixed

### DIFF
--- a/themes/nature/css/nature.css
+++ b/themes/nature/css/nature.css
@@ -38,6 +38,8 @@ body > .container {
     width: 400px;
     margin-left: auto;
     margin-right: auto;
+    background-color: rgba(255, 255, 255, 0.9);
+    padding: 20px;
 }
 
 .mauticform-selectbox, .mauticform-input, .mauticform-textarea {


### PR DESCRIPTION
Form preview on Nature theme is not readable.

### How to test
1. Create/edit a form. 
2. Select Nature theme.
3. Save the form.
4. Preview the form.

The text on nature background is not readable. Apply this PR and it will give the form a light background. Text will be readable.