### PR TITLE
Fixed issue that resulted in anonymous leads not getting converted on form submit

### DIFF
--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -343,6 +343,7 @@ class SubmissionModel extends CommonFormModel
         /** @var \Mautic\LeadBundle\Model\LeadModel $model */
         $model      = $this->factory->getModel('lead');
         $em         = $this->factory->getEntityManager();
+        $logger     = $this->factory->getLogger();
 
         //set the mapped data
         $leadFields = $this->factory->getModel('lead.field')->getRepository()->getAliases(null, true, false);
@@ -353,6 +354,8 @@ class SubmissionModel extends CommonFormModel
             $lead          = $model->getCurrentLead();
             $leadId        = $lead->getId();
             $currentFields = $model->flattenFields($lead->getFields());
+
+            $logger->debug('FORM: Not in kiosk mode so using current lead ID #' . $lead->getId());
         } else {
             // Default to a new lead in kiosk mode
             $lead = new Lead();
@@ -360,6 +363,8 @@ class SubmissionModel extends CommonFormModel
             $currentFields = $leadFieldMatches;
 
             $leadId = null;
+
+            $logger->debug('FORM: In kiosk mode so assuming a new lead');
         }
 
         $uniqueLeadFields = $this->factory->getModel('lead.field')->getUniqueIdentiferFields();
@@ -386,16 +391,26 @@ class SubmissionModel extends CommonFormModel
 
         // Closure to help search for a conflict
         $checkForIdentifierConflict = function($fieldSet1, $fieldSet2) {
-            // Find conflicts
-            $diff = array_diff($fieldSet1, $fieldSet2);
-            // Remove empty values
-            $diff = array_filter($diff);
+            // Find fields in both sets
+            $potentialConflicts = array_keys(
+                array_diff_key($fieldSet1, $fieldSet2)
+            );
 
-            return (count($diff));
+            $conflicts = array();
+            foreach ($potentialConflicts as $field) {
+                if (!empty($fieldSet1[$field]) && !empty($fieldSet2[$field])) {
+                    if (strtolower($fieldSet1[$field]) !== strtolower($fieldSet2[$field])) {
+                        $conflicts[] = $field;
+                    }
+                }
+            }
+
+            return array(count($conflicts), $conflicts);
         };
 
         // Get data for the form submission
         list ($data, $uniqueFieldsWithData) = $getData($leadFieldMatches);
+        $logger->debug('FORM: Unique fields submitted include ' . implode(', ', $uniqueFieldsWithData));
 
         // Check for duplicate lead
         /** @var \Mautic\LeadBundle\Entity\LeadRepository $leads */
@@ -403,20 +418,33 @@ class SubmissionModel extends CommonFormModel
 
         $uniqueFieldsCurrent = $getData($currentFields, true);
         if (count($leads)) {
+            $logger->debug(count($leads) . ' found based on unique identifiers');
+
             /** @var \Mautic\LeadBundle\Entity\Lead $foundLead */
             $foundLead = $leads[0];
+
+            $logger->debug('FORM: Testing lead ID# ' . $foundLead->getId() . ' for conflicts');
 
             // Check for a conflict with the currently tracked lead
             $foundLeadFields =  $model->flattenFields($foundLead->getFields());
 
             // Get unique identifier fields for the found lead then compare with the lead currently tracked
             $uniqueFieldsFound = $getData($foundLeadFields, true);
-            $hasConflict       = $checkForIdentifierConflict($uniqueFieldsFound, $uniqueFieldsCurrent);
+            list($hasConflict, $conflicts) = $checkForIdentifierConflict($uniqueFieldsFound, $uniqueFieldsCurrent);
 
             if ($inKioskMode || $hasConflict) {
                 // Use the found lead without merging because there is some sort of conflict with unique identifiers or in kiosk mode and thus should not merge
                 $lead = $foundLead;
+
+                if ($hasConflict) {
+                    $logger->debug('FORM: Conflicts found in ' . implode(', ' , $conflicts) . ' so not merging');
+                } else {
+                    $logger->debug('FORM: In kiosk mode so not merging');
+                }
+
             } else {
+                $logger->debug('FORM: Merging leads ' . $lead->getId() . ' and ' . $foundLead->getId());
+
                 // Merge the found lead with currently tracked lead
                 $lead = $model->mergeLeads($lead, $foundLead);
             }
@@ -428,11 +456,16 @@ class SubmissionModel extends CommonFormModel
 
         if (!$inKioskMode) {
             // Check for conflicts with the submitted data and the currently tracked lead
-            $hasConflict = $checkForIdentifierConflict($uniqueFieldsWithData, $uniqueFieldsCurrent);
+            list($hasConflict, $conflicts) = $checkForIdentifierConflict($uniqueFieldsWithData, $uniqueFieldsCurrent);
+
+            $logger->debug('FORM: Current unique lead fields ' . implode(', ', array_keys($uniqueFieldsCurrent)) . ' = ' . implode(', ', $uniqueFieldsCurrent));
+
             if ($hasConflict) {
                 // There's a conflict so create a new lead
                 $lead = new Lead();
                 $lead->setNewlyCreated(true);
+
+                $logger->debug('FORM: Conflicts found in ' . implode(', ' , $conflicts) . ' between current tracked lead and submitted data so assuming a new lead');
             }
         }
 
@@ -443,6 +476,7 @@ class SubmissionModel extends CommonFormModel
         if ($lead->isNewlyCreated()) {
             if (!$inKioskMode) {
                 $lead->addIpAddress($ipAddress);
+                $logger->debug('FORM: Associating ' . $ipAddress->getIpAddress() . ' to lead');
             }
 
             // last active time
@@ -452,6 +486,8 @@ class SubmissionModel extends CommonFormModel
             $leadIpAddresses = $lead->getIpAddresses();
             if (!$leadIpAddresses->contains($ipAddress)) {
                 $lead->addIpAddress($ipAddress);
+
+                $logger->debug('FORM: Associating ' . $ipAddress->getIpAddress() . ' to lead');
             }
         }
 

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -9,6 +9,7 @@
 
 namespace Mautic\LeadBundle\Model;
 
+use Doctrine\ORM\PersistentCollection;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\CoreBundle\Model\FormModel;
@@ -710,11 +711,16 @@ class LeadModel extends FormModel
      */
     public function mergeLeads(Lead $lead, Lead $lead2, $autoMode = true)
     {
+        $logger  = $this->factory->getLogger();
+        $logger->debug('LEAD: Merging leads');
+
         $leadId  = $lead->getId();
         $lead2Id = $lead2->getId();
 
         //if they are the same lead, then just return one
         if ($leadId === $lead2Id) {
+            $logger->debug('LEAD: Leads are the same');
+
             return $lead;
         }
 
@@ -726,6 +732,7 @@ class LeadModel extends FormModel
             $mergeWith = $lead2;
             $mergeFrom = $lead;
         }
+        $logger->debug('LEAD: Lead ID# ' . $mergeFrom->getId() . ' will be merged into ID# ' . $mergeWith->getId());
 
         //dispatch pre merge event
         $event = new LeadMergeEvent($mergeWith, $mergeFrom);
@@ -737,6 +744,8 @@ class LeadModel extends FormModel
         $ipAddresses = $mergeFrom->getIpAddresses();
         foreach ($ipAddresses as $ip) {
             $mergeWith->addIpAddress($ip);
+
+            $logger->debug('LEAD: Associating with IP ' . $ip->getIpAddress());
         }
 
         //merge fields
@@ -746,6 +755,8 @@ class LeadModel extends FormModel
                 //overwrite old lead's data with new lead's if new lead's is not empty
                 if (!empty($details['value'])) {
                     $mergeWith->addUpdatedField($alias, $details['value']);
+
+                    $logger->debug('LEAD: Updated ' . $alias . ' = ' . $details['value']);
                 }
             }
         }
