### PR TITLE
Campaign lead boolean field value fix

### DIFF
--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -592,8 +592,8 @@ class AjaxController extends CommonAjaxController
         $choiceTypes = array('boolean', 'country', 'region', 'lookup', 'timezone', 'select', 'radio');
 
         if ($leadField && in_array($leadField->getType(), $choiceTypes)) {
-            $properties = $field->getProperties();
-            $fieldType = $field->getType();
+            $properties = $leadField->getProperties();
+            $fieldType  = $leadField->getType();
             if (!empty($properties['list'])) {
                 // Lookup/Select options
                 $options = explode('|', $properties['list']);

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -592,12 +592,19 @@ class AjaxController extends CommonAjaxController
         $choiceTypes = array('boolean', 'country', 'region', 'lookup', 'timezone', 'select', 'radio');
 
         if ($leadField && in_array($leadField->getType(), $choiceTypes)) {
-            $properties = $leadField->getProperties();
-
+            $properties = $field->getProperties();
+            $fieldType = $field->getType();
             if (!empty($properties['list'])) {
                 // Lookup/Select options
                 $options = explode('|', $properties['list']);
-            } else {
+            } elseif (!empty($properties) && $fieldType == 'boolean') {
+                // Boolean options
+                $options = array(
+                    0 => $properties['no'],
+                    1 => $properties['yes']
+                );
+            } elseif (!empty($properties)) {
+                // fallback
                 $options = $properties;
             }
             $dataArray['options'] = $options;

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
@@ -71,14 +71,21 @@ class CampaignEventLeadFieldValueType extends AbstractType
 
             if (isset($data['field'])) {
                 $field = $fieldModel->getRepository()->findOneBy(array('alias' => $data['field']));
+                
                 if ($field) {
                     $properties = $field->getProperties();
                     $fieldType = $field->getType();
                     if (!empty($properties['list'])) {
                         // Lookup/Select options
                         $fieldValues = explode('|', $properties['list']);
-                    } elseif (!empty($properties)) {
+                    } elseif (!empty($properties) && $fieldType == 'boolean') {
                         // Boolean options
+                        $fieldValues = array(
+                            0 => $properties['no'],
+                            1 => $properties['yes']
+                        );
+                    } elseif (!empty($properties)) {
+                        // fallback
                         $fieldValues = $properties;
                     }
                 }


### PR DESCRIPTION
Fix for https://github.com/mautic/mautic/issues/1300

### Testing
1. Make sure you have a boolean lead field. If not, create one.
2. Make a list with 2 or more leads.
3. Set the boolean field to true (or yes) to one of the leads.
4. Create a campaign which will test the boolean field condition. For example like the campaign below.
5. Run the `mautic:campaign:update` command to get the leads from the list to the campaign.
6. Run the `mautic:campaign:trigger` command to execute the campaign.

![mautic-boolean-value-fix](https://cloud.githubusercontent.com/assets/1235442/12064628/3bd8e736-afc8-11e5-9f83-93d9c812b5cb.png)

The result is that all leads from the list will get the false tag. Doesn't matter what value was in the boolean field.

Apply this PR, remove the tags from the leads, clone the campaign and run the commands again. This time the leads should get the right tags. All other conditions has to work as well.
