### PR TITLE
Not only admins can unlock an entity, but all who have permission to edit

### DIFF
--- a/app/bundles/CoreBundle/Controller/FormController.php
+++ b/app/bundles/CoreBundle/Controller/FormController.php
@@ -93,9 +93,9 @@ class FormController extends CommonController
                     $this->permissionBase.':edit'
                 );
             }
-        } else {
-            return $this->get('mautic.helper.user')->getUser()->isAdmin();
         }
+
+        return $this->get('mautic.helper.user')->getUser()->isAdmin();
     }
 
     /**

--- a/app/bundles/CoreBundle/Controller/FormController.php
+++ b/app/bundles/CoreBundle/Controller/FormController.php
@@ -79,15 +79,17 @@ class FormController extends CommonController
      */
     protected function canEdit($entity = null)
     {
+        $security = $this->get('mautic.security');
+        
         if ($this->permissionBase) {
-            if ($entity) {
-                return $this->get('mautic.security')->hasEntityAccess(
+            if ($entity && $security->checkPermissionExists($this->permissionBase.':editown')) {
+                return $security->hasEntityAccess(
                     $this->permissionBase.':editown',
                     $this->permissionBase.':editother',
                     $entity->getCreatedBy()
                 );
-            } else {
-                return $this->get('mautic.security')->isGranted(
+            } elseif ($security->checkPermissionExists($this->permissionBase.':edit')) {
+                return $security->isGranted(
                     $this->permissionBase.':edit'
                 );
             }

--- a/app/bundles/CoreBundle/Controller/FormController.php
+++ b/app/bundles/CoreBundle/Controller/FormController.php
@@ -81,18 +81,18 @@ class FormController extends CommonController
     {
         if ($this->permissionBase) {
             if ($entity) {
-                return $this->factory->getSecurity()->hasEntityAccess(
+                return $this->get('mautic.security')->hasEntityAccess(
                     $this->permissionBase.':editown',
                     $this->permissionBase.':editother',
                     $entity->getCreatedBy()
                 );
             } else {
-                return $this->factory->getSecurity()->isGranted(
+                return $this->get('mautic.security')->isGranted(
                     $this->permissionBase.':edit'
                 );
             }
         } else {
-            return $this->factory->getUser()->isAdmin();
+            return $this->get('mautic.helper.user')->getUser()->isAdmin();
         }
     }
 
@@ -118,7 +118,7 @@ class FormController extends CommonController
 
         $modelClass   = $this->getModel($model);
         $nameFunction = $modelClass->getNameGetter();
-        $this->permissionBase = $model->getPermissionBase();
+        $this->permissionBase = $modelClass->getPermissionBase();
 
         if ($this->canEdit($entity)) {
             $override     = $this->get('translator')->trans(
@@ -251,7 +251,7 @@ class FormController extends CommonController
     protected function indexStandard($page = 1)
     {
         //set some permissions
-        $permissions = $this->factory->getSecurity()->isGranted(
+        $permissions = $this->get('mautic.security')->isGranted(
             array(
                 $this->permissionBase.':view',
                 $this->permissionBase.':viewown',
@@ -346,7 +346,7 @@ class FormController extends CommonController
             'page'        => $page,
             'limit'       => $limit,
             'permissions' => $permissions,
-            'security'    => $this->factory->getSecurity(),
+            'security'    => $this->get('mautic.security'),
             'tmpl'        => $this->request->get('tmpl', 'index')
         );
 
@@ -382,7 +382,7 @@ class FormController extends CommonController
     {
         $model    = $this->getModel($this->modelName);
         $entity   = $model->getEntity($objectId);
-        $security = $this->factory->getSecurity();
+        $security = $this->get('mautic.security');
 
         if ($entity === null) {
             $page = $this->factory->getSession()->get($this->sessionBase.'.page', 1);
@@ -482,7 +482,7 @@ class FormController extends CommonController
         $model  = $this->getModel($this->modelName);
         $entity = $model->getEntity();
 
-        if (!$this->factory->getSecurity()->isGranted($this->permissionBase.':create')) {
+        if (!$this->get('mautic.security')->isGranted($this->permissionBase.':create')) {
             return $this->accessDenied();
         }
 
@@ -619,7 +619,7 @@ class FormController extends CommonController
                     )
                 )
             );
-        } elseif (!$this->factory->getSecurity()->hasEntityAccess(
+        } elseif (!$this->get('mautic.security')->hasEntityAccess(
             $this->permissionBase.':editown',
             $this->permissionBase.':editother',
             $entity->getCreatedBy()
@@ -740,8 +740,8 @@ class FormController extends CommonController
         $entity = $model->getEntity($objectId);
 
         if ($entity != null) {
-            if (!$this->factory->getSecurity()->isGranted($this->permissionBase.':create')
-                || !$this->factory->getSecurity()->hasEntityAccess(
+            if (!$this->get('mautic.security')->isGranted($this->permissionBase.':create')
+                || !$this->get('mautic.security')->hasEntityAccess(
                     $this->permissionBase.':viewown',
                     $this->permissionBase.':viewother',
                     $entity->getCreatedBy()
@@ -800,7 +800,7 @@ class FormController extends CommonController
                     'msg'     => $this->langStringBase.'.error.notfound',
                     'msgVars' => array('%id%' => $objectId)
                 );
-            } elseif (!$this->factory->getSecurity()->hasEntityAccess(
+            } elseif (!$this->get('mautic.security')->hasEntityAccess(
                 $this->permissionBase.':deleteown',
                 $this->permissionBase.':deleteother',
                 $entity->getCreatedBy()
@@ -870,7 +870,7 @@ class FormController extends CommonController
                         'msg'     => $this->langStringBase.'.error.notfound',
                         'msgVars' => array('%id%' => $objectId)
                     );
-                } elseif (!$this->factory->getSecurity()->hasEntityAccess(
+                } elseif (!$this->get('mautic.security')->hasEntityAccess(
                     $this->permissionBase.':deleteown',
                     $this->permissionBase.':deleteother',
                     $entity->getCreatedBy()


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/1523
| BC breaks? | N
| Deprecations? | N

#### Description:
Only the administrators can unlock a locked entity. In theory, everyone who has the edit right should be able to unlock and edit a locked entity.

The issue here is that the permissionBase property of controllers isn't usually set, but the unlock methods in the CommonController have access to model and it seems that every model has the getPermissionBase method which holds the permissionBase, so it should work with every bundle we have now. I added a fallback to isAdmin check for BC.

#### Steps to test this PR:
1. Apply this PR and test again.
2. Not only emails but every Mautic entity should get unlocked by user who has permission to edit now.

#### Steps to reproduce the bug:
I hate to link for the steps to reproduce, but it's very nicely described here: https://github.com/mautic/mautic/issues/1523#issuecomment-221835684
