### PR TITLE
Froala is stripping some tags. Fixed (again)

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -583,13 +583,13 @@ var Mautic = {
                         Mautic.showChangeThemeWarning = true;
                     });
 
-                    textarea.froalaEditor(mQuery.extend(options, Mautic.basicFroalaOptions));
+                    textarea.froalaEditor(mQuery.extend(Mautic.basicFroalaOptions, options));
                 } else {
-                    textarea.froalaEditor(mQuery.extend({
+                    textarea.froalaEditor(mQuery.extend(Mautic.basicFroalaOptions, {
                         // Set custom buttons with separator between them.
                         toolbarButtons: minButtons,
                         heightMin: 100
-                    }, Mautic.basicFroalaOptions));
+                    }));
                 }
             });
         }


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/1959#issuecomment-235069508
| BC breaks? | N
| Deprecations? | N

#### Description:
This was [fixed previously](https://github.com/mautic/mautic/pull/2032/commits/70c8f37612909e4a0eb9e050054eda5f5c65b472), but it was reverted probably in some manual merge later.

#### Steps to test this PR:
1. Apply this PR.
2. Regenerated prod assets or us dev environment
3. Test again. The meta tag should stay.

#### Steps to reproduce the bug:
1. Try to save an email or page with `<meta charset="utf-8">` in the header
- it gets stripped onBeforeSave.

