### PR TITLE
Prevented potential XSS with form CSS embedding

### DIFF
--- a/app/bundles/FormBundle/Controller/PublicController.php
+++ b/app/bundles/FormBundle/Controller/PublicController.php
@@ -241,7 +241,7 @@ class PublicController extends CommonFormController
     public function previewAction($id = 0)
     {
         $objectId          = (empty($id)) ? InputHelper::int($this->request->get('id')) : $id;
-        $css               = InputHelper::raw($this->request->get('css'));
+        $css               = InputHelper::string($this->request->get('css'));
         $model             = $this->factory->getModel('form.form');
         $form              = $model->getEntity($objectId);
         $customStylesheets = (!empty($css)) ? explode(',', $css) : array();


### PR DESCRIPTION
## Description
There's a "hidden" feature to embed custom CSS stylesheets into iframe forms that could potentially allow a XSS which this PR fixes.

## Steps to reproduce
Use the public URL of a form and append `?css=<tag>test</tag>` and check the source.  It should attempt to load a URL with the tags embedded. 

## Steps to test

Apply the PR and repeat. This time tags should be stripped. 
