### PR TITLE
ProgressBar in command line printed to stderr, changed to stdout

### DIFF
--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -27,7 +27,7 @@ use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Model\ListModel;
 use Monolog\Logger;
-use Symfony\Component\Console\Helper\ProgressBar;
+use Mautic\CoreBundle\Helper\ProgressBarHelper;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 
@@ -945,7 +945,7 @@ class CampaignModel extends CommonFormModel
             $maxCount = ($maxLeads) ? $maxLeads : $leadCount;
 
             if ($output) {
-                $progress = new ProgressBar($output, $maxCount);
+                $progress = ProgressBarHelper::init($output, $maxCount);
                 $progress->start();
             }
 
@@ -1021,7 +1021,7 @@ class CampaignModel extends CommonFormModel
             $maxCount = ($maxLeads) ? $maxLeads : $leadCount;
 
             if ($output) {
-                $progress = new ProgressBar($output, $maxCount);
+                $progress = ProgressBarHelper::init($output, $maxCount);
                 $progress->start();
             }
 

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -29,7 +29,7 @@ use Mautic\CoreBundle\Helper\Chart\PieChart;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\LeadBundle\Model\LeadModel;
 use Monolog\Logger;
-use Symfony\Component\Console\Helper\ProgressBar;
+use Mautic\CoreBundle\Helper\ProgressBarHelper;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -535,7 +535,7 @@ class EventModel extends CommonFormModel
         $maxCount = ($max) ? $max : $totalStartingEvents;
 
         if ($output) {
-            $progress = new ProgressBar($output, $maxCount);
+            $progress = ProgressBarHelper::init($output, $maxCount);
             $progress->start();
         }
 
@@ -1107,7 +1107,7 @@ class EventModel extends CommonFormModel
         gc_enable();
 
         if ($output) {
-            $progress = new ProgressBar($output, $maxCount);
+            $progress = ProgressBarHelper::init($output, $maxCount);
             $progress->start();
             if ($max) {
                 $progress->setProgress($totalEventCount);
@@ -1352,7 +1352,7 @@ class EventModel extends CommonFormModel
 
         if ($leadCount) {
             if ($output) {
-                $progress = new ProgressBar($output, $maxCount);
+                $progress = ProgressBarHelper::init($output, $maxCount);
                 $progress->start();
                 if ($max) {
                     $progress->advance($totalEventCount);

--- a/app/bundles/CoreBundle/Command/ApplyUpdatesCommand.php
+++ b/app/bundles/CoreBundle/Command/ApplyUpdatesCommand.php
@@ -11,7 +11,7 @@ namespace Mautic\CoreBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Helper\ProgressBar;
+use Mautic\CoreBundle\Helper\ProgressBarHelper;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
@@ -95,7 +95,7 @@ EOT
         }
 
         // Start a progress bar, don't give a max number of steps because it is conditional
-        $progressBar = new ProgressBar($output);
+        $progressBar = ProgressBarHelper::init($output);
         $progressBar->setFormat('Step %current% [%bar%] <info>%message%</info>');
 
         if ($package) {

--- a/app/bundles/CoreBundle/Command/ConvertConfigCommand.php
+++ b/app/bundles/CoreBundle/Command/ConvertConfigCommand.php
@@ -11,7 +11,6 @@ namespace Mautic\CoreBundle\Command;
 
 use Camspiers\JsonPretty\JsonPretty;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;

--- a/app/bundles/CoreBundle/Helper/ProgressBarHelper.php
+++ b/app/bundles/CoreBundle/Helper/ProgressBarHelper.php
@@ -22,7 +22,7 @@ class ProgressBarHelper
      * @param OutputInterface $output
      * @param int             $maxCount
      *
-     + @return ProgressBar
+     * @return ProgressBar
      */
     public static function init(OutputInterface $output, $maxCount = 0)
     {

--- a/app/bundles/CoreBundle/Helper/ProgressBarHelper.php
+++ b/app/bundles/CoreBundle/Helper/ProgressBarHelper.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2016 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Helper;
+
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\ProgressBar;
+
+class ProgressBarHelper
+{
+    /**
+     * Avoid printing progress bar to stderr
+     * https://github.com/symfony/symfony/issues/18744
+     *
+     * @param OutputInterface $output
+     * @param int             $maxCount
+     *
+     + @return ProgressBar
+     */
+    public static function init(OutputInterface $output, $maxCount = 0)
+    {
+        $output = $output instanceof StreamOutput ? new StreamOutput($output->getStream()) : $output;
+        return new ProgressBar($output, $maxCount);
+    }
+}

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -23,7 +23,7 @@ use Mautic\CoreBundle\Helper\Chart\LineChart;
 use Mautic\CoreBundle\Helper\Chart\BarChart;
 use Mautic\CoreBundle\Helper\Chart\PieChart;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
-use Symfony\Component\Console\Helper\ProgressBar;
+use Mautic\CoreBundle\Helper\ProgressBarHelper;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
@@ -526,7 +526,7 @@ class ListModel extends FormModel
             $maxCount = ($maxLeads) ? $maxLeads : $leadCount;
 
             if ($output) {
-                $progress = new ProgressBar($output, $maxCount);
+                $progress = ProgressBarHelper::init($output, $maxCount);
                 $progress->start();
             }
 
@@ -621,7 +621,7 @@ class ListModel extends FormModel
             $maxCount = ($maxLeads) ? $maxLeads : $leadCount;
 
             if ($output) {
-                $progress = new ProgressBar($output, $maxCount);
+                $progress = ProgressBarHelper::init($output, $maxCount);
                 $progress->start();
             }
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2202
| BC breaks? | N
| Deprecations? | N

#### Description:
Since Symfony 2.8 the output of ProgressBar was printed to stderr. That caused an error report for users who control only the stderr even though there was none.

The solution is far from elegant, but it's the only that worked for me. See the associated issue for more info about that.

#### Steps to test this PR:
1. Make sure all commands which use the ProgressBar still works:
`app/console mautic:campaigns:update`
`app/console mautic:campaigns:trigger`
`app/console mautic:segments:update`
`app/console mautic:update:apply` - this one will be hard to test when there is no version to update to. Maybe just review the code.

#### Steps to reproduce the bug:
1. crontab -e
2. MAILTO="hosting@mycompany.com" */5 * * * * php /path/to/app/console mautic:campaigns:trigger --env=prod > /dev/null
 

