### PR TITLE
Fix of importing donotcontact information

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -984,6 +984,8 @@ class LeadModel extends FormModel
                     "%user%" => $this->factory->getUser()->getUsername()
                 ));
 
+                // The email must be set for successful unsubscribtion
+                $lead->addUpdatedField('email', $data[$fields['email']]);
                 $this->unsubscribeLead($lead, $reason, false);
             }
         }


### PR DESCRIPTION
## Description
The DoNotContat information cannot be imported. Reported at https://github.com/mautic/mautic/issues/1601

## Steps to reproduce
Try to import this lead list:
```
email,doNotEmail
adfsadf@gluetools.com,1
asdfasdfs@huaweisymantec.com,1
asdfasf@mwmg.com,0
asdfasdf.oishi@netgear.com,true
afsdf@commandsoft.com,false
aziz.asd@postmoderngroup.com,TRUE
```
None of the leads will be marked as DoNotContact

## Steps to test
Apply this PR and import again. The leads who should be marked as DoNotContact will be marked so in their Mautic profile.
