### PR TITLE
Fix an untranslated string error.

### DIFF
--- a/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
@@ -612,7 +612,7 @@ class ReportSubscriber extends CommonSubscriber
             'display_name' => 'mautic.lead.report.points.table',
             'columns'      => array_merge($columns, $pointColumns, $event->getIpColumn())
         ];
-        $event->addTable('lead.pointlog', $data, 'leads');
+        $event->addTable('lead.pointlog', $data, 'contacts');
 
         // Register graphs
         $context = 'lead.pointlog';

--- a/app/bundles/ReportBundle/Translations/en_US/messages.ini
+++ b/app/bundles/ReportBundle/Translations/en_US/messages.ini
@@ -1,5 +1,4 @@
 mautic.report.dashboard.widgets="Report Widgets"
-mautic.report.dashboard.widgets="Report Widgets"
 mautic.report.dashboard.widgets.full_report="View Full Report"
 mautic.report.field.category_id="Category ID"
 mautic.report.field.category_name="Category name"


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
In the "Data Source" dropdown that is shown when adding or editing a report, there is an untranslated group name. This PR fixes that by moving the child item to the appropriate "Contacts" group. This also removes a duplicated translation string. 

#### Steps to test this PR:
1. Apply the PR
2. Check the "Data Source" dropdown and ensure that the "Contact Point Log" is now under the "Contacts" group heading.

#### Steps to reproduce the bug:
1. Create a new Report
2. Open the "Data Source" dropdown list and scroll down. You'll see that "Contact Point Log" is under an untranslated group heading instead of under the "Contacts" group heading.