### PR TITLE
Fixed bad route name for dashboard "Created contacts" widget

### DIFF
--- a/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
@@ -58,7 +58,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
     );
 
     /**
-     * Set a widget detail when needed 
+     * Set a widget detail when needed
      *
      * @param WidgetDetailEvent $event
      *
@@ -68,7 +68,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
     {
         $this->checkPermissions($event);
         $canViewOthers = $event->hasPermission('form:forms:viewother');
-        
+
         if ($event->getType() == 'created.leads.in.time') {
             $widget = $event->getWidget();
             $params = $widget->getParams();
@@ -170,9 +170,9 @@ class DashboardSubscriber extends MainDashboardSubscriber
                     'bodyItems'   => $items,
                     'raw'         => $lists
                 ));
-               
+
             }
-            
+
             $event->setTemplate('MauticCoreBundle:Helper:table.html.php');
             $event->stopPropagation();
             return;
@@ -310,7 +310,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
                     'raw'         => $owners
                 ));
             }
-            
+
             $event->setTemplate('MauticCoreBundle:Helper:table.html.php');
             $event->stopPropagation();
             return;
@@ -365,7 +365,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
                     'raw'         => $creators
                 ));
             }
-            
+
             $event->setTemplate('MauticCoreBundle:Helper:table.html.php');
             $event->stopPropagation();
             return;
@@ -389,7 +389,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
                 // Build table rows with links
                 if ($leads) {
                     foreach ($leads as &$lead) {
-                        $leadUrl = $this->factory->getRouter()->generate('mautic_lead_action', array('objectAction' => 'view', 'objectId' => $lead['id']));
+                        $leadUrl = $this->factory->getRouter()->generate('mautic_contact_action', array('objectAction' => 'view', 'objectId' => $lead['id']));
                         $row = array(
                             array(
                                 'value' => $lead['name'],
@@ -409,7 +409,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
                     'raw'         => $leads
                 ));
             }
-            
+
             $event->setTemplate('MauticCoreBundle:Helper:table.html.php');
             $event->stopPropagation();
             return;


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      |  Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  |  https://github.com/mautic/mautic/issues/2054, https://www.mautic.org/community/index.php/4917-mautic-error-500-route-issue/0#p13125

## Description

The Created Contacts dashboard widget causes an exception due to a renamed route in 2.0. This PR fixes it. 

## Steps to reproduce the bug (if applicable)

Add the Created contacts widget to the dashboard and you should experience the bug.

## Steps to test this PR

Apply the PR and the dashboard should be viewable with the created contacts widget.