### PR TITLE
Fixed issue that caused subsequent campaign membership building to fail due to a SQL exception

### DIFF
--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -333,6 +333,8 @@ class CampaignRepository extends CommonRepository
     }
 
     /**
+     * Returns leads that are part of a lead list that belongs to a campaign
+     *
      * @param       $id
      * @param array $lists
      * @param array $args
@@ -376,14 +378,13 @@ class CampaignRepository extends CommonRepository
             }
         }
 
-        // Exclude leads manually removed from the campaign
+        // Exclude leads already part of or manually removed from the campaign
         $subq = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->select('null')
             ->from(MAUTIC_TABLE_PREFIX.'campaign_leads', 'campaign_leads')
             ->where(
                 $q->expr()->andX(
                     $q->expr()->eq('campaign_leads.lead_id', 'list_leads.lead_id'),
-                    $q->expr()->eq('campaign_leads.manually_removed', ':false'),
                     $q->expr()->eq('campaign_leads.campaign_id', (int) $id)
                 )
             );

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -10,7 +10,6 @@
 namespace Mautic\CampaignBundle\Model;
 
 use Doctrine\ORM\PersistentCollection;
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Model\FormModel as CommonFormModel;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\LeadBundle\Entity\Lead;
@@ -648,6 +647,7 @@ class CampaignModel extends CommonFormModel
                         $this->getRepository()->saveEntity($campaignLead);
                     } catch (\Exception $exception) {
                         $dispatchEvent = false;
+                        $this->factory->getLogger()->log('error', $exception->getMessage());
                     }
                 } else {
                     $this->em->detach($campaignLead);
@@ -670,6 +670,7 @@ class CampaignModel extends CommonFormModel
                     $this->getRepository()->saveEntity($campaignLead);
                 } catch (\Exception $exception) {
                     $dispatchEvent = false;
+                    $this->factory->getLogger()->log('error', $exception->getMessage());
                 }
             }
 
@@ -821,7 +822,6 @@ class CampaignModel extends CommonFormModel
         $batchLimiters = array(
             'dateTime' => $this->factory->getDate()->toUtcString()
         );
-
 
         if (count($lists)) {
             // Get a count of new leads


### PR DESCRIPTION
**Description**

Here's the scenario.

Two campaigns. In campaign 1, a lead A was manually removed from the campaign. Lead B is supposed to be added to campaign 2. But when running the command `mautic:campaign:update` Lead B is never added to campaign 2 although the progress counter indicates a lead was processed.

Reason. A bad query allowed leads that were manually removed from campaigns to be included in the results for finding leads that need to be added to the campaign. This led to a duplicate key SQL exception which then led to Doctrine shutting down the entity manager which then causes any subsequent entity manipulations to throw an Entity Manager is closed exception. (I hate that about Doctrine). It's a bit of a PITA to recover from that because of the EM getting injected into the different services and thus all have to be "reset." Anyway, so fixed the query that caused the manually removed lead from being included in the results to prevent the SQL error to begin with.

**Testing**

1. Create a lead list and add a lead to it
2. Create a campaign and use that list as the lead source
3. Run `mautic:campaign:update` to add the lead from the first list to the campaign.
4. View the lead's profile and click the Campaigns action button top right and manually remove the lead from the campaign.
5. Create a second lead list and add a different lead to it
6. Create a second campaign and use the second list as the lead source
7. Now run the `mautic:campaign:update` command again. It should say that campaign 1 and campaign 2 both had one lead affected.
8. View campaign 2's list of leads and notice that no lead is included.
9. Apply the PR and now run `mautic:campaign:update` again. This time, the first campaign should have 0 leads affected, the second 1 lead affected, and viewing the campaign's leads should now include the second lead as well.