### PR TITLE
Prevented triggering cache warmup when the configuration is saved

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -482,13 +482,16 @@ class AppKernel extends Kernel
         $class = $this->getContainerClass();
 
         $cache = new \Symfony\Component\Config\ConfigCache($this->getContainerFile(true), $this->debug);
-        $fresh = true;
+
+        $fresh = file_exists($this->getCacheDir().'/classes.php');
         if (!$cache->isFresh()) {
             $container = $this->buildContainer();
             $container->compile();
             $this->dumpContainer($cache, $container, $class, $this->getContainerBaseClass());
 
-            $fresh = false;
+            if ($this->debug) {
+                $fresh = false;
+            }
         }
 
         require_once $cache;
@@ -496,6 +499,7 @@ class AppKernel extends Kernel
         $this->container = new $class();
         $this->container->set('kernel', $this);
 
+        // Warm up the cache if classes.php is missing or in dev mode
         if (!$fresh && $this->container->has('cache_warmer')) {
             $this->container->get('cache_warmer')->warmUp($this->container->getParameter('kernel.cache_dir'));
         }
@@ -504,7 +508,7 @@ class AppKernel extends Kernel
     /**
      * Builds the service container.
      *
-     * @return ContainerBuilder The compiled service container
+     * @return \Symfony\Component\DependencyInjection\ContainerBuilder The compiled service container
      *
      * @throws \RuntimeException
      */
@@ -529,7 +533,7 @@ class AppKernel extends Kernel
         }
 
         // Only rebuild the classes if it doesn't exist or if the kernel is booted through the console meaning likely cache:clear is used
-        if (defined('IN_MAUTIC_CONSOLE') || !file_exists($this->getCacheDir().'/classes.map')) {
+        if (defined('IN_MAUTIC_CONSOLE') || !file_exists($this->getCacheDir().'/classes.php')) {
             $container->addCompilerPass(new DependencyInjection\AddClassesToCachePass($this));
         }
 


### PR DESCRIPTION
**Description**

In 1.2.2, it was changed to where the entire cache did not need to be wiped when saving Mautic's Configuration rather only Symfony's container file.  However, a cache 'warm up' was still being triggered which meant that Doctrine was regenerating all of it's Proxy classes/files and possible compilers from other bundles.  This leads to an unnecessary overhead after saving the configuration.

This PR change the behavior to only warm up the cache if Symfony's cached classes.php is missing which means that the entire folder was simply deleted.  The `cache:clear` command remains unaffected since it uses it's own mechanisms to warm up the cache.