### PR TITLE
Adds support for transliteration of aliases

### DIFF
--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -35,10 +35,9 @@ class AssetModel extends FormModel
         if (empty($this->inConversion)) {
             $alias = $entity->getAlias();
             if (empty($alias)) {
-                $alias = strtolower(InputHelper::alphanum($entity->getTitle(), false, '-'));
-            } else {
-                $alias = strtolower(InputHelper::alphanum($alias, false, '-'));
+                $alias = $entity->getTitle();
             }
+            $alias = $this->cleanAlias($alias, '', false, '-');
 
             //make sure alias is not already taken
             $repo      = $this->getRepository();

--- a/app/bundles/CategoryBundle/Model/CategoryModel.php
+++ b/app/bundles/CategoryBundle/Model/CategoryModel.php
@@ -10,7 +10,6 @@
 namespace Mautic\CategoryBundle\Model;
 
 use Mautic\CategoryBundle\Event\CategoryEvent;
-use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CategoryBundle\CategoryEvents;
@@ -52,10 +51,9 @@ class CategoryModel extends FormModel
     {
         $alias = $entity->getAlias();
         if (empty($alias)) {
-            $alias = strtolower(InputHelper::alphanum($entity->getTitle(), false, '-'));
-        } else {
-            $alias = strtolower(InputHelper::alphanum($alias, false, '-'));
+            $alias = $entity->getTitle();
         }
+        $alias = $this->cleanAlias($alias, '', false, '-');
 
         //make sure alias is not already taken
         $repo      = $this->getRepository();

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -370,4 +370,16 @@ class InputHelper
 
         return $value;
     }
+
+    /**
+     * Converts UTF8 into Latin
+     *
+     * @param $value
+     *
+     * @return mixed
+     */
+    public static function transliterate($value)
+    {
+        return \URLify::transliterate($value);
+    }
 }

--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -356,15 +356,25 @@ class FormModel extends CommonModel
      * Cleans a string to be used as an alias. The returned string will be alphanumeric or underscore, less than 25 characters
      * and if it is a reserved SQL keyword, it will be prefixed with f_
      *
