### PR TITLE
fix argument on slot destoy

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -384,7 +384,7 @@ Mautic.initSlotListeners = function() {
         slotToolbar.appendTo(handle);
         slot.hover(function() {
             deleteLink.click(function(e) {
-                slot.trigger('slot:destroy', {slot, type});
+                slot.trigger('slot:destroy', {slot: slot, type: type});
                 mQuery.each(Mautic.builderSlots, function(i, slotParams) {
                     if (slotParams.slot.is(slot)) {
                         Mautic.builderSlots.splice(i, 1);


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  #1975 

## Description

Dashboard cann't display with IE11.
It seems to should set event's argument as PlainObject.

## Steps to reproduce the bug (if applicable)

1. clean install with c5f966ba
2. login with IE11.
3. dashboard can not display. at this time, debug console says "SCRIPT1003: Excepted ':'"

## Steps to test this PR

1. appy patch
2. login with IE11.
3. dashboard can display and no error in debug console.