### PR TITLE
iContact: Auth error handeling added

### DIFF
--- a/plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
@@ -79,6 +79,16 @@ class IcontactIntegration extends EmailAbstractIntegration
 
         $response = $this->makeRequest($url, $parameters);
 
+        // Validation kind of error
+        if (isset($response['errors'][0])) {
+            return $response['errors'][0];
+        }
+
+        // Timeout kind of error
+        if (isset($response['errors']['message'])) {
+            return $response['errors']['message'];
+        }
+
         $keys = array();
         if (!empty($response['accounts'])) {
             $keys['accountId'] = $response['accounts'][0]['accountId'];
@@ -89,7 +99,7 @@ class IcontactIntegration extends EmailAbstractIntegration
             if (!empty($response['clientfolders'])) {
                 $keys['clientFolderId'] = $response['clientfolders'][0]['clientFolderId'];
 
-               $this->extractAuthKeys($keys, 'clientFolderId');
+                $this->extractAuthKeys($keys, 'clientFolderId');
             }
         }
     }


### PR DESCRIPTION
I tested the iContact integration. The authentication seemed to work fine, but it didn't actually happen. When I inspected the code, the validation returned error that the username is wrong. This PR adds the error handling - displays the error to the user.

### Testing
- Try to authorize the iContact integration with a wrong username

It will show the success message, but you won't be able to map the fields. Apply this plugin and try again. It will show the right error message.