### PR TITLE
Fix some twig asset usage

### DIFF
--- a/app/bundles/CoreBundle/Templating/Twig/Extension/AssetExtension.php
+++ b/app/bundles/CoreBundle/Templating/Twig/Extension/AssetExtension.php
@@ -48,20 +48,24 @@ class AssetExtension extends Twig_Extension
         return 'asset';
     }
 
-    public function outputSystemStylesheets($name)
+    public function outputSystemStylesheets()
     {
         ob_start();
 
-        $this->helper->outputSystemStylesheets($name);
+        $this->helper->outputSystemStylesheets();
 
         return ob_get_clean();
     }
 
-    public function outputSystemScripts($name)
+    /**
+     * @param bool $includeEditor
+     * @return string
+     */
+    public function outputSystemScripts($includeEditor = false)
     {
         ob_start();
 
-        $this->helper->outputSystemScripts($name);
+        $this->helper->outputSystemScripts($includeEditor);
 
         return ob_get_clean();
     }
@@ -75,11 +79,11 @@ class AssetExtension extends Twig_Extension
         return ob_get_clean();
     }
 
-    public function outputStyles($name)
+    public function outputStyles()
     {
         ob_start();
 
-        $this->helper->outputStyles($name);
+        $this->helper->outputStyles();
 
         return ob_get_clean();
     }

--- a/app/bundles/CoreBundle/Templating/Twig/Extension/AssetExtension.php
+++ b/app/bundles/CoreBundle/Templating/Twig/Extension/AssetExtension.php
@@ -97,8 +97,8 @@ class AssetExtension extends Twig_Extension
         return ob_get_clean();
     }
 
-    public function getAssetUrl($path, $packageName = null, $version = null)
+    public function getAssetUrl($path, $packageName = null, $version = null, $absolute = false, $ignorePrefix = false)
     {
-        return $this->helper->getUrl($path, $packageName, $version);
+        return $this->helper->getUrl($path, $packageName, $version, $absolute, $ignorePrefix);
     }
 }


### PR DESCRIPTION
This fixes up a a couple mistakes in the Twig `AssetExtension` class, where some variables were mis-named and a couple methods accepted variables that shouldn't, because they weren't used. 