### PR TITLE
Form embed URL fixed

### DIFF
--- a/app/bundles/FormBundle/Views/Form/details.html.php
+++ b/app/bundles/FormBundle/Views/Form/details.html.php
@@ -302,7 +302,7 @@ $isStandalone = $activeForm->isStandalone();
                 <div class="modal-body">
                     <p><?php echo $view['translator']->trans('mautic.form.form.help.automaticcopy'); ?></p>
                     <h3><?php echo $view['translator']->trans('mautic.form.form.help.automaticcopy.js'); ?></h3>
-                    <textarea class="form-control" readonly onclick="this.setSelectionRange(0, this.value.length);">&lt;script type="text/javascript" src="<?php echo $view['router']->path(
+                    <textarea class="form-control" readonly onclick="this.setSelectionRange(0, this.value.length);">&lt;script type="text/javascript" src="<?php echo $view['router']->url(
                             'mautic_form_generateform',
                             array('id' => $activeForm->getId()),
                             true
@@ -310,7 +310,7 @@ $isStandalone = $activeForm->isStandalone();
                     <h3 class="pt-lg"><?php echo $view['translator']->trans(
                             'mautic.form.form.help.automaticcopy.iframe'
                         ); ?></h3>
-                    <textarea class="form-control" readonly onclick="this.setSelectionRange(0, this.value.length);">&lt;iframe src="<?php echo $view['router']->path(
+                    <textarea class="form-control" readonly onclick="this.setSelectionRange(0, this.value.length);">&lt;iframe src="<?php echo $view['router']->url(
                             'mautic_form_preview',
                             array('id' => $activeForm->getId()),
                             true


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
The form embed doesn't show the full URL
![mautic-form-embed-issue](https://cloud.githubusercontent.com/assets/1235442/16681089/fb14b4e4-44f2-11e6-8859-73250b7d77a2.png)

## Steps to reproduce the bug (if applicable)
Go to a form detail and open the Automatic form embed modal.

## Steps to test this PR
After this PR is applied, the embed will look like this:
![mautic-form-embed-fix](https://cloud.githubusercontent.com/assets/1235442/16681110/1b2e30f2-44f3-11e6-9de9-2cb7ce7a7207.png)

