### PR TITLE
Fixed issue where scheduled events were not accounted for when processing inaction paths

### DIFF
--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -1328,13 +1328,13 @@ class EventModel extends CommonFormModel
                     if ($grandParentId) {
                         $logger->debug('CAMPAIGN: Checking for leads based on grand parent execution.');
 
-                        $leadLog         = $repo->getEventLog($campaignId, $campaignLeadIds, array($grandParentId), array_keys($events));
+                        $leadLog         = $repo->getEventLog($campaignId, $campaignLeadIds, array($grandParentId), array_keys($events), true);
                         $applicableLeads = array_keys($leadLog);
                     } else {
                         $logger->debug('CAMPAIGN: Checking for leads based on exclusion due to being at root level');
 
                         // The event has no grandparent (likely because the decision is first in the campaign) so find leads that HAVE
-                        // already executed the events in the root level
+                        // already executed the events in the root level and exclude them
                         $havingEvents      = (isset($actionEvents[$parentId]))
                             ? array_merge($actionEvents[$parentId], array_keys($events))
                             : array_keys(
@@ -1346,7 +1346,7 @@ class EventModel extends CommonFormModel
                         // Only use leads that are not applicable
                         $applicableLeads = array_diff($campaignLeadIds, $unapplicableLeads);
 
-                        unset($excludeLeads, $unapplicableLeads);
+                        unset($unapplicableLeads);
                     }
 
                     if (empty($applicableLeads)) {
@@ -1698,7 +1698,7 @@ class EventModel extends CommonFormModel
                 if ($triggerOn > $now) {
                     $logger->debug(
                         'CAMPAIGN: Date to execute ('.$triggerOn->format('Y-m-d H:i:s T').') is later than now ('.$now->format('Y-m-d H:i:s T')
-                        .') so schedule'
+                        .')' . (($action['decisionPath'] == 'no') ? ' so ignore' : ' so schedule')
                     );
 
                     // Save some RAM for batch processing


### PR DESCRIPTION
**Description**

This fixes https://mautic.org/community/index.php/1412-campaign-workflow-not-executing-properly/p1.

The issue is that if an inaction path is associated with a decision attached to an event that was scheduled, the time the action was created was used when determining the timeframe to allot the lead to execute the decision.  This meant that actions associated with the inaction path would be executed before a scheduled email was even sent to the lead.

Setup a similar campaign to 

![](http://alan.direct/drop/2016-01-04_13-58-10.png)

Process it via the `mautic:campaign:trigger` command. The first email should be scheduled for 2 minutes.  Wait one minute and run the command again. The second email should be fired off even though the leads have not received the first email (because it's scheduled to be sent in another minute).  Wait another minute and run the command again, this time the first emails will be sent off.

Add new leads to the campaign or truncate the campaign_lead_event_log table, apply the PR, and repeat.  For at least one lead, execute the action after the first email is sent.  This time the second email should be sent 1 minute after the first email is actually sent (and not before). Of course the second email should not be sent to the lead that executed the decision.
