### PR TITLE
Fixed issue that caused URLs with ampersands to not get replaced as trackables

### DIFF
--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -1230,8 +1230,8 @@ class Email extends FormEntity
      */
     public function cleanUrlsInContent()
     {
-        $this->plainText  = $this->decodeAmpersands($this->plainText);
-        $this->customHtml = $this->decodeAmpersands($this->customHtml);
+        $this->decodeAmpersands($this->plainText);
+        $this->decodeAmpersands($this->customHtml);
     }
 
     /**
@@ -1239,10 +1239,8 @@ class Email extends FormEntity
      * This even works with double encoded ampersands
      *
      * @param $content
-     *
-     * @return mixed
      */
-    private function decodeAmpersands($content)
+    private function decodeAmpersands(&$content)
     {
         if (preg_match_all('/((https?|ftps?):\/\/)([a-zA-Z0-9-\.{}]*[a-zA-Z0-9=}]*)(\??)([^\s\"\]]+)?/i', $content, $matches)) {
             foreach ($matches[0] as $url) {
@@ -1255,8 +1253,5 @@ class Email extends FormEntity
                 $content = str_replace($url, $newUrl, $content);
             }
         }
-
-        return $content;
     }
-
 }

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -173,25 +173,6 @@ class EmailModel extends FormModel
             $entity->setRevision($revision);
         }
 
-        // Ensure links in template content don't have encoded ampersands
-        if ($entity->getTemplate()) {
-            $content = $entity->getContent();
-
-            foreach ($content as $key => $value) {
-                $content[$key] = $this->cleanUrlsInContent($value);
-            }
-
-            $entity->setContent($content);
-        } else {
-            // Ensure links in HTML don't have encoded ampersands
-            $htmlContent = $this->cleanUrlsInContent($entity->getCustomHtml());
-            $entity->setCustomHtml($htmlContent);
-        }
-
-        // Ensure links in PLAIN TEXT don't have encoded ampersands
-        $plainContent = $this->cleanUrlsInContent($entity->getPlainText());
-        $entity->setPlainText($plainContent);
-
         // Reset the variant hit and start date if there are any changes and if this is an A/B test
         // Do it here in addition to the blanket resetVariants call so that it's available to the event listeners
         $changes = $entity->getChanges();
@@ -1733,30 +1714,5 @@ class EmailModel extends FormModel
         );
 
         return $upcomingEmails;
-    }
-
-    /**
-     * Check all links in content and remove &amp;
-     * This even works with double encoded ampersands
-     *
-     * @param string $content
-     *
-     * @return string
-     */
-    private function cleanUrlsInContent($content)
-    {
-        if (preg_match_all('/((https?|ftps?):\/\/)([a-zA-Z0-9-\.{}]*[a-zA-Z0-9=}]*)(\??)([^\s\"\]]+)?/i', $content, $matches)) {
-            foreach ($matches[0] as $url) {
-                $newUrl = $url;
-
-                while (strpos($newUrl, '&amp;') !== false) {
-                    $newUrl = str_replace('&amp;', '&', $newUrl);
-                }
-
-                $content = str_replace($url, $newUrl, $content);
-            }
-        }
-
-        return $content;
     }
 }


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/pull/2060
| BC breaks? | na
| Deprecations? | na 

### Required
#### Description:

With the builder changes where every email how has a template associated, content bypassed the method that decoded ampersands in URLs. Thus the URL was not found with a tracking token/URL.

#### Steps to reproduce the bug:
1. Create a new segment email with a URL with a ampersand in the query. For example `http://url.com/index.php?foo=bar&bar=foo`
2. Save the email
3. Send the email to a segment
4. Examine the email body to find the URL was not replaced with a trackable

#### Steps to test this PR:
1. Apply PR
2. Repeat above
3. Note the URL should now be a trackable