### PR TITLE
Negative points actions not shown contacts' event logs

### DIFF
--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -703,13 +703,12 @@ class Lead extends FormEntity
      */
     public function addPointsChangeLogEntry($type, $name, $action, $pointsDelta, IpAddress $ip)
     {
-        if ($pointsDelta <= 0) {
-            // No need to record this
-
+        if ($pointsDelta === 0) {
+            // No need to record a null delta
             return;
         }
 
-        //create a new points change event
+        // Create a new points change event
         $event = new PointsChangeLog();
         $event->setType($type);
         $event->setEventName($name);


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | None 
| BC breaks? | No
| Deprecations? | No

#### Description:

Negative points actions would be applied to a contact but not be shown in their event log

#### Steps to test this PR:

1. Set up a negative points action
2. Have it applied to a contact
3. Verify that the point loss is shown in their event log

#### Steps to reproduce the bug:

1. Set up a negative points action
2. Have it applied to a contact
3. Notice that the point loss is not shown in their event log