### PR TITLE
Date filter php date support

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -1122,7 +1122,7 @@ class LeadListRepository extends CommonRepository
         foreach ($keys as $key) {
             $strings[$key] = $this->translator->trans($key);
         }
- 
+
         return $strings;
     }
 

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -475,7 +475,7 @@ class LeadListRepository extends CommonRepository
         $options   = $this->getFilterExpressionFunctions();
         $groups    = array();
         $groupExpr = $q->expr()->andX();
-
+#print_r($filters); die();
         foreach ($filters as $k => $details) {
             $column = isset($leadTable[$details['field']]) ? $leadTable[$details['field']] : false;
 
@@ -529,7 +529,7 @@ class LeadListRepository extends CommonRepository
             $parameter        = $this->generateRandomParameterName();
             $exprParameter    = ":$parameter";
             $ignoreAutoFilter = false;
-
+            
             // Special handling of relative date strings
             if ($details['type'] == 'datetime' || $details['type'] == 'date') {
                 $relativeDateStrings = $this->getRelativeDateStrings();
@@ -678,6 +678,16 @@ class LeadListRepository extends CommonRepository
                             break;
                     }
 
+                    // check does this match php date params pattern?
+                    if(stristr($string[0], '-') or stristr($string[0], '+')){
+                        $date = new \DateTime('now');
+                        $date->modify($string);
+                        $dateTime = $date->format('Y-m-d H:i:s');
+                        $dtHelper->setDateTime($dateTime, null);
+                        $key = $string;
+                        $isRelative = true;
+                    }
+                    
                     if ($isRelative) {
                         if ($requiresBetween) {
                             $startWith = ($isTimestamp) ? $dtHelper->toUtcString('Y-m-d H:i:s') : $dtHelper->toUtcString('Y-m-d');
@@ -1112,7 +1122,6 @@ class LeadListRepository extends CommonRepository
         foreach ($keys as $key) {
             $strings[$key] = $this->translator->trans($key);
         }
-
         return $strings;
     }
 

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -475,7 +475,7 @@ class LeadListRepository extends CommonRepository
         $options   = $this->getFilterExpressionFunctions();
         $groups    = array();
         $groupExpr = $q->expr()->andX();
-#print_r($filters); die();
+
         foreach ($filters as $k => $details) {
             $column = isset($leadTable[$details['field']]) ? $leadTable[$details['field']] : false;
 
@@ -529,7 +529,7 @@ class LeadListRepository extends CommonRepository
             $parameter        = $this->generateRandomParameterName();
             $exprParameter    = ":$parameter";
             $ignoreAutoFilter = false;
-            
+
             // Special handling of relative date strings
             if ($details['type'] == 'datetime' || $details['type'] == 'date') {
                 $relativeDateStrings = $this->getRelativeDateStrings();

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -1122,7 +1122,7 @@ class LeadListRepository extends CommonRepository
         foreach ($keys as $key) {
             $strings[$key] = $this->translator->trans($key);
         }
-
+ 
         return $strings;
     }
 

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -1122,6 +1122,7 @@ class LeadListRepository extends CommonRepository
         foreach ($keys as $key) {
             $strings[$key] = $this->translator->trans($key);
         }
+
         return $strings;
     }
 

--- a/app/bundles/LeadBundle/Form/DataTransformer/FieldFilterTransformer.php
+++ b/app/bundles/LeadBundle/Form/DataTransformer/FieldFilterTransformer.php
@@ -43,7 +43,7 @@ class FieldFilterTransformer implements DataTransformerInterface
 
         foreach ($rawFilters as $k => $f) {
            if ($f['type'] == 'datetime') {
-                if (in_array($f['filter'], $this->relativeDateStrings)) {
+                if (in_array($f['filter'], $this->relativeDateStrings) or stristr($f['filter'][0], '-') or stristr($f['filter'][0], '+')) {
                     continue;
                 }
 
@@ -73,7 +73,7 @@ class FieldFilterTransformer implements DataTransformerInterface
 
         foreach ($rawFilters as $k => $f) {
             if ($f['type'] == 'datetime') {
-                if (in_array($f['filter'], $this->relativeDateStrings)) {
+                if (in_array($f['filter'], $this->relativeDateStrings) or stristr($f['filter'][0], '-') or stristr($f['filter'][0], '+')) {
                     continue;
                 }
 


### PR DESCRIPTION
## Description

This PR adds support for php date in datetime filter. In current version you could select leads which have been active since 5 days ago by entering value "Date Last Active, greater than or equal, -5 days" but system changes this value into datetime.

This PR changes this behavior and handles the value as relative value if field contains + or - sign at the beginning of the input value.


## Steps to reproduce


## Steps to test

Pull changed code and create datetime field for lead. 
Set datetimevalue ie 5 days ago. 
Create filter to test filtering with different values.
Note as this is for relative time, so check that lead count in list changes based on time.
