### PR TITLE
Wrap Email Stats Collection in User Check

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -28,7 +28,10 @@ class PublicController extends CommonFormController
 
         if (!empty($stat)) {
             $emailEntity = $stat->getEmail();
-            $model->hitEmail($stat, $this->request, true);
+
+            if ($this->factory->getSecurity()->isAnonymous()) {
+                $model->hitEmail($stat, $this->request, true);
+            }
 
             $tokens = $stat->getTokens();
             if (is_array($tokens)) {


### PR DESCRIPTION
This fixes #1395 by wrapping in-browser email views with an `isAnonymous()` check to ensure purity of email stats & view history.

**Test Directions**
Open a lead and send them an email through the lead interface (top right dropdown -> send email), then refresh the lead page. You will see that the sent email has been added to the user history. Click the email title in the history, and you'll be taken to the public in-browser view page for that email. Go back to the lead view page and you'll see that there is a new "email opened" entry under the email history, logging you as the admin viewing that page. 

Apply this PR, the repeat the process. You will not see a new entry for the email view history.