### PR TITLE
Prevented errors related to Doctrine unsupported types 

### DIFF
--- a/app/config/config.php
+++ b/app/config/config.php
@@ -176,6 +176,12 @@ $dbalSettings = array(
     'types'    => array(
         'array'    => 'Mautic\CoreBundle\Doctrine\Type\ArrayType',
         'datetime' => 'Mautic\CoreBundle\Doctrine\Type\UTCDateTimeType'
+    ),
+    // Prevent Doctrine from crapping out with "unsupported type" errors due to it examining all tables in the database and not just Mautic's
+    'mapping_types' => array(
+        'enum'  => 'string',
+        'point' => 'string',
+        'bit'   => 'string',
     )
 );
 


### PR DESCRIPTION
**Description**

Apparently Doctrine examines all tables in the database regardless if they are used by Mautic or not.  A few common types that are not supported by Doctrine will cause it to throw exceptions breaking Mautic.  This forces Doctrine to handle them as strings just to prevent it from throwing an exception.  Existing tables are not manipulated by Doctrine but just examined.  

This becomes an issue when Mautic tries to update the schema.

**Testing**

Create a table in the same MySQL database as Mautic with enum, point, and/or bit column types. Then run the command `doctrine:schema:update --dump-sql` which should throw an unsupported type exception.  After the PR, clear Symfony's cache and try again.  The issue should be resolved.