### PR TITLE
Improved Email creation flow part 1

### DIFF
--- a/app/bundles/EmailBundle/Views/Email/form.html.php
+++ b/app/bundles/EmailBundle/Views/Email/form.html.php
@@ -11,12 +11,14 @@ $view->extend('MauticCoreBundle:Default:content.html.php');
 $view['slots']->set('mauticContent', 'email');
 
 $variantParent = $email->getVariantParent();
+$isExisting = $email->getId();
+
 $subheader = ($variantParent) ? '<div><span class="small">' . $view['translator']->trans('mautic.email.header.editvariant', array(
     '%name%' => $email->getName(),
     '%parent%' => $variantParent->getName()
 )) . '</span></div>' : '';
 
-$header = ($email->getId()) ?
+$header = $isExisting ?
     $view['translator']->trans('mautic.email.header.edit',
         array('%name%' => $email->getName())) :
     $view['translator']->trans('mautic.email.header.new');
@@ -32,23 +34,21 @@ if (!isset($attachmentSize)) {
 ?>
 
 <?php echo $view['form']->start($form); ?>
+
 <div class="box-layout">
     <div class="col-md-9 height-auto bg-white">
         <div class="row">
             <div class="col-xs-12">
                 <!-- tabs controls -->
                 <ul class="bg-auto nav nav-tabs pr-md pl-md">
-                    <li class="active"><a href="#email-container" role="tab" data-toggle="tab"><?php echo $view['translator']->trans('mautic.email.email'); ?></a></li>
-                    <li class=""><a href="#advanced-container" role="tab" data-toggle="tab"><?php echo $view['translator']->trans('mautic.core.advanced'); ?></a></li>
-                    <li class=""><a href="#source-container" role="tab" data-toggle="tab"><?php echo $view['translator']->trans('mautic.core.content'); ?></a></li>
+                    <li <?php echo !$isExisting ? "class='active'" : ""; ?>><a href="#email-container" role="tab" data-toggle="tab"><?php echo $view['translator']->trans('mautic.core.form.theme'); ?></a></li>
+                    <li <?php echo $isExisting ? "class='active'" : ""; ?>><a href="#source-container" role="tab" data-toggle="tab"><?php echo $view['translator']->trans('mautic.core.content'); ?></a></li>
+                    <li><a href="#advanced-container" role="tab" data-toggle="tab"><?php echo $view['translator']->trans('mautic.core.advanced'); ?></a></li>
                 </ul>
                 <!--/ tabs controls -->
                 <div class="tab-content pa-md">
-                    <div class="tab-pane fade in active bdr-w-0" id="email-container">
+                    <div class="tab-pane fade <?php echo !$isExisting ? "in active" : ""; ?> bdr-w-0" id="email-container">
                         <div class="row">
-                            <div class="col-md-12">
-                                <?php echo $view['form']->row($form['subject']); ?>
-                            </div>
                             <div class="col-md-12">
                                 <?php echo $view['form']->row($form['template']); ?>
                             </div>
@@ -58,6 +58,33 @@ if (!isset($attachmentSize)) {
                             'themes' => $themes,
                             'active' => $form['template']->vars['value']
                         )); ?>
+                    </div>
+
+                    <div class="tab-pane fade <?php echo $isExisting ? "in active" : ""; ?> bdr-w-0" id="source-container">
+                        <div class="row">
+                          <div class="col-md-12">
+                              <?php echo $view['form']->row($form['subject']); ?>
+                          </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12" id="customHtmlContainer" style="min-height: 325px;">
+                                <?php echo $view['form']->row($form['customHtml']); ?>
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="pull-left">
+                                    <?php echo $view['form']->label($form['plainText']); ?>
+                                </div>
+                                <div class="text-right pr-10">
+                                    <i class="fa fa-spinner fa-spin ml-2 plaintext-spinner hide"></i>
+                                    <a class="small" onclick="Mautic.autoGeneratePlaintext();"><?php echo $view['translator']->trans('mautic.email.plaintext.generate'); ?></a>
+                                </div>
+                                <div class="clearfix"></div>
+                                <?php echo $view['form']->widget($form['plainText']); ?>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="tab-pane fade bdr-w-0" id="advanced-container">
@@ -90,28 +117,6 @@ if (!isset($attachmentSize)) {
                                 </div>
                                 <div class="clearfix"></div>
                                 <?php echo $view['form']->widget($form['assetAttachments']); ?>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="tab-pane fade bdr-w-0" id="source-container">
-                        <div class="row">
-                            <div class="col-md-12" id="customHtmlContainer" style="min-height: 325px;">
-                                <?php echo $view['form']->row($form['customHtml']); ?>
-                            </div>
-                        </div>
-
-                        <div class="row">
-                            <div class="col-md-12">
-                                <div class="pull-left">
-                                    <?php echo $view['form']->label($form['plainText']); ?>
-                                </div>
-                                <div class="text-right pr-10">
-                                    <i class="fa fa-spinner fa-spin ml-2 plaintext-spinner hide"></i>
-                                    <a class="small" onclick="Mautic.autoGeneratePlaintext();"><?php echo $view['translator']->trans('mautic.email.plaintext.generate'); ?></a>
-                                </div>
-                                <div class="clearfix"></div>
-                                <?php echo $view['form']->widget($form['plainText']); ?>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? | N

### Required
#### Description:
This pull request accomplishes the first step of some basic improvements to the email creation and editing workflow. We change the order and naming of the tabs, the starting tab, and the location of the email subject.

#### Steps to test this PR:
1. Apply PR
2. Create a new email
3. Notice first tab is "Theme"
4. Verify "Subject" input field shows on the "Content" tab.

_Alternate_
2. Edit an existing email
3. Notice first tab is "Content"