### PR TITLE
Fixed issue where oauth2 config settings were invisible

### DIFF
--- a/app/bundles/ApiBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ApiBundle/Form/Type/ConfigType.php
@@ -27,45 +27,57 @@ class ConfigType extends AbstractType
      */
     public function buildForm (FormBuilderInterface $builder, array $options)
     {
-        $builder->add('api_enabled', 'yesno_button_group', array(
-            'label'       => 'mautic.api.config.form.api.enabled',
-            'data'        => (bool) $options['data']['api_enabled'],
-            'attr'        => array(
-                'tooltip' => 'mautic.api.config.form.api.enabled.tooltip'
+        $builder->add(
+            'api_enabled',
+            'yesno_button_group',
+            array(
+                'label' => 'mautic.api.config.form.api.enabled',
+                'data'  => (bool) $options['data']['api_enabled'],
+                'attr'  => array(
+                    'tooltip' => 'mautic.api.config.form.api.enabled.tooltip'
+                )
             )
-        ));
+        );
 
-        $builder->add('api_oauth2_access_token_lifetime', 'number', array(
-            'label'       => 'mautic.api.config.form.api.oauth2_access_token_lifetime',
-            'attr'        => array(
-                'tooltip' => 'mautic.api.config.form.api.oauth2_access_token_lifetime.tooltip',
-                'class'   => 'form-control',
-                'data-show-on' => '{"config_apiconfig_api_enabled_1:checked":["1"]}',
-            ),
-            'constraints' => array(
-                new NotBlank(
-                    array(
-                        'message' => 'mautic.core.value.required'
+        $builder->add(
+            'api_oauth2_access_token_lifetime',
+            'number',
+            array(
+                'label'       => 'mautic.api.config.form.api.oauth2_access_token_lifetime',
+                'attr'        => array(
+                    'tooltip'      => 'mautic.api.config.form.api.oauth2_access_token_lifetime.tooltip',
+                    'class'        => 'form-control',
+                    'data-show-on' => '{"config_apiconfig_api_enabled_1":"checked"}',
+                ),
+                'constraints' => array(
+                    new NotBlank(
+                        array(
+                            'message' => 'mautic.core.value.required'
+                        )
                     )
                 )
             )
-        ));
+        );
 
-        $builder->add('api_oauth2_refresh_token_lifetime', 'number', array(
-            'label'       => 'mautic.api.config.form.api.oauth2_refresh_token_lifetime',
-            'attr'        => array(
-                'tooltip' => 'mautic.api.config.form.api.oauth2_refresh_token_lifetime.tooltip',
-                'class'   => 'form-control',
-                'data-show-on' => '{"config_apiconfig_api_enabled_1:checked":["1"]}',
-            ),
-            'constraints' => array(
-                new NotBlank(
-                    array(
-                        'message' => 'mautic.core.value.required'
+        $builder->add(
+            'api_oauth2_refresh_token_lifetime',
+            'number',
+            array(
+                'label'       => 'mautic.api.config.form.api.oauth2_refresh_token_lifetime',
+                'attr'        => array(
+                    'tooltip'      => 'mautic.api.config.form.api.oauth2_refresh_token_lifetime.tooltip',
+                    'class'        => 'form-control',
+                    'data-show-on' => '{"config_apiconfig_api_enabled_1":"checked"}',
+                ),
+                'constraints' => array(
+                    new NotBlank(
+                        array(
+                            'message' => 'mautic.core.value.required'
+                        )
                     )
                 )
             )
-        ));
+        );
     }
 
     /**


### PR DESCRIPTION
**Description**
The oauth2 settings for the config were invisible whether the API was enabled or not.  This PR fixes this.

**Testing**
Go to the Configuration -> API Settings tab.  Only the api enabled switch is visible.  Flipping it to on does not show the oauth2 options.

After the PR, the two oauth2 lifetime settings should become visible when the API is enabled.