### PR TITLE
Feature email dynamic content

### DIFF
--- a/app/bundles/DynamicContentBundle/Config/config.php
+++ b/app/bundles/DynamicContentBundle/Config/config.php
@@ -109,5 +109,14 @@ return [
                 ],
             ],
         ],
+        'other' => [
+            'mautic.helper.dynamicContent' => [
+                'class'     => 'Mautic\DynamicContentBundle\Helper\DynamicContentHelper',
+                'arguments' => [
+                    'mautic.dynamicContent.model.dynamicContent',
+                    'mautic.campaign.model.event',
+                    'event_dispatcher'
+                ]
+            ],]
     ],
 ];

--- a/app/bundles/DynamicContentBundle/Config/config.php
+++ b/app/bundles/DynamicContentBundle/Config/config.php
@@ -8,6 +8,8 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
+use Mautic\DynamicContentBundle\EventListener\BuilderSubscriber;
+
 return [
     'menu' => [
         'main' => [
@@ -64,6 +66,13 @@ return [
                     'mautic.page.model.trackable',
                     'mautic.page.helper.token',
                     'mautic.asset.helper.token'
+                ]
+            ],
+            'mautic.dynamicContent.token.subscriber' => [
+                'class' => BuilderSubscriber::class,
+                'arguments' => [
+                    'mautic.factory',
+                    'mautic.helper.dynamicContent'
                 ]
             ]
         ],

--- a/app/bundles/DynamicContentBundle/Controller/Api/DynamicContentApiController.php
+++ b/app/bundles/DynamicContentBundle/Controller/Api/DynamicContentApiController.php
@@ -43,35 +43,8 @@ class DynamicContentApiController extends CommonController
 
     public function getAction($objectAlias)
     {
-        /** @var EventModel $campaignEventModel */
-        $campaignEventModel = $this->getModel('campaign.event');
-
-        $response = $campaignEventModel->triggerEvent('dwc.decision', $objectAlias, 'dwc.decision.' . $objectAlias);
-        $content  = null;
-        $lead     = $this->getModel('lead')->getCurrentLead();
-
-        if (is_array($response) && !empty($response['action']['dwc.push_content'])) {
-            $content = array_shift($response['action']['dwc.push_content']);
-        } else {
-            /** @var DynamicContentModel $dwcModel */
-            $dwcModel = $this->getModel('dynamicContent');
-
-            $data = $dwcModel->getSlotContentForLead($objectAlias, $lead);
-
-            if (!empty($data)) {
-                $content = $data['content'];
-                $dwc = $dwcModel->getEntity($data['id']);
-
-                if ($dwc instanceof DynamicContent) {
-                    $dwcModel->createStatEntry($dwc, $lead, $objectAlias);
-
-                    $tokenEvent = new TokenReplacementEvent($content, $lead, ['slot' => $objectAlias, 'dynamic_content_id' => $dwc->getId()]);
-                    $this->factory->getDispatcher()->dispatch(DynamicContentEvents::TOKEN_REPLACEMENT, $tokenEvent);
-                    
-                    $content = $tokenEvent->getContent();
-                }
-            }
-        }
+        $lead    = $this->getModel('lead')->getCurrentLead();
+        $content = $this->get('mautic.helper.dynamicContent')->getDynamicContentForLead($objectAlias, $lead);
         
         return empty($content) ? new Response('', Response::HTTP_NOT_FOUND) : new Response($content);
     }

--- a/app/bundles/DynamicContentBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/BuilderSubscriber.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @copyright   2016 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+namespace Mautic\DynamicContentBundle\EventListener;
+
+use Mautic\CoreBundle\EventListener\CommonSubscriber;
+use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\CoreBundle\Helper\BuilderTokenHelper;
+use Mautic\DynamicContentBundle\Helper\DynamicContentHelper;
+use Mautic\EmailBundle\EmailEvents;
+use Mautic\EmailBundle\Event\EmailBuilderEvent;
+use Mautic\EmailBundle\Event\EmailSendEvent;
+
+class BuilderSubscriber extends CommonSubscriber
+{
+    /**
+     * @var DynamicContentHelper
+     */
+    protected $dynamicContentHelper;
+
+    /**
+     * BuilderSubscriber constructor.
+     *
+     * @param MauticFactory        $factory
+     * @param DynamicContentHelper $dynamicContentHelper
+     */
+    public function __construct(MauticFactory $factory, DynamicContentHelper $dynamicContentHelper)
+    {
+        parent::__construct($factory);
+
+        $this->dynamicContentHelper = $dynamicContentHelper;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            EmailEvents::EMAIL_ON_BUILD => ['onEmailBuild', 0],
+            EmailEvents::EMAIL_ON_DISPLAY => ['onEmailGenerate', 0],
+            EmailEvents::EMAIL_ON_SEND => ['onEmailGenerate', 0]
+        ];
+    }
+
+    /**
+     * @param EmailBuilderEvent $event
+     */
+    public function onEmailBuild(EmailBuilderEvent $event)
+    {
+        $event->addToken('{content=slot_name}', $this->translator->trans('mautic.dynamicContent.dynamicContent'));
+    }
+
+    /**
+     * @param EmailSendEvent $event
+     */
+    public function onEmailDisplay(EmailSendEvent $event)
+    {
+        $content = $event->getContent();
+
+        preg_match_all('', $content, $matches, PREG_SET_ORDER);
+    }
+}

