### PR TITLE
Field help message shows up if defined

### DIFF
--- a/app/bundles/FormBundle/Views/Field/group.html.php
+++ b/app/bundles/FormBundle/Views/Field/group.html.php
@@ -44,9 +44,9 @@ $label = (!$field['showLabel']) ? '' : <<<HTML
                 <label $labelAttr for="$firstId">{$view->escape($field['label'])}</label>
 HTML;
 
-$help = (empty($helpMessage)) ? '' : <<<HTML
+$help = (empty($field['helpMessage'])) ? '' : <<<HTML
 
-                <span class="mauticform-helpmessage">{$helpMessage}</span>
+                <span class="mauticform-helpmessage">{$field['helpMessage']}</span>
 HTML;
 
 $options = array();

--- a/app/bundles/FormBundle/Views/Field/select.html.php
+++ b/app/bundles/FormBundle/Views/Field/select.html.php
@@ -43,9 +43,9 @@ $label = (!$field['showLabel']) ? '' : <<<HTML
 HTML;
 
 
-$help = (empty($helpMessage)) ? '' : <<<HTML
+$help = (empty($field['helpMessage'])) ? '' : <<<HTML
 
-                <span class="mauticform-helpmessage">{$helpMessage}</span>
+                <span class="mauticform-helpmessage">{$field['helpMessage']}</span>
 HTML;
 
 $emptyOption = (empty($properties['empty_value'])) ? '' : <<<HTML

--- a/app/bundles/FormBundle/Views/Field/text.html.php
+++ b/app/bundles/FormBundle/Views/Field/text.html.php
@@ -25,9 +25,9 @@ $label = (!$field['showLabel']) ? '' : <<<HTML
 HTML;
 
 
-$help = (empty($helpMessage)) ? '' : <<<HTML
+$help = (empty($field['helpMessage'])) ? '' : <<<HTML
 
-                <span class="mauticform-helpmessage">{$helpMessage}</span>
+                <span class="mauticform-helpmessage">{$field['helpMessage']}</span>
 HTML;
 
 if ($containerType == 'textarea'):


### PR DESCRIPTION
Help message defined in a form field didn't show up. Reported at https://github.com/mautic/mautic/issues/975.

### Testing
Insert some Help Message for different types of form field. The help message won't show up. After the PR, the help message will show up in the form edit view and after save in the preview as well.