### PR TITLE
Password reset link was destroyed by tracking pixel

### DIFF
--- a/app/bundles/UserBundle/Model/UserModel.php
+++ b/app/bundles/UserBundle/Model/UserModel.php
@@ -261,7 +261,7 @@ class UserModel extends FormModel
         $mailer->setSubject($this->translator->trans('mautic.user.user.passwordreset.subject'));
         $body = $this->translator->trans('mautic.user.user.passwordreset.email.body', array('%name%' => $user->getFirstName(), '%resetlink%' => $resetLink));
         $body = str_replace('\\n', "\n", $body);
-        $mailer->setBody($body, 'text/plain');
+        $mailer->setBody($body, 'text/plain', null, true);
 
         $mailer->send();
     }


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  https://github.com/mautic/mautic/issues/1998

## Description
The tracking pixel image was added to the password reset email which destroyed the reset link like that:
![mautic-reset-before](https://cloud.githubusercontent.com/assets/1235442/16731775/2c07fcda-477a-11e6-820a-e6e306d6e010.png)

It really doesn't make sense to send the tracking pixel in that email so I removed it and now it looks like this:
![mautic-reset-after](https://cloud.githubusercontent.com/assets/1235442/16731789/41c8ab1e-477a-11e6-8baa-7af480bb0cf0.png)

## Steps to reproduce the bug (if applicable)
Try to reset your Mautic password.

## Steps to test this PR
Apply this PR and test again.
