### PR TITLE
Updates the file manager ACL to use Symfony's session instead of $_SESSION

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/connectors/php/user.config.php
+++ b/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/connectors/php/user.config.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 // Boot Symfony
 require_once __DIR__ . '/../../../../../../../../../bootstrap.php.cache';
@@ -37,7 +38,7 @@ $container->get('event_dispatcher')->dispatch(KernelEvents::REQUEST, $event);
 $session       = $container->get('session');
 $securityToken = $container->get('security.token_storage');
 $token         = $securityToken->getToken();
-$authenticated = count($token->getRoles());
+$authenticated = ($token instanceof TokenInterface) ? count($token->getRoles()) : false;
 
 /**
  *	Check if user is authorized

--- a/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/connectors/php/user.config.php
+++ b/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/connectors/php/user.config.php
@@ -35,7 +35,7 @@ function auth() {
     // You can insert your own code over here to check if the user is authorized.
     // If you use a session variable, you've got to start the session first (session_start())
 
-    return (!empty($userId));
+    return (false !== $userId);
 }
 
 // @todo Work on plugins registration
@@ -51,7 +51,7 @@ function auth() {
 
 $fm = new Filemanager();
 
-if ($userId) {
+if (false !== $userId) {
     $userDir = $session->get('mautic.imagepath', false);
     $baseDir = $session->get('mautic.basepath', false);
     $docRoot = $session->get('mautic.docroot', false);

--- a/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/connectors/php/user.config.php
+++ b/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/connectors/php/user.config.php
@@ -16,12 +16,13 @@
  *	@copyright	Authors
  */
 
-if (!isset($_COOKIE['mautic_session_name'])) {
-    die();
-}
-session_name($_COOKIE['mautic_session_name']);
-
-session_start();
+// Boot Symfony
+require_once __DIR__ . '/../../../../../../../../../bootstrap.php.cache';
+require_once __DIR__ . '/../../../../../../../../../AppKernel.php';
+$kernel = new AppKernel('prod', false);
+$kernel->boot();
+$session = $kernel->getContainer()->get('session');
+$userId  = $session->get('mautic.user', false);
 
 /**
  *	Check if user is authorized
@@ -30,12 +31,12 @@ session_start();
  *	@return boolean true if access granted, false if no access
  */
 function auth() {
+    global $userId;
     // You can insert your own code over here to check if the user is authorized.
     // If you use a session variable, you've got to start the session first (session_start())
 
-    return (!empty($_SESSION['_sf2_attributes']['mautic.user']));
+    return (!empty($userId));
 }
-
 
 // @todo Work on plugins registration
 // if (isset($config['plugin']) && !empty($config['plugin'])) {
@@ -50,10 +51,10 @@ function auth() {
 
 $fm = new Filemanager();
 
-if (isset($_SESSION['_sf2_attributes'])) {
-    $userDir = $_SESSION['_sf2_attributes']['mautic.imagepath'];
-    $baseDir = $_SESSION['_sf2_attributes']['mautic.basepath'];
-    $docRoot = $_SESSION['_sf2_attributes']['mautic.docroot'];
+if ($userId) {
+    $userDir = $session->get('mautic.imagepath', false);
+    $baseDir = $session->get('mautic.basepath', false);
+    $docRoot = $session->get('mautic.docroot', false);
 
     if (substr($userDir, -1) !== '/') {
         $userDir .= '/';

--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -415,7 +415,7 @@ return array(
             'class'        => 'Mautic\CoreBundle\IpLookup\MaxmindPrecisionLookup'
         ),
         'maxmind_download' => array(
-            'display_name' => 'MaxMind - GeoIP2 City Download',
+            'display_name' => 'MaxMind - GeoLite2 City Download',
             'class'        => 'Mautic\CoreBundle\IpLookup\MaxmindDownloadLookup'
         ),
         'telize' => array(


### PR DESCRIPTION
**Description**

The filemanager handles ACL through a custom function. Before, we simply checked for a user ID in the session.  This PR hardens security by booting Symfony and checking for an authenticated user.

**Testing**

Apply the PR. Edit/create a landing page and click the Image button then Browse Server. If logged into Mautic, images should show.  Now, leave the popup/filemanager open and log out of Mautic in the parent window.  Go back to the filemanager and refresh.  You should get an access denied message.