### PR TITLE
Reversed tracking pixel streaming prior to heavier logic due 

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -114,11 +114,11 @@ class PublicController extends CommonFormController
      */
     public function trackingImageAction($idHash)
     {
-        TrackingPixelHelper::sendResponse($this->request);
-
         /** @var \Mautic\EmailBundle\Model\EmailModel $model */
         $model    = $this->factory->getModel('email');
         $model->hitEmail($idHash, $this->request);
+
+        return TrackingPixelHelper::getResponse($this->request);
     }
 
     /**

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -321,13 +321,12 @@ class PublicController extends CommonFormController
      */
     public function trackingImageAction()
     {
-        // Send response to keep from slowing down a website
-        TrackingPixelHelper::sendResponse($this->request);
-
         //Create page entry
         /** @var \Mautic\PageBundle\Model\PageModel $model */
         $model   = $this->factory->getModel('page');
         $model->hitPage(null, $this->request);
+
+        return TrackingPixelHelper::getResponse($this->request);
     }
 
     /**


### PR DESCRIPTION
**Description**

Cookies are not getting generated due to the tracking pixel already have been streamed to the browser.  Whoops. (The image encoding masked the warnings/exceptions and thus wasn't caught)

Fixes #1049 

**Testing**

Insert the tracking pixel into a page and hit up the page in an anonymous browser.  Look at the cookies in the developer console and they will not be there.  Check the logs and you'll see warnings about headers already been sent. 

After the PR, the cookies will be created.