### PR TITLE
Search boxes and table action button 1px fix

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -1094,7 +1094,6 @@ h6,
   background-color: inherit;
   border-radius: 0;
 }
-
 .container .page-header {
   margin: -15px -15px 15px -15px;
 }
@@ -1449,8 +1448,8 @@ a.media {
 .media-list.media-list-feed .media > .media-object:before {
   content: '';
   position: absolute;
-  top: -246%;
-  bottom: 0;
+  top: -200%;
+  bottom: -200%;
   width: 1px;
   left: 50%;
   background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiB2aWV3Qm94PSIwIDAgMSAxIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJub25lIj48bGluZWFyR3JhZGllbnQgaWQ9Imxlc3NoYXQtZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPjxzdG9wIG9mZnNldD0iMCUiIHN0b3AtY29sb3I9InJnYigyNTUsIDI1NSwgMjU1KSIgc3RvcC1vcGFjaXR5PSIwIi8+PHN0b3Agb2Zmc2V0PSIxMCUiIHN0b3AtY29sb3I9IiNlNWU1ZTUiIHN0b3Atb3BhY2l0eT0iMSIvPjxzdG9wIG9mZnNldD0iOTAlIiBzdG9wLWNvbG9yPSIjZTVlNWU1IiBzdG9wLW9wYWNpdHk9IjEiLz48c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9InJnYigyMjksIDIyOSwgMjI5KSIgc3RvcC1vcGFjaXR5PSIwIi8+PC9saW5lYXJHcmFkaWVudD48cmVjdCB4PSIwIiB5PSIwIiB3aWR0aD0iMSIgaGVpZ2h0PSIxIiBmaWxsPSJ1cmwoI2xlc3NoYXQtZ2VuZXJhdGVkKSIgLz48L3N2Zz4=);
@@ -4535,4 +4534,7 @@ body.noscroll {
 .table .input-group-sm .dropdown-toggle {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
+}
+.input-group .input-group-btn button {
+  height: 32px;
 }

--- a/app/bundles/CoreBundle/Assets/css/app.less
+++ b/app/bundles/CoreBundle/Assets/css/app.less
@@ -167,8 +167,7 @@ label.required:after {
   z-index: 9999;
 }
 
-body.noscroll
-{
+body.noscroll {
   overflow: hidden;
 }
 
@@ -191,5 +190,13 @@ body.noscroll
   .dropdown-toggle {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
+  }
+}
+
+.input-group {
+  .input-group-btn {
+    button {
+      height: 32px;
+    }
   }
 }

--- a/app/bundles/CoreBundle/Views/Helper/list_actions.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/list_actions.html.php
@@ -28,7 +28,7 @@ if (!isset($route)) {
         <input type="checkbox" data-target="tbody" data-toggle="selectrow" class="list-checkbox" name="cb<?php echo $id; ?>" value="<?php echo $id; ?>" />
     </span>
 
-    <div class="btn-group">
+    <div class="input-group-btn">
         <button type="button" class="btn btn-default btn-sm dropdown-toggle btn-nospin" data-toggle="dropdown">
             <i class="fa fa-angle-down "></i>
         </button>


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed issues  |  /

## Description
I've noticed a 1px jumps in the buttons appended to an input like the search box and the table actions dropdown. As David didn't notice this issue, I bet it's another linux (Ubuntu in my case) issue. I can see it in Chromium as well as in Firefox.

## Steps to reproduce the bug (if applicable)
Visit for example the Lead manager - the table view. You should see this:
![1px-fix-before](https://cloud.githubusercontent.com/assets/1235442/14859883/6b9c7704-0ca6-11e6-9be8-6acd724beeb5.png)

## Steps to test this PR
Apply this PR and it should get to the smooth state like this:
![1px-fix-after](https://cloud.githubusercontent.com/assets/1235442/14859906/81441e9a-0ca6-11e6-8f21-709b5eaa0829.png)

I wonder how you'll see it in other OSes..