### PR TITLE
Fix for publish status toggle on DynamicContent

### DIFF
--- a/app/bundles/DynamicContentBundle/Assets/js/dynamicContent.js
+++ b/app/bundles/DynamicContentBundle/Assets/js/dynamicContent.js
@@ -83,7 +83,7 @@ Mautic.dynamicContentOnLoad = function (container, response) {
 
         window.close();
     } else if (mQuery(container + ' #list-search').length) {
-        Mautic.activateSearchAutocomplete('list-search', 'dwc');
+        Mautic.activateSearchAutocomplete('list-search', 'dynamicContent');
     }
 };
 

--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -25,6 +25,16 @@ use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 class DynamicContentModel extends FormModel
 {
     /**
+     * Retrieve the permissions base
+     *
+     * @return string
+     */
+    public function getPermissionBase()
+    {
+        return 'dynamicContent:dynamicContents';
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @return DynamicContentRepository


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | #2067 
| BC breaks? | N/A
| Deprecations? | N/A


#### Description: 
(taken from #2607)
On the page that list your dynamic contents, there are toggles to quickly publish / unpublish them. Using them causes the spinner to show forever. The JS console indicates that the server responded with an error 500. The error in question is provided in the appropriate section below.


#### Steps to test this PR:
1. Create a dynamic content
2. Go to the page that lists your dynamic contents (yourmautic/s/dwc)
3. Click on the switch to toggle the published state of your content
4. You should see the spinner showing forever
5. Apply the PR, and retest. You'll successfully toggle the publish status.