### PR TITLE
Make sure that the froala's form.submit event is triggered before froala's style cleared

### DIFF
--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -100,15 +100,6 @@ Mautic.emailOnLoad = function (container, response) {
 
     var plaintext = mQuery('#emailform_plainText');
     Mautic.initAtWho(plaintext, plaintext.attr('data-token-callback'));
-
-    // update textarea from Froala's CodeMirror view on save
-    var form = mQuery('form[name="emailform"]');
-    var textarea = mQuery('textarea.builder-html');
-    if (form.length && textarea.length) {
-        form.on('before.submit.ajaxform', function() {
-            textarea.froalaEditor('events.trigger', 'form.submit');
-        });
-    }
 };
 
 Mautic.emailOnUnload = function(id) {
@@ -122,6 +113,9 @@ Mautic.fixFroalaEmailOutput = function() {
     if (mQuery('form[name="emailform"]').length) {
         var textarea = mQuery('textarea.builder-html');
         mQuery('form[name="emailform"]').on('before.submit.ajaxform', function() {
+            // update textarea from Froala's CodeMirror view on save
+            textarea.froalaEditor('events.trigger', 'form.submit');
+
             var editorHtmlString = textarea.val();
             Mautic.buildBuilderIframe(editorHtmlString, 'helper-iframe-for-html-manipulation');
             var editorHtml = mQuery('iframe#helper-iframe-for-html-manipulation').contents();

--- a/app/bundles/PageBundle/Assets/js/page.js
+++ b/app/bundles/PageBundle/Assets/js/page.js
@@ -38,15 +38,6 @@ Mautic.pageOnLoad = function (container) {
 
     Mautic.intiSelectTheme(mQuery('#page_template'));
     Mautic.fixFroalaPageOutput();
-
-    // update textarea from Froala's CodeMirror view on save
-    var form = mQuery('form[name="page"]');
-    var textarea = mQuery('textarea.builder-html');
-    if (form.length && textarea.length) {
-        form.on('before.submit.ajaxform', function() {
-            textarea.froalaEditor('events.trigger', 'form.submit');
-        });
-    }
 };
 
 Mautic.pageOnUnload = function (id) {
@@ -57,6 +48,9 @@ Mautic.fixFroalaPageOutput = function() {
     if (mQuery('form[name="page"]').length) {
         var textarea = mQuery('textarea.builder-html');
         mQuery('form[name="page"]').on('before.submit.ajaxform', function() {
+            // update textarea from Froala's CodeMirror view on save
+            textarea.froalaEditor('events.trigger', 'form.submit');
+
             var editorHtmlString = textarea.val();
             Mautic.buildBuilderIframe(editorHtmlString, 'helper-iframe-for-html-manipulation');
             var editorHtml = mQuery('iframe#helper-iframe-for-html-manipulation').contents();


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
With the 2.0.1 PR's merged together, there is again an issue with table border styles which are added by Froala.

## Steps to reproduce the bug (if applicable)
Save a table-based page or email and preview it. You should see the borders around all tables.

## Steps to test this PR
Apply this PR, refresh your browser (in dev mode) or build prod assets (in production mode) and save the email/page again. The borders should disappear.