### PR TITLE
Set roundmode on attribution field #1956 #1957

### DIFF
--- a/app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
+++ b/app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
@@ -97,6 +97,7 @@ class LeadFieldData extends AbstractFixture implements OrderedFixtureInterface, 
                 $type = 'datetime';
             } elseif ($name == 'attribution') {
                 $type = 'number';
+                $entity->setProperties(["roundmode" => 4, "precision" => 2]);
             } else {
                 $type = 'text';
             }

--- a/app/bundles/LeadBundle/Form/Type/LeadType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadType.php
@@ -145,7 +145,7 @@ class LeadType extends AbstractType
                         'mapped'        => false,
                         'constraints'   => $constraints,
                         'precision'     => $properties['precision'],
-                        'rounding_mode' => (int) $properties['roundmode']
+                        'rounding_mode' => isset($properties['roundmode']) ? (int) $properties['roundmode'] : 0
                     )
                 );
             } elseif (in_array($type, array('date', 'datetime', 'time'))) {


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | y
| New feature?  | n
| BC breaks?    | n
| Deprecations? | n
| Fixed issues  |  #1956 #1957

## Description
The installer creates the lead fiels using Doctrine fixtures. The fixtures are missing the round mode for the new field attribution, which breaks the contact form.

## Steps to reproduce the bug (if applicable)

## Steps to test this PR

