### PR TITLE
Fixes encoding issue in asset naming

### DIFF
--- a/app/bundles/CoreBundle/Templating/Helper/AssetsHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/AssetsHelper.php
@@ -540,7 +540,7 @@ class AssetsHelper extends CoreAssetsHelper
     public function shortenText($text, $charCount = null)
     {
         if ($charCount && strlen($text) > $charCount) {
-            return substr($text, 0, $charCount) . '...';
+            return mb_substr($text, 0, $charCount, "utf-8") . '...';
         }
 
         return $text;


### PR DESCRIPTION
## Description
Encoding problem (with ajax call) on the dashboard if 30th character (in title's ressources) is not ascii character.


## Steps to reproduce

1. Add asset with name : 
> Webmec - Du nurturing au tél**é**marketing.pdf

2. Go to dashboard. 

3. You have got an error 500 with log `500 Malformed UTF-8 characters, possibly incorrectly encoded` at 
`/vendor/symfony/http-foundation/Symfony/Component/HttpFoundation/JsonResponse.php (line #145) 
/vendor/symfony/http-foundation/Symfony/Component/HttpFoundation/JsonResponse.php (line #49)
/app/bundles/CoreBundle/Controller/CommonController.php (line #272
/app/bundles/CoreBundle/Controller/CommonController.php (line #90)`

## Steps to test
0. Apply PR.
1. Go to dashboard.
2. Go to an another page.
3. Come back to the dashboard.
4. His works ! :)
