### PR TITLE
Email permission fix

### DIFF
--- a/app/bundles/CoreBundle/Views/Helper/page_actions.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/page_actions.html.php
@@ -24,6 +24,8 @@ echo '<div class="std-toolbar btn-group">';
 
 foreach ($templateButtons as $action => $enabled) {
 
+    if (!$enabled) continue;
+
     $btnClass = 'btn btn-default';
 
     switch ($action) {

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -632,8 +632,8 @@ class EmailController extends FormController
                 )
             );
         } elseif (!$this->factory->getSecurity()->hasEntityAccess(
-            'email:emails:viewown',
-            'email:emails:viewother',
+            'email:emails:editown',
+            'email:emails:editother',
             $entity->getCreatedBy()
         )
         ) {


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://www.mautic.org/community/index.php/5098-emails-permission/0#p13780
| BC breaks? | N
| Deprecations? | N

#### Description:
A user with only email:view and email:viewown permission could edit any email. Also all the new/edit/clone buttons were there for him to click. This PR fixes the wrong permission in the edit method and hides the buttons to which the user doesn't have the permission to execute. 

#### Steps to test this PR:
1. Apply this PR and refresh the page
2. You should not be able to edit an email even if you hack the HTTP request. You cannot test it easily because there is no button to do so.
3. You should see only buttons which you have permission to.
4. When you log as the administrator, all the buttons should be there and you should be able to edit any email.

#### Steps to reproduce the bug:
1. Create a role with only email:view and email:viewown permissions.
2. Create a user with this role.
3. Log in as this user.

- You are able to edit any existing email.
- You can see the new/edit/clone buttons.