### PR TITLE
Added the new token Froala plugin which triggers the atWho dropdown

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -572,7 +572,7 @@ var Mautic = {
                     //     settings.extraPlugins = "sourcedialog,docprops,filemanager";
                     // }
 
-                    var maxButtons = ['undo', 'redo' , '|', 'bold', 'italic', 'underline', 'strikeThrough', 'fontFamily', 'fontSize', 'color', 'paragraphFormat', 'align', 'orderedList', 'unorderedList', 'quote', 'strikethrough', 'outdent', 'indent', 'clearFormatting','insertLink', 'insertImage','insertTable', 'html', 'fullscrean'];
+                    var maxButtons = ['undo', 'redo' , '|', 'bold', 'italic', 'underline', 'strikeThrough', 'fontFamily', 'fontSize', 'color', 'paragraphFormat', 'align', 'orderedList', 'unorderedList', 'quote', 'strikethrough', 'outdent', 'indent', 'clearFormatting','insertLink', 'insertImage','insertTable', 'html', 'fullscreen'];
 
                     if (textarea.hasClass('editor-advanced') || textarea.hasClass('editor-basic-fullpage')) {
                         var options = {

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -347,7 +347,7 @@ Mautic.initSlotListeners = function() {
                 Mautic.initAtWho(editor.$el, Mautic.getBuilderTokensMethod(), editor);
             });
 
-            var buttons = ['bold', 'italic', 'fontSize', 'insertImage', 'insertLink', 'undo', 'redo', '-', 'paragraphFormat', 'align', 'color', 'formatOL', 'formatUL', 'indent', 'outdent'];
+            var buttons = ['bold', 'italic', 'fontSize', 'insertImage', 'insertLink', 'insertTable', 'undo', 'redo', '-', 'paragraphFormat', 'align', 'color', 'formatOL', 'formatUL', 'indent', 'outdent', 'token'];
 
             var inlineFroalaOptions = {
                 toolbarInline: true,

--- a/app/bundles/CoreBundle/Assets/js/libraries/froala/plugins/token.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/froala/plugins/token.js
@@ -1,0 +1,64 @@
+/*!
+ * froala_editor v2.3.3 (https://www.froala.com/wysiwyg-editor)
+ * License https://froala.com/wysiwyg-editor/terms/
+ * Copyright 2014-2016 Mautic team
+ */
+
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['jquery'], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        // Node/CommonJS
+        module.exports = function( root, jQuery ) {
+            if ( jQuery === undefined ) {
+                // require('jQuery') returns a factory that requires window to
+                // build a jQuery instance, we normalize how we use modules
+                // that require this pattern but the window provided is a noop
+                // if it's defined (how jquery works)
+                if ( typeof window !== 'undefined' ) {
+                    jQuery = require('jquery');
+                }
+                else {
+                    jQuery = require('jquery')(root);
+                }
+            }
+            factory(jQuery);
+            return jQuery;
+        };
+    } else {
+        // Browser globals
+        factory(jQuery);
+    }
+}(function ($) {
+
+  'use strict';
+
+  $.FE.PLUGINS.token = function (editor) {
+
+    function apply () {
+      editor.html.insert('{');
+      editor.$el.keyup();
+      editor.toolbar.hide();
+    }
+
+    return {
+      apply: apply
+    }
+  }
+
+  // Register the token command.
+  $.FE.RegisterCommand('token', {
+    title: 'Insert token',
+    callback: function (cmd) {
+      this.token.apply();
+    },
+    plugin: 'token'
+  })
+
+  // Add the token icon.
+  $.FE.DefineIcon('token', {
+    NAME: 'tag'
+  });
+
+}));

--- a/app/bundles/CoreBundle/Templating/Helper/AssetsHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/AssetsHelper.php
@@ -507,7 +507,8 @@ class AssetsHelper
             $plugins . 'quote.js?v' . $this->version,
             $plugins . 'table.js?v' . $this->version,
             $plugins . 'url.js?v' . $this->version,
-            $plugins . 'video.js?v' . $this->version
+            $plugins . 'video.js?v' . $this->version,
+            $plugins . 'token.js?v' . $this->version
         );
     }
 


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | N
| New feature?  | Y
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
This PR adds a new plugin to the Froala editor in the page/email builder which will basically just insert the `{` character to the cursor place and triggers keyUp event which triggers the atWho library.

The reason for this button was that the token dropdown is hidden and this way users might discover it sooner.

![mautic-token-button](https://cloud.githubusercontent.com/assets/1235442/16492451/276c10b2-3ee2-11e6-8296-7b442ab7b44b.png)
![mautic-token-button-clicked](https://cloud.githubusercontent.com/assets/1235442/16492453/29f0e268-3ee2-11e6-9504-5c2c6688ccf5.png)


## Steps to test this PR

Make sure the token button works for you.
