### PR TITLE
Fixes a bug where integer casting array_keys were not saved to local config file

### DIFF
--- a/app/bundles/CoreBundle/Configurator/Configurator.php
+++ b/app/bundles/CoreBundle/Configurator/Configurator.php
@@ -251,7 +251,7 @@ class Configurator
 
         $count = $counter = count($array);
         foreach ($array as $key => $value) {
-            if (is_string($key)) {
+            if (is_string($key) or is_numeric($key)) {
                 if ($counter === $count) {
                     $string .= str_repeat("\t", $level + 1);
                 }


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  #1757

## Description
If we take a look at [PHP manual](http://php.net/manual/en/language.types.array.php) refering to Array types, we can read this:

```
The key can either be an integer or a string. The value can be of any type.
Additionally the following key casts will occur:
Strings containing valid integers will be cast to the integer type. E.g. the key "8" will actually be stored under 8. On the other hand "08" will not be cast, as it isn't a valid decimal integer.
```

That means, any array key casting to integer, PHP will convert it to integer, so if the array key it's "301" or "302" as in this case, the following condition returned `false`:

```php
if (is_string($key))
{
    //do whatever
}
```

## Steps to reproduce the bug
Available at #1757

## Steps to test this PR
Follow the #1757 steps, your page doesn't redirect and an error is thrown.

On a clean install (because if `app/config/local.php` contains already the parameter `redirect_list_types`, this will fail forever because the parameter (wrong one) is taken from there...

Apply this PR, go to "Configuration" and hit "Apply" or "Save & close", make sure your `app/config/local.php` contains the right value under redirect_list_types parameter (array with "301" and "302" keys) and retest again. Now the page should get redirected correctly (keep in mind that only Unpublished pages are redirected)

…ot parsed correctly