-     * @param $alias
-     *
+     * @param string   $alias
+     * @param string   $prefix Used when the alias is a reserved keyword by the database platform
+     * @param int|bool $maxLength Maximum number of characters used; 0 to disable
+     * @param string   $spaceCharacter Character to replace spaces with
      * @return string
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function cleanAlias($alias)
+    public function cleanAlias($alias, $prefix = '', $maxLength = false, $spaceCharacter = '_')
     {
+        // Transliterate to latin characters
+        $alias = InputHelper::transliterate(trim($alias));
+
         // Some labels are quite long if a question so cut this short
-        $alias = substr(strtolower(InputHelper::alphanum($alias, false, '_')), 0, 25);
+        $alias = strtolower(InputHelper::alphanum($alias, false, $spaceCharacter));
+
+        // Trim if applicable
+        if ($maxLength) {
+            $alias = substr($alias, 0, $maxLength);
+        }
 
         if (substr($alias, -1) == '_') {
             $alias = substr($alias, 0, -1);
@@ -375,7 +385,7 @@ class FormModel extends CommonModel
         $reservedWords = $databasePlatform->getReservedKeywordsList();
 
         if ($reservedWords->isKeyword($alias) || is_numeric($alias)) {
-            $alias = 'f_' . $alias;
+            $alias = $prefix . $alias;
         }
 
         return $alias;

--- a/app/bundles/FormBundle/Model/FieldModel.php
+++ b/app/bundles/FormBundle/Model/FieldModel.php
@@ -72,7 +72,7 @@ class FieldModel extends CommonFormModel
      */
     public function generateAlias($label, &$aliases)
     {
-        $alias = $this->cleanAlias($label);
+        $alias = $this->cleanAlias($label, 'f_', 25);
 
         //make sure alias is not already taken
         $testAlias = $alias;

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -229,7 +229,7 @@ class FormModel extends CommonFormModel
         $isNew = ($entity->getId()) ? false : true;
 
         if ($isNew) {
-            $alias = substr(strtolower(InputHelper::alphanum($entity->getName())), 0, 10);
+            $alias = $this->cleanAlias($entity->getName(), '', 10);
             $entity->setAlias($alias);
         }
 
@@ -443,10 +443,10 @@ class FormModel extends CommonFormModel
      * @param $form
      * @param $formHtml
      */
-    public function populateValuesWithGetParameters($form, &$formHtml)
+    public function populateValuesWithGetParameters(Form $form, &$formHtml)
     {
-        $request = $this->factory->getRequest();
-        $formName = strtolower(\Mautic\CoreBundle\Helper\InputHelper::alphanum($form->getName()));
+        $request  = $this->factory->getRequest();
+        $formName = $form->getAlias();
 
         $fields = $form->getFields();
         foreach ($fields as $f) {

--- a/app/bundles/FormBundle/Views/Builder/form.html.php
+++ b/app/bundles/FormBundle/Views/Builder/form.html.php
@@ -6,6 +6,7 @@
  * @link        http://mautic.org
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
+use \Mautic\CoreBundle\Helper\InputHelper;
 
 $formName = '_' . strtolower(
     InputHelper::alphanum(

--- a/app/bundles/FormBundle/Views/Builder/form.html.php
+++ b/app/bundles/FormBundle/Views/Builder/form.html.php
@@ -7,7 +7,13 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-$formName = '_' . strtolower(\Mautic\CoreBundle\Helper\InputHelper::alphanum($form->getName()));
+$formName = '_' . strtolower(
+    InputHelper::alphanum(
+        InputHelper::transliterate(
+            $form->getName()
+        )
+    )
+);
 $fields   = $form->getFields();
 $required = array();
 ?>

--- a/app/bundles/FormBundle/Views/Builder/form.html.php
+++ b/app/bundles/FormBundle/Views/Builder/form.html.php
@@ -6,8 +6,15 @@
  * @link        http://mautic.org
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
+use \Mautic\CoreBundle\Helper\InputHelper;
 
-$formName = strtolower(\Mautic\CoreBundle\Helper\InputHelper::alphanum($form->getName()));
+$formName = strtolower(
+    InputHelper::alphanum(
+        InputHelper::transliterate(
+            $form->getName()
+        )
+    )
+);
 $fields   = $form->getFields();
 $required = array();
 ?>

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -93,11 +93,11 @@ class FieldModel extends FormModel
 
         if ($isNew) {
             if (empty($alias)) {
-                $alias = strtolower(InputHelper::alphanum($entity->getName()));
+                $alias = $entity->getName();
             }
 
             // clean the alias
-            $alias = $this->cleanAlias($alias);
+            $alias = $this->cleanAlias($alias, 'f_', 25);
 
             // make sure alias is not already taken
             $repo      = $this->getRepository();

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -103,10 +103,9 @@ class ListModel extends FormModel
 
         $alias = $entity->getAlias();
         if (empty($alias)) {
-            $alias = strtolower(InputHelper::alphanum($entity->getName(), false, '-'));
-        } else {
-            $alias = strtolower(InputHelper::alphanum($alias, false, '-'));
+            $alias = $entity->getName();
         }
+        $alias = $this->cleanAlias($alias, '', false, '-');
 
         //make sure alias is not already taken
         $repo      = $this->getRepository();

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -76,10 +76,9 @@ class PageModel extends FormModel
         if (empty($this->inConversion)) {
             $alias = $entity->getAlias();
             if (empty($alias)) {
-                $alias = strtolower(InputHelper::alphanum($entity->getTitle(), false, '-'));
-            } else {
-                $alias = strtolower(InputHelper::alphanum($alias, false, '-'));
+                $alias = $entity->getTitle();
             }
+            $alias = $this->cleanAlias($alias, '', false, '-');
 
             //make sure alias is not already taken
             $repo      = $this->getRepository();

--- a/build/processfiles.php
+++ b/build/processfiles.php
@@ -507,6 +507,16 @@ system('rm vendor/webfactory/exceptions-bundle/phpunit.xml.dist');
 system('rm vendor/webfactory/exceptions-bundle/README.md');
 system('rm vendor/webfactory/exceptions-bundle/UPGRADING.md');
 
+// jbroadway/urlify
+system('rm -rf vendor/jbroadway/urlify/tests');
+system('rm vendor/jbroadway/urlify/.gitignore');
+system('rm vendor/jbroadway/urlify/.travis.yml');
+system('rm vendor/jbroadway/urlify/composer.json');
+system('rm vendor/jbroadway/urlify/INSTALL');
+system('rm vendor/jbroadway/urlify/LICENSE');
+system('rm vendor/jbroadway/urlify/phpunit.xml');
+system('rm vendor/jbroadway/urlify/README.md');
+
 // Find any .git directories and nuke them
 system('find . -type d -name .git -exec rm -rf {} \\;');
 

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,8 @@
         "phpoffice/phpexcel": "1.8.0",
         "joomla/http": "~1.1",
         "joomla/filter": "~1.1",
-        "mrclay/minify": "2.2.0"
+        "mrclay/minify": "2.2.0",
+        "jbroadway/urlify": "^1.0"
     },
     "require-dev": {
         "symfony/twig-bundle": "2.5.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "48ef35a464de5399c31ddf014992f383",
+    "hash": "0fc2d12807f7d94b91d89968547ccba4",
+    "content-hash": "607c6aa015b6c9804ffa0546f036c94e",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -881,7 +882,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/4e85ba638acf62e1afe735f94b0c51aa971f8773",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/d196ddc229f50c66c5a015c158adb78a2dfb4351",
                 "reference": "65978aa4e9ffca3bb632225ad8c6320077d80d85",
                 "shasum": ""
             },
@@ -1341,6 +1342,60 @@
             "time": "2014-11-20 16:49:30"
         },
         {
+            "name": "jbroadway/urlify",
+            "version": "1.0.5-stable",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jbroadway/urlify.git",
+                "reference": "b5f13d860d9da34e4adece6a93e46e0292ab6aa7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jbroadway/urlify/zipball/b5f13d860d9da34e4adece6a93e46e0292ab6aa7",
+                "reference": "b5f13d860d9da34e4adece6a93e46e0292ab6aa7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "URLify": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "authors": [
+                {
+                    "name": "Johnny Broadway",
+                    "email": "johnny@johnnybroadway.com",
+                    "homepage": "http://www.johnnybroadway.com/"
+                }
+            ],
+            "description": "PHP port of URLify.js from the Django project. Transliterates non-ascii characters for use in URLs.",
+            "homepage": "https://github.com/jbroadway/urlify",
+            "keywords": [
+                "encode",
+                "iconv",
+                "link",
+                "slug",
+                "translit",
+                "transliterate",
+                "transliteration",
+                "url",
+                "urlify"
+            ],
+            "time": "2015-05-29 13:53:37"
+        },
+        {
             "name": "jdorn/sql-formatter",
             "version": "v1.2.17",
             "source": {
@@ -1766,7 +1821,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/Gaufrette/zipball/9d52413665284f9c96e0cef399fc14e68ac0aa5a",
+                "url": "https://api.github.com/repos/KnpLabs/Gaufrette/zipball/434dddb4319bde3ebb3421b77f321440bada8e42",
                 "reference": "4c73bb66ff41d7c9beb57372a82047cf5dcc6d1c",
                 "shasum": ""
             },
@@ -1850,7 +1905,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/KnpMenu/zipball/620a9e4b53a940cee370e51cd4e3457a819af815",
+                "url": "https://api.github.com/repos/KnpLabs/KnpMenu/zipball/c6ad49933babd06a27b2f962a3469601ec9038b8",
                 "reference": "c40075bea26f63dd5b81ca5b3cdd2b54d38e811f",
                 "shasum": ""
             },
@@ -1914,7 +1969,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/KnpMenuBundle/zipball/ec727eee47b7365e8a82d8b8cefe8096e6cd2590",
+                "url": "https://api.github.com/repos/KnpLabs/KnpMenuBundle/zipball/f8c6b24a846e3713899f02e72604a78d80bb1b37",
                 "reference": "2a2e1295c8f39f39875343934af159957bcdcc06",
                 "shasum": ""
             },
@@ -2502,12 +2557,12 @@
             "target-dir": "Symfony/Component/ClassLoader",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/ClassLoader.git",
+                "url": "https://github.com/symfony/class-loader.git",
                 "reference": "c5311911ee5bf1c4bfcd8b5788037e7534e4e17d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/ClassLoader/zipball/c5311911ee5bf1c4bfcd8b5788037e7534e4e17d",
+                "url": "https://api.github.com/repos/symfony/class-loader/zipball/c5311911ee5bf1c4bfcd8b5788037e7534e4e17d",
                 "reference": "c5311911ee5bf1c4bfcd8b5788037e7534e4e17d",
                 "shasum": ""
             },
@@ -2553,12 +2608,12 @@
             "target-dir": "Symfony/Component/Config",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Config.git",
+                "url": "https://github.com/symfony/config.git",
                 "reference": "b5063937fab6fdfb7bacc00bc8c0cd7ee0c50070"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/b5063937fab6fdfb7bacc00bc8c0cd7ee0c50070",
+                "url": "https://api.github.com/repos/symfony/config/zipball/b5063937fab6fdfb7bacc00bc8c0cd7ee0c50070",
                 "reference": "b5063937fab6fdfb7bacc00bc8c0cd7ee0c50070",
                 "shasum": ""
             },
@@ -2604,12 +2659,12 @@
             "target-dir": "Symfony/Component/Console",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Console.git",
+                "url": "https://github.com/symfony/console.git",
                 "reference": "0e5e18ae09d3f5c06367759be940e9ed3f568359"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/0e5e18ae09d3f5c06367759be940e9ed3f568359",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0e5e18ae09d3f5c06367759be940e9ed3f568359",
                 "reference": "0e5e18ae09d3f5c06367759be940e9ed3f568359",
                 "shasum": ""
             },
@@ -2662,12 +2717,12 @@
             "target-dir": "Symfony/Component/Debug",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Debug.git",
+                "url": "https://github.com/symfony/debug.git",
                 "reference": "fca5696e0c9787722baa8f2ad6940dfd7a6a6941"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Debug/zipball/fca5696e0c9787722baa8f2ad6940dfd7a6a6941",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/fca5696e0c9787722baa8f2ad6940dfd7a6a6941",
                 "reference": "fca5696e0c9787722baa8f2ad6940dfd7a6a6941",
                 "shasum": ""
             },
@@ -2723,12 +2778,12 @@
             "target-dir": "Symfony/Component/DependencyInjection",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/DependencyInjection.git",
+                "url": "https://github.com/symfony/dependency-injection.git",
                 "reference": "d9fe6837d74aed11e5ee741cd6b6dfe45e0af78e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/d9fe6837d74aed11e5ee741cd6b6dfe45e0af78e",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/d9fe6837d74aed11e5ee741cd6b6dfe45e0af78e",
                 "reference": "d9fe6837d74aed11e5ee741cd6b6dfe45e0af78e",
                 "shasum": ""
             },
