### PR TITLE
Bug fix: campaign open email trigger was giving an error when email w…

### DIFF
--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -96,7 +96,10 @@ class CampaignSubscriber extends CommonSubscriber
     public function onEmailOpen(EmailOpenEvent $event)
     {
         $email = $event->getEmail();
-        $this->factory->getModel('campaign.event')->triggerEvent('email.open', $email, 'email.open' . $email->getId());
+        if($email != null)
+        {
+            $this->factory->getModel('campaign.event')->triggerEvent('email.open', $email, 'email.open' . $email->getId());
+        }
     }
 
     /**


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | y
| New feature?  | n 
| BC breaks?    | n
| Deprecations? | n
| Fixed issues  |  1

## Description
Campaign open email action was erroring when email was null, this fix checks if email is null before triggering action.

