### PR TITLE
Fixed lead list view own permission

### DIFF
--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -49,15 +49,14 @@ class ListController extends FormController
 
         $filter           = array();
         $filter['string'] = $this->request->get('search', $this->factory->getSession()->get('mautic.leadlist.filter', ''));
-        $this->factory->getSession()->set('mautic.leadlist.filter', $filter['string']);
-        $tmpl       = $this->request->isXmlHttpRequest() ? $this->request->get('tmpl', 'index') : 'index';
 
         if (!$permissions['lead:lists:viewother']) {
-            $translator      = $this->get('translator');
-            $mine            = $translator->trans('mautic.core.searchcommand.ismine');
-            $global          = $translator->trans('mautic.lead.list.searchcommand.isglobal');
-            $filter["force"] = " ($mine or $global)";
+            $filter['force'][] =
+                array('column' => 'l.createdBy', 'expr' => 'eq', 'value' => $this->factory->getUser()->getId());
         }
+
+        $this->factory->getSession()->set('mautic.leadlist.filter', $filter['string']);
+        $tmpl       = $this->request->isXmlHttpRequest() ? $this->request->get('tmpl', 'index') : 'index';
 
         $items = $model->getEntities(
             array(


### PR DESCRIPTION
I was working on fix for https://github.com/mautic/mautic/issues/1213, but I maybe don't fully understand the problematic of why the code is how it is so this PR is more for discussion than suggested change. Questions are probably to @alanhartless:

1. If the permission is `lead:lists:viewother` apply filter `$filter["force"] = " ($mine or $global)";`. Is that some really old, unnecessary code or does it have some deep meaning I don't get (as usual)?
2. Why there is no `lead:lists:viewown` permission and `lead:leads:viewown` is used for lead lists instead? Viewing lead lists is required to view leads?