### PR TITLE
lead import: doNotEmail handled before the lead fields - SQL error fixed

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -976,6 +976,19 @@ class LeadModel extends FormModel
         }
         unset($fields['points']);
 
+        // Set unsubscribe status
+        if (!empty($fields['doNotEmail']) && !empty($data[$fields['doNotEmail']]) && $hasEmail) {
+            $doNotEmail = filter_var($data[$fields['doNotEmail']], FILTER_VALIDATE_BOOLEAN);
+            if ($doNotEmail) {
+                $reason = $this->factory->getTranslator()->trans('mautic.lead.import.by.user', array(
+                    "%user%" => $this->factory->getUser()->getUsername()
+                ));
+
+                $this->unsubscribeLead($lead, $reason, false);
+            }
+        }
+        unset($fields['doNotEmail']);
+
         if ($owner !== null) {
             $lead->setOwner($this->em->getReference('MauticUserBundle:User', $owner));
         }
@@ -991,19 +1004,6 @@ class LeadModel extends FormModel
                 $lead->addUpdatedField($leadField, $data[$importField]);
             }
         }
-
-        // Set unsubscribe status
-        if (!empty($fields['doNotEmail']) && !empty($data[$fields['doNotEmail']]) && $hasEmail) {
-            $doNotEmail = filter_var($data[$fields['doNotEmail']], FILTER_VALIDATE_BOOLEAN);
-            if ($doNotEmail) {
-                $reason = $this->factory->getTranslator()->trans('mautic.lead.import.by.user', array(
-                    "%user%" => $this->factory->getUser()->getUsername()
-                ));
-
-                $this->unsubscribeLead($lead, $reason, false);
-            }
-        }
-        unset($fields['doNotEmail']);
 
         $lead->imported = true;
 


### PR DESCRIPTION
Fix for https://github.com/mautic/mautic/issues/1344

If doNotEmail is imported, it causes a SQL error. It is caused by wrong order of imported values. The doNotEmail has to be handled before the lead fields.

### Testing
1. Try to import this CSV file:

```
email,firstname,lastname,doNotEmail
john@gmail.com, John, Doe, 1
```

It should throw the error and the imported lead will be ignored. Apply this PR and try again. The lead should be imported and when you view his profile, it will be marked as **Do Not Contact**.