### PR TITLE
Store new arrays as JSON instead of serialized PHP array

### DIFF
--- a/app/bundles/CoreBundle/Doctrine/Type/ArrayType.php
+++ b/app/bundles/CoreBundle/Doctrine/Type/ArrayType.php
@@ -16,73 +16,32 @@ use Doctrine\DBAL\Types\ConversionException;
 use Mautic\CoreBundle\Helper\UTF8Helper;
 
 /**
- * Type that maps a PHP array to a clob SQL type.
+ * Type that maps a PHP/JSON array to a clob SQL type.
  *
  * @since 2.0
  */
-class ArrayType extends \Doctrine\DBAL\Types\ArrayType
+class ArrayType extends \Doctrine\DBAL\Types\JsonArrayType
 {
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
-    {
-        if (!is_array($value)) {
-            return (null === $value) ? 'N;' : 'a:0:{}';
-        }
-
-        // MySQL will crap out on corrupt UTF8 leading to broken serialized strings
-        array_walk(
-            $value,
-            function (&$entry) {
-                $entry = UTF8Helper::toUTF8($entry);
-            }
-        );
-
-        $serialized = serialize($value);
-
-        if (false !== strpos($serialized, chr(0))) {
-            $serialized = str_replace("\0", '__NULL_BYTE__', $serialized);
-            throw new ConversionException('Serialized array includes null-byte. This cannot be saved as a text. Please check if you not provided object with protected or private members. Serialized Array: '.$serialized);
-        }
-
-        return $serialized;
-    }
-
-    /**
-     * @param mixed $value
-     *
-     * @return array
-     */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        try {
-            $value = parent::convertToPHPValue($value, $platform);
-            if (!is_array($value) || (1 > count($value))) {
-                return $value;
-            }
-
-            foreach ($value as $key => $element) {
-                if (!is_object($element)) {
-                    continue;
-                }
-
-                $reflectionObject     = new \ReflectionObject($element);
-                $reflectionProperties = $reflectionObject->getProperties(\ReflectionProperty::IS_PROTECTED | \ReflectionProperty::IS_PRIVATE);
-
-                // Let's check if $value contains objects with private or protected members.
-                // If it contains such objects we have to remove them from $array.
-                // This will "heal" the database. There must be no null bytes.
-                if (0 < count($reflectionProperties)) {
-                    unset($value[$key]);
-                }
-            }
-
-            return $value;
-        } catch (ConversionException $exception) {
-            return [];
-        } catch (\ErrorException $exeption) {
-            return [];
+        if ($value === null) {
+            return null;
         }
+
+        $value = (is_resource($value)) ? stream_get_contents($value) : $value;
+
+        if (substr($value, 0, 1) === '{') {
+            return parent::convertToPHPValue($value, $platform);
+        }
+
+        $val = unserialize($value);
+        if ($val === false && $value != 'b:0;') {
+            throw ConversionException::conversionFailed($value, $this->getName());
+        }
+
+        return $val;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? | N |
| Related user documentation PR URL | / |
| Related developer documentation PR URL | / |
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/1890, https://github.com/mautic/mautic/issues/1756, https://github.com/mautic/mautic/issues/1329, https://github.com/mautic/mautic/issues/1029, https://www.mautic.org/community/index.php/413-error-500-on-leads-page-after-editing-lead/0 |
| BC breaks? | N |
| Deprecations? | serialized PHP arrays in current databases, applying unserialize on database output will cause an error |
#### Description

**This PR must also replace all the un/serialize() functions used across Mautic, therefore, this PR is not fully ready to be merged. It might have to wait for Mautic 3.0**

Serialized arrays often suffers issues:

> It turns out that if there's a ", ', :, or ; in any of the array values the serialization gets corrupted.

_([Source](https://davidwalsh.name/php-serialize-unserialize-issues))_

As @PatchRanger [pointed out](https://github.com/mautic/mautic/issues/1329#issuecomment-232697573), the json_decode/encode should fix this. So this PR simply checks if the serialized array is JSON. If so, it decodes it as JSON. If not, it encodes it as PHP serialized array.

All new/updated arrays will be JSON encoded.

Other advantages of JSON are:
- more easily readable by humans
- json_encode is faster then unserialize
- json also requires much less space than serialized array _([source](http://cw-internetdienste.de/2015/05/04/serialize-vs-json_encode/))_
- safe (no problem with unserialized object execution)
#### Steps to test this PR
1. Go to a campaign
2. Make some change in the canvas (add an action or something)
3. Save the campaign

You may peep into the database and check that the canvas_settings array is really encoded by JSON. All Mautic must still work.
#### Steps to reproduce the bug

I wasn't actually ever able to replicate it, but you may try to replicate an issue from the issues above.


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/2040"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

