### PR TITLE
Fixed device query from throwing sql error

### DIFF
--- a/app/bundles/CoreBundle/Model/AbstractCommonModel.php
+++ b/app/bundles/CoreBundle/Model/AbstractCommonModel.php
@@ -234,13 +234,16 @@ abstract class AbstractCommonModel
     /**
      * Decode a string appended to URL into an array
      *
-     * @param $string
+     * @param      $string
+     * @param bool $urlDecode
      *
      * @return mixed
      */
-    public function decodeArrayFromUrl($string)
+    public function decodeArrayFromUrl($string, $urlDecode = true)
     {
-        return unserialize(base64_decode(urldecode($string)));
+        $raw = $urlDecode ? urldecode($string) : $string;
+
+        return unserialize(base64_decode($raw));
     }
 
     /**

--- a/app/bundles/LeadBundle/Entity/LeadDeviceRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadDeviceRepository.php
@@ -35,21 +35,14 @@ class LeadDeviceRepository extends CommonRepository
         \DateTime $fromDate = null,
         \DateTime $toDate = null
     ) {
-        $inIds = (!is_array($statIds)) ? [$statIds] : $statIds;
-
-        if (empty($inIds)) {
-            return [];
-        }
-
         $sq = $this->_em->getConnection()->createQueryBuilder();
         $sq->select('es.id as id, es.device as device')
             ->from(MAUTIC_TABLE_PREFIX.'lead_devices', 'es');
-        if ($statIds) {
-            if (!is_array($statIds)) {
-                $statIds = [(int) $statIds];
-            }
+        if (!empty($statIds)) {
+            $inIds = (!is_array($statIds)) ? [(int) $statIds] : $statIds;
+
             $sq->where(
-                $sq->expr()->in('es.id', $statIds)
+                $sq->expr()->in('es.id', $inIds)
             );
         }
 

--- a/app/bundles/LeadBundle/Entity/LeadDeviceRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadDeviceRepository.php
@@ -26,12 +26,19 @@ class LeadDeviceRepository extends CommonRepository
      *
      * @return array
      */
-    public function getDevice($statIds, $lead,  $deviceName = null, $deviceBrand = null, $deviceModel = null, \DateTime $fromDate = null, \DateTime $toDate = null)
-    {
-        $inIds = (!is_array($statIds)) ? array($statIds) : $statIds;
+    public function getDevice(
+        $statIds,
+        $lead,
+        $deviceName = null,
+        $deviceBrand = null,
+        $deviceModel = null,
+        \DateTime $fromDate = null,
+        \DateTime $toDate = null
+    ) {
+        $inIds = (!is_array($statIds)) ? [$statIds] : $statIds;
 
         if (empty($inIds)) {
-            return array();
+            return [];
         }
 
         $sq = $this->_em->getConnection()->createQueryBuilder();
@@ -39,7 +46,7 @@ class LeadDeviceRepository extends CommonRepository
             ->from(MAUTIC_TABLE_PREFIX.'lead_devices', 'es');
         if ($statIds) {
             if (!is_array($statIds)) {
-                $statIds = array((int) $statIds);
+                $statIds = [(int) $statIds];
             }
             $sq->where(
                 $sq->expr()->in('es.id', $statIds)
@@ -48,24 +55,30 @@ class LeadDeviceRepository extends CommonRepository
 
         if ($deviceName !== null) {
             $sq->where(
-                $sq->expr()->eq('es.device', $deviceName)
-            );
+                $sq->expr()->eq('es.device', ':device')
+            )
+                ->setParameter('device', $deviceName);
         }
+
         if ($deviceBrand !== null) {
             $sq->where(
-                $sq->expr()->eq('es.device_brand', $deviceBrand)
-            );
+                $sq->expr()->eq('es.device_brand', ':deviceBrand')
+            )
+                ->setParameter('deviceBrand', $deviceBrand);
         }
+
         if ($deviceModel !== null) {
             $sq->where(
-                $sq->expr()->eq('es.device_model', $deviceModel)
+                $sq->expr()->eq('es.device_model', ':deviceModel')
+            )
+                ->setParameter('deviceModel', $deviceModel);
+        }
+
+        if ($lead !== null) {
+            $sq->where(
+                $sq->expr()->eq('es.lead_id', $lead->getId())
             );
         }
-    if ($lead !== null) {
-        $sq->where(
-            $sq->expr()->eq('es.lead_id', $lead->getId())
-        );
-    }
 
         if ($fromDate !== null) {
             //make sure the date is UTC
@@ -84,8 +97,6 @@ class LeadDeviceRepository extends CommonRepository
         //get totals
         $device = $sq->execute()->fetchAll();
 
-
-
-        return (!empty($device))?$device[0]:array();
+        return (!empty($device)) ? $device[0] : [];
     }
 }

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -663,9 +663,8 @@ class PageModel extends FormModel
                     $decoded = false;
                     if (isset($query['d'])) {
                         // parse_str auto urldecodes
-                        $query   = @unserialize(base64_decode($query['d']));
+                        $query   = $this->decodeArrayFromUrl($query['d'], false);
                         $decoded = true;
-                        unset($query['d']);
                     }
 
                     if (is_array($query) && !empty($query)) {

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -663,12 +663,12 @@ class PageModel extends FormModel
                     $decoded = false;
                     if (isset($query['d'])) {
                         // parse_str auto urldecodes
-                        $query   = unserialize(base64_decode($query['d']));
+                        $query   = @unserialize(base64_decode($query['d']));
                         $decoded = true;
                         unset($query['d']);
                     }
 
-                    if (!empty($query)) {
+                    if (is_array($query) && !empty($query)) {
                         if (isset($query['page_url'])) {
                             $pageURL = $query['page_url'];
                             if (!$decoded) {


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | not reported that I know of
| BC breaks? | na
| Deprecations? | na

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

The query used to search prior devices had where statements that were not parameterized leading SQL errors due to MySQL interpreting the values as table columns.

#### Steps to test this PR:
1. Browse to a Mautic landing page with multiple devices if possible which should load successfully then validate a device entry was added to lead_devices for the lead.

### As applicable
#### Steps to reproduce the bug:
1. Good question - saw it in the logs; desktop browsers do not seem to populate device brand and model and thus likely repeat PR test steps on a mobile device.
