### PR TITLE
Post Upgrade fix for corrupt lead IP data

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -100,6 +100,9 @@ return array(
             ),
             'mautic.core.configbundle.subscriber' => array(
                 'class' => 'Mautic\CoreBundle\EventListener\ConfigSubscriber'
+            ),
+            'mautic.upgrade.subscriber'           => array(
+                'class' => 'Mautic\CoreBundle\EventListener\UpgradeSubscriber'
             )
         ),
         'forms'   => array(

--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -10,6 +10,7 @@
 namespace Mautic\CoreBundle\Controller;
 
 use Mautic\CoreBundle\CoreEvents;
+use Mautic\CoreBundle\Event\UpgradeEvent;
 use Mautic\CoreBundle\Event\GlobalSearchEvent;
 use Mautic\CoreBundle\Event\CommandListEvent;
 use Mautic\CoreBundle\Helper\InputHelper;
@@ -627,6 +628,9 @@ class AjaxController extends CommonController
                 $dataArray['postmessage'] = $postMessage;
             }
         }
+
+        // Execute the mautic.post_upgrade event
+        $this->factory->getDispatcher()->dispatch(CoreEvents::POST_UPGRADE, new UpgradeEvent($dataArray));
 
         // A way to keep the upgrade from failing if the session is lost after
         // the cache is cleared by upgrade.php

--- a/app/bundles/CoreBundle/CoreEvents.php
+++ b/app/bundles/CoreBundle/CoreEvents.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Mautic
- * @copyright   2014 Mautic Contributors. All rights reserved.
+ * @copyright   2016 Mautic Contributors. All rights reserved.
  * @author      Mautic
  * @link        http://mautic.org
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html

--- a/app/bundles/CoreBundle/CoreEvents.php
+++ b/app/bundles/CoreBundle/CoreEvents.php
@@ -67,4 +67,22 @@ final class CoreEvents
      * @var string
      */
     const BUILD_CANVAS_CONTENT = 'mautic.build_canvas_content';
+
+    /**
+     * The mautic.pre_upgrade is dispatched before an upgrade.
+     *
+     * The event listener receives a Mautic\CoreBundle\Event\UpgradeEvent instance.
+     *
+     * @var string
+     */
+    const PRE_UPGRADE = 'mautic.pre_upgrade';
+
+    /**
+     * The mautic.post_upgrade is dispatched after an upgrade.
+     *
+     * The event listener receives a Mautic\CoreBundle\Event\UpgradeEvent instance.
+     *
+     * @var string
+     */
+    const POST_UPGRADE = 'mautic.post_upgrade';
 }

--- a/app/bundles/CoreBundle/Event/UpgradeEvent.php
+++ b/app/bundles/CoreBundle/Event/UpgradeEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Mautic
- * @copyright   2014 Mautic Contributors. All rights reserved.
+ * @copyright   2016 Mautic Contributors. All rights reserved.
  * @author      Mautic
  * @link        http://mautic.org
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
@@ -9,8 +9,6 @@
 
 namespace Mautic\CoreBundle\Event;
 
