### PR TITLE
Asset preview fixed

### DIFF
--- a/app/bundles/AssetBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/CampaignSubscriber.php
@@ -58,7 +58,7 @@ class CampaignSubscriber extends CommonSubscriber
     public function onAssetDownload(AssetEvent $event)
     {
         $asset = $event->getAsset();
-        $this->factory->getModel('campaign')->triggerEvent('asset.download', $asset, 'asset.download.'.$asset->getId());
+        $this->factory->getModel('campaign.event')->triggerEvent('asset.download', $asset, 'asset.download.'.$asset->getId());
     }
 
     /**


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Steps to reproduce the bug (if applicable)
Go to an asset detail. The preview does not work. Download URL either. It will throw error:

`Attempted to call an undefined method named "triggerEvent" of class "Mautic\CampaignBundle\Model\CampaignModel".`

## Steps to test this PR
Apply this PR and test again. The asset should appear.

