### PR TITLE
Email copy improvements

### DIFF
--- a/app/bundles/EmailBundle/Entity/Copy.php
+++ b/app/bundles/EmailBundle/Entity/Copy.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2015 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use JMS\Serializer\Annotation as Serializer;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+use Mautic\CoreBundle\Entity\IpAddress;
+use Mautic\CoreBundle\Helper\EmojiHelper;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
+/**
+ * Class Copy
+ *
+ * @package Mautic\EmailBundle\Entity
+ */
+class Copy
+{
+
+    /**
+     * MD5 hash of the content
+     *
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var \DateTime
+     */
+    private $dateCreated;
+
+    /**
+     * @var string
+     */
+    private $body;
+
+    /**
+     * @var
+     */
+    private $subject;
+
+    /**
+     * @param ORM\ClassMetadata $metadata
+     */
+    public static function loadMetadata (ORM\ClassMetadata $metadata)
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('email_copies')
+            ->setCustomRepositoryClass('Mautic\EmailBundle\Entity\CopyRepository');
+
+        $builder->createField('id', 'string')
+            ->isPrimaryKey()
+            ->length(32)
+            ->build();
+
+        $builder->createField('dateCreated', 'datetime')
+            ->columnName('date_created')
+            ->build();
+
+        $builder->addNullableField('body', 'text');
+
+        $builder->addNullableField('subject', 'text');
+    }
+
+    /**
+     * @param $id
+     *
+     * @return $this
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return Email
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param Email $email
+     *
+     * @return Copy
+     */
+    public function setEmail($email)
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDateCreated()
+    {
+        return $this->dateCreated;
+    }
+
+    /**
+     * @param \DateTime $dateCreated
+     *
+     * @return Copy
+     */
+    public function setDateCreated($dateCreated)
+    {
+        $this->dateCreated = $dateCreated;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * @param string $body
+     *
+     * @return Copy
+     */
+    public function setBody($body)
+    {
+        $this->body = $body;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getSubject()
+    {
+        return $this->subject;
+    }
+
+    /**
+     * @param mixed $subject
+     *
+     * @return Copy
+     */
+    public function setSubject($subject)
+    {
+        $this->subject = $subject;
+
+        return $this;
+    }
+}

--- a/app/bundles/EmailBundle/Entity/Copy.php
+++ b/app/bundles/EmailBundle/Entity/Copy.php
@@ -10,12 +10,9 @@
 namespace Mautic\EmailBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use JMS\Serializer\Annotation as Serializer;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
-use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Helper\EmojiHelper;
-use Mautic\LeadBundle\Entity\Lead;
-use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
+
 /**
  * Class Copy
  *
@@ -145,6 +142,9 @@ class Copy
      */
     public function setBody($body)
     {
+        // Ensure it's clean of emoji
+        $body = EmojiHelper::toShort($body);
+
         $this->body = $body;
 
         return $this;
@@ -165,6 +165,9 @@ class Copy
      */
     public function setSubject($subject)
     {
+        // Ensure it's clean of emoji
+        $subject = EmojiHelper::toShort($subject);
+
         $this->subject = $subject;
 
         return $this;

--- a/app/bundles/EmailBundle/Entity/CopyRepository.php
+++ b/app/bundles/EmailBundle/Entity/CopyRepository.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2015 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Entity;
+
+use Doctrine\ORM\NoResultException;
+use Mautic\CoreBundle\Entity\CommonRepository;
+
+/**
+ * Class CopyRepository
+ */
+class CopyRepository extends CommonRepository
+{
+
+    /**
+     * @param      $string   md5 hash or content
+     * @param null $subject  If $string is the content, pass the subject to include it in the hash
+     *
+     * @return array
+     */
+    public function findByHash($string, $subject = null)
+    {
+        if (null !== $subject) {
+            // Combine subject with $string and hash together
+            $string = $subject . $string;
+        }
+
+        // Assume that $string is already a md5 hash if 32 characters
+        $hash = (strlen($string) !== 32) ? $hash = md5($string) : $string;
+
+        $q = $this->createQueryBuilder($this->getTableAlias());
+        $q->where(
+            $q->expr()->eq($this->getTableAlias().'.id', ':id')
+        )
+            ->setParameter('id', $hash);
+
+        try {
+            $result = $q->getQuery()->getSingleResult();
+        } catch (NoResultException $exception) {
+            $result = null;
+        }
+
+        return $result;
+    }
+
+
+    /**
+     * @return string
+     */
+    public function getTableAlias()
+    {
+        return 'ec';
+    }
+}

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -144,18 +144,33 @@ class EmailRepository extends CommonRepository
      */
     public function getEmailPendingLeads($emailId, $variantIds = null, $listIds = null, $countOnly = false, $limit = null)
     {
+        if (null === $listIds) {
+            // Get a list of lists
+            $q = $this->_em->getConnection()->createQueryBuilder();
+            $q->select('el.leadlist_id')
+                ->from(MAUTIC_TABLE_PREFIX.'email_list_xref', 'el')
+                ->where('el.email_id = ' . (int) $emailId);
+
+            $results  = $q->execute()->fetchAll();
+            $listIds = array();
+
+            foreach ($results as $row) {
+                $listIds[] = $row['leadlist_id'];
+            }
+        }
+
         $q = $this->_em->getConnection()->createQueryBuilder();
 
         $sq = $this->_em->getConnection()->createQueryBuilder();
-        $sq->select('dne.lead_id')
+        $sq->select('null')
             ->from(MAUTIC_TABLE_PREFIX.'email_donotemail', 'dne')
             ->where(
-                $sq->expr()->isNotNull('dne.lead_id')
+                $sq->expr()->eq('dne.lead_id', 'l.id')
             );
 
         $sq2 = $this->_em->getConnection()->createQueryBuilder();
         $sqExpr = $sq2->expr()->andX(
-            $sq2->expr()->isNotNull('stat.lead_id')
+            $sq2->expr()->eq('stat.lead_id', 'l.id')
         );
 
         if ($variantIds) {
@@ -169,7 +184,7 @@ class EmailRepository extends CommonRepository
             );
         }
 
-        $sq2->select('stat.lead_id')
+        $sq2->select('null')
             ->from(MAUTIC_TABLE_PREFIX.'email_stats', 'stat')
             ->where($sqExpr);
 
@@ -181,11 +196,8 @@ class EmailRepository extends CommonRepository
         }
         $q->from(MAUTIC_TABLE_PREFIX . 'leads', 'l')
             ->join('l', MAUTIC_TABLE_PREFIX . 'lead_lists_leads', 'll', 'l.id = ll.lead_id')
-            ->join('ll', MAUTIC_TABLE_PREFIX . 'email_list_xref', 'el', 'el.leadlist_id = ll.leadlist_id');
-
-        $q->where($q->expr()->eq('el.email_id', $emailId))
-            ->andWhere('l.id NOT IN ' . sprintf("(%s)",$sq->getSQL()))
-            ->andWhere('l.id NOT IN ' . sprintf("(%s)",$sq2->getSQL()));
+            ->andWhere(sprintf("NOT EXISTS (%s)",$sq->getSQL()))
+            ->andWhere(sprintf("NOT EXISTS (%s)",$sq2->getSQL()));
 
         if ($listIds != null) {
             if (!is_array($listIds)) {

--- a/app/bundles/EmailBundle/Entity/Stat.php
+++ b/app/bundles/EmailBundle/Entity/Stat.php
@@ -150,7 +150,7 @@ class Stat
 
         $builder->createManyToOne('email', 'Email')
             ->inversedBy('stats')
-            ->addJoinColumn('email_id', 'id', true, false, 'CASCADE')
+            ->addJoinColumn('email_id', 'id', true, false, 'SET NULL')
             ->build();
 
         $builder->addLead(true, 'SET NULL');

--- a/app/bundles/EmailBundle/Entity/Stat.php
+++ b/app/bundles/EmailBundle/Entity/Stat.php
@@ -106,8 +106,15 @@ class Stat
 
     /**
      * @var string
+     *
+     * @deprecated 1.2.3 - to be removed in 2.0
      */
     private $copy;
+
+    /**
+     * @var Copy
+     */
+    private $storedCopy;
 
     /**
      * @var int
@@ -202,7 +209,14 @@ class Stat
             ->nullable()
             ->build();
 
+        /**
+         * @deprecated 1.2.3 - to be removed in 2.0
+         */
         $builder->addNullableField('copy', 'text');
+
+        $builder->createManyToOne('storedCopy', 'Mautic\EmailBundle\Entity\Copy')
+            ->addJoinColumn('copy_id', 'id', true, false, 'SET NULL')
+            ->build();
 
         $builder->addNullableField('openCount', 'integer', 'open_count');
 
@@ -515,6 +529,8 @@ class Stat
     }
 
     /**
+     * @deprecated 1.2.3 - to be removed in 2.0
+     *
      * @return mixed
      */
     public function getCopy()
@@ -523,6 +539,8 @@ class Stat
     }
 
     /**
+     * @deprecated 1.2.3 - to be removed in 2.0
+     *
      * @param mixed $copy
      *
      * @return Stat
@@ -616,6 +634,26 @@ class Stat
     public function setOpenDetails($openDetails)
     {
         $this->openDetails = $openDetails;
+
+        return $this;
+    }
+
+    /**
+     * @return Copy
+     */
+    public function getStoredCopy()
+    {
+        return $this->storedCopy;
+    }
+
+    /**
+     * @param Copy $storedCopy
+     *
+     * @return Stat
+     */
+    public function setStoredCopy(Copy $storedCopy)
+    {
+        $this->storedCopy = $storedCopy;
 
         return $this;
     }

--- a/app/bundles/EmailBundle/Entity/StatRepository.php
+++ b/app/bundles/EmailBundle/Entity/StatRepository.php
@@ -253,9 +253,10 @@ class StatRepository extends CommonRepository
     {
         $query = $this->createQueryBuilder('s');
 
-        $query->select('IDENTITY(s.email) AS email_id, s.id, s.dateRead, s.dateSent, e.name, e.subject, s.isRead, s.isFailed, s.viewedInBrowser, s.retryCount, IDENTITY(s.list) AS list_id, l.name as list_name, s.trackingHash as idHash, s.openDetails')
+        $query->select('IDENTITY(s.email) AS email_id, s.id, s.dateRead, s.dateSent, e.name, e.subject, s.isRead, s.isFailed, s.viewedInBrowser, s.retryCount, IDENTITY(s.list) AS list_id, l.name as list_name, s.trackingHash as idHash, s.openDetails, ec.subject as storedSubject')
             ->leftJoin('MauticEmailBundle:Email', 'e', 'WITH', 'e.id = s.email')
             ->leftJoin('MauticLeadBundle:LeadList', 'l', 'WITH', 'l.id = s.list')
+            ->leftJoin('MauticEmailBundle:Copy', 'ec', 'WITH', 'ec.id = s.storedCopy')
             ->where(
                 $query->expr()->andX(
                     $query->expr()->eq('IDENTITY(s.lead)', $leadId),

--- a/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
@@ -40,14 +40,13 @@ class LeadSubscriber extends CommonSubscriber
     public function onTimelineGenerate(LeadTimelineEvent $event)
     {
         // Set available event types
-        $eventTypeKeySent = 'email.sent';
+        $eventTypeKeySent  = 'email.sent';
         $eventTypeNameSent = $this->translator->trans('mautic.email.sent');
         $event->addEventType($eventTypeKeySent, $eventTypeNameSent);
 
-        $eventTypeKeyRead = 'email.read';
+        $eventTypeKeyRead  = 'email.read';
         $eventTypeNameRead = $this->translator->trans('mautic.email.read');
         $event->addEventType($eventTypeKeyRead, $eventTypeNameRead);
-
 
         // Decide if those events are filtered
         $filters = $event->getEventFilters();
@@ -70,30 +69,34 @@ class LeadSubscriber extends CommonSubscriber
         // Add the events to the event array
         foreach ($stats as $stat) {
             if ($stat['dateRead'] && $event->isApplicable($eventTypeKeyRead, true)) {
-                $event->addEvent(array(
-                    'event'     => $eventTypeKeyRead,
-                    'eventLabel' => $eventTypeNameRead,
-                    'timestamp' => $stat['dateRead'],
-                    'extra'     => array(
-                        'stats' => $stat,
-                        'type'  => 'read'
-                    ),
-                    'contentTemplate' => 'MauticEmailBundle:SubscribedEvents\Timeline:index.html.php'
-                ));
+                $event->addEvent(
+                    array(
+                        'event'           => $eventTypeKeyRead,
+                        'eventLabel'      => $eventTypeNameRead,
+                        'timestamp'       => $stat['dateRead'],
+                        'extra'           => array(
+                            'stat' => $stat,
+                            'type' => 'read'
+                        ),
+                        'contentTemplate' => 'MauticEmailBundle:SubscribedEvents\Timeline:index.html.php'
+                    )
+                );
             }
 
             // Email read
             if ($stat['dateSent'] && $event->isApplicable($eventTypeKeySent)) {
-                $event->addEvent(array(
-                    'event'           => $eventTypeKeySent,
-                    'eventLabel'      => $eventTypeNameSent,
-                    'timestamp'       => $stat['dateSent'],
-                    'extra'           => array(
-                        'stats' => $stat,
-                        'type'  => 'sent'
-                    ),
-                    'contentTemplate' => 'MauticEmailBundle:SubscribedEvents\Timeline:index.html.php'
-                ));
+                $event->addEvent(
+                    array(
+                        'event'           => $eventTypeKeySent,
+                        'eventLabel'      => $eventTypeNameSent,
+                        'timestamp'       => $stat['dateSent'],
+                        'extra'           => array(
+                            'stat' => $stat,
+                            'type' => 'sent'
+                        ),
+                        'contentTemplate' => 'MauticEmailBundle:SubscribedEvents\Timeline:index.html.php'
+                    )
+                );
             }
         }
     }

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -48,6 +48,14 @@ class EmailModel extends FormModel
     }
 
     /**
+     * @return \Mautic\EmailBundle\Entity\CopyRepository
+     */
+    public function getCopyRepository ()
+    {
+        return $this->factory->getEntityManager()->getRepository('MauticEmailBundle:Copy');
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getPermissionBase ()
@@ -1079,24 +1087,7 @@ class EmailModel extends FormModel
             }
 
             //create a stat
-            $stat = new Stat();
-            $stat->setDateSent(new \DateTime());
-
-            $stat->setEmail($useEmail['entity']);
-            $stat->setLead($this->em->getReference('MauticLeadBundle:Lead', $lead['id']));
-            if ($listId) {
-                $stat->setList($this->em->getReference('MauticLeadBundle:LeadList', $listId));
-            }
-            $stat->setEmailAddress($lead['email']);
-            $stat->setTrackingHash($idHash);
-            if (!empty($source)) {
-                $stat->setSource($source[0]);
-                $stat->setSourceId($source[1]);
-            }
-            $stat->setCopy($mailer->getBody());
-            $stat->setTokens($mailer->getTokens());
-
-            $saveEntities[$lead['email']] = $stat;
+            $saveEntities[$lead['email']] = $mailer->createEmailStat(false, null, $listId);
 
             // Up sent counts
             $emailId = $useEmail['entity']->getId();
@@ -1104,9 +1095,6 @@ class EmailModel extends FormModel
                 $emailSentCounts[$emailId] = 0;
             }
             $emailSentCounts[$emailId]++;
-
-            // Save RAM
-            unset($stat);
 
             $batchCount++;
             if ($batchCount >= $useEmail['limit']) {
@@ -1210,19 +1198,7 @@ class EmailModel extends FormModel
             $mailer->queue(true);
 
             if ($saveStat) {
-                //create a stat
-                $stat = new Stat();
-                $stat->setDateSent(new \DateTime());
-                $stat->setEmailAddress($user['email']);
-                $stat->setTrackingHash($idHash);
-                if (!empty($source)) {
-                    $stat->setSource($source[0]);
-                    $stat->setSourceId($source[1]);
-                }
-                $stat->setCopy($mailer->getBody());
-                $stat->setTokens($mailer->getTokens());
-
-                $saveEntities[] = $stat;
+                $saveEntities[] = $mailer->createEmailStat(false, $user['email']);
             }
         }
 

--- a/app/bundles/EmailBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/EmailBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -7,8 +7,17 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-$item = $event['extra']['stats'];
+$item    = $event['extra']['stat'];
+$subject = $view['translator']->trans('mautic.email.timeline.event.custom_email');
 
+if (!empty($item['storedSubject'])) {
+	$subject .= ': '.$item['storedSubject'];
+} elseif (!empty($item['subject'])) {
+	/**
+	 * @deprecated 1.2.3 - to be removed in 2.0
+	 */
+	$subject = ': '.$item['subject'];
+}
 ?>
 
 <li class="wrapper email-read">
@@ -17,7 +26,7 @@ $item = $event['extra']['stats'];
 	    <div class="panel-body">
 	    	<h3>
 	    		<a target="_new" href="<?php echo $view['router']->generate('mautic_email_webview', array("idHash" => $item['idHash'])); ?>">
-				    <?php echo (!empty($item['name'])) ? $item['name'] : $view['translator']->trans('mautic.email.timeline.event.custom_email'); ?>
+				    <?php echo $subject; ?>
 				</a>
 			</h3>
             <p class="mb-0"><?php echo $view['translator']->trans('mautic.core.timeline.event.time', array('%date%' => $view['date']->toFullConcat($event['timestamp']), '%event%' => $event['eventLabel'])); ?></p>

--- a/app/migrations/Version20151207000000.php
+++ b/app/migrations/Version20151207000000.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2015 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Class Version20151207000000
+ */
+
+class Version20151207000000 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        if ($schema->hasTable($this->prefix.'email_copies')) {
+
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function mysqlUp(Schema $schema)
+    {
+        $this->addSql('CREATE TABLE '.$this->prefix.'email_copies (id VARCHAR(32) NOT NULL, date_created DATETIME NOT NULL, body LONGTEXT DEFAULT NULL, subject LONGTEXT DEFAULT NULL, PRIMARY KEY(id))  DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE '.$this->prefix.'email_stats ADD copy_id VARCHAR(32) DEFAULT NULL');
+        $this->addSql('ALTER TABLE '.$this->prefix.'email_stats ADD CONSTRAINT '.$this->generatePropertyName('email_stats', 'fk', array('copy_id')).' FOREIGN KEY (copy_id) REFERENCES '.$this->prefix.'email_copies (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX '.$this->generatePropertyName('email_stats', 'idx', array('copy_id')).' ON '.$this->prefix.'email_stats (copy_id)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function postgresqlUp(Schema $schema)
+    {
+        $this->addSql('CREATE TABLE '.$this->prefix.'email_copies (id VARCHAR(32) NOT NULL, date_created TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, body TEXT DEFAULT NULL, subject TEXT DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('ALTER TABLE '.$this->prefix.'email_stats ADD copy_id VARCHAR(32) DEFAULT NULL');
+        $this->addSql('ALTER TABLE '.$this->prefix.'email_stats ADD CONSTRAINT '.$this->generatePropertyName('email_stats', 'fk', array('copy_id')).' FOREIGN KEY (copy_id) REFERENCES '.$this->prefix.'email_copies (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX '.$this->generatePropertyName('email_stats', 'idx', array('copy_id')).' ON '.$this->prefix.'email_stats (copy_id)');
+    }
+}

--- a/app/migrations/Version20151207000000.php
+++ b/app/migrations/Version20151207000000.php
@@ -42,6 +42,9 @@ class Version20151207000000 extends AbstractMauticMigration
         $this->addSql('ALTER TABLE '.$this->prefix.'email_stats ADD copy_id VARCHAR(32) DEFAULT NULL');
         $this->addSql('ALTER TABLE '.$this->prefix.'email_stats ADD CONSTRAINT '.$this->generatePropertyName('email_stats', 'fk', array('copy_id')).' FOREIGN KEY (copy_id) REFERENCES '.$this->prefix.'email_copies (id) ON DELETE SET NULL');
         $this->addSql('CREATE INDEX '.$this->generatePropertyName('email_stats', 'idx', array('copy_id')).' ON '.$this->prefix.'email_stats (copy_id)');
+
+        $this->addSql('ALTER TABLE '.$this->prefix.'email_stats DROP FOREIGN KEY '.$this->findPropertyName('email_stats', 'fk', 'A832C1C9'));
+        $this->addSql('ALTER TABLE '.$this->prefix.'email_stats ADD CONSTRAINT '.$this->generatePropertyName('email_stats', 'fk', array('email_id')).' FOREIGN KEY (email_id) REFERENCES '.$this->prefix.'emails (id) ON DELETE SET NULL');
     }
 
     /**
@@ -53,5 +56,8 @@ class Version20151207000000 extends AbstractMauticMigration
         $this->addSql('ALTER TABLE '.$this->prefix.'email_stats ADD copy_id VARCHAR(32) DEFAULT NULL');
         $this->addSql('ALTER TABLE '.$this->prefix.'email_stats ADD CONSTRAINT '.$this->generatePropertyName('email_stats', 'fk', array('copy_id')).' FOREIGN KEY (copy_id) REFERENCES '.$this->prefix.'email_copies (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->addSql('CREATE INDEX '.$this->generatePropertyName('email_stats', 'idx', array('copy_id')).' ON '.$this->prefix.'email_stats (copy_id)');
+
+        $this->addSql('ALTER TABLE ' . $this->prefix . 'email_stats DROP CONSTRAINT ' . $this->findPropertyName('email_stats', 'fk', 'A832C1C9'));
+        $this->addSql('ALTER TABLE '.$this->prefix.'email_stats ADD CONSTRAINT '.$this->generatePropertyName('email_stats', 'fk', array('email_id')).' FOREIGN KEY (email_id) REFERENCES '.$this->prefix.'emails (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
 }


### PR DESCRIPTION
**Description**

Mautic stores a copy of each email sent in it's email_stats table but this has resulted in very large tables when emails contain graphics.  This PR addresses this by creating a table that stores a copy of the content and referenced by the email_stats table instead.  This should decrease the space required significantly and fixes #857.

**Testing**

Apply the PR and run `doctrine:migrations:migrate` to update the schema.

Send an email to a lead directly (lead profile -> send email). It'll help to embed the {webview_url} token somewhere to make it easy to click through to the web view.

After sending, check the email_copies table for the new entry.  Send a different email and/or edit the email content of the original sent and send a second email.  This should result in a new entry into the email_copies table.  

Delete the originally sent email from Mautic's email list then click through to the webview or directly browse to it by gleaning the tracking hash from the email_stats table and go to /email/view/TRACKING_HASH. The content should display.

Now send an email to a lead list. After sending, check the email_stats table for entries created and ensure list_id is populated appropriately.