### PR TITLE
Removed extra name and company info from contact overview page

### DIFF
--- a/app/bundles/LeadBundle/Views/Lead/lead.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/lead.html.php
@@ -367,22 +367,6 @@ $view['slots']->set(
                     <div class="collapse<?php echo ($avatarPanelState == 'expanded') ? ' in' : ''; ?>"
                          id="lead-avatar-block">
                         <img class="img-responsive" src="<?php echo $img; ?>" alt="<?php echo $leadName; ?> "/>
-                        <div class="pa-sm">
-                            <?php if ($leadActualName && $leadCompany): ?>
-                            <h2>
-                                <div>
-                                    <?php echo $leadName; ?>
-                                </div>
-                                <div class="mt-xs span-block small">
-                                    <?php echo $leadCompany; ?>
-                                </div>
-                                <?php elseif ($leadActualName || $leadCompany): ?>
-                                    <h2>
-                                        <?php echo ($leadActualName) ? $leadActualName : $leadCompany; ?>
-                                    </h2>
-                                <?php endif; ?>
-                        </div>
-                        <hr/>
                     </div>
                 </div>
 


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? | N

### Required
#### Description:
This PR removes the contact name and company name from the righthand column when viewing an individual contact record. Due to the name appearing at the top of the page, this location was redundant. 

#### Steps to test this PR:
1. Apply PR
2. Visit a contact page
3. Verify extra-large name and company name are removed from righthand column.