### PR TITLE
Segments table sorting

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -74,8 +74,8 @@ class LeadController extends FormController
         $session->set('mautic.lead.filter', $search);
 
         //do some default filtering
-        $orderBy    = $this->factory->getSession()->get('mautic.lead.orderby', 'l.last_active');
-        $orderByDir = $this->factory->getSession()->get('mautic.lead.orderbydir', 'DESC');
+        $orderBy    = $session->get('mautic.lead.orderby', 'l.last_active');
+        $orderByDir = $session->get('mautic.lead.orderbydir', 'DESC');
 
         $filter      = array('string' => $search, 'force' => '');
         $translator  = $this->factory->getTranslator();

--- a/app/bundles/LeadBundle/Views/List/list.html.php
+++ b/app/bundles/LeadBundle/Views/List/list.html.php
@@ -23,10 +23,27 @@ $listCommand = $view['translator']->trans('mautic.lead.lead.searchcommand.list')
                     'checkall' => 'true',
                     'target'   => '#leadListTable'
                 ));
+
+                echo $view->render('MauticCoreBundle:Helper:tableheader.html.php', array(
+                    'sessionVar' => 'leadlist',
+                    'orderBy'    => 'l.name',
+                    'text'       => 'mautic.core.name',
+                    'class'      => 'col-leadlist-name'
+                ));
+
+                echo $view->render('MauticCoreBundle:Helper:tableheader.html.php', array(
+                    'sessionVar' => 'leadlist',
+                    'text'       => 'mautic.lead.list.thead.leadcount',
+                    'class'      => 'visible-md visible-lg col-leadlist-leadcount'
+                ));
+
+                echo $view->render('MauticCoreBundle:Helper:tableheader.html.php', array(
+                    'sessionVar' => 'leadlist',
+                    'orderBy'    => 'l.id',
+                    'text'       => 'mautic.core.id',
+                    'class'      => 'visible-md visible-lg col-leadlist-id'
+                ));
                 ?>
-                <th class="col-leadlist-name"><?php echo $view['translator']->trans('mautic.core.name'); ?></th>
-                <th class="visible-md visible-lg col-leadlist-leadcount"><?php echo $view['translator']->trans('mautic.lead.list.thead.leadcount'); ?></th>
-                <th class="visible-md visible-lg col-leadlist-id"><?php echo $view['translator']->trans('mautic.core.id'); ?></th>
             </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | N
| New feature?  | Y
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
This PR adds ability for segments table to be sorted by name and ID.

## Steps to test this PR
Apply this PR and navigate to Segments manager. If you click on _Name_ or _ID_ column heading the rows will re-order.