### PR TITLE
Improved membership building queries by removing order by

### DIFF
--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -352,8 +352,7 @@ class CampaignRepository extends CommonRepository
         if ($countOnly) {
             $q->select('max(list_leads.lead_id) as max_id, count(distinct(list_leads.lead_id)) as lead_count');
         } else {
-            $q->select('distinct(list_leads.lead_id) as id')
-                ->orderBy('list_leads.lead_id', 'ASC');
+            $q->select('distinct(list_leads.lead_id) as id');
         }
 
         $q->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'list_leads');
@@ -442,8 +441,7 @@ class CampaignRepository extends CommonRepository
         if ($countOnly) {
             $q->select('max(campaign_leads.lead_id) as max_id, count(campaign_leads.lead_id) as lead_count');
         } else {
-            $q->select('campaign_leads.lead_id as id')
-                ->orderBy('campaign_leads.lead_id', 'ASC');
+            $q->select('campaign_leads.lead_id as id');
         }
 
         $q->from(MAUTIC_TABLE_PREFIX.'campaign_leads', 'campaign_leads')
@@ -456,7 +454,7 @@ class CampaignRepository extends CommonRepository
 
         if ($batchLimiters) {
             $expr->add(
-                // Only leads part of the campaign at the time of count
+            // Only leads part of the campaign at the time of count
                 $q->expr()->lte('campaign_leads.date_added', $q->expr()->literal($batchLimiters['dateTime']))
             );
 

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -308,10 +308,8 @@ class LeadListRepository extends CommonRepository
                     $select = 'count(l.id) as lead_count, max(l.id) as max_id';
                 } elseif ($idOnly) {
                     $select = 'l.id';
-                    $q->orderBy('l.id', 'ASC');
                 } else {
                     $select = 'l.*';
-                    $q->orderBy('l.id', 'ASC');
                 }
 
                 $q->select($select)
@@ -401,13 +399,11 @@ class LeadListRepository extends CommonRepository
                         ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'll');
                 } elseif ($idOnly) {
                     $q->select('ll.lead_id as id')
-                        ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'll')
-                        ->orderBy('ll.lead_id', 'ASC');
+                        ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'll');
                 } else {
                     $q->select('l.*')
                         ->from(MAUTIC_TABLE_PREFIX.'leads', 'l')
-                        ->join('l', MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'll', 'l.id = ll.lead_id')
-                        ->orderBy('ll.lead_id', 'ASC');
+                        ->join('l', MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'll', 'l.id = ll.lead_id');
                 }
 
                 // Filter by list


### PR DESCRIPTION
**Description**

This PR simply removes the order by clause for a few of the queries used to build lead list and campaign membership. This significantly reduces query time for large lead numbers and is not necessary since we use a max ID to ensure the same data pool when batching.  

**Testing**

Test adding and removing leads to lead lists and campaigns using the `mautic:lists:update` and `mautic:campaigns:update` commands. It should still function as before.