### PR TITLE
Switch SMTP-transport according to Owner

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -175,7 +175,9 @@ class AppKernel extends Kernel
             new Mautic\SmsBundle\MauticSmsBundle(),
             new Mautic\StageBundle\MauticStageBundle(),
             new Mautic\UserBundle\MauticUserBundle(),
-            new Mautic\WebhookBundle\MauticWebhookBundle()
+            new Mautic\WebhookBundle\MauticWebhookBundle(),
+            // Other
+            new TDM\SwiftMailerEventBundle\TDMSwiftMailerEventBundle(),
         ];
 
         //dynamically register Mautic Plugin Bundles

--- a/app/bundles/EmailBundle/Command/ProcessEmailQueueCommand.php
+++ b/app/bundles/EmailBundle/Command/ProcessEmailQueueCommand.php
@@ -99,7 +99,7 @@ EOT
                     rename($failedFile, $tmpFilename);
 
                     $message = unserialize(file_get_contents($tmpFilename));
-                    if ($message !== false && is_object($message) && get_class($message) === 'Swift_Message') {
+                    if ($message !== false && is_object($message) && is_a($message, '\Swift_Message')) {
                         $tryAgain = false;
                         if ($dispatcher->hasListeners(EmailEvents::EMAIL_RESEND)) {
                             $event = new QueueEmailEvent($message);

--- a/app/bundles/EmailBundle/Controller/AjaxController.php
+++ b/app/bundles/EmailBundle/Controller/AjaxController.php
@@ -289,10 +289,11 @@ class AjaxController extends CommonAjaxController
                     $translator = $this->factory->getTranslator();
 
                     if ($settings['send_test'] == 'true') {
-                        $message = new \Swift_Message(
-                            $translator->trans('mautic.email.config.mailer.transport.test_send.subject'),
-                            $translator->trans('mautic.email.config.mailer.transport.test_send.body')
-                        );
+                        /** @var \Swift_Message $message */
+                        $message = \Swift_DependencyContainer::getInstance()->lookup('message.message');
+                        $message = $message
+                            ->setSubject($translator->trans('mautic.email.config.mailer.transport.test_send.subject'))
+                            ->setBody($translator->trans('mautic.email.config.mailer.transport.test_send.body'));
 
                         $user = $this->factory->getUser();
 

--- a/app/bundles/EmailBundle/EmailEvents.php
+++ b/app/bundles/EmailBundle/EmailEvents.php
@@ -138,6 +138,34 @@ final class EmailEvents
     const EMAIL_RESEND = 'mautic.on_email_resend';
 
     /**
+     * @todo Description of EMAIL_MAILER_PRE_SEND_PROCESS.
+     *
+     * @var string
+     */
+    const EMAIL_MAILER_PRE_SEND_PROCESS = 'tdm.swiftmailer.mailer.pre_send_process';
+
+    /**
+     * @todo Description of EMAIL_MAILER_PRE_SEND_CLEANUP.
+     *
+     * @var string
+     */
+    const EMAIL_MAILER_PRE_SEND_CLEANUP = 'tdm.swiftmailer.mailer.pre_send_cleanup';
+
+    /**
+     * @todo Description of EMAIL_TRANSPORT_PRE_SEND_PROCESS.
+     *
+     * @var string
+     */
+    const EMAIL_TRANSPORT_PRE_SEND_PROCESS = 'tdm.swiftmailer.transport.pre_send_process';
+
+    /**
+     * @todo Description of EMAIL_TRANSPORT_PRE_SEND_CLEANUP.
+     *
+     * @var string
+     */
+    const EMAIL_TRANSPORT_PRE_SEND_CLEANUP = 'tdm.swiftmailer.transport.post_send_cleanup';
+
+    /**
      * The mautic.email.on_campaign_trigger_action event is fired when the campaign action triggers.
      *
      * The event listener receives a

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -681,7 +681,13 @@ class MailHelper
     public function getMessageInstance()
     {
         try {
-            $message = ($this->tokenizationSupported) ? MauticMessage::newInstance() : \Swift_Message::newInstance();
+            $message = (
+              $this->tokenizationSupported
+              ||
+              $transport instanceof \Swift_Transport_AbstractSmtpTransport
+            )
+              ? MauticMessage::newInstance()
+              : \Swift_Message::newInstance();
 
             return $message;
         } catch (\Exception $e) {

--- a/app/bundles/EmailBundle/Swiftmailer/Message/MauticMessage.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Message/MauticMessage.php
@@ -9,7 +9,9 @@
 
 namespace Mautic\EmailBundle\Swiftmailer\Message;
 
-class MauticMessage extends \Swift_Message
+use TDM\SwiftMailerEventBundle\Model\MessageMetadataInterface;
+
+class MauticMessage extends \Swift_Message implements MessageMetadataInterface
 {
 
     /**
@@ -47,20 +49,59 @@ class MauticMessage extends \Swift_Message
     }
 
     /**
+     * @param $email
+     * @param $key
+     * @param $value
+     */
+    public function setMetadata($email, $key, $value)
+    {
+        $this->metadata[$email][$key] = $value;
+    }
+
+    /**
+     * Check whether there is metadata.
+     *
+     * @return array
+     */
+    public function hasMetadata($email, $key = null)
+    {
+        return (
+            !empty($this->metadata[$email])
+            &&
+            is_array($this->metadata[$email])
+            &&
+            (is_null($key) || isset($this->metadata[$email][$key]))
+        );
+    }
+
+    /**
      * Get the metadata
      *
      * @return array
      */
-    public function getMetadata()
+    public function getMetadata($email = null, $key = null)
     {
-        return $this->metadata;
+        if (is_null($email)) {
+            return $this->metadata;
+        }
+        elseif (is_null($key)) {
+            return $this->metadata[$email];
+        }
+        else {
+            return $this->metadata[$email][$key];
+        }
     }
 
     /**
      * Clears the metadata
      */
-    public function clearMetadata() {
-        $this->metadata = array();
+    public function clearMetadata($email = null) {
+        if (!is_null($email)) {
+            unset($this->metadata[$email]);
+        }
+        else {
+            $this->metadata = array();
+        }
     }
 
     /**

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -457,7 +457,9 @@ class UserController extends FormController
                 if ($valid = $this->isFormValid($form)) {
                     $subject = InputHelper::clean($form->get('msg_subject')->getData());
                     $body    = InputHelper::clean($form->get('msg_body')->getData());
-                    $message = \Swift_Message::newInstance()
+                    /** @var \Swift_Message $message */
+                    $message = \Swift_DependencyContainer::getInstance()->lookup('message.message');
+                    $message = $message
                         ->setSubject($subject)
                         ->setFrom($currentUser->getEmail(), $currentUser->getName())
                         ->setTo($user->getEmail(), $user->getName())

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -315,6 +315,10 @@ $container->setParameter(
     'JMS\Serializer\Naming\IdenticalPropertyNamingStrategy'
 );
 
+$container->loadFromExtension('tdm_swift_mailer_event', array(
+    'message'     => '\Mautic\EmailBundle\Swiftmailer\Message\MauticMessage',
+));
+
 // Monolog formatter
 $container->register('mautic.monolog.fulltrace.formatter', 'Monolog\Formatter\LineFormatter')
     ->addMethodCall('includeStacktraces', array(true));

--- a/composer.json
+++ b/composer.json
@@ -95,8 +95,16 @@
         "twilio/sdk": "^4.10",
 
         "stack/run": "^1.0",
-        "stack/builder": "^1.0"
+        "stack/builder": "^1.0",
+
+        "tdm/swiftmailer-events-bundle": "dev-master"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/PatchRanger/SwiftmailerEventsBundle"
+        }
+    ],
     "require-dev": {
         "symfony/web-profiler-bundle": "~2.8",
         "liip/functional-test-bundle": "^1.3.4",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | y |
| New feature? | y |
| Related user documentation PR URL | n |
| Related developer documentation PR URL | n |
| Issues addressed (#s or URLs) | #1889 |
| BC breaks? | n |
| Deprecations? | n |
### Required:
- Incorporates https://github.com/mautic/mautic/pull/2021
- Adds dependency on https://github.com/PatchRanger/SwiftmailerEventsBundle .
  I've created an issue to merge it into SwiftmailerBundle: https://github.com/symfony/swiftmailer-bundle/issues/142 - in case it succeeds, we would get rid of such additional dependency.
#### Description

The problem is mostly described in #1889.
The solution is based on [this article](https://blog.anodetome.com/2013/07/12/dynamic-smtp-settings-per-message-in-symfony2/).
It adds SMTP-credentials to messages before putting into spool and uses it for authentication.
It needs UI: separate email settings (similar to global) for each individual Owner. Right now it doesn't have any configuration or UI, the only way to change its behavior is hardcode.
I am not able to complete it - so please feel free to fork & finish.
#### Steps to test this PR
1. Hardcode required credentials in corresponding section of `EmailSubscriber::onEmailMailerPreSendProcess`.
2. Create user with the same email as provided above.
3. Set Mautic mail transport to some working SMTP-server.
4. Set Mautic mail spool type to file spool.
5. Get (choose or create) a contact with Owner from №2.
6. Try to send any email to the contact.

Expected result: it should be placed into email spool, processed by cron and finally delivered to you with provided in №1 login as sender.
#### Steps to reproduce the bug
1. Create user with some email.
2. Set Mautic mail transport to some working SMTP-server.
3. Set Mautic mail spool type to file spool.
4. Get (choose or create) a contact with Owner from №1.
5. Try to send any email to the contact.

Expected result: it should be placed into email spool, processed by cron and finally delivered to you with provided in №1 login as sender.
Real result: all emails are always sent with global SMTP-account as sender, Owner has no influence on this.
#### List deprecations along with the new alternative
1. I am not sure about `EmailEvents::EMAIL_ON_SEND` and `EmailEvents::EMAIL_MAILER_PRE_SEND_PROCESS`: looks like they are quite the same and may be merged. But I am not confident enough.
#### List backwards compatibility breaks
1. I've changed `MauticMessage` metadata-related methods definitions. But looks like they're backward-compatible, please check.
