### PR TITLE
Fixed issue #2025 problem with re-enabling bounced contacts

### DIFF
--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -69,14 +69,14 @@ class AjaxController extends CommonAjaxController
                         "id"    => $r['id']
                     );
                 }
-            } 
+            }
             elseif ($field == "hit_url") {
                 $dataArray[] = array(
                     'value' => ''
                 );
             } else {
                 $results = $this->getModel('lead.field')->getLookupResults($field, $filter);
-                foreach ($results as $r) { 
+                foreach ($results as $r) {
                     $dataArray[] = array('value' => $r[$field]);
                 }
             }
@@ -331,7 +331,7 @@ class AjaxController extends CommonAjaxController
             /** @var \Mautic\LeadBundle\Model\LeadModel $model */
             $model = $this->getModel('lead');
             /** @var \Mautic\LeadBundle\Entity\DoNotContact $dnc */
-            $dnc = $this->getEntityManager()->getRepository('MauticLeadBundle:DoNotContact')->findOneBy(
+            $dnc = $this->factory->getEntityManager()->getRepository('MauticLeadBundle:DoNotContact')->findOneBy(
                 array(
                     'id' => $dncId
                 )


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | #2025 
| BC breaks? | N
| Deprecations? | N

### Required
#### Description:
This PR fixes a bug when re-enabling previously bounced contacts. The error was related to a mistyped call.

#### Steps to test this PR:
1. Apply PR
2. Mark as bounced email on a contact
3. Click the flag to re-enable the contact
4. Verify that the contact is re-enabled

### As applicable
#### Steps to reproduce the bug:
1. Check a bounced contact
2. Click the flag to re-enable the contact.
3. Observe the contact is not re-enabled and the ajax call "hangs"
4. Check the error log for the message