### PR TITLE
Fixed Form Field ordering, edit, remove highlight caused by double _

### DIFF
--- a/app/bundles/FormBundle/Views/Builder/form.html.php
+++ b/app/bundles/FormBundle/Views/Builder/form.html.php
@@ -7,7 +7,7 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-$formName = strtolower(\Mautic\CoreBundle\Helper\InputHelper::alphanum($form->getName()));
+$formName = '_' . strtolower(\Mautic\CoreBundle\Helper\InputHelper::alphanum($form->getName()));
 $fields   = $form->getFields();
 $required = array();
 ?>
@@ -16,10 +16,10 @@ $required = array();
 
 <?php if ($form->getRenderStyle()) echo $view->render($theme.'MauticFormBundle:Builder:style.html.php', array('form' => $form, 'formName' => $formName)); ?>
 
-<div id="mauticform_wrapper_<?php echo $formName ?>" class="mauticform_wrapper">
-    <form autocomplete="false" role="form" method="post" action="<?php echo $view['router']->generate('mautic_form_postresults', array('formId' => $form->getId()), true); ?>" id="mauticform_<?php echo $formName ?>" data-mautic-form="<?php echo $formName ?>">
-        <div class="mauticform-error" id="mauticform_<?php echo $formName ?>_error"></div>
-        <div class="mauticform-message" id="mauticform_<?php echo $formName ?>_message"></div>
+<div id="mauticform_wrapper<?php echo $formName ?>" class="mauticform_wrapper">
+    <form autocomplete="false" role="form" method="post" action="<?php echo $view['router']->generate('mautic_form_postresults', array('formId' => $form->getId()), true); ?>" id="mauticform<?php echo $formName ?>" data-mautic-form="<?php echo ltrim($formName, '_') ?>">
+        <div class="mauticform-error" id="mauticform<?php echo $formName ?>_error"></div>
+        <div class="mauticform-message" id="mauticform<?php echo $formName ?>_message"></div>
         <div class="mauticform-innerform">
 <?php
 foreach ($fields as $f):
@@ -35,9 +35,9 @@ endforeach;
 ?>
 
 
-            <input type="hidden" name="mauticform[formId]" id="mauticform_<?php echo $formName ?>_id" value="<?php echo $form->getId(); ?>" />
-            <input type="hidden" name="mauticform[return]" id="mauticform_<?php echo $formName ?>_return" value="" />
-            <input type="hidden" name="mauticform[formName]" id="mauticform_<?php echo $formName ?>_name" value="<?php echo $formName; ?>" />
+            <input type="hidden" name="mauticform[formId]" id="mauticform<?php echo $formName ?>_id" value="<?php echo $form->getId(); ?>" />
+            <input type="hidden" name="mauticform[return]" id="mauticform<?php echo $formName ?>_return" value="" />
+            <input type="hidden" name="mauticform[formName]" id="mauticform<?php echo $formName ?>_name" value="<?php echo ltrim($formName, '_'); ?>" />
 
         </div>
     </form>

--- a/app/bundles/FormBundle/Views/Builder/script.html.php
+++ b/app/bundles/FormBundle/Views/Builder/script.html.php
@@ -31,7 +31,7 @@ $fields   = $form->getFields();
     }
 
     /** This is needed for each form **/
-    MauticFormValidations['<?php echo $formName; ?>'] = {
+    MauticFormValidations['<?php echo ltrim($formName, '_'); ?>'] = {
 <?php
 foreach($fields as $f):
 if (!$f->isRequired()) continue;

--- a/app/bundles/FormBundle/Views/Field/field_helper.php
+++ b/app/bundles/FormBundle/Views/Field/field_helper.php
@@ -27,8 +27,8 @@ $defaultLabelClass = 'mauticform-'.$defaultLabelClass;
 $name  = (empty($ignoreName)) ? ' name="mauticform['.$field['alias'].']"' : '';
 $value = (isset($field['defaultValue'])) ? ' value="'.$field['defaultValue'].'"' : ' value=""';
 if (empty($ignoreId)) {
-    $inputId = 'id="mauticform_input_'.$formName.'_'.$field['alias'].'"';
-    $labelId = 'id="mauticform_label_'.$formName.'_'.$field['alias'].'" for="mauticform_input_'.$formName.'_'.$field['alias'].'"';
+    $inputId = 'id="mauticform_input'.$formName.'_'.$field['alias'].'"';
+    $labelId = 'id="mauticform_label'.$formName.'_'.$field['alias'].'" for="mauticform_input'.$formName.'_'.$field['alias'].'"';
 } else {
     $inputId = $labelId = '';
 }
@@ -67,7 +67,7 @@ if (!empty($inForm)) {
 }
 
 // Container
-$containerAttr         = 'id="mauticform_'.$formName.'_'.$id.'" '.htmlspecialchars_decode($field['containerAttributes']);
+$containerAttr         = 'id="mauticform'.$formName.'_'.$id.'" '.htmlspecialchars_decode($field['containerAttributes']);
 if (!isset($containerClass))
     $containerClass = $containerType;
 $defaultContainerClass = 'mauticform-row mauticform-'.$containerClass;

--- a/app/bundles/FormBundle/Views/Field/freetext.html.php
+++ b/app/bundles/FormBundle/Views/Field/freetext.html.php
@@ -23,7 +23,7 @@ $formButtons = (!empty($inForm)) ? $view->render('MauticFormBundle:Builder:actio
 $label = (!$field['showLabel']) ? '' :
 <<<HTML
 
-                <h3 $labelAttr id="mauticform_label_{$field['alias']} for="mauticform_input_{$formName}_{$field['alias']}">
+                <h3 $labelAttr id="mauticform_label_{$field['alias']} for="mauticform_input{$formName}_{$field['alias']}">
                     {$view->escape($field['label'])}
                 </h3>
 HTML;
@@ -32,7 +32,7 @@ HTML;
 $html = <<<HTML
 
             <div $containerAttr>{$formButtons}{$label}
-                <div $inputAttr id="mauticform_input_{$formName}_{$field['alias']}">
+                <div $inputAttr id="mauticform_input{$formName}_{$field['alias']}">
                     $text
                 </div>
             </div>


### PR DESCRIPTION
Issues this PR fixes:
- Form field ordering is not working (https://github.com/mautic/mautic/issues/942)
- When trying to remove a field, the field doesn't get red.
- Fields get duplicated on edit. I tried to solve it in https://github.com/mautic/mautic/pull/908, but this solves the other 2 issues as well.

### How to test
Edit a form fields and you should be able to notice that by editing a field the field get duplicated. If you try to delete a field, the field background doesn't change color to red like for example actions do. The change of field ordering doesn't get saved.

This PR solves it all.

These issues were introduced by my modifications when I added form names to ID names so more forms could be in one page. Sorry for that.