@@ -2784,12 +2839,12 @@
             "target-dir": "Symfony/Bridge/Doctrine",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/DoctrineBridge.git",
+                "url": "https://github.com/symfony/doctrine-bridge.git",
                 "reference": "d6a2d571b8521ec5036fa77b815c864e16b99752"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/DoctrineBridge/zipball/d6a2d571b8521ec5036fa77b815c864e16b99752",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/d6a2d571b8521ec5036fa77b815c864e16b99752",
                 "reference": "d6a2d571b8521ec5036fa77b815c864e16b99752",
                 "shasum": ""
             },
@@ -2853,12 +2908,12 @@
             "target-dir": "Symfony/Component/EventDispatcher",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/EventDispatcher.git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
                 "reference": "672593bc4b0043a0acf91903bb75a1c82d8f2e02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/672593bc4b0043a0acf91903bb75a1c82d8f2e02",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/672593bc4b0043a0acf91903bb75a1c82d8f2e02",
                 "reference": "672593bc4b0043a0acf91903bb75a1c82d8f2e02",
                 "shasum": ""
             },
@@ -2912,12 +2967,12 @@
             "target-dir": "Symfony/Component/Filesystem",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Filesystem.git",
+                "url": "https://github.com/symfony/filesystem.git",
                 "reference": "fdc5f151bc2db066b51870d5bea3773d915ced0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/fdc5f151bc2db066b51870d5bea3773d915ced0b",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/fdc5f151bc2db066b51870d5bea3773d915ced0b",
                 "reference": "fdc5f151bc2db066b51870d5bea3773d915ced0b",
                 "shasum": ""
             },
