### PR TITLE
css fix for search on lead timeline hidding in the backgroung

### DIFF
--- a/app/bundles/LeadBundle/Assets/css/lead.css
+++ b/app/bundles/LeadBundle/Assets/css/lead.css
@@ -138,3 +138,7 @@ ul.tag-cloud li {
 #lead_merge_lead_to_merge_chosen .chosen-search {
     display:none;
 }
+.history-search{
+    overflow: visible!important;
+    height: 53px;
+}

--- a/app/bundles/LeadBundle/Views/Lead/historyfilter.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/historyfilter.html.php
@@ -16,7 +16,7 @@
             <span class="the-icon fa fa-search text-muted mt-xs"></span>
         </div>
         <?php if (isset($eventTypes) && is_array($eventTypes)) : ?>
-            <div class=" panel-footer text-muted">
+            <div class="history-search panel-footer text-muted">
                 <div class="col-sm-6">
                     <select name="includeEvents[]" multiple="multiple" class="form-control bdr-w-0" data-placeholder="<?php echo $view['translator']->trans('mautic.lead.lead.filter.bundles.include.placeholder'); ?>">
                         <?php foreach ($eventTypes as $typeKey => $typeName) : ?>


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | y
| New feature?  | n
| BC breaks?    | n
| Deprecations? | n
| Fixed issues  |  n

## Description
this PR fixes lead's history search from hiding in the background
## Steps to reproduce the bug (if applicable)
go to any lead click on either search boxes on the lead, it hides on the background (tested on chrome)
## Steps to test this PR
apply this PR
search box should not be hiding anymore
