### PR TITLE
Fixed query that caused manually removed leads from a list to still receive emails

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -180,8 +180,14 @@ class EmailRepository extends CommonRepository
                 ->orderBy('l.id');
         }
         $q->from(MAUTIC_TABLE_PREFIX . 'leads', 'l')
-            ->join('l', MAUTIC_TABLE_PREFIX . 'lead_lists_leads', 'll', 'l.id = ll.lead_id')
-            ->join('ll', MAUTIC_TABLE_PREFIX . 'email_list_xref', 'el', 'el.leadlist_id = ll.leadlist_id');
+            ->join('l', MAUTIC_TABLE_PREFIX . 'lead_lists_leads', 'll',
+                $q->expr()->andX(
+                    $q->expr()->eq('l.id', 'll.lead_id'),
+                    $q->expr()->eq('ll.manually_removed', ':false')
+                )
+            )
+            ->join('ll', MAUTIC_TABLE_PREFIX . 'email_list_xref', 'el', 'el.leadlist_id = ll.leadlist_id')
+            ->setParameter('false', false, 'boolean');
 
         $q->where($q->expr()->eq('el.email_id', $emailId))
             ->andWhere('l.id NOT IN ' . sprintf("(%s)",$sq->getSQL()))


### PR DESCRIPTION
**Description**

Leads manually removed from a lead list would still be counted and sent emails for a List email.  This PR fixes this.

**Testing**

Create a lead list and an List based email and of course assign the created lead list to it. Populate the lead list using a filter.  Go to Emails and note the number of pending.  Go back to lead lists and click to view the leads belonging to the lead list.  Click on one of the leads then click Lists from the action menu.  Remove the lead from the lead list.  Go back to Emails and note that the pending count is still the same.

Apply the PR then look at the pending count.  This time it should be one less.  Can take it a step further, send the email and ensure the removed lead does not receive it.