### PR TITLE
Form template added to the goldstar theme

### DIFF
--- a/themes/goldstar/html/form.html.twig
+++ b/themes/goldstar/html/form.html.twig
@@ -1,4 +1,4 @@
-{% extends ":nature:base.html.twig" %}
+{% extends ":goldstar:base.html.twig" %}
 
 {% block content %}
     {% if message is defined %}


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  /

## Description
Every theme must have the form theme even though it's not listed it the features list in the configuration.

## Steps to reproduce the bug (if applicable)
Create a form with the Goldstar theme, preview it. You should see the error.

## Steps to test this PR
Apply this PR and the preview should display the preview of the form.
