### PR TITLE
Adding a new option to sendPageView to handle pixel onload

### DIFF
--- a/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
@@ -79,7 +79,15 @@ class BuildJsSubscriber extends CommonSubscriber
                 }
             }
 
-            m.trackingPixel = (new Image()).src = m.pageTrackingUrl + '?' + m.serialize(params);
+            var img = new Image();
+
+            if (typeof pageview[3] === 'object') {
+                if (typeof pageview[3]['onload'] === 'function') {
+                    img.onload = pageview[3]['onload'];
+                }
+            }
+
+            m.trackingPixel = img.src = m.pageTrackingUrl + '?' + m.serialize(params);
         });
 
         


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y 
| Related user documentation PR URL | https://github.com/mautic/documentation/pull/68
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #2065  
| BC breaks? | N
| Deprecations? | N

Add the possibility to call a callback function when pixel is loaded on 3rd page (mtc.js)
A new "options" parameter has been added for sendPageview.

Usage :

    options = {
        onload: function() { alert("Pixel is loaded"); }
    };

    mt('send','pageview',{},options);