### PR TITLE
Fixed the check if setUnsubscribed method exists

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1238,7 +1238,7 @@ class EmailModel extends FormModel
             $dnc->setEmailAddress($address);
             $dnc->setDateAdded(new \DateTime());
             $method = 'set'.ucfirst($tag);
-            if (method_exists($dnc, $method)) {
+            if (!method_exists($dnc, $method)) {
                 $method = 'setBounced';
             }
             $dnc->$method();


### PR DESCRIPTION
Reported in https://github.com/mautic/mautic/issues/1387, https://github.com/mautic/mautic/issues/1345 and https://github.com/mautic/mautic/issues/1322.

The unsubscribe function will mark the email as bounced instead of unsubscribed.

### Testing

1. Send an email to a lead with the unsubscribe link
2. Click the link in the email
3. Check the DB table email_donotemail or the lead profile. It is marked as bounced.
4. Apply this PR code and repeat. Lead should get the proper unsubscribed tag.