### PR TITLE
Prevented mailer from adding plain text mime type over and over 

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -145,6 +145,11 @@ class MailHelper
     protected $plainText = '';
 
     /**
+     * @var bool
+     */
+    protected $plainTextSet = false;
+
+    /**
      * @var array
      */
     protected $assets = array();
@@ -208,7 +213,7 @@ class MailHelper
             $this->transport->setMauticFactory($factory);
         }
 
-        $this->message    = $this->getMessageInstance();
+        $this->message = $this->getMessageInstance();
     }
 
     /**
@@ -256,8 +261,10 @@ class MailHelper
             $this->message->setSubject($this->subject);
             $this->message->setBody($this->body['content'], $this->body['contentType'], $this->body['charset']);
 
-            if (!empty($this->plainText)) {
+            if (!$this->plainTextSet && !empty($this->plainText)) {
                 $this->message->addPart($this->plainText, 'text/plain');
+
+                $this->plainTextSet = true;
             }
 
             if (!$isQueueFlush) {
@@ -469,7 +476,7 @@ class MailHelper
 
             unset($this->headers, $this->email, $this->source, $this->assets, $this->globalTokens, $this->message, $this->subject, $this->body, $this->plainText, $this->assets, $this->attachedAssets);
 
-            $this->headers = $this->source  = $this->assets = $this->globalTokens = $this->assets = $this->attachedAssets = array();
+            $this->headers = $this->source = $this->assets = $this->globalTokens = $this->assets = $this->attachedAssets = array();
             $this->email   = null;
             $this->subject = $this->plainText = '';
             $this->body    = array(
@@ -479,6 +486,7 @@ class MailHelper
             );
 
             $this->tokenizationEnabled = false;
+            $this->plainTextSet        = false;
 
             $this->message = $this->getMessageInstance();
         }
@@ -689,6 +697,7 @@ class MailHelper
         unset($vars);
 
         if ($returnContent) {
+
             return $content;
         }
 
@@ -721,7 +730,8 @@ class MailHelper
      */
     public function setPlainText($content)
     {
-        $this->plainText = $content;
+        $this->plainText    = $content;
+        $this->plainTextSet = false;
     }
 
     /**


### PR DESCRIPTION
**Description**

When sending a list email with a plain text for a mail that does not support tokenization (i.e. SMTP), the plain text body was added incrementally to each email sent.  So if 100 emails were sent in the batch, the 100th email would have 100 text/plain mime parts.  This caused some mailers to reject the message (such as Amazon SES that only allows 100 mime parts total). This PR fixes this.

**Testing**

Setup a list email with both HTML and plaintext parts to send to several leads and send.  Review the source of the last email and you should see several text/plain mime parts.  After the PR, only one text/plain mime part should exist.