### PR TITLE
Fix for broken avatar images

### DIFF
--- a/app/bundles/CoreBundle/Templating/Helper/GravatarHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/GravatarHelper.php
@@ -72,7 +72,7 @@ class GravatarHelper extends Helper
      */
     public function getImage($email, $size = '250', $default = null)
     {
-        $localDefault = ($this->devMode || in_array($this->request->getHost(), $this->devHosts) || in_array($this->request->getClientIp(), ['127.0.0.1', 'fe80::1', '::1'])) ?
+        $localDefault = ($this->devMode || in_array($this->request->getClientIp(), array_merge($this->devHosts, ['127.0.0.1', 'fe80::1', '::1']))) ?
             'https://www.mautic.org/media/images/default_avatar.png' :
             $this->avatarHelper->getDefaultAvatar(true);
         $url          = 'https://www.gravatar.com/avatar/' . md5(strtolower(trim($email))) . '?s='.$size;

--- a/app/bundles/CoreBundle/Templating/Helper/GravatarHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/GravatarHelper.php
@@ -26,6 +26,11 @@ class GravatarHelper extends Helper
     private $devMode;
 
     /**
+     * @var array
+     */
+    private $devHosts = [];
+
+    /**
      * @var
      */
     private $imageDir;
@@ -39,6 +44,12 @@ class GravatarHelper extends Helper
      * @var AvatarHelper
      */
     private $avatarHelper;
+
+    /**
+     * @var null|\Symfony\Component\HttpFoundation\Request
+     */
+    private $request;
+
     /**
      * @param MauticFactory $factory
      */
@@ -48,6 +59,8 @@ class GravatarHelper extends Helper
         $this->imageDir     = $factory->getSystemPath('images');
         $this->assetHelper  = $factory->getHelper('template.assets');
         $this->avatarHelper = $factory->getHelper('template.avatar');
+        $this->request      = $factory->getRequest();
+        $this->devHosts     = (array) $factory->getParameter('dev_hosts');
     }
 
     /**
@@ -59,10 +72,10 @@ class GravatarHelper extends Helper
      */
     public function getImage($email, $size = '250', $default = null)
     {
-        $localDefault     = ($this->devMode) ?
+        $localDefault = ($this->devMode || in_array($this->request->getHost(), $this->devHosts) || in_array($this->request->getClientIp(), ['127.0.0.1', 'fe80::1', '::1'])) ?
             'https://www.mautic.org/media/images/default_avatar.png' :
             $this->avatarHelper->getDefaultAvatar(true);
-        $url              = 'https://www.gravatar.com/avatar/' . md5(strtolower(trim($email))) . '?s='.$size;
+        $url          = 'https://www.gravatar.com/avatar/' . md5(strtolower(trim($email))) . '?s='.$size;
 
         if ($default === null) {
             $default = $localDefault;


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | #1101 
| BC breaks? | N
| Deprecations? | N

#### Description:
Local and non-web-accessible mautic installs that were used outside of index_dev.php never showed the default avatar for contacts or users due to Gravatar not being able to access the default avatar we provided to them.

#### Steps to test this PR:
1. Apply the PR
2. Repeat the steps detailed below for reproducing the bug
3. Instead of not seeing the avatar, you should see the default avatar.

#### Steps to reproduce the bug:
1. Create a local mautic install
2. Create a contact with a bogus email address
3. Go to the contact page and see that the avatar does not load.