### PR TITLE
fixed Social sign on button calling wrong popup

### DIFF
--- a/app/bundles/PluginBundle/Views/Auth/postauth.html.php
+++ b/app/bundles/PluginBundle/Views/Auth/postauth.html.php
@@ -21,6 +21,9 @@ function postFormHandler() {
     window.close()
 
 }
+(function() {
+   postFormHandler();
+})();
 JS;
 ?>
 <script>

--- a/plugins/MauticSocialBundle/Form/Type/SocialLoginType.php
+++ b/plugins/MauticSocialBundle/Form/Type/SocialLoginType.php
@@ -60,7 +60,7 @@ class SocialLoginType extends AbstractType
                     'authUrl_'.$integrationObject->getName(),
                     'hidden',
                     [
-                        'data' => $model->buildUrl('mautic_integration_auth_user', $integration, true, []),
+                        'data' => $model->buildUrl('mautic_integration_auth_postauth', $integration, true, []),
                     ]
                 );
 


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | n
| BC breaks?    | n
| Deprecations? | n
| Fixed issues  |  n

## Description

Social Sign on button was calling the wrong popup window to authorize app for user

## Steps to test this PR
apply this PR and social login button will pre populate data now after its been authorized by user.