### PR TITLE
Use mautic.transport.amazon service to check connection rather than a new instance

### DIFF
--- a/app/bundles/EmailBundle/Controller/AjaxController.php
+++ b/app/bundles/EmailBundle/Controller/AjaxController.php
@@ -261,12 +261,13 @@ class AjaxController extends CommonAjaxController
                 case 'smtp':
                     $mailer = new \Swift_SmtpTransport($settings['host'], $settings['port'], $settings['encryption']);
                     break;
-                case 'mautic.transport.amazon':
-                    $mailer = new AmazonTransport($settings['amazon_region']);
-                    break;
                 default:
                     if ($this->container->has($transport)) {
                         $mailer = $this->container->get($transport);
+
+                        if ('mautic.transport.amazon' == $transport) {
+                            $mailer->setHost($settings['amazon_region']);
+                        }
                     }
             }
 


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | na
| BC breaks? | no
| Deprecations? | no

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

This PR simply changes how a connection with Amazon SES is tested through the Configuration. Before a new instance of the transport was created but this bypassed the already setup service. So this switches to using the service instead.

#### Steps to test this PR:
1. Test a connection to Amazon SES. It should still work after the PR is applied.
