### PR TITLE
Fix ignored operators on update points actions for standalone forms

### DIFF
--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -657,13 +657,46 @@ class Lead extends FormEntity
     }
 
     /**
-     * Adds/substracts from current points
+     * Add from current points
      *
      * @param $points
      */
     public function addToPoints($points)
     {
         $newPoints = $this->points + $points;
+        $this->setPoints($newPoints);
+    }
+
+    /**
+     * Subtract from current points
+     *
+     * @param $points
+     */
+    public function subtractToPoints($points)
+    {
+        $newPoints = $this->points - $points;
+        $this->setPoints($newPoints);
+    }
+
+    /**
+     * Multipy current points
+     *
+     * @param $points
+     */
+    public function multiplyPoints($points)
+    {
+        $newPoints = $this->points * $points;
+        $this->setPoints($newPoints);
+    }
+
+    /**
+     * Divide current points
+     *
+     * @param $points
+     */
+    public function dividePoints($points)
+    {
+        $newPoints = $this->points / $points;
         $this->setPoints($newPoints);
     }
 

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -657,47 +657,31 @@ class Lead extends FormEntity
     }
 
     /**
-     * Add from current points
+     * @param integer $points
+     * @param string  $operator
      *
-     * @param $points
+     * @return Lead
      */
-    public function addToPoints($points)
+    public function adjustPoints($points, $operator='plus')
     {
-        $newPoints = $this->points + $points;
-        $this->setPoints($newPoints);
-    }
+        switch ($operator) {
+            case 'plus':
+                $this->points += $points;
+                break;
+            case 'minus':
+                $this->points -= $points;
+                break;
+            case 'times':
+                $this->points *= $points;
+                break;
+            case 'divide':
+                $this->points /= $points;
+                break;
+            default:
+                throw new \UnexpectedValueException('Invalid operator');
+        }
 
-    /**
-     * Subtract from current points
-     *
-     * @param $points
-     */
-    public function subtractFromPoints($points)
-    {
-        $newPoints = $this->points - $points;
-        $this->setPoints($newPoints);
-    }
-
-    /**
-     * Multipy current points
-     *
-     * @param $points
-     */
-    public function multiplyPoints($points)
-    {
-        $newPoints = $this->points * $points;
-        $this->setPoints($newPoints);
-    }
-
-    /**
-     * Divide current points
-     *
-     * @param $points
-     */
-    public function dividePoints($points)
-    {
-        $newPoints = $this->points / $points;
-        $this->setPoints($newPoints);
+        return $this;
     }
 
     /**

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -672,7 +672,7 @@ class Lead extends FormEntity
      *
      * @param $points
      */
-    public function subtractToPoints($points)
+    public function subtractFromPoints($points)
     {
         $newPoints = $this->points - $points;
         $this->setPoints($newPoints);

--- a/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
@@ -143,7 +143,7 @@ class CampaignSubscriber extends CommonSubscriber
         $somethingHappened = false;
 
         if ($lead !== null && !empty($points)) {
-            $lead->addToPoints($points);
+            $lead->adjustPoints($points);
 
             //add a lead point change log
             $log = new PointsChangeLog();

--- a/app/bundles/LeadBundle/Helper/FormEventHelper.php
+++ b/app/bundles/LeadBundle/Helper/FormEventHelper.php
@@ -49,7 +49,7 @@ class FormEventHelper
                 $lead->addToPoints($config['points']);
                 break;
             case 'minus':
-                $lead->subtractToPoints($config['points']);
+                $lead->subtractFromPoints($config['points']);
                 break;
             case 'times':
                 $lead->multiplyPoints($config['points']);

--- a/app/bundles/LeadBundle/Helper/FormEventHelper.php
+++ b/app/bundles/LeadBundle/Helper/FormEventHelper.php
@@ -44,22 +44,7 @@ class FormEventHelper
 
         $oldPoints = $lead->getPoints();
 
-        switch ($config['operator']) {
-            case 'plus':
-                $lead->addToPoints($config['points']);
-                break;
-            case 'minus':
-                $lead->subtractFromPoints($config['points']);
-                break;
-            case 'times':
-                $lead->multiplyPoints($config['points']);
-                break;
-            case 'divide':
-                $lead->dividePoints($config['points']);
-                break;
-            default:
-                throw new \UnexpectedValueException('Invalid operator');
-        }
+        $lead->adjustPoints($config['points'], $config['operator']);
 
         $newPoints = $lead->getPoints();
 

--- a/app/bundles/LeadBundle/Helper/FormEventHelper.php
+++ b/app/bundles/LeadBundle/Helper/FormEventHelper.php
@@ -22,13 +22,13 @@ use Mautic\LeadBundle\Entity\PointsChangeLog;
 class FormEventHelper
 {
     /**
-     * @param               $lead
+     * @param Lead          $lead
      * @param MauticFactory $factory
      * @param               $action
      * @param               $config
      * @param               $form
      */
-    public static function changePoints ($lead, MauticFactory $factory, $action, $config, $form)
+    public static function changePoints (Lead $lead, MauticFactory $factory, $action, $config, $form)
     {
         $model = $factory->getModel('lead');
 
@@ -40,11 +40,31 @@ class FormEventHelper
         $event->setIpAddress($factory->getIpAddress());
         $event->setDateAdded(new \DateTime());
 
-        $event->setDelta($config['points']);
         $event->setLead($lead);
 
+        $oldPoints = $lead->getPoints();
+
+        switch ($config['operator']) {
+            case 'plus':
+                $lead->addToPoints($config['points']);
+                break;
+            case 'minus':
+                $lead->subtractToPoints($config['points']);
+                break;
+            case 'times':
+                $lead->multiplyPoints($config['points']);
+                break;
+            case 'divide':
+                $lead->dividePoints($config['points']);
+                break;
+            default:
+                throw new \UnexpectedValueException('Invalid operator');
+        }
+
+        $newPoints = $lead->getPoints();
+
+        $event->setDelta($newPoints - $oldPoints);
         $lead->addPointsChangeLog($event);
-        $lead->addToPoints($config['points']);
 
         $model->saveEntity($lead, false);
     }
@@ -72,5 +92,5 @@ class FormEventHelper
         }
     }
 
-   
+
 }

--- a/app/bundles/PointBundle/Model/PointModel.php
+++ b/app/bundles/PointBundle/Model/PointModel.php
@@ -278,7 +278,7 @@ class PointModel extends CommonFormModel
 
                 if ($pointsChange) {
                     $delta = $action->getDelta();
-                    $lead->addToPoints($delta);
+                    $lead->adjustPoints($delta);
                     $parsed = explode('.', $action->getType());
                     $lead->addPointsChangeLogEntry(
                         $parsed[0],


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | None found
| BC breaks? | No
| Deprecations? | No

#### Description:

![image](https://cloud.githubusercontent.com/assets/18265735/17218078/d0a5e328-54e6-11e6-8c03-790550b9c930.png)

The operator dropdown in the adjust contact's points of standalone forms 

#### Steps to test this PR:

1. Make a standalone form with an **Adjust contact's points** action
2. Choose an operator other than plus
3. Have a contact submit the form
4. Check that the contact's points have correctly been updated

#### Steps to reproduce the bug:

Follow the above instructions before applying this patch