### PR TITLE
Lead table: Last Active dates fixed

### DIFF
--- a/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
@@ -163,7 +163,7 @@ class DateHelper extends Helper
         } else {
             $interval = $this->helper->getDiff('now', null, true);
 
-            return $this->translator->trans('mautic.core.date.ago', array('%days%' => $interval->format('%d')));
+            return $this->translator->trans('mautic.core.date.ago', array('%days%' => $interval->days));
         }
     }
 

--- a/app/bundles/LeadBundle/Views/Lead/list_rows.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/list_rows.html.php
@@ -100,7 +100,11 @@
                     ?>
                     <span class="label label-default"<?php echo $style; ?>><?php echo $item->getPoints(); ?></span>
                 </td>
-                <td class="visible-md visible-lg"><?php echo $view['date']->toText($item->getLastActive()); ?></td>
+                <td class="visible-md visible-lg">
+                    <abbr title="<?php echo $view['date']->toFull($item->getLastActive()); ?>">
+                        <?php echo $view['date']->toText($item->getLastActive()); ?>
+                    </abbr>
+                </td>
                 <td class="visible-md visible-lg"><?php echo $item->getId(); ?></td>
             </tr>
         <?php endforeach; ?>


### PR DESCRIPTION
Last Active column in the Leads table wasn't snowing correct amount of days. Reported in https://github.com/mautic/mautic/issues/935

This PR fixes it and adds an abbreviation which shows the full date on hover so users don't have to count what date it actually is. 