### PR TITLE
The Notification entity doesn't have the getTitle() method. Changed to getName().

### DIFF
--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -567,7 +567,7 @@ class NotificationController extends FormController
                     array(
                         'updateSelect'      => $form['updateSelect']->getData(),
                         'notificationId'    => $entity->getId(),
-                        'notificationTitle' => $entity->getTitle(),
+                        'notificationTitle' => $entity->getName(),
                         'notificationLang'  => $entity->getLanguage()
                     )
                 );


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
A notification throw PHP error on edit > save

## Steps to reproduce the bug (if applicable)
Open the Campaign builder and create a new Notification action. In there create a new notification, save it. Edit it, save it. It'll throw an error.

## Steps to test this PR
Apply the PR and edit the notification again. The error should be gone.