### PR TITLE
[LeadBundle]: add ip addresses to reports

### DIFF
--- a/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
@@ -48,7 +48,12 @@ class ReportSubscriber extends CommonSubscriber
         if ($event->checkContext(array('leads', 'lead.pointlog'))) {
             $prefix     = 'l.';
             $userPrefix = 'u.';
+            $ipPrefix = 'i.';
             $columns    = array(
+                $ipPrefix . 'ip_address' => array(
+                    'label' => 'mautic.core.ipaddress',
+                    'type'  => 'text'
+                ),
                 $prefix . 'date_identified' => array(
                     'label' => 'mautic.lead.report.date_identified',
                     'type'  => 'datetime'
@@ -167,6 +172,8 @@ class ReportSubscriber extends CommonSubscriber
 
             $qb->from(MAUTIC_TABLE_PREFIX . 'leads', 'l');
             $qb->leftJoin('l', MAUTIC_TABLE_PREFIX . 'users', 'u', 'u.id = l.owner_id');
+            $qb->leftJoin('l', MAUTIC_TABLE_PREFIX . 'lead_ips_xref', 'lip', 'lip.lead_id = l.id');
+            $qb->leftJoin('lip', MAUTIC_TABLE_PREFIX . 'ip_addresses', 'i', 'i.id = lip.ip_id');
 
             $event->setQueryBuilder($qb);
         } elseif ($context == 'lead.pointlog') {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1405 

## Description

When creating a report of leads, there is a lack of exporting the IP address of a lead. 

## Steps to test

Go to the Lead reports, edit the current one, add the new "IP address" column and check if it's visible in the table after save. The IP addresses should be populated, ordering by IP address should work and the IP addresses should also be in the report export.