@@ -2962,12 +3017,12 @@
             "target-dir": "Symfony/Component/Finder",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Finder.git",
+                "url": "https://github.com/symfony/finder.git",
                 "reference": "a2d5caa65c513e4acc5a849d91b24d5d2ed2a584"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Finder/zipball/a2d5caa65c513e4acc5a849d91b24d5d2ed2a584",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/a2d5caa65c513e4acc5a849d91b24d5d2ed2a584",
                 "reference": "a2d5caa65c513e4acc5a849d91b24d5d2ed2a584",
                 "shasum": ""
             },
@@ -3078,12 +3133,12 @@
             "target-dir": "Symfony/Bundle/FrameworkBundle",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/FrameworkBundle.git",
+                "url": "https://github.com/symfony/framework-bundle.git",
                 "reference": "e5f241acd9b89840552461a492dafd8708cf2f39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/FrameworkBundle/zipball/e5f241acd9b89840552461a492dafd8708cf2f39",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/e5f241acd9b89840552461a492dafd8708cf2f39",
                 "reference": "e5f241acd9b89840552461a492dafd8708cf2f39",
                 "shasum": ""
             },
@@ -3161,12 +3216,12 @@
             "target-dir": "Symfony/Component/HttpFoundation",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/HttpFoundation.git",
