### PR TITLE
Prefill the blank theme content on new email/page

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -3449,7 +3449,9 @@ var Mautic = {
 
         if (customHtml.length) {
 
-            if (!customHtml.val().length) {
+            var emptyFroalaContent = '<!DOCTYPE html><html><head><title></title></head><body></body></html>';
+
+            if (!customHtml.val().length || customHtml.val() === emptyFroalaContent) {
                 Mautic.setThemeHtml(themeField.val());
             }
 
@@ -3472,7 +3474,7 @@ var Mautic = {
                 // Load the theme HTML to the source textarea
                 Mautic.setThemeHtml(currentLink.attr('data-theme'));
 
-                // Manipulate classes to achieve the theme selection illustion
+                // Manipulate classes to achieve the theme selection illusion
                 mQuery('.theme-list .panel').removeClass('theme-selected');
                 currentLink.closest('.panel').addClass('theme-selected');
                 mQuery('.theme-list .select-theme-selected').addClass('hide');


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

#### Description:
When creating a new email or page, the blank theme is pre-selected, but the content isn't loaded. This PR fixes it.

#### Steps to test this PR:
1. Apply this PR
2. Use the dev mode or regenerate the prod assets
3. Run the test again
- The Content tab should contain the blank theme HTML
- The existing emails/pages must still show its previous content, not a fresh theme HTML.

#### Steps to reproduce the bug:
1. Create a new email/page and go to the Content tab.
- it is empty
