### PR TITLE
Fix owner segment filters. Closes #1297

### DIFF
--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -206,7 +206,7 @@ Mautic.leadEmailOnLoad = function(container, response) {
 }
 
 Mautic.activateLeadFieldTypeahead = function(field, target, options) {
-    if (options) {
+    if (typeof options !== 'undefined' && ((!mQuery.isArray(options) && options !== '') || (mQuery.isArray(options) && options.length))) {
         var keys = [], values = [];
         //check to see if there is a key/value split
         if (typeof options == 'string') {
@@ -234,13 +234,15 @@ Mautic.activateLeadFieldTypeahead = function(field, target, options) {
         });
     }
 
+    var filterId = field.replace("display", "filter");
     mQuery(fieldTypeahead).on('typeahead:selected', function (event, datum) {
-        if (mQuery("#" + field + "_id").length && datum["id"]) {
-            mQuery("#" + field + "_id").val(datum["id"]);
+
+        if (mQuery("#" + filterId).length && datum["id"]) {
+            mQuery("#" + filterId).val(datum["id"]);
         }
     }).on('typeahead:autocompleted', function (event, datum) {
-        if (mQuery("#" + field + "_id").length && datum["id"]) {
-            mQuery("#" + field + "_id").val(datum["id"]);
+        if (mQuery("#" + filterId).length && datum["id"]) {
+            mQuery("#" + filterId).val(datum["id"]);
         }
     });
 };
@@ -282,6 +284,7 @@ Mautic.leadlistOnLoad = function(container) {
         var target = mQuery(this).attr('data-target');
         var options = mQuery(this).attr('data-options');
         var field  = mQuery(this).attr('id');
+
         Mautic.activateLeadFieldTypeahead(field, target, options);
     });
 };
@@ -456,11 +459,13 @@ Mautic.addLeadListFilter = function (elId) {
         //switch the filter and display elements
         var oldFilter = mQuery(filterEl);
         var newDisplay = mQuery(oldFilter).clone();
-        mQuery(newDisplay).attr('name', filterBase + '[display]');
+        mQuery(newDisplay).attr('name', filterBase + '[display]')
+            .attr('id', filterIdBase + 'display');
 
         var oldDisplay = mQuery(prototype).find("input[name='" + filterBase + "[display]']");
         var newFilter = mQuery(oldDisplay).clone();
-        mQuery(newFilter).attr('name', filterBase + '[filter]');
+        mQuery(newFilter).attr('name', filterBase + '[filter]')
+            .attr('id', filterIdBase + 'filter');
 
         mQuery(oldFilter).replaceWith(newFilter);
         mQuery(oldDisplay).replaceWith(newDisplay);
@@ -468,7 +473,7 @@ Mautic.addLeadListFilter = function (elId) {
         var fieldCallback = mQuery(filterId).data("field-callback");
         if (fieldCallback && typeof Mautic[fieldCallback] == 'function') {
             var fieldOptions = mQuery(filterId).data("field-list");
-            Mautic[fieldCallback](filterIdBase + 'filter', elId, fieldOptions);
+            Mautic[fieldCallback](filterIdBase + 'display', elId, fieldOptions);
         }
     } else {
         mQuery(filter).attr('type', fieldType);


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | #1297 
| BC breaks? | N
| Deprecations? | N

#### Description:
Owner filters on segments have not been working recently. This PR addresses that.

#### Steps to test this PR:
1. Apply PR and clear cache
2. Build production assets via `app/console mautic:assets:generate` or access your mautic through index_dev.php
3. Use the reproduction steps below to ensure the bugs no longer exist.

#### Steps to reproduce the bug:
1. Create a new segment
2. On the filters tab, add an "Owner" filter. 
3. (first bug) - When typing into the field, the owner should auto-complete when typing a name. Currently it does not.
4. (second bug) - Add the name of an owner, or their ID, and click apply. It fails here no matter what you put in to the field. Even after save (when the autocomplete feature works for some reason), using the autocomplete to select a name fails on save.
