### PR TITLE
Fix unescaped quotes in bar graphs

### DIFF
--- a/app/bundles/FormBundle/Views/SubscribedEvents/AbTest/submissions.html.php
+++ b/app/bundles/FormBundle/Views/SubscribedEvents/AbTest/submissions.html.php
@@ -18,6 +18,7 @@ if ($support['data']) {
 }
 
 ?>
+
 <div class="panel ovf-h bg-auto bg-light-xs abtest-bar-chart">
     <div class="panel-body box-layout">
         <div class="col-xs-8 va-m">
@@ -40,7 +41,7 @@ if ($support['data']) {
     mQuery(document).ready(function() {
         mQuery('#abStatsModal').on('shown.bs.modal', function (event) {
             var canvas = document.getElementById("abtest-bar-chart");
-            var barData = mQuery.parseJSON('<?php echo json_encode($chart->render()); ?>');
+            var barData = mQuery.parseJSON('<?php echo str_replace('\'', '\\\'', json_encode($chart->render())); ?>');
             var barGraph = new Chart(canvas, {type: 'bar', data: barData});
         });
     });

--- a/app/bundles/PageBundle/Views/SubscribedEvents/AbTest/bargraph.html.php
+++ b/app/bundles/PageBundle/Views/SubscribedEvents/AbTest/bargraph.html.php
@@ -8,7 +8,7 @@
  */
 
 $support = $results['support'];
-$label   = $view['translator']->trans($variants['criteria'][$results['basedOn']]['label']);
+$label = $view['translator']->trans($variants['criteria'][$results['basedOn']]['label']);
 $chart = new \Mautic\CoreBundle\Helper\Chart\BarChart($support['labels']);
 
 if ($support['data']) {
@@ -41,7 +41,7 @@ if ($support['data']) {
     mQuery(document).ready(function() {
         mQuery('#abStatsModal').on('shown.bs.modal', function (event) {
             var canvas = document.getElementById("abtest-bar-chart");
-            var barData = mQuery.parseJSON('<?php echo json_encode($chart->render()); ?>');
+            var barData = mQuery.parseJSON('<?php echo str_replace('\'', '\\\'', json_encode($chart->render())); ?>');
             var barGraph = new Chart(canvas, {type: 'bar', data: barData});
         });
     });


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | None found
| BC breaks? | No
| Deprecations? | No

#### Description:

![image](https://cloud.githubusercontent.com/assets/18265735/17245229/d7066be4-5585-11e6-8524-96476af6f66c.png)

In the bar graphs charts resulting from an A/B test, languages containing simple quotes in the chart legend were not escaped properly.
This resulted in the browser failing to parse the JS.

This pull request addresses this problem.

#### Steps to test this PR:
1. Switch to a language containing a quote in said location (such as French)
2. Make an A/B tested email
3. Send it
4. Open the stat modal
5. See that it works!

#### Steps to reproduce the bug:
1. Switch to a language containing a quote in said location (such as French)
2. Make an A/B tested email
3. Send it
4. Open the email
5. Check your browser's console for an parsing error message