### PR TITLE
Fix #1329: Messages in queue not always exactly \Swift_Message

### DIFF
--- a/app/bundles/EmailBundle/Command/ProcessEmailQueueCommand.php
+++ b/app/bundles/EmailBundle/Command/ProcessEmailQueueCommand.php
@@ -99,7 +99,7 @@ EOT
                     rename($failedFile, $tmpFilename);
 
                     $message = unserialize(file_get_contents($tmpFilename));
-                    if ($message !== false && is_object($message) && get_class($message) === 'Swift_Message') {
+                    if ($message !== false && is_object($message) && is_a($message, '\Swift_Message')) {
                         $tryAgain = false;
                         if ($dispatcher->hasListeners(EmailEvents::EMAIL_RESEND)) {
                             $event = new QueueEmailEvent($message);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | y
| New feature?  | n
| BC breaks?    | n
| Deprecations? | n
| Fixed issues  |  #1329 

## Description
https://github.com/mautic/mautic/issues/1329#issuecomment-232109083

## Reason
Clearing of email queue got stuck because of MauticMessage instance & incorrect clearing condition.