### PR TITLE
Fix for widgets not updating when the locale is changed.

### DIFF
--- a/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
@@ -220,6 +220,7 @@ class WidgetDetailEvent extends CommonEvent
             'params' => $params,
             'width'  => $this->getWidget()->getWidth(),
             'height' => $this->getWidget()->getHeight(),
+            'locale' => $this->translator->getLocale()
         );
 
         return $this->uniqueId = $this->getType().'_'.substr(md5(json_encode($uniqueSettings)), 0, 16);


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? | N

#### Description:
If widgets get cached and you switch locales, they will still show the lang strings from the previous locales.

#### Steps to test this PR:
1. Redo the steps to produce the bug after merging the PR.
2. See that the widgets update with the correct lang strings.

#### Steps to reproduce the bug:
1. Login to mautic and go to the dashboard to trigger a widget generation & cache.
2. Switch your locale in the site configuration.
3. Go back to the dashboard after saving and see that the lang strings in the widgets have not been updated.