+                "url": "https://github.com/symfony/http-foundation.git",
                 "reference": "e8fd1b73ac1c3de1f76c73801ddf1a8ecb1c1c9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/HttpFoundation/zipball/e8fd1b73ac1c3de1f76c73801ddf1a8ecb1c1c9c",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/e8fd1b73ac1c3de1f76c73801ddf1a8ecb1c1c9c",
                 "reference": "e8fd1b73ac1c3de1f76c73801ddf1a8ecb1c1c9c",
                 "shasum": ""
             },
@@ -3215,12 +3270,12 @@
             "target-dir": "Symfony/Component/HttpKernel",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/HttpKernel.git",
+                "url": "https://github.com/symfony/http-kernel.git",
                 "reference": "a3f0ed713255c0400a2db38b3ed01989ef4b7322"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/HttpKernel/zipball/a3f0ed713255c0400a2db38b3ed01989ef4b7322",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/a3f0ed713255c0400a2db38b3ed01989ef4b7322",
                 "reference": "a3f0ed713255c0400a2db38b3ed01989ef4b7322",
                 "shasum": ""
             },
@@ -3293,12 +3348,12 @@
             "target-dir": "Symfony/Component/Intl",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Intl.git",
+                "url": "https://github.com/symfony/intl.git",
                 "reference": "4e2720da07bb0731064aaaa7ad854e5b23908ce6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Intl/zipball/4e2720da07bb0731064aaaa7ad854e5b23908ce6",
+                "url": "https://api.github.com/repos/symfony/intl/zipball/4e2720da07bb0731064aaaa7ad854e5b23908ce6",
                 "reference": "4e2720da07bb0731064aaaa7ad854e5b23908ce6",
                 "shasum": ""
             },
@@ -3369,12 +3424,12 @@
             "target-dir": "Symfony/Bridge/Monolog",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/MonologBridge.git",
+                "url": "https://github.com/symfony/monolog-bridge.git",
                 "reference": "e6fab2da01f1eec137a837cb77a461cc382bae50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/MonologBridge/zipball/e6fab2da01f1eec137a837cb77a461cc382bae50",
