### PR TITLE
Changed signature from string to text to allow more than 255 characters; added 1.3 migration class

### DIFF
--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -204,7 +204,7 @@ class User extends FormEntity implements AdvancedUserInterface, \Serializable
             ->nullable()
             ->build();
 
-        $builder->createField('signature', 'string')
+        $builder->createField('signature', 'text')
             ->nullable()
             ->build();
 
@@ -319,7 +319,8 @@ class User extends FormEntity implements AdvancedUserInterface, \Serializable
                     'locale',
                     'lastLogin',
                     'lastActive',
-                    'onlineStatus'
+                    'onlineStatus',
+                    'signature'
                 )
             )
             ->build();

--- a/app/migrations/Version20160225000000.php
+++ b/app/migrations/Version20160225000000.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2016 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Class Version20160225000000
+ */
+
+class Version20160225000000 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        $pageHitTable = $schema->getTable($this->prefix.'users');
+        if ($pageHitTable->hasColumn('signature')) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function mysqlUp(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE ' . $this->prefix.'users ADD signature LONGTEXT DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function postgresqlUp(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE ' . $this->prefix . 'users ADD signature TEXT DEFAULT NULL');
+    }
+}


### PR DESCRIPTION
**Description**

The PR merged that added the signature support for users had the field defined as a string which results in a char(255) column.  Changed this to text to remove the 255 character limit.

Also added a migration class for the release.

**Testing**
Apply the PR
Run `php app/console doctrine:migrations:migrate`
It should show the query executed and have a success message.  
Validate the column was added to the users table and also try to login which should be successful without a schema exception. 
Login to the database and delete 20160225000000 from the migrations table
Rerun the migrate command above and this time you should get a message the migration was skipped 