### PR TITLE
Small permission issues fixed

### DIFF
--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -14,6 +14,8 @@ $view['slots']->set("headerTitle", $email->getName());
 $isVariant    = $email->isVariant(true);
 $showVariants = count($variants['children']);
 $emailType    = $email->getEmailType();
+$edit = $view['security']->hasEntityAccess($permissions['email:emails:editown'], $permissions['email:emails:editother'], $email->getCreatedBy());
+
 if (empty($emailType)) {
     $emailType = 'template';
 }
@@ -40,16 +42,17 @@ $customButtons[] = array(
     'btnText'   => 'mautic.email.send.example'
 );
 
-$customButtons[] = array(
-    'attr' => array(
-        'data-toggle' => 'ajax',
-        'href'        => $view['router']->generate('mautic_email_action', array("objectAction" => "clone", "objectId" => $email->getId())),
+if ($edit) {
+    $customButtons[] = array(
+        'attr' => array(
+            'data-toggle' => 'ajax',
+            'href'        => $view['router']->generate('mautic_email_action', array("objectAction" => "clone", "objectId" => $email->getId())),
         ),
         'iconClass' => 'fa fa-copy',
         'btnText'   => 'mautic.core.form.clone'
-);
+    );
+}
 
-$edit = $view['security']->hasEntityAccess($permissions['email:emails:editown'], $permissions['email:emails:editother'], $email->getCreatedBy());
 $view['slots']->set('actions', $view->render('MauticCoreBundle:Helper:page_actions.html.php', array(
     'item'       => $email,
     'templateButtons' => array(

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -128,7 +128,7 @@ class ListController extends FormController
      */
     public function newAction ()
     {
-        if (!$this->factory->getSecurity()->isGranted('lead:lists:editother')) {
+        if (!$this->factory->getSecurity()->isGranted('lead:leads:viewown')) {
             return $this->accessDenied();
         }
 

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -128,7 +128,7 @@ class ListController extends FormController
      */
     public function newAction ()
     {
-        if (!$this->factory->getSecurity()->isGranted('lead:leads:viewown')) {
+        if (!$this->factory->getSecurity()->isGranted('lead:lists:editother')) {
             return $this->accessDenied();
         }
 

--- a/app/bundles/LeadBundle/Views/Lead/index.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/index.html.php
@@ -81,44 +81,46 @@ if ($indexMode == 'list') {
     );
 }
 
-$customButtons = array_merge(
-    $customButtons,
-    array(
+if ($permissions['lead:leads:editown'] || $permissions['lead:leads:editother']) {
+    $customButtons = array_merge(
+        $customButtons,
         array(
-            'attr'      => array(
-                'class'       => 'btn btn-default btn-sm btn-nospin',
-                'data-toggle' => 'ajaxmodal',
-                'data-target' => '#MauticSharedModal',
-                'href'        => $view['router']->generate('mautic_lead_action', array('objectAction' => 'batchLists')),
-                'data-header' => $view['translator']->trans('mautic.lead.batch.lists')
+            array(
+                'attr'      => array(
+                    'class'       => 'btn btn-default btn-sm btn-nospin',
+                    'data-toggle' => 'ajaxmodal',
+                    'data-target' => '#MauticSharedModal',
+                    'href'        => $view['router']->generate('mautic_lead_action', array('objectAction' => 'batchLists')),
+                    'data-header' => $view['translator']->trans('mautic.lead.batch.lists')
+                ),
+                'tooltip' => $view['translator']->trans('mautic.lead.batch.lists'),
+                'iconClass' => 'fa fa-list'
             ),
-            'tooltip' => $view['translator']->trans('mautic.lead.batch.lists'),
-            'iconClass' => 'fa fa-list'
-        ),
-        array(
-            'attr'      => array(
-                'class'       => 'btn btn-default btn-sm btn-nospin',
-                'data-toggle' => 'ajaxmodal',
-                'data-target' => '#MauticSharedModal',
-                'href'        => $view['router']->generate('mautic_lead_action', array('objectAction' => 'batchCampaigns')),
-                'data-header' => $view['translator']->trans('mautic.lead.batch.campaigns'),
+            array(
+                'attr'      => array(
+                    'class'       => 'btn btn-default btn-sm btn-nospin',
+                    'data-toggle' => 'ajaxmodal',
+                    'data-target' => '#MauticSharedModal',
+                    'href'        => $view['router']->generate('mautic_lead_action', array('objectAction' => 'batchCampaigns')),
+                    'data-header' => $view['translator']->trans('mautic.lead.batch.campaigns'),
+                ),
+                'tooltip' => $view['translator']->trans('mautic.lead.batch.campaigns'),
+                'iconClass' => 'fa fa-clock-o'
             ),
-            'tooltip' => $view['translator']->trans('mautic.lead.batch.campaigns'),
-            'iconClass' => 'fa fa-clock-o'
-        ),
-        array(
-            'attr'      => array(
-                'class'       => 'hidden-xs btn btn-default btn-sm btn-nospin',
-                'data-toggle' => 'ajaxmodal',
-                'data-target' => '#MauticSharedModal',
-                'href'        => $view['router']->generate('mautic_lead_action', array('objectAction' => 'batchDnc')),
-                'data-header' => $view['translator']->trans('mautic.lead.batch.dnc'),
-            ),
-            'tooltip' => $view['translator']->trans('mautic.lead.batch.dnc'),
-            'iconClass' => 'fa fa-send text-danger'
+            array(
+                'attr'      => array(
+                    'class'       => 'hidden-xs btn btn-default btn-sm btn-nospin',
+                    'data-toggle' => 'ajaxmodal',
+                    'data-target' => '#MauticSharedModal',
+                    'href'        => $view['router']->generate('mautic_lead_action', array('objectAction' => 'batchDnc')),
+                    'data-header' => $view['translator']->trans('mautic.lead.batch.dnc'),
+                ),
+                'tooltip' => $view['translator']->trans('mautic.lead.batch.dnc'),
+                'iconClass' => 'fa fa-send text-danger'
+            )
         )
-    )
-);
+    );
+}
 ?>
 
 <div class="panel panel-default bdr-t-wdh-0 mb-0">

--- a/app/bundles/LeadBundle/Views/List/index.html.php
+++ b/app/bundles/LeadBundle/Views/List/index.html.php
@@ -12,7 +12,7 @@ $view['slots']->set("headerTitle", $view['translator']->trans('mautic.lead.list.
 
 $view['slots']->set('actions', $view->render('MauticCoreBundle:Helper:page_actions.html.php', array(
     'templateButtons' => array(
-        'new' => $permissions['lead:lists:editother']
+        'new' => true // this is intentional. Each lead can segment leads
     ),
     'routeBase' => 'leadlist',
     'langVar'   => 'lead.list'

--- a/app/bundles/LeadBundle/Views/List/index.html.php
+++ b/app/bundles/LeadBundle/Views/List/index.html.php
@@ -12,7 +12,7 @@ $view['slots']->set("headerTitle", $view['translator']->trans('mautic.lead.list.
 
 $view['slots']->set('actions', $view->render('MauticCoreBundle:Helper:page_actions.html.php', array(
     'templateButtons' => array(
-        'new' => true // this is intentional. Each lead can segment leads
+        'new' => true // this is intentional. Each user can segment leads
     ),
     'routeBase' => 'leadlist',
     'langVar'   => 'lead.list'

--- a/app/bundles/LeadBundle/Views/List/index.html.php
+++ b/app/bundles/LeadBundle/Views/List/index.html.php
@@ -12,7 +12,7 @@ $view['slots']->set("headerTitle", $view['translator']->trans('mautic.lead.list.
 
 $view['slots']->set('actions', $view->render('MauticCoreBundle:Helper:page_actions.html.php', array(
     'templateButtons' => array(
-        'new' => true
+        'new' => $permissions['lead:lists:editother']
     ),
     'routeBase' => 'leadlist',
     'langVar'   => 'lead.list'


### PR DESCRIPTION
## Description
The issue is described in https://github.com/mautic/mautic/issues/1600 (quoted bellow)

## Steps to reproduce
Quote from the issue:
2) We have one user-role called viewer, where ONLY view permissions are set on all modules (It has all view permissions set which exists in Mautic, nothing else). If I login as user with this role, I've no permissions to create/edit/delete, except:

Leads => Manage Leads: I can still use the functions "Batch edit the selected leads' lists", "Batch edit the selected leads' campaigns" and "Set selected leads as Do Not Contact" (Maybe that is fine and not an issue? I dont know which permissions you need for this actions)

Leads => Manage Lists: I can create new Smart-List, which saves successful! (Without "create" permissions!?)

Emails => Select an Email Template: The "Clone" button is visible, but the click results in "Apparently you don't have access to this area." which is fine (So, hide the button)

## Steps to test
Apply this PR and check the buttons are there when you have the edit permissions and they aren't there when you don't.
