### PR TITLE
Escape output for AssetBundle views

### DIFF
--- a/app/bundles/AssetBundle/Views/SubscribedEvents/BuilderToken/index.html.php
+++ b/app/bundles/AssetBundle/Views/SubscribedEvents/BuilderToken/index.html.php
@@ -10,7 +10,7 @@ $searchBtnClass = (!empty($searchValue)) ? "fa-eraser" : "fa-search";
 ?>
 
 <div class="input-group ma-5">
-    <input type="search" class="form-control" id="assetBuilderTokenSearch" name="search" placeholder="<?php echo $view['translator']->trans('mautic.core.search.placeholder'); ?>" value="<?php echo $searchValue; ?>" autocomplete="false" data-toggle="livesearch" data-target="#assetBuilderTokens" data-action="<?php echo $view['router']->generate('mautic_asset_buildertoken_index', array('page' => $page)); ?>" />
+    <input type="search" class="form-control" id="assetBuilderTokenSearch" name="search" placeholder="<?php echo $view->escape($view['translator']->trans('mautic.core.search.placeholder')); ?>" value="<?php echo $searchValue; ?>" autocomplete="false" data-toggle="livesearch" data-target="#assetBuilderTokens" data-action="<?php echo $view['router']->generate('mautic_asset_buildertoken_index', array('page' => $page)); ?>" />
     <div class="input-group-btn">
         <button type="button" class="btn btn-default btn-search btn-filter" data-livesearch-parent="assetBuilderTokenSearch">
             <i class="fa <?php echo $searchBtnClass; ?> fa-fw"></i>

--- a/app/bundles/AssetBundle/Views/SubscribedEvents/BuilderToken/list.html.php
+++ b/app/bundles/AssetBundle/Views/SubscribedEvents/BuilderToken/list.html.php
@@ -15,9 +15,9 @@ if ($tmpl == 'index') {
     <?php if (count($items)) : ?>
     <div class="list-group">
         <?php foreach ($items as $i) : ?>
-            <a href="#" class="list-group-item" data-token='<a href="%url={assetlink=<?php echo $i->getId(); ?>}%">%text=<?php echo $i->getName(); ?>%</a>' data-drop="showBuilderLinkModal">
+            <a href="#" class="list-group-item" data-token='<a href="%url={assetlink=<?php echo $i->getId(); ?>}%">%text=<?php echo $view->escape($i->getName()); ?>%</a>' data-drop="showBuilderLinkModal">
                 <div>
-                    <span><i class="fa fa-fw fa-file-o"></i><?php echo $i->getName() . ' (' . $i->getLanguage() . ')'; ?></span>
+                    <span><i class="fa fa-fw fa-file-o"></i><?php echo $view->escape($i->getName()) . ' (' . $i->getLanguage() . ')'; ?></span>
                 </div>
             </a>
         <?php endforeach; ?>

--- a/app/bundles/AssetBundle/Views/SubscribedEvents/Search/global.html.php
+++ b/app/bundles/AssetBundle/Views/SubscribedEvents/Search/global.html.php
@@ -9,11 +9,11 @@
 ?>
 <?php if (!empty($showMore)): ?>
 <a href="<?php echo $this->container->get('router')->generate('mautic_asset_index', array('search' => $searchString)); ?>" data-toggle="ajax">
-    <span><?php echo $view['translator']->trans('mautic.core.search.more', array("%count%" => $remaining)); ?></span>
+    <span><?php echo $view->escape($view['translator']->trans('mautic.core.search.more', array("%count%" => $remaining))); ?></span>
 </a>
 <?php else: ?>
 <a href="<?php echo $this->container->get('router')->generate('mautic_asset_action', array('objectAction' => 'view', 'objectId' => $asset->getId())); ?>" data-toggle="ajax">
-    <?php echo $asset->getTitle(); ?>
+    <?php echo $view->escape($asset->getTitle()); ?>
     <span class="label label-default pull-right" data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.asset.downloadcount'); ?>" data-placement="left">
         <?php echo $asset->getDownloadCount(); ?>
     </span>

--- a/app/bundles/AssetBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/AssetBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -19,10 +19,10 @@ $item = $event['extra']['asset'];
 	    		<a href="<?php echo $view['router']->generate('mautic_asset_action',
 				    array("objectAction" => "view", "objectId" => $item->getId())); ?>"
 				   data-toggle="ajax">
-				    <?php echo $item->getTitle(); ?>
+				    <?php echo $view->escape($item->getTitle()); ?>
 				</a>
 			</h3>
-            <p class="mb-0"><?php echo $view['translator']->trans('mautic.core.timeline.event.time', array('%date%' => $view['date']->toFullConcat($event['timestamp']), '%event%' => $event['eventLabel'])); ?></p>
+            <p class="mb-0"><?php echo $view->escape($view['translator']->trans('mautic.core.timeline.event.time', array('%date%' => $view['date']->toFullConcat($event['timestamp']), '%event%' => $event['eventLabel']))); ?></p>
 	    </div>
 	    <?php if (isset($event['extra'])) : ?>
 	        <!-- <div class="panel-footer">


### PR DESCRIPTION
I noticed an issue in email builder tool, to reproduce it I uploaded a PDF file (about BGP) as asset using *L'articolo riguardante BGP* in title, so you can see the bad output in **Asset** from email builder
<img width="270" alt="schermata 2015-11-24 alle 15 26 48" src="https://cloud.githubusercontent.com/assets/1416945/11370005/e2da4508-92c1-11e5-914f-0ae5304743d4.png">

The patch I applied is escaping strings, so the output is the following
<img width="279" alt="schermata 2015-11-24 alle 15 35 48" src="https://cloud.githubusercontent.com/assets/1416945/11370050/2fc10884-92c2-11e5-8804-a8707de916b3.png">

