### PR TITLE
Made integration required keys actually required in the form

### DIFF
--- a/app/bundles/PluginBundle/Assets/js/plugin.js
+++ b/app/bundles/PluginBundle/Assets/js/plugin.js
@@ -8,8 +8,7 @@ Mautic.initiateIntegrationAuthorization = function() {
 
 Mautic.loadIntegrationAuthWindow = function(response) {
     if (response.newContent) {
-        response.target = '#IntegrationEditModal .modal-body-content';
-        Mautic.processPageContent(response);
+        Mautic.processModalContent(response, '#IntegrationEditModal');
     } else {
         Mautic.stopPageLoadingBar();
         Mautic.stopIconSpinPostEvent();


### PR DESCRIPTION
**Description**

When testing #1218, I found that keys required to authorize the plugin were left to the integration to validate and throw if missing.  This led to confusion as to why the fix in that PR was not getting triggered because I was trying to test without adding any keys at all but I still got authorization success message in the popup window. So this PR adds constraints to the keys that are required and only to password fields if no data exists (since it'll be empty on subsequent saves).  

**Testing**
Click the iContact integration.  If you already have keys saved, you may have to manually delete the icontact row from plugin_integration_settings or use another integration that has not been saved. Try to save the integration with empty keys and it should let you.  For iContact, it'll give a authorization success message which is not true.

After the PR, delete the row from plugin_integration_settings to start from scratch.  Try authorizing with empty keys and it should return with validation failures. (Use the dev environment because this includes a JS change). Fill in all the required keys and Authorize (it may still say success unless PR #1218 is applied). Go back to the form and try to save again.  It should save even though the password field is empty (since it already has data saved) but if you remove one of the non-password keys and save, it'll fail validation.