### PR TITLE
Fixed issue with the DateHelper::toText function that showed future dates as "x days ago"

### DIFF
--- a/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
@@ -146,6 +146,8 @@ class DateHelper extends Helper
      * @param        $datetime
      * @param string $timezone
      * @param string $fromFormat
+     *
+     * @return string
      */
     public function toText($datetime, $timezone = 'local', $fromFormat = 'Y-m-d H:i:s')
     {
@@ -159,11 +161,18 @@ class DateHelper extends Helper
         $dt = $this->helper->getLocalDateTime();
 
         if ($textDate) {
+
             return $this->translator->trans('mautic.core.date.' . $textDate, array('%time%' => $dt->format("g:i a")));
         } else {
             $interval = $this->helper->getDiff('now', null, true);
 
-            return $this->translator->trans('mautic.core.date.ago', array('%days%' => $interval->days));
+            if ($interval->invert) {
+                // In the past
+                return $this->translator->trans('mautic.core.date.ago', array('%days%' => $interval->days));
+            } else {
+                // In the future
+                return $this->toFullConcat($datetime, $timezone, $fromFormat);
+            }
         }
     }
 


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N 
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  

## Description

Mautic's DateHelper::toText which converts a DateTime to "Tomorrow, 10:00 am" or "Yesterday, 05:00 pm" would convert future dates that are greater than 1 day to "10 days ago" even though it's 10 days in the future. This PR takes that into account and uses the date if the date is in the future and diff is more than 1 day.

## Steps to reproduce the bug (if applicable)

See below. 

## Steps to test this PR

Do a code review. We actually don't use a future date with toText() in core Mautic. If you want to test it, hack this into a layout `echo $view['date']->toText('2016-12-12 00:00:00');`
