### PR TITLE
Fixes wrong condition in campaign stats

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -192,7 +192,7 @@ class LeadRepository extends CommonRepository
             ->orderBy('date_added', 'ASC');
 
         if (isset($options['campaign_id'])) {
-            $q->andwhere($q->expr()->gte('cl.campaign_id', (int) $options['campaign_id']));
+            $q->andwhere($q->expr()->eq('cl.campaign_id', (int) $options['campaign_id']));
         }
 
         $datesAdded = $q->execute()->fetchAll();


### PR DESCRIPTION
This PR fix wrong condition in getLeadStats
This bug caused that the statistics were calculated leads from all of the following campaigns.
Issue  #1316

![image](https://cloud.githubusercontent.com/assets/462477/13728060/0eb04f34-e90b-11e5-8544-e8f8f919ea49.png)