@@ -756,12 +767,15 @@ class LeadModel extends FormModel
 
         if ($oldOwner === null) {
             $mergeWith->setOwner($newOwner);
+
+            $logger->debug('LEAD: New owner is ' . $newOwner->getId());
         }
 
         //sum points
         $mergeWithPoints = $mergeWith->getPoints();
         $mergeFromPoints = $mergeFrom->getPoints();
         $mergeWith->setPoints($mergeWithPoints + $mergeFromPoints);
+        $logger->debug('LEAD: Adding ' . $mergeFromPoints . ' points to lead');
 
         //merge tags
         $mergeFromTags = $mergeFrom->getTags();
@@ -1028,11 +1042,18 @@ class LeadModel extends FormModel
      */
     public function modifyTags(Lead $lead, $tags, array $removeTags = null, $persist = true)
     {
+        $logger   = $this->factory->getLogger();
         $leadTags = $lead->getTags();
+
+        if ($leadTags) {
+            $logger->debug('LEAD: Lead currently has tags '.implode(', ', $leadTags->getKeys()));
+        }
 
         if (!is_array($tags)) {
             $tags = explode(',', $tags);
         }
+
+        $logger->debug('LEAD: Adding ' . implode(', ', $tags) . ' to lead ID# ' . $lead->getId());
 
         array_walk($tags, create_function('&$val', '$val = trim($val); \Mautic\CoreBundle\Helper\InputHelper::clean($val);'));
 
@@ -1045,6 +1066,7 @@ class LeadModel extends FormModel
 
                 if (array_key_exists($tag, $foundTags) && $leadTags->contains($foundTags[$tag])) {
                     $lead->removeTag($foundTags[$tag]);
+                    $logger->debug('LEAD: Removed ' . $tag);
                 }
             } else {
                 // Tag to be added
@@ -1053,8 +1075,11 @@ class LeadModel extends FormModel
                     $newTag = new Tag();
                     $newTag->setTag($tag);
                     $lead->addTag($newTag);
+                    $logger->debug('LEAD: Added ' . $tag);
                 } elseif (!$leadTags->contains($foundTags[$tag])) {
                     $lead->addTag($foundTags[$tag]);
+
+                    $logger->debug('LEAD: Added ' . $tag);
                 }
             }
         }
@@ -1064,6 +1089,7 @@ class LeadModel extends FormModel
                 // Tag to be removed
                 if (array_key_exists($tag, $foundTags) && $leadTags->contains($foundTags[$tag])) {
                     $lead->removeTag($foundTags[$tag]);
+                    $logger->debug('LEAD: Removed ' . $tag);
                 }
             }
         }


### PR DESCRIPTION
**Description**

If an anonymous lead submitted a form, a new lead was created rather than the anonymous lead being updated.  This resulted in things like tags not being applied to the form submission's lead.  This fixes #1011.

**Testing**

1. Create a form with an email field
2. Embed the tracking pixel into a 3rd party page with a query of `tags=FormTest`
3. Browse to the web page via an anonymous browser
4. Now browse to the public form submit page (/form/ID) and submit the form with an email not already tracked in Mautic
5. Login/go back to Mautic -> Manage Leads -> search `tag:FormTest is:anonymous` and you should see an anonymous lead and note the ID.  Then search for the email and should note a separate lead (different ID).

Apply the PR and delete the two leads from above and repeat.  This time, the anonymous lead should become the identified lead and keep all tags, etc intact.