### PR TITLE
Landing page find by slug fixes

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -982,16 +982,12 @@ class CommonRepository extends EntityRepository
                 }
             }
 
-            if (isset($metadata->fieldMappings['language'])) {
+            if ($lang && isset($metadata->fieldMappings['language'])) {
                 $q->setParameter('lang', $lang);
 
                 $expr->add(
                     $q->expr()->eq($this->getTableAlias().'.language', ':lang')
                 );
-            } elseif (null !== $lang) {
-                // This entity does not have a language mapping so return null
-
-                return null;
             }
 
             // Check for variants and return parent only

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -994,6 +994,13 @@ class CommonRepository extends EntityRepository
                 return null;
             }
 
+            // Check for variants and return parent only
+            if (isset($metadata->associationMappings['variantParent'])) {
+                $expr->add(
+                    $q->expr()->isNull($this->getTableAlias().'.variantParent')
+                );
+            }
+
             $q->where($expr);
 
             $entity = $q->getQuery()->getSingleResult();

--- a/app/bundles/CoreBundle/Model/CommonModel.php
+++ b/app/bundles/CoreBundle/Model/CommonModel.php
@@ -238,11 +238,9 @@ class CommonModel
             $category = null;
         }
 
-        if (null === $lang) {
-            // Default to en
-            $lang = 'en';
-        } elseif (!isset($locales[$lang])) {
+        if ($lang && !isset($locales[$lang])) {
             // Language doesn't exist so return false
+
             return false;
         }
 

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -37,7 +37,6 @@ class PublicController extends CommonFormController
         /** @var \Mautic\PageBundle\Model\PageModel $model */
         $model      = $this->factory->getModel('page.page');
         $security   = $this->factory->getSecurity();
-        $translator = $this->get('translator');
         $entity     = $model->getEntityBySlugs($slug);
 
         if (!empty($entity)) {


### PR DESCRIPTION
**Description**

This fixes two issues introduced with #1238.

1. A landing page that is an A/B test would return 404
2. A landing page assigned a locale but not as a translation of another landing page would 404

**Testing**
1. Create a landing page then create an A/B test from it.  Click the Page URL button from the landing page details page.  It should 404. 
2. Create a landing page and assign it a language. Click the Page URL button from the landing page details page.  It should 404. 
3. Apply the PR and repeat the above and both should now find the landing page.  Also repeat the testing steps in #1238 to ensure the language bar/translated pages still work.
