### PR TITLE
Add Réunion region

### DIFF
--- a/app/bundles/CoreBundle/Assets/json/regions.json
+++ b/app/bundles/CoreBundle/Assets/json/regions.json
@@ -985,6 +985,7 @@
 		"Puy-de-D\u00f4me",
 		"Pyr\u00e9n\u00e9es-Atlantiques",
 		"Pyr\u00e9n\u00e9es-Orientales",
+		"R%C3%A9union",
 		"Rh\u00f4ne",
 		"Sa\u00f4ne-et-Loire",
 		"Sarthe",

--- a/app/bundles/CoreBundle/Assets/json/regions.json
+++ b/app/bundles/CoreBundle/Assets/json/regions.json
@@ -985,7 +985,7 @@
 		"Puy-de-D\u00f4me",
 		"Pyr\u00e9n\u00e9es-Atlantiques",
 		"Pyr\u00e9n\u00e9es-Orientales",
-		"R%C3%A9union",
+		"R\u00e9union",
 		"Rh\u00f4ne",
 		"Sa\u00f4ne-et-Loire",
 		"Sarthe",


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Yes|
| New feature?  | No|
| BC breaks?    | No|
| Deprecations? | No|
| Fixed issues  |  No|

## Description
I make WordPress Plugin that connect WooCommerce and Mautic.
I found the region named "Réunion" is missing.
https://github.com/woothemes/woocommerce/blob/master/i18n/countries.php#L198

### What about Reunion ?
Réunion (French: La Réunion, IPA: [la ʁeynjɔ̃] ( listen); previously Île Bourbon) is an insular region of France located in the Indian Ocean. It is situated east of Madagascar and about 175 kilometres (109 mi) southwest of Mauritius, the nearest island. As of 2014, its population numbered 844,994 inhabitants.
https://en.wikipedia.org/wiki/R%C3%A9union

## Steps to reproduce the bug (if applicable)
- Go to "Contacts".
- push "+ New" button
- Search "Réunion" on "State" select box, and "Réunion" is not found.

## Steps to test this PR
- Go to "Contacts".
- push "+ New" button
- Search "Réunion" on "State" select box, and "Réunion" is found.
