### PR TITLE
Fixed trackable link conversion that had other attributes with href

### DIFF
--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -419,8 +419,8 @@ class BuilderSubscriber extends CommonSubscriber
             // For HTML, replace only the links; leaving the link text (if a URL) intact
             foreach ($emailTrackedLinks[$emailId]['secondContentReplace'] as $search => $replace) {
                 $content = preg_replace(
-                    '/<a(.*?)href=(["\'])'.preg_quote($search, '/').'(.*?)\\2(.*?)>/i',
-                    '<a$1href=$2'.$replace.'$3$2$4>',
+                    '/<a(.*?) href=(["\'])'.preg_quote($search, '/').'(.*?)\\2(.*?)>/i',
+                    '<a$1 href=$2'.$replace.'$3$2$4>',
                     $content
                 );
             }


### PR DESCRIPTION
**Description**

If the HTML of an email is copied out of another editor, data attributes may result in a link not getting converted to Mautic's trackables. For example, a link like 

`<a data-mce-href="http://mylink.com" href="http://mylink.com">Click</a>`

Would result in data-mce-href's value being replaced with the click tracking URL but not the actual href. This PR fixes this by adjusting the preg_replace pattern and replacement to only match the true href attribute.

**Testing**

Create an list email with the above link and send it to the list. The emails received will be the raw URL and not the trackable. But if looking at the message source, you'll see data-mce-href was replaced with the trackable.  Apply the PR and repeat. This time the true href tag will be converted and thus clicks tracked.