### PR TITLE
Dispatch the LEAD_LIST_CHANGE event after entities have been persisted

### DIFF
--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -721,7 +721,8 @@ class ListModel extends FormModel
             $lists = array($lists);
         }
 
-        $persistLists = $dispatchEvents = array();
+        $persistLists   = array();
+        $dispatchEvents = array();
 
         foreach ($lists as $listId) {
             if (!isset($this->leadChangeLists[$listId])) {
@@ -857,7 +858,10 @@ class ListModel extends FormModel
             $lists = array($lists);
         }
 
-        $persistLists = $deleteLists = $dispatchEvents = array();
+        $persistLists   = array();
+        $deleteLists    = array();
+        $dispatchEvents = array();
+
         foreach ($lists as $listId) {
             if (!isset($this->leadChangeLists[$listId])) {
                 // List no longer exists in the DB so continue to the next

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -721,10 +721,10 @@ class ListModel extends FormModel
             $lists = array($lists);
         }
 
-        $persistLists = array();
+        $persistLists = $dispatchEvents = array();
 
-        foreach ($lists as $listid) {
-            if (!isset($this->leadChangeLists[$listid])) {
+        foreach ($lists as $listId) {
+            if (!isset($this->leadChangeLists[$listId])) {
                 // List no longer exists in the DB so continue to the next
                 continue;
             }
@@ -735,14 +735,14 @@ class ListModel extends FormModel
                 $listLead = $this->getListLeadRepository()->findOneBy(
                     array(
                         'lead' => $lead,
-                        'list' => $this->leadChangeLists[$listid]
+                        'list' => $this->leadChangeLists[$listId]
                     )
                 );
             } else {
                 $listLead = $this->em->getReference('MauticLeadBundle:ListLead',
                     array(
                         'lead' => $leadId,
-                        'list' => $listid
+                        'list' => $listId
                     )
                 );
             }
@@ -752,7 +752,8 @@ class ListModel extends FormModel
                     $listLead->setManuallyRemoved(false);
                     $listLead->setManuallyAdded($manuallyAdded);
 
-                    $persistLists[] = $listLead;
+                    $persistLists[]   = $listLead;
+                    $dispatchEvents[] = $listId;
                 } else {
                     // Detach from Doctrine
                     $this->em->detach($listLead);
@@ -761,19 +762,13 @@ class ListModel extends FormModel
                 }
             } else {
                 $listLead = new ListLead();
-                $listLead->setList($this->leadChangeLists[$listid]);
+                $listLead->setList($this->leadChangeLists[$listId]);
                 $listLead->setLead($lead);
                 $listLead->setManuallyAdded($manuallyAdded);
                 $listLead->setDateAdded($dateManipulated);
 
-                $persistLists[] = $listLead;
-            }
-
-            if (!$batchProcess && $this->dispatcher->hasListeners(LeadEvents::LEAD_LIST_CHANGE)) {
-                $event = new ListChangeEvent($lead, $this->leadChangeLists[$listid], true);
-                $this->dispatcher->dispatch(LeadEvents::LEAD_LIST_CHANGE, $event);
-
-                unset($event);
+                $persistLists[]   = $listLead;
+                $dispatchEvents[] = $listId;
             }
         }
 
@@ -790,6 +785,13 @@ class ListModel extends FormModel
         if ($batchProcess) {
             // Detach for batch processing to preserve memory
             $this->em->detach($lead);
+        } elseif (!empty($dispatchEvents) && ($this->dispatcher->hasListeners(LeadEvents::LEAD_LIST_CHANGE))) {
+            foreach ($dispatchEvents as $listId) {
+                $event = new ListChangeEvent($lead, $this->leadChangeLists[$listId]);
+                $this->dispatcher->dispatch(LeadEvents::LEAD_LIST_CHANGE, $event);
+
+                unset($event);
+            }
         }
 
         unset($lead, $persistLists, $lists);
@@ -855,23 +857,21 @@ class ListModel extends FormModel
             $lists = array($lists);
         }
 
-        $persistLists = $deleteLists = array();
-        foreach ($lists as $listid) {
-            if (!isset($this->leadChangeLists[$listid])) {
+        $persistLists = $deleteLists = $dispatchEvents = array();
+        foreach ($lists as $listId) {
+            if (!isset($this->leadChangeLists[$listId])) {
                 // List no longer exists in the DB so continue to the next
                 continue;
             }
 
-            $dispatchEvent = false;
-
             $listLead = (!$skipFindOne) ?
                 $this->getListLeadRepository()->findOneBy(array(
                     'lead' => $lead,
-                    'list' => $this->leadChangeLists[$listid]
+                    'list' => $this->leadChangeLists[$listId]
                 )) :
                 $this->em->getReference('MauticLeadBundle:ListLead', array(
                     'lead' => $leadId,
-                    'list' => $listid
+                    'list' => $listId
                 ));
 
             if ($listLead == null) {
@@ -881,25 +881,16 @@ class ListModel extends FormModel
 
             if (($manuallyRemoved && $listLead->wasManuallyAdded()) || (!$manuallyRemoved && !$listLead->wasManuallyAdded())) {
                 //lead was manually added and now manually removed or was not manually added and now being removed
-                $dispatchEvent = true;
-
-                $deleteLists[] = $listLead;
+                $deleteLists[]    = $listLead;
+                $dispatchEvents[] = $listId;
             } elseif ($manuallyRemoved && !$listLead->wasManuallyAdded()) {
-                $dispatchEvent = true;
-
                 $listLead->setManuallyRemoved(true);
 
-                $persistLists[] = $listLead;
+                $persistLists[]   = $listLead;
+                $dispatchEvents[] = $listId;
             }
 
             unset($listLead);
-
-            if (!$batchProcess && $dispatchEvent && $this->dispatcher->hasListeners(LeadEvents::LEAD_LIST_CHANGE)) {
-                $event = new ListChangeEvent($lead, $this->leadChangeLists[$listid], false);
-                $this->dispatcher->dispatch(LeadEvents::LEAD_LIST_CHANGE, $event);
-
-                unset($event);
-            }
         }
 
         if (!empty($persistLists)) {
@@ -919,6 +910,13 @@ class ListModel extends FormModel
         if ($batchProcess) {
             // Detach for batch processing to preserve memory
             $this->em->detach($lead);
+        } elseif (!empty($dispatchEvents) && ($this->dispatcher->hasListeners(LeadEvents::LEAD_LIST_CHANGE))) {
+            foreach ($dispatchEvents as $listId) {
+                $event = new ListChangeEvent($lead, $this->leadChangeLists[$listId], false);
+                $this->dispatcher->dispatch(LeadEvents::LEAD_LIST_CHANGE, $event);
+
+                unset($event);
+            }
         }
 
         unset($lead, $deleteLists, $persistLists, $lists);


### PR DESCRIPTION
**Description**
For listeners that happen to query the database for list membership would fail since the modified entities were not persisted until after the event was dispatched.  This PR moves the event dispatching to after the entities are persisted to the database.   

**Testing**
Mainly to ensure that campaign listener is still working.  Create a list and associate it with a campaign.  Add a lead to the list and make sure the lead is also added to the campaign.