### PR TITLE
Fix call to inexistant method

### DIFF
--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -75,7 +75,7 @@ class AjaxController extends CommonController
                 $parts     = explode(":", $action);
                 $namespace = 'Mautic';
                 $isPlugin  = false;
-                
+
                 if (count($parts) == 3 && $parts['0'] == 'plugin') {
                     $namespace = 'MauticPlugin';
                     array_shift($parts);
@@ -448,7 +448,7 @@ class AjaxController extends CommonController
             // the cache is cleared by upgrade.php
             /** @var \Mautic\CoreBundle\Helper\CookieHelper $cookieHelper */
             $cookieHelper = $this->factory->getHelper('cookie');
-            $cookieHelper->delete('mautic_update');
+            $cookieHelper->deleteCookie('mautic_update');
         } else {
             // Extract the archive file now
             if (!$zipper->extractTo(dirname($this->container->getParameter('kernel.root_dir')).'/upgrade')) {


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | None
| BC breaks? | No
| Deprecations? | No

#### Description:

I stumbled upon a bad call to the method `CookieHelper::deleteCookie`.

#### Steps to test this PR:
1. I don't know how to test this but I gladly would

#### Steps to reproduce the bug:
1. Same as above