### PR TITLE
Empty form field alias/column name fix

### DIFF
--- a/app/bundles/FormBundle/Controller/FieldController.php
+++ b/app/bundles/FormBundle/Controller/FieldController.php
@@ -100,6 +100,11 @@ class FieldController extends CommonFormController
                     }
                     $formField['alias'] = $this->factory->getModel('form.field')->generateAlias($formField['label'], $aliases);
 
+                    if (empty($formField['alias'])) {
+                        // Likely a bogus label so generate random alias for column name
+                        $formField['alias'] = uniqid('f_');
+                    }
+
                     // Force required for captcha
                     if ($formField['type'] == 'captcha') {
                         $formField['isRequired'] = true;
@@ -116,7 +121,6 @@ class FieldController extends CommonFormController
                     } else {
                         $fields[$keyId] = $formField;
                     }
-
 
                     $session->set('mautic.form.'.$formId.'.fields.modified', $fields);
 


### PR DESCRIPTION
**Description**

If the label validation is circumvented using simply a period or some other punctuation, an empty alias may result leading to SQL issues since a column for the field couldn't be generated.  This prevents that by checking for an empty alias and generating a random string that can be used as a column name.

**Testing**
Add a form field and use a period for the label.  Save and check the form's table.  No column will exist for that and if you submit the form, a 500 will result.

After the PR, repeat the process and this time a random name will be generated for the column and all should work well.