### PR TITLE
displaying UTM tags timeline section query parameters all the time in…

### DIFF
--- a/app/bundles/LeadBundle/Entity/UtmTagRepository.php
+++ b/app/bundles/LeadBundle/Entity/UtmTagRepository.php
@@ -35,7 +35,7 @@ class UtmTagRepository extends CommonRepository
             ->from('MauticLeadBundle:UtmTag', 'ut');
 
         $qb->where(
-            'ut.lead = ' . $lead->getId() . 'and (ut.utmCampaign is not null or ut.utmContent is not null or ut.utmMedium is not null or ut.utmSource is not null or ut.utmTerm is not null)'
+            'ut.lead = ' . $lead->getId()
         );
 
         if (isset($options['filters']['search']) && $options['filters']['search']) {


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | y
| New feature?  | n
| BC breaks?    | n
| Deprecations? | n
| Fixed issues  |  1

## Description
url parameters are now being saved in the utmtags contact's table, but only showing in timeline if there is a utm parameter being filled.
## Steps to reproduce the bug (if applicable)
send different parameters on landing pages or URLs tracked by mautic and these parameters don't show anywhere.
## Steps to test this PR
Apply this PR, send parameters in landing pages example mylandingpage/?email=me@myemail.com and all paramenters including UTM tags should show under the UTM tags history in the contact's timeline
… lead profile