### PR TITLE
Fixed map on the contact detail page for FireFox

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -1012,13 +1012,12 @@ var Mautic = {
             // trash created map objects to save some memory
             if (typeof Mautic.mapObjects !== 'undefined') {
                 mQuery.each(Mautic.mapObjects, function (i, map) {
-                    map.removeAllMarkers();
-                    map.remove();
+                    Mautic.destroyMap(map);
                 });
                 Mautic.mapObjects = [];
             }
 
-	    // trash tokens to save some memory
+    	    // trash tokens to save some memory
             if (typeof Mautic.builderTokens !== 'undefined') {
                 Mautic.builderTokens = {};
             }
@@ -3355,74 +3354,96 @@ var Mautic = {
 
         if (maps.length) {
             maps.each(function(index, element) {
-                var wrapper = mQuery(element);
+                Mautic.renderMap(mQuery(element));
+            });
+        }
+    },
+
+    renderMap: function(wrapper) {
+        // Map render causes a JS error on FF when the element is hidden
+        if (wrapper.is(':visible')) {
+
+            var data = wrapper.data('map-data');
+            if (typeof data === 'undefined' || !data.length) {
                 try {
-                    var data = mQuery.parseJSON(wrapper.text());
+                    data = mQuery.parseJSON(wrapper.text());
+                    wrapper.data('map-data', data);
                 } catch (error) {
 
                     return;
                 }
+            }
+            
+            // Markers have numerical indexes
+            var firstKey = Object.keys(data)[0];
 
-                // Markers have numerical indexes
-                var firstKey = Object.keys(data)[0];
+            // Check type of data
+            if (firstKey == "0") {
+                // Markers
+                var markersData = data,
+                    regionsData = {};
+            } else {
+                // Regions
+                var markersData = {},
+                    regionsData = data;
+            }
 
-                // Check type of data
-                if (firstKey == "0") {
-                    // Markers
-                    var markersData = data,
-                        regionsData = {};
-                } else {
-                    // Regions
-                    var markersData = {},
-                        regionsData = data;
-                }
-
-                wrapper.text('');
-                wrapper.vectorMap({
-                    backgroundColor: 'transparent',
-                    zoomOnScroll: false,
-                    markers: markersData,
-                    markerStyle: {
-                        initial: {
-                            fill: '#40C7B5'
-                        },
-                        selected: {
-                            fill: '#40C7B5'
-                        }
+            wrapper.text('');
+            wrapper.vectorMap({
+                backgroundColor: 'transparent',
+                zoomOnScroll: false,
+                markers: markersData,
+                markerStyle: {
+                    initial: {
+                        fill: '#40C7B5'
                     },
-                    regionStyle: {
-                        initial: {
-                            "fill": '#dce0e5',
-                            "fill-opacity": 1,
-                            "stroke": 'none',
-                            "stroke-width": 0,
-                            "stroke-opacity": 1
-                        },
-                        hover: {
-                            "fill-opacity": 0.7,
-                            "cursor": 'pointer'
-                        }
-                    },
-                    map: 'world_mill_en',
-                    series: {
-                        regions: [{
-                            values: regionsData,
-                            scale: ['#dce0e5', '#40C7B5'],
-                            normalizeFunction: 'polynomial'
-                        }]
-                    },
-                    onRegionTipShow: function (event, label, index) {
-                        if (data[index] > 0) {
-                            label.html(
-                                '<b>'+label.html()+'</b></br>'+
-                                data[index]+' Leads'
-                            );
-                        }
+                    selected: {
+                        fill: '#40C7B5'
                     }
-                });
-                Mautic.mapObjects.push(wrapper.vectorMap('get', 'mapObject'));
+                },
+                regionStyle: {
+                    initial: {
+                        "fill": '#dce0e5',
+                        "fill-opacity": 1,
+                        "stroke": 'none',
+                        "stroke-width": 0,
+                        "stroke-opacity": 1
+                    },
+                    hover: {
+                        "fill-opacity": 0.7,
+                        "cursor": 'pointer'
+                    }
+                },
+                map: 'world_mill_en',
+                series: {
+                    regions: [{
+                        values: regionsData,
+                        scale: ['#dce0e5', '#40C7B5'],
+                        normalizeFunction: 'polynomial'
+                    }]
+                },
+                onRegionTipShow: function (event, label, index) {
+                    if (data[index] > 0) {
+                        label.html(
+                            '<b>'+label.html()+'</b></br>'+
+                            data[index]+' Leads'
+                        );
+                    }
+                }
             });
+            Mautic.mapObjects.push(wrapper);
+            return wrapper;
         }
+    },
+
+    /**
+     * Destroy a jVector map
+     */
+    destroyMap: function(wrapper) {
+        var map = wrapper.vectorMap('get', 'mapObject');
+        map.removeAllMarkers();
+        map.remove();
+        wrapper.empty();
     },
 
     /**

--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -3341,7 +3341,6 @@ var Mautic = {
      * @param mQuery element scope
      */
     renderMaps: function(scope) {
-        if (!Mautic.mapObjects) Mautic.mapObjects = [];
         var maps = [];
 
         if (mQuery.type(scope) === 'string') {
@@ -3362,7 +3361,7 @@ var Mautic = {
     renderMap: function(wrapper) {
         // Map render causes a JS error on FF when the element is hidden
         if (wrapper.is(':visible')) {
-
+            if (!Mautic.mapObjects) Mautic.mapObjects = [];
             var data = wrapper.data('map-data');
             if (typeof data === 'undefined' || !data.length) {
                 try {
@@ -3431,6 +3430,7 @@ var Mautic = {
                     }
                 }
             });
+            wrapper.addClass('map-rendered');
             Mautic.mapObjects.push(wrapper);
             return wrapper;
         }
@@ -3440,10 +3440,13 @@ var Mautic = {
      * Destroy a jVector map
      */
     destroyMap: function(wrapper) {
-        var map = wrapper.vectorMap('get', 'mapObject');
-        map.removeAllMarkers();
-        map.remove();
-        wrapper.empty();
+        if (wrapper.hasClass('map-rendered')) {
+            var map = wrapper.vectorMap('get', 'mapObject');
+            map.removeAllMarkers();
+            map.remove();
+            wrapper.empty();
+            wrapper.removeClass('map-rendered');
+        }
     },
 
     /**

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -120,8 +120,17 @@ Mautic.leadOnLoad = function (container, response) {
         }
     }
 
+    var leadMap = [];
+
     mQuery(document).on('shown.bs.tab', 'a#load-lead-map', function (e) {
-        mQuery('#place-container svg').resize();
+        leadMap = Mautic.renderMap(mQuery('#place-container .vector-map'));
+    });
+
+    mQuery('a[data-toggle="tab"]').not('a#load-lead-map').on('shown.bs.tab', function (e) {
+        if (leadMap.length) {
+            Mautic.destroyMap(leadMap);
+            leadMap = [];
+        }
     });
 
     Mautic.initUniqueIdentifierFields();


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2212
| BC breaks? | /
| Deprecations? | /

#### Description:
The map in the Places tab on a contact detail when viewed in FireFox did not show up correctly and threw a JS error. It's because firefox doesn't work with SVG object which are not visible.

This PR changes the behavior to render the map only when the Places tab is opened and destroyed when another tab is opened. It seems it is the only way to do it. Some other project had to [deal with it](https://github.com/NESCent/dplace/pull/169) the same way.

#### Steps to test this PR:
1. Apply this PR.
2. Generate the prod assets or use the dev mode.
3. Refresh the FireFox and the map should be rendered.

#### Steps to reproduce the bug:
1. Open a contact detail with some IP geo data in FireFox
- The map is not usable and a JS error shows up.
