### PR TITLE
Feature Request - Auto Match Integration Fields with Mautic Fields

### DIFF
--- a/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
+++ b/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
@@ -67,7 +67,7 @@ class FeatureSettingsType extends AbstractType
             list ($specialInstructions, $alertType) = $integration_object->getFormNotes('leadfield_match');
 
             /**
-             * Auto Match Integration Fields with Mautic Fields
+             * Auto Match Integration Fields with Mautic Fields.
              */
             $flattenLeadFields = array();
             foreach (array_values($leadFields) as $fieldsWithoutGroups) {
@@ -76,7 +76,7 @@ class FeatureSettingsType extends AbstractType
             $fieldsIntersection = array_intersect(array_keys($fields), array_keys($flattenLeadFields));
 
             $autoMatchedFields = array();
-            foreach($fieldsIntersection as $field){
+            foreach ($fieldsIntersection as $field) {
               $autoMatchedFields[$field] = $field;
             }
 

--- a/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
+++ b/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
@@ -66,11 +66,25 @@ class FeatureSettingsType extends AbstractType
 
             list ($specialInstructions, $alertType) = $integration_object->getFormNotes('leadfield_match');
 
+            /**
+             * Auto Match Integration Fields with Mautic Fields
+             */
+            $flattenLeadFields = array();
+            foreach (array_values($leadFields) as $fieldsWithoutGroups) {
+                $flattenLeadFields = array_merge($flattenLeadFields,$fieldsWithoutGroups);
+            }
+            $fieldsIntersection = array_intersect(array_keys($fields), array_keys($flattenLeadFields));
+
+            $autoMatchedFields = array();
+            foreach($fieldsIntersection as $field){
+              $autoMatchedFields[$field] = $field;
+            }
+
             $form->add('leadFields', 'integration_fields', array(
                 'label'                => 'mautic.integration.leadfield_matches',
                 'required'             => true,
                 'lead_fields'          => $leadFields,
-                'data'                 => isset($data['leadFields']) ? $data['leadFields'] : array(),
+                'data'                 => isset($data['leadFields']) && !empty($data['leadFields']) ? $data['leadFields'] : $autoMatchedFields,
                 'integration_fields'   => $fields,
                 'special_instructions' => $specialInstructions,
                 'alert_type'           => $alertType

--- a/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
+++ b/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
@@ -73,7 +73,11 @@ class FeatureSettingsType extends AbstractType
             foreach (array_values($leadFields) as $fieldsWithoutGroups) {
                 $flattenLeadFields = array_merge($flattenLeadFields,$fieldsWithoutGroups);
             }
-            $fieldsIntersection = array_intersect(array_keys($fields), array_keys($flattenLeadFields));
+            
+            $integrationFields  = array_keys($fields);
+            $flattenLeadFields  = array_keys($flattenLeadFields);
+            $fieldsIntersection = array_uintersect($integrationFields, $flattenLeadFields, "strcasecmp");
+
 
             $autoMatchedFields = array();
             foreach ($fieldsIntersection as $field) {

--- a/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
+++ b/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
@@ -71,9 +71,9 @@ class FeatureSettingsType extends AbstractType
              */
             $flattenLeadFields = array();
             foreach (array_values($leadFields) as $fieldsWithoutGroups) {
-                $flattenLeadFields = array_merge($flattenLeadFields,$fieldsWithoutGroups);
+                $flattenLeadFields = array_merge($flattenLeadFields, $fieldsWithoutGroups);
             }
-            
+
             $integrationFields  = array_keys($fields);
             $flattenLeadFields  = array_keys($flattenLeadFields);
             $fieldsIntersection = array_uintersect($integrationFields, $flattenLeadFields, "strcasecmp");
@@ -81,7 +81,7 @@ class FeatureSettingsType extends AbstractType
 
             $autoMatchedFields = array();
             foreach ($fieldsIntersection as $field) {
-              $autoMatchedFields[$field] = $field;
+                $autoMatchedFields[$field] = strtolower($field);
             }
 
             $form->add('leadFields', 'integration_fields', array(


### PR DESCRIPTION
As some fields might be required for some integrations, this PR will try to auto match the integration fields with the Mautic fields that have the same name.

# Testing
1. Configure a new Plugin Integration (e.g. Hubspot)
2. Go to the *Lead Field Mapping* tab
3. Check if any field comes already selected

In Hubspot example the following fields should be auto-matched:
*firstname, lastname, email, phone, fax, city, state, country, company, website*
