### PR TITLE
Fix for improperly escaped configuration strings

### DIFF
--- a/app/bundles/CoreBundle/Command/LanguageConfigCommand.php
+++ b/app/bundles/CoreBundle/Command/LanguageConfigCommand.php
@@ -146,7 +146,7 @@ EOT
             if (is_array($value)) {
                 $string .= $this->renderArray($value, $level + 1);
             } else {
-                $string .= '"'.addslashes($value).'"';
+                $string .= '"'.addcslashes($value, '\\"').'"';
             }
 
             $counter--;

--- a/app/bundles/CoreBundle/Configurator/Configurator.php
+++ b/app/bundles/CoreBundle/Configurator/Configurator.php
@@ -221,7 +221,7 @@ class Configurator
         foreach ($this->parameters as $key => $value) {
             if ($value !== '') {
                 if (is_string($value)) {
-                    $value = "'" . addslashes($value) . "'";
+                    $value = "'" . addcslashes($value, '\\\'') . "'";
                 } elseif (is_bool($value)) {
                     $value = ($value) ? 'true' : 'false';
                 } elseif (is_null($value)) {
@@ -261,7 +261,7 @@ class Configurator
             if (is_array($value)) {
                 $string .= $this->renderArray($value, $level + 1);
             } else {
-                $string .= '"'.addslashes($value).'"';
+                $string .= '"'.addcslashes($value, '\\"').'"';
             }
 
             $counter--;


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | #1047, #1301
| BC breaks? | N
| Deprecations? | N

#### Description:


#### Steps to test this PR:
1. Apply this PR
2. Try to reproduce the bug using instructions below.

#### Steps to reproduce the bug:
1. Create a new database user with the password of `with"and'` (this allows you to test both types of quote escaping) and create a new `mautic_test` db. Grant access to that db to the user you created.
2. Walk through the setup steps, using the created db user/password.
3. You'll get an error similar to `SQLSTATE[HY000] [1045] Access denied for user 'mautic_test_user'@'localhost' (using password: YES)`