+                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/e6fab2da01f1eec137a837cb77a461cc382bae50",
                 "reference": "e6fab2da01f1eec137a837cb77a461cc382bae50",
                 "shasum": ""
             },
@@ -3426,12 +3481,12 @@
             "version": "v2.7.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/MonologBundle.git",
+                "url": "https://github.com/symfony/monolog-bundle.git",
                 "reference": "9320b6863404c70ebe111e9040dab96f251de7ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/MonologBundle/zipball/9320b6863404c70ebe111e9040dab96f251de7ac",
+                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/9320b6863404c70ebe111e9040dab96f251de7ac",
                 "reference": "9320b6863404c70ebe111e9040dab96f251de7ac",
                 "shasum": ""
             },
@@ -3486,12 +3541,12 @@
             "target-dir": "Symfony/Component/OptionsResolver",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/OptionsResolver.git",
+                "url": "https://github.com/symfony/options-resolver.git",
                 "reference": "31e56594cee489e9a235b852228b0598b52101c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/OptionsResolver/zipball/31e56594cee489e9a235b852228b0598b52101c1",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/31e56594cee489e9a235b852228b0598b52101c1",
                 "reference": "31e56594cee489e9a235b852228b0598b52101c1",
                 "shasum": ""
             },
@@ -3591,12 +3646,12 @@
             "target-dir": "Symfony/Component/PropertyAccess",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/PropertyAccess.git",
+                "url": "https://github.com/symfony/property-access.git",
                 "reference": "0ce73304d8acd87ab3a75155c889f9cc8ac9d28d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/PropertyAccess/zipball/0ce73304d8acd87ab3a75155c889f9cc8ac9d28d",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/0ce73304d8acd87ab3a75155c889f9cc8ac9d28d",
                 "reference": "0ce73304d8acd87ab3a75155c889f9cc8ac9d28d",
                 "shasum": ""
             },
@@ -3798,12 +3853,12 @@
             "target-dir": "Symfony/Bundle/SecurityBundle",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/SecurityBundle.git",
+                "url": "https://github.com/symfony/security-bundle.git",
                 "reference": "6adb8e508e9ed21abaa6b01184beef91ece8c8ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/SecurityBundle/zipball/6adb8e508e9ed21abaa6b01184beef91ece8c8ba",
+                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/6adb8e508e9ed21abaa6b01184beef91ece8c8ba",
                 "reference": "6adb8e508e9ed21abaa6b01184beef91ece8c8ba",
                 "shasum": ""
             },
@@ -3916,12 +3971,12 @@
             "target-dir": "Symfony/Bridge/Swiftmailer",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/SwiftmailerBridge.git",
+                "url": "https://github.com/symfony/swiftmailer-bridge.git",
                 "reference": "c05a143d5a3bc0b16ee4b1c6f6260b6f4a70d13a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/SwiftmailerBridge/zipball/c05a143d5a3bc0b16ee4b1c6f6260b6f4a70d13a",
+                "url": "https://api.github.com/repos/symfony/swiftmailer-bridge/zipball/c05a143d5a3bc0b16ee4b1c6f6260b6f4a70d13a",
                 "reference": "c05a143d5a3bc0b16ee4b1c6f6260b6f4a70d13a",
                 "shasum": ""
             },
@@ -3969,12 +4024,12 @@
             "version": "v2.3.8",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/SwiftmailerBundle.git",
+                "url": "https://github.com/symfony/swiftmailer-bundle.git",
                 "reference": "970b13d01871207e81d17b17ddda025e7e21e797"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/SwiftmailerBundle/zipball/970b13d01871207e81d17b17ddda025e7e21e797",
+                "url": "https://api.github.com/repos/symfony/swiftmailer-bundle/zipball/970b13d01871207e81d17b17ddda025e7e21e797",
                 "reference": "970b13d01871207e81d17b17ddda025e7e21e797",
                 "shasum": ""
             },
