### PR TITLE
Wrong check for IMAP extension (Fix #980)

### DIFF
--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -289,7 +289,7 @@ class CheckStep implements StepInterface
             $messages[] = 'mautic.install.function.xml';
         }
 
-        if (function_exists('imap_open')) {
+        if (!function_exists('imap_open')) {
             $messages[] = 'mautic.install.extension.imap';
         }
 


### PR DESCRIPTION
The installer was raising the IMAP error if the extension was installed.  We only want the message if it isn't there.