### PR TITLE
Email without name should have a to: email@email.com

### DIFF
--- a/app/bundles/EmailBundle/Controller/AjaxController.php
+++ b/app/bundles/EmailBundle/Controller/AjaxController.php
@@ -295,9 +295,14 @@ class AjaxController extends CommonAjaxController
                         );
 
                         $user = $this->factory->getUser();
+                        $userFullName=trim($user->getFirstName().' '.$user->getLastName());
 
                         $message->setFrom(array($settings['from_email'] => $settings['from_name']));
-                        $message->setTo(array($user->getEmail() => $user->getFirstName().' '.$user->getLastName()));
+                        if ($userFullName) {
+                            $message->setTo(array($user->getEmail() => $user->getFirstName().' '.$user->getLastName()));
+                        } else {
+                            $message->setTo(array($user->getEmail()));
+                        }
 
                         $mailer->send($message);
                     }

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -925,7 +925,11 @@ class MailHelper
     public function setTo($addresses, $name = null)
     {
         if (!is_array($addresses)) {
-            $addresses = array($addresses => $name);
+            if (($name !== null) && (trim($name))) {
+                $addresses = array($addresses => trim($name));
+            } else {
+                $addresses = array($addresses);
+            }
         }
 
         $this->checkBatchMaxRecipients(count($addresses));


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #2131 
| BC breaks? | N
| Deprecations? | N

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:
When a contact has an email but no firstname and no lastname, email is send to " " < the@email.com >.
When firstname and lastname are empty, the "To:" field should be email only, without " " and < >

#### Steps to test this PR:
1. Create a user without firstname and lastname
2. Send an email with mautic.
3. Check To: header. Now it's To: email@email.com and not To: " " < email@email.com >
