### PR TITLE
Value can't be in the radio/checkbox group field attributes

### DIFF
--- a/app/bundles/FormBundle/Views/Field/field_helper.php
+++ b/app/bundles/FormBundle/Views/Field/field_helper.php
@@ -25,7 +25,13 @@ $defaultInputClass = 'mauticform-'.$defaultInputClass;
 $defaultLabelClass = 'mauticform-'.$defaultLabelClass;
 
 $name  = (empty($ignoreName)) ? ' name="mauticform['.$field['alias'].']"' : '';
-$value = (isset($field['defaultValue'])) ? ' value="'.$field['defaultValue'].'"' : ' value=""';
+
+if ($field['type'] == 'checkboxgrp' || $field['type'] == 'radiogrp') {
+    $value = '';
+} else {
+    $value = (isset($field['defaultValue'])) ? ' value="'.$field['defaultValue'].'"' : ' value=""';
+}
+
 if (empty($ignoreId)) {
     $inputId = 'id="mauticform_input_'.$formName.'_'.$field['alias'].'"';
     $labelId = 'id="mauticform_label_'.$formName.'_'.$field['alias'].'" for="mauticform_input_'.$formName.'_'.$field['alias'].'"';


### PR DESCRIPTION
Reported in https://www.mautic.org/community/index.php/803-checkboxes-fields-don-t-register-values-in-forms/0#p3203

### How to test
1. Create a form with checkbox and radio group.
2. Save the form.
3. Preview the form.
4. Select some choices from the fields.
5. Submit the form.
6. Look at the form results. 

Before the PR: The selected values are not saved.
After the PR: The selected values are saved correctly.