### PR TITLE
Page title fixed by title token

### DIFF
--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -91,6 +91,10 @@ class EmailSendEvent extends CommonEvent
             $this->subject = $args['subject'];
         }
 
+        if (!$this->subject && isset($args['email']) && $args['email'] instanceof Email) {
+            $this->subject = $args['email']->getSubject();
+        }
+
         if (isset($args['idHash'])) {
             $this->idHash = $args['idHash'];
         }

--- a/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
@@ -73,7 +73,8 @@ class BuilderSubscriber extends CommonSubscriber
         $tokens = array(
             '{unsubscribe_text}' => $this->translator->trans('mautic.email.token.unsubscribe_text'),
             '{webview_text}'     => $this->translator->trans('mautic.email.token.webview_text'),
-            '{signature}'        => $this->translator->trans('mautic.email.token.signature')
+            '{signature}'        => $this->translator->trans('mautic.email.token.signature'),
+            '{subject}'          => $this->translator->trans('mautic.email.subject')
         );
 
         if ($event->tokensRequested(array_keys($tokens))) {
@@ -137,6 +138,7 @@ class BuilderSubscriber extends CommonSubscriber
     {
         $idHash = $event->getIdHash();
         $lead   = $event->getLead();
+        $email  = $event->getEmail();
 
         if ($idHash == null) {
             // Generate a bogus idHash to prevent errors for routes that may include it
@@ -161,8 +163,8 @@ class BuilderSubscriber extends CommonSubscriber
         $event->addToken('{webview_text}', $webviewText);
 
         // Show public email preview if the lead is not known to prevent 404
-        if (empty($lead['id']) && $event->getEmail()) {
-            $event->addToken('{webview_url}', $model->buildUrl('mautic_email_preview', array('objectId' => $event->getEmail()->getId())));
+        if (empty($lead['id']) && $email) {
+            $event->addToken('{webview_url}', $model->buildUrl('mautic_email_preview', array('objectId' => $email->getId())));
         } else {
             $event->addToken('{webview_url}', $model->buildUrl('mautic_email_webview', array('idHash' => $idHash)));
         }
@@ -180,6 +182,8 @@ class BuilderSubscriber extends CommonSubscriber
 
         $signatureText = str_replace('|FROM_NAME|', $fromName, nl2br($signatureText));
         $event->addToken('{signature}', $signatureText);
+
+        $event->addToken('{subject}', $event->getSubject());
     }
 
     /**

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -186,8 +186,8 @@ class BuilderSubscriber extends CommonSubscriber
             $content = str_ireplace($this->titleRegex, $page->getTitle(), $content);
         }
 
-        if (strpos($content, $this->titleRegex) !== false) {
-            $content = str_ireplace($this->titleRegex, $page->getMetaDescription(), $content);
+        if (strpos($content, $this->descriptionRegex) !== false) {
+            $content = str_ireplace($this->descriptionRegex, $page->getMetaDescription(), $content);
         }
 
         $clickThrough = ['source' => ['page', $page->getId()]];

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -38,6 +38,8 @@ class BuilderSubscriber extends CommonSubscriber
     protected $pageTokenRegex = '{pagelink=(.*?)}';
     protected $langBarRegex = '{langbar}';
     protected $shareButtonsRegex = '{sharebuttons}';
+    protected $titleRegex = '{pagetitle}';
+    protected $descriptionRegex = '{pagemetadescription}';
     protected $emailIsInternalSend = false;
     protected $emailEntity = null;
 
@@ -119,6 +121,8 @@ class BuilderSubscriber extends CommonSubscriber
                     [
                         $this->langBarRegex      => $this->translator->trans('mautic.page.token.lang'),
                         $this->shareButtonsRegex => $this->translator->trans('mautic.page.token.share'),
+                        $this->titleRegex        => $this->translator->trans('mautic.core.title'),
+                        $this->descriptionRegex  => $this->translator->trans('mautic.page.form.metadescription'),
                     ]
                 )
             );
@@ -176,6 +180,14 @@ class BuilderSubscriber extends CommonSubscriber
         if (strpos($content, $this->shareButtonsRegex) !== false) {
             $buttons = $this->renderSocialShareButtons();
             $content = str_ireplace($this->shareButtonsRegex, $buttons, $content);
+        }
+
+        if (strpos($content, $this->titleRegex) !== false) {
+            $content = str_ireplace($this->titleRegex, $page->getTitle(), $content);
+        }
+
+        if (strpos($content, $this->titleRegex) !== false) {
+            $content = str_ireplace($this->titleRegex, $page->getMetaDescription(), $content);
         }
 
         $clickThrough = ['source' => ['page', $page->getId()]];

--- a/themes/blank/html/base.html.twig
+++ b/themes/blank/html/base.html.twig
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
+        {% if page is defined %}
         <title>{pagetitle}</title>
         <meta name="description" content="{pagemetadescription}">
+        {% endif %}
         {{ outputHeadDeclarations() }}
     </head>
     <body>

--- a/themes/blank/html/base.html.twig
+++ b/themes/blank/html/base.html.twig
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html>
     <head>
-        {% if page is defined %}
-            <title>{{ page.getTitle() }}</title>
-            <meta name="description" content="{{ page.metaDescription }}">
-        {% endif %}
+        <title>{pagetitle}</title>
+        <meta name="description" content="{pagemetadescription}">
         {{ outputHeadDeclarations() }}
     </head>
     <body>

--- a/themes/blank/html/email.html.twig
+++ b/themes/blank/html/email.html.twig
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <title>{subject}</title>
     </head>
     <body style="margin:0">
         <div data-section-wrapper>

--- a/themes/goldstar/html/base.html.twig
+++ b/themes/goldstar/html/base.html.twig
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html>
     <head>
-        {% if page is defined %}
-        <title>{{ page.getTitle() }}</title>
-        <meta name="description" content="{{ page.getMetaDescription() }}">
-        {% endif %}
+        <title>{pagetitle}</title>
+        <meta name="description" content="{pagemetadescription}">
         <link rel="stylesheet" href="{{ getAssetUrl('themes/goldstar/css/goldstar.css') }}" type="text/css" />
     </head>
     <body>

--- a/themes/goldstar/html/email.html.twig
+++ b/themes/goldstar/html/email.html.twig
@@ -9,6 +9,7 @@
     <meta name="format-detection" content="date=no" />
     <meta name="format-detection" content="address=no" />
     <meta name="format-detection" content="telephone=no" />
+    <title>{subject}</title>
     
 
     <style type="text/css" media="screen">

--- a/themes/neopolitan/html/base.html.twig
+++ b/themes/neopolitan/html/base.html.twig
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html>
     <head>
-        {% if page is defined %}
-        <title>{{ page.getTitle() }}</title>
-        <meta name="description" content="{{ page.getMetaDescription() }}">
-        {% endif %}
+        <title>{pagetitle}</title>
+        <meta name="description" content="{pagemetadescription}">
         <link rel="stylesheet" href="{{ getAssetUrl('themes/neopolitan/css/neopolitan.css') }}" type="text/css" />
     </head>
     <body style="padding: 0;margin: 0;display: block;background: #ffffff;-webkit-text-size-adjust: none;-webkit-font-smoothing: antialiased;width: 100%;height: 100%;color: #37302d;font-size: 16px;" bgcolor="#ffffff">

--- a/themes/neopolitan/html/base.html.twig
+++ b/themes/neopolitan/html/base.html.twig
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
+        {% if page is defined %}
         <title>{pagetitle}</title>
         <meta name="description" content="{pagemetadescription}">
+        {% endif %}
         <link rel="stylesheet" href="{{ getAssetUrl('themes/neopolitan/css/neopolitan.css') }}" type="text/css" />
     </head>
     <body style="padding: 0;margin: 0;display: block;background: #ffffff;-webkit-text-size-adjust: none;-webkit-font-smoothing: antialiased;width: 100%;height: 100%;color: #37302d;font-size: 16px;" bgcolor="#ffffff">

--- a/themes/neopolitan/html/email.html.twig
+++ b/themes/neopolitan/html/email.html.twig
@@ -3,6 +3,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{subject}</title>
     <!-- Designed by https://github.com/kaytcat -->
     <!-- Robot header image designed by Freepik.com -->
 

--- a/themes/neopolitan/html/page.html.twig
+++ b/themes/neopolitan/html/page.html.twig
@@ -170,7 +170,6 @@
             <tr>
                 <td style="color: #bbbbbb;font-size: 12px;font-family: 'Droid Sans', 'Helvetica Neue', 'Arial', 'sans-serif' !important;font-weight: 400;text-align: center;" data-slot-container>
                     <div data-slot="text">
-                        <a href="{webview_url}" style="text-decoration: none;border: 0;outline: none;color: #bbbbbb;">View in browser</a> | <a href="{unsubscribe_url}" style="text-decoration: none;border: 0;outline: none;color: #bbbbbb;">Unsubscribe</a> | <a href="#" style="text-decoration: none;border: 0;outline: none;color: #bbbbbb;">Contact</a>
                         <br><br>
                     </div>
                 </td>

--- a/themes/oxygen/html/base.html.twig
+++ b/themes/oxygen/html/base.html.twig
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
+        {% if page is defined %}
         <title>{pagetitle}</title>
         <meta name="description" content="{pagemetadescription}">
+        {% endif %}
         <link rel="stylesheet" href="{{ getAssetUrl('themes/oxygen/css/oxygen.css') }}" type="text/css" />
     </head>
     <body>

--- a/themes/oxygen/html/base.html.twig
+++ b/themes/oxygen/html/base.html.twig
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html>
     <head>
-        {% if page is defined %}
-        <title>{{ page.getTitle() }}</title>
-        <meta name="description" content="{{ page.getMetaDescription() }}">
-        {% endif %}
+        <title>{pagetitle}</title>
+        <meta name="description" content="{pagemetadescription}">
         <link rel="stylesheet" href="{{ getAssetUrl('themes/oxygen/css/oxygen.css') }}" type="text/css" />
     </head>
     <body>

--- a/themes/oxygen/html/email.html.twig
+++ b/themes/oxygen/html/email.html.twig
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <title>{subject}</title>
     </head>
     <body style="font-family: 'Oxygen', 'Helvetica Neue', 'Arial', 'sans-serif' !important;-webkit-font-smoothing: antialiased;-webkit-text-size-adjust: none;height: 100%;color: #676767;width: 100% !important;margin: 0 !important;">
         <div data-section-wrapper align="center" valign="top" width="100%" style="background-color: #f7f7f7;font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 20px 0 30px;" class="content-padding">

--- a/themes/skyline/html/base.html.twig
+++ b/themes/skyline/html/base.html.twig
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html>
     <head>
-        {% if page is defined %}
-        <title>{{ page.getTitle() }}</title>
-        <meta name="description" content="{{ page.getMetaDescription() }}">
-        {% endif %}
+        <title>{pagetitle}</title>
+        <meta name="description" content="{pagemetadescription}">
         <link rel="stylesheet" href="{{ getAssetUrl('themes/skyline/css/skyline.css') }}" type="text/css" />
     </head>
     <body style="padding:0; margin:0; display:block; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">

--- a/themes/skyline/html/base.html.twig
+++ b/themes/skyline/html/base.html.twig
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
+        {% if page is defined %}
         <title>{pagetitle}</title>
         <meta name="description" content="{pagemetadescription}">
+        {% endif %}
         <link rel="stylesheet" href="{{ getAssetUrl('themes/skyline/css/skyline.css') }}" type="text/css" />
     </head>
     <body style="padding:0; margin:0; display:block; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">

--- a/themes/skyline/html/email.html.twig
+++ b/themes/skyline/html/email.html.twig
@@ -3,7 +3,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Skyline Reignite Email</title>
+    <title>{subject}</title>
     <style type="text/css">
         @import url(https://fonts.googleapis.com/css?family=Lato:400);
 

--- a/themes/sunday/html/base.html.twig
+++ b/themes/sunday/html/base.html.twig
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html>
     <head>
-        {% if page is defined %}
-        <title>{{ page.getTitle() }}</title>
-        <meta name="description" content="{{ page.getMetaDescription() }}">
-        {% endif %}
+        <title>{pagetitle}</title>
+        <meta name="description" content="{pagemetadescription}">
         <link rel="stylesheet" href="{{ getAssetUrl('themes/oxygen/css/oxygen.css') }}" type="text/css" />
     </head>
     <body offset="0" class="body" style="padding: 0;margin: 0;display: block;background: #eeebeb;-webkit-text-size-adjust: none;-webkit-font-smoothing: antialiased;width: 100%;height: 100%;color: #6f6f6f;font-weight: 400;font-size: 18px;" bgcolor="#eeebeb">

--- a/themes/sunday/html/base.html.twig
+++ b/themes/sunday/html/base.html.twig
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
+        {% if page is defined %}
         <title>{pagetitle}</title>
         <meta name="description" content="{pagemetadescription}">
+        {% endif %}
         <link rel="stylesheet" href="{{ getAssetUrl('themes/oxygen/css/oxygen.css') }}" type="text/css" />
     </head>
     <body offset="0" class="body" style="padding: 0;margin: 0;display: block;background: #eeebeb;-webkit-text-size-adjust: none;-webkit-font-smoothing: antialiased;width: 100%;height: 100%;color: #6f6f6f;font-weight: 400;font-size: 18px;" bgcolor="#eeebeb">

--- a/themes/sunday/html/email.html.twig
+++ b/themes/sunday/html/email.html.twig
@@ -3,7 +3,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title></title>
+    <title>{subject}</title>
     <!-- Designed by https://github.com/kaytcat -->
     <!-- Header image designed by Freepik.com -->
 
@@ -295,7 +295,7 @@
                             <tr>
                                 <td data-slot-container style="color: #27aa90;font-size: 14px;text-align: center;font-family: Arial, sans-serif;border-collapse: collapse;">
                                     <div data-slot="text">
-                                        <a href="{webview_url}‍" style="color: #27aa90;text-decoration: none;">View in browser</a> | <a href="#" style="color: #27aa90;text-decoration: none;">Contact</a> | <a href="{unsubscribe_url}" style="color: #27aa90;text-decoration: none;">Unsubscribe</a>
+                                        <a href="{webview_url}" style="color: #27aa90;text-decoration: none;">View in browser</a> | <a href="#" style="color: #27aa90;text-decoration: none;">Contact</a> | <a href="{unsubscribe_url}" style="color: #27aa90;text-decoration: none;">Unsubscribe</a>
                                     </div>
                                 </td>
                             </tr>

--- a/themes/sunday/html/page.html.twig
+++ b/themes/sunday/html/page.html.twig
@@ -164,7 +164,6 @@
                             <tr>
                                 <td data-slot-container style="color: #27aa90;font-size: 14px;text-align: center;font-family: Arial, sans-serif;border-collapse: collapse;">
                                     <div data-slot="text">
-                                        <a href="{webview_url}‍" style="color: #27aa90;text-decoration: none;">View in browser</a> | <a href="#" style="color: #27aa90;text-decoration: none;">Contact</a> | <a href="{unsubscribe_url}" style="color: #27aa90;text-decoration: none;">Unsubscribe</a>
                                     </div>
                                 </td>
                             </tr>


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/22
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2056
| BC breaks? | N
| Deprecations? | N

#### Description:
The title, metadescription and subject doesn't work as in the Mautic 1 themes so this PR adds the new tokens instead: `{pagetitle}` and `{pagemetadescription}` for pages and `{subject}` for emails which are used in the head of the current themes. They can be used in the email/page content also elsewhere.

#### Steps to test this PR:
1. Apply this PR and the title should change every time you change it in the page and refresh the preview page.
2. The same will work with metadescription. The problem is that now the meta tags get stripped out. After https://github.com/mautic/mautic/pull/2032 will be merged, this should work as well.
3. In case of emails, the title is filled with the subject. The title should be there if you view the email preview as well as if you send the email to a contact and click the web view link.
4. Unsubscribe and form pages must still work.

#### Steps to reproduce the bug:
1. Create a page and set the title.
2. Save the page.
3. Open the page preview and check what title it has.
4. Edit the page and change the title.
