### PR TITLE
Lead merge owner fix

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -9,7 +9,6 @@
 
 namespace Mautic\LeadBundle\Model;
 
-use Doctrine\ORM\PersistentCollection;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\CoreBundle\Model\FormModel;
@@ -773,7 +772,7 @@ class LeadModel extends FormModel
         $oldOwner = $mergeWith->getOwner();
         $newOwner = $mergeFrom->getOwner();
 
-        if ($oldOwner === null) {
+        if ($oldOwner === null && $newOwner !== null) {
             $mergeWith->setOwner($newOwner);
 
             $logger->debug('LEAD: New owner is ' . $newOwner->getId());

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -924,7 +924,7 @@ class ListModel extends FormModel
             return;
         }
 
-        if ($leadSleepTime < 0) {
+        if ($leadSleepTime < 1) {
             usleep($leadSleepTime * 1000);
         } else {
             sleep($leadSleepTime);

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -9,8 +9,6 @@
 
 namespace Mautic\LeadBundle\Model;
 
-use Mautic\CoreBundle\Factory\MauticFactory;
-use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
@@ -36,21 +34,6 @@ class ListModel extends FormModel
      * @var array
      */
     private $leadChangeLists = array();
-
-    /**
-     * @var
-     */
-    private $batchSleepTime;
-
-    /**
-     * @param MauticFactory $factory
-     */
-    public function __construct(MauticFactory $factory)
-    {
-        parent::__construct($factory);
-
-        $this->batchSleepTime = $factory->getParameter('batch_sleep_time', 1);
-    }
 
     /**
      * {@inheritdoc}
@@ -479,7 +462,7 @@ class ListModel extends FormModel
             // Add leads
             while ($start < $leadCount) {
                 // Keep CPU down for large lists; sleep per $limit batch
-                sleep($this->batchSleepTime);
+                $this->batchSleep();
 
                 $newLeadList = $this->getLeadsByList(
                     $list,
@@ -506,7 +489,7 @@ class ListModel extends FormModel
 
                     $leadsProcessed++;
                     if ($output && $leadsProcessed < $maxCount) {
-                        $progress->setCurrent($leadsProcessed);
+                        $progress->setProgress($leadsProcessed);
                     }
 
                     if ($maxLeads && $leadsProcessed >= $maxLeads) {
@@ -588,7 +571,7 @@ class ListModel extends FormModel
             // Remove leads
             while ($start < $leadCount) {
                 // Keep CPU down for large lists; sleep per $limit batch
-                sleep($this->batchSleepTime);
+                $this->batchSleep();
 
                 $removeLeadList = $this->getLeadsByList(
                     $list,
@@ -612,7 +595,7 @@ class ListModel extends FormModel
 
                     $leadsProcessed++;
                     if ($output && $leadsProcessed < $maxCount) {
-                        $progress->setCurrent($leadsProcessed);
+                        $progress->setProgress($leadsProcessed);
                     }
 
                     if ($maxLeads && $leadsProcessed >= $maxLeads) {
@@ -924,5 +907,27 @@ class ListModel extends FormModel
         $args['idOnly'] = $idOnly;
 
         return $this->getRepository()->getLeadsByList($lists, $args);
+    }
+
+    /**
+     * Batch sleep according to settings
+     */
+    protected function batchSleep()
+    {
+        $leadSleepTime = $this->factory->getParameter('batch_lead_sleep_time', false);
+        if ($leadSleepTime === false) {
+            $leadSleepTime = $this->factory->getParameter('batch_sleep_time', 1);
+        }
+
+        if (empty($leadSleepTime)) {
+
+            return;
+        }
+
+        if ($leadSleepTime < 0) {
+            usleep($leadSleepTime * 1000);
+        } else {
+            sleep($leadSleepTime);
+        }
     }
 }


### PR DESCRIPTION
**Description**
Fixes error related to a debug log statement when a lead doesn't have an owner which had the possibility of preventing form posts or being able to manually merge.

Also adjusted advanced batch list sleep moderation to support microseconds or even be disabled.

**Testing**
Try to manually merge one lead into another using the Merge button (from a lead's profile) and it should result in the non-object error.  After the PR, they'll merge.