### PR TITLE
Fixed abnormal lead getEntities behavior

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -119,10 +119,10 @@ class LeadRepository extends CommonRepository
         }
 
         $q = $this->_em->getConnection()->createQueryBuilder()
-        ->select('l.id')
-        ->from(MAUTIC_TABLE_PREFIX . 'leads', 'l')
-        ->where("$col = :search")
-        ->setParameter("search", $value);
+            ->select('l.id')
+            ->from(MAUTIC_TABLE_PREFIX . 'leads', 'l')
+            ->where("$col = :search")
+            ->setParameter("search", $value);
 
         if ($ignoreId) {
             $q->andWhere('l.id != :ignoreId')
@@ -143,8 +143,8 @@ class LeadRepository extends CommonRepository
             $q->where(
                 $q->expr()->in('l.id', ':ids')
             )
-            ->setParameter('ids', $ids)
-            ->orderBy('l.dateAdded', 'DESC');
+                ->setParameter('ids', $ids)
+                ->orderBy('l.dateAdded', 'DESC');
             $results = $q->getQuery()->getResult();
 
             /** @var Lead $lead */
@@ -489,18 +489,9 @@ class LeadRepository extends CommonRepository
         //DBAL
         $dq = $this->_em->getConnection()->createQueryBuilder();
         $dq->select('count(l.id) as count')
-            ->from(MAUTIC_TABLE_PREFIX . 'leads', 'l')
-            ->leftJoin('l', MAUTIC_TABLE_PREFIX . 'lead_lists_leads', 'll', 'l.id = ll.lead_id');
+            ->from(MAUTIC_TABLE_PREFIX . 'leads', 'l');
         $this->buildWhereClause($dq, $args);
 
-         // Why is this here?
-        $dq->andWhere(
-            $dq->expr()->orX(
-                $dq->expr()->isNull('ll.manually_removed'),
-                $dq->expr()->eq('ll.manually_removed', ':false')
-            )
-        )
-            ->setParameter('false', false, 'boolean');
         //get a total count
         $result = $dq->execute()->fetchAll();
         $total  = $result[0]['count'];
@@ -516,6 +507,7 @@ class LeadRepository extends CommonRepository
         //loop over results to put fields in something that can be assigned to the entities
         $fieldValues = array();
         $groups      = array('core', 'social', 'personal', 'professional');
+
         foreach ($results as $result) {
             $leadId = $result['id'];
             //unset all the columns that are not fields
@@ -535,6 +527,7 @@ class LeadRepository extends CommonRepository
                 }
             }
         }
+
         unset($results, $fields);
 
         //get an array of IDs for ORM query
@@ -741,12 +734,39 @@ class LeadRepository extends CommonRepository
             case $this->translator->trans('mautic.lead.lead.searchcommand.list'):
                 //obtain the list details
                 $list = $this->_em->getRepository("MauticLeadBundle:LeadList")->findOneByAlias($string);
+
                 if (!empty($list)) {
-                    $expr = $q->expr()->eq('ll.leadlist_id', (int) $list->getId());
+                    $listId = (int) $list->getId();
                 } else {
                     //force a bad expression as the list doesn't exist
-                    $expr = $q->expr()->eq('ll.leadlist_id', 0);
+                    $listId = 0;
                 }
+
+                $sq = $this->_em->getConnection()->createQueryBuilder()
+                    ->select('ll.lead_id')
+                    ->from(MAUTIC_TABLE_PREFIX . 'lead_lists_leads', 'll');
+
+                $sq->where(
+                    $sq->expr()->andX(
+                        $sq->expr()->eq('ll.leadlist_id', $listId),
+                        $sq->expr()->orX(
+                            $sq->expr()->isNull('ll.manually_removed'),
+                            $sq->expr()->eq('ll.manually_removed', ':false')
+                        )
+                    )
+                )
+                    ->setParameter('false', false, 'boolean');
+                $results = $sq->execute()->fetchAll();
+
+                $leadIds = array();
+                foreach ($results as $row) {
+                    $leadIds[] = $row['lead_id'];
+                }
+                if (!count($leadIds)) {
+                    $leadIds[] = 0;
+                }
+                $expr = $q->expr()->in('l.id', $leadIds);
+
                 break;
             case $this->translator->trans('mautic.core.searchcommand.ip'):
                 // search by IP
@@ -842,9 +862,9 @@ class LeadRepository extends CommonRepository
      */
     protected function getDefaultOrder()
     {
-       return array(
-           array('l.last_active', 'DESC')
-       );
+        return array(
+            array('l.last_active', 'DESC')
+        );
     }
 
     /**


### PR DESCRIPTION
**Description**

A bad query was found that resulted in abnormal behavior with lead lists when a lead is in multiple lists.  Leads are a mix of DBAL and ORM due to the use of custom columns on the table (and thus ORM cannot be completely supported due to the inability of Doctrine to map dynamic properties; ugly).  Because of this, there is a query to obtain a list of leads via DBAL then using the IDs from that list, a second query is done to hydrate ORM objects. 

There was a bad query used that resulted in duplicate IDs in the DBAL query that lead to the incorrect number of leads pulled in the ORM query.  A lead was duplicated x the number of lists they belonged to.  Let's say pagination is set to 5 per page.  If a lead belonged to 3 lists, that lead was returned 3 times by the DBAL query.  Then when the ORM query is executed, only 3 results  were returned when it should have been 5.  That's because there were only 3 unique IDs.  

This PR fixes that.  It's possible but not confirmed that this could also be the fix to #938.  If there were inconsistencies with the number of leads returned based on limit and start, leads may have been processed twice by the campaigns and lead lists.  The batch processing of campaigns and lists detach the lead entity from memory after its done could result in the "A new entity was found through the relationship" errors if that entity is used later. This is theory as I haven't tried to reproduce those other errors yet :-)

**Testing**
Add a lead to several lead lists.  Ensure that one of the lists have more than 5 leads in it.  Filter leads by that list then set the pagination to 5 per page.  The number of leads displayed should be less than 5 with multiple pages.  

After the PR, filter by the lead list again and this time, 5 per page should show.  