### PR TITLE
Update CampaignController.php

### DIFF
--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -884,7 +884,8 @@ class CampaignController extends FormController
         $campaign = $model->getEntity($objectId);
 
         // Generate temporary ID
-        $tempId = sha1(uniqid(mt_rand(), true));
+        $tempId = 'mautic_'.sha1(uniqid(mt_rand(), true));
+
 
         // load sources to session
         $currentSources = $model->getLeadSources($objectId);


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  

## Description
If the "$tempId" begins with a number, will already consistent with the
presence to "campaign ID", there is a case that overwrite the data
corresponding to that.

## Steps to reproduce the bug (if applicable)

## Steps to test this PR

If the "$tempId" begins with a number, will already consistent with the
presence to "campaign ID", there is a case that overwrite the data
corresponding to that.