### PR TITLE
Unsubscribe fix

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -17,6 +17,7 @@ use Mautic\CoreBundle\Helper\TrackingPixelHelper;
 use Mautic\EmailBundle\Swiftmailer\Transport\InterfaceCallbackTransport;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Event\EmailSendEvent;
+use Mautic\LeadBundle\Entity\DoNotContact;
 use Symfony\Component\HttpFoundation\Response;
 
 class PublicController extends CommonFormController
@@ -123,7 +124,7 @@ class PublicController extends CommonFormController
                 $leadModel->setCurrentLead($lead);
             }
 
-            $model->setDoNotContact($stat, $translator->trans('mautic.email.dnc.unsubscribed'), 'unsubscribed');
+            $model->setDoNotContact($stat, $translator->trans('mautic.email.dnc.unsubscribed'), DoNotContact::UNSUBSCRIBED);
 
             $message = $this->factory->getParameter('unsubscribe_message');
             if (!$message) {

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -1162,7 +1162,7 @@ class Email extends FormEntity
      *
      * @return $this
      */
-    public function setUnsubscribeForm (Form $unsubscribeForm)
+    public function setUnsubscribeForm (Form $unsubscribeForm = null)
     {
         $this->unsubscribeForm = $unsubscribeForm;
 

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1312,6 +1312,29 @@ class EmailModel extends FormModel
     }
 
     /**
+     * Remove a Lead's EMAIL DNC entry.
+     *
+     * @param string $email
+     */
+    public function removeDoNotContact($email)
+    {
+        /** @var \Mautic\LeadBundle\Entity\LeadRepository $leadRepo */
+        $leadRepo = $this->em->getRepository('MauticLeadBundle:Lead');
+        $leadId   = (array) $leadRepo->getLeadByEmail($email, true);
+
+        /** @var \Mautic\LeadBundle\Entity\Lead[] $leads */
+        $leads = [];
+
+        foreach ($leadId as $lead) {
+            $leads[] = $leadRepo->getEntity($lead['id']);
+        }
+
+        foreach ($leads as $lead) {
+            $this->leadModel->removeDncForLead($lead, 'email');
+        }
+    }
+
+    /**
      * @param           $email
      * @param string    $reason
      * @param string    $comments

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1018,28 +1018,6 @@ class LeadModel extends FormModel
     }
 
     /**
-     * Remove a Lead's EMAIL DNC entry.
-     *
-     * @param string $email
-     */
-    public function removeDncForEmail($email)
-    {
-        $repo = $this->getRepository();
-        $leadId = (array) $repo->getLeadByEmail($email, true);
-
-        /** @var \Mautic\LeadBundle\Entity\Lead[] $leads */
-        $leads = [];
-
-        foreach ($leadId as $lead) {
-            $leads[] = $repo->getEntity($lead['id']);
-        }
-
-        foreach ($leads as $lead) {
-            $this->removeDncForLead($lead, 'email');
-        }
-    }
-
-    /**
      * Create a DNC entry for a lead
      *
      * @param Lead         $lead

--- a/themes/goldstar/html/base.html.twig
+++ b/themes/goldstar/html/base.html.twig
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
+        {% if page is defined %}
         <title>{{ page.getTitle() }}</title>
         <meta name="description" content="{{ page.getMetaDescription() }}">
+        {% endif %}
         <link rel="stylesheet" href="{{ getAssetUrl('themes/goldstar/css/goldstar.css') }}" type="text/css" />
     </head>
     <body>

--- a/themes/neopolitan/html/base.html.twig
+++ b/themes/neopolitan/html/base.html.twig
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
+        {% if page is defined %}
         <title>{{ page.getTitle() }}</title>
         <meta name="description" content="{{ page.getMetaDescription() }}">
+        {% endif %}
         <link rel="stylesheet" href="{{ getAssetUrl('themes/neopolitan/css/neopolitan.css') }}" type="text/css" />
     </head>
     <body style="padding: 0;margin: 0;display: block;background: #ffffff;-webkit-text-size-adjust: none;-webkit-font-smoothing: antialiased;width: 100%;height: 100%;color: #37302d;font-size: 16px;" bgcolor="#ffffff">

--- a/themes/oxygen/html/base.html.twig
+++ b/themes/oxygen/html/base.html.twig
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
+        {% if page is defined %}
         <title>{{ page.getTitle() }}</title>
         <meta name="description" content="{{ page.getMetaDescription() }}">
+        {% endif %}
         <link rel="stylesheet" href="{{ getAssetUrl('themes/oxygen/css/oxygen.css') }}" type="text/css" />
     </head>
     <body>

--- a/themes/skyline/html/base.html.twig
+++ b/themes/skyline/html/base.html.twig
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
+        {% if page is defined %}
         <title>{{ page.getTitle() }}</title>
         <meta name="description" content="{{ page.getMetaDescription() }}">
+        {% endif %}
         <link rel="stylesheet" href="{{ getAssetUrl('themes/skyline/css/skyline.css') }}" type="text/css" />
     </head>
     <body style="padding:0; margin:0; display:block; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">

--- a/themes/sunday/html/base.html.twig
+++ b/themes/sunday/html/base.html.twig
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
+        {% if page is defined %}
         <title>{{ page.getTitle() }}</title>
         <meta name="description" content="{{ page.getMetaDescription() }}">
+        {% endif %}
         <link rel="stylesheet" href="{{ getAssetUrl('themes/oxygen/css/oxygen.css') }}" type="text/css" />
     </head>
     <body offset="0" class="body" style="padding: 0;margin: 0;display: block;background: #eeebeb;-webkit-text-size-adjust: none;-webkit-font-smoothing: antialiased;width: 100%;height: 100%;color: #6f6f6f;font-weight: 400;font-size: 18px;" bgcolor="#eeebeb">

--- a/themes/sunday/html/message.html.twig
+++ b/themes/sunday/html/message.html.twig
@@ -1,7 +1,7 @@
 {% extends ":sunday:base.html.twig" %}
 
 {% block content %}
-    <div class="well text-center">
+    <div style="width: 800px; margin: 40px auto">
         <h2>{{ message|raw }}</h2>
         {% if content is defined %}
         <div class="text-left">{{ content|raw }}</div>


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  https://github.com/mautic/mautic/issues/1947

## Description
The unsubscribe and resubscribe pages throw a SQL error.

## Steps to reproduce the bug (if applicable)
Send an email with `{unsubscribe_text}‍` token. Send the email to an actual lead with your email address. Click the unsubscribe link.

Also, removing the Unsubscribe feedback form throws an error. Try to add one, save the form. Remove it and save again. You should see the error.

## Steps to test this PR
Apply this PR and click the link again. Also, try to resubscribe. That was also broken.

Try to remove the Unsubscribe feedback form now, it should work.