### PR TITLE
Reordered menu 

### DIFF
--- a/app/bundles/AssetBundle/Config/config.php
+++ b/app/bundles/AssetBundle/Config/config.php
@@ -55,7 +55,7 @@ return array(
                     'route'     => 'mautic_asset_index',
                     'access'    => array('asset:assets:viewown', 'asset:assets:viewother'),
                     'parent'    => 'mautic.core.components',
-                    'priority'  => 100,
+                    'priority'  => 300,
                 )
             )
         )

--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -55,13 +55,11 @@ return array(
 
     'menu'     => array(
         'main' => array(
-            'priority' => 70,
-            'items'    => array(
-                'mautic.campaign.menu.index' => array(
-                    'iconClass' => 'fa-clock-o',
-                    'route'     => 'mautic_campaign_index',
-                    'access'    => 'campaign:campaigns:view'
-                )
+            'mautic.campaign.menu.index' => array(
+                'iconClass' => 'fa-clock-o',
+                'route'     => 'mautic_campaign_index',
+                'access'    => 'campaign:campaigns:view',
+                'priority'  => 50
             )
         )
     ),

--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -80,16 +80,15 @@ return array(
     ),
     'menu'       => array(
         'main'  => array(
-            'priority' => 15,
-            'items'    => array(
-                'mautic.core.channels' => array(
-                    'id'        => 'mautic_channels_root',
-                    'iconClass' => 'fa-rss'
-                ),
-                'mautic.core.components' => array(
-                    'id'        => 'mautic_components_root',
-                    'iconClass' => 'fa-puzzle-piece'
-                )
+            'mautic.core.components' => array(
+                'id'        => 'mautic_components_root',
+                'iconClass' => 'fa-puzzle-piece',
+                'priority'  => 60
+            ),
+            'mautic.core.channels' => array(
+                'id'        => 'mautic_channels_root',
+                'iconClass' => 'fa-rss',
+                'priority'  => 40
             )
         ),
         'admin' => array(

--- a/app/bundles/CoreBundle/Event/MenuEvent.php
+++ b/app/bundles/CoreBundle/Event/MenuEvent.php
@@ -62,15 +62,18 @@ class MenuEvent extends Event
     /**
      * Add items to the menu
      *
-     * @param array $items
+     * @param array $menuItems
      *
      * @return void
      */
-    public function addMenuItems(array $items)
+    public function addMenuItems(array $menuItems)
     {
+        $defaultPriority = isset($menuItems['priority']) ? $menuItems['priority'] : 9999;
+        $items           = isset($menuItems['items']) ? $menuItems['items'] : $menuItems;
+
         $isRoot = isset($items['name']) && ($items['name'] == 'root' || $items['name'] == 'admin');
         if (!$isRoot) {
-            $this->helper->createMenuStructure($items);
+            $this->helper->createMenuStructure($items, 0, $defaultPriority);
 
             $this->menuItems['children'] = array_merge_recursive($this->menuItems['children'], $items);
         } else {
@@ -95,7 +98,8 @@ class MenuEvent extends Event
     public function getMenuItems()
     {
         $this->helper->placeOrphans($this->menuItems['children'], true);
-
+        $this->helper->sortByPriority($this->menuItems['children']);
+        
         return $this->menuItems;
     }
 

--- a/app/bundles/CoreBundle/EventListener/CommonSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CommonSubscriber.php
@@ -109,20 +109,14 @@ class CommonSubscriber implements EventSubscriberInterface
 
             foreach ($bundles as $bundle) {
                 if (!empty($bundle['config']['menu'][$name])) {
-                    $menu        = $bundle['config']['menu'][$name];
-                    $menuItems[] = array(
-                        'priority' => !isset($menu['priority']) ? 9999 : $menu['priority'],
-                        'items'    => !isset($menu['items']) ? $menu : $menu['items']
+                    $menu = $bundle['config']['menu'][$name];
+                    $event->addMenuItems(
+                        array(
+                            'priority' => !isset($menu['priority']) ? 9999 : $menu['priority'],
+                            'items'    => !isset($menu['items']) ? $menu : $menu['items']
+                        )
                     );
                 }
-            }
-
-            /** @var \Mautic\CoreBundle\Menu\MenuHelper $menuHelper */
-            $menuHelper = $this->factory->getHelper('menu');
-            $menuHelper->sortByPriority($menuItems);
-
-            foreach ($menuItems as $items) {
-                $event->addMenuItems($items['items']);
             }
 
             $allItems[$name] = $event->getMenuItems();

--- a/app/bundles/FormBundle/Config/config.php
+++ b/app/bundles/FormBundle/Config/config.php
@@ -89,7 +89,7 @@ return array(
                     'route'     => 'mautic_form_index',
                     'access'    => array('form:forms:viewown', 'form:forms:viewother'),
                     'parent'    => 'mautic.core.components',
-                    'priority'  => 80
+                    'priority'  => 200
                 )
             )
         )

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -128,17 +128,18 @@ return array(
     ),
     'menu'     => array(
         'main' => array(
-            'priority' => 80,
             'items'    => array(
                 'mautic.lead.leads' => array(
                     'iconClass' => 'fa-user',
                     'access'    => array('lead:leads:viewown', 'lead:leads:viewother'),
-                    'route' => 'mautic_lead_index'
+                    'route' => 'mautic_lead_index',
+                    'priority' => 80
                 ),
                 'mautic.lead.list.menu.index'  => array(
                     'iconClass' => 'fa-pie-chart',
                     'access'    => array('lead:leads:viewown', 'lead:leads:viewother'),
                     'route' => 'mautic_leadlist_index',
+                    'priority' => 70
                 )
             )
         ),

--- a/app/bundles/PageBundle/Config/config.php
+++ b/app/bundles/PageBundle/Config/config.php
@@ -65,13 +65,13 @@ return array(
 
     'menu' => array(
         'main' => array(
-            'priority' => 65,
             'items'    => array(
                 'mautic.page.pages' => array(
                     'route' => 'mautic_page_index',
                     'id'        => 'mautic_page_root',
-                    'iconClass' => 'fa-file-text-o',
-                    'access'    => array('page:pages:viewown', 'page:pages:viewother')
+                    'access'    => array('page:pages:viewown', 'page:pages:viewother'),
+                    'parent'    => 'mautic.core.components',
+                    'priority'  => 100
                 )
             )
         )

--- a/app/bundles/PointBundle/Config/config.php
+++ b/app/bundles/PointBundle/Config/config.php
@@ -53,21 +53,19 @@ return array(
 
     'menu'     => array(
         'main' => array(
-            'priority' => 40,
-            'items'    => array(
-                'mautic.points.menu.root' => array(
-                    'id'        => 'mautic_points_root',
-                    'iconClass' => 'fa-calculator',
-                    'access'    => array('point:points:view', 'point:triggers:view'),
-                    'children'  => array(
-                        'mautic.point.menu.index'         => array(
-                            'route'  => 'mautic_point_index',
-                            'access' => 'point:points:view'
-                        ),
-                        'mautic.point.trigger.menu.index' => array(
-                            'route'  => 'mautic_pointtrigger_index',
-                            'access' => 'point:triggers:view'
-                        )
+            'mautic.points.menu.root' => array(
+                'id'        => 'mautic_points_root',
+                'iconClass' => 'fa-calculator',
+                'access'    => array('point:points:view', 'point:triggers:view'),
+                'priority'  => 30,
+                'children'  => array(
+                    'mautic.point.menu.index'         => array(
+                        'route'  => 'mautic_point_index',
+                        'access' => 'point:points:view'
+                    ),
+                    'mautic.point.trigger.menu.index' => array(
+                        'route'  => 'mautic_pointtrigger_index',
+                        'access' => 'point:triggers:view'
                     )
                 )
             )

--- a/app/bundles/ReportBundle/Config/config.php
+++ b/app/bundles/ReportBundle/Config/config.php
@@ -50,16 +50,14 @@ return array(
 
     'menu'     => array(
         'main' => array(
-            'priority' => 10,
-            'items'    => array(
-                'mautic.report.reports' => array(
-                    'route'     => 'mautic_report_index',
-                    'iconClass' => 'fa-line-chart',
-                    'access'    => array(
-                        'report:reports:viewown',
-                        'report:reports:viewother'
-                    )
-                )
+            'mautic.report.reports' => array(
+                'route'     => 'mautic_report_index',
+                'iconClass' => 'fa-line-chart',
+                'access'    => array(
+                    'report:reports:viewown',
+                    'report:reports:viewother'
+                ),
+                'priority' => 20
             )
         )
     ),


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | N
| New feature?  | Y
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  

## Description
This reorders the main menu as contacts, segments, components, campaigns, channels, points along with moving landing pages into components

In order to split components and channels (both defined by CoreBundle), priority support had to be added on per item level (and not just at the bundle level).

## Steps to test this PR
Apply the PR, clear Symfony's cache and note the menu order. 