### PR TITLE
Removed the First/Every time option to add points from point action

### DIFF
--- a/app/bundles/PageBundle/Form/Type/PointActionUrlHitType.php
+++ b/app/bundles/PageBundle/Form/Type/PointActionUrlHitType.php
@@ -39,14 +39,14 @@ class PointActionUrlHitType extends AbstractType
             )
         ));
 
-        $default = (isset($options['data']) && isset($options['data']['first_time'])) ? $options['data']['first_time'] : false;
-        $builder->add('first_time', 'yesno_button_group', array(
-            'label'       => 'mautic.page.point.action.form.first.time.only',
-            'attr'        => array(
-                'tooltip' => 'mautic.page.point.action.form.first.time.only.descr'
-            ),
-            'data'        => $default
-        ));
+        // $default = (isset($options['data']) && isset($options['data']['first_time'])) ? $options['data']['first_time'] : false;
+        // $builder->add('first_time', 'yesno_button_group', array(
+        //     'label'       => 'mautic.page.point.action.form.first.time.only',
+        //     'attr'        => array(
+        //         'tooltip' => 'mautic.page.point.action.form.first.time.only.descr'
+        //     ),
+        //     'data'        => $default
+        // ));
 
         $builder->add('page_hits', 'integer', array(
             'label'       => 'mautic.page.hits',

--- a/app/bundles/PageBundle/Views/FormTheme/Point/pointaction_urlhit_widget.html.php
+++ b/app/bundles/PageBundle/Views/FormTheme/Point/pointaction_urlhit_widget.html.php
@@ -23,12 +23,12 @@ $timeFrames = array(
 </div>
 
 <div class="row">
-    <div class="col-xs-6">
+    <div class="col-xs-12">
         <?php echo $view['form']->row($form['page_hits']); ?>
     </div>
-    <div class="col-xs-6">
-        <?php echo $view['form']->row($form['first_time']); ?>
-    </div>
+    <!-- <div class="col-xs-6">
+        <?php //echo $view['form']->row($form['first_time']); ?>
+    </div> -->
 </div>
 
 <div class="row">


### PR DESCRIPTION
Because every point action can be executed only once per lead (https://github.com/mautic/mautic/blob/staging/app/bundles/PointBundle/Model/PointModel.php#L195) I removed the option to modify points every time because it was not working and it was only confusing users.

I discussed the change with Alan. It would require a big code change to make this option working. It will have to be implemented into every point action. We can do that for another version. Just want to squeeze this into 1.2.3 so the users won't be confused.

Reported for example here:
- https://www.mautic.org/community/index.php/1322-incremental-page-hit-points/0
- https://github.com/mautic/mautic/issues/929

### Testing
1. Create / Edit a point action with **Visit specific URL** type.

Before the PR there will be switch button to execute it every time or only for the first time. After the PR, this option will be gone. This PR doesn't bring any functionality change.