### PR TITLE
Fixes #1325. Saves clone before redirecting to new edit page.

### DIFF
--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -773,25 +773,36 @@ class EmailController extends FormController
      */
     public function cloneAction($objectId)
     {
+        /** @var \Mautic\EmailBundle\Model\EmailModel $model */
         $model  = $this->factory->getModel('email');
-        $clone = $model->getEntity($objectId);
+        $original = $model->getEntity($objectId);
 
-        if ($clone != null) {
+        if ($original != null) {
             if (!$this->factory->getSecurity()->isGranted('email:emails:create')
                 || !$this->factory->getSecurity()->hasEntityAccess(
                     'email:emails:viewown',
                     'email:emails:viewother',
-                    $clone->getCreatedBy()
+                    $original->getCreatedBy()
                 )
             ) {
                 return $this->accessDenied();
             }
 
             /** @var \Mautic\EmailBundle\Entity\Email $clone */
-            $clone = clone $clone;
+            $clone = clone $original;
+
+            $model->saveEntity($clone);
+
+            return $this->redirect($this->generateUrl(
+                'mautic_email_action',
+                array(
+                    'objectAction' => 'edit',
+                    'objectId' => $clone->getId()
+                )
+            ));
         }
 
-        return $this->newAction($clone);
+        return $this->newAction($original);
     }
 
     /**


### PR DESCRIPTION
Fixes #1325

The approach I took to fix this is to persist the cloned email entity, then redirect the user to the edit page for that newly created entity, rather than cloning the original entity and passing that as a variable to the `newAction` method, which does not persist the entity prior to loading the page.

**Testing:**

Create an email with a builder template and add some content. Go to the detail view of that email and clone it. Then click Save & Close. Reopen email and then click builder, you'll see that the content from the originally created email is missing.

Apply this patch and repeat the steps. The content remains.