### PR TITLE
Fix to referrer in tracking pixel being ignored

### DIFF
--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -614,7 +614,10 @@ class PageModel extends FormModel
         }
 
         $hit->setCode($code);
-        $hit->setReferer($request->server->get('HTTP_REFERER'));
+        if (!$hit->getReferer()) {
+            $hit->setReferer($request->server->get('HTTP_REFERER'));
+        }
+
         $hit->setUserAgent($request->server->get('HTTP_USER_AGENT'));
         $hit->setRemoteHost($request->server->get('REMOTE_HOST'));
 


### PR DESCRIPTION
**Description**
The referrer is set from the tracking pixel but later overridden with the $_SERVER value.  

**Testing**
Use a tracking pixel and append `page_referrer=https://someurl.com`.  Look at the page hits table and notice that the referrer will be set to that of the value in $_SERVER.  After the PR, the referrer passed in the URL will be saved to the DB instead.