### PR TITLE
Building lead list membership optimizations

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -285,7 +285,11 @@ class LeadListRepository extends CommonRepository
                 $parameters = array();
                 $expr       = $this->getListFilterExpr($filters, $parameters, $q, false);
                 foreach ($parameters as $k => $v) {
-                    $q->setParameter($k, $v);
+                    if (is_bool($v)) {
+                        $q->setParameter($k, $v, 'boolean');
+                    } else {
+                        $q->setParameter($k, $v);
+                    }
                 }
 
                 if ($countOnly) {

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -372,15 +372,14 @@ class ListModel extends FormModel
 
     /**
      * @param string $alias
-     * @param bool $withLeads
      *
      * @return mixed
      */
-    public function getUserLists($alias = '', $withLeads = false)
+    public function getUserLists($alias = '')
     {
         $user  = (!$this->security->isGranted('lead:lists:viewother')) ?
             $this->factory->getUser() : false;
-        $lists = $this->em->getRepository('MauticLeadBundle:LeadList')->getLists($user, $alias, '', $withLeads);
+        $lists = $this->em->getRepository('MauticLeadBundle:LeadList')->getLists($user, $alias);
 
         return $lists;
     }
@@ -388,13 +387,11 @@ class ListModel extends FormModel
     /**
      * Get a list of global lead lists
      *
-     * @param bool $withLeads
-     *
      * @return mixed
      */
-    public function getGlobalLists($withLeads = false)
+    public function getGlobalLists()
     {
-        $lists = $this->em->getRepository('MauticLeadBundle:LeadList')->getGlobalLists($withLeads);
+        $lists = $this->em->getRepository('MauticLeadBundle:LeadList')->getGlobalLists();
         return $lists;
     }
 
@@ -429,8 +426,6 @@ class ListModel extends FormModel
             array(
                 'countOnly'     => true,
                 'newOnly'       => true,
-                'dynamic'       => true,
-                'includeManual' => false,
                 'batchLimiters' => $batchLimiters
             )
         );
@@ -468,9 +463,7 @@ class ListModel extends FormModel
                     $list,
                     true,
                     array(
-                        'dynamic'       => true,
                         'newOnly'       => true,
-                        'includeManual' => false,
                         // No start set because of newOnly thus always at 0
                         'limit'         => $limit,
                         'batchLimiters' => $batchLimiters
@@ -528,26 +521,14 @@ class ListModel extends FormModel
             }
         }
 
-        $fullList = $this->getLeadsByList(
-            $list,
-            true,
-            array(
-                'dynamic'       => true,
-                'existingOnly'  => true,
-                'includeManual' => false,
-                'batchLimiters' => $batchLimiters
-            )
-        );
-
         // Get a count of leads to be removed
         $removeLeadCount = $this->getLeadsByList(
             $list,
             true,
             array(
-                'countOnly'     => true,
-                'includeManual' => false,
-                'filterOutIds'  => $fullList[$id],
-                'batchLimiters' => $batchLimiters
+                'countOnly'      => true,
+                'nonMembersOnly' => true,
+                'batchLimiters'  => $batchLimiters
             )
         );
 
@@ -578,9 +559,9 @@ class ListModel extends FormModel
                     true,
                     array(
                         // No start because the items are deleted so always 0
-                        'limit'         => $limit,
-                        'filterOutIds'  => $fullList[$id],
-                        'batchLimiters' => $batchLimiters
+                        'limit'          => $limit,
+                        'nonMembersOnly' => true,
+                        'batchLimiters'  => $batchLimiters
                     )
                 );
 
@@ -925,7 +906,7 @@ class ListModel extends FormModel
         }
 
         if ($leadSleepTime < 1) {
-            usleep($leadSleepTime * 1000);
+            usleep($leadSleepTime * 1000000);
         } else {
             sleep($leadSleepTime);
         }


### PR DESCRIPTION
**Description**

This optimizes lead list building for large lead bases when using the `mautic:list:update` command.  The query redesigns were tested against a lead database of 2 million fake leads.  

**Testing**

There are many facets to this so systematically testing the scenarios is required:

1. Test general filter with just lead profile data.  Run `mautic:list:update -i ID` (replace ID with the id of the list) and ensure that proper leads are added.
2. Test a filter with including a lead list(s) and excluding lead list(s)
3. Test a filter with including a lead tag(s) and excluding lead tag(s)
4. Test Bounced Email and Unsubscribed filters for both equal and not equal
5. Test a mixture of the above
6. Test adding leads to one list, then build a second list that has filters that will match the lead.  Run the command twice to ensure that duplicate entry SQL errors do not occur (because the query returned duplicate lead ids which should not happen)
7. Modify a filter so that leads no longer match and ensure that the correct leads are removed.

And anything else you can think of.  Basically lead lists should continue to work as expected :-)