### PR TITLE
Fix lead history ordering

### DIFF
--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -97,7 +97,7 @@ class LeadTimelineEvent extends Event
                 $e['timestamp'] = $dt->getDateTime();
                 unset($dt);
             }
-            $dateString = $e['timestamp']->format('Y-m-d H:i');
+            $dateString = $e['timestamp']->format('Y-m-d H:i:s');
             if (!isset($byDate[$dateString])) {
                 $byDate[$dateString] = array();
             }


### PR DESCRIPTION
Lead history wasn't order correctly by date . This PR added seconds to date ordering.