### PR TITLE
Allow email form fields to be populated by query string parameters

### DIFF
--- a/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
@@ -215,8 +215,7 @@ class CorePermissions
                 $entity->setName(strtolower($name));
 
                 $bit   = 0;
-		$pluginBundles = $this->getPluginBundles();
-                $class = $this->getPermissionObject($bundle, true, array_key_exists(ucfirst($bundle) . "Bundle", $pluginBundles));
+                $class = $this->getPermissionObject($bundle);
 
                 foreach ($perms as $perm) {
                     //get the bit for the perm

--- a/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
@@ -215,7 +215,8 @@ class CorePermissions
                 $entity->setName(strtolower($name));
 
                 $bit   = 0;
-                $class = $this->getPermissionObject($bundle);
+		$pluginBundles = $this->getPluginBundles();
+                $class = $this->getPermissionObject($bundle, true, array_key_exists(ucfirst($bundle) . "Bundle", $pluginBundles));
 
                 foreach ($perms as $perm) {
                     //get the bit for the perm

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -490,6 +490,7 @@ class FormModel extends CommonFormModel
 
                 switch ($f->getType()) {
                     case 'text':
+                    case 'email':
                         if (preg_match('/<input(.*?)id="mauticform_input_'.$formName.'_'.$alias.'"(.*?)value="(.*?)"(.*?)\/>/i', $formHtml, $match)) {
                             $replace  = '<input'.$match[1].'id="mauticform_input_'.$formName.'_'.$alias.'"'.$match[2].'value="'.urldecode($value).'"'.$match[4].'/>';
                             $formHtml = str_replace($match[0], $replace, $formHtml);

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -490,7 +490,6 @@ class FormModel extends CommonFormModel
 
                 switch ($f->getType()) {
                     case 'text':
-                    case 'email':
                         if (preg_match('/<input(.*?)id="mauticform_input_'.$formName.'_'.$alias.'"(.*?)value="(.*?)"(.*?)\/>/i', $formHtml, $match)) {
                             $replace  = '<input'.$match[1].'id="mauticform_input_'.$formName.'_'.$alias.'"'.$match[2].'value="'.urldecode($value).'"'.$match[4].'/>';
                             $formHtml = str_replace($match[0], $replace, $formHtml);


### PR DESCRIPTION
This is a replacement for [PR number 1093](https://github.com/mautic/mautic/pull/1093). I have redone the changes in a different branch to maintain separation.

Description copied from 1093:

It is possible to pass default form fields via query parameters for fields such as text input. However, email field types are not processed hence it is not default email values are not enabled. I think this is an important feature most visitors expect the form to prepopulate with their email address when clicking through from an email.
