### PR TITLE
Number lead field params fix

### DIFF
--- a/app/bundles/LeadBundle/Views/Field/form.html.php
+++ b/app/bundles/LeadBundle/Views/Field/form.html.php
@@ -147,7 +147,6 @@ $defaultBoolTemplate = $view['form']->widget($form['default_bool_template']);
 <?php
     echo $view->render('MauticLeadBundle:Field:properties_number.html.php');
     echo $view->render('MauticLeadBundle:Field:properties_boolean.html.php');
-    echo $view->render('MauticLeadBundle:Field:properties_number.html.php');
     echo $view->render('MauticLeadBundle:Field:properties_select.html.php', array(
         'selectTemplate' => $selectTemplate
     ));

--- a/app/bundles/LeadBundle/Views/Field/properties_number.html.php
+++ b/app/bundles/LeadBundle/Views/Field/properties_number.html.php
@@ -26,7 +26,7 @@ $options = array(
         <div class="form-group col-xs-12 col-sm-8 col-md-6">
             <label class="control-label"><?php echo $view['translator']->trans('mautic.lead.field.form.properties.numberrounding'); ?></label>
             <div class="input-group">
-                <select class="form-control" autocomplete="false" name="leadfield[properties][roundmode]">
+                <select class="form-control not-chosen" autocomplete="false" name="leadfield[properties][roundmode]">
                     <?php foreach ($options as $v => $l): ?>
                     <option value="<?php echo $v; ?>"<?php if ($roundMode == $v) echo ' selected="selected"'; ?>><?php echo $view['translator']->trans($l); ?></option>
                     <?php endforeach; ?>


### PR DESCRIPTION
When you try to create a new lead field type number, there are 2 bugs:

1. The field parameters are loaded twice
2. The Rounding Mode select box does not display the options.

This PR fixes both.

### Testing
1. To to *Leads* / *Manage Fields* / *New*
2. Select the **Data Type**: **Number**

You should be able to see both issues mentioned above. After the PR, those issues should be fixed.