### PR TITLE
Sms small improvements

### DIFF
--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -281,7 +281,7 @@ class SmsController extends FormController
         $logs = $this->factory->getModel('core.auditLog')->getLogForObject('sms', $sms->getId(), $sms->getDateAdded());
 
         // Get click through stats
-        $trackableLinks = $model->getSmsClickStats($sms->getId());
+        // $trackableLinks = $model->getSmsClickStats($sms->getId());
 
         return $this->delegateView(
             array(
@@ -295,7 +295,7 @@ class SmsController extends FormController
                 'viewParameters'  => array(
                     'sms'   => $sms,
                     'stats'          => $stats,
-                    'trackableLinks' => $trackableLinks,
+                    // 'trackableLinks' => $trackableLinks,
                     'logs'           => $logs,
                     'permissions'    => $security->isGranted(
                         array(

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -214,6 +214,7 @@ class SmsController extends FormController
                     'permissions' => $permissions,
                     'model'       => $model,
                     'security'    => $this->factory->getSecurity(),
+                    'configured'  => $this->factory->getParameter('sms_enabled')
                 ),
                 'contentTemplate' => 'MauticSmsBundle:Sms:list.html.php',
                 'passthroughVars' => array(

--- a/app/bundles/SmsBundle/Form/Type/SmsType.php
+++ b/app/bundles/SmsBundle/Form/Type/SmsType.php
@@ -116,13 +116,13 @@ class SmsType extends AbstractType
         );
 
         //add category
-        $builder->add(
-            'category',
-            'category',
-            array(
-                'bundle' => 'email'
-            )
-        );
+        // $builder->add(
+        //     'category',
+        //     'category',
+        //     array(
+        //         'bundle' => 'email'
+        //     )
+        // );
 
         //add lead lists
         $transformer = new IdToEntityModelTransformer($this->em, 'MauticLeadBundle:LeadList', 'id', true);

--- a/app/bundles/SmsBundle/Translations/en_US/messages.ini
+++ b/app/bundles/SmsBundle/Translations/en_US/messages.ini
@@ -91,3 +91,8 @@ mautic.sms.timeline.type="Type"
 mautic.sms.timeline.status.delivered="Delivered"
 mautic.sms.timeline.status.failed="Failed"
 mautic.sms.timeline.content.heading="Message Content"
+
+mautic.sms.disabled="Text Messages are currently disabled"
+mautic.sms.enable.in.configuration="Enable and configure Text Messages in the Mautic configuration."
+mautic.sms.create.in.campaign.builder="Seems there are none! Try changing a filter (if applicable) or create a new one in the Campaign Builder."
+

--- a/app/bundles/SmsBundle/Views/Sms/details.html.php
+++ b/app/bundles/SmsBundle/Views/Sms/details.html.php
@@ -42,12 +42,14 @@ $view['slots']->set('actions', $view->render('MauticCoreBundle:Helper:page_actio
             </div>
             <!--/ sms detail collapseable toggler -->
 
-           <?php echo $view->render('MauticSmsBundle:Sms:' . $smsType . '_graph.html.php',
-               array(
-                   'stats'        => $stats,
-                   'sms' => $sms
-               )
-           ); ?>
+           <?php 
+           // echo $view->render('MauticSmsBundle:Sms:' . $smsType . '_graph.html.php',
+           //     array(
+           //         'stats' => $stats,
+           //         'sms'  => $sms
+           //     )
+           // ); 
+           ?>
 
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/SmsBundle/Views/Sms/form.html.php
+++ b/app/bundles/SmsBundle/Views/Sms/form.html.php
@@ -55,7 +55,7 @@ if (!isset($attachmentSize)) {
             <div id="leadList"<?php echo ($smsType == 'template') ? ' class="hide"' : ''; ?>>
                 <?php echo $view['form']->row($form['lists']); ?>
             </div>
-            <?php echo $view['form']->row($form['category']); ?>
+            <?php //echo $view['form']->row($form['category']); ?>
             <?php echo $view['form']->row($form['language']); ?>
             <div class="hide">
                 <div id="publishStatus"<?php echo ($smsType == 'list') ? ' class="hide"' : ''; ?>>

--- a/app/bundles/SmsBundle/Views/Sms/index.html.php
+++ b/app/bundles/SmsBundle/Views/Sms/index.html.php
@@ -23,7 +23,7 @@ $view['slots']->set("headerTitle", $view['translator']->trans('mautic.sms.smses'
         'templateButtons' => array(
             'delete' => $permissions['sms:smses:deleteown'] || $permissions['sms:smses:deleteother']
         ),
-        'filters'     => $filters
+        // 'filters'     => $filters // @todo
     )); ?>
 
     <div class="page-list">

--- a/app/bundles/SmsBundle/Views/Sms/list.html.php
+++ b/app/bundles/SmsBundle/Views/Sms/list.html.php
@@ -122,6 +122,8 @@ if (count($items)):
         'sessionVar'      => 'sms'
     )); ?>
 </div>
+<?php elseif (!$configured): ?>
+    <?php echo $view->render('MauticCoreBundle:Helper:noresults.html.php', array('header' => 'mautic.sms.disabled', 'message' => 'mautic.sms.enable.in.configuration')); ?>
 <?php else: ?>
-    <?php echo $view->render('MauticCoreBundle:Helper:noresults.html.php'); ?>
+    <?php echo $view->render('MauticCoreBundle:Helper:noresults.html.php', array('message' => 'mautic.sms.create.in.campaign.builder')); ?>
 <?php endif; ?>


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | N
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
While testing SMS bundle I noticed few small issues:

### 1. Better empty messages which would guide users to the solution
This is the original message:
![mautic-sms-original](https://cloud.githubusercontent.com/assets/1235442/14984355/8f80a050-1142-11e6-9f1c-b02de68b8b67.png)
It was misleading users because there is no "New" button. Why? Firstly, because the Text Message bundle was not enabled and configured. So with this PR, the user will see:
![mautic-sms-disabled](https://cloud.githubusercontent.com/assets/1235442/14984531/75f9da92-1143-11e6-84b4-142051c7b29c.png)
When the user configures the bundle, he still won't see the "New" button. Why? Because the SMS can be created only from the Campaign Builder. So he'll see this message:
![mautic-sms-empty](https://cloud.githubusercontent.com/assets/1235442/14984557/99fcd746-1143-11e6-84e0-f86611bce389.png)

### 2. SMS bundle doesn't have its categories
So I rather hid them in the SMS list filter and in the SMS form.

### 3. Hidden PHP errors
When you save the SMS form and you are in the dev mode, you'll be able to see a error message for a couple of milliseconds and if you'll look at the error log, you'll see the error. The source of the error is loading the view which is not ready for it. I commented out the lines which caused the errors.

## Steps to test this PR

Before applying this PR you can go through the 3 points above to see the problem. Apply the PR and control that the issues were fixed as described.