### PR TITLE
Bug in ponts and triggers API endpoint

### DIFF
--- a/app/bundles/PointBundle/Entity/Point.php
+++ b/app/bundles/PointBundle/Entity/Point.php
@@ -149,7 +149,6 @@ class Point extends FormEntity
                 array(
                     'id',
                     'name',
-                    'alias',
                     'category',
                     'type',
                     'description'

--- a/app/bundles/PointBundle/Entity/Trigger.php
+++ b/app/bundles/PointBundle/Entity/Trigger.php
@@ -147,9 +147,7 @@ class Trigger extends FormEntity
                 array(
                     'id',
                     'name',
-                    'alias',
                     'category',
-                    'type',
                     'description'
                 )
             )


### PR DESCRIPTION
## Description
Correction for metaproperties for endpoint points and trigger.

## Steps to reproduce

1. Call the endpoint API Points or Trigger. 
2. We get the error : 

> Property Mautic\PointBundle\Entity\Point::$alias does not exist

## Steps to test

1. Call the endpoint API Points or Trigger.
2. We get the expected result.
