### PR TITLE
Use email services rather than creating a new object when testing email connection

### DIFF
--- a/app/bundles/EmailBundle/Controller/AjaxController.php
+++ b/app/bundles/EmailBundle/Controller/AjaxController.php
@@ -344,24 +344,17 @@ class AjaxController extends CommonAjaxController
             $transport = $settings['transport'];
 
             switch($transport) {
-                case 'mautic.transport.mandrill':
-                    $mailer = new MandrillTransport();
-                    break;
-                case 'mautic.transport.sendgrid':
-                    $mailer = new SendgridTransport();
-                    break;
-                case 'mautic.transport.amazon':
-                    $mailer = new AmazonTransport();
-                    break;
-                case 'mautic.transport.postmark':
-                    $mailer = new PostmarkTransport();
-                    break;
                 case 'gmail':
                     $mailer = new \Swift_SmtpTransport('smtp.gmail.com', 465, 'ssl');
                     break;
                 case 'smtp':
                     $mailer = new \Swift_SmtpTransport($settings['host'], $settings['port'], $settings['encryption']);
                     break;
+
+                default:
+                    if ($this->container->has($transport)) {
+                        $mailer = $this->container->get($transport);
+                    }
             }
 
             if (method_exists($mailer, 'setMauticFactory')) {


### PR DESCRIPTION
**Description**
This is a dev change to use the email service rather than a newly created object to ensure the configured class from the container is used (which may use compilers to force other ports, etc). This also sets the ground work for plugins that may add custom mailers although we still need to adjust the config choice list to not be hardcoded.

**Testing**
After applying the PR, if you have an Amazon, Sendgrid, Mandrill, or Postmark account, go to Configuration enter the details and make sure the  connection is successful.