### PR TITLE
Lead engagement chart: $eventDate doesn't contain seconds

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -345,7 +345,7 @@ class LeadController extends FormController
 
         $events = array();
         foreach ($eventsByDate as $eventDate => $dateEvents) {
-            $datetime = \DateTime::createFromFormat('Y-m-d H:i:s', $eventDate);
+            $datetime = \DateTime::createFromFormat('Y-m-d H:i', $eventDate);
             if ($datetime > $fromDate) {
                 $total++;
                 $allEngagements[] = array(


### PR DESCRIPTION
The engagement chart on lead detail doesn't show any engagement even though the lead did many actions. The problem was that it was expecting the date of the action to have seconds, but it doesn't.

Reported in https://www.mautic.org/community/index.php/855-no-data-in-engagement-graph/0#p3451

### How to test
Find a lead with some actions like form submit, page hit and so on. The engagement chart can show points gained line, but it doesn't show the engagement line. It will display the engagement line after this PR.