### PR TITLE
Fixed authorization issue for maxmind IP lookup

### DIFF
--- a/app/bundles/CoreBundle/IpLookup/AbstractIpLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/AbstractIpLookup.php
@@ -78,6 +78,7 @@ abstract class AbstractIpLookup
         $this->ip        = $ip;
         $this->connector = HttpFactory::getHttp();
         $this->logger    = $logger;
+        $this->auth      = $auth;
     }
 
     /**

--- a/app/bundles/CoreBundle/IpLookup/AbstractIpLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/AbstractIpLookup.php
@@ -18,6 +18,7 @@ abstract class AbstractIpLookup
 {
     public $city = '';
     public $region = '';
+    public $zipcode = '';
     public $country = '';
     public $latitude = '';
     public $longitude = '';

--- a/app/bundles/CoreBundle/IpLookup/AbstractMaxmindIpLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/AbstractMaxmindIpLookup.php
@@ -15,11 +15,34 @@ namespace Mautic\CoreBundle\IpLookup;
 abstract class AbstractMaxmindIpLookup extends AbstractIpLookup
 {
     /**
+     * Fetches the data for the given IP address
+     *
+     * @return $this
+     */
+    public function getData()
+    {
+        $url = $this->getUrl();
+
+        try {
+            $headers = array(
+                'Authorization' => 'Basic ' . base64_encode($this->auth),
+            );
+            $response = $this->connector->{$this->method}($url, $headers);
+
+            $this->parseData($response->body);
+        } catch (\Exception $exception) {
+            if ($this->logger) {
+                $this->logger->warning('IP LOOKUP: ' . $exception->getMessage());
+            }
+        }
+    }
+
+    /**
      * @return string
      */
     protected function getUrl()
     {
-        $url = "https://{$this->auth}@geoip.maxmind.com/geoip/v2.1/";
+        $url = "https://geoip.maxmind.com/geoip/v2.1/";
 
         switch ($this->getName()) {
             case 'maxmind_country':

--- a/app/bundles/CoreBundle/IpLookup/AbstractMaxmindIpLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/AbstractMaxmindIpLookup.php
@@ -69,6 +69,9 @@ abstract class AbstractMaxmindIpLookup extends AbstractIpLookup
         $data = json_decode($response);
 
         if ($data && empty($data->error)) {
+            if (isset($data->postal)) {
+                $this->zipcode = $data->postal->code;
+            }
             $this->city      = $data->city->names->en;
             if (isset($data->subdivisions[0])) {
                 $this->region = $data->subdivisions[0]->names->en;

--- a/app/bundles/CoreBundle/IpLookup/AbstractMaxmindIpLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/AbstractMaxmindIpLookup.php
@@ -72,14 +72,23 @@ abstract class AbstractMaxmindIpLookup extends AbstractIpLookup
             if (isset($data->postal)) {
                 $this->zipcode = $data->postal->code;
             }
-            $this->city      = $data->city->names->en;
-            if (isset($data->subdivisions[0])) {
-                $this->region = $data->subdivisions[0]->names->en;
-            }
             $this->country   = $data->country->names->en;
+            $this->city      = $data->city->names->en;
+
+            if (isset($data->subdivisions[0])) {
+                if (count($data->subdivisions) > 1) {
+                    // Use the first listed as the country and second as state
+                    // UK -> England -> Winchester
+                    $this->country = $data->subdivisions[0]->names->en;
+                    $this->region  = $data->subdivisions[1]->names->en;
+                } else {
+                    $this->region = $data->subdivisions[0]->names->en;
+                }
+            }
+
             $this->latitude  = $data->location->latitude;
             $this->longitude = $data->location->longitude;
-            $this->timezone = $data->location->time_zone;
+            $this->timezone  = $data->location->time_zone;
 
             if (isset($data->traits->isp)) {
                 $this->isp = $data->traits->isp;

--- a/app/bundles/CoreBundle/IpLookup/AbstractMaxmindIpLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/AbstractMaxmindIpLookup.php
@@ -70,7 +70,9 @@ abstract class AbstractMaxmindIpLookup extends AbstractIpLookup
 
         if ($data && empty($data->error)) {
             $this->city      = $data->city->names->en;
-            $this->region    = $data->subdivisions->names->en;
+            if (isset($data->subdivisions[0])) {
+                $this->region = $data->subdivisions[0]->names->en;
+            }
             $this->country   = $data->country->names->en;
             $this->latitude  = $data->location->latitude;
             $this->longitude = $data->location->longitude;

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -213,6 +213,10 @@ class LeadModel extends FormModel
             if (!empty($details['country']) && empty($fields['core']['country']['value'])) {
                 $entity->addUpdatedField('country', $details['country']);
             }
+
+            if (!empty($details['zipcode']) && empty($fields['core']['zipcode']['value'])) {
+                $entity->addUpdatedField('zipcode', $details['zipcode']);
+            }
         }
 
         parent::saveEntity($entity, $unlock);


### PR DESCRIPTION
**Description**
Maxmind IP lookup failed due to requiring basic auth.  This PR fixes it.

**Testing**
Using Maxmind credentials to search an IP.  Before, no data would be fetched.  With the PR, data will be fetched.