### PR TITLE
Hotfix for CORSMiddleware not functioning in SaaS.

### DIFF
--- a/app/middlewares/CORSMiddleware.php
+++ b/app/middlewares/CORSMiddleware.php
@@ -16,6 +16,8 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class CORSMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterface
 {
+    use ConfigAwareTrait;
+
     const PRIORITY = 1000;
 
     /**
@@ -56,16 +58,9 @@ class CORSMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterf
     public function __construct(HttpKernelInterface $app)
     {
         $this->app = $app;
-
-        $localConfig = __DIR__.'/../config/local.php';
-
-        if (file_exists($localConfig)) {
-            /** @var array $parameters */
-            include $localConfig;
-
-            $this->restrictCORSDomains = array_key_exists('cors_restrict_domains', $parameters) ? (bool) $parameters['cors_restrict_domains'] : true;
-            $this->validCORSDomains = array_key_exists('cors_valid_domains', $parameters) ? (array) $parameters['cors_valid_domains'] : [];
-        }
+        $this->config = $this->getConfig();
+        $this->restrictCORSDomains = array_key_exists('cors_restrict_domains', $this->config) ? (bool) $this->config['cors_restrict_domains'] : true;
+        $this->validCORSDomains = array_key_exists('cors_valid_domains', $this->config) ? (array) $this->config['cors_valid_domains'] : [];
     }
 
     /**

--- a/app/middlewares/ConfigAwareTrait.php
+++ b/app/middlewares/ConfigAwareTrait.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2016 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Middleware;
+
+trait ConfigAwareTrait
+{
+    /**
+     * @var array
+     */
+    protected $config = [];
+
+    /**
+     * @return array
+     */
+    public function getConfig()
+    {
+        // Include paths
+        $root = realpath(__DIR__ . '/..');
+
+        /** @var array $paths  */
+        include $root . '/config/paths.php';
+
+        /** @var $parameters */
+        include str_replace('%kernel.root_dir%', $root, $paths['local_config']);
+
+        $localParameters = $parameters;
+
+        //check for parameter overrides
+        if (file_exists($root.'/config/parameters_local.php')) {
+            include $root.'/config/parameters_local.php';
+            $localParameters = array_merge($localParameters, $parameters);
+        }
+
+        return $localParameters;
+    }
+}


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | Y

#### Description:
This fixes CORSMiddleware to be config aware in the saas environment. It now loads the correct local config file for a given SaaS instance.


#### Steps to test this PR:
1. Setup Dynamic Content in a Mautic SaaS installation. Go through the steps to trigger it and it just simply does not work. 
2. Apply the PR, and you'll see that it now works.