### PR TITLE
Fixes empty password reset emails

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -319,7 +319,11 @@ class MailHelper
             }
 
             $this->message->setSubject($this->subject);
-            $this->message->setBody($this->body['content'], $this->body['contentType'], $this->body['charset']);
+            // Only set body if not empty or if plain text is empty - this ensures an empty HTML body does not show for
+            // messages only with plain text            
+            if (!empty($this->body['content']) || empty($this->plainText)) {
+                $this->message->setBody($this->body['content'], $this->body['contentType'], $this->body['charset']);
+            }
             $this->setMessagePlainText($isQueueFlush);
 
             if (!$isQueueFlush) {

--- a/app/bundles/UserBundle/Model/UserModel.php
+++ b/app/bundles/UserBundle/Model/UserModel.php
@@ -28,7 +28,7 @@ class UserModel extends FormModel
      * @var MailHelper
      */
     protected $mailHelper;
-    
+
     public function __construct(MailHelper $mailHelper)
     {
         $this->mailHelper = $mailHelper;
@@ -255,13 +255,19 @@ class UserModel extends FormModel
         $mailer = $this->mailHelper->getMailer();
 
         $resetToken = $this->getResetToken($user);
-        $resetLink = $this->router->generate('mautic_user_passwordresetconfirm', array('token' => $resetToken), true);
+        $resetLink  = $this->router->generate('mautic_user_passwordresetconfirm', ['token' => $resetToken], true);
 
-        $mailer->setTo(array($user->getEmail() => $user->getName()));
+        $mailer->setTo([$user->getEmail() => $user->getName()]);
         $mailer->setSubject($this->translator->trans('mautic.user.user.passwordreset.subject'));
-        $body = $this->translator->trans('mautic.user.user.passwordreset.email.body', array('%name%' => $user->getFirstName(), '%resetlink%' => $resetLink));
-        $body = str_replace('\\n', "\n", $body);
-        $mailer->setBody($body, 'text/plain', null, true);
+        $text = $this->translator->trans(
+            'mautic.user.user.passwordreset.email.body',
+            ['%name%' => $user->getFirstName(), '%resetlink%' => '<a href="'.$resetLink.'">'.$resetLink.'</a>']
+        );
+        $text = str_replace('\\n', "\n", $text);
+        $html = nl2br($text);
+
+        $mailer->setBody($html);
+        $mailer->setPlainText(strip_tags($text));
 
         $mailer->send();
     }


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #1998 
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

For some email clients, the password reset email was blank. This is due to the user password reset code only setting a plain text part but the mailer still set an empty HTML part leading to some clients displaying the empty HTML part by default.

So this PR does two things
1. Adds an HTML part for the password reset email
2. Fixes the MailHelper to only set an HTML part if the content is not empty or if no plain text has been set.

#### Steps to test this PR:
1. Apply PR
2. Click the Reset Password link on the login page and follow through
3. Examine the source of the email received - it should have a HTML and plain text parts with content

### As applicable
#### Steps to reproduce the bug:
1. With current code, test the steps above and examine the source of the email. The HTML part will not have any content whereas the plain text part does.
