### PR TITLE
Fix issue 2137 problem with DoNotContact "Reason" code

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1300,7 +1300,7 @@ class EmailModel extends FormModel
      * @param string $reason
      * @param bool   $flush
      */
-    public function setDoNotContact(Stat $stat, $comments, $reason = 'bounced', $flush = true)
+    public function setDoNotContact(Stat $stat, $comments, $reason = DoNotContact::BOUNCED, $flush = true)
     {
         $lead = $stat->getLead();
 


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | #2137, https://www.mautic.org/community/index.php/5107-bounce-processing-inserts-bad-data-type-reason-bug/p1#p13841
| BC breaks? | N
| Deprecations? | N

### Required
#### Description:
This PR fixes a bug with DoNotContact reasons failing a DB insert query.

#### Steps to test this PR:
1. Apply PR
2. Send an email with a known bad address (to force a bounced address)
3. Verify the contact was added to the lead_donotcontact table with a proper reason code

### As applicable
#### Steps to reproduce the bug:
1. Send an email with a known bad address (to force a bounced email)
2. Check error logs for message related to `incorrect integer value`
