### PR TITLE
Memory limit check added to installation suggestions

### DIFF
--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -403,6 +403,11 @@ class CheckStep implements StepInterface
      */
     public function toBytes($val) {
         $val = trim($val);
+
+        if ($val == -1) {
+            return PHP_INT_MAX;
+        }
+
         $last = strtolower($val[strlen($val)-1]);
         switch($last) {
             // The 'G' modifier is available since PHP 5.1.0

--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -303,6 +303,13 @@ class CheckStep implements StepInterface
             }
         }
 
+        $memoryLimit = $this->toBytes(ini_get('memory_limit'));
+        $suggestedLimit = 128 * 1024 * 1024;
+
+        if ($memoryLimit < $suggestedLimit) {
+            $messages[] = 'mautic.install.memory.limit';
+        }
+
         if (!class_exists('\\Locale')) {
             $messages[] = 'mautic.install.module.intl';
         }
@@ -385,5 +392,28 @@ class CheckStep implements StepInterface
         }
 
         return $parameters;
+    }
+
+    /**
+     * Takes the memory limit string form php.ini and returns numeric value in bytes.
+     *
+     * @param string $val
+     *
+     * @return integer
+     */
+    public function toBytes($val) {
+        $val = trim($val);
+        $last = strtolower($val[strlen($val)-1]);
+        switch($last) {
+            // The 'G' modifier is available since PHP 5.1.0
+            case 'g':
+                $val *= 1024;
+            case 'm':
+                $val *= 1024;
+            case 'k':
+                $val *= 1024;
+        }
+
+        return $val;
     }
 }

--- a/app/bundles/InstallBundle/Translations/en_US/messages.ini
+++ b/app/bundles/InstallBundle/Translations/en_US/messages.ini
@@ -60,6 +60,7 @@ mautic.install.function.sessionstart="Install and enable the <strong>session</st
 mautic.install.function.simplexml="Install and enable the <strong>SimpleXML</strong> extension."
 mautic.install.function.tokengetall="Install and enable the <strong>Tokenizer</strong> extension."
 mautic.install.function.xml="Install and enable the <strong>XML</strong> extension."
+mautic.install.memory.limit="The memory_limit setting in php.ini is lower than suggested minimal limit of 128MB. Mautic can have troubles to process larger datasets and even to install."
 mautic.install.heading.almost.configured="Mautic is almost configured, but..."
 mautic.install.heading.check.environment="Mautic Installation - Environment Check"
 mautic.install.heading.configured="Mautic is installed! Visit <a href='https://www.mautic.org/getting-started' target='_blank'>Getting Started</a> for the next steps."

--- a/app/bundles/InstallBundle/Translations/en_US/messages.ini
+++ b/app/bundles/InstallBundle/Translations/en_US/messages.ini
@@ -60,7 +60,7 @@ mautic.install.function.sessionstart="Install and enable the <strong>session</st
 mautic.install.function.simplexml="Install and enable the <strong>SimpleXML</strong> extension."
 mautic.install.function.tokengetall="Install and enable the <strong>Tokenizer</strong> extension."
 mautic.install.function.xml="Install and enable the <strong>XML</strong> extension."
-mautic.install.memory.limit="The memory_limit setting in php.ini is lower than suggested minimal limit of 128MB. Mautic can have troubles to process larger datasets and even to install."
+mautic.install.memory.limit="The <strong>memory_limit</strong> setting in your PHP configuration is lower than the suggested minimum limit of 128MB. Mautic can have performance issues with large datasets without sufficient memory."
 mautic.install.heading.almost.configured="Mautic is almost configured, but..."
 mautic.install.heading.check.environment="Mautic Installation - Environment Check"
 mautic.install.heading.configured="Mautic is installed! Visit <a href='https://www.mautic.org/getting-started' target='_blank'>Getting Started</a> for the next steps."


### PR DESCRIPTION
Some users experience troubles with low memory_limit. As it was suggested in 

https://www.mautic.org/community/index.php/1080-error-500-when-1st-call-of-index-php/0#p4499

I added the warning message in the first installation step which will show up if the memory_limit setting is lower than 128MB. For string to int value conversion was used the method suggested in

http://php.net/manual/en/function.ini-get.php

as official example so it shouldn't cause troubles with various values.

> Note: When querying memory size values
>Many ini memory size values, such as upload_max_filesize, are stored in the php.ini file in shorthand notation. ini_get() will return the exact string stored in the php.ini file and NOT its integer equivalent. Attempting normal arithmetic functions on these values will not have otherwise expected results. The example above shows one way to convert shorthand notation into bytes, much like how the PHP source does it.