### PR TITLE
Bug fix: pushLead function missing, added it back

### DIFF
--- a/app/bundles/PluginBundle/Helper/EventHelper.php
+++ b/app/bundles/PluginBundle/Helper/EventHelper.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2014 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\PluginBundle\Helper;
+
+use Mautic\CoreBundle\Factory\MauticFactory;
+
+/**
+ * Class EventHelper
+ *
+ * @package Mautic\PluginBundle\Helper
+ */
+class EventHelper
+{
+
+    /**
+     * @param               $lead
+     * @param MauticFactory $factory
+     */
+    static public function pushLead($config, $lead, MauticFactory $factory)
+    {
+        /** @var \Mautic\PluginBundle\Helper\IntegrationHelper $integrationHelper */
+        $integrationHelper = $factory->getHelper('integration');
+
+        $integration = (!empty($config['integration'])) ? $config['integration'] : null;
+        $feature     = (empty($integration)) ? 'push_lead' : null;
+
+        $services = $integrationHelper->getIntegrationObjects($integration, $feature);
+        $success  = false;
+
+        foreach ($services as $name => $s) {
+            $settings = $s->getIntegrationSettings();
+            if (!$settings->isPublished()) {
+                continue;
+            }
+
+            if (method_exists($s, 'pushLead')) {
+                if ($s->pushLead($lead, $config)) {
+                    $success = true;
+                }
+            }
+        }
+
+        return $success;
+    }
+}


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | y
| New feature?  | n
| BC breaks?    | n
| Deprecations? | n
| Fixed issues  |  1

## Description
When submitting a form with an action to push lead to integration, it was erroring on form submit due to a helper function missing.

## Steps to reproduce the bug (if applicable)
create a form to push to integration, or create a point trigger with event: push to integration.  When the form is submitted or points triggered your would get an error due to missing function.
## Steps to test this PR

Apply this PR and form and point triggers should work again


