### PR TITLE
Fix error caused by extra parameter in function call on line 416

### DIFF
--- a/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -413,7 +413,7 @@ class Mailbox
      */
     public function searchMailbox($criteria = 'ALL')
     {
-        $mailsIds = imap_search($this->getImapStream(), $criteria, SE_UID, $this->serverEncoding);
+        $mailsIds = imap_search($this->getImapStream(), $criteria, SE_UID);
 
         return $mailsIds ? $mailsIds : array();
     }


### PR DESCRIPTION
Fix "PHP Notice:  Unknown: Specified character set not supported. (errflg=2) in Unknown on line 0" error caused by extra ", $this->serverEncoding" parameter in "imap_search()" function call on line 416