### PR TITLE
Fixed issue where bounced/unsubscribed filters no longer worked for segments

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -714,7 +714,7 @@ class LeadListRepository extends CommonRepository
             switch ($details['field']) {
                 case 'hit_url':
                     $operand = (($func == 'eq') || ($func == 'like')) ? 'EXISTS' : 'NOT EXISTS';
-                    
+
                     $subqb = $this->_em->getConnection()
                         ->createQueryBuilder()
                         ->select('null')
@@ -723,7 +723,7 @@ class LeadListRepository extends CommonRepository
                         case 'eq':
                         case 'neq':
                             $parameters[$parameter] = $details['filter'];
-                            
+
                             $subqb->where($q->expr()
                                 ->andX($q->expr()
                                 ->eq($alias . '.url', $exprParameter), $q->expr()
@@ -750,24 +750,26 @@ class LeadListRepository extends CommonRepository
                 case 'dnc_unsubscribed':
                 case 'dnc_bounced_sms':
                 case 'dnc_unsubscribed_sms':
-                    // Special handling of do not email
+                    // Special handling of do not contact
                     $func = (($func == 'eq' && $details['filter']) || ($func == 'neq' && !$details['filter'])) ? 'EXISTS' : 'NOT EXISTS';
 
-                    $parts = explode('_', $details['field']);
+                    $parts   = explode('_', $details['field']);
                     $channel = 'email';
 
                     if (count($parts) === 3) {
                         $channel = $parts[2];
                     }
 
+                    $channelParameter = $this->generateRandomParameterName();
+
                     $subqb = $this->_em->getConnection()->createQueryBuilder()
                         ->select('null')
-                        ->from(MAUTIC_TABLE_PREFIX . 'lead_donotcontact', $alias)
+                        ->from(MAUTIC_TABLE_PREFIX.'lead_donotcontact', $alias)
                         ->where(
                             $q->expr()->andX(
-                                $q->expr()->eq($alias . '.reason', $exprParameter),
-                                $q->expr()->eq($alias . '.lead_id', 'l.id'),
-                                $q->expr()->eq($alias . '.channel', $channel)
+                                $q->expr()->eq($alias.'.reason', $exprParameter),
+                                $q->expr()->eq($alias.'.lead_id', 'l.id'),
+                                $q->expr()->eq($alias.'.channel', ":$channelParameter")
                             )
                         );
 
@@ -787,7 +789,8 @@ class LeadListRepository extends CommonRepository
 
                     $ignoreAutoFilter = true;
 
-                    $parameters[$parameter] = ($parts[1] === 'bounced') ? DoNotContact::BOUNCED : DoNotContact::UNSUBSCRIBED;
+                    $parameters[$parameter]        = ($parts[1] === 'bounced') ? DoNotContact::BOUNCED : DoNotContact::UNSUBSCRIBED;
+                    $parameters[$channelParameter] = $channel;
 
                     break;
 


### PR DESCRIPTION
Please answer the following questions:

| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? | N |
| BC breaks? | N |
| Deprecations? | N |
| Fixed issues | #1767 |
## Description

The bounced or unsubscribed filters did not find leads as it should due to building a query with the channel without using a parameter.
## Steps to reproduce the bug (if applicable)

Create a new segment with a filer of unsubscribed = yes. Ensure you have leads that have unsubscribed or go through the email/unsubscribe process to add one. Run the `mautic:segment:update` command and note that the contact(s) will not be added.
## Steps to test this PR

Apply the PR and run the command again. This time the contact should be added.
