### PR TITLE
Updated styling on campaign warning to remove H4 tag

### DIFF
--- a/app/bundles/CampaignBundle/Views/Campaign/form.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/form.html.php
@@ -24,7 +24,7 @@ $view['slots']->set("headerTitle", $header);
     <div class="col-md-9 bg-auto height-auto bdr-r">
         <div class="pa-md">
             <?php if ($entity->getId() && $entity->isPublished()): ?>
-                <div class="alert alert-danger"><h4><?php echo $view['translator']->trans('mautic.campaign.modify.warning'); ?></h4></div>
+                <div class="alert alert-danger"><p><?php echo $view['translator']->trans('mautic.campaign.modify.warning'); ?></p></div>
             <?php endif; ?>
 
             <div class="row">


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? | N

### Required
#### Description:
This PR simply changes the H4 title tag on the campaign in progress warning message to a standard P tag. 

#### Steps to test this PR:
1. Apply the PR
2. Go to an existing campaign
3. Notice the edit warning on existing campaign message is paragraph text instead of heading text.
