### PR TITLE
fix A/B custom buttons erroring on variant details page

### DIFF
--- a/app/bundles/PageBundle/Views/Page/details.html.php
+++ b/app/bundles/PageBundle/Views/Page/details.html.php
@@ -42,7 +42,7 @@ $view['slots']->set(
         'MauticCoreBundle:Helper:page_actions.html.php',
         array(
             'item'            => $activePage,
-            'customButtons'   => $customButtons,
+            'customButtons'   => (isset($customButtons))?$customButtons:array(),
             'templateButtons' => array(
                 'edit'   => $security->hasEntityAccess(
                     $permissions['page:pages:editown'],


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  |  /

## Description
when you create an A/B test on a page it shows a custom Buttons error because create A/B test can only be done on a parent page
## Steps to reproduce the bug (if applicable)
create A/B test see error
## Steps to test this PR
apply PR and error should not appear, also de add A/B test dropdown button should only appear on the parent page.


