### PR TITLE
Landing Page menu item disappeared. This PR adds it back

### DIFF
--- a/app/bundles/PageBundle/Config/config.php
+++ b/app/bundles/PageBundle/Config/config.php
@@ -63,6 +63,19 @@ return array(
         )
     ),
 
+    'menu'     => array(
+        'main' => array(
+            'items'    => array(
+                'mautic.page.pages' => array(
+                    'route'     => 'mautic_page_index',
+                    'access'    => array('page:pages:viewown', 'page:pages:viewother'),
+                    'parent'    => 'mautic.campaigns.menu.root',
+                    'priority'  => 101
+                )
+            )
+        )
+    ),
+
     'categories' => array(
         'page' => null
     ),


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | Maybe?
| BC breaks?    | No
| Deprecations? | No
| Fixed issues  |  Nobody noticed yet

## Description
Landing Page menu item disappeared in some previous PR. This PR adds it as a subitem of campaigns.

## Steps to reproduce the bug (if applicable)
Make sure you are using the latest staging branch. Now try to find the Landing Page menu item. If you found it, you are more lucky than I am :)

## Steps to test this PR
Apply this PR, clear the cache and try to find it again. It should appear as a Campaign submenu item.