### PR TITLE
Fixes several issues with email sends

### DIFF
--- a/app/bundles/AssetBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/BuilderSubscriber.php
@@ -111,7 +111,7 @@ class BuilderSubscriber extends CommonSubscriber
         $model = $this->factory->getModel('asset');
 
         $clickthrough = array();
-        if ($event instanceof PageDisplayEvent || ($event instanceof EmailSendEvent && !$event->isInternalSend())) {
+        if ($event instanceof PageDisplayEvent || ($event instanceof EmailSendEvent && $event->shouldAppendClickthrough())) {
             $clickthrough = array('source' => $source);
 
             if ($leadId !== null) {
@@ -125,9 +125,9 @@ class BuilderSubscriber extends CommonSubscriber
 
         $tokens = array();
 
-        preg_match_all('/({|%7B)assetlink=(.*?)(}|%7D)/', $content, $matches);
-        if (!empty($matches[2])) {
-            foreach ($matches[2] as $key => $assetId) {
+        preg_match_all('/'.$this->assetToken.'/', $content, $matches);
+        if (!empty($matches[1])) {
+            foreach ($matches[1] as $key => $assetId) {
                 $token = $matches[0][$key];
 
                 if (isset($tokens[$token])) {

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -90,7 +90,7 @@ return array(
             'mautic.emailbuilder.subscriber'         => array(
                 'class' => 'Mautic\EmailBundle\EventListener\BuilderSubscriber'
             ),
-            'mautic.emailtoken_subscriber'     => array(
+            'mautic.emailtoken.subscriber'     => array(
                 'class' => 'Mautic\EmailBundle\EventListener\TokenSubscriber'
             ),
             'mautic.email.campaignbundle.subscriber' => array(

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -90,6 +90,9 @@ return array(
             'mautic.emailbuilder.subscriber'         => array(
                 'class' => 'Mautic\EmailBundle\EventListener\BuilderSubscriber'
             ),
+            'mautic.emailtoken_subscriber'     => array(
+                'class' => 'Mautic\EmailBundle\EventListener\TokenSubscriber'
+            ),
             'mautic.email.campaignbundle.subscriber' => array(
                 'class' => 'Mautic\EmailBundle\EventListener\CampaignSubscriber'
             ),

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -190,7 +190,7 @@ class EmailRepository extends CommonRepository
 
             if (empty($listIds)) {
                 // Prevent fatal error
-                $listIds[] = 0;
+                return ($countOnly) ? 0 : array();
             }
         } elseif (!is_array($listIds)) {
             $listIds = array($listIds);

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -187,6 +187,11 @@ class EmailRepository extends CommonRepository
             foreach ($lists as $list) {
                 $listIds[] = $list['leadlist_id'];
             }
+
+            if (empty($listIds)) {
+                // Prevent fatal error
+                $listIds[] = 0;
+            }
         } elseif (!is_array($listIds)) {
             $listIds = array($listIds);
         }

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -144,63 +144,77 @@ class EmailRepository extends CommonRepository
      */
     public function getEmailPendingLeads($emailId, $variantIds = null, $listIds = null, $countOnly = false, $limit = null)
     {
-        $q = $this->_em->getConnection()->createQueryBuilder();
-
-        $sq = $this->_em->getConnection()->createQueryBuilder();
-        $sq->select('dne.lead_id')
+        // Do not include leads in the do not email table
+        $dneQb = $this->_em->getConnection()->createQueryBuilder();
+        $dneQb->select('null')
             ->from(MAUTIC_TABLE_PREFIX.'email_donotemail', 'dne')
             ->where(
-                $sq->expr()->isNotNull('dne.lead_id')
+                $dneQb->expr()->eq('dne.lead_id', 'l.id')
             );
 
-        $sq2 = $this->_em->getConnection()->createQueryBuilder();
-        $sqExpr = $sq2->expr()->andX(
-            $sq2->expr()->isNotNull('stat.lead_id')
+        // Do not include leads that have already been emailed
+        $statQb    = $this->_em->getConnection()->createQueryBuilder()
+            ->select('null')
+            ->from(MAUTIC_TABLE_PREFIX.'email_stats', 'stat');
+
+        $statExpr = $statQb->expr()->andX(
+            $statQb->expr()->eq('stat.lead_id', 'l.id')
         );
 
         if ($variantIds) {
-            $variantIds[] = $emailId;
-            $sqExpr->add(
-                $sq->expr()->in('stat.email_id', $variantIds)
+            $variantIds[] = (int) $emailId;
+            $statExpr->add(
+                $statQb->expr()->in('stat.email_id', $variantIds)
             );
         } else {
-            $sqExpr->add(
-                $sq->expr()->eq('stat.email_id', $emailId)
+            $statExpr->add(
+                $statQb->expr()->eq('stat.email_id', (int) $emailId)
             );
         }
+        $statQb->where($statExpr);
 
-        $sq2->select('stat.lead_id')
-            ->from(MAUTIC_TABLE_PREFIX.'email_stats', 'stat')
-            ->where($sqExpr);
+        // Only include those who belong to the associated lead lists
+        if (null === $listIds) {
+            // Get a list of lists associated with this email
+            $lists = $this->_em->getConnection()->createQueryBuilder()
+                ->select('el.leadlist_id')
+                ->from(MAUTIC_TABLE_PREFIX.'email_list_xref', 'el')
+                ->where('el.email_id = ' . (int) $emailId)
+                ->execute()
+                ->fetchAll();
 
+            $listIds = array();
+            foreach ($lists as $list) {
+                $listIds[] = $list['leadlist_id'];
+            }
+        } elseif (!is_array($listIds)) {
+            $listIds = array($listIds);
+        }
+
+        $listQb = $this->_em->getConnection()->createQueryBuilder();
+        $listQb->select('null')
+            ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'll')
+            ->where(
+                $listQb->expr()->andX(
+                    $listQb->expr()->in('ll.leadlist_id', $listIds),
+                    $listQb->expr()->eq('ll.lead_id', 'l.id'),
+                    $listQb->expr()->eq('ll.manually_removed', ':false')
+                )
+            );
+
+        // Main query
+        $q  = $this->_em->getConnection()->createQueryBuilder();
         if ($countOnly) {
             $q->select('count(l.id) as count');
         } else {
             $q->select('l.*')
                 ->orderBy('l.id');
         }
-        $q->from(MAUTIC_TABLE_PREFIX . 'leads', 'l')
-            ->join('l', MAUTIC_TABLE_PREFIX . 'lead_lists_leads', 'll',
-                $q->expr()->andX(
-                    $q->expr()->eq('l.id', 'll.lead_id'),
-                    $q->expr()->eq('ll.manually_removed', ':false')
-                )
-            )
-            ->join('ll', MAUTIC_TABLE_PREFIX . 'email_list_xref', 'el', 'el.leadlist_id = ll.leadlist_id')
+        $q->from(MAUTIC_TABLE_PREFIX.'leads', 'l')
+            ->andWhere(sprintf('NOT EXISTS (%s)', $dneQb->getSQL()))
+            ->andWhere(sprintf('NOT EXISTS (%s)', $statQb->getSQL()))
+            ->andWhere(sprintf('EXISTS (%s)', $listQb->getSQL()))
             ->setParameter('false', false, 'boolean');
-
-        $q->where($q->expr()->eq('el.email_id', $emailId))
-            ->andWhere('l.id NOT IN ' . sprintf("(%s)",$sq->getSQL()))
-            ->andWhere('l.id NOT IN ' . sprintf("(%s)",$sq2->getSQL()));
-
-        if ($listIds != null) {
-            if (!is_array($listIds)) {
-                $listIds = array($listIds);
-            }
-            $q->andWhere(
-                $q->expr()->in('ll.leadlist_id', $listIds)
-            );
-        }
 
         // Has an email
         $q->andWhere(

--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -176,7 +176,7 @@ class EmailSendEvent extends CommonEvent
     public function setContent($content)
     {
         if ($this->helper !== null) {
-            $this->helper->setBody($content);
+            $this->helper->setBody($content, 'text/html', null, true);
         } else {
             $this->content = $content;
         }
@@ -318,5 +318,15 @@ class EmailSendEvent extends CommonEvent
     public function getTextHeaders()
     {
         return ($this->helper !== null) ? $this->helper->getCustomHeaders() : $this->headers;
+    }
+
+    /**
+     * Check if the listener should append it's own clickthrough in URLs or if the email tracking URL conversion process should take care of it
+     *
+     * @return bool
+     */
+    public function shouldAppendClickthrough()
+    {
+        return (!$this->isInternalSend() && null === $this->getEmail());
     }
 }

--- a/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
@@ -114,6 +114,5 @@ class BuilderSubscriber extends CommonSubscriber
         $event->addToken('{webview_text}', $webviewText);
 
         $event->addToken('{webview_url}', $model->buildUrl('mautic_email_webview', array('idHash' => $idHash)));
-
     }
 }

--- a/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2015 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\EventListener;
+
+use Mautic\CoreBundle\EventListener\CommonSubscriber;
+use Mautic\EmailBundle\EmailEvents;
+use Mautic\EmailBundle\Event\EmailSendEvent;
+
+/**
+ * Class TokenSubscriber
+ */
+class TokenSubscriber extends CommonSubscriber
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            EmailEvents::EMAIL_ON_SEND    => array('decodeTokens', 254),
+            EmailEvents::EMAIL_ON_DISPLAY => array('decodeTokens', 254)
+        );
+    }
+
+    /**
+     * @param EmailSendEvent $event
+     *
+     * @return void
+     */
+    public function decodeTokens(EmailSendEvent $event)
+    {
+        // Find and replace encoded tokens for trackable URL conversion
+        $content = $event->getContent();
+        $content = preg_replace('/(%7B)(.*?)(%7D)/i', '{$2}', $content);
+        $event->setContent($content);
+
+        if ($plainText = $event->getPlainText()) {
+            $plainText = preg_replace('/(%7B)(.*?)(%7D)/i', '{$2}', $plainText);
+            $event->setPlainText($plainText);
+        }
+    }
+}

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -234,13 +234,10 @@ class MailHelper
         }
 
         // Set system return path if applicable
-        $returnPath = $this->message->getReturnPath();
-        if (empty($returnPath)) {
-            if (!$isQueueFlush && $bounceEmail = $this->generateBounceEmail($this->idHash)) {
-                $this->message->setReturnPath($bounceEmail);
-            } elseif (!empty($this->returnPath)) {
-                $this->message->setReturnPath($this->returnPath);
-            }
+        if (!$isQueueFlush && $bounceEmail = $this->generateBounceEmail($this->idHash)) {
+            $this->message->setReturnPath($bounceEmail);
+        } elseif (!empty($this->returnPath)) {
+            $this->message->setReturnPath($this->returnPath);
         }
 
         if (empty($this->errors)) {

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -261,12 +261,7 @@ class MailHelper
 
             $this->message->setSubject($this->subject);
             $this->message->setBody($this->body['content'], $this->body['contentType'], $this->body['charset']);
-
-            if (!$this->plainTextSet && !empty($this->plainText)) {
-                $this->message->addPart($this->plainText, 'text/plain');
-
-                $this->plainTextSet = true;
-            }
+            $this->setMessagePlainText($isQueueFlush);
 
             if (!$isQueueFlush) {
                 // Set metadata if applicable
@@ -516,7 +511,7 @@ class MailHelper
      * @param array          $replace
      * @param \Swift_Message $message
      */
-    static function searchReplaceTokens($search, $replace, \Swift_Message &$message)
+    static public function searchReplaceTokens($search, $replace, \Swift_Message &$message)
     {
         // Body
         $body         = $message->getBody();
@@ -746,8 +741,7 @@ class MailHelper
      */
     public function setPlainText($content)
     {
-        $this->plainText    = $content;
-        $this->plainTextSet = false;
+        $this->plainText = $content;
     }
 
     /**
@@ -756,6 +750,38 @@ class MailHelper
     public function getPlainText()
     {
         return $this->plainText;
+    }
+
+    /**
+     * Set plain text for $this->message, replacing if necessary
+     *
+     * @return null|string
+     */
+    protected function setMessagePlainText()
+    {
+        if ($this->tokenizationEnabled && $this->plainTextSet) {
+            // No need to find and replace since tokenization happens at the transport level
+
+            return;
+        }
+
+        if ($this->plainTextSet) {
+            $children = (array) $this->message->getChildren();
+
+            /** @var \Swift_Mime_MimeEntity $child */
+            foreach ($children as $child) {
+                $childType = $child->getContentType();
+                if ($childType == 'text/plain' && $child instanceof \Swift_MimePart) {
+
+                    $child->setBody($this->plainText);
+
+                    break;
+                }
+            }
+        } else {
+            $this->message->addPart($this->plainText, 'text/plain');
+            $this->plainTextSet = true;
+        }
     }
 
     /**

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -491,6 +491,7 @@ class FormModel extends CommonFormModel
                 switch ($f->getType()) {
                     case 'text':
                     case 'email':
+                    case 'hidden':
                         if (preg_match('/<input(.*?)id="mauticform_input_'.$formName.'_'.$alias.'"(.*?)value="(.*?)"(.*?)\/>/i', $formHtml, $match)) {
                             $replace  = '<input'.$match[1].'id="mauticform_input_'.$formName.'_'.$alias.'"'.$match[2].'value="'.urldecode($value).'"'.$match[4].'/>';
                             $formHtml = str_replace($match[0], $replace, $formHtml);

--- a/app/bundles/PageBundle/Config/config.php
+++ b/app/bundles/PageBundle/Config/config.php
@@ -89,7 +89,7 @@ return array(
             'mautic.pagebuilder.subscriber'         => array(
                 'class' => 'Mautic\PageBundle\EventListener\BuilderSubscriber'
             ),
-            'mautic.pagetoken_subscriber'           => array(
+            'mautic.pagetoken.subscriber'           => array(
                 'class' => 'Mautic\PageBundle\EventListener\TokenSubscriber'
             ),
             'mautic.page.pointbundle.subscriber'    => array(

--- a/app/bundles/PageBundle/Config/config.php
+++ b/app/bundles/PageBundle/Config/config.php
@@ -89,6 +89,9 @@ return array(
             'mautic.pagebuilder.subscriber'         => array(
                 'class' => 'Mautic\PageBundle\EventListener\BuilderSubscriber'
             ),
+            'mautic.pagetoken_subscriber'           => array(
+                'class' => 'Mautic\PageBundle\EventListener\TokenSubscriber'
+            ),
             'mautic.page.pointbundle.subscriber'    => array(
                 'class' => 'Mautic\PageBundle\EventListener\PointSubscriber'
             ),

--- a/app/bundles/PageBundle/EventListener/TokenSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/TokenSubscriber.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2015 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\PageBundle\EventListener;
+
+use Mautic\CoreBundle\EventListener\CommonSubscriber;
+use Mautic\PageBundle\Event\PageDisplayEvent;
+use Mautic\PageBundle\PageEvents;
+
+/**
+ * Class TokenSubscriber
+ */
+class TokenSubscriber extends CommonSubscriber
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            PageEvents::PAGE_ON_DISPLAY => array('decodeTokens', 254)
+        );
+    }
+
+    /**
+     * @param PageDisplayEvent $event
+     *
+     * @return void
+     */
+    public function decodeTokens(PageDisplayEvent $event)
+    {
+        // Find and replace encoded tokens for trackable URL conversion
+        $content = $event->getContent();
+        $content = preg_replace('/(%7B)(.*?)(%7D)/i', '{$2}', $content);
+        $event->setContent($content);
+    }
+}

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -318,3 +318,41 @@ $container->setParameter(
 // Monolog formatter
 $container->register('mautic.monolog.fulltrace.formatter', 'Monolog\Formatter\LineFormatter')
     ->addMethodCall('includeStacktraces', array(true));
+
+//Register command line logging
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+$container->setParameter(
+    'console_exception_listener.class',
+    'Mautic\CoreBundle\EventListener\ConsoleExceptionListener'
+);
+$definitionConsoleExceptionListener = new Definition(
+    '%console_exception_listener.class%',
+    array(new Reference('monolog.logger.mautic'))
+);
+$definitionConsoleExceptionListener->addTag(
+    'kernel.event_listener',
+    array('event' => 'console.exception')
+);
+$container->setDefinition(
+    'mautic.kernel.listener.command_exception',
+    $definitionConsoleExceptionListener
+);
+
+$container->setParameter(
+    'console_terminate_listener.class',
+    'Mautic\CoreBundle\EventListener\ConsoleTerminateListener'
+);
+$definitionConsoleExceptionListener = new Definition(
+    '%console_terminate_listener.class%',
+    array(new Reference('monolog.logger.mautic'))
+);
+$definitionConsoleExceptionListener->addTag(
+    'kernel.event_listener',
+    array('event' => 'console.terminate')
+);
+$container->setDefinition(
+    'mautic.kernel.listener.command_terminate',
+    $definitionConsoleExceptionListener
+);

--- a/app/config/config_dev.php
+++ b/app/config/config_dev.php
@@ -60,44 +60,6 @@ $container->loadFromExtension("monolog", array(
     )
 ));
 
-//Register command line logging
-use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\Reference;
-
-$container->setParameter(
-    'console_exception_listener.class',
-    'Mautic\CoreBundle\EventListener\ConsoleExceptionListener'
-);
-$definitionConsoleExceptionListener = new Definition(
-    '%console_exception_listener.class%',
-    array(new Reference('logger'))
-);
-$definitionConsoleExceptionListener->addTag(
-    'kernel.event_listener',
-    array('event' => 'console.exception')
-);
-$container->setDefinition(
-    'mautic.kernel.listener.command_exception',
-    $definitionConsoleExceptionListener
-);
-
-$container->setParameter(
-    'console_terminate_listener.class',
-    'Mautic\CoreBundle\EventListener\ConsoleTerminateListener'
-);
-$definitionConsoleExceptionListener = new Definition(
-    '%console_terminate_listener.class%',
-    array(new Reference('logger'))
-);
-$definitionConsoleExceptionListener->addTag(
-    'kernel.event_listener',
-    array('event' => 'console.terminate')
-);
-$container->setDefinition(
-    'mautic.kernel.listener.command_terminate',
-    $definitionConsoleExceptionListener
-);
-
 // Allow overriding config without a requiring a full bundle or hacks
 if (file_exists(__DIR__ . '/config_override.php')) {
     $loader->import("config_override.php");


### PR DESCRIPTION
### Description

This PR fixes three main bugs discovered.

1. Fixes #1246 where links in emails send through a campaign were converted to trackables only for the first email.  Subsequent emails did not have trackable links. (List sends were not affected).
2. Emails sent through lead lists (batched) all had the same bounce/return path email rendering bounces in-effective for batch sends.
3. If a lead was part of more than one list assigned to an email, the ajax send process would never finish due to the count including duplicate leads but the actual lead processing did not.

(Also accidentally committed a small fix to forms prepopulating values for hidden fields https://github.com/mautic/mautic/pull/1266/files#diff-068791cef1a33e1b839aff9add5a4ba4R494)

### Testing

**Trackable Links**

1. Create a lead list with multiple leads
2. Create a template email with multiple links (try to test at least one `{assetlink=ID}`, `{pagelink=ID}` and any external link).
3. Create a campaign that simply sends the above email
4. Trigger the email and review the source of the emails received. The very first email will have links converted to trackables.  Subsequent emails will not. After the PR, all links in all emails should be trackable.

**Duplicate Bounce/Return Path and Ajax Batch Issue**

1. Setup bounce monitoring in Configuration
2. Create a second list that includes at least one of the leads that is in the first lead list.
3. Clone the above email and convert it to a List Email.  Assign both lead lists created above.
4. Send the email. Note the count of pending.  When you send, notice that the total number of leads do not match the pending count (it'll have a difference of the leads belonging to both lists).  Also note that the process will never finish since the number process never matches the total number to process.  Once it's noticed that the process won't finish, refresh the page.  Now there will be 0 leads pending.
5. Review the emails sent.  They will all have the same return path email (something+bounce_STRING@something.com).
6. Apply the PR and either truncate the email_stats table, or simply clone the email and try again.  This time, notice the process should finish.  Also notice that the return paths should now be unique per email sent.

