### PR TITLE
Added tooltip text to short form toggle

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -358,7 +358,10 @@ class FieldType extends AbstractType
             'isShortVisible',
             'yesno_button_group',
             [
-                'label' => 'mautic.lead.field.form.isshortvisible'
+                'label' => 'mautic.lead.field.form.isshortvisible',
+                'attr'  => [
+                    'tooltip' => 'mautic.lead.field.form.isshortvisible.tooltip'
+                ],
             ]
         );
 

--- a/app/bundles/LeadBundle/Translations/en_US/messages.ini
+++ b/app/bundles/LeadBundle/Translations/en_US/messages.ini
@@ -35,6 +35,7 @@ mautic.lead.field.form.confirmdelete="Delete the custom field, %name%? WARNING: 
 mautic.lead.field.form.group.help="Determines where this field will be displayed when viewing a specific contact."
 mautic.lead.field.form.islistable="Available for segments"
 mautic.lead.field.form.isshortvisible="Visible on short forms"
+mautic.lead.field.form.isshortvisible.tooltip="If set to yes, this field will be displayed in the quick add contact modal"
 mautic.lead.field.form.isuniqueidentifer="Is Unique Identifier"
 mautic.lead.field.form.isuniqueidentifer.tooltip="Set to yes if this field is a unique identifier for the contact (i.e. email, username, social media handle, etc)."
 mautic.lead.field.form.isuniqueidentifer.warning="WARNING: Inappropriately setting &quot;Is Unique Identifier&quot; to Yes could cause a mass merging of contacts and incorrectly tracked contact activity. Only set to Yes if this field tracks a unique value specific to the contact such as email, username, etc."


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | #2020 
| BC breaks? | N
| Deprecations? | N

### Required
#### Description:
This PR adds a tooltip to the short form field toggle visible when creating a new custom field. 
*Note*: This adds a new language string.

#### Steps to test this PR:
1. Apply the PR
2. Create or Edit a Contact Custom Field
3. Hover over the tooltip for `Visible on short forms`
4. You should see a new tooltip explaining the use case.