### PR TITLE
Category menu permission fix

### DIFF
--- a/app/bundles/CategoryBundle/Config/config.php
+++ b/app/bundles/CategoryBundle/Config/config.php
@@ -30,9 +30,10 @@ return array(
     'menu' => array(
         'admin' => array(
             'mautic.category.menu.index' => array(
-                'route'           => 'mautic_category_index',
-                'iconClass'       => 'fa-folder',
-                'id'              => 'mautic_category_index'
+                'route'     => 'mautic_category_index',
+                'access'    => 'category:categories:view',
+                'iconClass' => 'fa-folder',
+                'id'        => 'mautic_category_index'
             )
         )
     ),


### PR DESCRIPTION
If an user doesn't have permission to view categories, he still can see the menu item. When he click on it, he get access forbidden error. This PR hides the menu item if the user doesn't have permission to view categories.

### Testing
Make sure that after the PR and cache:clear:
1. User without permission to view categories doesn't view the category menu item.
2. User with permission to view categories can see category menu.