### PR TITLE
Editor fixes

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -543,80 +543,54 @@ var Mautic = {
             }
         }
 
-        mQuery.each(['editor', 'editor-basic', 'editor-advanced', 'editor-advanced-2rows', 'editor-fullpage', 'editor-basic-fullpage'], function (index, editorClass) {
-            if (mQuery(container + ' textarea.' + editorClass).length) {
-                mQuery(container + ' textarea.' + editorClass).each(function () {
-                    var textarea = mQuery(this);
+        if (mQuery(container + ' textarea.editor').length) {
+            mQuery(container + ' textarea.editor').each(function () {
+                var textarea = mQuery(this);
 
-
-
-                    // init AtWho in a froala editor
-                    if (textarea.hasClass('editor-builder-tokens')) {
-                        textarea.on('froalaEditor.initialized', function (e, editor) {
-                            Mautic.initAtWho(editor.$el, textarea.attr('data-token-callback'), editor);
-                        });
-                    }
-
-                    textarea.on('froalaEditor.blur', function (e, editor) {
-                        editor.popups.hideAll();
+                // init AtWho in a froala editor
+                if (textarea.hasClass('editor-builder-tokens')) {
+                    textarea.on('froalaEditor.initialized', function (e, editor) {
+                        Mautic.initAtWho(editor.$el, textarea.attr('data-token-callback'), editor);
                     });
+                }
 
-                    // var settings = {};
-
-                    // if (editorClass != 'editor') {
-                    //     // Set the custom editor toolbar
-                    //     var toolbar = editorClass.replace('editor-', '').replace('-', '_');
-                    //     settings.toolbar = toolbar;
-                    // }
-
-                    // if (editorClass != 'editor' && editorClass != 'editor-basic') {
-                    //     // Do not strip classes and the like
-                    //     settings.allowedContent = true;
-                    // }
-
-                    // if (editorClass == 'editor-fullpage' || editorClass == 'editor-basic-fullpage') {
-                    //     // Allow full page editing and add tools to update html document
-                    //     settings.fullPage     = true;
-                    //     settings.extraPlugins = "sourcedialog,docprops,filemanager";
-                    // }
-
-                    var maxButtons = ['undo', 'redo' , '|', 'bold', 'italic', 'underline', 'strikeThrough', 'fontFamily', 'fontSize', 'color', 'paragraphFormat', 'align', 'orderedList', 'unorderedList', 'quote', 'strikethrough', 'outdent', 'indent', 'clearFormatting','insertLink', 'insertImage','insertTable', 'html', 'fullscreen'];
-
-                    if (textarea.hasClass('editor-advanced') || textarea.hasClass('editor-basic-fullpage')) {
-                        var options = {
-                            // Set custom buttons with separator between them.
-                            toolbarButtons: maxButtons,
-                            toolbarButtonsMD: maxButtons,
-                            heightMin: 300
-                        };
-
-                        if (textarea.hasClass('editor-basic-fullpage')) {
-                            options.fullPage = true;
-                            options.htmlAllowedTags = ['.*'];
-                            options.htmlAllowedAttrs = ['.*'];
-                            options.htmlRemoveTags = [];
-                            options.lineBreakerTags = [];
-                        }
-
-                        textarea.froalaEditor(mQuery.extend(options, Mautic.basicFroalaOptions));
-                    } else if (editorClass == 'editor') {
-                        //     settings.removePlugins = 'resize';
-
-                        textarea.froalaEditor(mQuery.extend({
-                            // Set custom buttons with separator between them.
-                            toolbarButtons: maxButtons,
-                            toolbarButtonsMD: maxButtons,
-                            toolbarButtonsSM: ['undo', 'redo' , '-', 'bold', 'italic', 'underline'],
-                            toolbarButtonsXS: ['undo', 'redo' , '-', 'bold', 'italic', 'underline'],
-                            heightMin: 100
-                        }, Mautic.basicFroalaOptions));
-
-                    } else {
-                        textarea.froalaEditor(Mautic.basicFroalaOptions);
-                    }
+                textarea.on('froalaEditor.blur', function (e, editor) {
+                    editor.popups.hideAll();
                 });
-            }
-        });
+
+                var maxButtons = ['undo', 'redo' , '|', 'bold', 'italic', 'underline', 'strikeThrough', 'fontFamily', 'fontSize', 'color', 'paragraphFormat', 'align', 'orderedList', 'unorderedList', 'quote', 'strikethrough', 'outdent', 'indent', 'clearFormatting','insertLink', 'insertImage','insertTable', 'html', 'fullscreen'];
+                var minButtons = ['bold', 'italic', 'underline'];
+
+                if (textarea.hasClass('editor-advanced') || textarea.hasClass('editor-basic-fullpage')) {
+                    var options = {
+                        // Set custom buttons with separator between them.
+                        toolbarButtons: maxButtons,
+                        toolbarButtonsMD: maxButtons,
+                        heightMin: 300
+                    };
+
+                    if (textarea.hasClass('editor-basic-fullpage')) {
+                        options.fullPage = true;
+                        options.htmlAllowedTags = ['.*'];
+                        options.htmlAllowedAttrs = ['.*'];
+                        options.htmlRemoveTags = [];
+                        options.lineBreakerTags = [];
+                    }
+
+                    textarea.froalaEditor(mQuery.extend(options, Mautic.basicFroalaOptions));
+                } else {
+                    textarea.froalaEditor(mQuery.extend({
+                        // Set custom buttons with separator between them.
+                        toolbarButtons: minButtons,
+                        toolbarButtonsMD: minButtons,
+                        toolbarButtonsSM: minButtons,
+                        toolbarButtonsXS: minButtons,
+                        heightMin: 100
+                    }, Mautic.basicFroalaOptions));
+
+                }
+            });
+        }
 
         //activate shuffles
         if (mQuery('.shuffle-grid').length) {
@@ -1003,10 +977,8 @@ var Mautic = {
                 MauticVars.modalsReset = {};
             }
 
-            mQuery.each(['editor', 'editor-basic', 'editor-advanced', 'editor-advanced-2rows', 'editor-fullpage'], function (index, editorClass) {
-                mQuery(container + ' textarea.' + editorClass).each(function () {
-                    mQuery('textarea.'+editorClass).froalaEditor('destroy');
-                });
+            mQuery(container + ' textarea.editor').each(function () {
+                mQuery('textarea.'+editorClass).froalaEditor('destroy');
             });
 
             //turn off shuffle events

--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -593,6 +593,7 @@ var Mautic = {
                         if (textarea.hasClass('editor-basic-fullpage')) {
                             options.fullPage = true;
                             options.htmlAllowedTags = ['.*'];
+                            options.htmlAllowedAttrs = ['.*'];
                             options.htmlRemoveTags = [];
                             options.lineBreakerTags = [];
                         }

--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -978,7 +978,7 @@ var Mautic = {
             }
 
             mQuery(container + ' textarea.editor').each(function () {
-                mQuery('textarea.'+editorClass).froalaEditor('destroy');
+                mQuery('textarea.editor').froalaEditor('destroy');
             });
 
             //turn off shuffle events

--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -284,6 +284,7 @@ var Mautic = {
             imageManagerLoadURL: mauticBaseUrl + 's/file/list',
             imageManagerDeleteURL: mauticBaseUrl + 's/file/delete',
             useClasses: false,
+            imageOutputSize: true,
             htmlAllowedTags: ['a', 'abbr', 'address', 'area', 'article', 'aside', 'audio', 'b', 'base', 'bdi', 'bdo', 'blockquote', 'br', 'button', 'canvas', 'caption', 'cite', 'code', 'col', 'colgroup', 'datalist', 'dd', 'del', 'details', 'dfn', 'dialog', 'div', 'dl', 'dt', 'em', 'embed', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hgroup', 'hr', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'keygen', 'label', 'legend', 'li', 'link', 'main', 'map', 'mark', 'menu', 'menuitem', 'meter', 'nav', 'noscript', 'object', 'ol', 'optgroup', 'option', 'output', 'p', 'param', 'pre', 'progress', 'queue', 'rp', 'rt', 'ruby', 's', 'samp', 'script', 'style', 'section', 'select', 'small', 'source', 'span', 'strike', 'strong', 'sub', 'summary', 'sup', 'table', 'tbody', 'td', 'textarea', 'tfoot', 'th', 'thead', 'time', 'title', 'tr', 'track', 'u', 'ul', 'var', 'video', 'wbr', 'center'],
             htmlAllowedAttrs: ['data-atwho-at-query', 'data-section', 'data-section-wrapper', 'accept', 'accept-charset', 'accesskey', 'action', 'align', 'alt', 'async', 'autocomplete', 'autofocus', 'autoplay', 'autosave', 'background', 'bgcolor', 'border', 'charset', 'cellpadding', 'cellspacing', 'checked', 'cite', 'class', 'color', 'cols', 'colspan', 'content', 'contenteditable', 'contextmenu', 'controls', 'coords', 'data', 'data-.*', 'datetime', 'default', 'defer', 'dir', 'dirname', 'disabled', 'download', 'draggable', 'dropzone', 'enctype', 'for', 'form', 'formaction', 'headers', 'height', 'hidden', 'high', 'href', 'hreflang', 'http-equiv', 'icon', 'id', 'ismap', 'itemprop', 'keytype', 'kind', 'label', 'lang', 'language', 'list', 'loop', 'low', 'max', 'maxlength', 'media', 'method', 'min', 'multiple', 'name', 'novalidate', 'open', 'optimum', 'pattern', 'ping', 'placeholder', 'poster', 'preload', 'pubdate', 'radiogroup', 'readonly', 'rel', 'required', 'reversed', 'rows', 'rowspan', 'sandbox', 'scope', 'scoped', 'scrolling', 'seamless', 'selected', 'shape', 'size', 'sizes', 'span', 'src', 'srcdoc', 'srclang', 'srcset', 'start', 'step', 'summary', 'spellcheck', 'style', 'tabindex', 'target', 'title', 'type', 'translate', 'usemap', 'value', 'valign', 'width', 'wrap', 'contenteditable']
         };
@@ -575,7 +576,6 @@ var Mautic = {
                         options.htmlAllowedAttrs = ['.*'];
                         options.htmlRemoveTags = [];
                         options.lineBreakerTags = [];
-                        options.imageOutputSize = true;
                     }
 
                     textarea.froalaEditor(mQuery.extend(options, Mautic.basicFroalaOptions));

--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -578,6 +578,10 @@ var Mautic = {
                         options.lineBreakerTags = [];
                     }
 
+                    textarea.on('froalaEditor.focus', function (e, editor) {
+                        Mautic.showChangeThemeWarning = true;
+                    });
+
                     textarea.froalaEditor(mQuery.extend(Mautic.basicFroalaOptions, options));
                 } else {
                     textarea.froalaEditor(mQuery.extend(Mautic.basicFroalaOptions, {
@@ -3369,23 +3373,29 @@ var Mautic = {
         }
     },
 
-    froalaEmptyContent: '<!DOCTYPE html><html><head><title></title></head><body></body></html>',
-
     intiSelectTheme: function(themeField) {
         var customHtml = mQuery('textarea.builder-html');
+        var isNew = Mautic.isNewEntity('#page_sessionId, #emailform_sessionId');
+        Mautic.showChangeThemeWarning = true;
+
+        if (isNew) {
+            Mautic.showChangeThemeWarning = false;
+        }
+
         if (customHtml.length) {
 
-            if (!customHtml.val().length || customHtml.val() === Mautic.froalaEmptyContent) {
+            if (!customHtml.val().length) {
                 Mautic.setThemeHtml(themeField.val());
             }
 
             mQuery('[data-theme]').click(function(e) {
                 e.preventDefault();
                 var currentLink = mQuery(this);
-
-                if (customHtml.val().length && customHtml.val() !== Mautic.froalaEmptyContent) {
+                
+                if (Mautic.showChangeThemeWarning && customHtml.val().length) {
                     if (confirm('You will lose the current content if you switch the theme.')) {
                         customHtml.val('');
+                        Mautic.showChangeThemeWarning = false;
                     } else {
                         return;
                     }
@@ -3414,5 +3424,19 @@ var Mautic = {
             textarea.val(themeHtml);
             textarea.froalaEditor('html.set', themeHtml);
         });
+    },
+
+
+    /**
+     * Check if the the entity ID is temporary (for new entities)
+     *
+     * @param string idInputSelector
+     */
+    isNewEntity: function(idInputSelector) {
+        id = mQuery(idInputSelector);
+        if (id.length) {
+            return id.val().match("^new_");
+        }
+        return null;
     }
 };

--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -578,16 +578,15 @@ var Mautic = {
                         options.lineBreakerTags = [];
                     }
 
-                    textarea.froalaEditor(mQuery.extend(options, Mautic.basicFroalaOptions));
+                    textarea.froalaEditor(mQuery.extend(Mautic.basicFroalaOptions, options));
                 } else {
-                    textarea.froalaEditor(mQuery.extend({
-                        // Set custom buttons with separator between them.
+                    textarea.froalaEditor(mQuery.extend(Mautic.basicFroalaOptions, {
                         toolbarButtons: minButtons,
                         toolbarButtonsMD: minButtons,
                         toolbarButtonsSM: minButtons,
                         toolbarButtonsXS: minButtons,
                         heightMin: 100
-                    }, Mautic.basicFroalaOptions));
+                    }));
 
                 }
             });

--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -575,6 +575,7 @@ var Mautic = {
                         options.htmlAllowedAttrs = ['.*'];
                         options.htmlRemoveTags = [];
                         options.lineBreakerTags = [];
+                        options.imageOutputSize = true;
                     }
 
                     textarea.froalaEditor(mQuery.extend(options, Mautic.basicFroalaOptions));

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -41,16 +41,13 @@ Mautic.launchBuilder = function (formName, actionName) {
     var assets = Mautic.htmlspecialchars_decode(mQuery('[data-builder-assets]').html());
     themeHtml = themeHtml.replace('</head>', assets+'</head>');
 
-    var doc = Mautic.buildBuilderIframe(themeHtml, 'builder-template-content');
-
-    mQuery(doc).ready(function(){
+    Mautic.buildBuilderIframe(themeHtml, 'builder-template-content', function() {
         mQuery('#builder-overlay').addClass('hide');
         mQuery('.btn-close-builder').prop('disabled', false);
     });
 };
 
-Mautic.buildBuilderIframe = function(themeHtml, id) {
-
+Mautic.buildBuilderIframe = function(themeHtml, id, onLoadCallback) {
     if (mQuery('iframe#'+id).length) {
         var builder = mQuery('iframe#'+id);
     } else {
@@ -66,14 +63,18 @@ Mautic.buildBuilderIframe = function(themeHtml, id) {
         }).appendTo('.builder-content');
     }
 
+    builder.on('load', function() {
+        if (typeof onLoadCallback === 'function') {
+            onLoadCallback();
+        }
+    });
+
     // Build the iframe with the theme HTML in it
     var iframe = document.getElementById(id);
     var doc = iframe.contentDocument || iframe.contentWindow.document;
     doc.open();
     doc.write(themeHtml);
     doc.close();
-
-    return doc;
 };
 
 Mautic.htmlspecialchars_decode = function(encodedHtml) {
@@ -165,19 +166,36 @@ Mautic.destroySlots = function() {
     htmlTags[0].removeAttribute('class');
 };
 
+Mautic.clearThemeHtmlBeforeSave = function(form, callback) {
+    var form = mQuery(form);
+    var textarea = form.find('textarea.builder-html');
+
+    // update textarea from Froala's CodeMirror view on save
+    textarea.froalaEditor('events.trigger', 'form.submit');
+
+    // Return the styles added by Froala to its original state
+    var editorHtmlString = textarea.val();
+    Mautic.buildBuilderIframe(editorHtmlString, 'helper-iframe-for-html-manipulation', function() {
+        var editorHtml = mQuery('iframe#helper-iframe-for-html-manipulation').contents();
+        editorHtml = Mautic.clearFroalaStyles(editorHtml);
+        textarea.val(editorHtml.find('html').get(0).outerHTML);
+        callback();
+    });
+}
+
 Mautic.clearFroalaStyles = function(content) {
-    mQuery.each(content.find('td, th, table, strong'), function() {
-        var td = mQuery(this);
-        if (td.attr('fr-original-class')) {
-            td.attr('class', td.attr('fr-original-class'));
-            td.removeAttr('fr-original-class');
+    mQuery.each(content.find('td, th, table, [fr-original-class], [fr-original-style]'), function() {
+        var el = mQuery(this);
+        if (el.attr('fr-original-class')) {
+            el.attr('class', el.attr('fr-original-class'));
+            el.removeAttr('fr-original-class');
         }
-        if (td.attr('fr-original-style')) {
-            td.attr('style', td.attr('fr-original-style'));
-            td.removeAttr('fr-original-style');
+        if (el.attr('fr-original-style')) {
+            el.attr('style', el.attr('fr-original-style'));
+            el.removeAttr('fr-original-style');
         }
-        if (td.css('border') === '1px solid rgb(221, 221, 221)') {
-            td.css('border', '');
+        if (el.css('border') === '1px solid rgb(221, 221, 221)') {
+            el.css('border', '');
         }
     });
     content.find('link[href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/css/font-awesome.min.css"]').remove();

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -502,8 +502,11 @@ Mautic.initSlotListeners = function() {
             slot.froalaEditor(mQuery.extend(inlineFroalaOptions, Mautic.basicFroalaOptions));
             slot.froalaEditor('toolbar.hide');
         } else if (type === 'image') {
+            var image = slot.find('img');
+            // fix of badly destroyed image slot
+            image.removeAttr('data-froala.editor');
             // Init Froala editor
-            slot.find('img').froalaEditor(mQuery.extend({
+            image.froalaEditor(mQuery.extend({
                     linkList: [], // TODO push here the list of tokens from Mautic.getPredefinedLinks
                     useClasses: false,
                     imageEditButtons: ['imageReplace', 'imageAlign', 'imageAlt', 'imageSize', '|', 'imageLink', 'linkOpen', 'linkEdit', 'linkRemove']
@@ -576,7 +579,9 @@ Mautic.initSlotListeners = function() {
             params.slot.froalaEditor('destroy');
             params.slot.find('.atwho-inserted').atwho('destroy');
         } else if (params.type === 'image') {
-            params.slot.find('img').froalaEditor('destroy');
+            var image = params.slot.find('img');
+            image.removeAttr('data-froala.editor');
+            image.froalaEditor('destroy');
         }
 
         // Remove Symfony toolbar

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -499,19 +499,18 @@ Mautic.initSlotListeners = function() {
                 imageEditButtons: ['imageReplace', 'imageAlign', 'imageRemove', 'imageAlt', 'imageSize', '|', 'imageLink', 'linkOpen', 'linkEdit', 'linkRemove']
             };
 
-            slot.froalaEditor(mQuery.extend(inlineFroalaOptions, Mautic.basicFroalaOptions));
+            slot.froalaEditor(mQuery.extend(Mautic.basicFroalaOptions, inlineFroalaOptions));
             slot.froalaEditor('toolbar.hide');
         } else if (type === 'image') {
             var image = slot.find('img');
             // fix of badly destroyed image slot
             image.removeAttr('data-froala.editor');
             // Init Froala editor
-            image.froalaEditor(mQuery.extend({
+            image.froalaEditor(mQuery.extend(Mautic.basicFroalaOptions, {
                     linkList: [], // TODO push here the list of tokens from Mautic.getPredefinedLinks
                     useClasses: false,
                     imageEditButtons: ['imageReplace', 'imageAlign', 'imageAlt', 'imageSize', '|', 'imageLink', 'linkOpen', 'linkEdit', 'linkRemove']
-                },
-                Mautic.basicFroalaOptions
+                }
             ));
         } else if (type === 'button') {
             slot.find('a').click(function(e) {

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -6,6 +6,7 @@
 Mautic.launchBuilder = function (formName, actionName) {
     Mautic.builderMode     = (mQuery('#' + formName + '_template').val() == '') ? 'custom' : 'template';
     Mautic.builderFormName = formName;
+    Mautic.showChangeThemeWarning = true;
 
     mQuery('body').css('overflow-y', 'hidden');
 

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -34,8 +34,6 @@ Mautic.launchBuilder = function (formName, actionName) {
     // Disable the close button until everything is loaded
     mQuery('.btn-close-builder').prop('disabled', true);
 
-    var froalaDefaultHtmlCount = 69;
-
     // Load the theme from the custom HTML textarea
     var themeHtml = mQuery('textarea.builder-html').val();
 

--- a/app/bundles/CoreBundle/Assets/js/libraries/froala/plugins/filemanager.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/froala/plugins/filemanager.js
@@ -10,6 +10,7 @@ var FroalaEditorForFileManagerCurrentImage = null;
 // This method is called by the Filemanager after an image is selected
 function SetUrl( url, width, height, alt ) {
     if (typeof FroalaEditorForFileManagerCurrentImage !== 'undefined' && 
+        FroalaEditorForFileManagerCurrentImage !== null && 
         FroalaEditorForFileManagerCurrentImage.length && 
         FroalaEditorForFileManagerCurrentImage.prop('tagName') === 'IMG') {
         // Copy additional image attributes.

--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -117,10 +117,12 @@ Mautic.fixFroalaEmailOutput = function() {
             textarea.froalaEditor('events.trigger', 'form.submit');
 
             var editorHtmlString = textarea.val();
-            Mautic.buildBuilderIframe(editorHtmlString, 'helper-iframe-for-html-manipulation');
+            var doc = Mautic.buildBuilderIframe(editorHtmlString, 'helper-iframe-for-html-manipulation');
             var editorHtml = mQuery('iframe#helper-iframe-for-html-manipulation').contents();
             editorHtml = Mautic.clearFroalaStyles(editorHtml);
-            textarea.val(editorHtml.find('html').get(0).outerHTML);
+            mQuery(doc).on('load', function() {
+                textarea.val(editorHtml.find('html').get(0).outerHTML);
+            });
         });
     }
 }

--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -96,7 +96,6 @@ Mautic.emailOnLoad = function (container, response) {
     });
 
     Mautic.intiSelectTheme(mQuery('#emailform_template'));
-    Mautic.fixFroalaEmailOutput();
 
     var plaintext = mQuery('#emailform_plainText');
     Mautic.initAtWho(plaintext, plaintext.attr('data-token-callback'));
@@ -108,24 +107,6 @@ Mautic.emailOnUnload = function(id) {
     }
     mQuery('#emailform_customHtml').froalaEditor('popups.hideAll');
 };
-
-Mautic.fixFroalaEmailOutput = function() {
-    if (mQuery('form[name="emailform"]').length) {
-        var textarea = mQuery('textarea.builder-html');
-        mQuery('form[name="emailform"]').on('before.submit.ajaxform', function() {
-            // update textarea from Froala's CodeMirror view on save
-            textarea.froalaEditor('events.trigger', 'form.submit');
-
-            var editorHtmlString = textarea.val();
-            var doc = Mautic.buildBuilderIframe(editorHtmlString, 'helper-iframe-for-html-manipulation');
-            var editorHtml = mQuery('iframe#helper-iframe-for-html-manipulation').contents();
-            editorHtml = Mautic.clearFroalaStyles(editorHtml);
-            mQuery(doc).on('load', function() {
-                textarea.val(editorHtml.find('html').get(0).outerHTML);
-            });
-        });
-    }
-}
 
 Mautic.insertEmailBuilderToken = function(editorId, token) {
     var editor = Mautic.getEmailBuilderEditorInstances();

--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -87,12 +87,18 @@ Mautic.emailOnLoad = function (container, response) {
         Mautic.activateSearchAutocomplete('list-search', 'email');
     }
 
+    var textarea = mQuery('#emailform_customHtml');
+
     mQuery(document).on('shown.bs.tab', function (e) {
-        mQuery('#emailform_customHtml').froalaEditor('popups.hideAll');
+        textarea.froalaEditor('popups.hideAll');
+    });
+
+    mQuery('a[href="#source-container"]').on('shown.bs.tab', function (e) {
+        textarea.froalaEditor('html.set', textarea.val());
     });
 
     mQuery('.btn-builder').on('click', function (e) {
-        mQuery('#emailform_customHtml').froalaEditor('popups.hideAll');
+        textarea.froalaEditor('popups.hideAll');
     });
 
     Mautic.intiSelectTheme(mQuery('#emailform_template'));

--- a/app/bundles/EmailBundle/Form/Type/EmailType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailType.php
@@ -211,7 +211,7 @@ class EmailType extends AbstractType
                     'label_attr' => array('class' => 'control-label'),
                     'required'   => false,
                     'attr'       => array(
-                        'class'                => 'form-control editor-basic-fullpage editor-builder-tokens builder-html',
+                        'class'                => 'form-control editor editor-basic-fullpage editor-builder-tokens builder-html',
                         'data-token-callback'  => 'email:getBuilderTokens',
                         'data-token-activator' => '{'
                     )

--- a/app/bundles/EmailBundle/Views/Email/form.html.php
+++ b/app/bundles/EmailBundle/Views/Email/form.html.php
@@ -11,14 +11,14 @@ $view->extend('MauticCoreBundle:Default:content.html.php');
 $view['slots']->set('mauticContent', 'email');
 
 $variantParent = $email->getVariantParent();
-$subheader = ($variantParent) ? '<div><span class="small">' . $view['translator']->trans('mautic.email.header.editvariant', array(
+$subheader = ($variantParent) ? '<div><span class="small">' . $view['translator']->trans('mautic.email.header.editvariant', [
     '%name%' => $email->getName(),
     '%parent%' => $variantParent->getName()
-)) . '</span></div>' : '';
+]) . '</span></div>' : '';
 
 $header = ($email->getId()) ?
     $view['translator']->trans('mautic.email.header.edit',
-        array('%name%' => $email->getName())) :
+        ['%name%' => $email->getName()]) :
     $view['translator']->trans('mautic.email.header.new');
 
 $view['slots']->set("headerTitle", $header.$subheader);
@@ -29,9 +29,12 @@ if (!isset($attachmentSize)) {
     $attachmentSize = 0;
 }
 
+$attr = $form->vars['attr'];
+$attr['data-submit-callback-async'] = "clearThemeHtmlBeforeSave";
+
 ?>
 
-<?php echo $view['form']->start($form); ?>
+<?php echo $view['form']->start($form, ['attr' => $attr]); ?>
 <div class="box-layout">
     <div class="col-md-9 height-auto bg-white">
         <div class="row">
@@ -53,11 +56,11 @@ if (!isset($attachmentSize)) {
                                 <?php echo $view['form']->row($form['template']); ?>
                             </div>
                         </div>
-                        <?php echo $view->render('MauticCoreBundle:Helper:theme_select.html.php', array(
+                        <?php echo $view->render('MauticCoreBundle:Helper:theme_select.html.php', [
                             'type'   => 'email',
                             'themes' => $themes,
                             'active' => $form['template']->vars['value']
-                        )); ?>
+                        ]); ?>
                     </div>
 
                     <div class="tab-pane fade bdr-w-0" id="advanced-container">
@@ -150,24 +153,24 @@ if (!isset($attachmentSize)) {
 </div>
 <?php echo $view['form']->end($form); ?>
 
-<?php echo $view->render('MauticCoreBundle:Helper:builder.html.php', array(
+<?php echo $view->render('MauticCoreBundle:Helper:builder.html.php', [
     'type'          => 'email',
     'sectionForm'   => $sectionForm,
     'builderAssets' => $builderAssets,
     'slots'         => $slots,
     'objectId'      => $email->getSessionId()
-)); ?>
+]); ?>
 
 <?php
 $type = $email->getEmailType();
 if (empty($type) || !empty($forceTypeSelection)):
     echo $view->render('MauticCoreBundle:Helper:form_selecttype.html.php',
-        array(
+        [
             'item'               => $email,
-            'mauticLang'         => array(
+            'mauticLang'         => [
                 'newListEmail' => 'mautic.email.type.list.header',
                 'newTemplateEmail'   => 'mautic.email.type.template.header'
-            ),
+            ],
             'typePrefix'         => 'email',
             'cancelUrl'          => 'mautic_email_index',
             'header'             => 'mautic.email.type.header',
@@ -179,5 +182,5 @@ if (empty($type) || !empty($forceTypeSelection)):
             'typeTwoIconClass'   => 'fa-pie-chart',
             'typeTwoDescription' => 'mautic.email.type.list.description',
             'typeTwoOnClick'     => "Mautic.selectEmailType('list');",
-        ));
+        ]);
 endif;

--- a/app/bundles/FormBundle/Form/Type/FormFieldTextType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldTextType.php
@@ -24,7 +24,7 @@ class FormFieldTextType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $editor = ($options['editor']) ? ' editor-basic' : '';
+        $editor = ($options['editor']) ? ' editor editor-basic' : '';
 
         $builder->add('text', 'textarea', array(
             'label'      => 'mautic.form.field.type.freetext',

--- a/app/bundles/FormBundle/Form/Type/SubmitActionEmailType.php
+++ b/app/bundles/FormBundle/Form/Type/SubmitActionEmailType.php
@@ -60,7 +60,7 @@ class SubmitActionEmailType extends AbstractType
         $builder->add('message', 'textarea', array(
             'label'      => 'mautic.form.action.sendemail.message',
             'label_attr' => array('class' => 'control-label'),
-            'attr'       => array('class' => 'form-control editor-basic'),
+            'attr'       => array('class' => 'form-control editor editor-basic'),
             'required'   => false,
             'data'       => $message
         ));

--- a/app/bundles/LeadBundle/Form/Type/EmailType.php
+++ b/app/bundles/LeadBundle/Form/Type/EmailType.php
@@ -96,7 +96,7 @@ class EmailType extends AbstractType
                 'label'      => 'mautic.email.form.body',
                 'label_attr' => array('class' => 'control-label'),
                 'attr'       => array(
-                    'class'                => 'form-control editor-basic-fullpage editor-builder-tokens',
+                    'class'                => 'form-control editor editor-basic-fullpage editor-builder-tokens',
                     'data-token-callback'  => 'email:getBuilderTokens',
                     'data-token-activator' => '{'
                 )

--- a/app/bundles/PageBundle/Assets/js/page.js
+++ b/app/bundles/PageBundle/Assets/js/page.js
@@ -28,12 +28,18 @@ Mautic.pageOnLoad = function (container) {
         });
     }
 
+    var textarea = mQuery('#page_customHtml');
+
     mQuery(document).on('shown.bs.tab', function (e) {
-        mQuery('#page_customHtml').froalaEditor('popups.hideAll');
+        textarea.froalaEditor('popups.hideAll');
+    });
+
+    mQuery('a[href="#source-container"]').on('shown.bs.tab', function (e) {
+        textarea.froalaEditor('html.set', textarea.val());
     });
 
     mQuery('.btn-builder').on('click', function (e) {
-        mQuery('#page_customHtml').froalaEditor('popups.hideAll');
+        textarea.froalaEditor('popups.hideAll');
     });
 
     Mautic.intiSelectTheme(mQuery('#page_template'));

--- a/app/bundles/PageBundle/Assets/js/page.js
+++ b/app/bundles/PageBundle/Assets/js/page.js
@@ -37,28 +37,10 @@ Mautic.pageOnLoad = function (container) {
     });
 
     Mautic.intiSelectTheme(mQuery('#page_template'));
-    Mautic.fixFroalaPageOutput();
 };
 
 Mautic.pageOnUnload = function (id) {
     mQuery('#page_customHtml').froalaEditor('popups.hideAll');
-}
-
-Mautic.fixFroalaPageOutput = function() {
-    if (mQuery('form[name="page"]').length) {
-        var textarea = mQuery('textarea.builder-html');
-        mQuery('form[name="page"]').on('before.submit.ajaxform', function() {
-            // update textarea from Froala's CodeMirror view on save
-            textarea.froalaEditor('events.trigger', 'form.submit');
-            var editorHtmlString = textarea.val();
-            var doc = Mautic.buildBuilderIframe(editorHtmlString, 'helper-iframe-for-html-manipulation');
-            var editorHtml = mQuery('iframe#helper-iframe-for-html-manipulation').contents();
-            editorHtml = Mautic.clearFroalaStyles(editorHtml);
-            mQuery(doc).on('load', function(){
-                textarea.val(editorHtml.find('html').get(0).outerHTML);
-            });
-        });
-    }
 }
 
 Mautic.getPageAbTestWinnerForm = function(abKey) {

--- a/app/bundles/PageBundle/Assets/js/page.js
+++ b/app/bundles/PageBundle/Assets/js/page.js
@@ -50,12 +50,13 @@ Mautic.fixFroalaPageOutput = function() {
         mQuery('form[name="page"]').on('before.submit.ajaxform', function() {
             // update textarea from Froala's CodeMirror view on save
             textarea.froalaEditor('events.trigger', 'form.submit');
-
             var editorHtmlString = textarea.val();
-            Mautic.buildBuilderIframe(editorHtmlString, 'helper-iframe-for-html-manipulation');
+            var doc = Mautic.buildBuilderIframe(editorHtmlString, 'helper-iframe-for-html-manipulation');
             var editorHtml = mQuery('iframe#helper-iframe-for-html-manipulation').contents();
             editorHtml = Mautic.clearFroalaStyles(editorHtml);
-            textarea.val(editorHtml.find('html').get(0).outerHTML);
+            mQuery(doc).on('load', function(){
+                textarea.val(editorHtml.find('html').get(0).outerHTML);
+            });
         });
     }
 }

--- a/app/bundles/PageBundle/Form/Type/PageType.php
+++ b/app/bundles/PageBundle/Form/Type/PageType.php
@@ -94,7 +94,7 @@ class PageType extends AbstractType
                 'label'      => 'mautic.page.form.customhtml',
                 'required'   => false,
                 'attr'       => array(
-                    'class'                => 'form-control editor-basic-fullpage editor-builder-tokens builder-html',
+                    'class'                => 'form-control editor editor-basic-fullpage editor-builder-tokens builder-html',
                     'data-token-callback'  => 'page:getBuilderTokens',
                     'data-token-activator' => '{'
                 )

--- a/app/bundles/PageBundle/Views/Page/form.html.php
+++ b/app/bundles/PageBundle/Views/Page/form.html.php
@@ -11,22 +11,25 @@ $view->extend('MauticCoreBundle:Default:content.html.php');
 $view['slots']->set('mauticContent', 'page');
 
 $variantParent = $activePage->getVariantParent();
-$subheader = ($variantParent) ? '<div><span class="small">' . $view['translator']->trans('mautic.page.header.editvariant', array(
+$subheader = ($variantParent) ? '<div><span class="small">' . $view['translator']->trans('mautic.page.header.editvariant', [
     '%name%' => $activePage->getTitle(),
     '%parent%' => $variantParent->getTitle()
-)) . '</span></div>' : '';
+]) . '</span></div>' : '';
 
 $header = ($activePage->getId()) ?
     $view['translator']->trans('mautic.page.header.edit',
-        array('%name%' => $activePage->getTitle())) :
+        ['%name%' => $activePage->getTitle()]) :
     $view['translator']->trans('mautic.page.header.new');
 
 $view['slots']->set("headerTitle", $header.$subheader);
 
 $template = $form['template']->vars['data'];
+
+$attr = $form->vars['attr'];
+$attr['data-submit-callback-async'] = "clearThemeHtmlBeforeSave";
 ?>
 
-<?php echo $view['form']->start($form); ?>
+<?php echo $view['form']->start($form, ['attr' => $attr]); ?>
 <!-- start: box layout -->
 <div class="box-layout">
     <!-- container -->
@@ -48,11 +51,11 @@ $template = $form['template']->vars['data'];
                             </div>
                         </div>
 
-                        <?php echo $view->render('MauticCoreBundle:Helper:theme_select.html.php', array(
+                        <?php echo $view->render('MauticCoreBundle:Helper:theme_select.html.php', [
                             'type'   => 'page',
                             'themes' => $themes,
                             'active' => $form['template']->vars['value']
-                        )); ?>
+                        ]); ?>
                     </div>
 
                     <div class="tab-pane fade bdr-w-0" id="source-container">
@@ -106,10 +109,10 @@ $template = $form['template']->vars['data'];
 </div>
 <?php echo $view['form']->end($form); ?>
 
-<?php echo $view->render('MauticCoreBundle:Helper:builder.html.php', array(
+<?php echo $view->render('MauticCoreBundle:Helper:builder.html.php', [
     'type'          => 'page',
     'sectionForm'   => $sectionForm,
     'builderAssets' => $builderAssets,
     'slots'         => $slots,
     'objectId'      => $activePage->getSessionId()
-)); ?>
+]); ?>

--- a/themes/blank/html/page.html.twig
+++ b/themes/blank/html/page.html.twig
@@ -15,7 +15,6 @@
                                 We haven't heard from you for a while...
                                 <br>
                                 <br>
-                                {unsubscribe_text} | {webview_text}
                                 <br>
                             </div>
                         </div>


### PR DESCRIPTION
Please answer the following questions:

| Q             | A
| ------------- | ---
| Bug fix?      | Y
| New feature?  | N
| BC breaks?    | N
| Deprecations? | N
| Fixed issues  | https://github.com/mautic/mautic/issues/2026,  https://github.com/mautic/mautic/issues/2086, https://github.com/mautic/mautic/issues/2155, https://github.com/mautic/mautic/pull/2032, https://github.com/mautic/mautic/issues/1837, https://www.mautic.org/community/index.php//4923-landing-page-html-editor-doesn-t-work/p1

## Description
Froala adds some HTML which breaks the original HTML, so it must be returned to the original state before form save. I worked like this:

1. A before submit event triggered the clearing method.
2. The clearing method created a virtual iframe, pasted the Froala's HTML inside, a simple jQuery method selected the Froala styles.

The issue with this was that the pre-submit event was synchronous and if the HTML had many external JS and CSS in it, the iframe returned only the head part of the theme and forgot about the body. This resulted in a blank page/email.

This PR makes sure that the iframe is fully loaded before the clearing and fetching the cleared HTML back to the form textarea. The iframe load is asynchronous, so the pre-submit event technique couldn't be used.
A async callback method is defined as a form attr instead and if there is a form with this attr, the submit won't happen until the callback is called.

> What a nice thing would be if Froala cleared the styles which it adds itself without asking anyone!

Also, the editors were simplified in sense that the editor used for descriptions has only 3 buttons to format text. Then there `advanced-editor` in the DWT which has all buttons and the most powerful editor is `editor-basic-fullpage` which is used in the builders and it uses iframe for its content and allows to insert also CSS and JS in it.

This PR also changes the "change theme" warning which now shows up only if the user changes the content of selected theme when creating a new page/email. It will not show the warning if a theme is selected as the first thing when creating a new page/email.

## Steps to reproduce the bug (if applicable)
Try to insert this HTML to the landing page editor:
```
<!DOCTYPE html>
<html>
    <head>
        <meta charset="UTF-8" />
        <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet" type="text/css" />
        <title>Corso Come creare contenuti straordinari per il web</title>
        <meta name="viewport" content="initial-scale=1, width=device-width, maximum-scale=1, minimum-scale=1, user-scalable=no" />
        <script src="https://code.jquery.com/jquery-1.9.1.min.js" integrity="sha256-wS9gmOZBqsqWxgIVgA8Y9WcQOa7PgSIX+rPA0VL2rbQ=" crossorigin="anonymous"></script>
        <script src="https://code.jquery.com/ui/1.11.4/jquery-ui.min.js" integrity="sha256-xNjb53/rY+WmG+4L6tTl9m6PpqknWZvRt0rO1SRnJzw=" crossorigin="anonymous"></script>
        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.6.2/html5shiv.min.js"></script>
        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/classie/1.0.0/classie.min.js"></script>
        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.css" />
        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" />
    </head>
    <body>
        <div id="wrapper">
            HTML PAGE CODE
        </div>
    </body>
</html>
```
Save it and you should see a blank page without the `HTML PAGE CODE` text in it.

## Steps to test this PR
Apply this PR and either use the dev mode or build the prod assets. Refresh the page and try to save the same HTML again. The text should appear in the page preview now.

This PR modified the global method for submitting forms. All forms must still work.