### PR TITLE
Lead Fixes

### DIFF
--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -67,7 +67,7 @@ class ListModel extends FormModel
      */
     public function getPermissionBase()
     {
-        return 'lead:list';
+        return 'lead:lists';
     }
 
     /**

--- a/app/bundles/LeadBundle/Templating/Helper/AvatarHelper.php
+++ b/app/bundles/LeadBundle/Templating/Helper/AvatarHelper.php
@@ -40,7 +40,8 @@ class AvatarHelper extends Helper
         $leadEmail  = $lead->getEmail();
 
         if ($preferred == 'custom' ) {
-            if ($fmtime = filemtime($this->getAvatarPath(true) . '/avatar'.$lead->getId())) {
+            $avatarPath = $this->getAvatarPath(true) . '/avatar'.$lead->getId();
+            if (file_exists($avatarPath) && $fmtime = filemtime($avatarPath)) {
                 // Append file modified time to ensure the latest is used by browser
                 $img = $this->factory->getHelper('template.assets')->getUrl(
                     $this->getAvatarPath().'/avatar'.$lead->getId() . '?' . $fmtime,

--- a/app/bundles/LeadBundle/Views/List/list.html.php
+++ b/app/bundles/LeadBundle/Views/List/list.html.php
@@ -58,9 +58,7 @@ $listCommand = $view['translator']->trans('mautic.lead.lead.searchcommand.list')
                     </td>
                     <td>
                         <div>
-                            <?php if ($item->isGlobal()): ?>
-                            <i class="fa fa-fw fa-globe"></i>
-                            <?php endif; ?>
+                            <?php echo $view->render('MauticCoreBundle:Helper:publishstatus_icon.html.php', array('item' => $item, 'model' => 'lead.list')); ?>
                             <?php if ($security->hasEntityAccess(true, $permissions['lead:lists:editother'], $item->getCreatedBy())) : ?>
                                 <a href="<?php echo $view['router']->generate('mautic_leadlist_action', array('objectAction' => 'edit', 'objectId' => $item->getId())); ?>" data-toggle="ajax">
                                     <?php echo $item->getName(); ?> (<?php echo $item->getAlias(); ?>)
@@ -71,6 +69,9 @@ $listCommand = $view['translator']->trans('mautic.lead.lead.searchcommand.list')
                             <?php if (!$item->isGlobal() && $currentUser->getId() != $item->getCreatedBy()): ?>
                             <br />
                             <span class="small">(<?php echo $item->getCreatedByUser(); ?>)</span>
+                            <?php endif; ?>
+                            <?php if ($item->isGlobal()): ?>
+                                <i class="fa fa-fw fa-globe"></i>
                             <?php endif; ?>
                         </div>
                         <?php if ($description = $item->getDescription()): ?>


### PR DESCRIPTION
This makes the UI for publishing/unpublishing the lead lists consistent with other areas of mautic.

Also includes a fix for AvatarHelper to stop the PHP fatal in dev when it tries to stat a file that doesn't exist.

**Testing**
View the lead-lists list view page. It will look like this: 
![screen shot 2016-02-22 at 11 06 52 am](https://cloud.githubusercontent.com/assets/718028/13223986/833ba22a-d954-11e5-9536-5fabc7980476.png)

Apply the fix and then it will look like this instead:
![screen shot 2016-02-22 at 11 16 23 am](https://cloud.githubusercontent.com/assets/718028/13224280/c59034dc-d955-11e5-9b92-693e8e624700.png)

For the other part of the PR - the avatar fix - simply create a lead and upload a custom avatar. That file gets put into the media folder. Delete that file, then load up the lead index page in grid view in the the development environment (index_dev.php). You'll see a 500 error come up. After the code fix is applied, you'll see that that error is gone, and all images that are missing are properly replaced with the default avatar. 

