### PR TITLE
Timeline icons

### DIFF
--- a/app/bundles/AssetBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/LeadSubscriber.php
@@ -80,7 +80,8 @@ class LeadSubscriber extends CommonSubscriber
                 'extra'     => array(
                     'asset' => $model->getEntity($download['asset_id'])
                 ),
-                'contentTemplate' => 'MauticAssetBundle:SubscribedEvents\Timeline:index.html.php'
+                'contentTemplate' => 'MauticAssetBundle:SubscribedEvents\Timeline:index.html.php',
+                'icon'      => 'fa-download'
             ));
         }
     }

--- a/app/bundles/AssetBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/AssetBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -12,7 +12,7 @@ $item = $event['extra']['asset'];
 ?>
 
 <li class="wrapper asset-download">
-	<div class="figure"><span class="fa <?php echo isset($icons['asset']) ? $icons['asset'] : '' ?>"></span></div>
+	<div class="figure"><span class="fa <?php echo isset($event['icon']) ? $event['icon'] : '' ?>"></span></div>
 	<div class="panel">
 	    <div class="panel-body">
 	    	<h3>

--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -209,7 +209,8 @@ class LeadSubscriber extends CommonSubscriber
                     'extra'           => array(
                         'log' => $log
                     ),
-                    'contentTemplate' => $template
+                    'contentTemplate' => $template,
+                    'icon'            => 'fa-clock-o'
                 )
             );
         }

--- a/app/bundles/CampaignBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/CampaignBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -11,7 +11,7 @@ $item = $event['extra']['log'];
 ?>
 
 <li class="wrapper campaign-event">
-    <div class="figure"><span class="fa <?php echo isset($icons['campaigns']) ? $icons['campaigns'] : '' ?>"></span></div>
+    <div class="figure"><span class="fa <?php echo isset($event['icon']) ? $event['icon'] : '' ?>"></span></div>
     <div class="panel">
         <div class="panel-body">
             <h3>

--- a/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
@@ -78,7 +78,8 @@ class LeadSubscriber extends CommonSubscriber
                             'stat' => $stat,
                             'type' => 'read'
                         ),
-                        'contentTemplate' => 'MauticEmailBundle:SubscribedEvents\Timeline:index.html.php'
+                        'contentTemplate' => 'MauticEmailBundle:SubscribedEvents\Timeline:index.html.php',
+                        'icon'            => 'fa-envelope-o'
                     )
                 );
             }
@@ -94,7 +95,8 @@ class LeadSubscriber extends CommonSubscriber
                             'stat' => $stat,
                             'type' => 'sent'
                         ),
-                        'contentTemplate' => 'MauticEmailBundle:SubscribedEvents\Timeline:index.html.php'
+                        'contentTemplate' => 'MauticEmailBundle:SubscribedEvents\Timeline:index.html.php',
+                        'icon'            => 'fa-envelope'
                     )
                 );
             }

--- a/app/bundles/EmailBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/EmailBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -21,7 +21,7 @@ if (!empty($item['storedSubject'])) {
 ?>
 
 <li class="wrapper email-read">
-	<div class="figure"><span class="fa <?php echo isset($icons['email']) ? $icons['email'] : '' ?>"></span></div>
+	<div class="figure"><span class="fa <?php echo isset($event['icon']) ? $event['icon'] : '' ?>"></span></div>
 	<div class="panel">
 	    <div class="panel-body">
 	    	<h3>

--- a/app/bundles/FormBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/LeadSubscriber.php
@@ -84,7 +84,8 @@ class LeadSubscriber extends CommonSubscriber
                     'form'  => $formModel->getEntity($row['form_id']),
                     'page'  => $pageModel->getEntity($row['page_id'])
                 ),
-                'contentTemplate' => 'MauticFormBundle:SubscribedEvents\Timeline:index.html.php'
+                'contentTemplate' => 'MauticFormBundle:SubscribedEvents\Timeline:index.html.php',
+                'icon'            => 'fa-pencil-square-o'
             ));
         }
     }

--- a/app/bundles/FormBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/FormBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -19,7 +19,7 @@ if ($page->getId()) {
 ?>
 
 <li class="wrapper form-submitted">
-	<div class="figure"><span class="fa <?php echo isset($icons['form']) ? $icons['form'] : '' ?>"></span></div>
+	<div class="figure"><span class="fa <?php echo isset($event['icon']) ? $event['icon'] : '' ?>"></span></div>
 	<div class="panel">
 	    <div class="panel-body">
 	    	<h3>

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -14,7 +14,6 @@ use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\CoreBundle\Controller\AjaxController as CommonAjaxController;
 use Mautic\CoreBundle\Helper\BuilderTokenHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
-use Mautic\CoreBundle\Event\IconEvent;
 use Mautic\CoreBundle\CoreEvents;
 use Symfony\Component\HttpFoundation\Request;
 use Mautic\LeadBundle\LeadEvents;

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -224,16 +224,12 @@ class AjaxController extends CommonAjaxController
                 $events     = $event->getEvents();
                 $eventTypes = $event->getEventTypes();
 
-                $event = new IconEvent($this->factory->getSecurity());
-                $this->factory->getDispatcher()->dispatch(CoreEvents::FETCH_ICONS, $event);
-                $icons = $event->getIcons();
-
                 $timeline = $this->renderView('MauticLeadBundle:Lead:history.html.php', array(
                         'events'       => $events,
                         'eventTypes'   => $eventTypes,
                         'eventFilters' => $filter,
-                        'icons'        => $icons,
-                        'lead'         => $lead)
+                        'lead'         => $lead
+                    )
                 );
 
                 $dataArray['success']      = 1;

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -20,7 +20,6 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Form\Type\TagListType;
 use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Event\LeadTimelineEvent;
