### PR TITLE
Prevented saving dateLastActive updates to the audit log

### DIFF
--- a/app/bundles/CoreBundle/Entity/FormEntity.php
+++ b/app/bundles/CoreBundle/Entity/FormEntity.php
@@ -165,6 +165,7 @@ class FormEntity extends CommonEntity
         $this->dateModified = null;
         $this->checkedOut   = null;
         $this->isPublished  = false;
+        $this->changes      = array();
     }
 
     /**

--- a/app/bundles/CoreBundle/Event/CommonEvent.php
+++ b/app/bundles/CoreBundle/Event/CommonEvent.php
@@ -33,6 +33,11 @@ class CommonEvent extends Event
     protected $isNew = true;
 
     /**
+     * @var bool|array
+     */
+    protected $changes;
+
+    /**
      * Sets the entity manager for the event to use
      *
      * @param \Doctrine\ORM\EntityManager $em
@@ -59,6 +64,17 @@ class CommonEvent extends Event
      */
     public function getChanges()
     {
-        return ($this->entity && method_exists($this->entity, 'getChanges')) ? $this->entity->getChanges() : false;
+        if (null === $this->changes) {
+            $this->changes = false;
+            if ($this->entity && method_exists($this->entity, 'getChanges')) {
+                $this->changes = $this->entity->getChanges();
+                // Reset changes
+                if (method_exists($this->entity, 'resetChanges')) {
+                    $this->entity->resetChanges();
+                }
+            }
+        }
+
+        return $this->changes;
     }
 }


### PR DESCRIPTION
**Description**

If a lead's dateLastActive was the only thing updated, an audit log entry was added which is a lot of un-used and un-necessary entries.  This PR should prevent that.  It also prevents a duplicate entry to the audit log when a lead is saved and dateLastActive is added somewhere during one of the events executed from within onLeadPostSave() due to the entity's $changes array remaining intact after onLeadPostSave() processed the audit log the first time. So this PR clears the Entity's $changes the first time getChanges() is called from CommonEvent so that subsequent event listeners do not pick up the same changes again.  

**Testing**

Embed a tracking pixel into a 3rd party page.  In an anonymous browser, hit up that tracking pixel then check audit_log.  There should be an entry for a lead update where the details contains only a serialized array for dateLastActive.  After the PR, this entry should no longer get created.

