### PR TITLE
German language search command fix

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -515,16 +515,16 @@ class CommonRepository extends EntityRepository
         foreach ($commands as $k => $c) {
             if (is_array($c)) {
                 //subcommands
-                if (strtolower($this->translator->trans($k)) == $command) {
+                if ($this->translator->trans($k) == $command) {
                     foreach ($c as $subc) {
-                        if (strtolower($this->translator->trans($subc)) == $subcommand) {
+                        if ($this->translator->trans($subc) == $subcommand) {
                             return true;
                         }
                     }
                 }
-            } elseif (strtolower($this->translator->trans($c)) == $command) {
+            } elseif ($this->translator->trans($c) == $command) {
                 return true;
-            } elseif (strtolower($this->translator->trans($c)) == "{$command}:{$subcommand}") {
+            } elseif ($this->translator->trans($c) == "{$command}:{$subcommand}") {
                 $command    = "{$command}:{$subcommand}";
                 $subcommand = '';
 

--- a/app/bundles/CoreBundle/Helper/SearchStringHelper.php
+++ b/app/bundles/CoreBundle/Helper/SearchStringHelper.php
@@ -60,7 +60,7 @@ class SearchStringHelper
             self::$closingChars = $closingChars;
         }
 
-        $input = strtolower(trim(strip_tags($input)));
+        $input = trim(strip_tags($input));
 
         return self::splitUpSearchString($input);
     }
@@ -99,7 +99,7 @@ class SearchStringHelper
 
             if ($char == ':') {
                 //the string is a command
-                $command = strtolower(trim(substr($string, 0, -1)));
+                $command = trim(substr($string, 0, -1));
                 //does this have a negative?
                 if (strpos($command, '!') === 0) {
                     $filters->{$baseName}[$keyCount]->not = 1;

--- a/app/bundles/CoreBundle/Helper/SearchStringHelper.php
+++ b/app/bundles/CoreBundle/Helper/SearchStringHelper.php
@@ -111,7 +111,7 @@ class SearchStringHelper
                 //arrived at the end of a single word that is not within a quote or parenthesis so add it as standalone
                 if ($string != ' ') {
                     $string = trim($string);
-                    $type = ($string == 'or' || $string == 'and') ? $string : '';
+                    $type = (strtolower($string) == 'or' || strtolower($string) == 'and') ? $string : '';
                     self::setFilter($filters, $baseName, $keyCount, $string, $command, $overrideCommand, true, $type, (!empty($chars)));
                 }
                 continue;

--- a/app/bundles/CoreBundle/Helper/SearchStringHelper.php
+++ b/app/bundles/CoreBundle/Helper/SearchStringHelper.php
@@ -178,7 +178,7 @@ class SearchStringHelper
                                       $setUpNext = true)
     {
         if (!empty($type)) {
-            $filters->{$baseName}[$keyCount]->type = $type;
+            $filters->{$baseName}[$keyCount]->type = strtolower($type);
         } elseif ($setFilter) {
             $string = strtolower($string);
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2197
| BC breaks? | N
| Deprecations? | N

#### Description:
The search commands were somewhere changed to lower case and somewhere didn't which caused troubles in German translation where they use capitalized first letter for every noun. 

Funny thing is that there already was a PR fixing the German commands (https://github.com/mautic/mautic/pull/692) and it added the strtolowers.

#### Steps to test this PR:
1. Apply this PR.
2. Test again.
  - You should see only the contacts who belong to that list and the search command should be visible in the search input.
3. Test all search commands you can in any language. All should work.

#### Steps to reproduce the bug:
1.  Change Mautic language to German
2.  Go to the segment section
3.  Choose a segment and click on "Kontakte anzeigen" ("view contacts") 
- You should see all contacts and the search input is empty.
