### PR TITLE
Multilingual issue: Avoid empty form name in Javascript

### DIFF
--- a/app/bundles/FormBundle/Entity/Form.php
+++ b/app/bundles/FormBundle/Entity/Form.php
@@ -762,12 +762,13 @@ class Form extends FormEntity
      */
     public function generateFormName()
     {
-        return strtolower(
+        $name = strtolower(
             InputHelper::alphanum(
                 InputHelper::transliterate(
                     $this->name
                 )
             )
         );
+        return (empty($name)) ? 'form-' . $this->id : $name;
     }
 }


### PR DESCRIPTION
## Description

We are not able to create a new form without it's name, but we are able to use multibyte characters for the name. However, `generateFormName` method removes all non-alphanum characters, so this method can return empty string.

This causes an issue on public form. To see the detail of the issue, please visit this report:
https://www.mautic.org/community/index.php/1120-form-not-redirect

This pull request will fixes this report.

## Steps to reproduce

1. Create a new form with multibyte name (e.g. お問い合わせ)
2. Add `form/generated.js` to your site
3. Send the form. There is no response.

![mautic](https://cloud.githubusercontent.com/assets/514294/13202949/31639b94-d8ee-11e5-8430-128d5117667f.png)