### PR TITLE
Do Not Track IPs field didn't load saved values back to form. Fixed.

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -411,6 +411,6 @@ return array(
         'cookie_domain'                  => '',
         'cookie_secure'                  => null,
         'cookie_httponly'                => false,
-        'ignore_ips'                     => null,
+        'do_not_track_ips'               => null,
     )
 );


### PR DESCRIPTION
The Do Not Track IPs field saved the values correctly but then didn't load them back to the form. Reported in https://github.com/mautic/mautic/issues/1056

### Testing
1. Go to Mautic's config.
2. Fill in some values to "List of IPs to not track leads with (one per line)" textarea
3. Save

Current result: The field is empty after save.
Result after this PR is applied: The field holds the values you entered.

Don't forget to clear cache after this PR is applied.