### PR TITLE
Prevented fatal error when sending custom HTML email if system's configured default theme cannot be found

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -805,9 +805,10 @@ class EmailModel extends FormModel
         if (empty($emailSettings[$email->getId()])) {
 
             //used to house slots so they don't have to be fetched over and over for same template
-            $slots            = array();
-            $template         = $email->getTemplate();
-            $slots[$template] = $this->factory->getTheme($template)->getSlots('email');
+            $slots = array();
+            if ($template = $email->getTemplate()) {
+                $slots[$template] = $this->factory->getTheme($template)->getSlots('email');
+            }
 
             //store the settings of all the variants in order to properly disperse the emails
             //set the parent's settings
@@ -831,12 +832,14 @@ class EmailModel extends FormModel
 
                     foreach ($childrenVariant as $id => $child) {
                         if ($child->isPublished()) {
-                            $template = $child->getTemplate();
-                            if (isset($slots[$template])) {
-                                $useSlots = $slots[$template];
-                            } else {
-                                $slots[$template] = $this->factory->getTheme($template)->getSlots('email');
-                                $useSlots         = $slots[$template];
+                            $useSlots = array();
+                            if ($template = $child->getTemplate()) {
+                                if (isset($slots[$template])) {
+                                    $useSlots = $slots[$template];
+                                } else {
+                                    $slots[$template] = $this->factory->getTheme($template)->getSlots('email');
+                                    $useSlots         = $slots[$template];
+                                }
                             }
                             $variantSettings = $child->getVariantSettings();
 


### PR DESCRIPTION
**Description**

This should fix #1149.  This only happened if the system could not find the system configured default theme so that `$this->factory->getTheme($template)->getSlots('email');` would fatal because `$this->factory->getTheme($template)` returned `null` rather than a `ThemeHelper` object for the default theme (since `$template == ''` and thus no theme is found).  This PR fixes it.

**Testing**

Temporarily rename themes/Mauve to themes/Mauve2.  Create a list email with custom HTML and then try to send it to the list.  It should fatal with the error in #1149.  

Apply the PR and repeat.  This time it should work. 