### PR TITLE
This fixes issue that disables CSRF for forms by default

### DIFF
--- a/app/bundles/ApiBundle/EventListener/ApiSubscriber.php
+++ b/app/bundles/ApiBundle/EventListener/ApiSubscriber.php
@@ -29,9 +29,9 @@ class ApiSubscriber extends CommonSubscriber
     public static function getSubscribedEvents()
     {
         return array(
-            KernelEvents::REQUEST                 => array('onKernelRequest', 0),
-            ApiEvents::CLIENT_POST_SAVE           => array('onClientPostSave', 0),
-            ApiEvents::CLIENT_POST_DELETE         => array('onClientDelete', 0)
+            KernelEvents::REQUEST         => array('onKernelRequest', 255),
+            ApiEvents::CLIENT_POST_SAVE   => array('onClientPostSave', 0),
+            ApiEvents::CLIENT_POST_DELETE => array('onClientDelete', 0)
         );
     }
 
@@ -52,6 +52,7 @@ class ApiSubscriber extends CommonSubscriber
 
         // Check if /oauth or /api
         $isApiRequest = (strpos($requestUrl, '/oauth') !== false || strpos($requestUrl, '/api') !== false);
+        defined('MAUTIC_API_REQUEST') or define('MAUTIC_API_REQUEST', $isApiRequest);
 
         if ($isApiRequest && !$apiEnabled) {
 

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -400,9 +400,12 @@ class User extends FormEntity implements AdvancedUserInterface, \Serializable
     public function getRoles ()
     {
         $roles = array(
-            "ROLE_API",
             (($this->isAdmin()) ? "ROLE_ADMIN" : "ROLE_USER")
         );
+
+        if (defined('MAUTIC_API_REQUEST') && MAUTIC_API_REQUEST) {
+            $roles[] = "ROLE_API";
+        }
 
         return $roles;
     }

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -399,12 +399,16 @@ class User extends FormEntity implements AdvancedUserInterface, \Serializable
      */
     public function getRoles ()
     {
-        $roles = array(
-            (($this->isAdmin()) ? "ROLE_ADMIN" : "ROLE_USER")
-        );
+        $roles = array();
 
-        if (defined('MAUTIC_API_REQUEST') && MAUTIC_API_REQUEST) {
-            $roles[] = "ROLE_API";
+        if ($this->username) {
+            $roles = array(
+                (($this->isAdmin()) ? "ROLE_ADMIN" : "ROLE_USER")
+            );
+
+            if (defined('MAUTIC_API_REQUEST') && MAUTIC_API_REQUEST) {
+                $roles[] = "ROLE_API";
+            }
         }
 
         return $roles;


### PR DESCRIPTION
## Description

Forms did not use CSRF because all authenticated users had ROLE_API assigned in order to support form validation with use with the API.  The unintended side effect of this is that all forms had CSRF disabled. 

This PR fixes this by only assigning the ROLE_API role if the user is authenticated and the request is through /api. 

## Steps to reproduce

Review the source of any form within Mautic after logging in. Search for _token and it should not be found.

## Steps to test

Apply the PR and repeat above. This time _token should be found. Fill in the form and submit.  It should validate and save. Open the form again and inspect the source, find the _token input and change the value.  Submit. This time it should fail validation.

It is also important to test creating a lead through the API which should be successful (without a CSRF token).