### PR TITLE
Fix assets batchdelete that doesn't remove uploaded files

### DIFF
--- a/app/bundles/AssetBundle/EventListener/AssetSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/AssetSubscriber.php
@@ -70,5 +70,8 @@ class AssetSubscriber extends CommonSubscriber
             "ipAddress"  => $this->factory->getIpAddressFromRequest()
         );
         $this->factory->getModel('core.auditLog')->writeToLog($log);
+
+        //In case of batch delete, this method call remove the uploaded file
+        $asset->removeUpload();
     }
 }


### PR DESCRIPTION
With this PR I fix a bug on assets batchdelete. When you batchdelete assets, records on DB are correctly removed but not associated files on disk.

Steps to reproduce bug:
- Create some assets.
- Go to assets list.
- Select assets (one or more) and trigger a batchdelete.
- You can see that records are correctly removed from DB but files keep on disk.

This PR should fix the issue.