### PR TITLE
Select custom field

### DIFF
--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -495,7 +495,7 @@ Mautic.updateLeadFieldProperties = function(selectedVal) {
 
     if (selectedVal === 'datetime' || selectedVal === 'date' || selectedVal === 'time') {
         Mautic.activateDateTimeInputs(defaultValueField, selectedVal);
-    } else {
+    } else if (defaultValueField.hasClass('calendar-activated')) {
         defaultValueField.datetimepicker('destroy').removeClass('calendar-activated');
     }
 };

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -463,7 +463,7 @@ Mautic.updateLeadFieldProperties = function(selectedVal) {
     if (mQuery('#field-templates .'+selectedVal).length) {
         mQuery('#leadfield_properties').html('');
         mQuery('#leadfield_properties').append(mQuery('#field-templates .'+selectedVal).clone(true));
-    } else {
+    } else if (!mQuery('#leadfield_properties .'+selectedVal).length) {
         mQuery('#leadfield_properties').html('');
     }
 


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  https://www.mautic.org/community/index.php/3369-adding-new-option-to-custom-select-field/0#p10213

## Description
Select custom field doesn't show created options.

## Steps to reproduce the bug (if applicable)
Open a custom field type of select. Create one with some options if you don't have any and save. The options are not visible.

## Steps to test this PR
Apply this PR and the options should appear after refresh. Make sure that creating new select field let you create options.