### PR TITLE
Campaign condition: Lead field type number value fix

### DIFF
--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -586,11 +586,12 @@ class AjaxController extends CommonAjaxController
      */
     protected function updateLeadFieldValuesAction(Request $request)
     {
-        $alias      = InputHelper::clean($request->request->get('alias'));
-        $dataArray  = array('success' => 0, 'options' => null);
-        $leadField  = $this->factory->getModel('lead.field')->getRepository()->findOneBy(array('alias' => $alias));
+        $alias       = InputHelper::clean($request->request->get('alias'));
+        $dataArray   = array('success' => 0, 'options' => null);
+        $leadField   = $this->factory->getModel('lead.field')->getRepository()->findOneBy(array('alias' => $alias));
+        $choiceTypes = array('boolean', 'country', 'region', 'lookup', 'timezone', 'select', 'radio');
 
-        if ($leadField) {
+        if ($leadField && in_array($leadField->getType(), $choiceTypes)) {
             $properties = $leadField->getProperties();
 
             if (!empty($properties['list'])) {

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
@@ -66,11 +66,14 @@ class CampaignEventLeadFieldValueType extends AbstractType
             $form    = $e->getForm();
 
             $fieldValues = null;
+            $fieldType = null;
+            $choiceTypes = array('boolean', 'country', 'region', 'lookup', 'timezone', 'select', 'radio');
 
             if (isset($data['field'])) {
                 $field = $fieldModel->getRepository()->findOneBy(array('alias' => $data['field']));
                 if ($field) {
                     $properties = $field->getProperties();
+                    $fieldType = $field->getType();
                     if (!empty($properties['list'])) {
                         // Lookup/Select options
                         $fieldValues = explode('|', $properties['list']);
@@ -82,21 +85,21 @@ class CampaignEventLeadFieldValueType extends AbstractType
             }
 
             // Display selectbox for a field with choices, textbox for others
-            if (empty($fieldValues)) {
-                $form->add('value', 'text', array(
-                    'label'      => 'mautic.form.field.form.value',
-                    'label_attr' => array('class' => 'control-label'),
-                    'attr'       => array(
-                        'class'   => 'form-control'
-                    )
-                ));
-            } else {
+            if (!empty($fieldValues) && in_array($fieldType, $choiceTypes)) {
                 $form->add('value', 'choice', array(
                     'choices'    => $fieldValues,
                     'label'      => 'mautic.form.field.form.value',
                     'label_attr' => array('class' => 'control-label'),
                     'attr'       => array(
                         'class'   => 'form-control not-chosen'
+                    )
+                ));
+            } else {
+                $form->add('value', 'text', array(
+                    'label'      => 'mautic.form.field.form.value',
+                    'label_attr' => array('class' => 'control-label'),
+                    'attr'       => array(
+                        'class'   => 'form-control'
                     )
                 ));
             }


### PR DESCRIPTION
For a lead field type number cannot be added a numeric value because there is a select box. Reported in https://github.com/mautic/mautic/issues/1236

### Testing
1. Make sure you have a lead field type Number or create one.
2. Open the Campaign Builder and add the Lead Field Value condition.
3. Select the field type number.

Before the PR, it will show you a select box with values which doesn't make much sense. After the PR is applied, it will show a text box instead and you will be able to type in any value. The select box shill have to work for field types where are some predefined options (select, boolean, lookup, ...)