### PR TITLE
Fixed the "a" hot key because the ID/classes it depended on no longer…

### DIFF
--- a/app/bundles/LeadBundle/Assets/css/lead.css
+++ b/app/bundles/LeadBundle/Assets/css/lead.css
@@ -127,3 +127,11 @@ ul.tag-cloud li {
 .lead-merge-options {
     position: relative;
 }
+
+.contact-cards .panel-body {
+    max-height: 150px;
+}
+
+.contact-cards .img {
+    max-height: 115px;
+}

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -1,10 +1,10 @@
 //LeadBundle
 Mautic.leadOnLoad = function (container) {
     Mousetrap.bind('a', function(e) {
-        if(mQuery('#lead-quick-add').length) {
-            mQuery('#lead-quick-add').modal();
-        } else if (mQuery('#addNoteButton').length) {
-            mQuery('#addNoteButton').click();
+        if(mQuery('a.quickadd').length) {
+            mQuery('a.quickadd').click();
+        } else if (mQuery('a.btn-leadnote-add').length) {
+            mQuery('a.btn-leadnote-add').click();
         }
     });
 
@@ -117,7 +117,7 @@ Mautic.leadOnLoad = function (container) {
             mQuery('#anonymousLeadButton').removeClass('btn-primary');
         }
     }
-    
+
     mQuery(document).on('shown.bs.tab', 'a#load-lead-map', function (e) {
         Mautic.renderLeadMap();
     })

--- a/app/bundles/LeadBundle/Views/Lead/grid_cards.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/grid_cards.html.php
@@ -16,13 +16,13 @@
 
            $img = $view['lead_avatar']->getAvatar($item);
            ?>
-            <div class="shuffle shuffle-item grid col-sm-6 col-lg-4">
+            <div class="shuffle shuffle-item grid col-sm-6 col-lg-4 contact-cards">
                 <div data-color="#<?php echo $color; ?>" class="panel<?php if (!empty($highlight)) echo " highlight"; ?> card ovf-h" style="border-top: 3px solid #<?php echo $color; ?>;">
                     <div class="box-layout">
                         <div class="col-xs-4 va-m">
                             <div class="panel-body">
-                        <span class="img-wrapper img-rounded" style="width:100%">
-                            <img class="img img-responsive" src="<?php echo $img; ?>" />
+                        <span class="img-wrapper img-rounded">
+                            <img class="img" src="<?php echo $img; ?>" />
                         </span>
                             </div>
                         </div>

--- a/app/bundles/LeadBundle/Views/Lead/index.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/index.html.php
@@ -15,7 +15,7 @@ $buttons = $preButtons = array();
 if ($permissions['lead:leads:create']) {
     $preButtons[] = array(
         'attr'      => array(
-            'class'       => 'btn btn-default btn-nospin',
+            'class'       => 'btn btn-default btn-nospin quickadd',
             'data-toggle' => 'ajaxmodal',
             'data-target' => '#MauticSharedModal',
             'href'        => $view['router']->generate('mautic_lead_action', array('objectAction' => 'quickAdd')),


### PR DESCRIPTION
… existed. Also prevented the avatar on the card view from getting cutoff on large resolutions.

Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N 
| BC breaks?    |  N
| Deprecations? |  N
| Fixed issues  |  

## Description

The hotkey "a" no longer worked on the contact list to activate the quick add modal. Also on the lead's profile, "a" no longer activated the new note modal. 

Also, on large resolutions, the avatars on the card view were cut off because the card is maxed at a height of 150 but the avatars were set with img-responsive. 

## Steps to reproduce the bug (if applicable)

Go to the contact list and push "a" nothing will happen. Go to a contact's profile and click "a". Again nothing will happen.

On a bigger resolution with just a couple leads, view the card layout and the avatar will extend beyond the card (but hidden).

## Steps to test this PR

Apply the PR and repeat. This time the modals should activate. 

Avatars should remain within the card.

![](http://alan.direct/drop/2016-04-28_11-46-40-1.png)