### PR TITLE
Fixed an issue that converted unrecognized tokens from plain text into trackables

### DIFF
--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -493,6 +493,12 @@ class TrackableModel extends AbstractCommonModel
             $url = str_replace('&amp;', '&', $url);
         }
 
+        // If this is just a token, validate it's supported before going further
+        if (preg_match('/^{.*?}$/i', $url) && !$this->validateTokenIsTrackable($url)) {
+
+            return false;
+        }
+
         // Default key and final URL to the given $url
         $trackableKey = $trackableUrl = $url;
 

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
@@ -254,6 +254,31 @@ class TrackableModelTest extends WebTestCase
         $this->assertFalse(strpos($url, $content), 'https:// should have been stripped from the token URL');
     }
 
+
+    /**
+     * @testdox Test that tokens that are supposed to be ignored are
+     *
+     * @covers Mautic\PageBundle\Model\TrackableModel::validateTokenIsTrackable
+     * @covers Mautic\PageBundle\Model\TrackableModel::parseContentForTrackables
+     * @covers Mautic\PageBundle\Model\TrackableModel::prepareUrlForTracking
+     */
+    public function testUnsupportedTokensAreNotConverted()
+    {
+        $url   = '{random_token}';
+        $model = $this->getModel($url);
+
+        list($content, $trackables) = $model->parseContentForTrackables(
+            $this->generateContent($url, 'text'),
+            array(
+                '{unsubscribe_url}' => 'https://domain.com/email/unsubscribe/xxxxxxx'
+            ),
+            'email',
+            1
+        );
+
+        $this->assertEmpty($trackables, $content);
+    }
+
     /**
      * @testdox Test that a URL injected into the do not track list is not converted
      *


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/1948
| BC breaks? | n
| Deprecations? | n

### Required
#### Description:

If an email is parsed as plain text, anything with a `{..}` syntax was converted to a trackable link. This PR fixes that so that only recognized tokens are converted. 

#### Steps to test this PR:
1. Apply the PR
2. Create an email with plain text. In that plain text, add `{something}` and send the email to a contact.
3. It should not be converted to a token
4. Run the new unit test added to validate this scenario

### As applicable
#### Steps to reproduce the bug:
1. Create an email with plain text. In that plain text, add `{something}` and send the email to a contact.
2. Review the content and note the token was converted to a trackable link
