### PR TITLE
Fixed installer error that prevented being able to select email queue handling

### DIFF
--- a/app/bundles/InstallBundle/Configurator/Form/EmailStepType.php
+++ b/app/bundles/InstallBundle/Configurator/Form/EmailStepType.php
@@ -161,11 +161,7 @@ class EmailStepType extends AbstractType
             ),
             'label'       => 'mautic.install.form.email.spool_type',
             'expanded'    => true,
-            'empty_value' => false,
-            'attr'        => array(
-                'onchange' => 'MauticInstaller.toggleSpoolQueue();',
-                'tooltip'  => 'mautic.core.config.form.mailer.spool.type.tooltip'
-            )
+            'empty_value' => false
         ));
 
         $builder->add('mailer_spool_path', 'hidden');


### PR DESCRIPTION
**Description**

Fixes #927.  

**Testing**

Go through the installer and on step 3, try to select Queue.  It should fail with the noted error.  After the PR, selecting Queue should be possible without encountering the JS error.