### PR TITLE
Fix bug cannot view email node configuration in campaign builder without view others email permission

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -245,7 +245,7 @@ class EmailRepository extends CommonRepository
         }
 
         if (!$viewOther) {
-            $q->andWhere($q->expr()->eq('IDENTITY(e.createdBy)', ':id'))
+            $q->andWhere($q->expr()->eq('e.createdBy', ':id'))
                 ->setParameter('id', $this->currentUser->getId());
         }
 

--- a/app/bundles/EmailBundle/Form/Type/EmailListType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailListType.php
@@ -29,9 +29,9 @@ class EmailListType extends AbstractType
      */
     public function __construct(MauticFactory $factory) {
         $this->viewOther = $factory->getSecurity()->isGranted('email:emails:viewother');
-	$this->repo      = $factory->getModel('email')->getRepository();
+        $this->repo      = $factory->getModel('email')->getRepository();
 
-	$this->repo->setCurrentUser($factory->getUser());
+        $this->repo->setCurrentUser($factory->getUser());
     }
 
     /**

--- a/app/bundles/EmailBundle/Form/Type/EmailListType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailListType.php
@@ -29,7 +29,9 @@ class EmailListType extends AbstractType
      */
     public function __construct(MauticFactory $factory) {
         $this->viewOther = $factory->getSecurity()->isGranted('email:emails:viewother');
-        $this->repo      = $factory->getModel('email')->getRepository();
+	$this->repo      = $factory->getModel('email')->getRepository();
+
+	$this->repo->setCurrentUser($factory->getUser());
     }
 
     /**

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -490,6 +490,7 @@ class FormModel extends CommonFormModel
 
                 switch ($f->getType()) {
                     case 'text':
+                    case 'email':
                         if (preg_match('/<input(.*?)id="mauticform_input_'.$formName.'_'.$alias.'"(.*?)value="(.*?)"(.*?)\/>/i', $formHtml, $match)) {
                             $replace  = '<input'.$match[1].'id="mauticform_input_'.$formName.'_'.$alias.'"'.$match[2].'value="'.urldecode($value).'"'.$match[4].'/>';
                             $formHtml = str_replace($match[0], $replace, $formHtml);

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -490,7 +490,6 @@ class FormModel extends CommonFormModel
 
                 switch ($f->getType()) {
                     case 'text':
-                    case 'email':
                         if (preg_match('/<input(.*?)id="mauticform_input_'.$formName.'_'.$alias.'"(.*?)value="(.*?)"(.*?)\/>/i', $formHtml, $match)) {
                             $replace  = '<input'.$match[1].'id="mauticform_input_'.$formName.'_'.$alias.'"'.$match[2].'value="'.urldecode($value).'"'.$match[4].'/>';
                             $formHtml = str_replace($match[0], $replace, $formHtml);


### PR DESCRIPTION
# Reproduction:
1) Create a role with the following email permission: view, edit, publish delete own and create. Note that view others permission is not granted. Also grant permission to view and edit campaigns.
2) Create user with above role
3) Assume a previous campaign with send email node is available, otherwise create one.
4) Login as above user, go to campaigns builder and try to open the send email configuration node.
5) Notice that the configuration box does not load

The log below is observed in the log file:
[2015-11-17 09:26:35] mautic.ERROR: Fatal: Call to a member function getId() on a non-object - in file /homepages/6/d416965206/htdocs/rightmarket/poc-mautic/app/bundles/EmailBundle/Entity/EmailRepository.php - at line 249 [] 

This PR fixes the issue by setting the current user object.

Also just a note for people testing this, number 1148(#1148) is also related so might be worth testing it while you are here as well.