### PR TITLE
Fixed issue where cloned emails did not allow changing type

### DIFF
--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -804,12 +804,6 @@ class EmailController extends FormController
 
             /** @var \Mautic\EmailBundle\Entity\Email $clone */
             $clone = clone $clone;
-            $clone->clearStats();
-            $clone->setSentCount(0);
-            $clone->setReadCount(0);
-            $clone->setRevision(0);
-            $clone->setVariantSentCount(0);
-            $clone->setVariantStartDate(null);
         }
 
         return $this->newAction($clone);

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -191,7 +191,14 @@ class Email extends FormEntity
 
     public function __clone()
     {
-        $this->id = null;
+        $this->id               = null;
+        $this->stats            = new ArrayCollection();
+        $this->sentCount        = 0;
+        $this->readCount        = 0;
+        $this->revision         = 0;
+        $this->variantSentCount = 0;
+        $this->variantStartDate = null;
+        $this->emailType        = null;
 
         parent::__clone();
     }


### PR DESCRIPTION
**Description**

Cloning an email would not allow changing the type from list to template or visa versa.  This fixes that.

**Testing**

Clone an existing email and you will not be prompted to choose the type (list or template).  After the PR, you should be prompted.