### PR TITLE
Restrict access to users into CKEditor folders

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/connectors/php/user.config.php
+++ b/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/connectors/php/user.config.php
@@ -77,5 +77,11 @@ if (isset($_SESSION['_sf2_attributes'])) {
         $userDir = substr($userDir, 1);
     }
 
+    //Check if user directory exists. If not, create it
+    $fullDir = $docRoot . '/' . $userDir;
+    if (!file_exists($fullDir)) {
+        mkdir($fullDir, 0755);
+    }
+
     $fm->setFileRoot($userDir, $docRoot);
 }

--- a/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
@@ -137,7 +137,12 @@ class CoreSubscriber extends CommonSubscriber
         //set a couple variables used by Ckeditor's filemanager
         $session->set('mautic.docroot', $event->getRequest()->server->get('DOCUMENT_ROOT'));
         $session->set('mautic.basepath', $event->getRequest()->getBasePath());
-        $session->set('mautic.imagepath', $this->factory->getParameter('image_path'));
+        //If user is not an admin, restrict directory access to his own directory
+        $imagePath = $this->factory->getParameter('image_path');
+        if (!empty($user) && !$user->isAdmin()) {
+            $imagePath .= '/' . $user->getId();
+        }
+        $session->set('mautic.imagepath', $imagePath);
     }
 
     /**


### PR DESCRIPTION
At the moment Mautic users share the same folder **/media/images** when they open CKEditor (i.e. into the landing page builder). This could be a security issue, because simple system users can modify or even delete files loaded by other users or admin.

With this PR I restrict access to this common folder. 
Users can access only their own folders under **/media/images/:userID**. Administrators keep their role and they can access **/media/images**.