### PR TITLE
Lead owner field added to the quick add form

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -204,7 +204,6 @@ class LeadController extends FormController
     /*
      * Quick form controller route and view
      */
-
     public function quickAddAction()
     {
         /** @var \Mautic\LeadBundle\Model\LeadModel $model */
@@ -234,6 +233,10 @@ class LeadController extends FormController
         );
 
         $quickForm = $model->createForm($model->getEntity(), $this->get('form.factory'), $action, array('fields' => $fields, 'isShortForm' => true));
+
+        //set the default owner to the currently logged in user
+        $currentUser = $this->get('security.context')->getToken()->getUser();
+        $quickForm->get('owner')->setData($currentUser);
 
         return $this->delegateView(
             array(

--- a/app/bundles/LeadBundle/Form/Type/LeadType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadType.php
@@ -53,27 +53,6 @@ class LeadType extends AbstractType
         $builder->addEventSubscriber(new FormExitSubscriber('lead.lead', $options));
 
         if (!$options['isShortForm']) {
-            $transformer = new IdToEntityModelTransformer(
-                $this->factory->getEntityManager(),
-                'MauticUserBundle:User'
-            );
-            $builder->add(
-                $builder->create(
-                    'owner',
-                    'user_list',
-                    array(
-                        'label'      => 'mautic.lead.lead.field.owner',
-                        'label_attr' => array('class' => 'control-label'),
-                        'attr'       => array(
-                            'class' => 'form-control'
-                        ),
-                        'required'   => false,
-                        'multiple'   => false
-                    )
-                )
-                    ->addModelTransformer($transformer)
-            );
-
             $imageChoices = array(
                 'gravatar' => 'Gravatar',
                 'custom'   => 'mautic.lead.lead.field.custom_avatar'
@@ -299,6 +278,28 @@ class LeadType extends AbstractType
                     'onchange'              => 'Mautic.createLeadTag(this)'
                 )
             )
+        );
+
+        $transformer = new IdToEntityModelTransformer(
+            $this->factory->getEntityManager(),
+            'MauticUserBundle:User'
+        );
+
+        $builder->add(
+            $builder->create(
+                'owner',
+                'user_list',
+                array(
+                    'label'      => 'mautic.lead.lead.field.owner',
+                    'label_attr' => array('class' => 'control-label'),
+                    'attr'       => array(
+                        'class' => 'form-control'
+                    ),
+                    'required'   => false,
+                    'multiple'   => false
+                )
+            )
+            ->addModelTransformer($transformer)
         );
 
         if (!$options['isShortForm']) {


### PR DESCRIPTION
## Description
If a Mautic user have only permission to view/create/edit own leads and use the quick add form to add leads, she cannot view them because he can see only the leads she owns. So I added the owner field to the quick form and preset the option to currently logged in user.

Reported in https://github.com/mautic/mautic/issues/1529

## Steps to reproduce
Described also in https://github.com/mautic/mautic/issues/1529

## Steps to test

After you finish the steps to reproduce and be able to confirm the issue, apply the changes of this PR and test again. Now the lead added via the quick add form should be visible.
