### PR TITLE
OnClick event on color picker handeled differently so it works in FF

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -2860,7 +2860,10 @@ var Mautic = {
         var pickerOptions = mQuery(el).data('color-options');
         if (!pickerOptions) {
             pickerOptions = {
-                theme: 'bootstrap'
+                theme: 'bootstrap',
+                change: function (hex, opacity) {
+                    mQuery(el).trigger('change.minicolors', hex);
+                }
             };
         }
 

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -268,13 +268,15 @@ Mautic.initSections = function() {
             }
         });
 
-        sectionForm.find('.minicolors-panel').on('click', function() {
-            var field = mQuery(this).parent().find('input');
+        parent.mQuery('body').on('change.minicolors', function(e, hex) {
+            var field = mQuery(e.target);
+            var focussedSectionWrapper = mQuery('[data-section-focus]').parent();
+            var focussedSection = focussedSectionWrapper.find('[data-section]');
 
-            if (section.length && field.attr('id') === 'builder_section_content-background-color') {
-                Mautic.sectionBackgroundChanged(section, field.val());
+            if (focussedSection.length && field.attr('id') === 'builder_section_content-background-color') {
+                Mautic.sectionBackgroundChanged(focussedSection, field.val());
             } else if (field.attr('id') === 'builder_section_wrapper-background-color') {
-                Mautic.sectionBackgroundChanged(sectionWrapper, field.val());
+                Mautic.sectionBackgroundChanged(focussedSectionWrapper, field.val());
             }
         });
     });

--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -100,6 +100,15 @@ Mautic.emailOnLoad = function (container, response) {
 
     var plaintext = mQuery('#emailform_plainText');
     Mautic.initAtWho(plaintext, plaintext.attr('data-token-callback'));
+
+    // update textarea from Froala's CodeMirror view on save
+    var form = mQuery('form[name="emailform"]');
+    var textarea = mQuery('textarea.builder-html');
+    if (form.length && textarea.length) {
+        form.on('before.submit.ajaxform', function() {
+            textarea.froalaEditor('events.trigger', 'form.submit');
+        });
+    }
 };
 
 Mautic.emailOnUnload = function(id) {

--- a/app/bundles/PageBundle/Assets/js/page.js
+++ b/app/bundles/PageBundle/Assets/js/page.js
@@ -38,6 +38,15 @@ Mautic.pageOnLoad = function (container) {
 
     Mautic.intiSelectTheme(mQuery('#page_template'));
     Mautic.fixFroalaPageOutput();
+
+    // update textarea from Froala's CodeMirror view on save
+    var form = mQuery('form[name="page"]');
+    var textarea = mQuery('textarea.builder-html');
+    if (form.length && textarea.length) {
+        form.on('before.submit.ajaxform', function() {
+            textarea.froalaEditor('events.trigger', 'form.submit');
+        });
+    }
 };
 
 Mautic.pageOnUnload = function (id) {


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
1. Section background options worked only on doubleclick in Firefox.
2. Code view does not save the changes unless you switch back to editor first.

## Steps to reproduce the bug (if applicable)
1. Open the email or page builder in Firefox, highlight a section and try to change the background color.
2. Try to change something in the code view, save. The change will be gone.

## Steps to test this PR
Apply this PR and in dev mode or after rebuilding the assets and refreshing the browser try again.

