### PR TITLE
Fix the last page button to actually jump to the last page

### DIFF
--- a/app/bundles/CoreBundle/Views/Helper/pagination.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/pagination.html.php
@@ -73,10 +73,10 @@ endif;
     <div class="<?php echo $paginationWrapper; ?>">
         <ul class="pagination nm <?php echo $pageClass; ?>">
             <?php
-            $urlPage = "/" . ($page - $range);
-            $url     = (($page - $range) > 0) ? $baseUrl . $urlPage . $queryString : 'javascript: void(0);';
+            $urlPage = "/1";
+            $url     = ($page > 1) ? $baseUrl . $urlPage . $queryString : 'javascript: void(0);';
             $data    = ($url == 'javascript: void(0);') ? '' : ' data-toggle="ajax" data-target="' . $target . '"' . $menuLink;
-            $class   = (($page - $range) <= 0) ? ' class="disabled"' : '';
+            $class   = ($page <= 1) ? ' class="disabled"' : '';
             ?>
             <li<?php echo $class; ?>>
                 <?php  ?>
@@ -138,7 +138,7 @@ endif;
             $urlPage = "/" . $totalPages;
             $url     = ($page < $totalPages && $totalPages > $range) ? $baseUrl . $urlPage . $queryString : 'javascript: void(0);';
             $data    = ($url == 'javascript: void(0);') ? '' : ' data-toggle="ajax" data-target="' . $target . '"' . $menuLink;
-            $class   = (($page + $range) == $totalPages || $page === $totalPages) ? ' class="disabled"' : '';
+            $class   = ($page === $totalPages) ? ' class="disabled"' : '';
             ?>
             <li<?php echo $class; ?>>
                 <?php  ?>

--- a/app/bundles/CoreBundle/Views/Helper/pagination.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/pagination.html.php
@@ -135,9 +135,7 @@ endif;
             </li>
 
             <?php
-            $urlPage = "/" . ($page + $range);
-            if (($page + $range) > $totalPages)
-                $urlPage = "/" . $totalPages;
+            $urlPage = "/" . $totalPages;
             $url     = ($page < $totalPages && $totalPages > $range) ? $baseUrl . $urlPage . $queryString : 'javascript: void(0);';
             $data    = ($url == 'javascript: void(0);') ? '' : ' data-toggle="ajax" data-target="' . $target . '"' . $menuLink;
             $class   = (($page + $range) == $totalPages || $page === $totalPages) ? ' class="disabled"' : '';

--- a/app/bundles/CoreBundle/Views/Helper/pagination.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/pagination.html.php
@@ -136,7 +136,7 @@ endif;
 
             <?php
             $urlPage = "/" . $totalPages;
-            $url     = ($page < $totalPages && $totalPages > $range) ? $baseUrl . $urlPage . $queryString : 'javascript: void(0);';
+            $url     = ($page < $totalPages) ? $baseUrl . $urlPage . $queryString : 'javascript: void(0);';
             $data    = ($url == 'javascript: void(0);') ? '' : ' data-toggle="ajax" data-target="' . $target . '"' . $menuLink;
             $class   = ($page === $totalPages) ? ' class="disabled"' : '';
             ?>


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  #1464 

## Description

Fixes the issue addressed in #1464 where the "final page" button in list view didn't actually take you to the final page, but rather jumped you forward 4 pages. 

## Steps to reproduce the bug (if applicable)

Add ~200 leads (something to produce more than 4 pages worth given the selected number / page (default 20). Click the last button, and you'll only be jumped forward 4 pages.

## Steps to test this PR

Apply the PR, and follow the reproduction steps. This time, you'll actually be taken to the last page for the list.