### PR TITLE
Modify tag campaign action didn't remove the tags. Fixed

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1092,10 +1092,18 @@ class LeadModel extends FormModel
         }
 
         if ($removeTags !== null) {
+
+            $logger->debug('LEAD: Removing ' . implode(', ', $removeTags) . ' for lead ID# ' . $lead->getId());
+
+            array_walk($removeTags, create_function('&$val', '$val = trim($val); \Mautic\CoreBundle\Helper\InputHelper::clean($val);'));
+
+            // See which tags really exist
+            $foundRemoveTags = $this->getTagRepository()->getTagsByName($removeTags);
+
             foreach ($removeTags as $tag) {
                 // Tag to be removed
-                if (array_key_exists($tag, $foundTags) && $leadTags->contains($foundTags[$tag])) {
-                    $lead->removeTag($foundTags[$tag]);
+                if (array_key_exists($tag, $foundRemoveTags) && $leadTags->contains($foundRemoveTags[$tag])) {
+                    $lead->removeTag($foundRemoveTags[$tag]);
                     $logger->debug('LEAD: Removed ' . $tag);
                 }
             }


### PR DESCRIPTION
The "Modify lead's tags" decision is adding tags just fine, but removing tags doesn't work. I think I've read it in the forum or in a GH issue, but I cannot find it now. Anyway, I tested this case and it really doesn't work. This PR fixes it.

### Testing
1. Select one lead from a list and add it some tag. For example "tag1".
2. Create a campaign for example with a lead list source and with the "Modify lead's tags" action.
3. Configure the campaign action to remove the "tag1".
4. Run commands to add the leads from the list to the campaign and then execute the campaign.

The tag will not be removed. After the PR, truncate the campaign_lead_event_log table and trigger the campaign again. The tag form the lead should disappear.

The problem was in `$foundTags` which contained only tags which were suppose to be added.