### PR TITLE
Reverted bad code that broke plugin encryption for Hubspot

### DIFF
--- a/app/bundles/CoreBundle/Helper/EncryptionHelper.php
+++ b/app/bundles/CoreBundle/Helper/EncryptionHelper.php
@@ -55,7 +55,7 @@ class EncryptionHelper
     {
         $encrypt   = serialize($encrypt);
         $iv        = mcrypt_create_iv(mcrypt_get_iv_size(MCRYPT_RIJNDAEL_256, MCRYPT_MODE_CBC), MCRYPT_DEV_URANDOM);
-        $key       = pack('H*', sprintf('%u', CRC32($this->key)));
+        $key       = pack('H*', $this->key);
         $mac       = hash_hmac('sha256', $encrypt, substr(bin2hex($key), -32));
         $passcrypt = mcrypt_encrypt(MCRYPT_RIJNDAEL_256, $key, $encrypt . $mac, MCRYPT_MODE_CBC, $iv);
         $encoded   = base64_encode($passcrypt) . '|' . base64_encode($iv);
@@ -78,7 +78,8 @@ class EncryptionHelper
         if (strlen($iv) !== mcrypt_get_iv_size(MCRYPT_RIJNDAEL_256, MCRYPT_MODE_CBC)) {
             return false;
         }
-        $key       = pack('H*', sprintf('%u', CRC32($this->key)));
+
+        $key       = pack('H*', $this->key);
         $decrypted = trim(mcrypt_decrypt(MCRYPT_RIJNDAEL_256, $key, $decoded, MCRYPT_MODE_CBC, $iv));
         $mac       = substr($decrypted, -64);
         $decrypted = substr($decrypted, 0, -64);


### PR DESCRIPTION
**Description**

Some code that was being tested inadvertently got committed with a branch/PR and seems to be the cause for #1391 where Hubspot is not working. 

**Testing**

Requires a Hubspot account, authenticate with them, then try to edit the plugin. It should 500. After the PR, access should be restored. 