### PR TITLE
Fixes "A new entity was found through the relationship 'Mautic\AssetBundle\Entity\Download#lead'"

### DIFF
--- a/app/bundles/AssetBundle/Entity/AssetRepository.php
+++ b/app/bundles/AssetBundle/Entity/AssetRepository.php
@@ -252,7 +252,7 @@ class AssetRepository extends CommonRepository
             ->where('id = ' . (int) $id);
 
         if ($unique) {
-            $q->set('unique_download_count', 'unique_download_count + ' + (int) $increaseBy);
+            $q->set('unique_download_count', 'unique_download_count + ' . (int) $increaseBy);
         }
 
         $q->execute();

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1407,7 +1407,7 @@ class MailHelper
                     );
                 }
 
-                $assetModel->upDownloadCount($asset, count($this->assetStats));
+                $assetModel->upDownloadCount($asset, count($this->assetStats), true);
             }
         }
 


### PR DESCRIPTION
**Description**

When attaching an asset to an email and sending via a campaign, `A new entity was found through the relationship 'Mautic\AssetBundle\Entity\Download#lead'` will be encountered.  This PR fixes #938.

**Testing**
Create an asset and an email that attaches the asset.  Create a simple campaign that simply sends the email with the asset. Of course add a couple leads to the campaign. Run the `mautic:campaign:trigger` command and you should encounter the above error. 

 After the PR, the campaign should work (remember to truncate stats between tests or remove/add leads).