### PR TITLE
Fixed issue when reordering of select field options in the Form Builder causes error on field save

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -295,7 +295,7 @@ var Mautic = {
                     var order = 0;
                     mQuery('#' + prefix + '_list div.list-sortable div.input-group input').each(function () {
                         var name = mQuery(this).attr('name');
-                        name = name.replace(/\[list\]\[(.+)\]$/g, '') + '[list][' + order + ']';
+                        name = name.replace(/(\[list\]\[[0-9]+\])$/g, '') + '[list][' + order + ']';
                         mQuery(this).attr('name', name);
                         order++;
                     });


### PR DESCRIPTION
### Description

Reordering of select field options in the Form Builder causes error on field save
Fixes #1136 

### Steps to reproduce

1. Create new Form
2. Add select field
3. Add Label & Properties
4. Save.
5. Edit select field, and reorder properties.
6. Update.

### Steps to test
See above.