### PR TITLE
Fix for broken password minlength message in mautic installer

### DIFF
--- a/app/bundles/InstallBundle/Configurator/Form/UserStepType.php
+++ b/app/bundles/InstallBundle/Configurator/Form/UserStepType.php
@@ -147,7 +147,7 @@ class UserStepType extends AbstractType
                     new Assert\Length(
                         array(
                             'min'        => 6,
-                            'minMessage' => 'mautic.install.password.minlengt'
+                            'minMessage' => 'mautic.install.password.minlength'
                         )
                     )
                 )


### PR DESCRIPTION
**Description**
Fixing broken password min-length message in Mautic installer.
Minor fix: due to error in message config

**Steps to reproduce**:
When installing using installer in step 2, 
1. Give a small password having less than 6 characters in "Admin Password" text box.
2. Click "Next Step" button, then you can see "mautic.install.password.minlengt" message under "Admin Password" text box.

**Steps to test**

1. Apply PR in a fresh Mautic package. ie without installing.
2. Install mautic using installer through browser.
3. In Step 2 of installer, Give a small password having less than 6 characters in "Admin Password" text box. Check if message is showing properly.


