### PR TITLE
Update lead last active whenever a current lead is set (email open, etc)

### DIFF
--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -445,9 +445,6 @@ class SubmissionModel extends CommonFormModel
                 $lead->addIpAddress($ipAddress);
             }
 
-            // last active time
-            $lead->setLastActive(new \DateTime());
-
         } elseif (!$inKioskMode) {
             $leadIpAddresses = $lead->getIpAddresses();
             if (!$leadIpAddresses->contains($ipAddress)) {
@@ -462,6 +459,9 @@ class SubmissionModel extends CommonFormModel
             $event->setIpAddress($ipAddress);
             $lead->addPointsChangeLog($event);
         }
+
+        // last active time
+        $lead->setLastActive(new \DateTime());
 
         //create a new lead
         $model->saveEntity($lead, false);

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -475,6 +475,8 @@ class LeadModel extends FormModel
      * Get the current lead; if $returnTracking = true then array with lead, trackingId, and boolean of if trackingId
      * was just generated or not
      *
+     * @param bool|false $returnTracking
+     *
      * @return Lead|array
      */
     public function getCurrentLead($returnTracking = false)
@@ -572,6 +574,10 @@ class LeadModel extends FormModel
 
         $this->currentLead = $lead;
 
+        // Set last active
+        $this->currentLead->setLastActive(new \DateTime());
+
+        // Update tracking cookies if the lead is different
         if ($oldLead->getId() != $lead->getId()) {
 
             list($newTrackingId, $oldTrackingId) = $this->getTrackingCookie(true);
@@ -618,6 +624,8 @@ class LeadModel extends FormModel
 
     /**
      * Get or generate the tracking ID for the current session
+     *
+     * @param bool|false $forceRegeneration
      *
      * @return array
      */


### PR DESCRIPTION
**Description**

A lead's last active timestamp was only updated in certain circumstances.  This PR changes the behavior to update the lead's last active timestamp whenever setCurrentLead is used so that actions such as opens emails, etc will update the timestamp.

This fixes #1014.

**Testing**

Use a campaign to send an email to the lead.  Open the email then look at the lead's last active date in Mautic.  It won't be updated.  After the PR, repeat the process and this time the last active date should update to the time the lead opened the email.