### PR TITLE
Set the user timezone before comparing data

### DIFF
--- a/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
+++ b/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
@@ -123,7 +123,6 @@ class ChartQuery extends AbstractChart
         // Check if the date filters have already been applied
         if ($parameters = $query->getParameters()) {
             if (array_key_exists('dateTo', $parameters) || array_key_exists('dateFrom', $parameters)) {
-
                 return;
             }
         }
@@ -156,7 +155,6 @@ class ChartQuery extends AbstractChart
                     $query->setParameter('dateTo', $dateTo->format('Y-m-d H:i:s'));
                 }
             }
-
         }
     }
 
@@ -306,6 +304,7 @@ class ChartQuery extends AbstractChart
 
                     // Data from the database will always in UTC
                     $itemDate = new \DateTime($item['date'], $utcTz);
+                    $itemDate->setTimezone($previousDate->getTimezone());
 
                     if (!in_array($this->unit, array('H', 'i', 's'))) {
                         // Hours do not matter so let's reset to 00:00:00 for date comparison


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
The line charts data displays data moved by day or several hours depending on the Mautic timezone settings. The issue was in comparing the date range dates in user's timezone with date of the count in UTC. The database date was correctly initiated with UTC timezone, but not converted to user's timezone which made the difference.

## Steps to reproduce the bug (if applicable)
1. Make sure you have your timezone configured correctly and if you are in UTC timezone, it will work for you, so configure for example New York and pretend that you are there, move your clock -4 hours (or at least pretend that they show the New York time).
2. Put the "Contacts created in time" widget to the top of your dashboard and check what is the value today. Remember this number.
3. Add one more contact.
4. Go back to dashboard and check if the number you have in your head is raised +1. It probably isn't but yesterday's is probably. 

## Steps to test this PR
1. Apply this PR and refresh the dashboard. You should see the number move from yesterday to today and so it should contain the correct data in the day view.
2. Let's move to the hourly view. Filter the dashboard to display only the today. The line charts should zoom in and display the data per hour. The right data in the right hour.
3. The right data should be displayed in all views (hour, day, week, month, year)
