### PR TITLE
Template categories

### DIFF
--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -538,10 +538,18 @@ class MauticFactory
                     $config = include $theme->getRealPath().'/config.php';
                     if ($specificFeature != 'all') {
                         if (isset($config['features']) && in_array($specificFeature, $config['features'])) {
-                            $themes[$specificFeature][$theme->getBasename()] = $config['name'];
+                            $themes[$specificFeature][] = [
+                                'basename' => $theme->getBasename(),
+                                'name' => $config['name'],
+                                'category' => !empty($config['category']) ? $config['category'] : $this->getTranslator()->trans('mautic.core.form.uncategorized')
+                            ];
                         }
                     } else {
-                        $themes[$specificFeature][$theme->getBasename()] = $config['name'];
+                        $themes[$specificFeature][] = [
+                            'basename' => $theme->getBasename(),
+                            'name' => $config['name'],
+                            'category' => !empty($config['category']) ? $config['category'] : $this->getTranslator()->trans('mautic.core.form.uncategorized')
+                        ];
                     }
                 }
             }

--- a/app/bundles/CoreBundle/Form/Type/ThemeListType.php
+++ b/app/bundles/CoreBundle/Form/Type/ThemeListType.php
@@ -42,7 +42,23 @@ class ThemeListType extends AbstractType
         $factory = $this->factory;
         $resolver->setDefaults(array(
             'choices'       => function(Options $options) use ($factory) {
-                return $factory->getInstalledThemes($options['feature']);
+                $choices = array();
+
+                $themes = $factory->getInstalledThemes($options['feature']);
+
+                foreach ($themes as $theme) {
+                    $choices[$theme['category']][$theme['basename']] = $theme['name'];
+                }
+
+                //Sort by category
+                ksort($choices);
+
+                //Sort by theme name
+                foreach ($choices as $category => &$themes) {
+                    ksort($themes);
+                }
+
+                return $choices;
             },
             'expanded'      => false,
             'multiple'      => false,

--- a/app/bundles/CoreBundle/Templating/TemplateReference.php
+++ b/app/bundles/CoreBundle/Templating/TemplateReference.php
@@ -100,11 +100,15 @@ class TemplateReference extends BaseTemplateReference
             }
         } else {
             $themes = $this->factory->getInstalledThemes();
-            if (isset($themes[$controller])) {
-                //this is a file in a specific Mautic theme folder
-                $theme = $this->factory->getTheme($controller);
+            foreach ($themes as $theme) {
+                if ($theme['basename'] == $controller) {
+                    //this is a file in a specific Mautic theme folder
+                    $theme = $this->factory->getTheme($controller);
 
-                $template = $theme->getThemePath().'/html/'.$fileName;
+                    $template = $theme->getThemePath().'/html/'.$fileName;
+
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
This PR adds support for template categories. You have to add a **category** field in **config.php** file inside theme folder in order to work with categories.

Steps to test:
- Create a new theme or modify one already existing.
- Add the *category* field in *config.php* theme file (i.e. "Business", "Travel", etc.).
- Go to landing page creation.
- Under the themes selection, you can see that now themes are grouped into categories. You can search on categories, too (i.e. to easily retrieve all themes under the same category).

