### PR TITLE
Added support for a 'debug' key to config file to enable debug logging

### DIFF
--- a/app/config/config.php
+++ b/app/config/config.php
@@ -298,3 +298,7 @@ $container->setParameter(
     'jms_serializer.camel_case_naming_strategy.class',
     'JMS\Serializer\Naming\IdenticalPropertyNamingStrategy'
 );
+
+// Monolog formatter
+$container->register('mautic.monolog.fulltrace.formatter', 'Monolog\Formatter\LineFormatter')
+    ->addMethodCall('includeStacktraces', array(true));

--- a/app/config/config_dev.php
+++ b/app/config/config_dev.php
@@ -34,10 +34,11 @@ $container->loadFromExtension("monolog", array(
     ),
     "handlers" => array(
         "main"    => array(
-            "type"  => "rotating_file",
-            "path"  => "%kernel.logs_dir%/%kernel.environment%.php",
-            "level" => "debug",
-            "channels" => array(
+            "formatter" => "mautic.monolog.fulltrace.formatter",
+            "type"      => "rotating_file",
+            "path"      => "%kernel.logs_dir%/%kernel.environment%.php",
+            "level"     => "debug",
+            "channels"  => array(
                 "!mautic"
             ),
             "max_files" => 7
@@ -47,10 +48,11 @@ $container->loadFromExtension("monolog", array(
             "bubble" => false
         ),
         "mautic"    => array(
-            "type"  => "rotating_file",
-            "path"  => "%kernel.logs_dir%/mautic_%kernel.environment%.php",
-            "level" => "debug",
-            'channels' => array(
+            "formatter" => "mautic.monolog.fulltrace.formatter",
+            "type"      => "rotating_file",
+            "path"      => "%kernel.logs_dir%/mautic_%kernel.environment%.php",
+            "level"     => "debug",
+            'channels'  => array(
                 'mautic',
             ),
             "max_files" => 7

--- a/app/config/config_prod.php
+++ b/app/config/config_prod.php
@@ -23,13 +23,15 @@ $container->loadFromExtension("doctrine", array(
 ));
 */
 
-$debugMode = $container->getParameter('kernel.debug');
+$debugMode = $container->hasParameter('mautic.debug') ? $container->getParameter('mautic.debug') : $container->getParameter('kernel.debug');
+
 $container->loadFromExtension("monolog", array(
     "channels" => array(
         "mautic",
     ),
     "handlers" => array(
         "main"    => array(
+            "formatter"    => $debugMode ? "mautic.monolog.fulltrace.formatter" : null,
             "type"         => "fingers_crossed",
             "buffer_size"  => "200",
             "action_level" => ($debugMode) ? "debug" : "error",
@@ -45,9 +47,10 @@ $container->loadFromExtension("monolog", array(
             "max_files" => 7
         ),
         "mautic"    => array(
-            "type"  => "rotating_file",
-            "path"  => "%kernel.logs_dir%/mautic_%kernel.environment%.php",
-            "level" => ($debugMode) ? "debug" : "notice",
+            "formatter" => $debugMode ? "mautic.monolog.fulltrace.formatter" : null,
+            "type"      => "rotating_file",
+            "path"      => "%kernel.logs_dir%/mautic_%kernel.environment%.php",
+            "level"     => ($debugMode) ? "debug" : "notice",
             'channels' => array(
                 'mautic',
             ),


### PR DESCRIPTION
**Description**

Changing prod to log in debug mode meant modifying core files.  This PR makes it to where logging debug levels can be done by adding `'debug' => true` to the local.php file and deleting the cache.  It also adds tracing to debug mode to make it easier to debug some of the console commands throwing exceptions.  Obviously this only debugging production temporarily and not long term use or log sizes will explode :-)

**Testing**
Edit app/config/local.php and add `'debug' => true` and wipe the cache.  Do some stuff in Mautic and you should see the prod logs fill.  