### PR TITLE
Inject an ArrayCache instance when creating the entity manager configuration

### DIFF
--- a/app/bundles/InstallBundle/Controller/InstallController.php
+++ b/app/bundles/InstallBundle/Controller/InstallController.php
@@ -9,6 +9,7 @@
 
 namespace Mautic\InstallBundle\Controller;
 
+use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\Common\EventManager;
@@ -901,7 +902,7 @@ class InstallController extends CommonController
             }
 
             $driver = new StaticPHPDriver($paths);
-            $config = Setup::createConfiguration();
+            $config = Setup::createConfiguration($this->factory->getEnvironment(), null, new ArrayCache());
             $config->setMetadataDriverImpl(
                 $driver
             );


### PR DESCRIPTION
The installer creates a separate entity manager Configuration object for use in that process since we do not have a full configuration/environment set up yet.  Calling `Setup::createConfiguration()` without injecting a Doctrine Cache instance will cause the method to try and create a Cache object based on the environment's available options.  This pull request changes the installer so that an ArrayCache object is always injected into the Configuration object to bypass this auto-create code.