### PR TITLE
Prevented PHP warnings related to do not track IPs and config

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -411,6 +411,6 @@ return array(
         'cookie_domain'                  => '',
         'cookie_secure'                  => null,
         'cookie_httponly'                => false,
-        'do_not_track_ips'               => null,
+        'do_not_track_ips'               => array(),
     )
 );

--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -655,7 +655,13 @@ class MauticFactory
 
             // Ensure the do not track list is inserted
             $doNotTrack  = $this->getParameter('do_not_track_ips', array());
+            if (!is_array($doNotTrack)) {
+                $doNotTrack = array();
+            }
             $internalIps = $this->getParameter('do_not_track_internal_ips', array());
+            if (!is_array($internalIps)) {
+                $internalIps = array();
+            }
             $doNotTrack  = array_merge(array('127.0.0.1', '::1'), $doNotTrack, $internalIps);
             $ipAddress->setDoNotTrackList($doNotTrack);
 

--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -615,7 +615,13 @@ class MauticFactory
                     $ip = end($ips);
                 }
 
-                return trim($ip);
+                $ip = trim($ip);
+
+                // Validate IP
+                if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+
+                    return $ip;
+                }
             }
         }
 


### PR DESCRIPTION
**Description**

The config defaults do_not_track_ips to null which leads to PHP warning about array_merge and arguments not being an array.  Fixes #1134.

**Testing**

Ensure that your local.php does not have a do_not_track_ips entry so that the default is used. Browse to a landing page as an anonymous lead not on a local machine (won't trigger with a local IP).  The warning should be recorded.  After the PR, the warning should go away.