### PR TITLE
Fixed error on authorizing LinkedIn

### DIFF
--- a/plugins/MauticSocialBundle/Integration/LinkedInIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/LinkedInIntegration.php
@@ -100,7 +100,7 @@ class LinkedInIntegration extends SocialIntegration
     public function getUserData($identifier, &$socialCache)
     {
         $persistLead = false;
-        $accessToken = $this->getAccessToken($socialCache);
+        $accessToken = $this->getContactAccessToken($socialCache);
 
         if (!isset($accessToken['access_token'])) {
 


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N 
| BC breaks?    |  N
| Deprecations? | N
| Fixed issues  |  

## Description

When authorizing LinkedIn, an error occurs with:

 Fatal: Call to undefined method MauticPlugin\MauticSocialBundle\Integration\LinkedInIntegration::getAccessToken() - in file /plugins/MauticSocialBundle/Integration/LinkedInIntegration.php - at line 103

## Steps to reproduce the bug (if applicable)

Setup a linked in app, configure Mautic with client id and secret, and try to authorize. On returning to Mautic the above error will occur.

## Steps to test this PR

Apply the PR and repeat the above. This time it should authorize.