### PR TITLE
Fixed PHP error when a landing page contained the Facebook share button

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -358,18 +358,15 @@ class LeadController extends FormController
         $eventTypes   = $event->getEventTypes();
 
         // Get an engagement count
-        $translator     = $this->factory->getTranslator();
-
-        $fromDate       = (new \DateTime('first day of this month 00:00:00'))->modify('-6 months');
-        $toDate         = new \DateTime;
+        $translator  = $this->factory->getTranslator();
+        $fromDate    = (new \DateTime('first day of this month 00:00:00'))->modify('-6 months');
+        $toDate      = new \DateTime;
         $engagements = array();
-        $total          = 0;
+        $events      = array();
 
-        $events = array();
         foreach ($eventsByDate as $eventDate => $dateEvents) {
-            $datetime = \DateTime::createFromFormat('Y-m-d H:i', $eventDate);
+            $datetime = new \DateTime($eventDate);
             if ($datetime > $fromDate) {
-                $total++;
                 $engagements[] = array(
                     'date' => $eventDate,
                     'data' => 1

--- a/plugins/MauticSocialBundle/Views/Integration/Facebook/share.html.php
+++ b/plugins/MauticSocialBundle/Views/Integration/Facebook/share.html.php
@@ -8,9 +8,7 @@
  */
 
 $locale    = $app->getRequest()->getLocale();
-
-$settings = $field['properties'];
-
+$settings  = (!empty($field['properties'])) ? $field['properties'] : array();
 $layout    = (!empty($settings['layout'])) ? $settings['layout'] : 'standard';
 $action    = (!empty($settings['action'])) ? $settings['action'] : 'like';
 $showFaces = (!empty($settings['showFaces'])) ? 'true' : 'false';


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
Facebook share button caused PHP error `500 Internal Server Error - Notice: Undefined variable: field at plugins/MauticSocialBundle/Views/Integration/Facebook/share.html.php (line #12)` on landing page detail.

And it accidentally contains another fix which should be in the ChartJS 2.0 PR.

## Steps to reproduce the bug (if applicable)
1. Create a landing page.
2. Select a theme for that page.
3. Drag the social buttons to that page.
4. Save.
5. View the page at the public URL.

1. Open a contact detail. 
The Engagement dataset in the line chart is empty even though there are some engagements in the timeline for the past 6 month.

You should get the PHP error above.

## Steps to test this PR
Apply this PR and refresh the page on the public URL. The page should display without any error. 

And the engagement dataset contains the correct values.
