### PR TITLE
Commands address the change to contacts and segments

### DIFF
--- a/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
@@ -92,7 +92,7 @@ class TriggerCampaignCommand extends ModeratedCommand
                 $output->writeln('<info>'.$translator->trans('mautic.campaign.trigger.triggering', array('%id%' => $id)).'</info>');
 
                 if (!$negativeOnly && !$scheduleOnly) {
-                    //trigger starting action events for newly added leads
+                    //trigger starting action events for newly added contacts
                     $output->writeln('<comment>'.$translator->trans('mautic.campaign.trigger.starting').'</comment>');
                     $processed = $model->triggerStartingEvents($campaign, $totalProcessed, $batch, $max, $output);
                     $output->writeln(
@@ -136,7 +136,7 @@ class TriggerCampaignCommand extends ModeratedCommand
                 if ($c->isPublished()) {
                     $output->writeln('<info>'.$translator->trans('mautic.campaign.trigger.triggering', array('%id%' => $c->getId())).'</info>');
                     if (!$negativeOnly && !$scheduleOnly) {
-                        //trigger starting action events for newly added leads
+                        //trigger starting action events for newly added contacts
                         $output->writeln('<comment>'.$translator->trans('mautic.campaign.trigger.starting').'</comment>');
                         $processed = $model->triggerStartingEvents($c, $totalProcessed, $batch, $max, $output);
                         $output->writeln(

--- a/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
+++ b/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
@@ -19,9 +19,18 @@ class UpdateLeadListsCommand extends ModeratedCommand
     protected function configure()
     {
         $this
-            ->setName('mautic:leadlists:update')
+            ->setName('mautic:contactsegments:update')
             ->setAliases(
                 array(
+                    'mautic:segments:update',
+                    'mautic:update:contactsegments',
+                    'mautic:update:segments',
+                    'mautic:rebuild:contactsegments',
+                    'mautic:contactsegments:rebuild',
+                    'mautic:segments:rebuild',
+                    'mautic:rebuild:segments',
+
+                    // Following aliases: BC support; @deprecated 1.1.4; to be removed in 2.0
                     'mautic:lists:update',
                     'mautic:update:leadlists',
                     'mautic:update:lists',
@@ -29,15 +38,16 @@ class UpdateLeadListsCommand extends ModeratedCommand
                     'mautic:leadlists:rebuild',
                     'mautic:lists:rebuild',
                     'mautic:rebuild:lists',
+                    'mautic:leadlists:update'
                 )
             )
-            ->setDescription('Update contacts in smart lists based on new lead data.')
+            ->setDescription('Update contacts in smart segments based on new contact data.')
             ->addOption('--batch-limit', '-b', InputOption::VALUE_OPTIONAL, 'Set batch size of contacts to process per round. Defaults to 300.', 300)
             ->addOption(
                 '--max-contacts',
                 '-m',
                 InputOption::VALUE_OPTIONAL,
-                'Set max number of contacts to process per list for this script execution. Defaults to all.',
+                'Set max number of contacts to process per segment for this script execution. Defaults to all.',
                 false
             )
             ->addOption('--list-id', '-i', InputOption::VALUE_OPTIONAL, 'Specific ID to rebuild. Defaults to all.', false);


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | I wouldn't call it is a feature either
| BC breaks?    | No
| Deprecations? | Yes
| Fixed issues  |  /

## Description
With the renaming from leads to contacts and lists to segments, it'd be great to prepare also the commands in this fashion.

## Steps to test this PR
Apply the PR, clear the cache. All the current segment commands (aliases) should still work:

                    'mautic:lists:update',
                    'mautic:update:leadlists',
                    'mautic:update:lists',
                    'mautic:rebuild:leadlists',
                    'mautic:leadlists:rebuild',
                    'mautic:lists:rebuild',
                    'mautic:rebuild:lists',
                    'mautic:leadlists:update'

As well as the new ones:

                    'mautic:contactsegments:update',
                    'mautic:segments:update',
                    'mautic:update:contactsegments',
                    'mautic:update:segments',
                    'mautic:rebuild:contactsegments',
                    'mautic:contactsegments:rebuild',
                    'mautic:segments:rebuild',
                    'mautic:rebuild:segments'