### PR TITLE
array_unshift rewrites the numeric keys - fixes #1952

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/FilterType.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterType.php
@@ -232,7 +232,7 @@ class FilterType extends AbstractType
                     }
 
                     if ($fieldType == 'select') {
-                        // array_unshift cannot be used because numeric values gets lost as keys
+                        // array_unshift cannot be used because numeric values get lost as keys
                         $choices = array_reverse($choices, true);
                         $choices[''] = '';
                         $choices = array_reverse($choices, true);

--- a/app/bundles/LeadBundle/Form/Type/FilterType.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterType.php
@@ -232,7 +232,10 @@ class FilterType extends AbstractType
                     }
 
                     if ($fieldType == 'select') {
-                        array_unshift($choices, array('' => ''));
+                        // array_unshift cannot be used because numeric values gets lost as keys
+                        $choices = array_reverse($choices, true);
+                        $choices[''] = '';
+                        $choices = array_reverse($choices, true);
                     }
 
                     $customOptions['choices'] = $choices;


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/1952
| BC breaks? | N
| Deprecations? | N

#### Description:
If a contact field type of select has just the numeric values and if this field is used in a segment filter, the numeric values are not found because the `array_unshift` method rewrites the numeric keys.

#### Steps to test this PR:
- Apply this PR
- Update the segment filter - select the 23 again
- mautic:segments:update
- Observe that your segment has 2 contacts in it

#### Steps to reproduce the bug:
- Create a custom field of type Select
- Add options 22, 23 and 34 (just the numeric values)
- Create 2 contacts using this field and save the value 23 in the contact edit form for those 2 contacts
- Create a segment with a filter on this field (equals 23)
- mautic:segments:update
- Observe that your segment doesn't have the 2 contacts in it