--- a/app/bundles/DynamicContentBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/BuilderSubscriber.php
@@ -62,8 +62,8 @@ class BuilderSubscriber extends CommonSubscriber
      */
     public function onEmailDisplay(EmailSendEvent $event)
     {
-        $content = $event->getContent();
+        $content = $this->dynamicContentHelper->replaceTokensInContent($event->getContent(), $event->getLead());
 
-        preg_match_all('', $content, $matches, PREG_SET_ORDER);
+        $event->setContent($content);
     }
 }

--- a/app/bundles/DynamicContentBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/BuilderSubscriber.php
@@ -54,13 +54,13 @@ class BuilderSubscriber extends CommonSubscriber
      */
     public function onEmailBuild(EmailBuilderEvent $event)
     {
-        $event->addToken('{content=slot_name}', $this->translator->trans('mautic.dynamicContent.dynamicContent'));
+        $event->addToken('{dynamiccontent=slot_name}', $this->translator->trans('mautic.dynamicContent.dynamicContent'));
     }
 
     /**
      * @param EmailSendEvent $event
      */
-    public function onEmailDisplay(EmailSendEvent $event)
+    public function onEmailGenerate(EmailSendEvent $event)
     {
         $content = $this->dynamicContentHelper->replaceTokensInContent($event->getContent(), $event->getLead());
 

--- a/app/bundles/DynamicContentBundle/Helper/DynamicContentHelper.php
+++ b/app/bundles/DynamicContentBundle/Helper/DynamicContentHelper.php
@@ -92,7 +92,7 @@ class DynamicContentHelper
     public function replaceTokensInContent($content, $lead)
     {
         // Find all dynamic content tags
-        preg_match_all('/{(content)=(\w+)(?:\/}|}(?:([^{]*(?:{(?!\/\1})[^{]*)*){\/\1})?)/is', $content, $matches, PREG_SET_ORDER);
+        preg_match_all('/{(dynamiccontent)=(\w+)(?:\/}|}(?:([^{]*(?:{(?!\/\1})[^{]*)*){\/\1})?)/is', $content, $matches, PREG_SET_ORDER);
 
         foreach ($matches as $match) {
             $slot = $match[2];
@@ -104,7 +104,7 @@ class DynamicContentHelper
                 $dwcContent = $defaultContent;
             }
 
-            $content = str_replace($matches[0], '<div class="mautic-slot">' . $dwcContent . '</div>', $content);
+            $content = str_replace($matches[0], $dwcContent, $content);
         }
 
         return $content;

--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -131,13 +131,15 @@ class DynamicContentModel extends FormModel
 
     /**
      * @param      $slot
-     * @param Lead $lead
+     * @param Lead|array $lead
      * 
      * @return DynamicContent
      */
-    public function getSlotContentForLead($slot, Lead $lead)
+    public function getSlotContentForLead($slot, $lead)
     {
         $qb = $this->em->getConnection()->createQueryBuilder();
+
+        $id = $lead instanceof Lead ? $lead->getId() : $lead['id'];
         
         $qb->select('dc.id, dc.content')
             ->from(MAUTIC_TABLE_PREFIX.'dynamic_content', 'dc')
@@ -145,7 +147,7 @@ class DynamicContentModel extends FormModel
             ->andWhere($qb->expr()->eq('dcld.slot', ':slot'))
             ->andWhere($qb->expr()->eq('dcld.lead_id', ':lead_id'))
             ->setParameter('slot', $slot)
-            ->setParameter('lead_id', $lead->getId())
+            ->setParameter('lead_id', $id)
             ->orderBy('dcld.date_added', 'DESC')
             ->addOrderBy('dcld.id', 'DESC');
 
@@ -154,11 +156,15 @@ class DynamicContentModel extends FormModel
 
     /**
      * @param DynamicContent $dynamicContent
-     * @param Lead           $lead
+     * @param Lead|array     $lead
      * @param string         $source
      */
-    public function createStatEntry(DynamicContent $dynamicContent, Lead $lead, $source = null)
+    public function createStatEntry(DynamicContent $dynamicContent, $lead, $source = null)
     {
+        if (is_array($lead)) {
+            $lead = $this->em->getReference('MauticLeadBundle:Lead', $lead['id']);
+        }
+
         $stat = new Stat();
         $stat->setDateSent(new \DateTime());
         $stat->setLead($lead);


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Related user documentation PR URL | 
| BC breaks? | N
| Deprecations? | N

#### Description:
This PR allows you to embed dynamic content into your emails (campaign or one-off) in much the same way that you would embed the dynamic content into a web page. 

#### Steps to test this PR:
1. Verify that DynamicContent is working normally (it should be, since it's been active in core since 2.0)
2. Create an email and in one of the content areas, embed the following dynamic content token `{dynamiccontent=slot1}Here is the default content to show if no dynamic content replacement is found.{/dynamiccontent}`
3. Create a campaign with a form as the entry point. In that campaign, insert a *Request dynamic content* condition with a *Slot Name* of `slot1`, then select the default content.
4. Add some conditions below it attached to the yes side (green), then add some *Push dynamic content* actions with varying content as you wish.
5. Add the earlier created email as an action to that campaign, branched off the entry point. (You'll now have *Request dynamic content* and *Send email* as actions to perform branched off the campaign entry point.)
6. Embed that form into a website where you have the mautic tracking javascript installed.
7. In another browser (or just make sure you are logged out of your mautic instance), navigate to the form on the website where you placed it and fill it out. Based on how you set up the dynamic content condition/action tree, the email you receive will contain the appropriate dynamic content.