### PR TITLE
Fixed error if field attribute contains "class" keyword

### DIFF
--- a/app/bundles/FormBundle/Views/Field/field_helper.php
+++ b/app/bundles/FormBundle/Views/Field/field_helper.php
@@ -50,7 +50,7 @@ if (!empty($inForm)) {
     if ($field['labelAttributes'])
         $labelAttr .= ' '.htmlspecialchars_decode($field['labelAttributes']);
 
-    if (stripos($labelAttr, 'class') === false) {
+    if (stripos($labelAttr, 'class=') === false) {
         $labelAttr .= ' class="'.$defaultLabelClass.'"';
     } else {
         $labelAttr = str_ireplace('class="', 'class="'.$defaultLabelClass.' ', $labelAttr);
@@ -59,7 +59,7 @@ if (!empty($inForm)) {
     if ($field['inputAttributes'])
         $inputAttr .= ' '.htmlspecialchars_decode($field['inputAttributes']);
 
-    if (stripos($inputAttr, 'class') === false) {
+    if (stripos($inputAttr, 'class=') === false) {
         $inputAttr .= ' class="'.$defaultInputClass.'"';
     } else {
         $inputAttr = str_ireplace('class="', 'class="'.$defaultInputClass.' ', $inputAttr);
@@ -86,7 +86,7 @@ if (!empty($deleted)) {
     $defaultContainerClass .= ' bg-danger';
 }
 
-if (stripos($containerAttr, 'class') === false) {
+if (stripos($containerAttr, 'class=') === false) {
     $containerAttr .= ' class="'.$defaultContainerClass.'"';
 } else {
     $containerAttr = str_ireplace('class="', 'class="'.$defaultContainerClass.' ', $containerAttr);


### PR DESCRIPTION
When a form field container or input attribute contains the "class" keyword in the attribute name, it disable the edit button.

Reported in https://www.mautic.org/community/index.php//915-form-no-longer-editable-after-adding-field-attributes-to-fields/0

### Testing
1. Add a field container and/or input attribute called for example `class-inline-1`.
2. Apply the change.

It will not allow you to edit the field again. Apply this PR and it should get back to normal.