### PR TITLE
Textarea line breaks

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -550,8 +550,8 @@ class MailHelper
 
                 $bodyReplaced = str_ireplace($search, $replace, $childBody);
                 if ($childBody != $bodyReplaced) {
-                    $child->setBody($bodyReplaced);
-                    $childBody = $bodyReplaced;
+                    $childBody = strip_tags($bodyReplaced);
+                    $child->setBody($childBody);
                 }
             }
 

--- a/app/bundles/FormBundle/Helper/FormSubmitHelper.php
+++ b/app/bundles/FormBundle/Helper/FormSubmitHelper.php
@@ -22,6 +22,13 @@ class FormSubmitHelper
      */
     public static function sendEmail($tokens, $config, MauticFactory $factory, Lead $lead)
     {
+        // replace line brakes with <br> for textarea values
+        if ($tokens) {
+            foreach ($tokens as $token => &$value) {
+                $value = nl2br(html_entity_decode($value));
+            }
+        }
+
         $mailer = $factory->getMailer();
         $emails = (!empty($config['to'])) ? explode(',', $config['to']) : array();
 

--- a/app/bundles/FormBundle/Views/Result/list.html.php
+++ b/app/bundles/FormBundle/Views/Result/list.html.php
@@ -94,7 +94,13 @@ $formId = $form->getId();
                 </td>
                 <td><?php echo $item['ipAddress']['ipAddress']; ?></td>
                 <?php foreach($item['results'] as $r):?>
-                    <td><?php echo $r['value']; ?></td>
+                    <td>
+                        <?php if ($r['type'] == 'textarea') : ?>
+                            <?php echo nl2br(html_entity_decode($r['value'])); ?>
+                        <?php else : ?>
+                            <?php echo $r['value']; ?>
+                        <?php endif; ?>
+                    </td>
                 <?php endforeach; ?>
             </tr>
         <?php endforeach; ?>


### PR DESCRIPTION
Some longer text submitted by the textarea field was displayed as a one paragraph which makes it a bit hard to read. This PR replaces line breaks with `<br>` tags so the text is displayed with line breaks it was originally submitted with.

This issue is fixed in the form result table view and in the send result email.

Reported in https://github.com/mautic/mautic/issues/1081

### Testing
1. Create a new standalone form with email and textarea field.
2. Add the *Send Result* event. Save it.
3. Go to preview page and submit the form with multi line text (lines separated by enters).

Check the result table and the email which was sent. The textarea value is one single line. Apply the PR and submit the form again. The result table textarea values will be displayed with line breaks as you had submitted it and the email will have the line breaks as well.