### PR TITLE
Fixes Issue #2124 with improper filter button value

### DIFF
--- a/app/bundles/CoreBundle/Views/Helper/tableheader.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/tableheader.html.php
@@ -48,7 +48,7 @@ $tmpl         = (!empty($tmpl)) ? $tmpl : 'list';
             <input type="text" placeholder="<?php echo $view['translator']->trans('mautic.core.form.thead.filter'); ?>" autocomplete="false" class="form-control input-sm" value="<?php echo $value; ?>"<?php echo $toggle; ?> onchange="Mautic.filterTableData('<?php echo $sessionVar; ?>','<?php echo $filterBy; ?>',this.value,'<?php echo $tmpl; ?>','<?php echo $target; ?>'<?php if (!empty($baseUrl)): ?>, '<?php echo $baseUrl; ?>'<?php endif; ?>);" />
             <?php $inputClass =  (!empty($value)) ? 'fa-times' : 'fa-filter'; ?>
             <span class="input-group-btn">
-                <button class="btn btn-default btn-xs" onclick="Mautic.filterTableData('<?php echo $sessionVar; ?>','<?php echo $filterBy; ?>',<?php echo (!empty($value)) ? "''," : "this.value,"; ?>'<?php echo $tmpl; ?>','<?php echo $target; ?>'<?php if (!empty($baseUrl)): ?>, '<?php echo $baseUrl; ?>'<?php endif; ?>);">
+                <button class="btn btn-default btn-xs" onclick="Mautic.filterTableData('<?php echo $sessionVar; ?>','<?php echo $filterBy; ?>',<?php echo (!empty($value)) ? "''," : "mQuery(this).parent().prev().val(),"; ?>'<?php echo $tmpl; ?>','<?php echo $target; ?>'<?php if (!empty($baseUrl)): ?>, '<?php echo $baseUrl; ?>'<?php endif; ?>);">
                     <i class="fa fa-fw fa-lg <?php echo $inputClass; ?>"></i>
                 </button>
             </span>


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | #2124 
| BC breaks? | N
| Deprecations? | N

### Required
#### Description:
This PR fixes a bug where the filter button does not use the value of the filter input when filtering dynamic form results. See #2124 for a more detailed description of the problem. 

#### Steps to test this PR:
1. Apply the PR
2. Navigate to the results of a form created in Mautic
3. Filter by one of the form fields
4. Click the filter icon button next to the form field to perform the filtering (not clicking enter)
5. Verify the report is filtered correctly.

### As applicable
#### Steps to reproduce the bug:
1. Navigate to a form in Mautic
2. Enter filter text and click the filter button
3. The form will return with the filter value missing and without applying the filter text entered.