### PR TITLE
Fixed error when the email error message contains array of arrays

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1610,8 +1610,8 @@ class LeadController extends FormController
                         } else {
                             $errors = $mailer->getErrors();
 
+                            // Unset the array of failed email addresses
                             if (isset($errors['failures'])) {
-                                $errors[] = $this->get('translator')->trans('mautic.lead.for.email', array('%emails%' => implode('<br />', $errors['failures'])));
                                 unset($errors['failures']);
                             }
 

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1609,6 +1609,12 @@ class LeadController extends FormController
                             );
                         } else {
                             $errors = $mailer->getErrors();
+
+                            if (isset($errors['failures'])) {
+                                $errors[] = $this->get('translator')->trans('mautic.lead.for.email', array('%emails%' => implode('<br />', $errors['failures'])));
+                                unset($errors['failures']);
+                            }
+
                             $form->addError(
                                 new FormError(
                                     $this->factory->getTranslator()->trans(

--- a/app/bundles/LeadBundle/Translations/en_US/messages.ini
+++ b/app/bundles/LeadBundle/Translations/en_US/messages.ini
@@ -323,4 +323,3 @@ mautic.lead.webhook.event.lead.points="Lead Point Change (Increase / Decrease) E
 mautic.lead.webhook.event.lead.update="Lead Updated Event"
 mautic.lead.campaign.event.field="Lead Field"
 mautic.lead.campaign.event.field_descr="Select the lead field which holds the value you want to compare."
-mautic.lead.for.email="For email(s): %emails%"

--- a/app/bundles/LeadBundle/Translations/en_US/messages.ini
+++ b/app/bundles/LeadBundle/Translations/en_US/messages.ini
@@ -323,3 +323,4 @@ mautic.lead.webhook.event.lead.points="Lead Point Change (Increase / Decrease) E
 mautic.lead.webhook.event.lead.update="Lead Updated Event"
 mautic.lead.campaign.event.field="Lead Field"
 mautic.lead.campaign.event.field_descr="Select the lead field which holds the value you want to compare."
+mautic.lead.for.email="For email(s): %emails%"


### PR DESCRIPTION
If I try to send a direct email to a lead from a lead detail and there is some error, it ends up with a fatal error instead of a user notice about what is wrong. The problem fatal error was:
```
500 Internal Server Error - Notice: Array to string conversion
in app/bundles/LeadBundle/Controller/LeadController.php (line #1625)
```
The error is expected to be a string or one dimensional array, but in my case, the error was 2-dimensional:
```
array(2) {
  [0]=>
  string(189) "Connection could not be established with host smtp.gmail.com [ #0]
Log data:
++ Starting Swift_Transport_EsmtpTransport
!! Connection could not be established with host smtp.gmail.com [ #0]"
  ["failures"]=>
  array(1) {
    [0]=>
    string(33) "[censored]@gmail.com"
  }
}
```
### Testing
- Configure a GMail connection with wrong credentials.
- Go to a lead detail (the lead has to have an email).
- Send an email to a lead directly from the lead detail.

I discovered this bug, because it sends emails via the test email sent from the configuration, but it doesn't send anywhere else. I'll try to dig deeper as of why's that.