### PR TITLE
Show latest submissions by default

### DIFF
--- a/app/bundles/FormBundle/Controller/ResultController.php
+++ b/app/bundles/FormBundle/Controller/ResultController.php
@@ -65,8 +65,13 @@ class ResultController extends CommonFormController
             $start = 0;
         }
 
+        // Set order direction to desc if not set
+        if (!$session->get('mautic.formresult.'.$objectId.'.orderbydir', null)) {
+            $session->set('mautic.formresult.'.$objectId.'.orderbydir', 'DESC');
+        }
+
         $orderBy    = $session->get('mautic.formresult.'.$objectId.'.orderby', 's.date_submitted');
-        $orderByDir = $session->get('mautic.formresult.'.$objectId.'.orderbydir', 'ASC');
+        $orderByDir = $session->get('mautic.formresult.'.$objectId.'.orderbydir', 'DESC');
         $filters    = $session->get('mautic.formresult.'.$objectId.'.filters', array());
 
         $model = $this->factory->getModel('form.submission');
@@ -170,7 +175,7 @@ class ResultController extends CommonFormController
         }
 
         $orderBy    = $session->get('mautic.formresult.'.$objectId.'.orderby', 's.date_submitted');
-        $orderByDir = $session->get('mautic.formresult.'.$objectId.'.orderbydir', 'ASC');
+        $orderByDir = $session->get('mautic.formresult.'.$objectId.'.orderbydir', 'DESC');
         $filters    = $session->get('mautic.formresult.'.$objectId.'.filters', array());
 
         $args = array(


### PR DESCRIPTION
## Description
This was driving me crazy for a while so I better send the PR. The thing is that if you want to see the submissions, you in 99% cases want to see the latest subscriptions. Not the 2 year old. It always takes me a while to find out I'm looking at the old submissions and then I change the order.

## Steps to reproduce
Go to a form results (the form should have some) and you'll see that the default ordering is by oldest to newest.

## Steps to test
Apply this PR, log out, log in (to clear the session) and go to the form results again. Now the latest submissions should be on top.
