### PR TITLE
Fixed issue with sending attachments via Mandrill

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/AbstractTokenArrayTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/AbstractTokenArrayTransport.php
@@ -229,10 +229,10 @@ abstract class AbstractTokenArrayTransport implements InterfaceTokenTransport
                                 $swiftAttachment->setDisposition('inline');
                             }
 
-                            $message['attachments'] = array(
+                            $message['attachments'][] = array(
                                 'type'    => $swiftAttachment->getContentType(),
                                 'name'    => $swiftAttachment->getFilename(),
-                                'content' => $swiftAttachment->getEncoder()->encodeString($child->getBody())
+                                'content' => $swiftAttachment->getEncoder()->encodeString($swiftAttachment->getBody())
                             );
                         } catch (\Exception $e) {
                             error_log($e);


### PR DESCRIPTION
**Description**

This PR fixes issue where sending emails through Mandrill with attachments (assets) failed.

**Testing**

Create an email with an asset attached.  Using Mandrill as the transport, Send Example to yourself.  Check the logs and one of two errors may be present:

```
PHP Notice:  Undefined variable: child in app/bundles/EmailBundle/Swiftmailer/Transport/AbstractTokenArrayTransport.php on line 235
PHP Fatal error:  Call to a member function getBody() on null in app/bundles/EmailBundle/Swiftmailer/Transport/AbstractTokenArrayTransport.php on line 235
```

or 

```
[2015-10-21 17:54:42] mautic.ERROR: [MAIL ERROR] Mandrill error Log data: <<  << Validation error: {"message":{"attachments":["Please enter an array"]}} !! Mandrill error [] []
```

After the PR, repeat and you shouldn't get either of the errors and receive the email with the asset attached.