### PR TITLE
An empty value can be saved to the lead fields via API

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -332,7 +332,7 @@ class LeadApiController extends CommonApiController
             $parameters[$f->getName()] = $f->getData();
         }
 
-        $this->model->setFieldValues($entity, $parameters);
+        $this->model->setFieldValues($entity, $parameters, true);
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -285,7 +285,7 @@ class LeadModel extends FormModel
                     $curValue = $field['value'];
                     $newValue = $data[$alias];
 
-                    if ($curValue !== $newValue && (strlen($newValue) > 0 || strlen($newValue) === 0 && $overwriteWithBlank))) {
+                    if ($curValue !== $newValue && (strlen($newValue) > 0 || (strlen($newValue) === 0 && $overwriteWithBlank))) {
                         $field['value'] = $newValue;
                         $lead->addUpdatedField($alias, $newValue, $curValue);
                     }

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -285,7 +285,7 @@ class LeadModel extends FormModel
                     $curValue = $field['value'];
                     $newValue = $data[$alias];
 
-                    if ($curValue !== $newValue && (!empty($newValue) || (empty($newValue) && $overwriteWithBlank))) {
+                    if ($curValue !== $newValue && (strlen($newValue) > 0 || strlen($newValue) === 0 && $overwriteWithBlank))) {
                         $field['value'] = $newValue;
                         $lead->addUpdatedField($alias, $newValue, $curValue);
                     }


### PR DESCRIPTION
An empty value, for example `0` cannot be saved to a lead field through API. The API Tester can be configured like this to test it:
![mautic-save-gender-0](https://cloud.githubusercontent.com/assets/1235442/11841015/83e26e14-a3fa-11e5-979e-7f7e2b4444da.png)

Notes for testing:
-  Edit a lead who exists (has an ID)
- Try to save 0 to an existing custom field. In my case it was gender.

After the PR, the `0` value will be saved correctly.
