### PR TITLE
Generate copies of sent email based on sent content and not the email itself

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1664,10 +1664,8 @@ class MailHelper
         $emailModel = $this->factory->getModel('email');
 
         // Save a copy of the email - use email ID if available simply to prevent from having to rehash over and over
-        $id = (null !== $this->email) ? $this->email->getId() : md5($this->subject.$this->body['content']);
-        if (!isset($copies[$id])) {
-            $hash = (strlen($id) !== 32) ? md5($this->subject.$this->body['content']) : $id;
-
+        $hash = md5($this->subject.$this->body['content']);
+        if (!isset($copies[$hash])) {
             $copy        = $emailModel->getCopyRepository()->findByHash($hash);
             $copyCreated = false;
             if (null === $copy) {
@@ -1680,12 +1678,12 @@ class MailHelper
             }
 
             if ($copy || $copyCreated) {
-                $copies[$id] = $hash;
+                $copies[$hash] = $hash;
             }
         }
 
-        if (isset($copies[$id])) {
-            $stat->setStoredCopy($this->factory->getEntityManager()->getReference('MauticEmailBundle:Copy', $copies[$id]));
+        if (isset($copies[$hash])) {
+            $stat->setStoredCopy($this->factory->getEntityManager()->getReference('MauticEmailBundle:Copy', $copies[$hash]));
         }
 
         if ($persist) {


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Maybe
| New feature?  | 
| BC breaks?    | 
| Deprecations? | 
| Fixed issues  |  

## Description
(Sorry about long description)

To fully understand what's happening, I think I have to explain what we're doing internally first:

- We need to send dynamic content inside email based on customer country and language (so we haven't to create 20 emails. One for each country-language combination)
- We've made a plugin to handle this by using translations (label => language, value stored at DB) and tokens {translation=23|Hello there}. Then inside the Listener, we replace custom tokens with the desired translation based on contact information
- We also use other custom tokens to redirect customers to right website based on country and language (/whatever/ch/de => goes to whatever Switzerland website in german language)

"Yes, fine... Now tell us what do you want... :D"

As we have only 1 email entity with custom tokens inside and the copy is based mainly on the email ID, only 1 copy is created for all contacts, so all contacts see the same when they click on "View in browser link".

"Tokens are managed separately". Yes, but we need to replace them inside the content to allow Mautic Core make his job on creating the trackables (EmailBundle->BuilderSubscriber parseContentForUrls() & convertUrlsToTokens())

## Steps to reproduce the bug (if applicable)


## Steps to test this PR

