### PR TITLE
Fixed issue that would allow cron commands to run multiple processes

### DIFF
--- a/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
@@ -9,7 +9,7 @@
 
 namespace Mautic\CampaignBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Mautic\CoreBundle\Command\ModeratedCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Class TriggerCampaignCommand
  */
-class TriggerCampaignCommand extends ContainerAwareCommand
+class TriggerCampaignCommand extends ModeratedCommand
 {
     /**
      * {@inheritdoc}
@@ -52,6 +52,8 @@ class TriggerCampaignCommand extends ContainerAwareCommand
                 0
             )
             ->addOption('--force', '-f', InputOption::VALUE_NONE, 'Force execution even if another process is assumed running.');
+
+        parent::configure();
     }
 
     /**
@@ -79,43 +81,11 @@ class TriggerCampaignCommand extends ContainerAwareCommand
         $negativeOnly = $input->getOption('negative-only');
         $batch        = $input->getOption('batch-limit');
         $max          = $input->getOption('max-events');
-        $force        = $input->getOption('force');
 
-        // Prevent script overlap
-        $checkFile      = $checkFile = $container->getParameter('kernel.cache_dir').'/../script_executions.json';
-        $command        = 'mautic:campaign:trigger';
-        $key            = ($id) ? $id : 'all';
-        $executionTimes = array();
+        if (!$this->checkRunStatus($input, $output, ($id) ? $id : 'all')) {
 
-        if (file_exists($checkFile)) {
-            // Get the time in the file
-            $executionTimes = json_decode(file_get_contents($checkFile), true);
-            if (!is_array($executionTimes)) {
-                $executionTimes = array();
-            }
-
-            if ($force || empty($executionTimes['in_progress'][$command][$key])) {
-                // Just started
-                $executionTimes['in_progress'][$command][$key] = time();
-            } else {
-                // In progress
-                $check = $executionTimes['in_progress'][$command][$key];
-
-                if ($check + 1800 <= time()) {
-                    // Has been 30 minutes so override
-                    $executionTimes['in_progress'][$command][$key] = time();
-                } else {
-                    $output->writeln('<error>Script in progress. Use -f or --force to force execution.</error>');
-
-                    return 0;
-                }
-            }
-        } else {
-            // Just started
-            $executionTimes['in_progress'][$command][$key] = time();
+            return 0;
         }
-
-        file_put_contents($checkFile, json_encode($executionTimes));
 
         if ($id) {
             /** @var \Mautic\CampaignBundle\Entity\Campaign $campaign */
@@ -214,8 +184,7 @@ class TriggerCampaignCommand extends ContainerAwareCommand
             unset($campaigns);
         }
 
-        unset($executionTimes['in_progress'][$command][$key]);
-        file_put_contents($checkFile, json_encode($executionTimes));
+        $this->completeRun();
 
         return 0;
     }

--- a/app/bundles/CoreBundle/Command/ModeratedCommand.php
+++ b/app/bundles/CoreBundle/Command/ModeratedCommand.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2015 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class ModeratedCommand extends ContainerAwareCommand
+{
+    protected $checkfile;
+    protected $key;
+    protected $executionTimes = array();
+
+    /**
+     * Set moderation options
+     */
+    protected function configure()
+    {
+        $this->addOption('--force', '-f', InputOption::VALUE_NONE, 'Force execution even if another process is assumed running.');
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     * @param                 $key
+     *
+     * @return bool
+     */
+    protected function checkRunStatus(InputInterface $input, OutputInterface $output, $key)
+    {
+        $force     = $input->getOption('force');
+        $timeout   = $this->getContainer()->hasParameter('mautic.command_timeout') ?
+            $this->getContainer()->getParameter('mautic.command_timeout') : 1800;
+        $checkFile = $this->checkfile = $this->getContainer()->getParameter('kernel.cache_dir').'/../script_executions.json';
+        $command   = $this->getName();
+        $this->key = $key;
+
+        if (file_exists($checkFile)) {
+            // Get the time in the file
+            $this->executionTimes = json_decode(file_get_contents($checkFile), true);
+            if (!is_array($this->executionTimes)) {
+                $this->executionTimes = array();
+            }
+
+            if ($force || empty($this->executionTimes['in_progress'][$command][$key])) {
+                // Just started
+                $this->executionTimes['in_progress'][$command][$key] = time();
+            } else {
+                // In progress
+                $check = $this->executionTimes['in_progress'][$command][$key];
+
+                if ($check + $timeout <= time()) {
+                    $this->executionTimes['in_progress'][$command][$key] = time();
+                } else {
+                    $output->writeln('<error>Script in progress. Use -f or --force to force execution.</error>');
+
+                    return false;
+                }
+            }
+        } else {
+            // Just started
+            $this->executionTimes['in_progress'][$command][$key] = time();
+        }
+
+        file_put_contents($this->checkfile, json_encode($this->executionTimes));
+
+        return true;
+    }
+
+    /**
+     * Complete this run
+     */
+    protected function completeRun()
+    {
+        unset($this->executionTimes['in_progress'][$this->getName()][$this->key]);
+        file_put_contents($this->checkfile, json_encode($this->executionTimes));
+    }
+}


### PR DESCRIPTION
**Description**
The cron jobs aren't supposed to overlap due to the risk of duplicating records.  For the `mautic:list:update` and `mautic:campaign:update` commands, the time started was not actually written to file and thus allowing another process to fire while the first is still running.  This PR fixes that.

**Testing**
Create a list that will match enough leads to have enough time to start one command then in a second window, start a second.  Run the `mautic:lists:update` command in one console then before it finishes, execute it in a second console.  It should still fire.  

Now after the PR, repeat the process and this time the second console should give a message to use -f to force execution. 