### PR TITLE
Somehow forgotten PHP var removed from HTML

### DIFF
--- a/app/bundles/PageBundle/Views/Page/details.html.php
+++ b/app/bundles/PageBundle/Views/Page/details.html.php
@@ -130,7 +130,7 @@ $view['slots']->set(
                                         <?php echo $view['translator']->trans('mautic.page.pageviews'); ?>
                                     </h5>
                                 </div>
-                                <div class="col-xs-4 va-t text-right">$hasVariants
+                                <div class="col-xs-4 va-t text-right">
                                     <h3 class="text-white dark-sm"><span class="fa fa-eye"></span></h3>
                                 </div>
                             </div>


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
The detail of Mautic Landing Pages displays a PHP variable:
![mautic-hasvariants](https://cloud.githubusercontent.com/assets/1235442/15143677/40dd5ec0-16ab-11e6-8b8f-4f0722452ca3.png)

## Steps to test this PR
Apply this PR and the variable will be gone.
