### PR TITLE
Fixed saving form submit actions that didn't save due to #1221

### DIFF
--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -293,8 +293,10 @@ class FormController extends CommonFormController
                         $model->setFields($entity, $fields);
 
                         try {
+                            $unlockEntity = $form->get('buttons')->get('save')->isClicked() && !$entity->isStandalone();
+
                             //save the form first so that new fields are available to actions
-                            $model->saveEntity($entity);
+                            $model->saveEntity($entity, $unlockEntity);
 
                             if ($entity->isStandalone()) {
                                 //only save actions that are not to be deleted
@@ -302,6 +304,7 @@ class FormController extends CommonFormController
 
                                 //now set the actions
                                 $model->setActions($entity, $actions, $fields);
+                                $model->saveEntity($entity, $form->get('buttons')->get('save')->isClicked());
                             }
 
                             $this->addFlash('mautic.core.notice.created', array(
@@ -506,8 +509,10 @@ class FormController extends CommonFormController
                         $model->setFields($entity, $fields);
                         $model->deleteFields($entity, $deletedFields);
 
+                        $unlockEntity = $form->get('buttons')->get('save')->isClicked() && !$entity->isStandalone();
+
                         //save the form first so that new fields are available to actions
-                        $model->saveEntity($entity, $form->get('buttons')->get('save')->isClicked());
+                        $model->saveEntity($entity, $unlockEntity);
 
                         // Reset objectId to entity ID (can be session ID in case of cloned entity)
                         $objectId = $entity->getId();
@@ -518,6 +523,8 @@ class FormController extends CommonFormController
 
                             // Delete deleted actions
                             $this->factory->getModel('form.action')->deleteEntities($deletedActions);
+
+                            $model->saveEntity($entity, $form->get('buttons')->get('save')->isClicked());
                         } else {
                             // Clear the actions
                             $entity->clearActions();

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -228,7 +228,7 @@ class FormModel extends CommonFormModel
     {
         $isNew = ($entity->getId()) ? false : true;
 
-        if ($isNew) {
+        if ($isNew && !$entity->getAlias()) {
             $alias = $this->cleanAlias($entity->getName(), '', 10);
             $entity->setAlias($alias);
         }


### PR DESCRIPTION
**Description**

Due to the change in #1221, form actions didn't get saved.  This is because currently, the fields are added to the form entity and persisted to the database then the actions are added to the entity.  This is so the fields are available (with IDs) to the actions.  The problem is that after the actions were added, the entity was not persisted again.  Before the doctrine change tracking policy was switched, doctrine caught this automatically and persisted.  But since we changed the policy to deferred explicit, doctrine no longer did that for us leading to the issue.

**Testing**

1. Before the PR, create a new form, add a field and add a submit action.  
2. Save and you'll see the action in the Actions tab.  Refresh though and it disappears (because it was never persisted to the database).
3. Apply the PR and repeat.  It should save to the database and be available on a page refresh.