### PR TITLE
Button text and background color pickers implemented in the builder

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -423,6 +423,15 @@ Mautic.initSlotListeners = function() {
             // Trigger the slot:change event
             slot.trigger('slot:selected', slot);
 
+            // Destroy previously initiated minicolors
+            var minicolors = parent.mQuery('#slot-form-container .minicolors');
+            if (minicolors.length) {
+                parent.mQuery('#slot-form-container input[data-toggle="color"]').each(function() {
+                    mQuery(this).minicolors('destroy');
+                });
+                parent.mQuery('#slot-form-container').off('change.minicolors');
+            }
+
             // Update form in the Customize tab to the form of the focused slot type
             var focusType = mQuery(this).attr('data-slot');
             var focusForm = mQuery(parent.mQuery('script[data-slot-type-form="'+focusType+'"]').html());
@@ -563,7 +572,6 @@ Mautic.initSlotListeners = function() {
     Mautic.builderContents.on('slot:change', function(event, params) {
         // Change some slot styles when the values are changed in the slot edit form
         var fieldParam = params.field.attr('data-slot-param');
-        
         if (fieldParam === 'padding-top' || fieldParam === 'padding-bottom') {
             params.slot.css(fieldParam, params.field.val() + 'px');
         } else if (fieldParam === 'href') {

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -280,7 +280,6 @@ Mautic.initSections = function() {
         // Handle color change events
         sectionForm.on('keyup paste change touchmove', function(e) {
             var field = mQuery(e.target);
-
             if (section.length && field.attr('id') === 'builder_section_content-background-color') {
                 Mautic.sectionBackgroundChanged(section, field.val());
             } else if (field.attr('id') === 'builder_section_wrapper-background-color') {
@@ -288,11 +287,10 @@ Mautic.initSections = function() {
             }
         });
 
-        parent.mQuery('body').on('change.minicolors', function(e, hex) {
+        parent.mQuery('#section-form-container').on('change.minicolors', function(e, hex) {
             var field = mQuery(e.target);
             var focussedSectionWrapper = mQuery('[data-section-focus]').parent();
             var focussedSection = focussedSectionWrapper.find('[data-section]');
-
             if (focussedSection.length && field.attr('id') === 'builder_section_content-background-color') {
                 Mautic.sectionBackgroundChanged(focussedSection, field.val());
             } else if (field.attr('id') === 'builder_section_wrapper-background-color') {
@@ -468,6 +466,16 @@ Mautic.initSlotListeners = function() {
             focusForm.find('input[data-toggle="color"]').each(function() {
                 parent.Mautic.activateColorPicker(this);
             });
+
+            parent.mQuery('#slot-form-container').on('change.minicolors', function(e, hex) {
+                var field = mQuery(e.target);
+
+                // Store the slot settings as attributes
+                slot.attr('data-param-'+field.attr('data-slot-param'), field.val());
+
+                // Trigger the slot:change event
+                slot.trigger('slot:change', {slot: slot, field: field});
+            });
         });
 
         // Initialize different slot types
@@ -555,6 +563,7 @@ Mautic.initSlotListeners = function() {
     Mautic.builderContents.on('slot:change', function(event, params) {
         // Change some slot styles when the values are changed in the slot edit form
         var fieldParam = params.field.attr('data-slot-param');
+        
         if (fieldParam === 'padding-top' || fieldParam === 'padding-bottom') {
             params.slot.css(fieldParam, params.field.val() + 'px');
         } else if (fieldParam === 'href') {
@@ -571,6 +580,11 @@ Mautic.initSlotListeners = function() {
                 {padding: '15px 20px', fontSize: '18px'}
             ];
             params.slot.find('a').css(values[params.field.val()]);
+        } else if (fieldParam === 'background-color') {
+            params.slot.find('a').css(fieldParam, '#'+params.field.val());
+            params.slot.find('a').attr('background', '#'+params.field.val());
+        } else if (fieldParam === 'color') {
+            params.slot.find('a').css(fieldParam, '#'+params.field.val());
         }
     });
 

--- a/app/bundles/CoreBundle/Form/Type/SlotButtonType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotButtonType.php
@@ -77,27 +77,27 @@ class SlotButtonType extends SlotType
             ),
         ]);
 
-        // $builder->add('background-color', 'text', [
-        //     'label'      => 'mautic.core.background.color',
-        //     'label_attr' => ['class' => 'control-label'],
-        //     'required'   => false,
-        //     'attr'       => [
-        //         'class'           => 'form-control',
-        //         'data-slot-param' => 'background-color',
-        //         'data-toggle'     => 'color'
-        //     ],
-        // ]);
+        $builder->add('background-color', 'text', [
+            'label'      => 'mautic.core.background.color',
+            'label_attr' => ['class' => 'control-label'],
+            'required'   => false,
+            'attr'       => [
+                'class'           => 'form-control',
+                'data-slot-param' => 'background-color',
+                'data-toggle'     => 'color'
+            ],
+        ]);
 
-        // $builder->add('color', 'text', [
-        //     'label'      => 'mautic.core.text.color',
-        //     'label_attr' => ['class' => 'control-label'],
-        //     'required'   => false,
-        //     'attr'       => [
-        //         'class'           => 'form-control',
-        //         'data-slot-param' => 'color',
-        //         'data-toggle'     => 'color'
-        //     ],
-        // ]);
+        $builder->add('color', 'text', [
+            'label'      => 'mautic.core.text.color',
+            'label_attr' => ['class' => 'control-label'],
+            'required'   => false,
+            'attr'       => [
+                'class'           => 'form-control',
+                'data-slot-param' => 'color',
+                'data-toggle'     => 'color'
+            ],
+        ]);
     }
 
     /**


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

#### Description:
2 color pickers added to change the button text color and background color:
![mautic-button-color-picker](https://cloud.githubusercontent.com/assets/1235442/17402301/d56fef72-5a52-11e6-9e3a-05443ce58fc5.png)

#### Steps to test this PR:
1. Edit a page or email.
2. Open the builder.
3. Click on a existing button in the theme or add a new button slot.
4. The colors should change in the button as you select it in the color picker.
5. The colors must stay there when you save the item.
