### PR TITLE
fix PHP Exception

### DIFF
--- a/app/bundles/PluginBundle/Bundle/PluginBundleBase.php
+++ b/app/bundles/PluginBundle/Bundle/PluginBundleBase.php
@@ -33,7 +33,7 @@ abstract class PluginBundleBase extends Bundle
     {
         // BC support; @deprecated 1.1.4; to be removed in 2.0
         if (method_exists(get_called_class(), 'onInstall')) {
-            self::onInstall($factory);
+            static::onInstall($factory);
         }
 
         if ($metadata !== null) {
@@ -96,7 +96,7 @@ abstract class PluginBundleBase extends Bundle
                 ->setName($plugin->getName())
                 ->setVersion($plugin->getVersion());
 
-            self::onUpdate($addon, $factory);
+            static::onUpdate($addon, $factory);
         }
 
         // Not recommended although availalbe for simple schema changes - see updatePluginSchema docblock


### PR DESCRIPTION
fix this error: mautic.CRITICAL: Uncaught PHP Exception
Symfony\Component\Debug\Exception\UndefinedMethodException: "Attempted
to call method "onInstall" on class
"Mautic\PluginBundle\Bundle\PluginBundleBase"." at
C:\mautic\app\bundles\PluginBundle\Bundle\PluginBundleBase.php line 36
{"exception":"[object]
(Symfony\\Component\\Debug\\Exception\\UndefinedMethodException(code:
0): Attempted to call method \"onInstall\" on class
\"Mautic\\PluginBundle\\Bundle\\PluginBundleBase\". at
C:\\mautic\\app\\bundles\\PluginBundle\\Bundle\\PluginBundleBase.php:36)"}
[]