### PR TITLE
Fix campaigns list for users with restricted access to forms

### DIFF
--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -506,6 +506,7 @@ class CampaignModel extends CommonFormModel
 
                 $viewOther = $this->factory->getSecurity()->isGranted('form:forms:viewother');
                 $repo      = $this->factory->getModel('form')->getRepository();
+                $repo->setCurrentUser($this->factory->getUser());
 
                 $forms = $repo->getFormList('', 0, 0, $viewOther, 'campaign');
                 foreach ($forms as $form) {

--- a/app/bundles/FormBundle/Entity/FormRepository.php
+++ b/app/bundles/FormBundle/Entity/FormRepository.php
@@ -58,7 +58,7 @@ class FormRepository extends CommonRepository
         }
 
         if (!$viewOther) {
-            $q->andWhere($q->expr()->eq('IDENTITY(f.createdBy)', ':id'))
+            $q->andWhere($q->expr()->eq('f.createdBy', ':id'))
                 ->setParameter('id', $this->currentUser->getId());
         }
 


### PR DESCRIPTION
This PR fixes a bug in campaigns list for users with restricted access to forms.

Steps to reproduce bug:
- Create an user with a custom role and these permissions on forms: View own - Edit own - Create - Delete own - Publish own.
- Login with this new user.
- Go to Campaigns list.
- An error occured.

This fix should correct the issue.
