### PR TITLE
Fix AJAX response

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -54,3 +54,8 @@
         # RedirectTemp cannot be used instead
     </IfModule>
 </IfModule>
+
+<IfModule mod_php5.c>
+    # @link https://github.com/mautic/mautic/issues/1504
+    php_value always_populate_raw_post_data -1
+</IfModule>

--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -129,7 +129,13 @@ class CheckStep implements StepInterface
             $messages[] = 'mautic.install.magic_quotes_enabled';
         }
 
-        if (version_compare(PHP_VERSION, '5.6.0', '>=') && ini_get('always_populate_raw_post_data') != -1) {
+        if (
+            version_compare(PHP_VERSION, '5.6.0', '>=')
+            &&
+            version_compare(PHP_VERSION, '7', '<')
+            &&
+            ini_get('always_populate_raw_post_data') != -1
+        ) {
             $messages[] = 'mautic.install.always_populate_raw_post_data_enabled';
         }
 

--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -129,6 +129,10 @@ class CheckStep implements StepInterface
             $messages[] = 'mautic.install.magic_quotes_enabled';
         }
 
+        if (version_compare(PHP_VERSION, '5.6.0', '>=') && ini_get('always_populate_raw_post_data') != -1) {
+            $messages[] = 'mautic.install.always_populate_raw_post_data_enabled';
+        }
+
         if (!function_exists('json_encode')) {
             $messages[] = 'mautic.install.function.jsonencode';
         }

--- a/app/bundles/InstallBundle/Translations/en_US/messages.ini
+++ b/app/bundles/InstallBundle/Translations/en_US/messages.ini
@@ -1,3 +1,4 @@
+mautic.install.always_populate_raw_post_data_enabled="PHP version 5.6.x requires the PHP configuration directive always_populate_raw_post_data be set to -1. This is handled automatically by the .htaccess file when using Apache and mod_php5, but must be set manually in php.ini for other server configurations. Please add 'always_populate_raw_post_data = -1' to your php.ini and restart your web server."
 mautic.install.accelerator="For optimal performance, it's suggested to install an accelerator (like APC)."
 mautic.install.apc.version="When using APC, you must use version %minapc% or newer. You have version %currentapc% installed. Please update your APC extension."
 mautic.install.buggy.php.version="Due to bugs in PHP version 5.3.16, Mautic's dependencies do not properly work on this version of PHP. Please use a later version of PHP."


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  |  #1504

## Description
(see #1504)
Also take a look at very much related Drupal bug: https://www.drupal.org/node/2619702 .

## Reason
PHP 5.6 produces warnings and therefore prevents correct AJAX responses.
This PR also prevents lots of 

> mautic.ERROR: Fatal: Automatically populating $HTTP_RAW_POST_DATA is deprecated and will be removed in a future version. To avoid this warning set 'always_populate_raw_post_data' to '-1' in php.ini and use the php://input stream instead. - in file Unknown - at line 0 [] []

in logs.