### PR TITLE
ALT HTML attribute added to the email tracking img tag

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -791,7 +791,7 @@ class MailHelper
     {
         if (!$ignoreTrackingPixel) {
             // Append tracking pixel
-            $trackingImg = '<img style="display: none;" height="1" width="1" src="{tracking_pixel}" />';
+            $trackingImg = '<img style="display: none;" height="1" width="1" src="{tracking_pixel}" alt="mautic is open source marketing automation" />';
             if (strpos($content, '</body>') !== false) {
                 $content = str_replace('</body>', $trackingImg.'</body>', $content);
             } else {

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -791,7 +791,7 @@ class MailHelper
     {
         if (!$ignoreTrackingPixel) {
             // Append tracking pixel
-            $trackingImg = '<img style="display: none;" height="1" width="1" src="{tracking_pixel}" alt="mautic is open source marketing automation" />';
+            $trackingImg = '<img style="display: none;" height="1" width="1" src="{tracking_pixel}" alt="Mautic is open source marketing automation" />';
             if (strpos($content, '</body>') !== false) {
                 $content = str_replace('</body>', $trackingImg.'</body>', $content);
             } else {


### PR DESCRIPTION
Reported in https://github.com/mautic/mautic/issues/1349

This PR simply adds a ALT attribute to the tracking `<img/>` HTML tag so the HTML is valid.

### Testing
- Apply the PR and send an email to a lead via campaign or lead list.

The tracking `<img/>` in the bottom of the source code of the email message should have ALT attribute. 