### PR TITLE
Prevented detaching lead lists after being used that lead to "new entity found" exceptions with batch edits

### DIFF
--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -779,12 +779,6 @@ class ListModel extends FormModel
 
         if (!empty($persistLists)) {
             $this->getRepository()->saveEntities($persistLists);
-
-            // Detach the entities to save memory
-            foreach ($persistLists as $listEntity) {
-                $this->em->detach($listEntity);
-                unset($listEntity);
-            }
         }
 
         if ($batchProcess) {
@@ -904,12 +898,6 @@ class ListModel extends FormModel
 
         if (!empty($persistLists)) {
             $this->getRepository()->saveEntities($persistLists);
-
-            // Detach the entities to save memory
-            foreach ($persistLists as $listEntity) {
-                $this->em->detach($listEntity);
-                unset($listEntity);
-            }
         }
 
         if (!empty($deleteLists)) {


### PR DESCRIPTION
**Descriptions**

When using the batch feature to manipulate lead's lists (via Manage Leads), often a ```A new entity was found through the relationship 'Mautic\LeadBundle\Entity\LeadList#leads' that was not configured to cascade persist operations for entity: Mautic\LeadBundle\Entity\ListLead``` error occurred.  I think this has been traced down to a couple lines of code that detached the LeadList entity from Doctrine after being used which lead to the above error when the second lead was processed.

**Testing**

Go to Manage Leads and select multiple leads.  Click on the batch list edit button and add the lead to several lists and also remove them from a list they already belong to.  It might take a few tries but the error above should be encountered.  After the PR, that error should go away.  