### PR TITLE
Fixes issues where campaign dripflow are lost

### DIFF
--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -522,7 +522,9 @@ class CampaignController extends FormController
                             return $this->editAction($entity->getId(), true);
                         }
                     }
-                } else {
+                }
+
+                if (!$valid) {
                     $connections = $session->get('mautic.campaign.'.$sessionId.'.events.canvassettings');
                     $model->setCanvasSettings($entity, $connections, false, $modifiedEvents);
 

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -612,6 +612,7 @@ class CampaignController extends FormController
         $model      = $this->factory->getModel('campaign');
         $formData   = $this->request->request->get('campaign');
         $sessionId  = isset($formData['sessionId']) ? $formData['sessionId'] : null;
+        $session    = $this->factory->getSession();
 
         $isClone = false;
         if ($clonedEntity instanceof Campaign) {
@@ -626,8 +627,6 @@ class CampaignController extends FormController
                 $isClone = true;
             }
         }
-
-        $session = $this->factory->getSession();
 
         //set the page we came from
         $page = $this->factory->getSession()->get('mautic.campaign.page', 1);
@@ -677,6 +676,7 @@ class CampaignController extends FormController
         if (!$ignorePost && $this->request->getMethod() == 'POST') {
             $valid = false;
             if (!$cancelled = $this->isFormCancelled($form)) {
+
                 //set added/updated events
                 list($modifiedEvents, $deletedEvents, $campaignEvents) = $this->getSessionEvents($objectId);
 
@@ -702,6 +702,11 @@ class CampaignController extends FormController
                         );
                         $valid = false;
                     } else {
+                        // If this is a clone, we need to save the entity first to properly build the events, sources and canvas settings
+                        if ($isClone) {
+                            $model->getRepository()->saveEntity($entity);
+                        }
+
                         //set sources
                         $model->setLeadSources($entity, $addedSources, $deletedSources);
 
@@ -721,9 +726,6 @@ class CampaignController extends FormController
                         }
 
                         $model->saveEntity($entity, $form->get('buttons')->get('save')->isClicked());
-
-                        // Reset objectId to entity ID (can be session ID in case of cloned entity)
-                        $objectId = $entity->getId();
 
                         $this->addFlash(
                             'mautic.core.notice.updated',
@@ -789,8 +791,10 @@ class CampaignController extends FormController
         }
 
         if ($cleanSlate) {
-            //clean slate
-            $this->clearSessionComponents($objectId);
+            if (!$isClone) {
+                //clean slate
+                $this->clearSessionComponents($objectId);
+            }
 
             //load existing events into session
             $campaignEvents = array();
@@ -937,6 +941,9 @@ class CampaignController extends FormController
             }
 
             $campaign->setCanvasSettings($canvasSettings);
+
+            // Set the canvas settings into session to simulate edit
+            $this->get('session')->set('mautic.campaign.'.$tempId.'.events.canvassettings', $canvasSettings);
         }
 
         return $this->editAction($tempId, true, $campaign, $currentSources);

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -225,7 +225,11 @@ class CampaignModel extends CommonFormModel
                 $source = $connection['sourceId'];
                 $target = $connection['targetId'];
 
-                $sourceDecision = (!empty($connection['anchors'])) ? $connection['anchors'][0]['endpoint'] : null;
+                if (in_array($source, array('lists', 'forms'))) {
+                    // Only concerned with events and not sources
+                    continue;
+                }
+                $sourceDecision = (!empty($connection['anchors'][0])) ? $connection['anchors'][0]['endpoint'] : null;
 
                 if ($sourceDecision == 'leadsource') {
                     // Lead source connection that does not matter
@@ -346,12 +350,15 @@ class CampaignModel extends CommonFormModel
             }
 
             // Rebuild anchors
-            $anchors = array();
-            foreach ($connection['anchors'] as $k => $anchor) {
-                $type           = ($k === 0) ? 'source' : 'target';
-                $anchors[$type] = $anchor['endpoint'];
+            if (!isset($connection['anchors']['source'])) {
+                $anchors = array();
+                foreach ($connection['anchors'] as $k => $anchor) {
+                    $type           = ($k === 0) ? 'source' : 'target';
+                    $anchors[$type] = $anchor['endpoint'];
+                }
+
+                $connection['anchors'] = $anchors;
             }
-            $connection['anchors'] = $anchors;
         }
 
         $entity->setCanvasSettings($settings);


### PR DESCRIPTION
## Description
The dripflows of a campaign are lost in two occasions:

1. When cloning a campaign (even events are lost)
2. When saving a campaign that had no source selected (Fixes #1182)

## Steps to reproduce

1. Clone a campaign and save without editing anything. Then edit the new campaign. The events were not cloned. 
2. Clone a campaign and open the campaign builder (don't change anything), close the builder, and save. Edit the campaign and open the builder, the events exist but the dripflow was lost. 
3. Create a new campaign, open the builder and add a few events and connect them (do not add a source). Close the builder and save. You should get an error. Open the builder and note that the dripflow is lost. 

## Steps to test

Apply the PR, repeat the steps above, and this time events and dripflow should clone and remain intact. 
