### PR TITLE
Fixed issue where live URLs in the do not track array would fail

### DIFF
--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -28,7 +28,6 @@ class BuilderSubscriber extends CommonSubscriber
     private $shareButtonsRegex = '{sharebuttons}';
     private $emailIsInternalSend = false;
     private $emailEntity = null;
-    private $emailTrackedLinkSettings = array();
 
     /**
      * {@inheritdoc}

--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -542,7 +542,7 @@ class TrackableModel extends CommonModel
     {
         // Ensure it's not in the do not track list
         foreach ($this->doNotTrack as $notTrackable) {
-            if (preg_match('/'.preg_quote($notTrackable).'/i', $url)) {
+            if (preg_match('/'.preg_quote($notTrackable, '/').'/', $url)) {
 
                 return true;
             }

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
@@ -228,7 +228,7 @@ class TrackableModelTest extends WebTestCase
 
         $this->assertEmpty($trackables, $content);
     }
-    
+
     /**
      * @testdox Test that tokens that are supposed to be ignored are
      *
@@ -252,6 +252,28 @@ class TrackableModelTest extends WebTestCase
 
         $this->assertEmpty($trackables, $content);
         $this->assertFalse(strpos($url, $content), 'https:// should have been stripped from the token URL');
+    }
+
+    /**
+     * @testdox Test that a URL injected into the do not track list is not converted
+     *
+     * @covers Mautic\PageBundle\Model\TrackableModel::validateTokenIsTrackable
+     * @covers Mautic\PageBundle\Model\TrackableModel::parseContentForTrackables
+     * @covers Mautic\PageBundle\Model\TrackableModel::prepareUrlForTracking
+     */
+    public function testIgnoredUrlDoesNotCrash()
+    {
+        $url   = 'https://domain.com';
+        $model = $this->getModel($url, null, array($url));
+
+        list($content, $trackables) = $model->parseContentForTrackables(
+            $this->generateContent($url, 'html'),
+            array(),
+            'email',
+            1
+        );
+
+        $this->assertTrue((strpos($content, $url) !== false), $content);
     }
 
     /**


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    |  N
| Deprecations? | 
| Fixed issues  |  

## Description

This PR fixes two scenarios:

1. If a plugin injects an actual URL into the do not track event listener, preg_match would kill over due to // in the URL

2. If a token that is set as to not be tracked is prefixed with a schema, the schema is not removed since the tokens always have a schema in the value. 

## Steps to reproduce the bug (if applicable)

1. Not easy to reproduce without coding a listener or hacking code
2. Create an email with just `https://{unsubscribe_url}` (no other URL) and send it. The URL will result in `https://http://somedomain.com...`

## Steps to test this PR

Apply the PR, run the tests included and ensure success. Repeat #2 and it should result in `http://somedomain.com...`