### PR TITLE
Trigger color fix

### DIFF
--- a/app/bundles/PointBundle/Form/Type/TriggerType.php
+++ b/app/bundles/PointBundle/Form/Type/TriggerType.php
@@ -95,6 +95,7 @@ class TriggerType extends AbstractType
         );
 
         $color = $options['data']->getColor();
+
         $builder->add(
             'color',
             'text',
@@ -107,7 +108,7 @@ class TriggerType extends AbstractType
                     'tooltip'     => 'mautic.point.trigger.form.color_descr'
                 ),
                 'required'   => false,
-                'data'       => (empty($color)) ? $color : 'a0acb8',
+                'data'       => (!empty($color)) ? $color : 'a0acb8',
                 'empty_data' => 'a0acb8'
             )
         );

--- a/app/bundles/PointBundle/Views/Trigger/list.html.php
+++ b/app/bundles/PointBundle/Views/Trigger/list.html.php
@@ -95,7 +95,7 @@ $view->extend('MauticPointBundle:Trigger:index.html.php');
                 <td><?php echo $item->getPoints(); ?></td>
                 <?php
                 $color = $item->getColor();
-                $colorStyle = ($color) ? ' style="background-color: ' . $color . '"' : '';
+                $colorStyle = ($color) ? ' style="background-color: #' . $color . '"' : '';
                 ?>
                 <td<?php echo $colorStyle; ?>></td>
                 <td class="visible-md visible-lg"><?php echo $item->getId(); ?></td>


### PR DESCRIPTION
The Point Trigger color settings doesn't work.

### Testing
1. Navigate to *Points* / *Triggers*
2. Create / edit one trigger, configure the color
3. Save

The color won't be visible in the trigger list nor in the trigger form when you open it again. After the PR, the right color appears in both places.