### PR TITLE
Allow CSS/JS from the /media/images folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 !/media/images/avatar.png
 !/media/images/favicon.ico
 !/media/images/mautic_logo*
+!/media/images/.htaccess

--- a/media/images/.htaccess
+++ b/media/images/.htaccess
@@ -14,4 +14,13 @@ RemoveHandler .cgi .pl .py .pyc .pyo .phtml .php .php3 .php4 .php5 .php6 .pcgi .
 RemoveType .cgi .pl .py .pyc .pyo .phtml .php .php3 .php4 .php5 .php6 .pcgi .pcgi3 .pcgi4 .pcgi5 .pchi6 .inc
 SetHandler None
 SetHandler default-handler
+
 ForceType text/plain
+
+<FilesMatch "\.css$">
+    ForceType text/css
+</FilesMatch>
+
+<FilesMatch "\.js$">
+    ForceType text/js
+</FilesMatch>


### PR DESCRIPTION
**Description**

A while back, a file system icon was added to the editor which allowed css and js files to be uploaded through the editor. The file manager used has a single config file and is mapped to the images directory. Until a better solution can be put in place and BC code added (i.e. better wysiwyg and file manager), the .htaccess of the images directory forced CSS and JS files to be streamed as plain text resulting in HTML 5 docs ignoring them (due to being in strict mode). This PR adjusts the .htaccess to allow css and js mime types so they will work. 

**Testing**

Create a landing page and use the filemanager button to upload a CSS file

![](http://alan.direct/drop/2016-01-27_11-27-47.png)

Edit the source and add the uploaded file into the head tag as a `<link rel="stylesheet" type="text/css" href="media/images/thefile.css">`

Save, view the landing page, and view the developer console. There should be an error that the file was streamed as plain text. Apply the PR and check the mime type of the file via the developer console and now it should have been streamed as a text\css file. 