### PR TITLE
Dynamic choice filter's clear value was 2 instead of empty string

### DIFF
--- a/app/bundles/ReportBundle/Form/Type/DynamicFiltersType.php
+++ b/app/bundles/ReportBundle/Form/Type/DynamicFiltersType.php
@@ -39,14 +39,18 @@ class DynamicFiltersType extends AbstractType
                 'required'   => false
             ];
 
-            switch ($definition['type']){
+            switch ($definition['type']) {
                 case 'bool':
                 case 'boolean':
-                    $type = 'yesno_button_group';
-                    $args['choice_list'] = new ChoiceList(
-                        array(false, true, ''),
-                        array('mautic.core.form.no', 'mautic.core.form.yes', 'mautic.core.form.reset')
-                    );
+                    $type = 'button_group';
+                    $args['choices_as_values'] = true;
+                    $args['choices'] = [
+                        [
+                            'mautic.core.form.no'    => false,
+                            'mautic.core.form.yes'   => true,
+                            'mautic.core.form.reset' => ''
+                        ]
+                    ];
 
                     if (isset($options['data'][$definition['alias']])) {
                         $args['data'] = ((int) $options['data'][$definition['alias']] == 1);


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2064
| BC breaks? | N
| Deprecations? | N

#### Description:
I'm not exactly sure what is going on with the Symfony's ChoiceList class. It uses values `[0, 1, 2]` instead of given choice values `[false, true, '']`. There is some [confusion](https://github.com/symfony/symfony/issues/14350) in the Symfony community about it as well. I changed the dynamic filter choice parent from from the yesno_button_group to just button_group to avoid the ChoiceList completely and used a simple "choice" array instead.

#### Steps to test this PR:
1. If you recreated the error, you have to clear the session. Log out and back in to make it simple.
2. Apply this PR.
3. You shouldn't get the error when clearing the filter.

#### Steps to reproduce the bug:
1. Create a custom report with emails sent as the source
2. Add a 'is read' dynamic filter
3. Add some columns to build a report table.
4. View the report
5. Click on the 'clear' button for the 'is read' dynamic filter
6. You should get an internal server error
