### PR TITLE
Bug Fix : JS error on IE9

### DIFF
--- a/app/bundles/NotificationBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/BuildJsSubscriber.php
@@ -82,7 +82,7 @@ MauticJS.notification = {
     }
 };
 
-MauticJS.documentReady('MauticJS.notification.init');
+MauticJS.documentReady(MauticJS.notification.init);
 JS;
 
         $event->appendJs($js, 'Mautic Notification JS');


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      |  Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  #1973

## Description

When using the javascript with IE9, there is a javascript error generated (seems to be at MauticJS.documentReady, it expects a function and not a string...)

## Steps to reproduce the bug (if applicable)

Just open a page with the script included on IE9, and watch errors on console. You can also emulate IE9 with IE Developer Tools

## Steps to test this PR

Just reproduce with this PR

## Solution 

There was a mistake, as MautiJS.documentReady must have a function as parameter, and not a string. New browser are able to convert string to function, but not older one...