### PR TITLE
Change Doctrine's change tracking policy to deferred explicit

### DIFF
--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -627,8 +627,8 @@ class EventModel extends CommonFormModel
 
             $start += $limit;
 
-            $this->em->clear('MauticLeadBundle:Lead');
-            $this->em->clear('MauticUserBundle:User');
+            $this->em->clear('Mautic\LeadBundle\Entity\Lead');
+            $this->em->clear('Mautic\UserBundle\Entity\User');
 
             unset($leads, $campaignLeads);
 
@@ -1050,8 +1050,8 @@ class EventModel extends CommonFormModel
             }
 
             // Free RAM
-            $this->em->clear('MauticLeadBundle:Lead');
-            $this->em->clear('MauticUserBundle:User');
+            $this->em->clear('Mautic\LeadBundle\Entity\Lead');
+            $this->em->clear('Mautic\UserBundle\Entity\User');
             unset($events, $leads);
 
             $currentCount = ($max) ? $totalEventCount : $eventCount;
@@ -1368,8 +1368,8 @@ class EventModel extends CommonFormModel
                 $leadProcessedCount += count($campaignLeadIds);
 
                 // Save RAM
-                $this->em->clear('MauticLeadBundle:Lead');
-                $this->em->clear('MauticUserBundle:User');
+                $this->em->clear('Mautic\LeadBundle\Entity\Lead');
+                $this->em->clear('Mautic\UserBundle\Entity\User');
 
                 unset($leads, $campaignLeadIds, $leadLog);
 

--- a/app/bundles/CoreBundle/Doctrine/Mapping/ClassMetadataBuilder.php
+++ b/app/bundles/CoreBundle/Doctrine/Mapping/ClassMetadataBuilder.php
@@ -10,6 +10,7 @@
 namespace Mautic\CoreBundle\Doctrine\Mapping;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 /**
  * Class ClassMetadataBuilder
@@ -21,6 +22,17 @@ use Doctrine\ORM\Mapping\ClassMetadata;
  */
 class ClassMetadataBuilder extends \Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder
 {
+    /**
+     * @param \Doctrine\ORM\Mapping\ClassMetadataInfo $cm
+     */
+    public function __construct(ClassMetadataInfo $cm)
+    {
+        parent::__construct($cm);
+
+        // Default all Mautic entities to explicit
+        $this->setChangeTrackingPolicyDeferredExplicit();
+    }
+
     /**
      * Creates a ManyToOne Association Builder.
      *

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -171,9 +171,9 @@ class CommonRepository extends EntityRepository
      */
     public function saveEntity($entity, $flush = true)
     {
-        $this->_em->persist($entity);
+        $this->getEntityManager()->persist($entity);
         if ($flush) {
-            $this->_em->flush();
+            $this->getEntityManager()->flush($entity);
         }
     }
 
@@ -192,10 +192,10 @@ class CommonRepository extends EntityRepository
             $this->saveEntity($entity, false);
 
             if ((($k + 1) % $batchSize) === 0) {
-                $this->_em->flush();
+                $this->getEntityManager()->flush();
             }
         }
