### PR TITLE
Tracking pixels

### DIFF
--- a/app/bundles/CoreBundle/Helper/TrackingPixelHelper.php
+++ b/app/bundles/CoreBundle/Helper/TrackingPixelHelper.php
@@ -17,6 +17,12 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class TrackingPixelHelper
 {
+    public static function sendResponse(Request $request)
+    {
+        $response = self::getResponse($request);
+        $response->send();
+    }
+
     /**
      * @param Request $request
      *
@@ -36,12 +42,14 @@ class TrackingPixelHelper
         $response = new Response();
 
         //removing any content encoding like gzip etc.
-        $response->headers->set('Content-encoding', 'none');
+        $response->headers->set('Content-Encoding', 'none');
 
         //check to ses if request is a POST
         if ($request->getMethod() == 'GET') {
+            $response->headers->set('Connection', 'close');
+
             //return 1x1 pixel transparent gif
-            $response->headers->set('Content-type', 'image/gif');
+            $response->headers->set('Content-Type', 'image/gif');
             //avoid cache time on browser side
             $response->headers->set('Content-Length', '42');
             $response->headers->set('Cache-Control', 'private, no-cache, no-cache=Set-Cookie, proxy-revalidate');

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -114,18 +114,11 @@ class PublicController extends CommonFormController
      */
     public function trackingImageAction($idHash)
     {
-        $response = TrackingPixelHelper::getResponse($this->request);
+        TrackingPixelHelper::sendResponse($this->request);
 
         /** @var \Mautic\EmailBundle\Model\EmailModel $model */
         $model    = $this->factory->getModel('email');
         $model->hitEmail($idHash, $this->request);
-
-        $size = strlen($response->getContent());
-        $response->headers->set('Content-Length', $size);
-        $response->headers->set('Connection', 'close');
-
-        //generate image
-        return $response;
     }
 
     /**

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -321,14 +321,13 @@ class PublicController extends CommonFormController
      */
     public function trackingImageAction()
     {
-        $response = TrackingPixelHelper::getResponse($this->request);
+        // Send response to keep from slowing down a website
+        TrackingPixelHelper::sendResponse($this->request);
 
         //Create page entry
         /** @var \Mautic\PageBundle\Model\PageModel $model */
         $model   = $this->factory->getModel('page');
         $model->hitPage(null, $this->request);
-
-        return $response;
     }
 
     /**


### PR DESCRIPTION
**Description**

This PR changes the tracking pixel to stream the image first then handle the logic to hopefully see a better response time for images associated with heavy logic such as campaigns, etc.

**Testing**

Create a campaign something like (embed the tracking pixel in a 3rd party page and use that in the visits a page decision and add the link inside the email for easy access and to associate the lead with the page click):

![](http://alan.direct/drop/2015-10-21_21-09-44.png)

Execute the campaign.  After going through the campaign (remember to use an anonymous browsing session to open the link in the email), ensure the decisions were registered and the tags were added to the lead.  This indicates that the logic occurred after the tracking pixel was streamed to the browser.