### PR TITLE
Lead list filter UI improvements

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/libraries/chosen/bootstrap-chosen-variables.less
+++ b/app/bundles/CoreBundle/Assets/css/libraries/chosen/bootstrap-chosen-variables.less
@@ -6,7 +6,7 @@
 //
 // Submit bugfixes to: http://github.com/alxlit/bootstrap-chosen
 //
-
+@import "../bootstrap/less/variables";
 @chosen-background: @input-bg;
 @chosen-border: 1px solid @input-border;
 @chosen-border-radius: @input-border-radius;

--- a/app/bundles/CoreBundle/Assets/css/libraries/chosen/bootstrap-chosen.less
+++ b/app/bundles/CoreBundle/Assets/css/libraries/chosen/bootstrap-chosen.less
@@ -485,3 +485,13 @@
     background-repeat: no-repeat !important;
   }
 }
+
+.has-error select.form-control + .chosen-container.chosen-container-single .chosen-single,
+.has-error select.form-control + .chosen-container-multi .chosen-choices {
+  border-color: @state-danger-text;
+}
+
+.has-error select.form-control + .chosen-container.chosen-container-single .chosen-single,
+.has-error select.form-control + .chosen-container-multi .chosen-choices {
+  border-color: @state-danger-text;
+}

--- a/app/bundles/CoreBundle/Assets/css/libraries/libraries.css
+++ b/app/bundles/CoreBundle/Assets/css/libraries/libraries.css
@@ -8486,6 +8486,10 @@ button.close {
     background-repeat: no-repeat !important;
   }
 }
