### PR TITLE
Fixed issue that prevented some campaigns from kickoff

### DIFF
--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -594,7 +594,10 @@ class CampaignRepository extends CommonRepository
             $sq->select('null')
                 ->from(MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'e')
                 ->where(
-                    $sq->expr()->eq('cl.lead_id', 'e.lead_id')
+                    $sq->expr()->andX(
+                        $sq->expr()->eq('cl.lead_id', 'e.lead_id'),
+                        $sq->expr()->eq('e.campaign_id', (int) $campaignId)
+                    )
                 );
 
             $q->andWhere(


### PR DESCRIPTION
**Description**

Due to some recent changes, there was a bad query that prevented kicking off campaigns for leads that were already part of another campaign.  This PR fixes the query.

**Testing**

To reproduce, create a campaign, add a few leads, and trigger it.  Then add a second campaign with the same leads and trigger it.  The second campaign will not trigger the starting events.

Apply the PR, then try to trigger the second campaign.  This time they should go through.