-        $this->_em->flush();
+        $this->getEntityManager()->flush();
     }
 
     /**

--- a/app/bundles/CoreBundle/Model/AuditLogModel.php
+++ b/app/bundles/CoreBundle/Model/AuditLogModel.php
@@ -65,6 +65,8 @@ class AuditLogModel extends CommonModel
         $log->setUserName($userName);
 
         $this->em->getRepository("MauticCoreBundle:AuditLog")->saveEntity($log);
+
+        $this->em->detach($log);
     }
 
     /**

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -319,7 +319,7 @@ class LeadRepository extends CommonRepository
         $this->_em->persist($entity);
 
         if ($flush)
-            $this->_em->flush();
+            $this->_em->flush($entity);
 
         $fields = $entity->getUpdatedFields();
         if (!empty($fields)) {

--- a/app/bundles/LeadBundle/Helper/PointEventHelper.php
+++ b/app/bundles/LeadBundle/Helper/PointEventHelper.php
@@ -19,6 +19,9 @@ class PointEventHelper
     /**
      * @param $event
      * @param $factory
+     * @param $lead
+     *
+     * @return bool
      */
     public static function changeLists ($event, $factory, $lead)
     {

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -692,7 +692,9 @@ class LeadModel extends FormModel
      */
     public function addToLists($lead, $lists, $manuallyAdded = true)
     {
-        $this->factory->getModel('lead.list')->addLead($lead, $lists, $manuallyAdded);
+        /** @var \Mautic\LeadBundle\Model\ListModel $listModel */
+        $listModel = $this->factory->getModel('lead.list');
+        $listModel->addLead($lead, $lists, $manuallyAdded);
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -757,6 +757,9 @@ class ListModel extends FormModel
             $this->getRepository()->saveEntities($persistLists);
         }
 
+        // Clear ListLead entities from Doctrine memory
+        $this->em->clear('Mautic\LeadBundle\Entity\ListLead');
+
         if ($batchProcess) {
             // Detach for batch processing to preserve memory
             $this->em->detach($lead);
@@ -878,6 +881,9 @@ class ListModel extends FormModel
         if (!empty($deleteLists)) {
             $this->getRepository()->deleteEntities($deleteLists);
         }
+
+        // Clear ListLead entities from Doctrine memory
+        $this->em->clear('Mautic\LeadBundle\Entity\ListLead');
 
         if ($batchProcess) {
             // Detach for batch processing to preserve memory

--- a/app/bundles/PointBundle/Model/TriggerModel.php
+++ b/app/bundles/PointBundle/Model/TriggerModel.php
@@ -258,7 +258,6 @@ class TriggerModel extends CommonFormModel
         return $groups;
     }
 
-
     /**
      * Triggers a specific event
      *
@@ -368,6 +367,9 @@ class TriggerModel extends CommonFormModel
 
             if (!empty($persist)) {
                 $this->getEventRepository()->saveEntities($persist);
+
+                $this->em->clear('Mautic\PointBundle\Entity\LeadTriggerLog');
+                $this->em->clear('Mautic\PointBundle\Entity\TriggerEvent');
             }
         }
     }

--- a/app/migrations/Version20150521000000.php
+++ b/app/migrations/Version20150521000000.php
@@ -148,7 +148,7 @@ class Version20150521000000 extends AbstractMauticMigration
 
         if (!empty($actionEntities)) {
             $this->factory->getModel('point')->getRepository()->saveEntities($actionEntities);
-            $em->clear('MauticFormBundle:Action');
+            $em->clear('Mautic\FormBundle\Entity\Action');
         }
 
         foreach ($formFieldMatches as $leadFieldId => $formFieldIds) {
@@ -207,7 +207,7 @@ class Version20150521000000 extends AbstractMauticMigration
             }
 
             $formRepo->saveEntities($forms);
-            $em->clear('MauticFormBundle:Form');
+            $em->clear('Mautic\FormBundle\Entity\Form');
         }
 
         // Clear template for custom mode
@@ -256,7 +256,7 @@ class Version20150521000000 extends AbstractMauticMigration
 
         if (!empty($redirectEntities)) {
             $this->factory->getModel('page.redirect')->getRepository()->saveEntities($redirectEntities);
-            $em->clear('MauticPageBundle:Redirect');
+            $em->clear('Mautic\PageBundle\Entity\Redirect');
         }
 
         // Copy subjects as names


### PR DESCRIPTION
**Description**
Doctrine's default policy is to check for changes on every flush() of any entity stored in memory. This means that Doctrine will cycle over every property to examine for changes then attempt to flush it to the database.  This can cause issues for a couple reasons.  

1) Performance since a lot of entities in memory means that every flush is examining those entities. 

2) Unexpected things happen due to leads being detached yet Doctrine still has an entity in memory that has that lead as an association so "new entity" found errors are thrown when we didn't want to even persist the entity to begin with.

Mautic is already coded to persist before flush so this PR changes Mautic's entity default change tracking policy to deferred explicit so that ONLY entities that have been persisted will have it's properties compared and flushed to the database.  

The PR also changes CommonRepository::saveEntity() to only flush the entity given and not whatever Doctrine has in memory.

Finally, the PR fixes the use of EntityManager::clear() which used Doctrine's repository nomenclature instead of the entity namespaces which is what Doctrine uses in it's identity maps for tracking in-memory entities.  

**Testing**
1. Create a campaign with a give 10 points action
2. Add several leads to the campaign however you want
3. Create a point trigger to push a lead to a lead list when they hit 10 points
4. Run the `mautic:campaign:trigger` command

It should result in: `A new entity was found through the relationship 'Mautic\LeadBundle\Entity\ListLead#lead' that was not configured to cascade persist operations for entity: Mautic\LeadBundle\Entity\Lead with ID #68054. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist this association in the mapping for example @ManyToOne(..,cascade={"persist"}).` (Noted in #1194)

After the PR, the campaign should execute, the leads should get their points, and they should be addd to the lead list.
