### PR TITLE
Correction open email negative decision

### DIFF
--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -318,7 +318,10 @@ class EventModel extends CommonFormModel
                             $logger->debug('CAMPAIGN: ID# '.$child['id'].' is a decision');
 
                             continue;
-                        } else {
+                        } elseif ($child['decisionPath'] == 'no') {
+                            // non-action paths should not be processed by this because the contact already took action in order to get here
+                            $childrenTriggered = true;
+                        }else {
                             $logger->debug('CAMPAIGN: '.ucfirst($child['eventType']).' ID# '.$child['id'].' is being processed');
                         }
 
@@ -727,7 +730,7 @@ class EventModel extends CommonFormModel
             return false;
         }
 
-        if ($event['eventType'] == 'condition' || $event['eventType'] == 'action') {
+        if ($event['eventType'] == 'condition') {
             $allowNegative = true;
         }
 

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -727,7 +727,7 @@ class EventModel extends CommonFormModel
             return false;
         }
 
-        if ($event['eventType'] == 'condition') {
+        if ($event['eventType'] == 'condition' || $event['eventType'] == 'action') {
             $allowNegative = true;
         }
 


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  Y

## Description
In some case, decision not open mail not working.

## Steps to reproduce the bug (if applicable)
See campaigns on issue #1432  
This should resolve issue #1454 also


I did tests, but I am not 100% sure it does not impact other campagns actions.
The main difference is that the positive events (ie email open) are saved in campaign_lead_event_log table in all cases.



