### PR TITLE
Extended assets permissions

### DIFF
--- a/app/bundles/AssetBundle/Controller/AssetController.php
+++ b/app/bundles/AssetBundle/Controller/AssetController.php
@@ -65,7 +65,7 @@ class AssetController extends FormController
 
         if (!$permissions['asset:assets:viewother']) {
             $filter['force'][] =
-                array('column' => 'p.createdBy', 'expr' => 'eq', 'value' => $this->factory->getUser()->getId());
+                array('column' => 'a.createdBy', 'expr' => 'eq', 'value' => $this->factory->getUser()->getId());
         }
 
         $orderBy    = $this->factory->getSession()->get('mautic.asset.orderby', 'a.title');

--- a/app/bundles/AssetBundle/Security/Permissions/AssetPermissions.php
+++ b/app/bundles/AssetBundle/Security/Permissions/AssetPermissions.php
@@ -26,7 +26,7 @@ class AssetPermissions extends AbstractPermissions
     public function __construct($params)
     {
         parent::__construct($params);
-        $this->addStandardPermissions('assets');
+        $this->addExtendedPermissions('assets');
         $this->addStandardPermissions('categories');
     }
 
@@ -44,6 +44,6 @@ class AssetPermissions extends AbstractPermissions
     public function buildForm(FormBuilderInterface &$builder, array $options, array $data)
     {
         $this->addStandardFormFields('asset', 'categories', $builder, $data);
-        $this->addStandardFormFields('asset', 'assets', $builder, $data);
+        $this->addExtendedFormFields('asset', 'assets', $builder, $data);
     }
 }


### PR DESCRIPTION
With this PR I add the support to extended permissions on assets.

Steps to test:
- From administration panel, create a role with restricted assets permission (i.e. "view own" but not "view other").
- Assign this role to an user.
- Login with this user and create an asset.
- Login with your admin account and create an asset, too.
- Admin can see both assets but user can see only his own asset.

Code was almost ready, I add the extended form in admin area and fix a bug on assets list.