### PR TITLE
Chart report widgets fixed

### DIFF
--- a/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
+++ b/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
@@ -296,7 +296,7 @@ class ChartQuery extends AbstractChart
                      * PHP DateTime cannot parse the Y W (ex 2016 09)
                      * format, so we transform it into d-M-Y.
                      */
-                    if ($this->unit === 'W') {
+                    if ($this->unit === 'W' && isset($item['date'])) {
                         list($year, $week) = explode(' ', $item['date']);
                         $newDate = new \DateTime();
                         $newDate->setISODate($year, $week);

--- a/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
+++ b/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
@@ -296,7 +296,7 @@ class ChartQuery extends AbstractChart
                      * PHP DateTime cannot parse the Y W (ex 2016 09)
                      * format, so we transform it into d-M-Y.
                      */
-                    if ($this->unit === 'W' && $this->isMysql()) {
+                    if ($this->unit === 'W') {
                         list($year, $week) = explode(' ', $item['date']);
                         $newDate = new \DateTime();
                         $newDate->setISODate($year, $week);

--- a/app/bundles/CoreBundle/Views/Helper/table.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/table.html.php
@@ -44,8 +44,10 @@ if (!isset($shortenLinkText)) {
                                         <?php $item = str_replace(array('http://', 'https://'), '', $item); ?>
                                         <?php echo $view['assets']->shortenText($item['value'], $shortenLinkText); ?>
                                     </a>
-                                <?php else: ?>
+                                <?php elseif(isset($item['value'])): ?>
                                     <?php echo $item['value']; ?>
+                                <?php elseif(is_string($item)): ?>
+                                    <?php echo $item; ?>
                                 <?php endif; ?>
                             </td>
                         <?php endforeach; ?>

--- a/app/bundles/ReportBundle/Views/SubscribedEvents/Dashboard/widget.html.php
+++ b/app/bundles/ReportBundle/Views/SubscribedEvents/Dashboard/widget.html.php
@@ -15,6 +15,7 @@ if ($chartType === 'table') {
     echo $view->render(
         'MauticCoreBundle:Helper:table.html.php',
         [
+            'headItems'   => isset($chartData[0]) ? array_keys($chartData[0]) : [],
             'bodyItems'   => $chartData
         ]
     );

--- a/app/bundles/ReportBundle/Views/SubscribedEvents/Dashboard/widget.html.php
+++ b/app/bundles/ReportBundle/Views/SubscribedEvents/Dashboard/widget.html.php
@@ -7,6 +7,10 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
+if (isset($chartData['data'])) {
+    $chartData = $chartData['data'];
+}
+
 echo $view->render(
     'MauticCoreBundle:Helper:chart.html.php',
     [

--- a/app/bundles/ReportBundle/Views/SubscribedEvents/Dashboard/widget.html.php
+++ b/app/bundles/ReportBundle/Views/SubscribedEvents/Dashboard/widget.html.php
@@ -11,14 +11,23 @@ if (isset($chartData['data'])) {
     $chartData = $chartData['data'];
 }
 
-echo $view->render(
-    'MauticCoreBundle:Helper:chart.html.php',
-    [
-        'chartData'   => $chartData,
-        'chartType'   => $chartType,
-        'chartHeight' => $chartHeight
-    ]
-);
+if ($chartType === 'table') {
+    echo $view->render(
+        'MauticCoreBundle:Helper:table.html.php',
+        [
+            'bodyItems'   => $chartData
+        ]
+    );
+} else {
+    echo $view->render(
+        'MauticCoreBundle:Helper:chart.html.php',
+        [
+            'chartData'   => $chartData,
+            'chartType'   => $chartType,
+            'chartHeight' => $chartHeight
+        ]
+    );
+}
 ?>
 
 <div class="pull-right mr-md mb-md">


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
Pie chart report widgets break the dashboard, table report widgets doesn't display. 

## Steps to reproduce the bug (if applicable)
1. Create a new report widget.
2. Select the first option you have there.
3. Save and view if the widget content is correct.
4. Edit the widget and test another report widget
5. Repeat 1. - 4. untill you test all widgets.

You should see that pie charts cause a JS error and table content doesn't display.

## Steps to test this PR
Apply this PR and test again. All the report widgets should display correct content.
