### PR TITLE
Prevents SQL exception if a campaign is based on forms only

### DIFF
--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -817,20 +817,27 @@ class CampaignModel extends CommonFormModel
             'dateTime' => $this->factory->getDate()->toUtcString()
         );
 
-        // Get a count of new leads
-        $newLeadsCount = $repo->getCampaignLeadsFromLists(
-            $campaign->getId(),
-            $lists,
-            array(
-                'countOnly' => true,
-                'batchLimiters' => $batchLimiters
-            ));
 
-        // Ensure the same list is used each batch
-        $batchLimiters['maxId'] = (int) $newLeadsCount['maxId'];
+        if (count($lists)) {
+            // Get a count of new leads
+            $newLeadsCount = $repo->getCampaignLeadsFromLists(
+                $campaign->getId(),
+                $lists,
+                array(
+                    'countOnly'     => true,
+                    'batchLimiters' => $batchLimiters
+                )
+            );
 
-        // Number of total leads to process
-        $leadCount = (int) $newLeadsCount['count'];
+            // Ensure the same list is used each batch
+            $batchLimiters['maxId'] = (int) $newLeadsCount['maxId'];
+
+            // Number of total leads to process
+            $leadCount = (int) $newLeadsCount['count'];
+        } else {
+            // No lists to base campaign membership off of so ignore
+            $leadCount = 0;
+        }
 
         if ($output) {
             $output->writeln($this->translator->trans('mautic.campaign.rebuild.to_be_added', array('%leads%' => $leadCount, '%batch%' => $limit)));
@@ -910,8 +917,9 @@ class CampaignModel extends CommonFormModel
         );
 
         // Restart batching
-        $start     = $lastRoundPercentage = 0;
-        $leadCount = $removeLeadCount['count'];
+        $start                  = $lastRoundPercentage = 0;
+        $leadCount              = $removeLeadCount['count'];
+        $batchLimiters['maxId'] = $removeLeadCount['maxId'];
 
         if ($output) {
             $output->writeln($this->translator->trans('mautic.lead.list.rebuild.to_be_removed', array('%leads%' => $leadCount, '%batch%' => $limit)));


### PR DESCRIPTION
**Description**

If a campaign only has a form as a lead source (i.e. no lead lists), a SQL exception will throw when executing the `mautic:campaign:update` command.  

**Testing**
Create a campaign using only a form as a lead source.  Execute the `mautic:campaign:trigger` command.  Before the PR, an exception will throw due to a bad SQL statement. After the PR, the command will proceed.