### PR TITLE
Added clickthrough support to PageHits for both channel formats

### DIFF
--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -421,8 +421,15 @@ class PageModel extends FormModel
             }
 
             if (!empty($clickthrough['channel'])) {
-                $hit->setSource($clickthrough['channel'][0]);
-                $hit->setSourceId($clickthrough['channel'][1]);
+                if (count($clickthrough['channel']) === 1) {
+                    $channelId = reset($clickthrough['channel']);
+                    $channel   = key($clickthrough['channel']);
+                } else {
+                    $channel   = $clickthrough['channel'][0];
+                    $channelId = (int) $clickthrough['channel'][1];
+                }
+                $hit->setSource($channel);
+                $hit->setSourceId($channelId);
             } elseif (!empty($clickthrough['source'])) {
                 $hit->setSource($clickthrough['source'][0]);
                 $hit->setSourceId($clickthrough['source'][1]);


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | 
| BC breaks? | na
| Deprecations? | na 

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

Channel support was added to PageModel::hitPage in 2.0 or 2.1 but it seems that there are different formats for $channel. Some places have `['channel' => ['email' => 1]]` where some have `['channel' => ['email', 1]]`. This adds support for both till a single format is decided on.  

#### Steps to test this PR:
1. Create an email with a URL embedded and send it to a contact.
2. Click on the link through an anonymous browser.
3. Ensure nothing was logged about "Undefined offset 0" and "Undefined offset 1" in PageModel.php.  Also the stats in the email should show the URL as clicked.

### As applicable
#### Steps to reproduce the bug:
1. Repeat the above prior to applying the PR and should get the PHP notice logged 
