### PR TITLE
Minor edits to new dashboard Widgets/Charts

### DIFF
--- a/app/bundles/CoreBundle/Helper/Chart/AbstractChart.php
+++ b/app/bundles/CoreBundle/Helper/Chart/AbstractChart.php
@@ -34,14 +34,14 @@ abstract class AbstractChart
     /**
      * Date from
      *
-     * @var DateTime
+     * @var \DateTime
      */
     protected $dateFrom;
 
     /**
      * Date to
      *
-     * @var DateTime
+     * @var \DateTime
      */
     protected $dateTo;
 
@@ -71,7 +71,7 @@ abstract class AbstractChart
      *
      * @param  string  $unit
      *
-     * @return DateInterval
+     * @return \DateInterval
      */
     public function getUnitInterval($unit = null)
     {
@@ -111,8 +111,8 @@ abstract class AbstractChart
     /**
      * Sets the clones of the date range and validates it
      *
-     * @param DateTime $dateFrom
-     * @param DateTime $dateTo
+     * @param \DateTime $dateFrom
+     * @param \DateTime $dateTo
      */
     public function setDateRange(\DateTime $dateFrom, \DateTime $dateTo)
     {
@@ -129,7 +129,7 @@ abstract class AbstractChart
      * Modify the date to add one current time unit to it and subtract 1 second.
      * Can be used to get the current day results.
      *
-     * @param DateTime $date
+     * @param \DateTime $date
      */
     public function addOneUnitMinusOneSec(\DateTime &$date)
     {

--- a/app/bundles/CoreBundle/Helper/Chart/BarChart.php
+++ b/app/bundles/CoreBundle/Helper/Chart/BarChart.php
@@ -35,7 +35,7 @@ class BarChart extends AbstractChart implements ChartInterface
         'i' => 'H:i',
         'H' => 'M j ga',
         'd' => 'M j, y', 'D' => 'M j, y', // ('D' is BC. Can be removed when all charts use this class)
-        'W' => 'W',
+        'W' => '\W\e\e\k W', // (Week is escaped here so it's not interpreted when creating labels)
         'm' => 'M Y', 'M' => 'M Y', // ('M' is BC. Can be removed when all charts use this class)
         'Y' => 'Y',
     );
@@ -44,8 +44,8 @@ class BarChart extends AbstractChart implements ChartInterface
      * Defines the basic chart values, generates the time axe labels from it
      *
      * @param string   $unit {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
-     * @param DateTime $dateFrom
-     * @param DateTime $dateTo
+     * @param \DateTime $dateFrom
+     * @param \DateTime $dateTo
      * @param string   $dateFormat
      */
     public function __construct($unit, $dateFrom, $dateTo, $dateFormat = null)

--- a/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
+++ b/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
@@ -212,7 +212,7 @@ class ChartQuery extends AbstractChart
      * @param  string     $column name. The column must be type of datetime
      * @param  array      $filters will be added to where claues
      *
-     * @return Doctrine\DBAL\Query\QueryBuilder
+     * @return \Doctrine\DBAL\Query\QueryBuilder
      */
     public function prepareTimeDataQuery($table, $column, $filters = array())
     {
@@ -242,7 +242,7 @@ class ChartQuery extends AbstractChart
             $query->select($dateConstruct . ' AS date, COUNT(*) AS count')
                 ->groupBy($dateConstruct . $groupBy);
         } else {
-            throw new UnexpectedValueException(__CLASS__ . '::' . __METHOD__ . ' supports only MySql a PosgreSQL database platforms.');
+            throw new \UnexpectedValueException(__CLASS__ . '::' . __METHOD__ . ' supports only MySql a PosgreSQL database platforms.');
         }
 
         $query->from(MAUTIC_TABLE_PREFIX . $table, 't')
@@ -312,6 +312,17 @@ class ChartQuery extends AbstractChart
             $nextDate->add($oneUnit);
 
             foreach ($rawData as $key => $item) {
+                /**
+                 * PHP DateTime cannot parse the Y W (ex 2016 09)
+                 * format, so we transform it into d-M-Y.
+                 */
+                if ($this->unit === 'W') {
+                    list($year, $week)  = explode(' ', $item['date']);
+                    $newDate = new \DateTime();
+                    $newDate->setISODate($year, $week);
+                    $item['date'] = $newDate->format('d-M-Y');
+                }
+
                 $itemDate = new \DateTime($item['date'], new \DateTimeZone("UTC"));
 
                 // Place the right suma is between the time unit and time unit +1


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      |  Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  N/A

## Description

There was a bug with the chart dashboard widgets because php DateTime class could not properly parse a year's week number without additional code to help it along.

## Steps to reproduce the bug (if applicable)

Make sure your mautic has the latest staging merged into it, then setup your dashboard widgets. Change the dates at the top to be from Jan 1, 2016 April 11, 2016 (101 days) then click apply. At this point the blue bar will go then just not load anything. If you refresh the browser, you'll be presented with an error.

## Steps to test this PR

 Apply this PR, then refresh the page again and you'll see the widgets are working once again.

