### PR TITLE
Fixed issue that prevented validating the A/B test criteria fields

### DIFF
--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -19,7 +19,9 @@ use Mautic\CoreBundle\Helper\EmojiHelper;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Form\Validator\Constraints\LeadListAccess;
+use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 /**
@@ -361,8 +363,7 @@ class Email extends FormEntity
             'name',
             new NotBlank(
                 array(
-                    'message' => 'mautic.core.name.required',
-                    'groups'  => array('General')
+                    'message' => 'mautic.core.name.required'
                 )
             )
         );
@@ -371,8 +372,7 @@ class Email extends FormEntity
             'fromAddress',
             new \Symfony\Component\Validator\Constraints\Email(
                 array(
-                    'message' => 'mautic.core.email.required',
-                    'groups'  => array('General')
+                    'message' => 'mautic.core.email.required'
                 )
             )
         );
@@ -381,8 +381,7 @@ class Email extends FormEntity
             'replyToAddress',
             new \Symfony\Component\Validator\Constraints\Email(
                 array(
-                    'message' => 'mautic.core.email.required',
-                    'groups'  => array('General')
+                    'message' => 'mautic.core.email.required'
                 )
             )
         );
@@ -391,41 +390,41 @@ class Email extends FormEntity
             'bccAddress',
             new \Symfony\Component\Validator\Constraints\Email(
                 array(
-                    'message' => 'mautic.core.email.required',
-                    'groups'  => array('General')
+                    'message' => 'mautic.core.email.required'
                 )
             )
         );
 
-        $metadata->addPropertyConstraint(
-            'lists',
-            new LeadListAccess(
-                array(
-                    'message' => 'mautic.lead.lists.required',
-                    'groups'  => array('List')
-                )
-            )
-        );
+        $metadata->addConstraint(new Callback(array(
+            'callback' => function ($email, ExecutionContextInterface $context) {
+                $type = $email->getEmailType();
+                if ($type == 'list') {
+                    $validator  = $context->getValidator();
+                    $violations = $validator->validate(
+                        $email->getLists(),
+                        array(
+                            new LeadListAccess(
+                                array(
+                                    'message' => 'mautic.lead.lists.required'
+                                )
+                            ),
+                            new NotBlank(
+                                array(
+                                    'message' => 'mautic.lead.lists.required'
+                                )
+                            )
+                        )
+                    );
 
-        $metadata->addPropertyConstraint(
-            'lists',
-            new NotBlank(
-                array(
-                    'message' => 'mautic.lead.lists.required',
-                    'groups'  => array('List')
-                )
-            )
-        );
-    }
-
-    /**
-     * @param \Symfony\Component\Form\Form $form
-     *
-     * @return array
-     */
-    public static function determineValidationGroups(\Symfony\Component\Form\Form $form)
-    {
-        return ($form->getData()->getEmailType() == 'list') ? array('General', 'List') : array('General');
+                    if (count($violations) > 0) {
+                        $string = (string) $violations;
+                        $context->buildViolation($string)
+                            ->atPath('lists')
+                            ->addViolation();
+                    }
+                }
+            }
+        )));
     }
 
     /**

--- a/app/bundles/EmailBundle/Form/Type/EmailType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailType.php
@@ -392,11 +392,7 @@ class EmailType extends AbstractType
     {
         $resolver->setDefaults(
             array(
-                'data_class'        => 'Mautic\EmailBundle\Entity\Email',
-                'validation_groups' => array(
-                    'Mautic\EmailBundle\Entity\Email',
-                    'determineValidationGroups',
-                ),
+                'data_class' => 'Mautic\EmailBundle\Entity\Email'
             )
         );
 

--- a/app/bundles/PageBundle/Form/Type/PageType.php
+++ b/app/bundles/PageBundle/Form/Type/PageType.php
@@ -10,12 +10,13 @@
 namespace Mautic\PageBundle\Form\Type;
 
 use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceList;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Validator\Constraints\Valid;
 
 /**
  * Class PageType
@@ -37,17 +38,17 @@ class PageType extends AbstractType
      * @var \Doctrine\ORM\EntityManager
      */
     private $em;
-    
+
     /**
      * @var \Mautic\PageBundle\Model\PageModel
      */
     private $model;
-    
+
     /**
      * @var \Mautic\UserBundle\Model\UserModel
      */
     private $user;
-    
+
     /**
      * @var bool
      */
@@ -176,7 +177,7 @@ class PageType extends AbstractType
                     'required'   => false
                 )
             );
-            
+
             //Custom field for redirect type
             $redirectType = $options['data']->getRedirectType();
             $builder->add(
@@ -192,31 +193,31 @@ class PageType extends AbstractType
                     'empty_value' => 'mautic.page.form.redirecttype.none'
                 )
             );
-            
+
             //Custom field for redirect URL
             $model = $this->model;
             $model->getRepository()->setCurrentUser($this->user);
             $canViewOther = $this->canViewOther;
-            
+
             $dataOptions = '';
             $pages = $model->getRepository()->getPageList('', 0, 0, $canViewOther, 'variant', array($options['data']->getId()));
             foreach ($pages as $page) {
                 $dataOptions .= "|{$page['alias']}";
             }
-            
+
             $redirectUrl = $options['data']->getRedirectUrl();
             $builder->add(
-                'redirectUrl', 
+                'redirectUrl',
                 'url',
                 array(
-                      'required'    => true,
+                    'required'    => true,
                     'label'       => 'mautic.page.form.redirecturl',
                     'label_attr'  => array(
                         'class' => 'control-label'
                     ),
                     'attr'        => array(
-                        'class' => 'form-control', 
-                        'maxlength' => 200, 
+                        'class' => 'form-control',
+                        'maxlength' => 200,
                         'tooltip' => 'mautic.page.form.redirecturl.help',
                         'data-toggle' => 'field-lookup',
                         'data-target' => 'redirectUrl',
@@ -266,7 +267,7 @@ class PageType extends AbstractType
                 )
             );
 
-            $transformer = new \Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer($this->em, 'MauticPageBundle:Page', 'id');
+            $transformer = new IdToEntityModelTransformer($this->em, 'MauticPageBundle:Page', 'id');
             $builder->add(
                 $builder->create(
                     'translationParent',
@@ -314,11 +315,7 @@ class PageType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'data_class' => 'Mautic\PageBundle\Entity\Page',
-            'validation_groups' => array(
-                'Mautic\PageBundle\Entity\Page',
-                'determineValidationGroups'
-            )
+            'data_class' => 'Mautic\PageBundle\Entity\Page'
         ));
     }
 


### PR DESCRIPTION
**Description**
When creating an A/B test for pages or emails, the weight and criteria fields are required but not validated.  This _seems_ to be an issue with Symfony form validations when `validation_groups` is used.  (Reported at https://github.com/symfony/symfony/issues/15896 to get feedback).

This PR drops the use of validation_groups for emails and pages and use a Callback constraint workaround bypassing the issue.  

**Testing**
Create an A/B test and save without filling in the weight or criteria.  The form should save without an error which is the problem.

After the PR, the form should throw a constraint violation for the fields instead which is what is expected.