### PR TITLE
Forgotten Lead Route renamed to Contact route

### DIFF
--- a/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
@@ -389,7 +389,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
                 // Build table rows with links
                 if ($leads) {
                     foreach ($leads as &$lead) {
-                        $leadUrl = $this->factory->getRouter()->generate('mautic_lead_action', array('objectAction' => 'view', 'objectId' => $lead['id']));
+                        $leadUrl = $this->factory->getRouter()->generate('mautic_contact_action', array('objectAction' => 'view', 'objectId' => $lead['id']));
                         $row = array(
                             array(
                                 'value' => $lead['name'],


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? | N |
| Related user documentation PR URL | / |
| Related developer documentation PR URL | / |
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2054, https://www.mautic.org/community/index.php/4917-mautic-error-500-route-issue/0#p13125 |
| BC breaks? | N |
| Deprecations? | N |
### Required
#### Description:

There was a forgotten `mautic_lead_action` route in the "Created Contacts" dashboard widget. If this widget is present in the dashboard, the dashboard is not accessible.
#### Steps to test this PR:
1. Add the "Created Contacts" widget to the dashboard.
2. You should see the dashboard with the new widget.
### As applicable
#### Steps to reproduce the bug:
1. Add the "Created Contacts" widget to the dashboard.
2. You should see the error.
