### PR TITLE
Removed the necessity for count query for determining unique page hit or asset download

### DIFF
--- a/app/bundles/AssetBundle/Entity/DownloadRepository.php
+++ b/app/bundles/AssetBundle/Entity/DownloadRepository.php
@@ -22,26 +22,34 @@ class DownloadRepository extends CommonRepository
 {
 
     /**
-     * Get a count of unique downloads for the current tracking ID
+     * Determine if the download is a unique download
      *
      * @param $assetId
      * @param $trackingId
      *
-     * @return int
-     * @throws \Doctrine\ORM\NoResultException
-     * @throws \Doctrine\ORM\NonUniqueResultException
+     * @return bool
      */
-    public function getDownloadCountForTrackingId($assetId, $trackingId)
+    public function isUniqueDownload($assetId, $trackingId)
     {
-        $count = $this->createQueryBuilder('d')
-            ->select('count(d.id) as num')
-            ->where('IDENTITY(d.asset) = ' .$assetId)
-            ->andWhere('d.trackingId = :id')
-            ->setParameter('id', $trackingId)
-            ->getQuery()
-            ->getSingleResult();
+        $q  = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        $q2 = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
-        return (int) $count['num'];
+        $q2->select('null')
+            ->from(MAUTIC_TABLE_PREFIX.'asset_downloads', 'd');
+
+        $q2->where(
+            $q2->expr()->andX(
+                $q2->expr()->eq('d.tracking_id', ':id'),
+                $q2->expr()->eq('d.asset_id', (int) $assetId)
+            )
+        );
+
+        $q->select('u.is_unique')
+            ->from(sprintf('(SELECT (NOT EXISTS (%s)) is_unique)', $q2->getSQL()), 'u'
+            )
+            ->setParameter('id', $trackingId);
+
+        return (bool) $q->execute()->fetchColumn();
     }
 
     /**


### PR DESCRIPTION
**Description**

To determine if a page hit or an asset download was unique, I count query was performed using the tracking ID.  a) this wasn't needed if the cookie was just generated as we can assume the hit/download to be unique and b) the count query with a large data set regardless of indexes could cause significant delays. This PR addresses this by assuming a unique if the tracking cookie was just created and then using optimized queries that simply checks if the tracking ID exists.

**Testing**
Apply the PR then

1. Create a landing page and an asset (or use existing ones but be sure you don't have cookies lingering in the test browser)
2. If the using existing landing pages or assets, note the current counts in the database
3. In an anonymous browsing session, browse to a landing page. Check the hits and unique_hits counts in the pages table.  The first hit should see both increase by one.  Subsequent hits should only result in the hits column incrementing.  
4. Repeat the same process for an asset with the assets table and download_count/unique_download_count columns.