@@ -4460,7 +4515,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liip/LiipFunctionalTestBundle/zipball/e53b4b8b57b637e8243c17ace55b96a9441e25f2",
+                "url": "https://api.github.com/repos/liip/LiipFunctionalTestBundle/zipball/4d9114d49796b23b599d4b7cb63f8d8a918a6d44",
                 "reference": "933cde549faae84d4e5ad2f59480f6de86deaaf0",
                 "shasum": ""
             },
@@ -4561,12 +4616,12 @@
             "target-dir": "Symfony/Component/BrowserKit",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/BrowserKit.git",
+                "url": "https://github.com/symfony/browser-kit.git",
                 "reference": "329bdc10bff1e365abb8a3388d60a65630daf705"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/BrowserKit/zipball/329bdc10bff1e365abb8a3388d60a65630daf705",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/329bdc10bff1e365abb8a3388d60a65630daf705",
                 "reference": "329bdc10bff1e365abb8a3388d60a65630daf705",
                 "shasum": ""
             },
@@ -4617,12 +4672,12 @@
             "target-dir": "Symfony/Component/DomCrawler",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/DomCrawler.git",
+                "url": "https://github.com/symfony/dom-crawler.git",
                 "reference": "896d1fb78832e8c4a4e4e8565ffdf668a53e518f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/DomCrawler/zipball/896d1fb78832e8c4a4e4e8565ffdf668a53e518f",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/896d1fb78832e8c4a4e4e8565ffdf668a53e518f",
                 "reference": "896d1fb78832e8c4a4e4e8565ffdf668a53e518f",
                 "shasum": ""
             },
@@ -4671,12 +4726,12 @@
             "target-dir": "Symfony/Bridge/Twig",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/TwigBridge.git",
+                "url": "https://github.com/symfony/twig-bridge.git",
                 "reference": "4315490bf54152a587f785a428d3afcf0e98a7ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/TwigBridge/zipball/4315490bf54152a587f785a428d3afcf0e98a7ec",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/4315490bf54152a587f785a428d3afcf0e98a7ec",
                 "reference": "4315490bf54152a587f785a428d3afcf0e98a7ec",
                 "shasum": ""
             },
@@ -4748,12 +4803,12 @@
             "target-dir": "Symfony/Bundle/TwigBundle",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/TwigBundle.git",
+                "url": "https://github.com/symfony/twig-bundle.git",
                 "reference": "9f8fd54367a8a7729affa38be7a1d5d070def6ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/TwigBundle/zipball/9f8fd54367a8a7729affa38be7a1d5d070def6ce",
+                "url": "https://api.github.com/repos/symfony/twig-bundle/zipball/9f8fd54367a8a7729affa38be7a1d5d070def6ce",
                 "reference": "9f8fd54367a8a7729affa38be7a1d5d070def6ce",
                 "shasum": ""
             },
@@ -4807,12 +4862,12 @@
             "target-dir": "Symfony/Bundle/WebProfilerBundle",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/WebProfilerBundle.git",
+                "url": "https://github.com/symfony/web-profiler-bundle.git",
                 "reference": "cc2c3c38c26f69b25c0ce8ca8ba2ebf8e231a210"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/WebProfilerBundle/zipball/cc2c3c38c26f69b25c0ce8ca8ba2ebf8e231a210",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/cc2c3c38c26f69b25c0ce8ca8ba2ebf8e231a210",
                 "reference": "cc2c3c38c26f69b25c0ce8ca8ba2ebf8e231a210",
                 "shasum": ""
             },


### PR DESCRIPTION
**Description**
When creating new forms or new lead fields, the use of cyrillic languages would cause creating the tables or columns in the database to fail at worse, at best cause a random f_string column to be generated.  This PR adds transliteration support for the aliases to ensure they will not cause schema change issues.

**Testing**

Before the PR create a form and use a cyrillic label such as Цель проекта for the form label and create a new field with the same then save. Look at the results table for the form and it should have a name like `form_results_1_` and the column name for the field will be something like `f_56174e763d08f` because the cyrillic letters were all wiped out leaving an empty alias.  Looking at the forms table will also note an empty value for alias.

After the PR, the cyrillic letters should be converted into latin equivalents so that they are better supported across the board. 