### PR TITLE
Fixed issue where the first operator was not removed from a list

### DIFF
--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -415,7 +415,7 @@ Mautic.addLeadListFilter = function (elId) {
         }).remove();
     } else if (typeof operators.exclude != 'undefined') {
         mQuery('#' + filterIdBase + 'operator option').filter(function () {
-            return mQuery.inArray(mQuery(this).val(), operators['exclude']) > 0
+            return mQuery.inArray(mQuery(this).val(), operators['exclude']) !== -1
         }).remove();
     }
 


### PR DESCRIPTION
## Description
If adding a date added, date identified, etc filter to a lead list, the including/excluding options should be removed.  However, "including" remains when it should not.

## Steps to reproduce
1. Add a new lead list
2. Add a new date added filter
3. Click the operator dropdown and "including" is listed as an option

## Steps to test
1. Apply the PR
2. Repeat above in dev mode and this time "including" should not be present
