### PR TITLE
Prevented SMTP timeouts for batched email sends

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -185,6 +185,20 @@ class MailHelper
     protected $fatal = false;
 
     /**
+     * Large batch mail sends may result on timeouts with SMTP servers. This will will keep track of the number of sends and restart the connection once met.
+     *
+     * @var int
+     */
+    private $messageSentCount = 0;
+
+    /**
+     * Large batch mail sends may result on timeouts with SMTP servers. This will will keep track of when a transport was last started and force a restart after set number of minutes.
+     *
+     * @var int
+     */
+    private $transportStartTime;
+
+    /**
      * @param MauticFactory $factory
      * @param               $mailer
      * @param null          $from
@@ -194,6 +208,7 @@ class MailHelper
         $this->factory   = $factory;
         $this->mailer    = $mailer;
         $this->transport = $mailer->getTransport();
+
         try {
             $this->logger = new \Swift_Plugins_Loggers_ArrayLogger();
             $this->mailer->registerPlugin(new \Swift_Plugins_LoggerPlugin($this->logger));
@@ -317,6 +332,11 @@ class MailHelper
 
             try {
                 $failures = array();
+
+                if (!$this->transport->isStarted()) {
+                    $this->transportStartTime = time();
+                }
+
                 $this->mailer->send($this->message, $failures);
 
                 if (!empty($failures)) {
@@ -338,6 +358,9 @@ class MailHelper
                 );
             }
         }
+
+        $this->messageSentCount++;
+        $this->checkIfTransportNeedsRestart();
 
         $error = empty($this->errors);
 
@@ -1666,5 +1689,30 @@ class MailHelper
         }
 
         return $monitoredEmail;
+    }
+
+    /**
+     * A large number of mail sends may result on timeouts with SMTP servers. This checks for the number of email sends and restarts the transport if necessary
+     *
+     * @param bool $force
+     */
+    public function checkIfTransportNeedsRestart($force = false)
+    {
+        // Check if we should restart the SMTP transport
+        if ($this->transport instanceof \Swift_SmtpTransport) {
+            $maxNumberOfMessages = (method_exists($this->transport, 'getNumberOfMessagesTillRestart'))
+                ? $this->transport->getNumberOfMessagesTillRestart() : 50;
+
+            $maxNumberOfMinutes = (method_exists($this->transport, 'getNumberOfMinutesTillRestart'))
+                ? $this->transport->getNumberOfMinutesTillRestart() : 2;
+
+            $numberMinutesRunning = floor(time() - $this->transportStartTime) / 60;
+
+            if ($force || $this->messageSentCount >= $maxNumberOfMessages || $numberMinutesRunning >= $maxNumberOfMinutes) {
+                // Stop the transport
+                $this->transport->stop();
+                $this->messageSentCount = 0;
+            }
+        }
     }
 }


### PR DESCRIPTION
**Description**

Email sends using a SMTP server with timeouts will eventually fail due to connections timing out. This is an issue with Amazon SES which uses the SMTP protocol and Amazon has a timeout on connections.  Apparently SwiftMailer will hold open the connection until it is stopped/closed.  This was discovered through sending thousands of emails through Amazon SES where SwiftMailer eventually stop getting a response from Amazon because Amazon's load balancer killed the connection to the SMTP server (see the second bullet under "You lose connection with the SMTP endpoint" of http://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-issues.html).  

So this PR will manually close the connection after x number of emails sent and/or minutes to prevent this from happening.

**Testing**

This will be tricky to simulate unless you have thousands of emails to send through Amazon SES. :-) So just make sure that sending through SMTP and other mailers still work as expected.  