### PR TITLE
Fixed page hit and email sent/read counters to use a query instead of ORM

### DIFF
--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -205,7 +205,7 @@ class Email extends FormEntity
     }
 
     /**
-     *
+     * Clear stats
      */
     public function clearStats()
     {
@@ -213,7 +213,7 @@ class Email extends FormEntity
     }
 
     /**
-     *
+     * Clear variants
      */
     public function clearVariants()
     {
@@ -1062,30 +1062,6 @@ class Email extends FormEntity
     }
 
     /**
-     * Increase sent counts by one
-     */
-    public function upSentCounts ()
-    {
-        $this->sentCount++;
-        if (!empty($this->variantStartDate)) {
-            $this->variantSentCount++;
-        }
-    }
-
-    /**
-     * Decrease sent counts by one
-     */
-    public function downSentCounts ()
-    {
-        if ($this->sentCount) {
-            $this->sentCount--;
-            if (!empty($this->variantStartDate) && $this->variantSentCount) {
-                $this->variantSentCount--;
-            }
-        }
-    }
-
-    /**
      * @return mixed
      */
     public function getVariantReadCount ()
@@ -1187,7 +1163,6 @@ class Email extends FormEntity
         return $this;
     }
 
-
     /**
      * Add asset
      *
@@ -1221,5 +1196,4 @@ class Email extends FormEntity
     {
         return $this->assetAttachments;
     }
-
 }

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -411,4 +411,27 @@ class EmailRepository extends CommonRepository
             )
             ->execute();
     }
+
+    /**
+     * Up the read/sent counts
+     *
+     * @param            $id
+     * @param string     $type
+     * @param int        $increaseBy
+     * @param bool|false $variant
+     */
+    public function upCount($id, $type = 'sent', $increaseBy = 1, $variant = false)
+    {
+        $q = $this->_em->getConnection()->createQueryBuilder();
+
+        $q->update(MAUTIC_TABLE_PREFIX.'emails')
+            ->set($type . '_count', $type . '_count + ' . (int) $increaseBy)
+            ->where('id = ' . (int) $id);
+
+        if ($variant) {
+            $q->set('variant_' . $type . '_count', 'variant_' . $type . '_count + ' . (int) $increaseBy);
+        }
+
+        $q->execute();
+    }
 }

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -29,7 +29,6 @@ use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
  */
 class EmailModel extends FormModel
 {
-
     /**
      * {@inheritdoc}
      *
@@ -348,14 +347,10 @@ class EmailModel extends FormModel
 
             // Only up counts if associated with both an email and lead
             if ($email && $lead) {
-                $readCount = $email->getReadCount();
-                $readCount++;
-                $email->setReadCount($readCount);
-
-                if ($email->isVariant()) {
-                    $variantReadCount = $email->getVariantReadCount();
-                    $variantReadCount++;
-                    $email->setVariantReadCount($variantReadCount);
+                try {
+                    $this->getRepository()->upCount($email->getId(), 'read', 1, $email->isVariant());
+                } catch (\Exception $exception) {
+                    error_log($exception);
                 }
             }
         }
@@ -965,13 +960,14 @@ class EmailModel extends FormModel
         $useEmail = reset($emailSettings);
         $errors   = array();
         // Store stat entities
-        $saveEntities = array();
+        $saveEntities    = array();
+        $emailSentCounts = array();
 
         $mailer = $this->factory->getMailer(!$sendBatchMail);
 
         $contentGenerated = false;
 
-        $flushQueue = function($reset = true) use (&$mailer, &$saveEntities, &$errors, $sendBatchMail) {
+        $flushQueue = function($reset = true) use (&$mailer, &$saveEntities, &$errors, &$emailSentCounts, $sendBatchMail) {
 
             if ($sendBatchMail) {
                 $flushResult = $mailer->flushQueue();
@@ -986,7 +982,8 @@ class EmailModel extends FormModel
                             $errors[$saveEntities[$failedEmail]->getLead()->getId()] = $failedEmail;
 
                             // Down sent counts
-                            $saveEntities[$failedEmail]->getEmail()->downSentCounts();
+                            $emailId = $saveEntities[$failedEmail]->getEmail()->getId();
+                            $emailSentCounts[$emailId]++;
 
                             // Delete the stat
                             unset($saveEntities[$failedEmail]);
@@ -1080,8 +1077,12 @@ class EmailModel extends FormModel
 
             $saveEntities[$lead['email']] = $stat;
 
-            // Down sent counts
-            $saveEntities[$lead['email']]->getEmail()->upSentCounts();
+            // Up sent counts
+            $emailId = $useEmail['entity']->getId();
+            if (!isset($emailSentCounts[$emailId])) {
+                $emailSentCounts[$emailId] = 0;
+            }
+            $emailSentCounts[$emailId]++;
 
             // Save RAM
             unset($stat);
@@ -1102,13 +1103,24 @@ class EmailModel extends FormModel
         // Persist stats
         $statRepo->saveEntities($saveEntities);
 
+        // Update sent counts
+        foreach($emailSentCounts as $emailId => $count) {
+            $isVariant = $emailSettings[$emailId]['entity']->getVariantStartDate();
+
+            try {
+                $this->getRepository()->upCount($emailId, 'sent', $count, !empty($isVariant));
+            } catch (\Exception $exception) {
+                error_log($exception);
+            }
+        }
+
         // Free RAM
         foreach ($saveEntities as $stat) {
             $this->em->detach($stat);
             unset($stat);
         }
 
-        unset($emailSettings, $options, $tokens, $useEmail, $sendTo);
+        unset($emailSentCounts, $emailSettings, $options, $tokens, $useEmail, $sendTo);
 
         return $singleEmail ? (empty($errors)) : $errors;
     }

--- a/app/bundles/PageBundle/Entity/PageRepository.php
+++ b/app/bundles/PageBundle/Entity/PageRepository.php
@@ -312,4 +312,31 @@ class PageRepository extends CommonRepository
             )
             ->execute();
     }
+
+    /**
+     * Up the hit count
+     *
+     * @param            $id
+     * @param int        $increaseBy
+     * @param bool|false $unique
+     * @param bool|false $variant
+     */
+    public function upHitCount($id, $increaseBy = 1, $unique = false, $variant = false)
+    {
+        $q = $this->_em->getConnection()->createQueryBuilder();
+
+        $q->update(MAUTIC_TABLE_PREFIX.'pages')
+            ->set('hits', 'hits + ' . (int) $increaseBy)
+            ->where('id = ' . (int) $id);
+
+        if ($unique) {
+            $q->set('unique_hits', 'unique_hits + ' . (int) $increaseBy);
+        }
+
+        if ($variant) {
+            $q->set('variant_hits', 'variant_hits + ' . (int) $increaseBy);
+        }
+
+        $q->execute();
+    }
 }

