### PR TITLE
Fix quotes on login page to avoid unescaped quotes

### DIFF
--- a/app/bundles/ApiBundle/Views/Security/login.html.php
+++ b/app/bundles/ApiBundle/Views/Security/login.html.php
@@ -18,14 +18,14 @@ $view['slots']->set('header', $view['translator']->trans('mautic.api.oauth.heade
         <label for="username" class="sr-only"><?php echo $view['translator']->trans('mautic.user.auth.form.loginusername'); ?></label>
         <input type="text" id="username" name="_username"
                class="form-control input-lg" value="<?php echo $last_username ?>" required autofocus
-               placeholder='<?php echo $view['translator']->trans('mautic.user.auth.form.loginusername'); ?>' />
+               placeholder="<?php echo $view['translator']->trans('mautic.user.auth.form.loginusername'); ?>" />
     </div>
     <div class="input-group mb-md">
         <span class="input-group-addon"><i class="fa fa-key"></i></span>
         <label for="password" class="sr-only"><?php echo $view['translator']->trans('mautic.core.password'); ?>:</label>
         <input type="password" id="password" name="_password"
                class="form-control input-lg" required
-               placeholder='<?php echo $view['translator']->trans('mautic.core.password'); ?>' />
+               placeholder="<?php echo $view['translator']->trans('mautic.core.password'); ?>" />
     </div>
 
     <button class="btn btn-lg btn-primary btn-block" type="submit"><?php echo $view['translator']->trans('mautic.user.auth.form.loginbtn'); ?></button>

--- a/app/bundles/UserBundle/Views/Security/login.html.php
+++ b/app/bundles/UserBundle/Views/Security/login.html.php
@@ -23,14 +23,14 @@ endif;
         <label for="username" class="sr-only"><?php echo $view['translator']->trans('mautic.user.auth.form.loginusername'); ?></label>
         <input type="text" id="username" name="_username"
                class="form-control input-lg" value="<?php echo $last_username ?>" required autofocus
-               placeholder='<?php echo $view['translator']->trans('mautic.user.auth.form.loginusername'); ?>' />
+               placeholder="<?php echo $view['translator']->trans('mautic.user.auth.form.loginusername'); ?>" />
     </div>
     <div class="input-group mb-md">
         <span class="input-group-addon"><i class="fa fa-key"></i></span>
         <label for="password" class="sr-only"><?php echo $view['translator']->trans('mautic.core.password'); ?>:</label>
         <input type="password" id="password" name="_password"
                class="form-control input-lg" required
-               placeholder='<?php echo $view['translator']->trans('mautic.core.password'); ?>' />
+               placeholder="<?php echo $view['translator']->trans('mautic.core.password'); ?>" />
     </div>
 
     <div class="checkbox-inline custom-primary pull-left mb-md">


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | None
| BC breaks? | No
| Deprecations? | No

#### Description:

Placeholders on login screen used simple quotes, so when unescaped content containing simple quotes was inserted, it truncated the string such as "Nom d'utilisateur" ("User name" in French)

**This is potentially an XSS vulnerability. Is there a better method to make sure we escape all special characters in scenarios like this one?**

#### Steps to test this PR:
1. Switch Mautic to French
2. Logout
3. See the placeholder "Nom d'utilisateur..."

#### Steps to reproduce the bug:
1. Switch Mautic to French
2. Logout
3. See the broken placeholder "Nom d"