### PR TITLE
Fixes php 5.4 code syntax

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -104,6 +104,7 @@ class LeadEventLogRepository extends EntityRepository
         $leadIps = array();
 
         $query = $this->_em->getConnection()->createQueryBuilder();
+        $today = new DateTimeHelper();
         $query->from(MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'll')
             ->select('ll.event_id,
                     ll.campaign_id,
@@ -118,7 +119,7 @@ class LeadEventLogRepository extends EntityRepository
             ->leftJoin('ll', MAUTIC_TABLE_PREFIX.'campaigns', 'c', 'c.id = e.campaign_id')
             ->leftJoin('ll', MAUTIC_TABLE_PREFIX.'leads', 'l', 'l.id = ll.lead_id')
             ->where($query->expr()->gte('ll.trigger_date', ':today'))
-            ->setParameter('today', (new DateTimeHelper)->toUtcString());
+            ->setParameter('today', $today->toUtcString());
 
         if (isset($options['lead'])) {
             /** @var \Mautic\CoreBundle\Entity\IpAddress $ip */

--- a/app/bundles/CoreBundle/Form/Type/DateRangeType.php
+++ b/app/bundles/CoreBundle/Form/Type/DateRangeType.php
@@ -39,20 +39,24 @@ class DateRangeType extends AbstractType
     {
         $humanFormat = 'M j, Y';
 
+        $thirtyDays = new \DateTime('-30 days');
+        $dateFrom   = new \DateTime($options['data']['date_from']);
         $builder->add('date_from', 'text', array(
             'label'      => 'mautic.core.date.from',
             'label_attr' => array('class' => 'control-label'),
             'attr'       => array('class' => 'form-control'),
             'required'   => false,
-            'data'       => empty($options['data']['date_from']) ? (new \DateTime('-30 days'))->format($humanFormat) : (new \DateTime($options['data']['date_from']))->format($humanFormat),
+            'data'       => empty($options['data']['date_from']) ? $thirtyDays->format($humanFormat) : $dateFrom->format($humanFormat),
         ));
 
+        $now    = new \DateTime();
+        $dateTo = new \DateTime($options['data']['date_to']);
         $builder->add('date_to', 'text', array(
             'label'      => 'mautic.core.date.to',
             'label_attr' => array('class' => 'control-label'),
             'attr'       => array('class' => 'form-control'),
             'required'   => false,
-            'data'       => empty($options['data']['date_to']) ? (new \DateTime)->format($humanFormat) : (new \DateTime($options['data']['date_to']))->format($humanFormat)
+            'data'       => empty($options['data']['date_to']) ? $now->format($humanFormat) : $dateTo->format($humanFormat)
         ));
 
         $builder->add('apply', 'submit', array(

--- a/app/bundles/CoreBundle/Helper/ColorHelper.php
+++ b/app/bundles/CoreBundle/Helper/ColorHelper.php
@@ -80,8 +80,9 @@ class ColorHelper
      *
      * @return array
      */
-    public function getColorArray() {
-        return [$this->red, $this->green, $this->blue];
+    public function getColorArray()
+    {
+        return array($this->red, $this->green, $this->blue);
     }
 
     /**

--- a/app/bundles/CoreBundle/Tests/Helper/ColorHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Helper/ColorHelperTest.php
@@ -36,14 +36,14 @@ class ColorHelperTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatColorHexAreSetCorrectly()
     {
-        $colors = [
-            '#ccc'      => [204, 204, 204],
-            '#fff'      => [255, 255, 255],
-            '#000'      => [0, 0, 0],
-            '#333333'   => [51, 51, 51],
-            '#369'      => [51, 102, 153],
-            '#f8Ac30'   => [248, 172, 48]
-        ];
+        $colors = array(
+            '#ccc'      => array(204, 204, 204),
+            '#fff'      => array(255, 255, 255),
+            '#000'      => array(0, 0, 0),
+            '#333333'   => array(51, 51, 51),
+            '#369'      => array(51, 102, 153),
+            '#f8Ac30'   => array(248, 172, 48)
+        );
 
         foreach ($colors as $hex => $rgb) {
             $helper = new ColorHelper($hex);
@@ -61,14 +61,14 @@ class ColorHelperTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatColorHexAreConvertedBackToHexCorrectly()
     {
-        $colors = [
+        $colors = array(
             '#ccc'      => '#cccccc',
             '#fff'      => '#ffffff',
             '#000'      => '#000000',
             '#333333'   => '#333333',
             '#369'      => '#336699',
             '#f8Ac30'   => '#f8ac30'
-        ];
+        );
 
         foreach ($colors as $hex1 => $hex2) {
             $helper = new ColorHelper;
@@ -84,14 +84,14 @@ class ColorHelperTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatColorHexAreConvertedToRgbCorrectly()
     {
-        $colors = [
+        $colors = array(
             '#ccc'      => 'rgb(204,204,204)',
             '#fff'      => 'rgb(255,255,255)',
             '#000'      => 'rgb(0,0,0)',
             '#333333'   => 'rgb(51,51,51)',
             '#369'      => 'rgb(51,102,153)',
             '#f8Ac30'   => 'rgb(248,172,48)'
-        ];
+        );
 
         foreach ($colors as $hex => $rgb) {
             $helper = new ColorHelper($hex);
@@ -106,14 +106,14 @@ class ColorHelperTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatColorHexAreConvertedToRgbaCorrectly()
     {
-        $colors = [
+        $colors = array(
             '#ccc'      => 'rgba(204,204,204,%g)',
             '#fff'      => 'rgba(255,255,255,%g)',
             '#000'      => 'rgba(0,0,0,%g)',
             '#333333'   => 'rgba(51,51,51,%g)',
             '#369'      => 'rgba(51,102,153,%g)',
             '#f8Ac30'   => 'rgba(248,172,48,%g)'
-        ];
+        );
 
         foreach ($colors as $hex => $rgba) {
             $helper = new ColorHelper($hex);

--- a/app/bundles/DashboardBundle/Controller/DashboardController.php
+++ b/app/bundles/DashboardBundle/Controller/DashboardController.php
@@ -32,7 +32,7 @@ class DashboardController extends FormController
         $widgets         = $model->getWidgets();
 
         // Apply the default dashboard if no widget exists
-        if (!count($widgets)) {
+        if (!count($widgets) && $this->factory->getUser()->getId()) {
             return $this->applyDashboardFileAction('global.default');
         }
 

--- a/app/bundles/DashboardBundle/Model/DashboardModel.php
+++ b/app/bundles/DashboardBundle/Model/DashboardModel.php
@@ -136,7 +136,7 @@ class DashboardModel extends FormModel
         if ($widget->getCacheTimeout() == null || $widget->getCacheTimeout() == -1) {
             $widget->setCacheTimeout($this->factory->getParameter('cached_data_timeout'));
         }
-        
+
         // Merge global filter with widget params
         $widgetParams = $widget->getParams();
         $resultParams = array_merge($widgetParams, $filter);
@@ -219,9 +219,11 @@ class DashboardModel extends FormModel
      */
     public function getDefaultFilter()
     {
+        $lastMonth = new \DateTime();
+        $lastMonth->sub(new \DateInterval('P30D'));
+
         $session     = $this->factory->getSession();
         $today       = new \DateTime();
-        $lastMonth   = (new \DateTime())->sub(new \DateInterval('P30D'));
         $mysqlFormat = 'Y-m-d H:i:s';
         $dateFrom    = new \DateTime($session->get('mautic.dashboard.date.from', $lastMonth->format($mysqlFormat)));
         $dateTo      = new \DateTime($session->get('mautic.dashboard.date.to', $today->format($mysqlFormat)));

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -897,7 +897,7 @@ class MailHelper
      *
      * @return string
      */
-    public function getcontentHash()
+    public function getContentHash()
     {
         return $this->contentHash;
     }

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -339,9 +339,9 @@ class LeadController extends FormController
                         } elseif (!empty($details['region'])) {
                             $name = $details['region'];
                         }
-                        $place = array(
+                        $place    = array(
                             'latLng' => array($details['latitude'], $details['longitude']),
-                            'name' => $name,
+                            'name'   => $name,
                         );
                         $places[] = $place;
                     }
@@ -358,12 +358,13 @@ class LeadController extends FormController
         $eventTypes   = $event->getEventTypes();
 
         // Get an engagement count
-        $translator     = $this->factory->getTranslator();
+        $translator = $this->factory->getTranslator();
 
-        $fromDate       = (new \DateTime('first day of this month 00:00:00'))->modify('-6 months');
-        $toDate         = new \DateTime;
+        $fromDate = new \DateTime('first day of this month 00:00:00');
+        $fromDate->modify('-6 months');
+        $toDate      = new \DateTime;
         $engagements = array();
-        $total          = 0;
+        $total       = 0;
 
         $events = array();
         foreach ($eventsByDate as $eventDate => $dateEvents) {

--- a/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
+++ b/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
@@ -27,6 +27,6 @@ class DoNotContactRepository extends CommonRepository
      */
     public function getEntriesByLeadAndChannel(Lead $lead, $channel)
     {
-        return $this->findBy(['channel' => $channel, 'lead' => $lead]);
+        return $this->findBy(array('channel' => $channel, 'lead' => $lead));
     }
 }

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -742,7 +742,24 @@ class Lead extends FormEntity
      */
     public function addDoNotContactEntry(DoNotContact $doNotContact)
     {
-        $this->changes['dnc_status'] = array($doNotContact->getChannel(), $doNotContact->getComments());
+        $this->changes['dnc_channel_status'][$doNotContact->getChannel()] = array(
+            'reason'   => $doNotContact->getReason(),
+            'comments' => $doNotContact->getComments()
+        );
+
+        // @deprecated - to be removed in 2.0
+        switch ($doNotContact->getReason()) {
+            case DoNotContact::BOUNCED:
+                $type = 'bounced';
+                break;
+            case DoNotContact::MANUAL:
+                $type = 'manual';
+                break;
+            case DoNotContact::UNSUBSCRIBED:
+                $type = 'unsubscribed';
+                break;
+        }
+        $this->changes['dnc_status'] = array($type, $doNotContact->getComments());
 
         $this->doNotContact[] = $doNotContact;
 
@@ -754,7 +771,14 @@ class Lead extends FormEntity
      */
     public function removeDoNotContactEntry(DoNotContact $doNotContact)
     {
-        $this->changes['dnc_status'] = array('removed', $doNotContact->getChannel());
+        $this->changes['dnc_channel_status'][$doNotContact->getChannel()] = array(
+            'reason'     => DoNotContact::IS_CONTACTABLE,
+            'old_reason' => $doNotContact->getReason(),
+            'comments'   => $doNotContact->getComments()
+        );
+
+        // @deprecated to be removed in 2.0
+        $this->changes['dnc_status'] = array('removed', $doNotContact->getComments());
 
         $this->doNotContact->removeElement($doNotContact);
     }

--- a/app/bundles/PageBundle/Views/FormTheme/Config/_config_pageconfig_widget.html.php
+++ b/app/bundles/PageBundle/Views/FormTheme/Config/_config_pageconfig_widget.html.php
@@ -30,7 +30,7 @@
     (function(w,d,t,u,n,a,m){w['MauticTrackingObject']=n;
         w[n]=w[n]||function(){(w[n].q=w[n].q||[]).push(arguments)},a=d.createElement(t),
         m=d.getElementsByTagName(t)[0];a.async=1;a.src=u;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','<?php echo $view['router']->generate('mautic_js', [], Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL); ?>','mt');
+    })(window,document,'script','<?php echo $view['router']->generate('mautic_js', array(), Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL); ?>','mt');
 
     mt('send', 'pageview');
 &lt;/script&gt;</pre>

--- a/app/bundles/SmsBundle/Helper/SmsHelper.php
+++ b/app/bundles/SmsBundle/Helper/SmsHelper.php
@@ -118,7 +118,12 @@ class SmsHelper
         $event = new SmsSendEvent($sms->getMessage(), $lead);
         $event->setSmsId($smsId);
 
-        $dispatcher->dispatch(SmsEvents::SMS_ON_SEND, $event);
+        try {
+            $dispatcher->dispatch(SmsEvents::SMS_ON_SEND, $event);
+        } catch (\Exception $exception) {
+            // A listener has prevented this from being sent
+            return array('failed' => 1);
+        }
 
         $metadata = $smsApi->sendSms($leadPhoneNumber, $event->getContent());
 


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      |  Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  

## Description

This PR mainly reverts remnants of PHP 5.4 syntax to PHP 5.3 till we officially bump PHP minimum.

It also fixes a BC change to the Lead entity's change array for `dnc_status` 

## Steps to test this PR

Mainly do a code review and ensure the dashboard continues to work as expected.