### PR TITLE
Fix bug where clicking "new email" from campaign builder throws an error

### DIFF
--- a/app/bundles/AssetBundle/Entity/AssetRepository.php
+++ b/app/bundles/AssetBundle/Entity/AssetRepository.php
@@ -57,7 +57,7 @@ class AssetRepository extends CommonRepository
         }
 
         if (!$viewOther) {
-            $q->andWhere($q->expr()->eq('IDENTITY(a.createdBy)', ':id'))
+            $q->andWhere($q->expr()->eq('a.createdBy', ':id'))
                 ->setParameter('id', $this->currentUser->getId());
         }
 

--- a/app/bundles/AssetBundle/Form/Type/AssetListType.php
+++ b/app/bundles/AssetBundle/Form/Type/AssetListType.php
@@ -31,12 +31,12 @@ class AssetListType extends AbstractType
      */
     public function __construct(MauticFactory $factory)
     {
-	$viewOther = $factory->getSecurity()->isGranted('asset:assets:viewother');
-	$repo = $factory->getModel('asset')->getRepository();
+        $viewOther = $factory->getSecurity()->isGranted('asset:assets:viewother');
+        $repo = $factory->getModel('asset')->getRepository();
         $repo->setCurrentUser($factory->getUser());
         $choices = $repo->getAssetList('', 0, 0, $viewOther);
  
-	foreach ($choices as $asset) {
+        foreach ($choices as $asset) {
             $this->choices[$asset['language']][$asset['id']] = $asset['title'];
         }
 

--- a/app/bundles/AssetBundle/Form/Type/AssetListType.php
+++ b/app/bundles/AssetBundle/Form/Type/AssetListType.php
@@ -31,10 +31,12 @@ class AssetListType extends AbstractType
      */
     public function __construct(MauticFactory $factory)
     {
-        $viewOther = $factory->getSecurity()->isGranted('asset:assets:viewother');
-        $choices = $factory->getModel('asset')->getRepository()
-            ->getAssetList('', 0, 0, $viewOther);
-        foreach ($choices as $asset) {
+	$viewOther = $factory->getSecurity()->isGranted('asset:assets:viewother');
+	$repo = $factory->getModel('asset')->getRepository();
+        $repo->setCurrentUser($factory->getUser());
+        $choices = $repo->getAssetList('', 0, 0, $viewOther);
+ 
+	foreach ($choices as $asset) {
             $this->choices[$asset['language']][$asset['id']] = $asset['title'];
         }
 

--- a/app/bundles/FormBundle/Form/Type/FormListType.php
+++ b/app/bundles/FormBundle/Form/Type/FormListType.php
@@ -28,9 +28,9 @@ class FormListType extends AbstractType
      */
     public function __construct(MauticFactory $factory) {
         $this->viewOther = $factory->getSecurity()->isGranted('form:forms:viewother');
-	$this->repo      = $factory->getModel('form')->getRepository();
+        $this->repo      = $factory->getModel('form')->getRepository();
 
-	$this->repo->setCurrentUser($factory->getUser());
+        $this->repo->setCurrentUser($factory->getUser());
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)

--- a/app/bundles/FormBundle/Form/Type/FormListType.php
+++ b/app/bundles/FormBundle/Form/Type/FormListType.php
@@ -28,7 +28,9 @@ class FormListType extends AbstractType
      */
     public function __construct(MauticFactory $factory) {
         $this->viewOther = $factory->getSecurity()->isGranted('form:forms:viewother');
-        $this->repo      = $factory->getModel('form')->getRepository();
+	$this->repo      = $factory->getModel('form')->getRepository();
+
+	$this->repo->setCurrentUser($factory->getUser());
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -490,7 +490,6 @@ class FormModel extends CommonFormModel
 
                 switch ($f->getType()) {
                     case 'text':
-                    case 'email':
                         if (preg_match('/<input(.*?)id="mauticform_input_'.$formName.'_'.$alias.'"(.*?)value="(.*?)"(.*?)\/>/i', $formHtml, $match)) {
                             $replace  = '<input'.$match[1].'id="mauticform_input_'.$formName.'_'.$alias.'"'.$match[2].'value="'.urldecode($value).'"'.$match[4].'/>';
                             $formHtml = str_replace($match[0], $replace, $formHtml);


### PR DESCRIPTION
Fixing issue described [here on Mautic forum](https://www.mautic.org/community/index.php/1115-bug-when-creating-new-email)

**Reproduction:**

- Create a role with permission to create emails and then view, edit, delete publish own in emails, assets, forms, etc. For emails, also grant "view others" permission. Assume this role has full campaign permission for now.
- Login as an user with the above role
- Go to the campaign builder, add a send email step
- Click the "new email" button.
- You should see a popup displayed with an error:
[2015-11-06 09:16:01] mautic.ERROR: Fatal: Call to a member function getId() on a non-object - in file /homepages/6/d416965206/htdocs/rightmarket/poc-mautic/app/bundles/FormBundle/Entity/FormRepository.php - at line 62 [] []

This PR fixes the above issue and allows the user to create emails from the campaign builder.