### PR TITLE
Accidental PHP 5.4 array syntax replaced with PHP 5.3 syntax

### DIFF
--- a/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
+++ b/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
@@ -34,7 +34,7 @@ class SmsApiController extends CommonApiController
         $from = $this->request->get('From');
 
         if ($body === 'STOP' && $this->factory->getHelper('sms')->unsubscribe($from)) {
-            return new Response("<Response><Sms>You have been unsubscribed.</Sms></Response>", 200, ['Content-Type' => 'text/xml; charset=utf-8']);
+            return new Response("<Response><Sms>You have been unsubscribed.</Sms></Response>", 200, array('Content-Type' => 'text/xml; charset=utf-8');
         }
 
         // Return an empty response

--- a/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
+++ b/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
@@ -34,7 +34,7 @@ class SmsApiController extends CommonApiController
         $from = $this->request->get('From');
 
         if ($body === 'STOP' && $this->factory->getHelper('sms')->unsubscribe($from)) {
-            return new Response("<Response><Sms>You have been unsubscribed.</Sms></Response>", 200, array('Content-Type' => 'text/xml; charset=utf-8');
+            return new Response("<Response><Sms>You have been unsubscribed.</Sms></Response>", 200, array('Content-Type' => 'text/xml; charset=utf-8'));
         }
 
         // Return an empty response


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  https://www.mautic.org/community/index.php/3365-parse-error-with-sms-bundle-problem-installing-1-4-on-server/0#p10202

## Description
array syntax `[]` changed to `array()` to be compatible with PHP 5.3.

## Steps to reproduce the bug (if applicable)
Try to use Mautic with PHP 5.3.

## Steps to test this PR
Apply this PR and the error should be gone.
