### PR TITLE
Improve pending email count query times

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -246,7 +246,8 @@ class EmailRepository extends CommonRepository
         } else {
             $q->select('l.*');
 
-            // join a derived table of leads belonging to the lead lists
+            // use a derived table in order to retrieve distinct leads in case they belong to multiple
+            // lead lists associated with this email
             $listQb = $this->getEntityManager()->getConnection()->createQueryBuilder();
             $listQb->select('distinct(ll.lead_id) lead_id')
                 ->from(MAUTIC_TABLE_PREFIX . 'lead_lists_leads', 'll')

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -230,29 +230,37 @@ class EmailRepository extends CommonRepository
             $listIds = array($listIds);
         }
 
-        $listQb = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $listQb->select('null')
-            ->from(MAUTIC_TABLE_PREFIX . 'lead_lists_leads', 'll')
-            ->where(
-                $listQb->expr()->andX(
-                    $listQb->expr()->in('ll.leadlist_id', $listIds),
-                    $listQb->expr()->eq('ll.lead_id', 'l.id'),
-                    $listQb->expr()->eq('ll.manually_removed', ':false')
-                )
-            );
-
         // Main query
         $q  = $this->getEntityManager()->getConnection()->createQueryBuilder();
         if ($countOnly) {
-            $q->select('count(l.id) as count');
+            // distinct with an inner join seems faster
+            $q->select('count(distinct(l.id)) as count');
+
+            $q->innerJoin('l', MAUTIC_TABLE_PREFIX . 'lead_lists_leads', 'll',
+                $q->expr()->andX(
+                    $q->expr()->in('ll.leadlist_id', $listIds),
+                    $q->expr()->eq('ll.lead_id', 'l.id'),
+                    $q->expr()->eq('ll.manually_removed', ':false')
+                )
+            );
         } else {
-            $q->select('l.*')
-                ->orderBy('l.id');
+            $q->select('l.*');
+
+            // join a derived table of leads belonging to the lead lists
+            $listQb = $this->getEntityManager()->getConnection()->createQueryBuilder();
+            $listQb->select('distinct(ll.lead_id) lead_id')
+                ->from(MAUTIC_TABLE_PREFIX . 'lead_lists_leads', 'll')
+                ->where(
+                    $listQb->expr()->andX(
+                        $listQb->expr()->in('ll.leadlist_id', $listIds),
+                        $listQb->expr()->eq('ll.manually_removed', ':false')
+                    )
+                );
+            $q->innerJoin('l', sprintf('(%s)', $listQb->getSQL()), 'in_list', 'l.id = in_list.lead_id');
         }
         $q->from(MAUTIC_TABLE_PREFIX.'leads', 'l')
             ->andWhere(sprintf('NOT EXISTS (%s)', $dncQb->getSQL()))
             ->andWhere(sprintf('NOT EXISTS (%s)', $statQb->getSQL()))
-            ->andWhere(sprintf('EXISTS (%s)', $listQb->getSQL()))
             ->setParameter('false', false, 'boolean');
 
         // Has an email


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | N
| New feature?  | N 
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  

## Description

This optimizes the query generating the pending email counts which seems to yield faster query times for large data sets. In my test database of 2M leads, it was a difference of seconds versus milliseconds.

## Steps to test this PR

Apply the PR then ensure that pending email counts are accurate based on your setup and that emails sent is accurate. Also try including a contact in multiple segments to ensure it is not double counted.
