### PR TITLE
Fixed comments in the LeadRepository

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -30,6 +30,13 @@ class LeadRepository extends CommonRepository
     private $availableSearchFields = array();
 
     /**
+     * Required to get the color based on a lead's points
+     *
+     * @var TriggerModel
+     */
+    private $triggerModel;
+
+    /**
      * Used by search functions to search social profiles
      *
      * @param array $fields
@@ -50,22 +57,25 @@ class LeadRepository extends CommonRepository
     }
 
     /**
-     * Required to get the color based on a lead's points
-     * @var
+     * Sets trigger model
+     *
+     * @param TriggerModel $triggerModel
+     *
+     * @return void
      */
-    private $triggerModel;
-
-    public function setTriggerModel (TriggerModel $triggerModel)
+    public function setTriggerModel(TriggerModel $triggerModel)
     {
         $this->triggerModel = $triggerModel;
     }
 
     /**
      * Gets a list of unique values from fields for autocompletes
+     *
      * @param        $field
      * @param string $search
      * @param int    $limit
      * @param int    $start
+     *
      * @return array
      */
     public function getValueList($field, $search = '', $limit = 10, $start = 0)
@@ -244,7 +254,7 @@ class LeadRepository extends CommonRepository
     /**
      * @param $email
      *
-     * @return null
+     * @return integer|null
      */
     public function getLeadByEmail($email)
     {
@@ -312,7 +322,7 @@ class LeadRepository extends CommonRepository
      *
      * @param $entity
      * @param $flush
-     * @return int
+     * @return void
      */
     public function saveEntity($entity, $flush = true)
     {
@@ -425,7 +435,8 @@ class LeadRepository extends CommonRepository
     /**
      * {@inheritdoc}
      *
-     * @param int $id
+     * @param integer $id
+     *
      * @return mixed|null
      */
     public function getEntity($id = 0)
@@ -591,7 +602,7 @@ class LeadRepository extends CommonRepository
     /**
      * Function to remove non custom field columns from an arrayed lead row
      *
-     * @param $r
+     * @param array $r
      */
     protected function removeNonFieldColumns(&$r)
     {
@@ -603,8 +614,10 @@ class LeadRepository extends CommonRepository
     }
 
     /**
+     * Adds the "catch all" where clause to the QueryBuilder
      * @param QueryBuilder $q
      * @param              $filter
+     *
      * @return array
      */
     protected function addCatchAllWhereClause(&$q, $filter)
@@ -647,8 +660,11 @@ class LeadRepository extends CommonRepository
     }
 
     /**
+     * Adds the command where clause to the QueryBuilder
+     *
      * @param QueryBuilder $q
      * @param              $filter
+     *
      * @return array
      */
     protected function addSearchCommandWhereClause(&$q, $filter)
@@ -835,6 +851,8 @@ class LeadRepository extends CommonRepository
     }
 
     /**
+     * Returns the array of search commands.
+     *
      * @return array
      */
     public function getSearchCommands()
@@ -860,7 +878,9 @@ class LeadRepository extends CommonRepository
     }
 
     /**
-     * @return string
+     * Returns the array of columns with the default order
+     *
+     * @return array
      */
     protected function getDefaultOrder()
     {
@@ -872,7 +892,7 @@ class LeadRepository extends CommonRepository
     /**
      * Updates lead's lastActive with now date/time
      *
-     * @param $leadId
+     * @param integer $leadId
      */
     public function updateLastActive($leadId)
     {
@@ -884,6 +904,8 @@ class LeadRepository extends CommonRepository
 
     /**
      * Gets the ID of the latest ID
+     *
+     * @return integer
      */
     public function getMaxLeadId()
     {

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -60,8 +60,6 @@ class LeadRepository extends CommonRepository
      * Sets trigger model
      *
      * @param TriggerModel $triggerModel
-     *
-     * @return void
      */
     public function setTriggerModel(TriggerModel $triggerModel)
     {
@@ -322,7 +320,6 @@ class LeadRepository extends CommonRepository
      *
      * @param $entity
      * @param $flush
-     * @return void
      */
     public function saveEntity($entity, $flush = true)
     {
@@ -342,8 +339,6 @@ class LeadRepository extends CommonRepository
      * Persist an array of entities
      *
      * @param array $entities
-     *
-     * @return void
      */
     public function saveEntities($entities)
     {


### PR DESCRIPTION
A developer in the Slack chat was confused that `saveEntity` didn't return anything. I noticed the comment said it should. I updated the rest of comments when I was in it.