### PR TITLE
Prevent some tokenized URLs in emails from being converted to trackables

### DIFF
--- a/app/bundles/CoreBundle/Helper/EncryptionHelper.php
+++ b/app/bundles/CoreBundle/Helper/EncryptionHelper.php
@@ -55,7 +55,7 @@ class EncryptionHelper
     {
         $encrypt   = serialize($encrypt);
         $iv        = mcrypt_create_iv(mcrypt_get_iv_size(MCRYPT_RIJNDAEL_256, MCRYPT_MODE_CBC), MCRYPT_DEV_URANDOM);
-        $key       = pack('H*', $this->key);
+        $key       = pack('H*', sprintf('%u', CRC32($this->key)));
         $mac       = hash_hmac('sha256', $encrypt, substr(bin2hex($key), -32));
         $passcrypt = mcrypt_encrypt(MCRYPT_RIJNDAEL_256, $key, $encrypt . $mac, MCRYPT_MODE_CBC, $iv);
         $encoded   = base64_encode($passcrypt) . '|' . base64_encode($iv);
@@ -78,7 +78,7 @@ class EncryptionHelper
         if (strlen($iv) !== mcrypt_get_iv_size(MCRYPT_RIJNDAEL_256, MCRYPT_MODE_CBC)) {
             return false;
         }
-        $key       = pack('H*', $this->key);
+        $key       = pack('H*', sprintf('%u', CRC32($this->key)));
         $decrypted = trim(mcrypt_decrypt(MCRYPT_RIJNDAEL_256, $key, $decoded, MCRYPT_MODE_CBC, $iv));
         $mac       = substr($decrypted, -64);
         $decrypted = substr($decrypted, 0, -64);

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -633,21 +633,6 @@ class EmailController extends FormController
         )
         ) {
             return $this->accessDenied();
-        } elseif ($entity->getEmailType() == 'list' && $entity->getSentCount()) {
-            return $this->postActionRedirect(
-                array_merge(
-                    $postActionVars,
-                    array(
-                        'flashes' => array(
-                            array(
-                                'type'    => 'error',
-                                'msg'     => 'mautic.email.error.list_type.sent',
-                                'msgVars' => array('%name%' => $entity->getName())
-                            )
-                        )
-                    )
-                )
-            );
         } elseif ($model->isLocked($entity)) {
             //deny access if the entity is locked
             return $this->isLocked($postActionVars, $entity, 'email');

--- a/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
@@ -38,7 +38,7 @@ class TokenSubscriber extends CommonSubscriber
     {
         // Find and replace encoded tokens for trackable URL conversion
         $content = $event->getContent();
-        $content = preg_replace('/(%7B)(.*?)(%7D)/i', '{$2}', $content);
+        $content = preg_replace('/(%7B)(.*?)(%7D)/i', '{$2}', $content, -1, $count);
         $event->setContent($content);
 
         if ($plainText = $event->getPlainText()) {

--- a/app/bundles/EmailBundle/Helper/PlainTextHelper.php
+++ b/app/bundles/EmailBundle/Helper/PlainTextHelper.php
@@ -333,7 +333,7 @@ class PlainTextHelper
             return $display;
         }
 
-        if (preg_match('!^([a-z][a-z0-9.+-]+:)!i', $link) || preg_match('!^{(.*?)}!', $link)) {
+        if (preg_match('!^([a-z][a-z0-9.+-]+:)!i', $link) || preg_match('!({|%7B)(.*?)(}|%7D)!', $link)) {
             $url = $link;
         } else {
             $url = $this->options['base_url'];

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -17,9 +17,6 @@ $emailType    = $email->getEmailType();
 if (empty($emailType)) {
     $emailType = 'template';
 }
-$sentCount    = $email->getSentCount();
-
-$edit = ($emailType == 'template' || empty($sentCount)) && $security->hasEntityAccess($permissions['email:emails:editown'], $permissions['email:emails:editother'], $email->getCreatedBy());
 
 $customButtons = array();
 
@@ -52,11 +49,12 @@ $customButtons[] = array(
         'btnText'   => 'mautic.core.form.clone'
 );
 
+$edit = $view['security']->hasEntityAccess($permissions['email:emails:editown'], $permissions['email:emails:editother'], $email->getCreatedBy());
 $view['slots']->set('actions', $view->render('MauticCoreBundle:Helper:page_actions.html.php', array(
     'item'       => $email,
     'templateButtons' => array(
         'edit'       => $edit,
-        'delete'     => $security->hasEntityAccess($permissions['email:emails:deleteown'], $permissions['email:emails:deleteother'], $email->getCreatedBy()),
+        'delete'     => $view['security']->hasEntityAccess($permissions['email:emails:deleteown'], $permissions['email:emails:deleteother'], $email->getCreatedBy()),
         'abtest'     => (!$isVariant && $edit && $permissions['email:emails:create'])
     ),
     'routeBase'  => 'email',

--- a/app/bundles/EmailBundle/Views/Email/list.html.php
+++ b/app/bundles/EmailBundle/Views/Email/list.html.php
@@ -60,7 +60,7 @@ if (count($items)):
             <tr>
                 <td>
                     <?php
-                    $edit          = ((($type == 'list' && !$item->getSentCount()) || $type == 'template') && $security->hasEntityAccess($permissions['email:emails:editown'], $permissions['email:emails:editother'], $item->getCreatedBy()));
+                    $edit          = $view['security']->hasEntityAccess($permissions['email:emails:editown'], $permissions['email:emails:editother'], $item->getCreatedBy());
                     $customButtons = ($type == 'list') ? array(
                         array(
                             'attr' => array(
@@ -76,7 +76,7 @@ if (count($items)):
                         'templateButtons' => array(
                             'edit'       => $edit,
                             'clone'      => $permissions['email:emails:create'],
-                            'delete'     => $security->hasEntityAccess($permissions['email:emails:deleteown'], $permissions['email:emails:deleteother'], $item->getCreatedBy()),
+                            'delete'     => $view['security']->hasEntityAccess($permissions['email:emails:deleteown'], $permissions['email:emails:deleteother'], $item->getCreatedBy()),
                             'abtest'     => (!$hasVariants && $edit && $permissions['email:emails:create']),
                         ),
                         'routeBase'       => 'email',

--- a/app/bundles/PageBundle/Event/UntrackableUrlsEvent.php
+++ b/app/bundles/PageBundle/Event/UntrackableUrlsEvent.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2015 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\PageBundle\Event;
+
+use Mautic\EmailBundle\Entity\Email;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class UntrackableUrlsEvent
+ */
+class UntrackableUrlsEvent extends Event
+{
+    /**
+     * @var array
+     */
+    private $doNotTrack = array(
+        '{webview_url}',
+        '{unsubscribe_url}',
+        '{trackedlink=(.?)}',
+        // @todo - remove in 2.0
+        '{externallink=(.*?)}'
+    );
+
+    /**
+     * @var Email
+     */
+    private $email;
+
+    /**
+     * TrackableEvent constructor.
+     *
+     * @param Email $email
+     */
+    public function __construct(Email $email = null)
+    {
+        $this->email = $email;
+    }
+
+    /**
+     * set a URL or token to not convert to trackables
+     *
+     * @param $url
+     */
+    public function addNonTrackable($url)
+    {
+        $this->doNotTrack[$url] = true;
+    }
+
+    /**
+     * Get affected email
+     *
+     * @return Email
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * Get array of non-trackables
+     *
+     * @return array
+     */
+    public function getDoNotTrackList()
+    {
+        return $this->doNotTrack;
+    }
+}

--- a/app/bundles/PageBundle/Event/UntrackableUrlsEvent.php
+++ b/app/bundles/PageBundle/Event/UntrackableUrlsEvent.php
@@ -23,7 +23,9 @@ class UntrackableUrlsEvent extends Event
     private $doNotTrack = array(
         '{webview_url}',
         '{unsubscribe_url}',
-        '{trackedlink=(.?)}',
+        '{trackedlink=(.*?)}',
+        // Ignore lead fields with URLs for tracking since each is unique
+        '^{leadfield=(.*?)}',
         // @todo - remove in 2.0
         '{externallink=(.*?)}'
     );

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -588,7 +588,7 @@ class BuilderSubscriber extends CommonSubscriber
     private function validateLink($url, $currentTokens, &$foundLinks)
     {
         static $doNotTrack;
-var_dump($url);
+
         if (null === $doNotTrack) {
             $event      = $this->dispatcher->dispatch(
                 PageEvents::REDIRECT_DO_NOT_TRACK,

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -617,7 +617,10 @@ class BuilderSubscriber extends CommonSubscriber
 
         if (stripos($url, 'http://{') !== false || strpos($url, 'https://{') !== false || strpos($url, '{') === 0) {
             $token = str_ireplace(array('https://', 'http://'), '', $url);
-            $doNotTrackMatcher($token, $currentTokens[$token], $url);
+            // Ensure the token is valid to prevent errors
+            if (preg_match('/^\{.*?\}(\S+|$)/', $token)) {
+                $doNotTrackMatcher($token, $currentTokens[$token], $url);
+            }
         } elseif (substr($url, 0, 4) == 'http' || substr($url, 0, 3) == 'ftp') {
             $doNotTrackMatcher($url);
         }

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -679,6 +679,12 @@ class BuilderSubscriber extends CommonSubscriber
             return;
         }
 
+        // Ensure a applicable URL (rule out URLs as just #)
+        if (!isset($urlParts['host']) && !isset($urlParts['path'])) {
+
+            return;
+        }
+
         // Check for tokens in the query
         if (!empty($urlParts['query'])) {
             list($tokenizedParams, $untokenizedParams) = $parseTokenizedQuery($urlParts['query']);

--- a/app/bundles/PageBundle/Model/RedirectModel.php
+++ b/app/bundles/PageBundle/Model/RedirectModel.php
@@ -91,6 +91,11 @@ class RedirectModel extends FormModel
 
         $return = array();
         foreach ($urls as $key => $url) {
+            if (empty($url)) {
+
+                continue;
+            }
+
             if (isset($byUrl[$url])) {
                 $return[$key] = $byUrl[$url];
             } elseif ($createEntity) {

--- a/app/bundles/PageBundle/PageEvents.php
+++ b/app/bundles/PageBundle/PageEvents.php
@@ -79,4 +79,14 @@ final class PageEvents
      * @var string
      */
     const PAGE_POST_DELETE = 'mautic.page_post_delete';
+
+    /**
+     * The mautic.redirect_do_not_track event is thrown when converting email links to trackables/redirectables in order to compile of list of tokens/URLs
+     * to ignore.
+     *
+     * The event listener receives a Mautic\PageBundle\Event\UntrackableUrlsEvent instance.
+     *
+     * @var string
+     */
+    const REDIRECT_DO_NOT_TRACK = 'mautic.redirect_do_not_track';
 }


### PR DESCRIPTION
**Description**

Some tokens are getting converted to trackables such as the webview_url and unsubscribe_url tokens. The redirects are thus sending all clicks to the first sent lead specific URL.  This PR addresses this by filtering out those tokens plus adds an event so that other bundles/plugins can inject tokens/URLs that should not be tracked.

This fixes #1288.

**Testing**

1. Create a list email that include the {webview_url}, {unsubscribe_url}, and {pagelink=ID} tokens as links and also a generic URL.  
2. Send the list email to more than one lead.
3. In each email, all four links should have been converted to trackables.  If you click on the links for the {webview_url} from each of the emails, they'll all redirect to the unique URL for the FIRST lead.
4. Apply the PR, clear the stats from the email_stats table or just clone the email and resend.  This time the {webview_url} and {unsubscribe_url} tokens should not be converted to trackables and be unique per lead.

**Hot Fix**
For those looking for a quick fix to this, simply edit this line https://github.com/mautic/mautic/blob/41a1d847fe79993efac708c082db93e3de31f202/app/bundles/PageBundle/EventListener/BuilderSubscriber.php#L595 to be 

```
            if (!in_array($token, array('{webview_url}', '{unsubscribe_url}'))) {
                $foundLinks[$url] = $currentTokens[$token];
            }
```