### PR TITLE
Fixes finding landing page by slug for the parent of a translated page 

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -982,12 +982,20 @@ class CommonRepository extends EntityRepository
                 }
             }
 
-            if ($lang && isset($metadata->fieldMappings['language'])) {
-                $q->setParameter('lang', $lang);
+            if (isset($metadata->fieldMappings['language'])) {
+                if ($lang) {
+                    // Find the landing page with the specific requested locale
+                    $q->setParameter('lang', $lang);
 
-                $expr->add(
-                    $q->expr()->eq($this->getTableAlias().'.language', ':lang')
-                );
+                    $expr->add(
+                        $q->expr()->eq($this->getTableAlias().'.language', ':lang')
+                    );
+                } elseif (isset($metadata->associationMappings['translationParent'])) {
+                    // Find the parent translation
+                    $expr->add(
+                        $q->expr()->isNull($this->getTableAlias().'.translationParent')
+                    );
+                }
             }
 
             // Check for variants and return parent only

--- a/app/bundles/PageBundle/Form/Type/PageType.php
+++ b/app/bundles/PageBundle/Form/Type/PageType.php
@@ -263,7 +263,8 @@ class PageType extends AbstractType
                         'tooltip' => 'mautic.page.form.language.help',
                     ),
                     'required'   => false,
-                    'disabled'   => $isVariant
+                    'disabled'   => $isVariant,
+                    'empty_data' => 'en'
                 )
             );
 


### PR DESCRIPTION
**Description**

If a landing page is assigned to another as being a translation of that page, the given parent's URL will not find the parent landing page and results in a 404.  This is because multiple entities are found based on alias/slug alone (the parent and the subsequent translations) and thus resulted in Mautic saying can't find an exact match, so 404 it.

For example, 
Landing Page A is in English and `my-page` as the alias.
Landing Page B is in Dutch, has `my-page` as the alias, and has Landing Page A assigned as "is a translation of."

http://mysite.com/my-page (the default page) will result in a 404 although should result in Landing Page A
http://mysite.com/en/my-page will result in Landing Page A
http://mysite.com/nl/my-page will result in Landing Page B

So this PR fixes this by assuming `http://mysite.com/my-page` is in the language of the system default and finds the landing page accordingly. 

Also, if the language was cleared out from a landing page's form, an uh oh happened on save because language can't be null.  So if the language is removed in the form, the system default is automatically used.

**Testing**

1. Create the scenario above with Landing Page A and Landing Page B
2. View the page details of Landing Page A and click on the Public Url - it should 404
3. View the page details of Landing Page B (from the Translations tab) and click on the public URL - it should show the page
4. Apply the PR and now all three scenario URLs should work. 