### PR TITLE
Prevented fatal error when using cached dashboard report graph widget

### DIFF
--- a/app/bundles/ReportBundle/Views/SubscribedEvents/Dashboard/widget.html.php
+++ b/app/bundles/ReportBundle/Views/SubscribedEvents/Dashboard/widget.html.php
@@ -29,6 +29,13 @@ if ($chartType === 'table') {
         ]
     );
 }
+
+if (is_array($dateFrom)) {
+    // Using cached data
+    $dateFrom = new \DateTime($dateFrom['date'], new \DateTimeZone($dateFrom['timezone']));
+    $dateTo   = new \DateTime($dateTo['date'], new \DateTimeZone($dateTo['timezone']));
+}
+
 ?>
 
 <div class="pull-right mr-md mb-md">


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | na
| BC breaks? | N
| Deprecations? | N

### Required
#### Description:
When using a report graph as a widget and the dashboard widget cache is enabled, a fatal error will occur due to $dateFrom not being a \DateTime object

#### Steps to reproduce the bug:
1. Be sure that 0 is not set as the cache timeout for the dashboard in your config
2. Add a new report graph widget to the dashboard
3. If you don't get an error the first time, refresh and you should hit a 500 due to $dateTime is a non-object and cannot use format()

#### Steps to test this PR:
1.  Apply PR and repeat above. This time the widget should show

