### PR TITLE
Provides better support for plugins that use the page hit table

### DIFF
--- a/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -56,11 +56,13 @@ if ($event['extra']['hit']['dateLeft']) {
 					<?php if (isset($event['extra']['hit']['sourceName'])) : ?>
 					<dt><?php echo $view['translator']->trans('mautic.core.source'); ?>:</dt>
 					<dd class="ellipsis">
-						<a href="<?php echo $view['router']->generate('mautic_' . $event['extra']['hit']['source'] . '_action',
-						    array("objectAction" => "view", "objectId" => $event['extra']['hit']['sourceId'])); ?>"
-						   data-toggle="ajax">
+						<?php if (isset($event['extra']['hit']['sourceRoute'])): ?>
+						<a href="<?php echo $event['extra']['hit']['sourceRoute']; ?>" data-toggle="ajax">
 						    <?php echo $event['extra']['hit']['sourceName']; ?>
 						</a>
+						<?php else: ?>
+						<?php echo $event['extra']['hit']['sourceName']; ?>
+						<?php endif; ?>
 					</dd>
 					<?php endif; ?>
 				</dl>


### PR DESCRIPTION
**Description**
Plugins that leverage the page hit table's source/source ID columns would result in a 500 error when viewing the lead's timeline due to the page hit timeline listeners forcing a core setup for model and routing.  This PR adds some checks and compatibility enhancements to support plugins' use of the hit table in order to prevent these 500s.

**Testing**
A plugin is required to fully test but a quick hack is to edit the source of a page hit for a lead to something that doesn't exist.  Then hit up the lead's profile page.  It should result in a 406 error due to the model not being found.

After the PR, the lead timeline will load.
