### PR TITLE
Fixed issue that prevented obtaining update information

### DIFF
--- a/app/bundles/CoreBundle/Helper/LanguageHelper.php
+++ b/app/bundles/CoreBundle/Helper/LanguageHelper.php
@@ -154,7 +154,7 @@ class LanguageHelper
 
         // Get the language data
         try {
-            $data      = $this->connector->post('https://updates.mautic.org/index.php?option=com_mauticdownload&task=fetchLanguages', array(), null, 10);
+            $data      = $this->connector->post('https://updates.mautic.org/index.php?option=com_mauticdownload&task=fetchLanguages', array(), array(), 10);
             $languages = json_decode($data->body, true);
             $languages = $languages['languages'];
         } catch (\Exception $exception) {

--- a/app/bundles/CoreBundle/Helper/UpdateHelper.php
+++ b/app/bundles/CoreBundle/Helper/UpdateHelper.php
@@ -122,7 +122,7 @@ class UpdateHelper
                 'installSource' => $this->factory->getParameter('install_source', 'Mautic')
             );
 
-            $this->connector->post('https://updates.mautic.org/stats/send', $data, null, 10);
+            $this->connector->post('https://updates.mautic.org/stats/send', $data, array(), 10);
         } catch (\Exception $exception) {
             // Not so concerned about failures here, move along
         }
@@ -135,7 +135,7 @@ class UpdateHelper
                 'stability'  => $this->factory->getParameter('update_stability')
             );
 
-            $data    = $this->connector->post('https://updates.mautic.org/index.php?option=com_mauticdownload&task=checkUpdates', $appData, null, 10);
+            $data    = $this->connector->post('https://updates.mautic.org/index.php?option=com_mauticdownload&task=checkUpdates', $appData, array(), 10);
             $update  = json_decode($data->body);
         } catch (\Exception $exception) {
             // Log the error

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -418,7 +418,7 @@ $view['slots']->set(
                                                                    )
                                                                ); ?>"
                                                                data-toggle="confirmation"
-                                                               data-mesasge="<?php echo $view->escape(
+                                                               data-message="<?php echo $view->escape(
                                                                    $view["translator"]->trans(
                                                                        "mautic.email.abtest.confirmmakewinner",
                                                                        array("%name%" => $variant->getName())

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -424,22 +424,32 @@ Mautic.addLeadListFilter = function (elId) {
 };
 
 Mautic.leadfieldOnLoad = function (container) {
-
-    var fixHelper = function(e, ui) {
-        ui.children().each(function() {
-            mQuery(this).width(mQuery(this).width());
-        });
-        return ui;
-    };
-
     if (mQuery(container + ' .leadfield-list').length) {
+        var bodyOverflow = {};
         mQuery(container + ' .leadfield-list tbody').sortable({
             handle: '.fa-ellipsis-v',
-            helper: fixHelper,
+            helper: function(e, ui) {
+                ui.children().each(function() {
+                    mQuery(this).width(mQuery(this).width());
+                });
+
+                // Fix body overflow that messes sortable up
+                bodyOverflow.overflowX = mQuery('body').css('overflow-x');
+                bodyOverflow.overflowY = mQuery('body').css('overflow-y');
+                mQuery('body').css({
+                    overflowX: 'visible',
+                    overflowY: 'visible'
+                });
+
+                return ui;
+            },
             scroll: false,
             axis: 'y',
             containment: container + ' .leadfield-list',
-            stop: function(i) {
+            stop: function(e, ui) {
+                // Restore original overflow
+                mQuery('body').css(bodyOverflow);
+
                 // Get the page and limit
                 mQuery.ajax({
                     type: "POST",


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  

## Description

Due to a change in a dependency API that wasn't caught (https://github.com/joomla-framework/http/commit/ac1fd54c4ce3750ad750ee76fe0235a310e4624e
), fetching update and language files now fail. This PR addresses this by updating the calling function. This will need to be manually patched by individuals looking to update from Mautic 1.3.x to 1.4.

## Steps to reproduce the bug (if applicable)

1. Log out and back in then check your logs. Should see an error something similar to:
```ERROR - An error occurred while attempting to fetch updates: Catchable Fatal Error: Argument 3 passed to Joomla\Http\Http::post() must be of the type array, null given, called in app/bundles/CoreBundle/Helper/UpdateHelper.php on line 138...```

## Steps to test this PR

1. Apply the PR
2. Repeat above and this time no error should occur and an app/cache/lastUpdateCheck.txt file should exist.

Also snuck in a fix for sorting contact fields where scrolling caused the cloned element to be way off. Can test this by trying to sort the fields before and after the PR.