### PR TITLE
Fix link from roles overview to detail page

### DIFF
--- a/app/bundles/UserBundle/Views/Role/list.html.php
+++ b/app/bundles/UserBundle/Views/Role/list.html.php
@@ -68,7 +68,7 @@ endif;
                 </td>
                 <td>
                     <?php if ($permissions['edit']) : ?>
-                    <a href="<?php echo $view['router']->path('mautic_user_action', array('objectAction' => 'edit', 'objectId' => $item->getId())); ?>" data-toggle="ajax">
+                    <a href="<?php echo $view['router']->path('mautic_role_action', array('objectAction' => 'edit', 'objectId' => $item->getId())); ?>" data-toggle="ajax">
                         <?php echo $item->getName(); ?>
                     </a>
                     <?php else : ?>


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| Related user documentation PR URL | -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | -
| BC breaks? | no
| Deprecations? | no

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:
If you click on role name on the roles overview page it gets you to the detail page of a random user

#### Steps to test this PR:
1. Go to /s/roles
2. Click on the name of a role
3. You land on the detail page of that role

### As applicable
#### Steps to reproduce the bug:
1. Go to /s/roles
2. Click on the name of a role
3. You get to the user detail page