### PR TITLE
Add full Definition support to the Mautic config handler

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -320,18 +320,16 @@ return array(
                 )
             ),
             'mautic.menu.main'                   => array(
-                'class'          => 'Knp\Menu\MenuItem',
-                'factoryService' => 'mautic.menu.builder',
-                'factoryMethod'  => 'mainMenu',
-                'tag'            => 'knp_menu.menu',
-                'alias'          => 'main'
+                'class'   => 'Knp\Menu\MenuItem',
+                'factory' => array('@mautic.menu.builder', 'mainMenu'),
+                'tag'     => 'knp_menu.menu',
+                'alias'   => 'main',
             ),
             'mautic.menu.admin'                  => array(
-                'class'          => 'Knp\Menu\MenuItem',
-                'factoryService' => 'mautic.menu.builder',
-                'factoryMethod'  => 'adminMenu',
-                'tag'            => 'knp_menu.menu',
-                'alias'          => 'admin'
+                'class'   => 'Knp\Menu\MenuItem',
+                'factory' => array('@mautic.menu.builder', 'adminMenu'),
+                'tag'     => 'knp_menu.menu',
+                'alias'   => 'admin',
             ),
             'twig.controller.exception.class'    => 'Mautic\CoreBundle\Controller\ExceptionController',
             'monolog.handler.stream.class'       => 'Mautic\CoreBundle\Monolog\Handler\PhpHandler',

--- a/app/bundles/UserBundle/Config/config.php
+++ b/app/bundles/UserBundle/Config/config.php
@@ -135,28 +135,24 @@ return array(
         'other'  => array(
             // Authentication
             'mautic.user.manager'                    => array(
-                'class'          => 'Doctrine\ORM\EntityManager',
-                'arguments'      => 'Mautic\UserBundle\Entity\User',
-                'factoryService' => 'doctrine',
-                'factoryMethod'  => 'getManagerForClass'
+                'class'     => 'Doctrine\ORM\EntityManager',
+                'arguments' => 'Mautic\UserBundle\Entity\User',
+                'factory'   => array('@doctrine', 'getManagerForClass')
             ),
             'mautic.user.repository'                 => array(
-                'class'          => 'Mautic\UserBundle\Entity\UserRepository',
-                'arguments'      => 'Mautic\UserBundle\Entity\User',
-                'factoryService' => 'mautic.user.manager',
-                'factoryMethod'  => 'getRepository'
+                'class'     => 'Mautic\UserBundle\Entity\UserRepository',
+                'arguments' => 'Mautic\UserBundle\Entity\User',
+                'factory'   => array('@mautic.user.manager', 'getRepository')
             ),
             'mautic.permission.manager'              => array(
-                'class'          => 'Doctrine\ORM\EntityManager',
-                'arguments'      => 'Mautic\UserBundle\Entity\Permission',
-                'factoryService' => 'doctrine',
-                'factoryMethod'  => 'getManagerForClass'
+                'class'     => 'Doctrine\ORM\EntityManager',
+                'arguments' => 'Mautic\UserBundle\Entity\Permission',
+                'factory'   => array('@doctrine', 'getManagerForClass')
             ),
             'mautic.permission.repository'           => array(
-                'class'          => 'Mautic\UserBundle\Entity\PermissionRepository',
-                'arguments'      => 'Mautic\UserBundle\Entity\Permission',
-                'factoryService' => 'mautic.permission.manager',
-                'factoryMethod'  => 'getRepository'
+                'class'     => 'Mautic\UserBundle\Entity\PermissionRepository',
+                'arguments' => 'Mautic\UserBundle\Entity\Permission',
+                'factory'   => array('@mautic.permission.manager', 'getRepository')
             ),
             'mautic.user.provider'                   => array(
                 'class'     => 'Mautic\UserBundle\Security\Provider\UserProvider',


### PR DESCRIPTION
This pull request adds most feature support for the `Symfony\Component\DependencyInjection\Definition` to Mautic's config handler.  Specifically:

- Adds support for the Symfony 2.6 factory service definition
- Adds support for the (now deprecated) factoryClass service definition
- Adds the public, lazy, synthetic, abstract, file, configurator, and decorated service Definition options

The only feature not added is support for synchronized services which was deprecated in Symfony 2.7 anyway.  Otherwise the Mautic handler now has feature parity with the Symfony API.