### PR TITLE
Sort point actions by category fixed

### DIFF
--- a/app/bundles/PointBundle/Views/Point/list.html.php
+++ b/app/bundles/PointBundle/Views/Point/list.html.php
@@ -40,7 +40,7 @@ if ($tmpl == 'index') {
                     'MauticCoreBundle:Helper:tableheader.html.php',
                     array(
                         'sessionVar' => 'point',
-                        'orderBy'    => 'c.title',
+                        'orderBy'    => 'cat.title',
                         'text'       => 'mautic.core.category',
                         'class'      => 'visible-md visible-lg col-point-category'
                     )


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
Sorting point actions by the category column caused a SQL error.

## Steps to reproduce the bug (if applicable)
Go to Point Actions and sort by the category.

## Steps to test this PR
- Apply this PR
- Log out to clear the cache, log in again.
- Follow the step to reproduce
- The error is gone and sorting works.
