### PR TITLE
Portuguese map country names fix

### DIFF
--- a/app/bundles/DashboardBundle/Controller/DefaultController.php
+++ b/app/bundles/DashboardBundle/Controller/DefaultController.php
@@ -84,7 +84,7 @@ class DefaultController extends CommonController
             $clickRate = round($clickthroughCount / $sentReadCount['sent_count'] * 100);
         }
 
-        $countries = array_flip(Intl::getRegionBundle()->getCountryNames());
+        $countries = array_flip(Intl::getRegionBundle()->getCountryNames('en'));
         $mapData = array();
 
         /** @var \Mautic\LeadBundle\Entity\LeadRepository $leadRepository */


### PR DESCRIPTION
The dashboard map needs to convert country names like "Brazil" which is stored in the database to "BR" codes to work. Symfony's Intl component is used for that. But the Intl component translates country names to the current locale. So the "Brazil" then did not match with "Brasil" and therefor the country has zero leads even though they exists if the language is English. This PR forces English locale so the map will display correct data for every language.

### Testing
1. Take a close look at your dashboard map. Create a screenshot or something.
2. Change the language to Portuguese.
3. Look at the map again. Some countries should report no leads even though there were some.
4. Apply this PR and the data should look the same as with the English language.

In my Mautic, the EN map looks like this:
![en-map](https://cloud.githubusercontent.com/assets/1235442/12143378/81c51a32-b480-11e5-9fdf-f58649e3a64f.png)

And the Portuguese map before the fix like this:
![pr-map](https://cloud.githubusercontent.com/assets/1235442/12143396/99bf800a-b480-11e5-8de6-759ba5954538.png)

