### PR TITLE
Theme zip modification to support symlinked theme folder location

### DIFF
--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -451,6 +451,9 @@ class ThemeHelper
         $tmpPath   = $this->pathsHelper->getSystemPath('cache', true).'/tmp_'.$themeName.'.zip';
         $zipper    = new \ZipArchive();
         $finder    = new Finder();
+
+        if (file_exists($tmpPath)) @unlink($tmpPath);
+        
         $archive   = $zipper->open($tmpPath, \ZipArchive::CREATE);
 
         $finder->files()->in($themePath);
@@ -460,7 +463,7 @@ class ThemeHelper
         } else {
             foreach ($finder as $file) {
                 $filePath = $file->getRealPath();
-                $localPath = str_replace($themePath.'/', '', $filePath);
+                $localPath = $file->getRelativePathname();
                 $zipper->addFile($filePath, $localPath);
             }
             $zipper->close();


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2287
| BC breaks? | N
| Deprecations? | N

#### Description:
If the theme dir location was different from Mautic root, the zip file with the downloaded theme contained all directories from the OS root as described in the linked issue.

#### Steps to test this PR:
1. Apply this PR.
2. Make sure that you can still download your themes as you could before.

#### Steps to reproduce the bug:
1. You can see the issue at a mautic.net instance when you download a theme and look into the zip file.

