### PR TITLE
Fixes scope exception for filemanager

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/connectors/php/user.config.php
+++ b/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/connectors/php/user.config.php
@@ -28,9 +28,11 @@ require_once __DIR__ . '/../../../../../../../../../AppKernel.php';
 $kernel = new AppKernel('prod', false);
 $kernel->boot();
 $container  = $kernel->getContainer();
+$request    = Request::createFromGlobals();
+$container->enterScope('request');
+$container->set('request', $request, 'request');
 
 // Dispatch REQUEST event to setup authentication
-$request    = Request::createFromGlobals();
 $httpKernel = $container->get('http_kernel');
 $event      = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST);
 $container->get('event_dispatcher')->dispatch(KernelEvents::REQUEST, $event);


### PR DESCRIPTION
## Description
This fixes #1499 with an exception related to request scope due to CoreBundle/Templating/Twig/Extension/AssetExtension.php constructing with the templating.helper.assets service which requires the request scope.

## Steps to reproduce
Create a new landing page or email and click the image button then browse server.  You'll be greeted with a spinning circle.

## Steps to test
Apply the PR, then repeat the above. This time files should show.

