### PR TITLE
Signature UI fix in the profile form

### DIFF
--- a/app/bundles/UserBundle/Views/Profile/index.html.php
+++ b/app/bundles/UserBundle/Views/Profile/index.html.php
@@ -73,6 +73,7 @@ $view['slots']->set("headerTitle", $view['translator']->trans('mautic.user.accou
                         echo $view['form']->row($userForm['locale']);
                         echo $view['form']->row($userForm['plainPassword']['password']);
                         echo $view['form']->row($userForm['plainPassword']['confirm']);
+                        echo $view['form']->row($userForm['signature']);
                         ?>
                     </div>
                 </div>


### PR DESCRIPTION
I noticed that the signature textarea is super-ugly in the user profile form so here's a simple fix.

Before:
![mautic-profile-signature-ugly](https://cloud.githubusercontent.com/assets/1235442/13347905/a4b95f18-dc70-11e5-94d5-4c554f597657.png)

After:
![mautic-profile-signature-better](https://cloud.githubusercontent.com/assets/1235442/13347911/a809877e-dc70-11e5-9573-89442e35745d.png)

### Testing
1. In the Mautic administration, click on your name in the top right corner.
2. Select _Account_ item. You should see the same issue as captured in the screenshots above.
