### PR TITLE
Api form error fix

### DIFF
--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -318,13 +318,45 @@ class CommonApiController extends FOSRestController implements MauticController
             $view = $this->view(array($this->entityNameOne => $entity), $statusCode, $headers);
             $this->setSerializationContext($view);
         } else {
-            $view = $this->view($this->getFormErrorMessages($form), Codes::HTTP_BAD_REQUEST);
+            $formErrors = $this->getFormErrorMessages($form);
+            $msg = $this->getFormErrorMessage($formErrors);
+            return $this->returnError($msg, Codes::HTTP_BAD_REQUEST, $formErrors);
         }
 
         return $this->handleView($view);
     }
 
-    public function getFormErrorMessages(\Symfony\Component\Form\Form $form) {
+    public function getFormErrorMessage(array $formErrors)
+    {
+        $msg = '';
+
+        if ($formErrors) {
+            foreach ($formErrors as $key => $error) {
+                if (!$error) {
+                    continue;
+                }
+
+                if ($msg) {
+                    $msg .= ', ';
+                }
+
+                if (is_string($key)) {
+                    $msg .= $key.': ';
+                }
+
+                if (is_array($error)) {
+                    $msg .= $this->getFormErrorMessage($error);
+                } else {
+                    $msg .= $error;
+                }
+            }
+        }
+
+        return $msg;
+    }
+
+    public function getFormErrorMessages(\Symfony\Component\Form\Form $form)
+    {
         $errors = [];
 
         foreach ($form->getErrors() as $key => $error) {
@@ -455,6 +487,31 @@ class CommonApiController extends FOSRestController implements MauticController
     }
 
     /**
+     * Returns an error
+     *
+     * @param string  $msg
+     * @param integer $code
+     * @param array   $details
+     *
+     * @return Response
+     */
+    protected function returnError($msg, $code, $details = [])
+    {
+        $view = $this->view(
+            [
+                'error' => [
+                    'code'    => $code,
+                    'message' => $this->get('translator')->trans($msg, array(), 'flashes'),
+                    'details' => $details
+                ]
+            ],
+            $code
+        );
+
+        return $this->handleView($view);
+    }
+
+    /**
      * Returns a 403 Access Denied
      *
      * @param string $msg
@@ -463,17 +520,7 @@ class CommonApiController extends FOSRestController implements MauticController
      */
     protected function accessDenied($msg = 'mautic.core.error.accessdenied')
     {
-        $view = $this->view(
-            array(
-                'error' => array(
-                    'code'    => Codes::HTTP_FORBIDDEN,
-                    'message' => $this->get('translator')->trans($msg, array(), 'flashes')
-                )
-            ),
-            Codes::HTTP_FORBIDDEN
-        );
-
-        return $this->handleView($view);
+        return $this->returnError($msg, Codes::HTTP_FORBIDDEN);
     }
 
     /**
@@ -485,17 +532,7 @@ class CommonApiController extends FOSRestController implements MauticController
      */
     protected function notFound($msg = 'mautic.core.error.notfound')
     {
-        $view = $this->view(
-            array(
-                'error' => array(
-                    'code'    => Codes::HTTP_NOT_FOUND,
-                    'message' => $this->get('translator')->trans($msg, array(), 'flashes')
-                )
-            ),
-            Codes::HTTP_NOT_FOUND
-        );
-
-        return $this->handleView($view);
+        return $this->returnError($msg, Codes::HTTP_NOT_FOUND);
     }
 
     /**
@@ -507,17 +544,7 @@ class CommonApiController extends FOSRestController implements MauticController
      */
     protected function badRequest($msg = 'mautic.core.error.badrequest')
     {
-        $view = $this->view(
-            array(
-                'error' => array(
-                    'code'    => Codes::HTTP_BAD_REQUEST,
-                    'message' => $this->get('translator')->trans($msg, array(), 'flashes')
-                )
-            ),
-            Codes::HTTP_BAD_REQUEST
-        );
-
-        return $this->handleView($view);
+        return $this->returnError($msg, Codes::HTTP_BAD_REQUEST);
     }
 
     /**

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -337,7 +337,7 @@ class CommonApiController extends FOSRestController implements MauticController
 
         foreach ($form->all() as $child) {
             if (!$child->isValid()) {
-                $errors[$child->getName()] = $this->getErrorMessages($child);
+                $errors[$child->getName()] = $this->getFormErrorMessages($child);
             }
         }
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2102
| BC breaks? | Y
| Deprecations? | N

#### Description:
There was a bug when there was a form error during API call. This PR fixes the issue and also unifies the error messages that the error has always this format:

```
array(1) {
  'error' =>
  array(3) {
    'code' =>
    int(400)
    'message' =>
    string(33) "country: This value is not valid."
    'details' =>
    array(1) {
      'country' =>
      array(1) {
        0 => 'This value is not valid.'
      }
    }
  }
}
``` 

The details array is used only in the form error and displays the array of fields which has the error so users can show the error next to the field which has the wrong value.

#### Steps to test this PR:
1. Apply this PR and repeat the test

#### Steps to reproduce the bug:
1. Try to edit a contact with non-existent country
2. Or run the unit test in https://github.com/mautic/api-library/pull/47

#### List backwards compatibility breaks:
The form error returned an array of the form fields with array of error messages. This PR adds it to the error => details array and adds the error => message and error => code attributes to unify it with the rest of error messages. Since the form errors were broken anyway, I don't think this BC break will affect anyone.