### PR TITLE
JS tracking API changed to require less change in the future

### DIFF
--- a/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
@@ -44,7 +44,7 @@ var MauticJS = MauticJS || {};
 
 MauticJS.serialize = function(obj) {
     var str = [];
-    for(var p in obj)
+    for (var p in obj)
         if (obj.hasOwnProperty(p)) {
             str.push(encodeURIComponent(p) + "=" + encodeURIComponent(obj[p]));
         }
@@ -54,6 +54,24 @@ MauticJS.serialize = function(obj) {
 MauticJS.documentReady = function(f) {
     /in/.test(document.readyState) ? setTimeout('MauticJS.documentReady(' + f + ')', 9) : f();
 };
+
+if (typeof window[window.MauticTrackingObject] === 'undefined') {
+    console.log('Mautic tracking is not initiated correctly. Follow the documentation.');
+} else {
+    MauticJS.input = window[window.MauticTrackingObject];
+    MauticJS.inputQueue = MauticJS.input.q;
+
+    MauticJS.getInput = function(task, type) {
+        if (MauticJS.inputQueue.length) {
+            for (var i in MauticJS.inputQueue) {
+                if (MauticJS.inputQueue[i][0] === task && MauticJS.inputQueue[i][1] === type);
+                return MauticJS.inputQueue[i];
+            }
+        } else {
+            return false;
+        }
+    }
+}
 JS;
         $event->appendJs($js, 'Mautic Core');
     }

--- a/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
@@ -34,33 +34,43 @@ class BuildJsSubscriber extends CommonSubscriber
     public function onBuildJs(BuildJsEvent $event)
     {
         $router = $this->factory->getRouter();
-        $trackingUrl = str_replace(
+        $pageTrackingUrl = str_replace(
             array('http://', 'https://'),
             '',
             $router->generate('mautic_page_tracker', [], UrlGeneratorInterface::ABSOLUTE_URL)
         );
 
         $js = <<<JS
-(function(m, l, n, d){
-    m.trackingPixelUrl = (l.protocol == 'https:' ? 'https:' : 'http:') + '//{$trackingUrl}';
-    
-    var params = {
-        page_title: d.title,
-        page_language: n.language,
-        page_referrer: (d.referrer) ? d.referrer.split('/')[2] : '',
-        page_url: l.href
-    };
-    
-    // Merge user defined tracking pixel parameters.
-    if (m.hasOwnProperty("trackingPixelParams")) {
-        for (var attr in m.trackingPixelParams) {
-            params[attr] = m.trackingPixelParams[attr];
+(function(m, l, n, d) {
+    m.pageTrackingUrl = (l.protocol == 'https:' ? 'https:' : 'http:') + '//{$pageTrackingUrl}';
+
+    m.sendPageview = function(pageview) {
+
+        var params = {
+            page_title: d.title,
+            page_language: n.language,
+            page_referrer: (d.referrer) ? d.referrer.split('/')[2] : '',
+            page_url: l.href
+        };
+        
+        // Merge user defined tracking pixel parameters.
+        if (typeof pageview[2] === 'object') {
+            for (var attr in pageview[2]) {
+                params[attr] = pageview[2][attr];
+            }
+        }
+
+        m.trackingPixel = (new Image()).src = m.pageTrackingUrl + '?' + m.serialize(params);
+    }
+
+    if (typeof m.getInput === 'function') {
+        var pageview = m.getInput('send', 'pageview');
+
+        if (pageview) {
+            m.sendPageview(pageview)
         }
     }
-    
-    m.trackingPixelUrl += '?' + m.serialize(params);
-    
-    m.trackingPixel = (new Image()).src = m.trackingPixelUrl;
+
 })(MauticJS, location, navigator, document);
 JS;
 

--- a/app/bundles/PageBundle/Translations/en_US/messages.ini
+++ b/app/bundles/PageBundle/Translations/en_US/messages.ini
@@ -179,3 +179,6 @@ mautic.trackable.click_counts.none="There are no URLs currently being tracked fo
 mautic.trackable.click_track_id="Tracking ID"
 mautic.trackable.click_unique_count="Unique Clicks"
 mautic.trackable.click_url="URL"
+
+mautic.config.tab.pagetracking="3rd party website tracking code"
+mautic.config.tab.pagetracking.info="Insert following code at the end of the web page before ending <code>&lt;body/&gt;</code> tag. Mautic Landing Pages are tracked automatically. Use this only to track 3rd party websites."

--- a/app/bundles/PageBundle/Views/FormTheme/Config/_config_pageconfig_widget.html.php
+++ b/app/bundles/PageBundle/Views/FormTheme/Config/_config_pageconfig_widget.html.php
@@ -21,4 +21,18 @@
             </div>
         <?php endforeach; ?>
     </div>
+    <div class="panel-heading">
+        <h3 class="panel-title"><?php echo $view['translator']->trans('mautic.config.tab.pagetracking'); ?></h3>
+    </div>
+    <div class="panel-body">
+    <p><?php echo $view['translator']->trans('mautic.config.tab.pagetracking.info'); ?></p>
+<pre>&lt;script&gt;
+    (function(w,d,t,u,n,a,m){w['MauticTrackingObject']=n;
+        w[n]=w[n]||function(){(w[n].q=w[n].q||[]).push(arguments)},a=d.createElement(t),
+        m=d.getElementsByTagName(t)[0];a.async=1;a.src=u;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','<?php echo $view['router']->generate('mautic_js', [], Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL); ?>','mt');
+
+    mt('send', 'pageview');
+&lt;/script&gt;</pre>
+    </div>
 </div>


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | N
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
I suggest to build the JS tracking API the way it will suite even future needs for example for event tracking. This way our users won't have to change their tracking code so often. Current implementation triggered pageview query every time the JS was loaded. It's not that different from using the tracking pixel.

So my improvements are:

### GA-like initiation
The tracking code will change from simple
```
<script>
    MauticJS.trackingPixelParams = {email: 'me@gmail.com'};
</script>
<script src="http://me.mautic.com/mtc.js"></script>
```
to
```
<script>
    (function(w,d,t,u,n,a,m){w['MauticTrackingObject']=n;
        w[n]=w[n]||function(){(w[n].q=w[n].q||[]).push(arguments)},a=d.createElement(t),
        m=d.getElementsByTagName(t)[0];a.async=1;a.src=u;m.parentNode.insertBefore(a,m)
    })(window,document,'script','http://mautic.io/mautic-github/index_dev.php/mtc.js','mt');

    mt('send', 'pageview', {email: 'me@gmail.com'});
</script>
```

Advantages:
- User will define the pageview when he wants, not necessarily on JS load. This will allow tracking for example single page applications which can execute many pageviews without JS loading.
- User can define how the global var for Mautic Tracking will be called to avoid JS conflicts. In this case it's called `mt`, but can be changed easily.
- Plugins/bundles can implement more tracking events. For example [GA has](https://developers.google.com/analytics/devguides/collection/analyticsjs/pages) 'pageviews', 'events', 'social', 'screenview', 'timing', 'exception'

The implementation at mtc.js is not optimal and I'm sure it can be improved (we can get rid of the global MauticJS variable now) and more features can be added, but now we can change it without need for changing the public tracking code. That's the main purpose of this PR.

Because the tracking code is becoming more complicated, this PR generates it for each Mautic in the configuration:
![mautic-tracking-code](https://cloud.githubusercontent.com/assets/1235442/15040273/b782cd40-12b3-11e6-88d3-bf5a8386dcea.png)

## Steps to test this PR
1. apply this PR
2. copy the tracking code from configuration to a 3rd party website
3. Check that the tracking works
4. Try to add some additional params like `mt('send', 'pageview', {email: 'me@gmail.com'});` and check that the tracked lead is recorded with that email. (The email field must be publicly updatable)