### PR TITLE
Fixed issue that caused translations to not work

### DIFF
--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -235,16 +235,18 @@ class MauticFactory
      */
     public function getTranslator()
     {
-        /** @var \Mautic\CoreBundle\Translation\Translator $translator */
-        $translator = $this->container->get('translator');
+        if (defined('IN_MAUTIC_CONSOLE')) {
+            /** @var \Mautic\CoreBundle\Translation\Translator $translator */
+            $translator = $this->container->get('translator');
 
-        if ($translator->getLocale() === null) {
             $translator->setLocale(
                 $this->getParameter('locale')
             );
+
+            return $translator;
         }
 
-        return $translator;
+        return $this->container->get('translator');
     }
 
     /**


### PR DESCRIPTION
**Description**

Instead of returning the value of $this->locale, Symfony apparently automatically sets the locale from request which it defaults to as `en`.  This prevents translations from working.

**Testing**

Use another locale and it'll the UI will persist in english.

Fixes #1073 