### PR TITLE
Prevented PHP notice that $options['data']['email'] does not exist

### DIFF
--- a/app/bundles/EmailBundle/Form/Type/EmailSendType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailSendType.php
@@ -105,8 +105,6 @@ class EmailSendType extends AbstractType
                 ]
             );
 
-            $email = $options['data']['email'];
-
             // create button edit email
             $windowUrlEdit = $this->factory->getRouter()->generate(
                 'mautic_email_action',
@@ -125,7 +123,7 @@ class EmailSendType extends AbstractType
                     'attr'  => [
                         'class'    => 'btn btn-primary btn-nospin',
                         'onclick'  => 'Mautic.loadNewEmailWindow(Mautic.standardEmailUrl({"windowUrl": "'.$windowUrlEdit.'"}))',
-                        'disabled' => !isset($email),
+                        'disabled' => !isset($options['data']['email']),
                         'icon'     => 'fa fa-edit'
                     ],
                     'label' => 'mautic.email.send.edit.email'
@@ -142,7 +140,7 @@ class EmailSendType extends AbstractType
                     'attr'  => [
                         'class'    => 'btn btn-primary btn-nospin',
                         'onclick'  => 'Mautic.loadNewEmailWindow(Mautic.standardEmailUrl({"windowUrl": "'.$windowUrlPreview.'"}))',
-                        'disabled' => !isset($email),
+                        'disabled' => !isset($options['data']['email']),
                         'icon'     => 'fa fa-external-link'
                     ],
                     'label' => 'mautic.email.send.preview.email'


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

#### Description:
This PR prevents a PHP notice while creating a standalone form action.

#### Steps to test this PR:
1. Apply this PR.
2. Repeat the steps to test.
- The action form should appear without any PHP notice.

#### Steps to reproduce the bug:
1. Create or edit a form.
2. Add the **Send email to user** action.
- You should be able to see the error in the dev mode, or in the logs in prod mode.

