### PR TITLE
Fixed issue where tokens do not populate with Mandrill and form results email for non-leads

### DIFF
--- a/app/bundles/FormBundle/Helper/FormSubmitHelper.php
+++ b/app/bundles/FormBundle/Helper/FormSubmitHelper.php
@@ -30,23 +30,24 @@ class FormSubmitHelper
         }
 
         $mailer = $factory->getMailer();
-        $emails = (!empty($config['to'])) ? explode(',', $config['to']) : array();
+        $emails = (!empty($config['to'])) ? array_fill_keys(explode(',', $config['to']), null) : array();
 
         $mailer->setTo($emails);
 
         $leadEmail = $lead->getEmail();
+
         if (!empty($leadEmail)) {
             // Reply to lead for user convenience
             $mailer->setReplyTo($leadEmail);
         }
 
         if (!empty($config['cc'])) {
-            $emails = explode(',', $config['cc']);
+            $emails = array_fill_keys(explode(',', $config['cc']), null);
             $mailer->setCc($emails);
         }
 
         if (!empty($config['bcc'])) {
-            $emails = explode(',', $config['bcc']);
+            $emails = array_fill_keys(explode(',', $config['bcc']), null);
             $mailer->setBcc($emails);
         }
 


### PR DESCRIPTION
**Description**

This PR fixes an issue introduced in 1.2.3 with Mandrill, Form results email and addresses in configured in the to, cc or bcc fields (does not affect leads).  In those emails, tokens were not replaced resulting in the placeholders.

The issue was introduced by changes in https://github.com/mautic/mautic/pull/1211 to support Mandrill's immediate API feedback for single email addresses. Although it just exposed the issue this PR fixes.

**Testing**

Configure a form with a submit form results action.  Specify a custom to address.  Configure Mautic to use mandrill then submit the form.  The results should arrive with the token placeholders.  After the PR, these placeholders will be populated with the actual results.