### PR TITLE
Avoid to import anonymous leads if the CSV has empty rows

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1296,13 +1296,21 @@ class LeadController extends FormController
 
                                 $data = array_combine($headers, $data);
                                 try {
-                                    $merged = $model->importLead($importFields, $data, $defaultOwner, $defaultList, $defaultTags);
-
-                                    if ($merged) {
-                                        $stats['merged']++;
-                                    } else {
-                                        $stats['created']++;
+                                    $prevent = false;
+                                    foreach ($data as $key => $value) {
+                                        if ($value != "") {
+                                            $prevent = true;
+                                            break;
+                                        }
                                     }
+                                    if ($prevent) {
+                                        $merged = $model->importLead($importFields, $data, $defaultOwner, $defaultList, $defaultTags);
+                                        if ($merged) {
+                                            $stats['merged']++;
+                                        } else {
+                                            $stats['created']++;
+                                        }
+                                    }  
                                 } catch (\Exception $e) {
                                     // Email validation likely failed
                                     $stats['ignored']++;

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1310,7 +1310,11 @@ class LeadController extends FormController
                                         } else {
                                             $stats['created']++;
                                         }
-                                    }  
+                                    }     
+                                    else {
+                                        $stats['ignored']++;
+                                        $stats['failures'][$lineNumber] = $this->factory->getTranslator()->trans('mautic.lead.import.error.line_empty');
+                                    }        
                                 } catch (\Exception $e) {
                                     // Email validation likely failed
                                     $stats['ignored']++;


### PR DESCRIPTION
## Description
Anonymous leads are being created when the CSV file contains trailing delimiters (here ','). 

## Steps to reproduce
Create this CSV file. 
`Name,Email`
`PS,sodbg@dogvj.com`
`sog,osidbg@v.com`
`vodi,ein@c.in`
`,`
`,`
`,`
`,`
Import this CSV file. And check the list with is:anonymous, you can find 4 new anonymous leads created. 

## Implication
In case while importing, you specify the lead list name, the anonymous leads are created in the list. Say you import this CSV file to a new list "PS". Then PS will contain 7 new leads (assumption leads don't exist) with 4 anonymous leads. 
When you send emails to this list, the percentage of sent will be only 3/7 percent or 42% sent, and hence it will mess up the stats. 

## Steps to test

Refer Issue https://github.com/mautic/mautic/issues/1570 for more description.