### PR TITLE
Fix for relative path to jquery

### DIFF
--- a/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
@@ -112,11 +112,12 @@ JS;
 
     public function onBuildJsForVideo(BuildJsEvent $event)
     {
-        $formSubmitUrl = $this->factory->getRouter()->generate('mautic_form_postresults_ajax', [], UrlGeneratorInterface::ABSOLUTE_URL);
-        $mauticBaseUrl = $this->factory->getRouter()->generate('mautic_base_index', [], UrlGeneratorInterface::ABSOLUTE_URL);
-        $assetBaseUrl  = str_replace(['index.php/', 'index_dev.php/'], '', $mauticBaseUrl);
-        $mediaElementCss = $assetBaseUrl . 'media/css/mediaelementplayer.css';
-        $jQueryUrl = $assetBaseUrl . 'app/bundles/CoreBundle/Assets/js/libraries/2.jquery.js';
+        $router = $this->factory->getRouter();
+        $assetsHelper = $this->factory->getHelper('template.assets');
+        $formSubmitUrl = $router->generate('mautic_form_postresults_ajax', [], UrlGeneratorInterface::ABSOLUTE_URL);
+        $mauticBaseUrl = $router->generate('mautic_base_index', [], UrlGeneratorInterface::ABSOLUTE_URL);
+        $mediaElementCss = $assetsHelper->getUrl('media/css/mediaelementplayer.css', null, null, true);
+        $jQueryUrl = $assetsHelper->getUrl('app/bundles/CoreBundle/Assets/js/libraries/2.jquery.js', null, null, true);
 
         $mediaElementJs = <<<'JS'
 /*!


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? | N

#### Description:
Asset path for jQuery fails in some environments preventing gated video from functioning.

#### Steps to test this PR:
1. Setup gated video on a landing page
2. Ensure proper path to jQuery in `<head>` after applying this PR. 