### PR TITLE
Attempting to fix issue where Doctrine sometimes mixes old and new fields when cloning

### DIFF
--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -566,7 +566,7 @@ class FormController extends CommonFormController
                                 $alias = $model->cleanAlias($entity->getName(), '', 10);
                                 $entity->setAlias($alias);
                             }
-                            
+
                             if (!$entity->getId()) {
                                 // Set timestamps because this is a new clone
                                 $model->setTimestamps($entity, true, false);
@@ -690,6 +690,12 @@ class FormController extends CommonFormController
 
                 $id    = $formField->getId();
                 $field = $formField->convertToArray();
+
+                if (!$id) {
+                    // Cloned entity
+                    $id = $field['id'] = $field['sessionId'] = 'new' . hash('sha1', uniqid(mt_rand()));
+                }
+
                 unset($field['form']);
 
                 if (isset($customComponents['fields'][$field['type']])) {
@@ -731,6 +737,11 @@ class FormController extends CommonFormController
 
                 $id     = $formAction->getId();
                 $action = $formAction->convertToArray();
+
+                if (!$id) {
+                    // Cloned entity so use a random Id instead
+                    $action['id'] = $id = 'new' . hash('sha1', uniqid(mt_rand()));
+                }
                 unset($action['form']);
 
                 $modifiedActions[$id] = $action;

--- a/app/bundles/FormBundle/Entity/Action.php
+++ b/app/bundles/FormBundle/Entity/Action.php
@@ -63,6 +63,15 @@ class Action
     private $changes;
 
     /**
+     * Reset properties on clone
+     */
+    public function __clone()
+    {
+        $this->id   = null;
+        $this->form = null;
+    }
+    
+    /**
      * @param ORM\ClassMetadata $metadata
      */
     public static function loadMetadata (ORM\ClassMetadata $metadata)

--- a/app/bundles/FormBundle/Entity/Field.php
+++ b/app/bundles/FormBundle/Entity/Field.php
@@ -127,6 +127,15 @@ class Field
     private $sessionId;
 
     /**
+     * Reset properties on clone
+     */
+    public function __clone()
+    {
+        $this->id   = null;
+        $this->form = null;
+    }
+
+    /**
      * @param ORM\ClassMetadata $metadata
      */
     public static function loadMetadata (ORM\ClassMetadata $metadata)


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N 
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  

## Description

Sometimes (not always), when cloning a form, fields meant for the new form are added to the original form or visa versa. This issue seems to be inconsistently consistent and has not been reproducible based on specific steps. But it has happened often enough to be a definite issue.

When trying to debug this, I found that field and action IDs remained intact when cloning. I think that this caused Doctrine to change the original fields in some cases. Again, not sure what that case is since it's not consistent. But in an attempt to squash this bug, this PR simply ensures that cloned fields and actions have no association with the original

## Steps to reproduce the bug (if applicable)

Not sure. But I think it has something to do with Doctrine black magic in it's ORM and some unknown outside factor.

## Steps to test this PR

Mainly ensure cloning still works correctly. Clone a form, add and remove a field or two and actions then save. Ensure that the original form is still intact and that the new clone only has it's data.