### PR TITLE
Changed user agent in page_hits table from string to text to prevent sql errors

### DIFF
--- a/app/bundles/PageBundle/Entity/Hit.php
+++ b/app/bundles/PageBundle/Entity/Hit.php
@@ -224,7 +224,7 @@ class Hit
             ->nullable()
             ->build();
 
-        $builder->createField('userAgent', 'string')
+        $builder->createField('userAgent', 'text')
             ->columnName('user_agent')
             ->nullable()
             ->build();

--- a/app/migrations/Version20151120000000.php
+++ b/app/migrations/Version20151120000000.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2015 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Class Version20151120000000
+ */
+
+class Version20151120000000 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function mysqlUp(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE ' . $this->prefix.'page_hits CHANGE user_agent user_agent LONGTEXT DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function postgresqlUp(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE ' . $this->prefix . 'page_hits ALTER user_agent TYPE TEXT');
+    }
+}
+


### PR DESCRIPTION
**Description**

Long user agents resulted in SQL errors for the page hits table due to the 255 character limit.  This change removes that character limit.

**Testing**

Run the `doctrine:migration:migrate` command after applying the PR.  Then make sure that page_hits user_agent column is a text column and that user agent is saved on a page hit. Can possibly duplicate if you can spoof the user agent to something longer than 255 characters.