### PR TITLE
Fixed name of event that caused notifications to be processed for email sends in campaigns

### DIFF
--- a/app/bundles/NotificationBundle/NotificationEvents.php
+++ b/app/bundles/NotificationBundle/NotificationEvents.php
@@ -86,5 +86,5 @@ final class NotificationEvents
      *
      * @var string
      */
-    const ON_CAMPAIGN_TRIGGER_ACTION = 'mautic.email.on_campaign_trigger_action';
+    const ON_CAMPAIGN_TRIGGER_ACTION = 'mautic.notification.on_campaign_trigger_action';
 }

--- a/app/migrations/Version20160731000000.php
+++ b/app/migrations/Version20160731000000.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2016 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+/**
+ * Class Version20160731000000
+ */
+class Version20160731000000 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql("update {$this->prefix}campaign_lead_event_log log inner join {$this->prefix}campaign_events events on log.event_id = events.id set log.metadata = 'a:0:{}' where events.type = 'email.send' and log.metadata = 'a:2:{s:6:\"failed\";i:1;s:6:\"reason\";s:50:\"mautic.notification.campaign.failed.not_subscribed\";}'");
+    }
+}


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

### Required
#### Description:

The NotificationEvents::ON_CAMPAIGN_TRIGGER_ACTION had the same event name as EmailEvents::ON_CAMPAIGN_TRIGGER_ACTION which depending on the order Symfony loaded the events, may meant that the NotificationBundle's listener was used to process email sends. 

This is mainly a cosmetic issue that causes the event to not show up in a contact's timeline. Emails were still sent. 

#### Steps to reproduce the bug:
1.  This may take a few cache clears to hit it due to Symfony ordering events differently on different installations/cache builds
2. Create a campaign that has a send email event
3. Trigger the campaign from CLI 
4. Check the campaign_lead_event_log for the entries for the sent emails and note the metadata - if it has a serialized failed = 1 and a mautic.notification.campaign.failed.not_subscribed message, you hit the bug. 

#### Steps to test this PR:
1. Apply the PR
2. Repeat the above, and this time it should send the emails
3. Or code review and note the issue in the constant assignment
