### PR TITLE
Lead list with a boolean filter doesn't save first try

### DIFF
--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -324,7 +324,7 @@ Mautic.addLeadListFilter = function (elId) {
             var fieldOptions = mQuery(filterId).data("field-list");
 
             mQuery.each(fieldOptions, function(index, val) {
-                mQuery('<option>').val(val).text(val).appendTo(filterEl);
+                mQuery('<option>').val(index).text(val).appendTo(filterEl);
             });
         }
         mQuery(filter).attr('data-placeholder', label);
@@ -473,10 +473,6 @@ Mautic.updateLeadFieldProperties = function(selectedVal) {
     }
 };
 
-/**
- *
- * @param label
- */
 Mautic.updateLeadFieldBooleanLabels = function(el, label) {
     mQuery('#leadfield_defaultValue_' + label).parent().find('span').text(
         mQuery(el).val()

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -267,12 +267,7 @@ class ListController extends FormController
             }
 
             if ($cancelled || ($valid && $form->get('buttons')->get('save')->isClicked())) {
-                return $this->postActionRedirect(
-                    array_merge($postActionVars, array(
-                        'viewParameters'  => array('objectId' => $list->getId()),
-                        'contentTemplate' => 'MauticLeadBundle:List:index'
-                    ))
-                );
+                return $this->postActionRedirect($postActionVars);
             }
         } else {
             //lock the entity


### PR DESCRIPTION
**Description**
When creating a new lead list and adding a boolean based filter, the lead list will not save the first time because there is a validation error that is hit but not displayed.  The issue is due to the dynamically generated boolean filter row incorrectly sets the value of the select.  This PR fixes that.  

**Testing**
Create a new "boolean" type lead field
Create a new lead list and add the boolean field on the filters tab
Click save and close and you should be taken back to the form as if there a validation error (there is but not shown)
Click save and close again and the list will save.

After the PR, you should be able to click Save and close the first time and all will be good.