-use Mautic\CoreBundle\Helper\BuilderTokenHelper;
-use Symfony\Component\Process\Exception\InvalidArgumentException;
 use Symfony\Component\EventDispatcher\Event;
 
 /**

--- a/app/bundles/CoreBundle/Event/UpgradeEvent.php
+++ b/app/bundles/CoreBundle/Event/UpgradeEvent.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2014 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Event;
+
+use Mautic\CoreBundle\Helper\BuilderTokenHelper;
+use Symfony\Component\Process\Exception\InvalidArgumentException;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class BuilderEvent
+ *
+ * @package Mautic\PageBundle\Event
+ */
+class UpgradeEvent extends Event
+{
+    /**
+     * @var array
+     */
+    protected $status = array();
+
+    public function __construct(array $status)
+    {
+        $this->status = $status;
+    }
+
+    /**
+     * @return array
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    public function isSuccessful()
+    {
+        if (array_key_exists('success', $this->status)) {
+            return (bool) $this->status['success'];
+        }
+
+        return false;
+    }
+}

--- a/app/bundles/CoreBundle/EventListener/UpgradeSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/UpgradeSubscriber.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2014 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\EventListener;
+
+use Mautic\CoreBundle\CoreEvents;
+use Mautic\CoreBundle\Event\UpgradeEvent;
+use Mautic\CoreBundle\Helper\UTF8Helper;
+
+/**
+ * Class UpgradeSubscriber
+ */
+class UpgradeSubscriber extends CommonSubscriber
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            CoreEvents::POST_UPGRADE => array('postUpgrade', 0)
+        );
+    }
+
+    /**
+     * @param UpgradeEvent $event
+     *
+     * @return void
+     */
+    public function postUpgrade(UpgradeEvent $event)
+    {
+        $version = $this->factory->getKernel()->getVersion();
+
+        // In the upgrade to 1.3, we included a bugfix for corrupt ip data
+        if ($event->isSuccessful() && version_compare($version, '1.3', '<=')) {
+            $this->updateIpDetails();
+        }
+    }
+
+    /**
+     * Update the ip_details column to fix the bug in GH #1375
+     *
+     * @return void
+     */
+    private function updateIpDetails()
+    {
+        $connection = $this->factory->getEntityManager()->getConnection();
+        $query = $connection->createQueryBuilder()
+            ->select('*')
+            ->from(MAUTIC_TABLE_PREFIX . 'ip_addresses', 'ip');
+
+        $results = (array) $query->execute()->fetchAll();
+
+        foreach ($results as $result) {
+            $ipDetails = $this->getIpDetails($result['ip_address']);
+            $query2 = $connection->createQueryBuilder();
+
+            $query2->update(MAUTIC_TABLE_PREFIX . 'ip_addresses', 'ip')
+                ->set('ip.ip_details', $query2->expr()->literal($ipDetails))
+                ->where('ip.id = ' . (int) $result['id']);
+
+            $query2->execute();
+        }
+    }
+
+    /**
+     * @param $ip
+     *
+     * @return string
+     */
+    private function getIpDetails($ip)
+    {
+        $serviceName = $this->factory->getParameter('ip_lookup_service');
+
+        /** @var \Mautic\CoreBundle\Factory\IpLookupFactory $ipServiceFactory */
+        $ipServiceFactory = $this->factory->getKernel()->getContainer()->get('mautic.ip_lookup.factory');
+        $ipService = $ipServiceFactory->getService($serviceName);
+        $ipDetails = $ipService->setIpAddress($ip)->getDetails();
+
+        return $this->convertToArrayType($ipDetails);
+    }
+
+    /**
+     * Workaround to use the Mautic\CoreBundle\Doctrine\Type\ArrayType::convertToDatabaseValue
+     * without having to locate the Doctrine type manager.
+     *
+     * @param $value
+     * @return string
+     */
+    private function convertToArrayType($value)
+    {
+        if (!is_array($value)) {
+            return (null === $value) ? 'N;' : 'a:0:{}';
+        }
+
+        // MySQL will crap out on corrupt UTF8 leading to broken serialized strings
+        array_walk(
+            $value,
+            function (&$entry) {
+                $entry = UTF8Helper::toUTF8($entry);
+            }
+        );
+
+        $serialized = serialize($value);
+
+        return $serialized;
+    }
+}


### PR DESCRIPTION
This PR does a few things:

- Adds `CoreEvents::PRE_UPGRADE`
- Adds `CoreEvents::POST_UPGRADE`
- Creates an `UpgradeSubscriber` to fire after successful upgrade, using the `CoreEvents::POST_UPGRADE` event.

After a successful upgrade, the `UpgradeSubscriber::postUpgrade()` method is run which does a version compare on the declared kernel version. If it's 1.3 or less, it runs another method that updates the corrupt IP address data in the `ip_addresses` table, using IP data from the provider selected in the config.

**Testing**

Edit your `app/AppKernel.php` file, and change the `const MINOR_VERSION` to have a value of `1`. Logout of your Mautic instance, then log back in and navigate to `/s/update` (or click the update button in notifications). At this point, make sure you have at least one entry in your `ip_addresses` table (if you don't, use the SQL below before continuing.) AND that you have a valid service selected for your IP Lookup Service (I used GeoBytes).

At this point, you're going to need to edit some core code. I know, bad, right? Well, since we haven't actually released an update yet, if you do actually update, it will not run the post_upgrade event because that code doesn't exist in 1.2.4 (the version you'd be upgrading to). So you'll need to add the following to line 331 of `app/bundles/CoreBundle/Controller/AjaxController.php`, inside of the `updateSetUpdateLayoutAction()` method.

```php
// Execute the mautic.post_upgrade event
$this->factory->getDispatcher()->dispatch(CoreEvents::POST_UPGRADE, new UpgradeEvent(['success' => 1]));
die();
```

After making that change, click the upgrade button, wait 15 seconds, then check the entries in your `ip_addresses` table and see that they are properly updated and not corrupt. If you used the GeoBytes provider and the SQL below, your `ip_details` column for the row with `ip_address` of `98.121.114.35` will be:

`a:10:{s:4:"city";s:10:"Greensboro";s:6:"region";s:14:"North Carolina";s:7:"zipcode";s:0:"";s:7:"country";s:13:"United States";s:8:"latitude";s:9:"36.076000";s:9:"longitude";s:10:"-79.808899";s:3:"isp";s:0:"";s:12:"organization";s:0:"";s:8:"timezone";s:6:"-05:00";s:5:"extra";s:0:"";}`

Remove the code that you added to `AjaxController.php` and your testing is complete!

**SQL**
_Replace `mtc` with your table prefix_
```sql
INSERT INTO `mtc_ip_addresses` (`ip_address`, `ip_details`) VALUES ('98.121.114.35', 'N;');
```