### PR TITLE
Lead edit form won't display unpublished fields now

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/LeadType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadType.php
@@ -130,6 +130,7 @@ class LeadType extends AbstractType
 
         $fieldValues = (!empty($options['data'])) ? $options['data']->getFields() : array('filter' => array('isVisible' => true));
         foreach ($options['fields'] as $field) {
+            if ($field['isPublished'] === false) continue;
             $attr        = array('class' => 'form-control');
             $properties  = $field['properties'];
             $type        = $field['type'];


### PR DESCRIPTION
## Description
Fix of a broken Lead Edit Form if some lead field is unpublished. Reported in https://github.com/mautic/mautic/issues/1562

## Steps to reproduce
1. Make a lead field unpublished.
2. Check a lead edit form. There should be that unpublished field at the bottom of the page out of the form divs.

## Steps to test
Apply this PR and the unpublished field should be gone.

## The fix approach

Firstly, I tried to fix the database query to load only published fields. But it should be happening according to these lines: https://github.com/mautic/mautic/blob/staging/app/bundles/LeadBundle/Controller/LeadController.php#L626-L637

I also checked the DQL and parameters. The WHERE condition is there. I couldn't figure out what's wrong so I added the one-liner which fixes it easily, but not optimally.