+.has-error select.form-control + .chosen-container.chosen-container-single .chosen-single,
+.has-error select.form-control + .chosen-container-multi .chosen-choices {
+  border-color: #a94442;
+}
 .ms-container {
   background: transparent url('multiselect/switch.png') no-repeat 50% 50%;
   /*width: 370px;*/

--- a/app/bundles/CoreBundle/Templating/Helper/FormHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/FormHelper.php
@@ -79,16 +79,21 @@ class FormHelper extends \Symfony\Bundle\FrameworkBundle\Templating\Helper\FormH
     /**
      * Checks to see if the form and its children has an error
      *
-     * @param $form
+     * @param FormView $form
+     * @param array    $exluding
      *
      * @return bool
      */
-    public function containsErrors (FormView $form) {
+    public function containsErrors (FormView $form, array $exluding = array()) {
         if (count($form->vars['errors'])) {
             return true;
         }
-        foreach ($form->children as $child) {
-            if (count($child->vars['errors'])) {
+        foreach ($form->children as $key => $child) {
+            if (in_array($key, $exluding)) {
+                continue;
+            }
+
+            if (isset($child->vars['errors']) && count($child->vars['errors'])) {
                return true;
             }
 

--- a/app/bundles/EmailBundle/Entity/DoNotEmail.php
+++ b/app/bundles/EmailBundle/Entity/DoNotEmail.php
@@ -144,7 +144,7 @@ class DoNotEmail
     }
 
     /**
-     * @return mixed
+     * @return Lead
      */
     public function getLead ()
     {
@@ -152,7 +152,7 @@ class DoNotEmail
     }
 
     /**
-     * @param mixed $lead
+     * @param Lead $lead
      */
     public function setLead (Lead $lead)
     {

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -183,6 +183,13 @@ Mautic.leadlistOnLoad = function(container) {
     }
 
     if (mQuery('#leadlist_filters').length) {
+        mQuery('#available_filters').on('change', function() {
+            if (mQuery(this).val()) {
+                Mautic.addLeadListFilter(mQuery(this).val());
+                mQuery(this).val('');
+                mQuery(this).trigger('chosen:updated');
+            }
+        });
         mQuery('#leadlist_filters .remove-selected').each( function (index, el) {
             mQuery(el).on('click', function () {
                 mQuery(this).closest('.panel').animate(
@@ -262,7 +269,7 @@ Mautic.convertLeadFilterInput = function(el) {
 
 Mautic.addLeadListFilter = function (elId) {
     var filterId = '#available_' + elId;
-    var label    = mQuery(filterId + ' span.leadlist-filter-name').text();
+    var label    = mQuery(filterId).text();
 
     //create a new filter
 

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -190,6 +190,7 @@ Mautic.leadlistOnLoad = function(container) {
                 mQuery(this).trigger('chosen:updated');
             }
         });
+
         mQuery('#leadlist_filters .remove-selected').each( function (index, el) {
             mQuery(el).on('click', function () {
                 mQuery(this).closest('.panel').animate(
@@ -347,7 +348,7 @@ Mautic.addLeadListFilter = function (elId) {
             var fieldOptions = mQuery(filterId).data("field-list");
 
             mQuery.each(fieldOptions, function(index, val) {
-                mQuery('<option>').val(val).text(val).appendTo(filterEl);
+                mQuery('<option>').val(index).text(val).appendTo(filterEl);
             });
         }
     } else if (fieldType == 'lookup') {
@@ -491,10 +492,6 @@ Mautic.updateLeadFieldProperties = function(selectedVal) {
     }
 };
 
-/**
- *
- * @param label
- */
 Mautic.updateLeadFieldBooleanLabels = function(el, label) {
     mQuery('#leadfield_defaultValue_' + label).parent().find('span').text(
         mQuery(el).val()

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1940,18 +1940,18 @@ class LeadController extends FormController
             }
 
             if ($count = count($entities)) {
-                $dncEntities = array();
+                $persistEntities = array();
                 foreach ($entities as $lead) {
                     if ($this->factory->getSecurity()->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getCreatedBy())) {
 
-                        if ($dnc = $model->setDoNotContact($lead, null, $data['reason'], false, true)) {
-                            $dncEntities[] = $dnc;
+                        if ($model->setDoNotContact($lead, null, $data['reason'], false, true)) {
+                            $persistEntities[] = $lead;
                         }
                     }
                 }
 
                 // Save entities
-                $this->factory->getModel('email')->getRepository()->saveEntities($dncEntities);
+                $model->saveEntities($persistEntities);
             }
 
             $this->addFlash('mautic.lead.batch_leads_affected',

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -267,12 +267,7 @@ class ListController extends FormController
             }
 
             if ($cancelled || ($valid && $form->get('buttons')->get('save')->isClicked())) {
-                return $this->postActionRedirect(
-                    array_merge($postActionVars, array(
-                        'viewParameters'  => array('objectId' => $list->getId()),
-                        'contentTemplate' => 'MauticLeadBundle:List:index'
-                    ))
-                );
+                return $this->postActionRedirect($postActionVars);
             }
         } else {
             //lock the entity
@@ -281,7 +276,8 @@ class ListController extends FormController
 
         return $this->delegateView(array(
             'viewParameters'  => array(
-                'form'            => $this->setFormTheme($form, 'MauticLeadBundle:List:form.html.php', 'MauticLeadBundle:FormTheme\Filter')
+                'form'            => $this->setFormTheme($form, 'MauticLeadBundle:List:form.html.php', 'MauticLeadBundle:FormTheme\Filter'),
+                'currentListId'   => $objectId,
             ),
             'contentTemplate' => 'MauticLeadBundle:List:form.html.php',
             'passthroughVars' => array(
@@ -488,8 +484,8 @@ class ListController extends FormController
                     'msgVars' => array('%id%' => $list->getId())
                 );
             } elseif (!$list->isGlobal() && !$this->factory->getSecurity()->hasEntityAccess(
-                true, 'lead:lists:viewother', $list->getCreatedBy()
-            )) {
+                    true, 'lead:lists:viewother', $list->getCreatedBy()
+                )) {
                 return $this->accessDenied();
             } elseif ($model->isLocked($lead)) {
                 return $this->isLocked($postActionVars, $lead, 'lead');

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -170,6 +170,7 @@ class Lead extends FormEntity
             ->build();
 
         $builder->createOneToMany('doNotEmail', 'Mautic\EmailBundle\Entity\DoNotEmail')
+            ->orphanRemoval()
             ->mappedBy('lead')
             ->cascadePersist()
             ->fetchExtraLazy()

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -681,8 +681,8 @@ class Lead extends FormEntity
         } elseif ($doNotEmail->getUnsubscribed()) {
             $type = 'unsubscribed';
         }
-        $reason = "$type: ".$doNotEmail->getComments();
-        $this->changes['dnc_status'] = $reason;
+
+        $this->changes['dnc_status'] = array($type, $doNotEmail->getComments());
 
         $this->doNotEmail[] = $doNotEmail;
 
@@ -694,7 +694,13 @@ class Lead extends FormEntity
      */
     public function removeDoNotEmailEntry(DoNotEmail $doNotEmail)
     {
-        $this->changes['dnc_status'] = 'removed';
+        if ($doNotEmail->getBounced()) {
+            $type = $doNotEmail->isManual() ? 'manual' : 'bounced';
+        } elseif ($doNotEmail->getUnsubscribed()) {
+            $type = 'unsubscribed';
+        }
+
+        $this->changes['dnc_status'] = array('removed', $type);
 
         $this->doNotEmail->removeElement($doNotEmail);
     }

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -286,7 +286,6 @@ class Lead extends FormEntity
             } else {
                 $this->changes['tags']['removed'][] = $val;
             }
-
         } elseif ($this->$getter() != $val) {
             $this->changes[$prop] = array($this->$getter(), $val);
         }
@@ -677,6 +676,14 @@ class Lead extends FormEntity
      */
     public function addDoNotEmailEntry(DoNotEmail $doNotEmail)
     {
+        if ($doNotEmail->getBounced()) {
+            $type = $doNotEmail->isManual() ? 'manual' : 'bounced';
+        } elseif ($doNotEmail->getUnsubscribed()) {
+            $type = 'unsubscribed';
+        }
+        $reason = "$type: ".$doNotEmail->getComments();
+        $this->changes['dnc_status'] = $reason;
+
         $this->doNotEmail[] = $doNotEmail;
 
         return $this;
@@ -687,6 +694,8 @@ class Lead extends FormEntity
      */
     public function removeDoNotEmailEntry(DoNotEmail $doNotEmail)
     {
+        $this->changes['dnc_status'] = 'removed';
+
         $this->doNotEmail->removeElement($doNotEmail);
     }
 

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -944,7 +944,8 @@ class Lead extends FormEntity
      */
     public function setLastActive($lastActive)
     {
-        $this->lastActive = $lastActive;
+        $this->changes['dateLastActive'] = array($this->lastActive, $lastActive);
+        $this->lastActive                = $lastActive;
     }
 
     /**

--- a/app/bundles/LeadBundle/Form/Type/FilterType.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterType.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
  * Class FilterType
@@ -87,8 +88,12 @@ class FilterType extends AbstractType
             $displayAttr = array();
 
             $customOptions = array();
+
             switch ($fieldType) {
                 case 'leadlist':
+                    if (!isset($data['filter'])) {
+                        $data['filter'] = array();
+                    }
                     if (!is_array($data['filter'])) {
                         $data['filter'] = array($data['filter']);
                     }
@@ -97,6 +102,9 @@ class FilterType extends AbstractType
                     $type                      = 'choice';
                     break;
                 case 'tags':
+                    if (!isset($data['filter'])) {
+                        $data['filter'] = array();
+                    }
                     if (!is_array($data['filter'])) {
                         $data['filter'] = array($data['filter']);
                     }
@@ -207,6 +215,18 @@ class FilterType extends AbstractType
                     break;
             }
 
+            if (in_array($data['operator'], array('empty', '!empty'))) {
+                $attr['disabled'] = 'disabled';
+            } else {
+                $customOptions['constraints'] = array(
+                    new NotBlank(
+                        array(
+                            'message' => 'mautic.core.value.required'
+                        )
+                    )
+                );
+            }
+
             // @todo implement in UI
             if (in_array($data['operator'], array('between', '!between'))) {
                 $form->add(
@@ -229,7 +249,8 @@ class FilterType extends AbstractType
                         array(
                             'label' => false,
                             'attr'  => $attr,
-                            'data'  => $data['filter']
+                            'data'  => isset($data['filter']) ? $data['filter'] : '',
+                            'error_bubbling' => false,
                         ),
                         $customOptions
                     )
@@ -242,7 +263,8 @@ class FilterType extends AbstractType
                 array(
                     'label' => false,
                     'attr'  => $displayAttr,
-                    'data'  => $data['display']
+                    'data'  => $data['display'],
+                    'error_bubbling' => false
                 )
             );
 
@@ -310,7 +332,8 @@ class FilterType extends AbstractType
 
         $resolver->setDefaults(
             array(
-                'label' => false
+                'label' => false,
+                'error_bubbling' => false
             )
         );
     }

--- a/app/bundles/LeadBundle/Form/Type/FilterType.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterType.php
@@ -93,8 +93,7 @@ class FilterType extends AbstractType
                 case 'leadlist':
                     if (!isset($data['filter'])) {
                         $data['filter'] = array();
-                    }
-                    if (!is_array($data['filter'])) {
+                    } elseif (!is_array($data['filter'])) {
                         $data['filter'] = array($data['filter']);
                     }
                     $customOptions['choices']  = $options['lists'];
@@ -104,8 +103,7 @@ class FilterType extends AbstractType
                 case 'tags':
                     if (!isset($data['filter'])) {
                         $data['filter'] = array();
-                    }
-                    if (!is_array($data['filter'])) {
+                    } elseif (!is_array($data['filter'])) {
                         $data['filter'] = array($data['filter']);
                     }
                     $customOptions['choices']  = $options['tags'];
@@ -171,7 +169,9 @@ class FilterType extends AbstractType
 
                     if (in_array($data['operator'], array('in', '!in'))) {
                         $customOptions['multiple'] = true;
-                        if (!is_array($data['filter'])) {
+                        if (!isset($data['filter'])) {
+                            $data['filter'] = array();
+                        } elseif (!is_array($data['filter'])) {
                             $data['filter'] = array($data['filter']);
                         }
                     }

--- a/app/bundles/LeadBundle/Form/Type/LeadType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadType.php
@@ -10,6 +10,7 @@
 namespace Mautic\LeadBundle\Form\Type;
 
 use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer;
 use Mautic\CoreBundle\Form\DataTransformer\StringToDatetimeTransformer;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
@@ -52,20 +53,7 @@ class LeadType extends AbstractType
         $builder->addEventSubscriber(new FormExitSubscriber('lead.lead', $options));
 
         if (!$options['isShortForm']) {
-            $builder->add(
-                'tags',
-                'lead_tag',
-                array(
-                    'attr' => array(
-                        'data-placeholder'      => $this->factory->getTranslator()->trans('mautic.lead.tags.select_or_create'),
-                        'data-no-results-text'  => $this->factory->getTranslator()->trans('mautic.lead.tags.enter_to_create'),
-                        'data-allow-add'        => 'true',
-                        'onchange'              => 'Mautic.createLeadTag(this)'
-                    )
-                )
-            );
-
-            $transformer = new \Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer(
+            $transformer = new IdToEntityModelTransformer(
                 $this->factory->getEntityManager(),
                 'MauticUserBundle:User'
             );
@@ -295,6 +283,20 @@ class LeadType extends AbstractType
                 );
             }
         }
+
+        $builder->add(
+            'tags',
+            'lead_tag',
+            array(
+                'by_reference' => false,
+                'attr'         => array(
+                    'data-placeholder'      => $this->factory->getTranslator()->trans('mautic.lead.tags.select_or_create'),
+                    'data-no-results-text'  => $this->factory->getTranslator()->trans('mautic.lead.tags.enter_to_create'),
+                    'data-allow-add'        => 'true',
+                    'onchange'              => 'Mautic.createLeadTag(this)'
+                )
+            )
+        );
 
         if (!$options['isShortForm']) {
             $builder->add('buttons', 'form_buttons');

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -245,8 +245,6 @@ class ListModel extends FormModel
                     '!=',
                     'empty',
                     '!empty',
-                    'like',
-                    '!like',
                     'in',
                     '!in'
                 )
@@ -372,9 +370,9 @@ class ListModel extends FormModel
             // Set operators allowed
             if ($type == 'boolean') {
                 $choices[$field->getAlias()]['operators'] = $operators['bool'];
-            } elseif ($type == 'select') {
+            } elseif (in_array($type, array('select', 'country', 'timezone', 'region'))) {
                 $choices[$field->getAlias()]['operators'] = $operators['select'];
-            } elseif (in_array($type, array('lookup', 'lookup_id', 'select', 'text', 'email', 'url', 'timezone', 'email', 'tel', 'country', 'region'))) {
+            } elseif (in_array($type, array('lookup', 'lookup_id',  'text', 'email', 'url', 'email', 'tel'))) {
                 $choices[$field->getAlias()]['operators'] = $operators['text'];
             } else {
                 $choices[$field->getAlias()]['operators'] = $operators['default'];

--- a/app/bundles/LeadBundle/Views/FormTheme/Filter/_leadlist_filters_entry_widget.html.php
+++ b/app/bundles/LeadBundle/Views/FormTheme/Filter/_leadlist_filters_entry_widget.html.php
@@ -26,9 +26,12 @@ $filterType  = $form['field']->vars['value'];
             <?php echo $view['form']->widget($form['operator']); ?>
         </div>
 
-        <div class="col-xs-10 col-sm-5 padding-none">
+        <?php $hasErrors = count($form['filter']->vars['errors']) || count($form['display']->vars['errors']); ?>
+        <div class="col-xs-10 col-sm-5 padding-none<?php if ($hasErrors) echo " has-error"; ?>">
             <?php echo $view['form']->widget($form['filter']); ?>
+            <?php echo $view['form']->errors($form['filter']); ?>
             <?php echo $view['form']->widget($form['display']); ?>
+            <?php echo $view['form']->errors($form['display']); ?>
         </div>
 
         <div class="col-xs-2 col-sm-1">

--- a/app/bundles/LeadBundle/Views/List/form.html.php
+++ b/app/bundles/LeadBundle/Views/List/form.html.php
@@ -28,106 +28,120 @@ $templates = array(
     'lists'     => 'leadlist-template',
     'tags'      => 'tags-template'
 );
+
+$mainErrors   = ($view['form']->containsErrors($form, array('filters'))) ? 'class="text-danger"' : '';
+$filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text-danger"' : '';
 ?>
 
 <?php echo $view['form']->start($form); ?>
-    <div class="box-layout">
-        <div class="col-md-9 bg-white height-auto">
-            <div class="row">
-                <div class="col-xs-12">
-                    <ul class="bg-auto nav nav-tabs pr-md pl-md">
-                        <li class="active">
-                            <a href="#details" role="tab" data-toggle="tab"><?php echo $view['translator']->trans('mautic.core.details'); ?></a>
-                        </li>
-                        <li>
-                            <a href="#filters" role="tab" data-toggle="tab"><?php echo $view['translator']->trans('mautic.core.filters'); ?></a></a>
-                        </li>
-                    </ul>
+<div class="box-layout">
+    <div class="col-md-9 bg-white height-auto">
+        <div class="row">
+            <div class="col-xs-12">
+                <ul class="bg-auto nav nav-tabs pr-md pl-md">
+                    <li class="active">
+                        <a href="#details" role="tab" data-toggle="tab"<?php echo $mainErrors; ?>>
+                            <?php echo $view['translator']->trans('mautic.core.details'); ?>
+                            <?php if ($mainErrors): ?>
+                                <i class="fa fa-warning"></i>
+                            <?php endif; ?>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#filters" role="tab" data-toggle="tab"<?php echo $filterErrors; ?>>
+                            <?php echo $view['translator']->trans('mautic.core.filters'); ?>
+                            <?php if ($filterErrors): ?>
+                                <i class="fa fa-warning"></i>
+                            <?php endif; ?>
+                        </a>
+                    </li>
+                </ul>
 
-                    <!-- start: tab-content -->
-                    <div class="tab-content pa-md">
-                        <div class="tab-pane fade in active bdr-w-0" id="details">
-                            <div class="row">
-                                <div class="col-md-6">
-                                    <?php echo $view['form']->row($form['name']); ?>
-                                </div>
-                                <div class="col-md-6">
-                                    <?php echo $view['form']->row($form['alias']); ?>
-                                </div>
+                <!-- start: tab-content -->
+                <div class="tab-content pa-md">
+                    <div class="tab-pane fade in active bdr-w-0" id="details">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <?php echo $view['form']->row($form['name']); ?>
                             </div>
-                            <div class="row">
-                                <div class="col-xs-12">
-                                    <?php echo $view['form']->row($form['description']); ?>
-                                </div>
+                            <div class="col-md-6">
+                                <?php echo $view['form']->row($form['alias']); ?>
                             </div>
                         </div>
-                        <div class="tab-pane fade bdr-w-0" id="filters">
-                            <div class="form-group">
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <?php echo $view['form']->row($form['description']); ?>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="tab-pane fade bdr-w-0" id="filters">
+                        <div class="form-group">
+                            <div class="has-errors">
                                 <?php echo $view['form']->errors($form['filters']); ?>
-                                <div class="available-filters mb-md pl-0 col-md-4" data-prototype="<?php echo $view->escape($view['form']->row($form['filters']->vars['prototype'])); ?>" data-index="<?php echo $index + 1; ?>">
-                                    <select class="chosen form-control" id="available_filters">
-                                        <option value=""></option>
-                                        <?php
-                                        foreach ($fields as $value => $params):
-                                            $list      = (!empty($params['properties']['list'])) ? $params['properties']['list'] : array();
-                                            if (!is_array($list) && strpos($list, '|') !== false):
-                                                $parts = explode('||', $list);
-                                                if (count($parts) > 1):
-                                                    $labels = explode('|', $parts[0]);
-                                                    $values = explode('|', $parts[1]);
-                                                    $list = array_combine($values, $labels);
-                                                else:
-                                                    $list = explode('|', $list);
-                                                    $list = array_combine($list, $list);
-                                                endif;
+                            </div>
+                            <div class="available-filters mb-md pl-0 col-md-4" data-prototype="<?php echo $view->escape($view['form']->row($form['filters']->vars['prototype'])); ?>" data-index="<?php echo $index + 1; ?>">
+                                <select class="chosen form-control" id="available_filters">
+                                    <option value=""></option>
+                                    <?php
+                                    foreach ($fields as $value => $params):
+                                        $list      = (!empty($params['properties']['list'])) ? $params['properties']['list'] : array();
+                                        if (!is_array($list) && strpos($list, '|') !== false):
+                                            $parts = explode('||', $list);
+                                            if (count($parts) > 1):
+                                                $labels = explode('|', $parts[0]);
+                                                $values = explode('|', $parts[1]);
+                                                $list = array_combine($values, $labels);
+                                            else:
+                                                $list = explode('|', $list);
+                                                $list = array_combine($list, $list);
                                             endif;
-                                            $list      = json_encode($list);
-                                            $callback  = (!empty($params['properties']['callback'])) ? $params['properties']['callback'] : '';
-                                            $operators = (!empty($params['operators'])) ? $view->escape(json_encode($params['operators'])) : '{}';
-                                            ?>
-                                            <option value="<?php echo $value; ?>" id="available_<?php echo $value; ?>" data-field-type="<?php echo $params['properties']['type']; ?>" data-field-list="<?php echo $view->escape($list); ?>" data-field-callback="<?php echo $callback; ?>" data-field-operators="<?php echo $operators; ?>"><?php echo $view['translator']->trans($params['label']); ?></option>
-                                        <?php endforeach; ?>
-                                    </select>
-                                </div>
-                                <div class="clearfix"></div>
+                                        endif;
+                                        $list      = json_encode($list);
+                                        $callback  = (!empty($params['properties']['callback'])) ? $params['properties']['callback'] : '';
+                                        $operators = (!empty($params['operators'])) ? $view->escape(json_encode($params['operators'])) : '{}';
+                                        ?>
+                                        <option value="<?php echo $value; ?>" id="available_<?php echo $value; ?>" data-field-type="<?php echo $params['properties']['type']; ?>" data-field-list="<?php echo $view->escape($list); ?>" data-field-callback="<?php echo $callback; ?>" data-field-operators="<?php echo $operators; ?>"><?php echo $view['translator']->trans($params['label']); ?></option>
+                                    <?php endforeach; ?>
+                                </select>
                             </div>
-                            <div class="selected-filters" id="leadlist_filters">
-                                <?php echo $view['form']->widget($form['filters']); ?>
-                            </div>
+                            <div class="clearfix"></div>
+                        </div>
+                        <div class="selected-filters" id="leadlist_filters">
+                            <?php echo $view['form']->widget($form['filters']); ?>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-        <div class="col-md-3 bg-white height-auto bdr-l">
-            <div class="pr-lg pl-lg pt-md pb-md">
-                <?php echo $view['form']->row($form['isGlobal']); ?>
-                <?php echo $view['form']->row($form['isPublished']); ?>
-            </div>
+    </div>
+    <div class="col-md-3 bg-white height-auto bdr-l">
+        <div class="pr-lg pl-lg pt-md pb-md">
+            <?php echo $view['form']->row($form['isGlobal']); ?>
+            <?php echo $view['form']->row($form['isPublished']); ?>
         </div>
     </div>
+</div>
 <?php echo $view['form']->end($form); ?>
 
 <div class="hide" id="templates">
-<?php foreach ($templates as $dataKey => $template): ?>
-    <?php $attr = ($dataKey == 'tags') ? ' data-placeholder="' . $view['translator']->trans('mautic.lead.tags.select_or_create') . '" data-no-results-text="' . $view['translator']->trans('mautic.lead.tags.enter_to_create') . '" data-allow-add="true" onchange="Mautic.createLeadTag(this)"' : ''; ?>
-    <select class="form-control not-chosen <?php echo $template; ?>" name="leadlist[filters][__name__][filter]" id="leadlist_filters___name___filter"<?php echo $attr; ?>>
-        <option value=""></option>
-        <?php
-        if (isset($form->vars[$dataKey])):
-        foreach ($form->vars[$dataKey] as $value => $label):
-        if (is_array($label)):
-            echo "<optgroup label=\"$value\">$value</optgroup>\n";
-            foreach ($label as $optionValue => $optionLabel):
-                echo "<option value=\"$optionValue\">$optionLabel</option>\n";
-            endforeach;
-            echo "</optgroup>\n";
-        else:
-            echo "<option value=\"$value\">$label</option>\n";
-        endif;
-        endforeach;
-        endif;
-        ?>
-    </select>
-<?php endforeach; ?>
+    <?php foreach ($templates as $dataKey => $template): ?>
+        <?php $attr = ($dataKey == 'tags') ? ' data-placeholder="' . $view['translator']->trans('mautic.lead.tags.select_or_create') . '" data-no-results-text="' . $view['translator']->trans('mautic.lead.tags.enter_to_create') . '" data-allow-add="true" onchange="Mautic.createLeadTag(this)"' : ''; ?>
+        <select class="form-control not-chosen <?php echo $template; ?>" name="leadlist[filters][__name__][filter]" id="leadlist_filters___name___filter"<?php echo $attr; ?>>
+            <?php
+            if (isset($form->vars[$dataKey])):
+                foreach ($form->vars[$dataKey] as $value => $label):
+                    if (is_array($label)):
+                        echo "<optgroup label=\"$value\">$value</optgroup>\n";
+                        foreach ($label as $optionValue => $optionLabel):
+                            echo "<option value=\"$optionValue\">$optionLabel</option>\n";
+                        endforeach;
+                        echo "</optgroup>\n";
+                    else:
+                        echo "<option value=\"$value\">$label</option>\n";
+                    endif;
+                endforeach;
+            endif;
+            ?>
+        </select>
+    <?php endforeach; ?>
 </div>

--- a/app/bundles/LeadBundle/Views/List/form.html.php
+++ b/app/bundles/LeadBundle/Views/List/form.html.php
@@ -134,6 +134,8 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
                         endforeach;
                         echo "</optgroup>\n";
                     else:
+                        if ($dataKey == 'lists' && (isset($currentListId) && (int) $value === (int) $currentListId))
+                            continue;
                         echo "<option value=\"$value\">$label</option>\n";
                     endif;
                 endforeach;

--- a/app/bundles/LeadBundle/Views/List/form.html.php
+++ b/app/bundles/LeadBundle/Views/List/form.html.php
@@ -76,9 +76,6 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
                     </div>
                     <div class="tab-pane fade bdr-w-0" id="filters">
                         <div class="form-group">
-                            <div class="has-errors">
-                                <?php echo $view['form']->errors($form['filters']); ?>
-                            </div>
                             <div class="available-filters mb-md pl-0 col-md-4" data-prototype="<?php echo $view->escape($view['form']->row($form['filters']->vars['prototype'])); ?>" data-index="<?php echo $index + 1; ?>">
                                 <select class="chosen form-control" id="available_filters">
                                     <option value=""></option>

--- a/app/bundles/LeadBundle/Views/List/form.html.php
+++ b/app/bundles/LeadBundle/Views/List/form.html.php
@@ -64,43 +64,35 @@ $templates = array(
                         <div class="tab-pane fade bdr-w-0" id="filters">
                             <div class="form-group">
                                 <?php echo $view['form']->errors($form['filters']); ?>
-                                <div class="available-filters mb-md" data-prototype="<?php echo $view->escape($view['form']->row($form['filters']->vars['prototype'])); ?>" data-index="<?php echo $index + 1; ?>">
-                                    <div class="dropdown">
-                                        <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
-                                            <?php echo $view['translator']->trans('mautic.lead.list.form.filters.add'); ?>
-                                            <span class="caret"></span>
-                                        </button>
-                                        <ul class="dropdown-menu scrollable-menu" role="menu">
-                                            <?php
-                                            foreach ($fields as $value => $params):
-                                                $list      = (!empty($params['properties']['list'])) ? $params['properties']['list'] : array();
-                                                if (!is_array($list) && strpos($list, '|') !== false):
-                                                    $parts = explode('||', $list);
-                                                    if (count($parts) > 1):
-                                                        $labels = explode('|', $parts[0]);
-                                                        $values = explode('|', $parts[1]);
-                                                        $list = array_combine($values, $labels);
-                                                    else:
-                                                        $list = explode('|', $list);
-                                                        $list = array_combine($list, $list);
-                                                    endif;
+                                <div class="available-filters mb-md pl-0 col-md-4" data-prototype="<?php echo $view->escape($view['form']->row($form['filters']->vars['prototype'])); ?>" data-index="<?php echo $index + 1; ?>">
+                                    <select class="chosen form-control" id="available_filters">
+                                        <option value=""></option>
+                                        <?php
+                                        foreach ($fields as $value => $params):
+                                            $list      = (!empty($params['properties']['list'])) ? $params['properties']['list'] : array();
+                                            if (!is_array($list) && strpos($list, '|') !== false):
+                                                $parts = explode('||', $list);
+                                                if (count($parts) > 1):
+                                                    $labels = explode('|', $parts[0]);
+                                                    $values = explode('|', $parts[1]);
+                                                    $list = array_combine($values, $labels);
+                                                else:
+                                                    $list = explode('|', $list);
+                                                    $list = array_combine($list, $list);
                                                 endif;
-                                                $list      = json_encode($list);
-                                                $callback  = (!empty($params['properties']['callback'])) ? $params['properties']['callback'] : '';
-                                                $operators = (!empty($params['operators'])) ? $view->escape(json_encode($params['operators'])) : '{}';
-                                                ?>
-                                                <li>
-                                                    <a id="available_<?php echo $value; ?>" class="list-group-item" href="javascript:void(0);" onclick="Mautic.addLeadListFilter('<?php echo $value; ?>');" data-field-type="<?php echo $params['properties']['type']; ?>" data-field-list="<?php echo $view->escape($list); ?>" data-field-callback="<?php echo $callback; ?>" data-field-operators="<?php echo $operators; ?>">
-                                                        <span class="leadlist-filter-name"><?php echo $view['translator']->trans($params['label']); ?></span>
-                                                    </a>
-                                                </li>
-                                            <?php endforeach; ?>
-                                        </ul>
-                                    </div>
+                                            endif;
+                                            $list      = json_encode($list);
+                                            $callback  = (!empty($params['properties']['callback'])) ? $params['properties']['callback'] : '';
+                                            $operators = (!empty($params['operators'])) ? $view->escape(json_encode($params['operators'])) : '{}';
+                                            ?>
+                                            <option value="<?php echo $value; ?>" id="available_<?php echo $value; ?>" data-field-type="<?php echo $params['properties']['type']; ?>" data-field-list="<?php echo $view->escape($list); ?>" data-field-callback="<?php echo $callback; ?>" data-field-operators="<?php echo $operators; ?>"><?php echo $view['translator']->trans($params['label']); ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
                                 </div>
-                                <div class="selected-filters" id="leadlist_filters">
-                                    <?php echo $view['form']->widget($form['filters']); ?>
-                                </div>
+                                <div class="clearfix"></div>
+                            </div>
+                            <div class="selected-filters" id="leadlist_filters">
+                                <?php echo $view['form']->widget($form['filters']); ?>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
**Description**

This PR:

1. Converts list filters from a dropdown to a chosen select making it a lot easier to add filters 
2. Adds constraints values for operators other than "empty" or "not empty" to prevent PHP notices and query errors
3. Removed like/not like as operators for select boxes (not applicable without being able to add %)
4. Fixes special selects such as country, region, etc to support include/exclude operators
5. Adds a tags input to the lead quick add form
6. Fixed issue where using "equals no" or "not equals yes" did not work for bounce or unsubscribe status correctly since it's possible that there are no entries to being with for the "no" options.
7. Doing a bulk unsubscribe via the manage leads did not trigger the lead on save event.

**Testing**
Basically create new lead lists and add multiple filters.  Leave some values empty and attempt to save to make sure the new constraints work.