### PR TITLE
Unsubscribe page text made readable for the Skyline theme

### DIFF
--- a/themes/skyline/css/skyline.css
+++ b/themes/skyline/css/skyline.css
@@ -42,13 +42,22 @@ table {
 h1, h2, h3 {
     padding: 0;
     margin: 0;
-    color: #ffffff;
+    color: #37302d;
     font-weight: 400;
 }
 
 h3 {
     color: #21c5ba;
     font-size: 24px;
+}
+
+.well {
+    margin: 30px auto;
+    width: 800px;
+}
+
+.text-center {
+    text-align: center;
 }
 
 @media screen {


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

#### Description:
Unsubscribe page of emails using the Skyline theme is unreadable. The text is white on white background. The link is visible, so at least users can unsubscribe.

#### Steps to test this PR:
1. Apply this PR and refresh the unsubscribe page
2. Make sure that landing pages with Skyline theme still works.

#### Steps to reproduce the bug:
1. Create an email with Skyline theme and with the `{unsubscribe_text}` token
2. Send the email to your testing segment
3. Click the unsubscribe page and you should see the invisible text (what a joke)