--- a/app/bundles/PageBundle/Entity/RedirectRepository.php
+++ b/app/bundles/PageBundle/Entity/RedirectRepository.php
@@ -101,4 +101,26 @@ class RedirectRepository extends CommonRepository
 
         return $q->getQuery()->getResult();
     }
+
+    /**
+     * Up the hit count
+     *
+     * @param            $id
+     * @param int        $increaseBy
+     * @param bool|false $unique
+     */
+    public function upHitCount($id, $increaseBy = 1, $unique = false)
+    {
+        $q = $this->_em->getConnection()->createQueryBuilder();
+
+        $q->update(MAUTIC_TABLE_PREFIX.'page_redirects')
+            ->set('hits', 'hits + ' . (int) $increaseBy)
+            ->where('id = ' . (int) $id);
+
+        if ($unique) {
+            $q->set('unique_hits', 'unique_hits + ' . (int) $increaseBy);
+        }
+
+        $q->execute();
+    }
 }


### PR DESCRIPTION
**Description**

On busy sites, counters have a higher risk of getting off due to the use of ORM/PHP to increment the counters. So if a page is hit 10 times at the exact same time from 10 sources, the counter may only go up by 1.  This PR changes the counters to use a query (i.e. hits = hits + 1) rather than ORM to minimize the chances of losing up counts.

**Testing**

After the PR is applied, visit a Mautic landing page through an anonymous browsing session and ensure the hits count goes up. 

Send an email to a list or through a campaign.  Ensure the sent count goes up.  Then open the email and ensure the open count goes up.



