### PR TITLE
Fixed links containing ampersands not getting tracked

### DIFF
--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -338,7 +338,7 @@ class TrackableModel extends CommonModel
             // For HTML, replace only the links; leaving the link text (if a URL) intact
             foreach ($this->contentReplacements['second_pass'] as $search => $replace) {
                 $content = preg_replace(
-                    '/<a(.*?) href=(["\'])'.preg_quote($search, '/').'(.*?)\\2(.*?)>/i',
+                    '/<a(.*?) href=(["\'])'.preg_quote(str_replace('&', '&amp;', $search), '/').'(.*?)\\2(.*?)>/i',
                     '<a$1 href=$2'.$replace.'$3$2$4>',
                     $content
                 );


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      |  Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  

## Description

Links containing ampersands were not replaced with trackable token because preg_replace search|replace parameters didn't match since the ampersands of URL are saved to DB as ``&`` (I think it's forced on ``app/bundles/PageBundle/Model/RedirectModel.php``) and inside content are like ``&amp;``

## Steps to reproduce the bug

With 1.4 codebase, create email with links containing ampersands and send it in a campaign or list to yourself. You should see that the URLs are not tracked by Mautic (original ones shown)

## Steps to test this PR
Apply PR, repeat above and this time you should see URLs of your links as <your_mautic_domain>/<tracking_id> (they're tracked now)