### PR TITLE
fix 2 plugin bugs

### DIFF
--- a/app/bundles/PluginBundle/Bundle/PluginBundleBase.php
+++ b/app/bundles/PluginBundle/Bundle/PluginBundleBase.php
@@ -11,18 +11,17 @@ namespace Mautic\PluginBundle\Bundle;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\ORM\Tools\SchemaTool;
-use Mautic\PluginBundle\Entity\Addon;
 use Mautic\PluginBundle\Entity\Plugin;
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * Base Bundle class which should be extended by addon bundles
+ * Base Bundle class which should be extended by plugin bundles
  */
 abstract class PluginBundleBase extends Bundle
 {
     /**
-     * Called by PluginController::reloadAction when adding a new addon that's not already installed
+     * Called by PluginController::reloadAction when adding a new plugin that's not already installed
      *
      * @param Plugin        $plugin
      * @param MauticFactory $factory
@@ -72,7 +71,7 @@ abstract class PluginBundleBase extends Bundle
     }
 
     /**
-     * Called by PluginController::reloadAction when the addon version does not match what's installed
+     * Called by PluginController::reloadAction when the plugin version does not match what's installed
      *
      * @param Plugin        $plugin
      * @param MauticFactory $factory
@@ -83,23 +82,11 @@ abstract class PluginBundleBase extends Bundle
      */
     static public function onPluginUpdate(Plugin $plugin, MauticFactory $factory, $metadata = null, Schema $installedSchema = null)
     {
-        // BC support; @deprecated 1.1.4; to be removed in 2.0
         if (method_exists(get_called_class(), 'onUpdate')) {
-            // Create a bogus Addon
-            $addon = new Addon();
-            $addon->setAuthor($plugin->getAuthor())
-                ->setBundle($plugin->getBundle())
-                ->setDescription($plugin->getDescription())
-                ->setId($plugin->getId())
-                ->setIntegrations($plugin->getIntegrations())
-                ->setIsMissing($plugin->getIsMissing())
-                ->setName($plugin->getName())
-                ->setVersion($plugin->getVersion());
-
-            static::onUpdate($addon, $factory);
+            static::onUpdate($plugin, $factory);
         }
 
-        // Not recommended although availalbe for simple schema changes - see updatePluginSchema docblock
+        // Not recommended although available for simple schema changes - see updatePluginSchema docblock
         //self::updatePluginSchema($metadata, $installedSchema, $factory);
     }
 

--- a/app/bundles/PluginBundle/Entity/Addon.php
+++ b/app/bundles/PluginBundle/Entity/Addon.php
@@ -7,7 +7,7 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-namespace Mautic\AddonBundle\Entity;
+namespace Mautic\PluginBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 


### PR DESCRIPTION
1: bad namespace in Addon entity. This fix this error:
mautic.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalErrorException: "Compile Error: Cannot redeclare class Mautic\AddonBundle\Entity\Addon" at C:\mautic\app\bundles\PluginBundle\Entity\Addon.php line 22 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalErrorException(code: 0): Compile Error: Cannot redeclare class Mautic\\AddonBundle\\Entity\\Addon at C:\\mautic\\app\\bundles\\PluginBundle\\Entity\\Addon.php:22)"} []

2: in PluginBundleBase the onUpdate($addon, $factory) is outdated. In
the official guide [ https://developer.mautic.org/#install/upgrade ] the
onPluginInstall method is static public function onPluginInstall(Plugin
$plugin, MauticFactory $factory, $metadata = null). $plugin is a Plugin
object, not an Addon object. So Addon is no more used in
PluginBundleBase and then removed