### PR TITLE
Sunday theme tried to load oxygen css - fixed

### DIFF
--- a/themes/sunday/html/base.html.twig
+++ b/themes/sunday/html/base.html.twig
@@ -5,7 +5,7 @@
         <title>{pagetitle}</title>
         <meta name="description" content="{pagemetadescription}">
         {% endif %}
-        <link rel="stylesheet" href="{{ getAssetUrl('themes/'~template~'/css/oxygen.css') }}" type="text/css" />
+        <link rel="stylesheet" href="{{ getAssetUrl('themes/'~template~'/css/sunday.css') }}" type="text/css" />
     </head>
     <body offset="0" class="body" style="padding: 0;margin: 0;display: block;background: #eeebeb;-webkit-text-size-adjust: none;-webkit-font-smoothing: antialiased;width: 100%;height: 100%;color: #6f6f6f;font-weight: 400;font-size: 18px;" bgcolor="#eeebeb">
         {{ outputScripts('bodyOpen') }}


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

#### Description:
There is a copy/paste bug where the Sunday theme tries to load a css file called oxygen.css which doesn't exist

#### Steps to test this PR:
1. Apply this PR
2. Repeat the test and the right CSS should be loaded.

#### Steps to reproduce the bug:
1. Create a new page with Sunday theme
2. Save it
3. Preview it and open the dev tools. You should see that it tries to load a css which does not exist.

