### PR TITLE
Fix not tracked links on campaign 2+ leads

### DIFF
--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -389,8 +389,10 @@ class BuilderSubscriber extends CommonSubscriber
             $tokens['{trackedlink='.$link->getRedirectId().'}'] = $trackedUrl;
         }
 
+        $leadId = !empty($clickthrough) ? $clickthrough['lead'] : '0';
+
         // Search/replace
-        if (!isset($emailTrackedLinks[$emailId]['contentReplaced'])) {
+        if (!isset($emailTrackedLinks[$emailId]['contentReplaced'][$leadId])) {
             // Sort longer to shorter strings to ensure that URLs that share the same base are appropriately replaced
             krsort($emailTrackedLinks[$emailId]['secondContentReplace']);
 
@@ -426,7 +428,7 @@ class BuilderSubscriber extends CommonSubscriber
             }
             $event->setContent($content);
 
-            $emailTrackedLinks[$emailId]['contentReplaced'] = true;
+            $emailTrackedLinks[$emailId]['contentReplaced'][$leadId] = true;
 
             unset($firstSearch, $firstReplace, $secondSearch, $secondSearch, $content, $plainText);
         }


### PR DESCRIPTION
Fix Issue #1524
Before the change, the variable "contentReplaced" was referring only to "emailId" in a static variable of the function, while several other leads were subjected to the same routine, and then replace was nullified by a fake positive.

This change fix not tracked links on send queue with 2+ leads (ONLY Campaign)