### PR TITLE
Fixed email URLs not being properly tracked

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -103,6 +103,14 @@ class EmailModel extends FormModel
             $entity->setRevision($revision);
         }
 
+        // Ensure links in HTML don't have double encoded ampersands
+        $htmlContent = $this->cleanUrlsInContent($entity->getCustomHtml());
+        $entity->setCustomHtml($htmlContent);
+
+        // Ensure links in PLAIN TEXT don't have double encoded ampersands
+        $plainContent = $this->cleanUrlsInContent($entity->getPlainText());
+        $entity->setPlainText($plainContent);
+
         // Reset the variant hit and start date if there are any changes and if this is an A/B test
         // Do it here in addition to the blanket resetVariants call so that it's available to the event listeners
         $changes = $entity->getChanges();
@@ -1562,5 +1570,30 @@ class EmailModel extends FormModel
         );
 
         return $upcomingEmails;
+    }
+
+    /**
+     * Check all links in content and remove &amp;
+     * This even works with double encoded ampersands
+     *
+     * @param string $content
+     *
+     * @return string
+     */
+    private function cleanUrlsInContent($content)
+    {
+        if (preg_match_all('/((https?|ftps?):\/\/)([a-zA-Z0-9-\.{}]*[a-zA-Z0-9=}]*)(\??)([^\s\"\]]+)?/i', $content, $matches)) {
+            foreach ($matches[0] as $url) {
+                $newUrl = $url;
+
+                while (strpos($newUrl, '&amp;') !== false) {
+                    $newUrl = str_replace('&amp;', '&', $newUrl);
+                }
+
+                $content = str_replace($url, $newUrl, $content);
+            }
+        }
+
+        return $content;
     }
 }

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -103,11 +103,22 @@ class EmailModel extends FormModel
             $entity->setRevision($revision);
         }
 
-        // Ensure links in HTML don't have double encoded ampersands
-        $htmlContent = $this->cleanUrlsInContent($entity->getCustomHtml());
-        $entity->setCustomHtml($htmlContent);
+        // Ensure links in template content don't have encoded ampersands
+        if ($entity->getTemplate()) {
+            $content = $entity->getContent();
 
-        // Ensure links in PLAIN TEXT don't have double encoded ampersands
+            foreach ($content as $key => $value) {
+                $content[$key] = $this->cleanUrlsInContent($value);
+            }
+
+            $entity->setContent($content);
+        } else {
+            // Ensure links in HTML don't have encoded ampersands
+            $htmlContent = $this->cleanUrlsInContent($entity->getCustomHtml());
+            $entity->setCustomHtml($htmlContent);
+        }
+
+        // Ensure links in PLAIN TEXT don't have encoded ampersands
         $plainContent = $this->cleanUrlsInContent($entity->getPlainText());
         $entity->setPlainText($plainContent);
 

--- a/app/bundles/PageBundle/Model/RedirectModel.php
+++ b/app/bundles/PageBundle/Model/RedirectModel.php
@@ -82,7 +82,9 @@ class RedirectModel extends FormModel
         }
 
         // Ensure the URL saved to the database does not have encoded ampersands
-        $url = str_replace('&amp;', '&', $url);
+        while (strpos($url, '&amp;') !== false) {
+            $url = str_replace('&amp;', '&', $url);
+        }
 
         $repo     = $this->getRepository();
         $redirect = $repo->findOneBy(array('url' => $url));

--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -338,7 +338,7 @@ class TrackableModel extends CommonModel
             // For HTML, replace only the links; leaving the link text (if a URL) intact
             foreach ($this->contentReplacements['second_pass'] as $search => $replace) {
                 $content = preg_replace(
-                    '/<a(.*?) href=(["\'])'.preg_quote($search, '/').'(.*?)\\2(.*?)>/i',
+                    '/<a(.*?) href=(["\'])'.preg_quote(str_replace('&', '&amp;', $search), '/').'(.*?)\\2(.*?)>/i',
                     '<a$1 href=$2'.$replace.'$3$2$4>',
                     $content
                 );

--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -101,7 +101,9 @@ class TrackableModel extends CommonModel
         }
 
         // Ensure the URL saved to the database does not have encoded ampersands
-        $url = str_replace('&amp;', '&', $url);
+        while (strpos($url, '&amp;') !== false) {
+            $url = str_replace('&amp;', '&', $url);
+        }
 
         $trackable = $this->getRepository()->findByUrl($url, $channel, $channelId);
         if ($trackable == null) {
@@ -338,7 +340,7 @@ class TrackableModel extends CommonModel
             // For HTML, replace only the links; leaving the link text (if a URL) intact
             foreach ($this->contentReplacements['second_pass'] as $search => $replace) {
                 $content = preg_replace(
-                    '/<a(.*?) href=(["\'])'.preg_quote(str_replace('&', '&amp;', $search), '/').'(.*?)\\2(.*?)>/i',
+                    '/<a(.*?) href=(["\'])'.preg_quote($search, '/').'(.*?)\\2(.*?)>/i',
                     '<a$1 href=$2'.$replace.'$3$2$4>',
                     $content
                 );
@@ -358,7 +360,7 @@ class TrackableModel extends CommonModel
     /**
      * Find URLs in HTML and parse into trackables
      *
-     * @param  $html HTML content
+     * @param  string $html HTML content
      *
      * @return array
      */
@@ -398,7 +400,7 @@ class TrackableModel extends CommonModel
     /**
      * Find URLs in plain text and parse into trackables
      *
-     * @param  $text Plain text content
+     * @param  string $text Plain text content
      *
      * @return array
      */
@@ -452,7 +454,9 @@ class TrackableModel extends CommonModel
         $url = trim($url);
 
         // Ensure these are & for the sake of parsing
-        $url = str_replace('&amp;', '&', $url);
+        while (strpos($url, '&amp;') !== false) {
+            $url = str_replace('&amp;', '&', $url);
+        }
 
         // Default key and final URL to the given $url
         $trackableKey = $trackableUrl = $url;


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  N/A

## Description

See #1702. URL's with encoded ampersands were not being properly tracked. Fixed by ensuring all links in all content areas and custom html do not have encoded ampersands when saved to the database. Previously, ckeditor would send custom html content with ampersands (sometimes double encoded `&amp;amp;`), and plain text content not encoded. This had the effect of really complicating the parsing rules when working with the entity.

## Steps to reproduce the bug (if applicable)

With 1.4 codebase, create email with links containing ampersands and send it in a campaign or list to yourself. You should see that the URLs are not tracked by Mautic (original ones shown)

Also, when creating the email, make sure to manually type out the `&amp;` on your link before you save it. When you save, view the content of the email either in the editor or in the db, and you'll see the `&amp;` has been correctly replaced with `&`;

## Steps to test this PR

Apply PR, repeat above and this time you should see URLs of your links as / (they're tracked now)