### PR TITLE
Users - First and last name are required but are not labeled as such

### DIFF
--- a/app/bundles/UserBundle/Views/User/form.html.php
+++ b/app/bundles/UserBundle/Views/User/form.html.php
@@ -25,13 +25,14 @@ $view['slots']->set("headerTitle", $header);
     <div class="col-md-9 bg-auto height-auto bdr-r">
 		<div class="pa-md">
 			<div class="form-group mb-0">
-			    <label class="control-label mb-xs"><?php echo $view['translator']->trans('mautic.core.name'); ?></label>
 			    <div class="row">
                     <div class="col-sm-6<?php echo (count($form['firstName']->vars['errors'])) ? ' has-error' : ''; ?>">
+                    	<label class="control-label mb-xs"><?php echo $view['form']->label($form['firstName']); ?></label>
 			            <?php echo $view['form']->widget($form['firstName'], array('attr' => array('placeholder' => $form['firstName']->vars['label']))); ?>
                         <?php echo $view['form']->errors($form['firstName']); ?>
 			        </div>
                     <div class="col-sm-6<?php echo (count($form['lastName']->vars['errors'])) ? ' has-error' : ''; ?>">
+                        <label class="control-label mb-xs"><?php echo $view['form']->label($form['lastName']); ?></label>
 			            <?php echo $view['form']->widget($form['lastName'], array('attr' => array('placeholder' => $form['lastName']->vars['label']))); ?>
                         <?php echo $view['form']->errors($form['lastName']); ?>
 			        </div>


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Enhancement
| New feature? | Enhancement
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | #2103
| BC breaks? | No
| Deprecations? | No

#### Description:

When creating a user, the first and last name are required but are not labeled as such. This PR aims to fix this inconvenience.

#### Before

![image](https://cloud.githubusercontent.com/assets/18265735/17104191/174f909c-5282-11e6-8b8e-74b7cb9c7154.png)

#### After

![image](https://cloud.githubusercontent.com/assets/18265735/17104178/0946655c-5282-11e6-9f0d-54abf6cc8e26.png)

#### Steps to test this PR:
1. Create a new user
2. See the new labels