### PR TITLE
Fixed not being able to preview emails and only parse for links for emails to contacts

### DIFF
--- a/app/bundles/PageBundle/Entity/Redirect.php
+++ b/app/bundles/PageBundle/Entity/Redirect.php
@@ -14,6 +14,7 @@ use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\CoreBundle\Entity\FormEntity;
 use Doctrine\Common\Collections\ArrayCollection;
+use Mautic\EmailBundle\Entity\Email;
 
 /**
  * Class Redirect
@@ -54,6 +55,13 @@ class Redirect extends FormEntity
     private $trackables;
 
     /**
+     * @deprecated to be removed in 2.0
+     *
+     * @var
+     */
+    private $email;
+
+    /**
      * Redirect constructor.
      */
     public function __construct()
@@ -90,6 +98,9 @@ class Redirect extends FormEntity
             ->mappedBy('redirect')
             ->fetchExtraLazy()
             ->build();
+
+        // @deprecated to be removed in 2.0
+        $builder->addNamedField('email', 'integer', 'email_id', true);
     }
 
     /**
@@ -223,6 +234,34 @@ class Redirect extends FormEntity
     public function setTrackables($trackables)
     {
         $this->trackables = $trackables;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated to be removed in 2.0
+     *
+     * @return mixed
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * @deprecated to be removed in 2.0
+     *
+     * @param mixed $email
+     *
+     * @return Redirect
+     */
+    public function setEmail($email)
+    {
+        if ($email instanceof Email) {
+            $email = $email->getId();
+        }
+        
+        $this->email = $email;
 
         return $this;
     }

--- a/app/bundles/PageBundle/Entity/RedirectRepository.php
+++ b/app/bundles/PageBundle/Entity/RedirectRepository.php
@@ -51,7 +51,7 @@ class RedirectRepository extends CommonRepository
             );
         } else {
             $expr->add(
-                $q->expr()->eq('r.email', ':email')
+                $q->expr()->eq('r.email ', ':email')
             );
             $q->setParameter('email', $email);
         }

--- a/app/bundles/PageBundle/Entity/RedirectRepository.php
+++ b/app/bundles/PageBundle/Entity/RedirectRepository.php
@@ -51,7 +51,7 @@ class RedirectRepository extends CommonRepository
             );
         } else {
             $expr->add(
-                $q->expr()->eq('r.email ', ':email')
+                $q->expr()->eq('r.email', ':email')
             );
             $q->setParameter('email', $email);
         }


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      |  Y
| New feature?  | N 
| BC breaks?    |  N
| Deprecations? |  N
| Fixed issues  |  

## Description

Emails with links could not be previewed. Also previews (once fixed) and example emails, previews, and user based emails had links converted to lead trackables which isn't necessary. 

## Steps to reproduce the bug (if applicable)

With 1.4 codebase, create email with URL, save and preview. Should get an error.

## Steps to test this PR

Apply PR, repeat above and this time you should be able to preview the email. The link should be the original URL. Send the email to a lead and it should be converted to a trackable.