### PR TITLE
Changed the auto_enter mode from ckeditor to BR instead of P

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/config.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/config.js
@@ -12,7 +12,7 @@ CKEDITOR.editorConfig = function( config ) {
     config.extraPlugins  = 'sourcedialog';
     config.removePlugins = 'flash,forms,iframe';
 
-    config.enterMode = CKEDITOR.ENTER_P;
+    config.enterMode = CKEDITOR.ENTER_BR;
     config.fillEmptyBlocks = false;
     config.filebrowserImageBrowseUrl = mauticBasePath + '/' + mauticAssetPrefix + 'app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/index.html?type=Images';
     config.filebrowserBrowseUrl = mauticBasePath + '/' + mauticAssetPrefix + 'app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/index.html';


### PR DESCRIPTION
Please answer the following questions:

| Q              | A
| ------------- | ---
| Bug fix?    | yes - https://github.com/mautic/mautic/issues/1106
| New feature?  | no
| BC breaks?  | no
| Deprecations? | no
| Fixed issues  | 

## Description
Change the standard behaviour of the ckeditor enter mode from paragraph <p> to line break <br>. This is because for email formatting the <p> is really messing up the styling within gmail web client

## Steps to reproduce the bug (if applicable)
Create an email template with a slot
Create an email and enter text into the slot
Check the generated code for the wrapping <p>

## Steps to test this PR
Create an email template with a slot
Create an email and enter text into the slot
Check the generated code that no <p> is generated
Check the email quality within the gmail web client

