### PR TITLE
Fixed lead issue with points and email sends

### DIFF
--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -249,7 +249,7 @@ class EmailSendEvent extends CommonEvent
     }
 
     /**
-     * @return Lead
+     * @return array
      */
     public function getLead()
     {

--- a/app/bundles/EmailBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/PointSubscriber.php
@@ -96,6 +96,12 @@ class PointSubscriber extends CommonSubscriber
      */
     public function onEmailSend(EmailSendEvent $event)
     {
-        $this->factory->getModel('point')->triggerAction('email.send', $event->getEmail());
+        if ($leadArray = $event->getLead()) {
+            $lead = $this->factory->getEntityManager()->getReference('MauticLeadBundle:Lead', $leadArray['id']);
+        } else {
+
+            return;
+        }
+        $this->factory->getModel('point')->triggerAction('email.send', $event->getEmail(), null, $lead);
     }
 }

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -483,6 +483,10 @@ class LeadModel extends FormModel
     {
         if (!$returnTracking && $this->systemCurrentLead) {
             // Just return the system set lead
+            if (null === $this->systemCurrentLead) {
+                $this->systemCurrentLead = new Lead();
+            }
+
             return $this->systemCurrentLead;
         }
 

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -481,7 +481,7 @@ class LeadModel extends FormModel
      */
     public function getCurrentLead($returnTracking = false)
     {
-        if (!$returnTracking && $this->systemCurrentLead) {
+        if ((!$returnTracking && $this->systemCurrentLead) || defined('IN_MAUTIC_CONSOLE')) {
             // Just return the system set lead
             if (null === $this->systemCurrentLead) {
                 $this->systemCurrentLead = new Lead();
@@ -562,7 +562,7 @@ class LeadModel extends FormModel
      */
     public function setCurrentLead(Lead $lead)
     {
-        if ($this->systemCurrentLead) {
+        if ($this->systemCurrentLead || defined('IN_MAUTIC_CONSOLE')) {
             // Overwrite system current lead
             $this->systemCurrentLead = $lead;
 

--- a/app/bundles/PointBundle/Model/PointModel.php
+++ b/app/bundles/PointBundle/Model/PointModel.php
@@ -10,6 +10,7 @@
 namespace Mautic\PointBundle\Model;
 
 use Mautic\CoreBundle\Model\FormModel as CommonFormModel;
+use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PointBundle\Entity\Action;
 use Mautic\PointBundle\Entity\LeadPointLog;
 use Mautic\PointBundle\Entity\Point;
@@ -142,10 +143,11 @@ class PointModel extends CommonFormModel
      * @param $type
      * @param mixed $eventDetails passthrough from function triggering action to the callback function
      * @param mixed $typeId Something unique to the triggering event to prevent  unnecessary duplicate calls
+     * @param Lead  $lead
      *
      * @return void
      */
-    public function triggerAction($type, $eventDetails = null, $typeId = null)
+    public function triggerAction($type, $eventDetails = null, $typeId = null, Lead $lead = null)
     {
         //only trigger actions for anonymous users
         if (!$this->security->isAnonymous()) {
@@ -167,9 +169,17 @@ class PointModel extends CommonFormModel
         /** @var \Mautic\PointBundle\Entity\PointRepository $repo */
         $repo         = $this->getRepository();
         $availablePoints = $repo->getPublishedByType($type);
+        /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
         $leadModel    = $this->factory->getModel('lead');
-        $lead         = $leadModel->getCurrentLead();
         $ipAddress    = $this->factory->getIpAddress();
+        if (null === $lead) {
+            $lead = $leadModel->getCurrentLead();
+
+            if (null === $lead || !$lead->getId()) {
+
+                return;
+            }
+        }
 
         //get available actions
         $availableActions = $this->getPointActions();


### PR DESCRIPTION
**Description**

Having a point action that gives a lead points on an email send would cause warnings from campaign executions due to attempting to set cookies via the console.  This PR fixes that by a) Not setting cookies when obtaining the lead through a console command and b) passing the lead from an event into PointModel::triggerAction() so that it uses it rather than obtaining the lead from cookies (LeadModel::getCurrentLead()) which obviously won't work from the console.

**Testing**

Create a campaign to send an email.  Then create a point action that assigns points to a lead when an email is sent.  Add a lead or two to the campaign and execute it with the `mautic:campaign:trigger` command while in the dev environment.  Warnings should be generated about headers could not be set by the CookieHelper because content has already streamed.  Or whatever that error is.  

After the PR, repeat the process and the error should no longer happen AND the appropriate leads should be assigned the points.
