### PR TITLE
Fix for contact filtering in list view.

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -478,7 +478,8 @@ class LeadRepository extends CommonRepository
         //DBAL
         $dq = $this->_em->getConnection()->createQueryBuilder();
         $dq->select('count(l.id) as count')
-            ->from(MAUTIC_TABLE_PREFIX . 'leads', 'l');
+            ->from(MAUTIC_TABLE_PREFIX . 'leads', 'l')
+            ->leftJoin('l', MAUTIC_TABLE_PREFIX . 'users', 'u', 'u.id = l.owner_id');
         $this->buildWhereClause($dq, $args);
 
         //get a total count
@@ -681,20 +682,20 @@ class LeadRepository extends CommonRepository
                 $returnParameter = false;
                 break;
             case $this->translator->trans('mautic.lead.lead.searchcommand.isunowned'):
-                $expr = $q->expr()->$xFunc(
+                $expr = $q->expr()->orX(
                     $q->expr()->$eqFunc("l.owner_id", 0),
                     $q->expr()->$nullFunc("l.owner_id")
                 );
                 $returnParameter = false;
                 break;
             case $this->translator->trans('mautic.lead.lead.searchcommand.owner'):
-                $expr = $q->expr()->$xFunc(
-                    $q->expr()->$likeFunc('LOWER(u.firstName)', ':'.$unique),
-                    $q->expr()->$likeFunc('LOWER(u.lastName)', ':'.$unique)
+                $expr = $q->expr()->orX(
+                    $q->expr()->$likeFunc('LOWER(u.first_name)', ':'.$unique),
+                    $q->expr()->$likeFunc('LOWER(u.last_name)', ':'.$unique)
                 );
                 break;
             case $this->translator->trans('mautic.core.searchcommand.name'):
-                $expr = $q->expr()->$xFunc(
+                $expr = $q->expr()->orX(
                     $q->expr()->$likeFunc('LOWER(l.firstname)', ":$unique"),
                     $q->expr()->$likeFunc('LOWER(l.lastname)', ":$unique")
                 );


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  | N/A

## Description

Fixing up the name, owner, and is:unowned search filters. From the looks of it, these haven't worked in a while. 

1) When searching by `name:NAME`, the SQL query that is built searches the first AND last name for the query string, which is good, but both first and last name must contain the string. So if you search `name:Don`, then it will only return users whose first and last name BOTH contain `don`. 

2) When searching by `owner:NAME`, same as above.

3) When searching `is:unowned`, the SQL query that is built looks for contacts whose owner_id fields are both `NULL` AND `0`, which simply doesn't work.

## Steps to reproduce the bug (if applicable)

Quick add a contact named "John Doe" to your Mautic install (be sure to make yourself the owner as well). Go to main Contacts page, then search `name:John`. You won't get any results unless you have a user with the letter sequence `john` in BOTH their first and last name. Now search for `owner:NAME`, replacing NAME with your mautic user's first name. You again won't get any results (unless your first and last name are the same). 

## Steps to test this PR

Merge the PR and repeat the above process. You'll actually get results this time. I've done limited testing on it and this fixes it.