### PR TITLE
Campaign trigger on posgres SQL fix

### DIFF
--- a/app/bundles/CampaignBundle/Entity/EventRepository.php
+++ b/app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -354,6 +354,7 @@ class EventRepository extends CommonRepository
         $q = $this->_em->getConnection()->createQueryBuilder();
 
         $q->select('e.lead_id, e.event_id, e.date_triggered, e.is_scheduled')
+            ->groupBy('e.lead_id, e.event_id, e.date_triggered, e.is_scheduled')
             ->from(MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'e')
             ->where(
                 $q->expr()->eq('e.campaign_id', (int) $campaignId)


### PR DESCRIPTION
On triggering a campaign via command line I got this error:
```
  SQLSTATE[42803]: Grouping error: 7 ERROR:  column "e.lead_id" must appear in the GROUP BY clause or be used in  
   an aggregate function                                                                                          
  LINE 1: SELECT e.lead_id, e.event_id, e.date_triggered, e.is_schedul...                                         
                 ^    
```
GroupBy statement added to fulfill Postgres wishes.

### Testing

Run the `app/console mautic:campaign:trigger` command without any error.