### PR TITLE
Added support for Gmail bounces

### DIFF
--- a/app/bundles/EmailBundle/Command/ProcessFetchEmailCommand.php
+++ b/app/bundles/EmailBundle/Command/ProcessFetchEmailCommand.php
@@ -31,6 +31,7 @@ class ProcessFetchEmailCommand extends ContainerAwareCommand
         $this
             ->setName('mautic:fetch:email')
             ->setAliases(array(
+                'mautic:email:fetch',
                 'mautic:fetch:mail',
                 'mautic:check:email',
                 'mautic:check:mail'

--- a/app/bundles/EmailBundle/Exception/MailboxException.php
+++ b/app/bundles/EmailBundle/Exception/MailboxException.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2015 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Exception;
+
+
+class MailboxException extends \Exception
+{
+    public function __construct($message = null, $code = 0, \Exception $previous = null)
+    {
+        if (null === $message) {
+            $message = 'Error communicating with the IMAP server';
+
+            if (function_exists('imap_last_error')) {
+                $message .= ': '.imap_last_error();
+            }
+        }
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -694,18 +694,15 @@ class EmailModel extends FormModel
     /**
      * Get the number of leads this email will be sent to
      *
-     * @param Email      $email
-     * @param mixed      $listId              Leads for a specific lead list
-     * @param bool       $countOnly           If true, return count otherwise array of leads
-     * @param int        $limit               Max number of leads to retrieve
-     * @param bool       $includeVariants     If false, emails sent to a variant will not be included
-     * @param int|null   $leadIdBatchDivisor  If $countOnly is true, return the min/max IDs based on this batch size divisor. For example, 4 will return 4 groups of min/max lead Ids
-     * @param int|null   $minLeadId           Minimum lead ID for batching
-     * @param int|null   $maxLeadId           Maximum lead ID for batching
+     * @param Email $email
+     * @param mixed $listId          Leads for a specific lead list
+     * @param bool  $countOnly       If true, return count otherwise array of leads
+     * @param int   $limit           Max number of leads to retrieve
+     * @param bool  $includeVariants If false, emails sent to a variant will not be included
      *
      * @return int|array
      */
-    public function getPendingLeads(Email $email, $listId = null, $countOnly = false, $limit = null, $includeVariants = true, $leadIdBatchDivisor = null, $minLeadId = null, $maxLeadId = null)
+    public function getPendingLeads(Email $email, $listId = null, $countOnly = false, $limit = null, $includeVariants = true)
     {
         if ($includeVariants && $email->isVariant()) {
             $parent = $email->getVariantParent();
@@ -727,7 +724,7 @@ class EmailModel extends FormModel
             $variantIds = null;
         }
 
-        $total = $this->getRepository()->getEmailPendingLeads($email->getId(), $variantIds, $listId, $countOnly, $limit, $leadIdBatchDivisor, $minLeadId, $maxLeadId);
+        $total = $this->getRepository()->getEmailPendingLeads($email->getId(), $variantIds, $listId, $countOnly, $limit);
 
         return $total;
     }
@@ -735,15 +732,12 @@ class EmailModel extends FormModel
     /**
      * Send an email to lead lists
      *
-     * @param Email    $email
-     * @param array    $lists
-     * @param int      $limit
-     * @param int|null $minLeadId
-     * @param int|null $maxLeadId
-     *
+     * @param Email $email
+     * @param array $lists
+     * @param int   $limit
      * @return array array(int $sentCount, int $failedCount, array $failedRecipientsByList)
      */
-    public function sendEmailToLists (Email $email, $lists = null, $limit = null, $minLeadId = null, $maxLeadId = null)
+    public function sendEmailToLists (Email $email, $lists = null, $limit = null)
     {
         //get the leads
         if (empty($lists)) {
@@ -772,7 +766,7 @@ class EmailModel extends FormModel
             }
 
             $options['listId'] = $list->getId();
-            $leads             = $this->getPendingLeads($email, $list->getId(), false, $limit, true, $minLeadId, $maxLeadId);
+            $leads             = $this->getPendingLeads($email, $list->getId(), false, $limit);
             $leadCount         = count($leads);
             $sentCount        += $leadCount;
 

--- a/app/bundles/EmailBundle/MonitoredEmail/Message.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Message.php
@@ -33,6 +33,7 @@ class Message
     public $textHtml;
     public $dsnReport;
     public $dsnMessage;
+    public $xHeaders = array();
 
     /** @var Attachment[] */
     protected $attachments = array();


### PR DESCRIPTION
**Description**

Emails sent through Gmail are missed by the bounce parsing because Gmail doesn't seem to include a DSN report and are missed by the current regexes.  This PR adds support for Gmail bounce processing by capturing the X-Failed-Recipients header and adds regex for applicable SMTP error messages in https://support.google.com/a/answer/3726730. 

**Testing**

Configure Mautic to send mail through a Gmail account. Then configure Mautic to check bounces from a Gmail account (if needed, use a custom folder if the inbox is full of unread messages).

Create a fake lead with an obviously non-existent gmail account and send an email to the lead. Run the command to parse bounces.  Before the PR, the lead will not be marked as bounced.  After the PR, they should.