### PR TITLE
Fixes API due to mis-spelled isUniqueIdentifer

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadField.php
+++ b/app/bundles/LeadBundle/Entity/LeadField.php
@@ -91,6 +91,13 @@ class LeadField extends FormEntity
     private $isUniqueIdentifer = false;
 
     /**
+     * Workaround for incorrectly spelled $isUniqueIdentifer
+     *
+     * @var bool
+     */
+    private $isUniqueIdentifier = false;
+
+    /**
      * @var int
      */
     private $order = 0;
@@ -113,6 +120,7 @@ class LeadField extends FormEntity
     public static function loadMetadata (ORM\ClassMetadata $metadata)
     {
         $builder = new ClassMetadataBuilder($metadata);
+        $builder->addLifecycleEvent('identifierWorkaround', 'postLoad');
 
         $builder->setTable('lead_fields')
             ->setCustomRepositoryClass('Mautic\LeadBundle\Entity\LeadFieldRepository');
@@ -536,11 +544,10 @@ class LeadField extends FormEntity
      */
     public function setIsUniqueIdentifer($isUniqueIdentifer)
     {
-        $this->isUniqueIdentifer = $isUniqueIdentifer;
+        $this->isUniqueIdentifer = $this->isUniqueIdentifier = $isUniqueIdentifer;
 
         return $this;
     }
-
 
     /**
      * Wrapper for incorrectly spelled setIsUniqueIdentifer
@@ -549,7 +556,7 @@ class LeadField extends FormEntity
      */
     public function getIsUniqueIdentifier()
     {
-        return $this->isUniqueIdentifer;
+        return $this->getIsUniqueIdentifer();
     }
 
     /**
@@ -561,9 +568,7 @@ class LeadField extends FormEntity
      */
     public function setIsUniqueIdentifier($isUniqueIdentifier)
     {
-        $this->isUniqueIdentifer = $isUniqueIdentifer;
-
-        return $this;
+        return $this->setIsUniqueIdentifer($isUniqueIdentifier);
     }
 
     /**
@@ -656,5 +661,13 @@ class LeadField extends FormEntity
     public function setIsPubliclyUpdatable ($isPubliclyUpdatable)
     {
         $this->isPubliclyUpdatable = (bool)$isPubliclyUpdatable;
+    }
+
+    /**
+     * Workaround for mispelled isUniqueIdentifer
+     */
+    public function identifierWorkaround()
+    {
+        $this->isUniqueIdentifier = $this->isUniqueIdentifer;
     }
 }


### PR DESCRIPTION
**Description**
This adds a workaround to make the `isUniqueIdentifer` work with `isUniqueIdentifier` which prevented the /api/leads/list/fields end point from working.  It basically adds and updates `$isUniqueIdentifier` whenever `$isUniqueIdentifer` is updated in the setter functions and using Doctrine's postLoad lifecycle callback event.

It fixes #1015.

**Testing**
Use the API Tester and get /leads/list/fields and the error should be encountered.

After the PR, a list of fields should be returned.