### PR TITLE
Support for placeholder in config array (theme) for email slots

### DIFF
--- a/app/bundles/EmailBundle/Views/builder.html.php
+++ b/app/bundles/EmailBundle/Views/builder.html.php
@@ -18,9 +18,16 @@ $view['assets']->addScript('app/bundles/EmailBundle/Assets/builder/builder.js');
 $view['assets']->addStylesheet('app/bundles/EmailBundle/Assets/builder/builder.css');
 
 //Set the slots
-foreach ($slots as $slot) {
+foreach ($slots as $slot => $slotConfig) {
+    //support previous format where email slots are not defined with config array
+    if (is_numeric($slot)) {
+        $slot = $slotConfig;		
+        $slotConfig = array();
+    }
+
     $value = isset($content[$slot]) ? $content[$slot] : "";
-    $view['slots']->set($slot, "<div id=\"slot-{$slot}\" class=\"mautic-editable\" contenteditable=true data-placeholder=\"{$view['translator']->trans('mautic.page.builder.addcontent')}\">{$value}</div>");
+    $placeholder = isset($slotConfig['placeholder']) ? $slotConfig['placeholder'] : 'mautic.page.builder.addcontent'; 
+    $view['slots']->set($slot, "<div id=\"slot-{$slot}\" class=\"mautic-editable\" contenteditable=true data-placeholder=\"{$view['translator']->trans($placeholder)}\">{$value}</div>");
 }
 
 //add builder toolbar

--- a/app/bundles/EmailBundle/Views/public.html.php
+++ b/app/bundles/EmailBundle/Views/public.html.php
@@ -16,7 +16,12 @@ if (!empty($inBrowser)) {
 }
 
 //Set the slots
-foreach ($slots as $slot) {
+foreach ($slots as $slot => $slotConfig) {
+    if (is_numeric($slot)) {
+        $slot = $slotConfig;
+        $slotConfig = array();
+    }
+
     $value = isset($content[$slot]) ? $content[$slot] : "";
     $view['slots']->set($slot, $value);
 }

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -490,7 +490,6 @@ class FormModel extends CommonFormModel
 
                 switch ($f->getType()) {
                     case 'text':
-                    case 'email':
                         if (preg_match('/<input(.*?)id="mauticform_input_'.$formName.'_'.$alias.'"(.*?)value="(.*?)"(.*?)\/>/i', $formHtml, $match)) {
                             $replace  = '<input'.$match[1].'id="mauticform_input_'.$formName.'_'.$alias.'"'.$match[2].'value="'.urldecode($value).'"'.$match[4].'/>';
                             $formHtml = str_replace($match[0], $replace, $formHtml);


### PR DESCRIPTION
Previously, placeholders were not supported for email slots while buillding themes. The default message of "Click to add content" were always displayed in the email builder.

This PR added support for array configs in email slots with the placeholder element. This would put the custom placeholder message into the email builder.

Example theme config to show custom placeholder values below. This example demonstrate the values in supporting custom placeholder where I was able to give specific instructions like specifying the image size to be inserted or stipulate that the unsubscribe link is inserted in a specific place. The title slot in this example is left without a config array like previously and the default placeholder would be placed there instead.
```
$config = array(
    "name"        => "My Theme",
    "features"    => array(
        "email"
    ),
    "slots"       => array(
        "email" => array(
	    "header"          => array('placeholder' => 'Please insert image here with width=700px and height at least 367px'),
            "title",
	    "body"		    => array('placeholder' => 'Enter the email body here here'),
	    "unsubscribe"  => array('placeholder' => 'Drag and drop the unsubsribe text from the right hand column here')
        )
    )
);
```
Link to discussion on Mautic forum https://www.mautic.org/community/index.php/1089-placeholder-for-email-slots-in-builder 

Thanks escopez for your help!