### PR TITLE
Email link threw an error instead of the redirect

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -451,9 +451,7 @@ class EmailModel extends FormModel
                 'email' => (int) $emailId,
                 'lead'  => (int) $leadId
             ),
-            array(
-                array('dateSent', 'DESC')
-            )
+            array('dateSent' => 'DESC')
         );
     }
 


### PR DESCRIPTION
The email link redirects didn't work. It lead leads only to Uh Oh error page instead of the redirect. Error messages in logs are:
```
[2015-10-29 09:19:34] mautic.CRITICAL: Uncaught PHP Exception Doctrine\ORM\ORMException: "Invalid order by orientation specified for Mautic\EmailBundle\Entity\Stat#0" at vendor/doctrine/orm/lib/Doctrine/ORM/ORMException.php line 111 {"exception":"[object] (Doctrine\\ORM\\ORMException(code: 0): Invalid order by orientation specified for Mautic\\EmailBundle\\Entity\\Stat#0 at vendor/doctrine/orm/lib/Doctrine/ORM/ORMException.php:111)"} []
[2015-10-29 09:20:26] mautic.WARNING: PHP Warning: trim() expects parameter 1 to be string, array given - in file vendor/doctrine/orm/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php - at line 1168 [] []
```

### Testing
This has to be tested on a Mautic which is publicly accessible over WWW.
1. Create a list email with few links to various websites.
2. Send it to the list (which goes to your inbox).
3. Open the delivered email message in your email client.
4. Click on the links in it.