### PR TITLE
Contact notes fixes

### DIFF
--- a/app/bundles/LeadBundle/Controller/NoteController.php
+++ b/app/bundles/LeadBundle/Controller/NoteController.php
@@ -38,6 +38,10 @@ class NoteController extends FormController
             return $lead;
         }
 
+        if ($this->request->getMethod() == 'POST') {
+            $this->setListFilters();
+        }
+
         $session = $this->get('session');
 
         //set limits

--- a/app/bundles/LeadBundle/Controller/NoteController.php
+++ b/app/bundles/LeadBundle/Controller/NoteController.php
@@ -356,6 +356,7 @@ class NoteController extends FormController
      *
      * @param     $objectAction
      * @param int $objectId
+     * @param int $leadId
      *
      * @return Response
      */

--- a/app/bundles/LeadBundle/Views/Note/list.html.php
+++ b/app/bundles/LeadBundle/Views/Note/list.html.php
@@ -30,7 +30,7 @@ if ($tmpl == 'index') {
         'target'          => '#notes-container',
         'page'            => $page,
         'limit'           => $limit,
-        'sessionVar'      => 'note',
+        'sessionVar'      => 'lead.'.$lead->getId().'.note',
         'baseUrl'         => $view['router']->path('mautic_contactnote_index', array('leadId' => $lead->getId(), 'page' => $page))
     )); ?>
 </div>

--- a/app/bundles/LeadBundle/Views/Note/list.html.php
+++ b/app/bundles/LeadBundle/Views/Note/list.html.php
@@ -30,6 +30,7 @@ if ($tmpl == 'index') {
         'target'          => '#notes-container',
         'page'            => $page,
         'limit'           => $limit,
+        'sessionVar'      => 'note',
         'baseUrl'         => $view['router']->path('mautic_contactnote_index', array('leadId' => $lead->getId(), 'page' => $page))
     )); ?>
 </div>

--- a/app/bundles/LeadBundle/Views/Note/list.html.php
+++ b/app/bundles/LeadBundle/Views/Note/list.html.php
@@ -31,7 +31,7 @@ if ($tmpl == 'index') {
         'page'            => $page,
         'limit'           => $limit,
         'sessionVar'      => 'lead.'.$lead->getId().'.note',
-        'baseUrl'         => $view['router']->path('mautic_contactnote_index', array('leadId' => $lead->getId(), 'page' => $page))
+        'baseUrl'         => $view['router']->path('mautic_contactnote_index', array('leadId' => $lead->getId()))
     )); ?>
 </div>
 <?php endif; ?>


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/1966
| BC breaks? | N
| Deprecations? | N

#### Description:
This PR fixes:
1) The item limit select box
2) The pagination when going back to page 1
3) There is a PHP notice on contact details which has some notes:

`Undefined variable: sessionVar`

This PR creates the sessionVar.

#### Steps to test this PR:
1. Apply this PR, refresh the contact detail page and everything should work.

#### Steps to reproduce the bug:
1. Go to a contact detail which has at least 6 notes in it or create some.
2.  In the dev mode you notice right away the page is broken when you refresh the page. In the prod mode check the logs for the notice. 
3. If you change the note limit from 30 to 5, the notes will refresh itself, but the limit is back to 30.
4. If you'd have more than 30 notes, you could also confirm that going to page 2 and back to 1 will throw an error, but let's apply the PR and test it actually works when you will be able to change the limit to 5 items.

