### PR TITLE
Fixed issue where form field conflicts didn't force a new lead

### DIFF
--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -390,11 +390,13 @@ class SubmissionModel extends CommonFormModel
         };
 
         // Closure to help search for a conflict
-        $checkForIdentifierConflict = function($fieldSet1, $fieldSet2) {
+        $checkForIdentifierConflict = function($fieldSet1, $fieldSet2) use ($logger) {
             // Find fields in both sets
             $potentialConflicts = array_keys(
-                array_diff_key($fieldSet1, $fieldSet2)
+                array_intersect_key($fieldSet1, $fieldSet2)
             );
+
+            $logger->debug('FORM: Potential conflicts ' . implode(', ', array_keys($potentialConflicts)) . ' = ' . implode(', ', $potentialConflicts));
 
             $conflicts = array();
             foreach ($potentialConflicts as $field) {
@@ -460,6 +462,7 @@ class SubmissionModel extends CommonFormModel
 
             $logger->debug('FORM: Current unique lead fields ' . implode(', ', array_keys($uniqueFieldsCurrent)) . ' = ' . implode(', ', $uniqueFieldsCurrent));
 
+            $logger->debug('FORM: Submitted unique lead fields ' . implode(', ', array_keys($uniqueFieldsWithData)) . ' = ' . implode(', ', $uniqueFieldsWithData));
             if ($hasConflict) {
                 // There's a conflict so create a new lead
                 $lead = new Lead();


### PR DESCRIPTION
**Description**

Form field conflicts were allowing overwrites due to a bad array comparison. This PR fixes it so that forms submitted with conflicting unique identifier than the tracked lead or found lead from merging.

This mainly becomes a problem when a lead is pulled by IP instead of tracking cookie. We should consider #1030 because of this as well.

**Testing**

Submit a form with an email field and find the lead.  Then submit it a second time with a different email.  The first lead will be overwritten with the new lead even though it's a conflicting unique identifier.  After the PR, it should result in a new lead. 