### PR TITLE
$action var was overwritten. Changed to $formAction

### DIFF
--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -217,12 +217,12 @@ class FormController extends CommonFormController
         // Only show actions and fields that still exist
         $customComponents  = $model->getCustomComponents();
         $activeFormActions = array();
-        foreach ($activeForm->getActions() as $action) {
-            if (!isset($customComponents['actions'][$action->getType()])) {
+        foreach ($activeForm->getActions() as $formAction) {
+            if (!isset($customComponents['actions'][$formAction->getType()])) {
                 continue;
             }
-            $type                          = explode('.', $action->getType());
-            $activeFormActions[$type[0]][] = $action;
+            $type                          = explode('.', $formAction->getType());
+            $activeFormActions[$type[0]][] = $formAction;
         }
 
         $activeFormFields = array();


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
@mqueme noticed that standalone forms who have an action produces an error when accessing their detail page from the form table. The error won't show on refresh.

## Steps to reproduce the bug (if applicable)
Create a standalone form with some action, save, go to Forms table, open the form you've created.

## Steps to test this PR
Apply this PR and try to open the form again. It should open without any issue.
