### PR TITLE
Fix status code of empty dynamic content

### DIFF
--- a/app/bundles/DynamicContentBundle/Controller/Api/DynamicContentApiController.php
+++ b/app/bundles/DynamicContentBundle/Controller/Api/DynamicContentApiController.php
@@ -73,6 +73,6 @@ class DynamicContentApiController extends CommonController
             }
         }
         
-        return empty($content) ? new Response('', Response::HTTP_NOT_FOUND) : new Response($content);
+        return empty($content) ? new Response('', Response::HTTP_NO_CONTENT) : new Response($content);
     }
 }


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y

#### Description:

This PR updates the status code on empty dynamic content responses from 404 Not Found to 204 No Content.

### Testing
1. Setup dynamic content on your site by embedding the mtc.js file in your document head.
2. Request a non-existent dynamic content slot from your mautic site and inspect the network requests using your browser developer tools. The first OPTIONS request for the slot will return 204 No Content with valid Access-Control-* headers. The second request will also now be 204, instead of 404 as it was previously.