### PR TITLE
Significantly decrease campaign detail page load times

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -71,7 +71,7 @@ class LeadRepository extends CommonRepository
         $args = $this->convertOrmProperties('Mautic\\LeadBundle\\Entity\\Lead', $args);
 
         $sq = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $sq->select('DISTINCT(cl.lead_id)')
+        $sq->select('cl.lead_id')
             ->from(MAUTIC_TABLE_PREFIX.'campaign_leads', 'cl');
 
         $expr = $sq->expr()->andX(

--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -64,18 +64,17 @@ class LeadRepository extends CommonRepository
     {
         //DBAL
         $dq = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $dq->select('count(*) as count')
+        $dq->select('count(id) as count')
             ->from(MAUTIC_TABLE_PREFIX . 'leads', 'l');
 
         //Fix arguments if necessary
         $args = $this->convertOrmProperties('Mautic\\LeadBundle\\Entity\\Lead', $args);
 
         $sq = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $sq->select('null')
+        $sq->select('DISTINCT(cl.lead_id)')
             ->from(MAUTIC_TABLE_PREFIX.'campaign_leads', 'cl');
 
         $expr = $sq->expr()->andX(
-            $sq->expr()->eq('cl.lead_id', 'l.id'),
             $sq->expr()->eq('cl.manually_removed', ':false')
         );
         $dq->setParameter('false', false, 'boolean');
@@ -88,7 +87,7 @@ class LeadRepository extends CommonRepository
         $sq->where($expr);
 
         $dq->andWhere(
-            sprintf('EXISTS (%s)', $sq->getSQL())
+            sprintf('l.id IN (%s)', $sq->getSQL())
         );
 
         //get a total count


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | N
| New feature?  | N
| BC breaks?    | Needs Testing
| Deprecations? | N
| Fixed issues  |  N/A

## Description

While working on 2.0, I came across an issue with the campaign details page loaded incredibly slow (over 10 seconds) for a campaign with only a single contact, but a database with over 2M contacts. I was able to use the profiler to determine the cause of the slow page load, then optimized the offending queries and decreased the page load time from 10993ms to 793ms. 

## Steps to test this PR

Have a database with ~2M leads, and a campaign with any number of those leads active in it. Load into the detail view for that campaign and note the page load time. Click the "Contacts" tab to see the contacts for that campaign. Then apply this PR and load the page again and note the page load time. Check the "Contacts" tab again to ensure that it has all the same users as it had prior to applying the PR.

Query times before:

![screen shot 2016-06-15 at 5 19 43 pm](https://cloud.githubusercontent.com/assets/718028/16098239/fd75dfc2-331f-11e6-920d-93ec91635e4c.png)


Query times after: 

![screen shot 2016-06-15 at 5 19 34 pm](https://cloud.githubusercontent.com/assets/718028/16098245/053a6cc8-3320-11e6-9e7a-eb00227bbde6.png)
