### PR TITLE
Fixes entity not found error when there is a point action triggered when executing a campaign

### DIFF
--- a/app/bundles/FormBundle/Controller/PublicController.php
+++ b/app/bundles/FormBundle/Controller/PublicController.php
@@ -28,6 +28,7 @@ class PublicController extends CommonFormController
             return $this->accessDenied();
         }
 
+        $form          = null;
         $post          = $this->request->request->get('mauticform');
         $messengerMode = (!empty($post['messenger']));
         $server        = $this->request->server->all();

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1121,9 +1121,9 @@ class LeadModel extends FormModel
             }
         }
 
-        if ($removeTags !== null) {
+        if (!empty($removeTags)) {
 
-            $logger->debug('LEAD: Removing ' . implode(', ', $removeTags) . ' for lead ID# ' . $lead->getId());
+            $logger->debug('LEAD: Removing '.implode(', ', $removeTags).' for lead ID# '.$lead->getId());
 
             array_walk($removeTags, create_function('&$val', '$val = trim($val); \Mautic\CoreBundle\Helper\InputHelper::clean($val);'));
 
@@ -1134,7 +1134,7 @@ class LeadModel extends FormModel
                 // Tag to be removed
                 if (array_key_exists($tag, $foundRemoveTags) && $leadTags->contains($foundRemoveTags[$tag])) {
                     $lead->removeTag($foundRemoveTags[$tag]);
-                    $logger->debug('LEAD: Removed ' . $tag);
+                    $logger->debug('LEAD: Removed '.$tag);
                 }
             }
         }


### PR DESCRIPTION
**Description**

This prevents the following exception being thrown when there is a point action triggered while a campaign is being executed:

` [Doctrine\ORM\ORMInvalidArgumentException]                                                                                                                                                                                                                         
  A new entity was found through the relationship 'Mautic\PointBundle\Entity\LeadPointLog#lead' that was not configured to cascade persist operations for entity: Mautic\LeadBundle\Entity\Lead with ID #226. To solve this issue: Either explicitly call EntityMan  
  ager#persist() on this unknown entity or configure cascade persist  this association in the mapping for example @ManyToOne(..,cascade={"persist"}).`

**Testing**

1. Create a new point action for when a lead is sent an email (Points -> New)
2. Create a campaign that sends an email and ensure the campaign has more than one lead in it.
3. Execute the `mautic:campaign:trigger` command. You should get the above exception. 
4. Apply the PR and repeat the process (might have to truncate tables to start fresh). This time the campaign should be successful and each lead should have accumulated the defined points.