-use Mautic\CoreBundle\Event\IconEvent;
 use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Helper\Chart\LineChart;
 use Symfony\Component\Form\FormError;

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -412,10 +412,6 @@ class LeadController extends FormController
             }
         }
 
-        $event = new IconEvent($this->factory->getSecurity());
-        $this->factory->getDispatcher()->dispatch(CoreEvents::FETCH_ICONS, $event);
-        $icons = $event->getIcons();
-
         // We need the EmailRepository to check if a lead is flagged as do not contact
         /** @var \Mautic\EmailBundle\Entity\EmailRepository $emailRepo */
         $emailRepo = $this->factory->getModel('email')->getRepository();
@@ -435,7 +431,6 @@ class LeadController extends FormController
                     'eventTypes'        => $eventTypes,
                     'eventFilters'      => $filters,
                     'upcomingEvents'    => $upcomingEvents,
-                    'icons'             => $icons,
                     'engagementData'    => $engagementChart,
                     'noteCount'         => $this->factory->getModel('lead.note')->getNoteCount($lead, true),
                     'doNotContact'      => $emailRepo->checkDoNotEmail($fields['core']['email']['value']),

--- a/app/bundles/LeadBundle/Views/Lead/history.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/history.html.php
@@ -19,7 +19,7 @@
         <ul class="events">
             <?php foreach ($events as $event) : ?>
                 <?php if (isset($event['contentTemplate'])) : ?>
-                    <?php echo $view->render($event['contentTemplate'], array('event' => $event, 'icons' => $icons)); ?>
+                    <?php echo $view->render($event['contentTemplate'], array('event' => $event)); ?>
                 <?php endif; ?>
             <?php endforeach; ?>
         </ul>

--- a/app/bundles/LeadBundle/Views/Lead/lead.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/lead.html.php
@@ -307,14 +307,13 @@ $view['slots']->set(
                     array(
                         'eventTypes'   => $eventTypes,
                         'eventFilters' => $eventFilters,
-                        'lead'         => $lead,
-                        'icons'        => $icons
+                        'lead'         => $lead
                     )
                 ); ?>
                 <div id="timeline-container">
                     <?php echo $view->render(
                         'MauticLeadBundle:Lead:history.html.php',
-                        array('events' => $events, 'icons' => $icons)
+                        array('events' => $events)
                     ); ?>
                 </div>
             </div>

--- a/app/bundles/PageBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/LeadSubscriber.php
@@ -132,7 +132,8 @@ class LeadSubscriber extends CommonSubscriber
                         'page' => $model->getEntity($hit['page_id']),
                         'hit'  => $hit
                     ),
-                    'contentTemplate' => $template
+                    'contentTemplate' => $template,
+                    'icon'            => 'fa-link'
                 )
             );
         }

--- a/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -22,7 +22,7 @@ if ($event['extra']['hit']['dateLeft']) {
 	}
 }
 
-$icon = (isset($icons['page'])) ? $icons['page'] : '';
+$icon = (isset($event['icon'])) ? $event['icon'] : '';
 
 // Check for UTM codes
 $query = $event['extra']['hit']['query'];

--- a/app/bundles/PointBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/LeadSubscriber.php
@@ -97,13 +97,14 @@ class LeadSubscriber extends CommonSubscriber
         // Add the logs to the event array
         foreach ($logs as $log) {
             $event->addEvent(array(
-                'event'     => $eventTypeKey,
-                'eventLabel' => $eventTypeName,
-                'timestamp' => $log['dateAdded'],
-                'extra'     => array(
-                    'log' => $log
+                'event'           => $eventTypeKey,
+                'eventLabel'      => $eventTypeName,
+                'timestamp'       => $log['dateAdded'],
+                'extra'           => array(
+                    'log'           => $log
                 ),
-                'contentTemplate' => 'MauticPointBundle:SubscribedEvents\Timeline:index.html.php'
+                'contentTemplate' => 'MauticPointBundle:SubscribedEvents\Timeline:index.html.php',
+                'icon'            => 'fa-calculator'
             ));
         }
     }

--- a/app/bundles/PointBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/PointBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -12,7 +12,7 @@ $item = $event['extra']['log'];
 ?>
 
 <li class="wrapper point-gained">
-	<div class="figure"><span class="fa <?php echo isset($icons['points']) ? $icons['points'] : '' ?>"></span></div>
+	<div class="figure"><span class="fa <?php echo isset($event['icon']) ? $event['icon'] : '' ?>"></span></div>
 	<div class="panel">
 	    <div class="panel-body">
 	    	<h3>


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
Some contact timeline event icons disappeared with the menu restructure because the icons were loaded from there. This PR defines the icons in the event listener.

## Steps to reproduce the bug (if applicable)
Open a contact detail which has a lot of different events in the timeline. Most of the icons are gone.

## Steps to test this PR
Apply this PR and the icons should appear.
