### PR TITLE
Fixes #1072 where we had an auth key hard coded for GeoIps IP lookup service

### DIFF
--- a/app/bundles/CoreBundle/IpLookup/GeoipsIpLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/GeoipsIpLookup.php
@@ -17,7 +17,7 @@ class GeoipsIpLookup extends AbstractIpLookup
      */
     protected function getUrl()
     {
-        return "http://api.geoips.com/ip/{$this->ip}/key/ec9e4bbc7ac82d809c20c51c9ad2441f/output/json";
+        return "http://api.geoips.com/ip/{$this->ip}/key/{$this->auth}/output/json";
     }
 
     /**


### PR DESCRIPTION
**Description**

See #1072.  An auth key was hard coded for the GeoIPs service instead of using the configured key. This PR fixes that.  