### PR TITLE
Fixed an issue that caused the content to not restore when editing within same session

### DIFF
--- a/app/bundles/CoreBundle/Form/Type/DateRangeType.php
+++ b/app/bundles/CoreBundle/Form/Type/DateRangeType.php
@@ -39,30 +39,50 @@ class DateRangeType extends AbstractType
     {
         $humanFormat = 'M j, Y';
 
-        $thirtyDays = new \DateTime('-30 days');
-        $dateFrom   = new \DateTime($options['data']['date_from']);
-        $builder->add('date_from', 'text', array(
-            'label'      => 'mautic.core.date.from',
-            'label_attr' => array('class' => 'control-label'),
-            'attr'       => array('class' => 'form-control'),
-            'required'   => false,
-            'data'       => empty($options['data']['date_from']) ? $thirtyDays->format($humanFormat) : $dateFrom->format($humanFormat),
-        ));
+        $dateFrom = (empty($options['data']['date_from']))
+            ?
+            new \DateTime('-30 days')
+            :
+            new \DateTime($options['data']['date_from']);
 
-        $now    = new \DateTime();
-        $dateTo = new \DateTime($options['data']['date_to']);
-        $builder->add('date_to', 'text', array(
-            'label'      => 'mautic.core.date.to',
-            'label_attr' => array('class' => 'control-label'),
-            'attr'       => array('class' => 'form-control'),
-            'required'   => false,
-            'data'       => empty($options['data']['date_to']) ? $now->format($humanFormat) : $dateTo->format($humanFormat)
-        ));
+        $builder->add(
+            'date_from',
+            'text',
+            array(
+                'label'      => 'mautic.core.date.from',
+                'label_attr' => array('class' => 'control-label'),
+                'attr'       => array('class' => 'form-control'),
+                'required'   => false,
+                'data'       => $dateFrom->format($humanFormat),
+            )
+        );
 
-        $builder->add('apply', 'submit', array(
-            'label'      => 'mautic.core.form.apply',
-            'attr'       => array('class' => 'btn btn-default')
-        ));
+        $dateTo = (empty($options['data']['date_to']))
+            ?
+            new \DateTime()
+            :
+            new \DateTime($options['data']['date_to']);
+
+        $builder->add(
+            'date_to',
+            'text',
+            array(
+                'label'      => 'mautic.core.date.to',
+                'label_attr' => array('class' => 'control-label'),
+                'attr'       => array('class' => 'form-control'),
+                'required'   => false,
+                'data'       => $dateTo->format($humanFormat)
+            )
+        );
+
+        $builder->add(
+            'apply',
+            'submit',
+            array(
+                'label' => 'mautic.core.form.apply',
+                'attr'  => array('class' => 'btn btn-default')
+            )
+        );
 
         if (!empty($options["action"])) {
             $builder->setAction($options["action"]);

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -253,7 +253,7 @@ class EmailController extends FormController
         /** @var \Mautic\EmailBundle\Entity\Email $email */
         $email = $model->getEntity($objectId);
         //set the page we came from
-        $page = $this->factory->getSession()->get('mautic.email.page', 1);
+        $page  = $this->factory->getSession()->get('mautic.email.page', 1);
 
         // Init the date range filter form
         $dateRangeValues = $this->request->get('daterange', array());
@@ -963,6 +963,8 @@ class EmailController extends FormController
 
         if (is_array($newContent)) {
             $content = array_merge($content, $newContent);
+            // Update the content for processSlots
+            $entity->setContent($content);
         }
 
         // Replace short codes to emoji

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -807,6 +807,8 @@ class PageController extends FormController
 
         if (is_array($newContent)) {
             $content = array_merge($content, $newContent);
+            // Update the content for processSlots
+            $entity->setContent($content);
         }
 
         $this->addAssetsForBuilder();


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N 
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  #1797

## Description

This fixes an issue that was introduced in 1.3 where the content from a builder was not restored if the builder is closed and reopened during the same session.

It also prevents a PHP notice for the date range maps that slipped in with the commit.

## Steps to reproduce the bug (if applicable)

1. Create a new email 
2. Choose a theme
3. Open the builder
4. Change some content and close the builder
5. Reopen the builder and note the content is gone

Repeat with landing pages

## Steps to test this PR

Apply the PR, repeat the steps and content should be restored