### PR TITLE
Fixed issue that prevented being able to edit Point trigger events or Campaign events

### DIFF
--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -482,15 +482,17 @@ class CampaignController extends FormController
                         );
                         $valid = false;
                     } else {
+                        // Set lead sources
                         $model->setLeadSources($entity, $addedSources, $deletedSources);
 
                         $connections = $session->get('mautic.campaign.'.$sessionId.'.events.canvassettings');
+                        // Build and set Event entities
                         $model->setEvents($entity, $campaignEvents, $connections, $deletedEvents, $currentSources);
 
-                        //form is valid so process the data
+                        // Persist to the database before building connection so that IDs are available
                         $model->saveEntity($entity);
 
-                        //update canvas settings with new event IDs then save
+                        // Update canvas settings with new event IDs then save
                         $model->setCanvasSettings($entity, $connections);
 
                         $this->addFlash(
@@ -701,29 +703,27 @@ class CampaignController extends FormController
                         $valid = false;
                     } else {
                         //set sources
-
                         $model->setLeadSources($entity, $addedSources, $deletedSources);
 
                         //set events and connections
                         $connections = $session->get('mautic.campaign.'.$objectId.'.events.canvassettings');
+
                         if ($connections != null) {
+                            // Build and persist events
                             $model->setEvents($entity, $campaignEvents, $connections, $deletedEvents, $currentSources);
 
-                            //form is valid so process the data
-                            $model->saveEntity($entity, $form->get('buttons')->get('save')->isClicked());
-
-                            // Reset objectId to entity ID (can be session ID in case of cloned entity)
-                            $objectId = $entity->getId();
-
-                            //update canvas settings with new event IDs then save
+                            // Update canvas settings with new event IDs if applicable then save
                             $model->setCanvasSettings($entity, $connections);
 
                             if (!empty($deletedEvents)) {
                                 $this->factory->getModel('campaign.event')->deleteEvents($entity->getEvents(), $modifiedEvents, $deletedEvents);
                             }
-                        } else {
-                            $model->saveEntity($entity, $form->get('buttons')->get('save')->isClicked());
                         }
+
+                        $model->saveEntity($entity, $form->get('buttons')->get('save')->isClicked());
+
+                        // Reset objectId to entity ID (can be session ID in case of cloned entity)
+                        $objectId = $entity->getId();
 
                         $this->addFlash(
                             'mautic.core.notice.updated',

--- a/app/bundles/CampaignBundle/Controller/EventController.php
+++ b/app/bundles/CampaignBundle/Controller/EventController.php
@@ -230,6 +230,7 @@ class EventController extends CommonFormController
                             $event['name'] = $this->get('translator')->trans($event['settings']['label']);
                         }
                         $modifiedEvents[$objectId] = $event;
+
                         $session->set('mautic.campaign.' . $campaignId . '.events.modified', $modifiedEvents);
                     } else {
                         $success = 0;

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -174,11 +174,12 @@ class CampaignModel extends CommonFormModel
      *
      * @return array
      */
-    public function setEvents (Campaign &$entity, $sessionEvents, $sessionConnections, $deletedEvents)
+    public function setEvents (Campaign $entity, $sessionEvents, $sessionConnections, $deletedEvents)
     {
         $existingEvents = $entity->getEvents();
-
-        $events = $hierarchy = $parentUpdated = array();
+        $events =
+        $hierarchy =
+        $parentUpdated = array();
 
         //set the events from session
         foreach ($sessionEvents as $id => $properties) {
@@ -285,6 +286,11 @@ class CampaignModel extends CommonFormModel
             return ($aOrder < $bOrder) ? -1 : 1;
         });
 
+        // Persist events if campaign is being edited
+        if ($entity->getId()) {
+            $this->getEventRepository()->saveEntities($events);
+        }
+
         return $events;
     }
 
@@ -366,7 +372,7 @@ class CampaignModel extends CommonFormModel
      * @param string   $root
      * @param int      $order
      */
-    private function buildOrder ($hierarchy, &$events, &$entity, $root = 'null', $order = 1)
+    private function buildOrder ($hierarchy, &$events, $entity, $root = 'null', $order = 1)
     {
         $count = count($hierarchy);
 
@@ -374,7 +380,6 @@ class CampaignModel extends CommonFormModel
             if ($parent == $root || $count === 1) {
                 $events[$eventId]->setOrder($order);
                 $entity->addEvent($eventId, $events[$eventId]);
-
                 unset($hierarchy[$eventId]);
                 if (count($hierarchy)) {
                     $this->buildOrder($hierarchy, $events, $entity, $eventId, $order + 1);

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -213,8 +213,6 @@ class FormController extends CommonFormController
             $activeFormFields[] = $field;
         }
 
-        $model->getEntities(array('factory' => $this->factory));
-
         return $this->delegateView(array(
             'viewParameters'  => array(
                 'activeForm'  => $activeForm,
@@ -245,7 +243,8 @@ class FormController extends CommonFormController
     /**
      * Generates new form and processes post data
      *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|Response
+     * @return array|\Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
+     * @throws \Exception
      */
     public function newAction()
     {
@@ -293,21 +292,23 @@ class FormController extends CommonFormController
                         $model->setFields($entity, $fields);
 
                         try {
-                            $alias = $model->cleanAlias($entity->getName(), '', 10);
-                            $entity->setAlias($alias);
-
                             if ($entity->isStandalone()) {
-                                // save the form first so that new fields are available to actions
-                                // use the repository function to not trigger the listeners twice
+                                // Set alias to prevent SQL errors
+                                $alias = $model->cleanAlias($entity->getName(), '', 10);
+                                $entity->setAlias($alias);
+
+                                // Save the form first and new actions so that new fields are available to actions.
+                                // Using the repository function to not trigger the listeners twice.
                                 $model->getRepository()->saveEntity($entity);
 
-                                //only save actions that are not to be deleted
-                                $actions  = array_diff_key($modifiedActions, array_flip($deletedActions));
+                                // Only save actions that are not to be deleted
+                                $actions = array_diff_key($modifiedActions, array_flip($deletedActions));
 
-                                //now set the actions
-                                $model->setActions($entity, $actions, $fields);
+                                // Set and persist actions
+                                $model->setActions($entity, $actions);
                             }
 
+                            // Save and trigger listeners
                             $model->saveEntity($entity, $form->get('buttons')->get('save')->isClicked());
 
                             $this->addFlash('mautic.core.notice.created', array(
@@ -422,7 +423,8 @@ class FormController extends CommonFormController
      */
     public function editAction($objectId, $ignorePost = false, $forceTypeSelection = false)
     {
-        $model      = $this->factory->getModel('form.form');
+        /** @var \Mautic\FormBundle\Model\FormModel $model */
+        $model      = $this->factory->getModel('form');
         $formData   = $this->request->request->get('mauticform');
         $sessionId  = isset($formData['sessionId']) ? $formData['sessionId'] : null;
 
@@ -517,30 +519,30 @@ class FormController extends CommonFormController
                         $model->deleteFields($entity, $deletedFields);
 
                         if ($entity->isStandalone()) {
-                            // save the form first so that new fields are available to actions
-                            // use the repository method to not trigger listeners twice
-                            $model->getRepository()->saveEntity($entity);
-
-                            //now set the actions
-                            $model->setActions($entity, $actions, $fields);
+                            if (count($actions)) {
+                                // Now set and persist the actions
+                                $model->setActions($entity, $actions);
+                            }
 
                             // Delete deleted actions
-                            $this->factory->getModel('form.action')->deleteEntities($deletedActions);
+                            if (count($deletedActions)) {
+                                $this->factory->getModel('form.action')->deleteEntities($deletedActions);
+                            }
                         } else {
                             // Clear the actions
                             $entity->clearActions();
 
                             // Delete all actions
-                            $this->factory->getModel('form.action')->deleteEntities(array_keys($modifiedActions));
+                            if (count($modifiedActions)) {
+                                $this->factory->getModel('form.action')->deleteEntities(array_keys($modifiedActions));
+                            }
                         }
 
+                        // Persist and execute listeners
                         $model->saveEntity($entity, $form->get('buttons')->get('save')->isClicked());
 
                         // Reset objectId to entity ID (can be session ID in case of cloned entity)
                         $objectId = $entity->getId();
-
-                        // Delete fields
-                        $this->factory->getModel('form.field')->deleteEntities($deletedFields);
 
                         $this->addFlash(
                             'mautic.core.notice.updated',

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -155,6 +155,13 @@ class FormModel extends CommonFormModel
             $order++;
             $entity->addField($properties['id'], $field);
         }
+
+        // Persist if the entity is known
+        if ($entity->getId()) {
+            /** @var \Mautic\FormBundle\Model\FieldModel $fieldModel */
+            $fieldModel = $this->factory->getModel('form.field');
+            $fieldModel->saveEntities($entity->getFields());
+        }
     }
 
     /**
@@ -164,13 +171,22 @@ class FormModel extends CommonFormModel
     public function deleteFields(Form $entity, $sessionFields)
     {
         if (empty($sessionFields)) {
+
             return;
         }
+
         $existingFields = $entity->getFields();
+        $deleteFields   = array();
         foreach ($sessionFields as $fieldId) {
             if (isset($existingFields[$fieldId])) {
                 $entity->removeField($fieldId, $existingFields[$fieldId]);
+                $deleteFields[] = $existingFields[$fieldId];
             }
+        }
+
+        // Delete fields from db
+        if (count($deleteFields)) {
+            $this->factory->getModel('form.field')->deleteEntities($deleteFields);
         }
     }
 
@@ -218,6 +234,13 @@ class FormModel extends CommonFormModel
             $action->setOrder($order);
             $order++;
             $entity->addAction($properties['id'], $action);
+        }
+
+        // Persist if form is being edited
+        if ($entity->getId()) {
+            /** @var \Mautic\FormBundle\Model\ActionModel $actionModel */
+            $actionModel = $this->factory->getModel('form.action');
+            $actionModel->saveEntities($entity->getActions());
         }
     }
 

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -180,7 +180,7 @@ class FormModel extends CommonFormModel
         foreach ($sessionFields as $fieldId) {
             if (isset($existingFields[$fieldId])) {
                 $entity->removeField($fieldId, $existingFields[$fieldId]);
-                $deleteFields[] = $existingFields[$fieldId];
+                $deleteFields[] = $fieldId;
             }
         }
 

--- a/app/bundles/PointBundle/Controller/TriggerController.php
+++ b/app/bundles/PointBundle/Controller/TriggerController.php
@@ -182,7 +182,8 @@ class TriggerController extends FormController
      */
     public function newAction($entity = null)
     {
-        $model     = $this->factory->getModel('point.trigger');
+        /** @var \Mautic\PointBundle\Model\TriggerModel $model */
+        $model = $this->factory->getModel('point.trigger');
 
         if (!($entity instanceof Trigger)) {
             /** @var \Mautic\PointBundle\Entity\Trigger $entity */
@@ -225,7 +226,6 @@ class TriggerController extends FormController
                     } else {
                         $model->setEvents($entity, $events);
 
-                        //form is valid so process the data
                         $model->saveEntity($entity);
 
                         $this->addFlash('mautic.core.notice.created', array(
@@ -241,15 +241,6 @@ class TriggerController extends FormController
                             //return edit view so that all the session stuff is loaded
                             return $this->editAction($entity->getId(), true);
                         }
-
-                        /*
-                        $viewParameters = array(
-                            'objectAction' => 'view',
-                            'objectId'     => $entity->getId()
-                        );
-                        $returnUrl      = $this->generateUrl('mautic_pointtrigger_action', $viewParameters);
-                        $template       = 'MauticPointBundle:Trigger:view';
-                        */
                     }
                 }
             }
@@ -312,10 +303,12 @@ class TriggerController extends FormController
      */
     public function editAction($objectId, $ignorePost = false)
     {
+        /** @var \Mautic\PointBundle\Model\TriggerModel $model */
         $model      = $this->factory->getModel('point.trigger');
         $entity     = $model->getEntity($objectId);
         $session    = $this->factory->getSession();
         $cleanSlate = true;
+
         //set the page we came from
         $page = $this->factory->getSession()->get('mautic.point.trigger.page', 1);
 
@@ -380,7 +373,9 @@ class TriggerController extends FormController
                         $model->saveEntity($entity, $form->get('buttons')->get('save')->isClicked());
 
                         //delete entities
-                        $this->factory->getModel('point.triggerEvent')->deleteEntities($deletedEvents);
+                        if (count($deletedEvents)) {
+                            $this->factory->getModel('point.triggerEvent')->deleteEntities($deletedEvents);
+                        }
 
                         $this->addFlash('mautic.core.notice.updated', array(
                             '%name%'      => $entity->getName(),
@@ -390,17 +385,6 @@ class TriggerController extends FormController
                                 'objectId'     => $entity->getId()
                             ))
                         ));
-
-                        if ($form->get('buttons')->get('save')->isClicked()) {
-                            /*
-                            $viewParameters = array(
-                                'objectAction' => 'view',
-                                'objectId'     => $entity->getId()
-                            );
-                            $returnUrl      = $this->generateUrl('mautic_pointtrigger_action', $viewParameters);
-                            $template       = 'MauticPointBundle:Trigger:view';
-                            */
-                        }
                     }
                 }
             } else {

--- a/app/bundles/PointBundle/Model/TriggerModel.php
+++ b/app/bundles/PointBundle/Model/TriggerModel.php
@@ -199,7 +199,7 @@ class TriggerModel extends CommonFormModel
      *
      * @return void
      */
-    public function setEvents(Trigger &$entity, $sessionEvents)
+    public function setEvents(Trigger $entity, $sessionEvents)
     {
         $order   = 1;
         $existingActions = $entity->getEvents();
@@ -216,11 +216,18 @@ class TriggerModel extends CommonFormModel
                 if (method_exists($event, $func)) {
                     $event->$func($v);
                 }
-                $event->setTrigger($entity);
             }
+            $event->setTrigger($entity);
             $event->setOrder($order);
             $order++;
             $entity->addTriggerEvent($properties['id'], $event);
+        }
+
+        // Persist if editing the trigger
+        if ($entity->getId()) {
+            /** @var \Mautic\PointBundle\Model\TriggerEventModel $eventModel */
+            $eventModel = $this->factory->getModel('point.triggerEvent');
+            $eventModel->saveEntities($entity->getEvents());
         }
     }
 


### PR DESCRIPTION
**Description**

So surprised this bug hasn't been discovered earlier as it's apparently been around for a long while :-). Due to the way Doctrine handles associations, owner/inverse, etc, it turns out that edited Campaign events and Trigger events did not persist to the database.  New events would persist but edited events did not.  This PR fixes it.

This did not affect forms because a call was made to delete fields/actions whether there were any or not.  This forced Doctrine to examine and persist changes to the database.  

**Testing**
1. Edit a campaign, click Launch Campaign Builder, double click an existing event and edit something.  Update/Save.  Close the builder then click Save & Close.  Edit the campaign again and check to see if the event's changed values persisted.  Before the PR they will not.
2. Edit a trigger, click the Events tab and edit something in an existing event (description, or whatever).  Save & Close then edit again.  Check if the values persisted.  Before they PR they will not.

Apply the PR then repeat the above two tests.  This time, edited events should persist.

Also test, creating new triggers, campaigns, and forms to ensure all the events, fields, actions persist.  Also test forms to ensure they still work as expected since some changes was made to clean it up a bit.  

**Hot Fix for Campaigns**

For those wanting a quick hot fix,  add `$this->factory->getModel('campaign.event')->getRepository()->saveEntities($entity->getEvents());` right after https://github.com/mautic/mautic/blob/master/app/bundles/CampaignBundle/Controller/CampaignController.php#L723