### PR TITLE
BugFix: fixed factory call on social login form

### DIFF
--- a/plugins/MauticSocialBundle/Config/config.php
+++ b/plugins/MauticSocialBundle/Config/config.php
@@ -49,7 +49,10 @@ return [
         'forms'  => [
             'mautic.form.type.social.sociallogin'              => [
                 'class'     => 'MauticPlugin\MauticSocialBundle\Form\Type\SocialLoginType',
-                'arguments' => 'mautic.helper.integration',
+                'arguments' => [
+                    'mautic.helper.integration',
+                    'mautic.factory',
+                    ],
                 'alias'     => 'sociallogin',
             ],
             'mautic.form.type.social.facebook'                 => [

--- a/plugins/MauticSocialBundle/Config/config.php
+++ b/plugins/MauticSocialBundle/Config/config.php
@@ -51,7 +51,7 @@ return [
                 'class'     => 'MauticPlugin\MauticSocialBundle\Form\Type\SocialLoginType',
                 'arguments' => [
                     'mautic.helper.integration',
-                    'mautic.factory',
+                    'mautic.form.model.form',
                     ],
                 'alias'     => 'sociallogin',
             ],

--- a/plugins/MauticSocialBundle/Form/Type/SocialLoginType.php
+++ b/plugins/MauticSocialBundle/Form/Type/SocialLoginType.php
@@ -12,7 +12,7 @@ namespace MauticPlugin\MauticSocialBundle\Form\Type;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-
+use Mautic\CoreBundle\Factory\MauticFactory;
 
 /**
  * Class FacebookLoginType
@@ -25,15 +25,17 @@ class SocialLoginType extends AbstractType
      * @var IntegrationHelper
      */
     private $helper;
+    private $factory;
 
     /**
      * SocialLoginType constructor.
      *
      * @param IntegrationHelper $helper
      */
-    public function __construct(IntegrationHelper $helper)
+    public function __construct(IntegrationHelper $helper, MauticFactory $factory)
     {
         $this->helper = $helper;
+        $this->factory = $factory;
     }
 
     /**

--- a/plugins/MauticSocialBundle/Form/Type/SocialLoginType.php
+++ b/plugins/MauticSocialBundle/Form/Type/SocialLoginType.php
@@ -9,10 +9,10 @@
 
 namespace MauticPlugin\MauticSocialBundle\Form\Type;
 
+use Mautic\FormBundle\MauticFormBundle;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Mautic\CoreBundle\Factory\MauticFactory;
 
 /**
  * Class FacebookLoginType
@@ -25,17 +25,17 @@ class SocialLoginType extends AbstractType
      * @var IntegrationHelper
      */
     private $helper;
-    private $factory;
+    private $formModel;
 
     /**
      * SocialLoginType constructor.
      *
      * @param IntegrationHelper $helper
      */
-    public function __construct(IntegrationHelper $helper, MauticFactory $factory)
+    public function __construct(IntegrationHelper $helper, $form)
     {
         $this->helper = $helper;
-        $this->factory = $factory;
+        $this->formModel = $form;
     }
 
     /**
@@ -49,8 +49,7 @@ class SocialLoginType extends AbstractType
 
         foreach ($integrationObjects as $integrationObject) {
             if ($integrationObject->getIntegrationSettings()->isPublished()) {
-                /** @var \Mautic\AssetBundle\Model\AssetModel $model */
-                $model = $this->factory->getModel('form');
+                $model = $this->formModel;
                 $integrations .= $integrationObject->getName().",";
                 $integration = [
                     'integration' => $integrationObject->getName(),

--- a/plugins/MauticSocialBundle/Form/Type/SocialLoginType.php
+++ b/plugins/MauticSocialBundle/Form/Type/SocialLoginType.php
@@ -10,6 +10,7 @@
 namespace MauticPlugin\MauticSocialBundle\Form\Type;
 
 use Mautic\FormBundle\MauticFormBundle;
+use Mautic\FormBundle\Model\FormModel;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -32,7 +33,7 @@ class SocialLoginType extends AbstractType
      *
      * @param IntegrationHelper $helper
      */
-    public function __construct(IntegrationHelper $helper, $form)
+    public function __construct(IntegrationHelper $helper, FormModel $form)
     {
         $this->helper = $helper;
         $this->formModel = $form;


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | y
| New feature?  | 
| BC breaks?    | 
| Deprecations? | 
| Fixed issues  |  

## Description
Fix factory call on social login plugin buttons
## Steps to reproduce the bug (if applicable)
try to add a new social login button on a form, it throws an error
## Steps to test this PR
Apply this PR it should now let you add the button, possible fix for callback window not working.
