### PR TITLE
Campaign pie chart label fix

### DIFF
--- a/app/bundles/CampaignBundle/Assets/css/campaign.css
+++ b/app/bundles/CampaignBundle/Assets/css/campaign.css
@@ -129,3 +129,7 @@
 .campaign-event-buttons .btn-edit {
     background: #337ab7;
 }
+
+.stat-boxes .pie-legend li {
+    display: inline;
+}

--- a/app/bundles/DashboardBundle/Assets/css/dashboard.css
+++ b/app/bundles/DashboardBundle/Assets/css/dashboard.css
@@ -84,10 +84,10 @@
     width: 30px;
 }
 
-.dashboard-widgets .chart-wrapper {
+.chart-wrapper {
     position: relative;
 }
-.dashboard-widgets .legend {
+.chart-wrapper .legend {
     background: #000;
     opacity: 0;
     position: absolute;
@@ -99,19 +99,19 @@
     color: #fff;
     -webkit-transition: all 0.3s ease-in-out;
 }
-.dashboard-widgets .card:hover .legend {
+.chart-wrapper:hover .legend {
     opacity: 0.8;
 }
-.dashboard-widgets .legend ul {
+.chart-wrapper .legend ul {
     list-style: none;
     margin: 0;
     padding: 5px 0;
 }
-.dashboard-widgets .legend li {
+.chart-wrapper .legend li {
     margin: 0 10px;
     padding: 5px 0;
 }
-.dashboard-widgets .legend li span {
+.chart-wrapper .legend li span {
     display: inline-block;
     width: 14px;
     height: 8px;

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1457,7 +1457,7 @@ class EmailModel extends FormModel
         $read = $query->fetchCount($readQ);
         $failed = $query->fetchCount($failedQ);
 
-        $chart->setDataset($this->factory->getTranslator()->trans('mautic.email.graph.pie.ignored.read.failed.ignored'), ($sent - $read));
+        $chart->setDataset($this->factory->getTranslator()->trans('mautic.email.graph.pie.ignored.read.failed.ignored'), ($sent - $read - $failed));
         $chart->setDataset($this->factory->getTranslator()->trans('mautic.email.graph.pie.ignored.read.failed.read'), $read);
         $chart->setDataset($this->factory->getTranslator()->trans('mautic.email.graph.pie.ignored.read.failed.failed'), $failed);
 


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
The new chart library generates the labels automatically. The labels for pie chart on campaign detail wasn't styled:
![mautic-campaign-pie-label](https://cloud.githubusercontent.com/assets/1235442/15113866/2560d9a6-15f7-11e6-876e-56103d2bc239.png)

Now the labels appear on hover like this:
![mautic-campaign-pie-label-fixed](https://cloud.githubusercontent.com/assets/1235442/15113876/3728e5d4-15f7-11e6-8264-18a065ed2e1b.png)

## Steps to test this PR
Go to a campaign detail page. The best would be if the campaign has some emails sent. You should see the labels like on the first picture. Apply this PR and you'll see the labels styled.

Also the labels have to still work at the dashboard pie widgets.
