### PR TITLE
Fixed #1325 - cloning content of email theme

### DIFF
--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -807,24 +807,27 @@ class EmailController extends FormController
     public function cloneAction($objectId)
     {
         $model  = $this->factory->getModel('email');
-        $clone = $model->getEntity($objectId);
+        $entity = $model->getEntity($objectId);
 
-        if ($clone != null) {
+        if ($entity != null) {
             if (!$this->factory->getSecurity()->isGranted('email:emails:create')
                 || !$this->factory->getSecurity()->hasEntityAccess(
                     'email:emails:viewown',
                     'email:emails:viewother',
-                    $clone->getCreatedBy()
+                    $entity->getCreatedBy()
                 )
             ) {
                 return $this->accessDenied();
             }
 
-            /** @var \Mautic\EmailBundle\Entity\Email $clone */
-            $clone = clone $clone;
+            $entity      = clone $entity;
+            $session     = $this->factory->getSession();
+            $contentName = 'mautic.emailbuilder.'.$entity->getSessionId().'.content';
+            
+            $session->set($contentName, $entity->getContent());
         }
 
-        return $this->newAction($clone);
+        return $this->newAction($entity);
     }
 
     /**

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -199,6 +199,7 @@ class Email extends FormEntity
         $this->variantSentCount = 0;
         $this->variantStartDate = null;
         $this->emailType        = null;
+        $this->sessionId        = 'new_' . hash('sha1', uniqid(mt_rand()));
 
         parent::__clone();
     }


### PR DESCRIPTION
Fix for https://github.com/mautic/mautic/issues/1325. Steps to recreate are described there.

### Testing
1. Apply this PR.
2. Clone an email which uses a theme and has some content in it.
3. Do not open the Email Builder and save the clone.
4. Open the cloned email. The content should be there.