### PR TITLE
Fixes transport mailer callbacks that set an email rather than hashId for DNC processing

### DIFF
--- a/app/bundles/EmailBundle/Tests/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModel.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2016 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests;
+
+use Doctrine\ORM\EntityManager;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\CoreBundle\Helper\ThemeHelper;
+use Mautic\CoreBundle\Translation\Translator;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\EmailBundle\Helper\MailHelper;
+use Mautic\EmailBundle\MonitoredEmail\Mailbox;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
+use Mautic\LeadBundle\Model\LeadModel;
+use Mautic\PageBundle\Model\TrackableModel;
+use Mautic\UserBundle\Model\UserModel;
+
+class EmailModel extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test that processMailerCallback handles an array of emails correctly
+     */
+    public function testProcessMailerCallbackWithEmails()
+    {
+        // Setup dependencies
+        $ipLookupHelper = $this->getMockBuilder(IpLookupHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $themeHelper = $this->getMockBuilder(ThemeHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mailboxHelper = $this->getMockBuilder(Mailbox::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mailHelper = $this->getMockBuilder(MailHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $leadModel = $this->getMockBuilder(LeadModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $leadModel->expects($this->once())
+            ->method('addDncForLead')
+            ->will($this->returnValue(true));
+
+        $trackableModel = $this->getMockBuilder(TrackableModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $userModel = $this->getMockBuilder(UserModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $coreParametersHelper = $this->getMockBuilder(CoreParametersHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // Setup the translator
+        $translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $translator->expects($this->any())
+            ->method('has')
+            ->will($this->returnValue(false));
+
+        // Setup the StatRepository
+        $statRepository = $this->getMockBuilder(StatRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $leadEntity = $this->getMockBuilder(Lead::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $leadEntity->expects($this->any())
+            ->method('getId')
+            ->will($this->returnValue(1));
+
+        // Setup the LeadRepository
+        $leadRepository = $this->getMockBuilder(LeadRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $leadRepository->expects($this->exactly(2))
+            ->method('getLeadByEmail')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['foo@bar.com', true, 1],
+                        ['notfound@nowhere.com', true, null]
+                    ]
+                )
+            );
+
+        // Setup the EntityManager
+        $entityManager = $this
+            ->getMockBuilder(EntityManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entityManager->expects($this->any())
+            ->method('getRepository')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['MauticLeadBundle:Lead', $leadRepository],
+                        ['MauticEmailBundle:Stat', $statRepository]
+                    ]
+                )
+            );
+        $entityManager->expects($this->any())
+            ->method('getReference')
+            ->will($this->returnValue($leadEntity));
+
+        $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
+            $ipLookupHelper,
+            $themeHelper,
+            $mailboxHelper,
+            $mailHelper,
+            $leadModel,
+            $trackableModel,
+            $userModel,
+            $coreParametersHelper
+        );
+
+        $emailModel->setTranslator($translator);
+        $emailModel->setEntityManager($entityManager);
+
+        $response = $response = [
+            2 => [
+                'emails' => [
+                    'foo@bar.com'          => 'some reason',
+                    'notfound@nowhere.com' => 'some reason'
+                ]
+            ]
+        ];
+
+        $dnc = $emailModel->processMailerCallback($response);
+
+        $this->assertCount(1, $dnc);
+    }
+
+    /**
+     * Test that processMailerCallback handles an array of hashIds correctly
+     */
+    public function testProcessMailerCallbackWithHashIds()
+    {
+        // Setup dependencies
+        $ipLookupHelper = $this->getMockBuilder(IpLookupHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $themeHelper = $this->getMockBuilder(ThemeHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mailboxHelper = $this->getMockBuilder(Mailbox::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mailHelper = $this->getMockBuilder(MailHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $leadModel = $this->getMockBuilder(LeadModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $trackableModel = $this->getMockBuilder(TrackableModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $userModel = $this->getMockBuilder(UserModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $coreParametersHelper = $this->getMockBuilder(CoreParametersHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // Setup the translator
+        $translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $translator->expects($this->any())
+            ->method('has')
+            ->will($this->returnValue(false));
+
+        // Setup the StatRepository
+        $statRepository = $this->getMockBuilder(StatRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $statRepository->expects($this->once())
+            ->method('getTableAlias')
+            ->will($this->returnValue('s'));
+
+        $leadEntity = $this->getMockBuilder(Lead::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $leadEntity->expects($this->any())
+            ->method('getId')
+            ->will($this->returnValue(1));
+
+        $emailEntity = $this->getMockBuilder(Email::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $emailEntity->expects($this->any())
+            ->method('getId')
+            ->will($this->returnValue(1));
+
+        $statEntity = new Stat();
+        $statEntity->setTrackingHash('xyz123');
+        $statEntity->setLead($leadEntity);
+        $statEntity->setEmail($emailEntity);
+
+        $statRepository->expects($this->any())
+            ->method('getEntities')
+            ->will($this->returnValue([$statEntity]));
+
+        // Setup the EntityManager
+        $entityManager = $this
+            ->getMockBuilder(EntityManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entityManager->expects($this->any())
+            ->method('getRepository')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['MauticEmailBundle:Stat', $statRepository]
+                    ]
+                )
+            );
+        $entityManager->expects($this->any())
+            ->method('getReference')
+            ->will($this->returnValue($leadEntity));
+
+        $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
+            $ipLookupHelper,
+            $themeHelper,
+            $mailboxHelper,
+            $mailHelper,
+            $leadModel,
+            $trackableModel,
+            $userModel,
+            $coreParametersHelper
+        );
+
+        $emailModel->setTranslator($translator);
+        $emailModel->setEntityManager($entityManager);
+
+        $response = [
+            2 => [
+                'hashIds' => [
+                    'xyz123' => 'some reason',
+                    '123xyz' => 'some reason' // not found
+                ]
+            ]
+        ];
+
+        $dnc = $emailModel->processMailerCallback($response);
+
+        $this->assertCount(1, $dnc);
+    }
+}

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1166,7 +1166,7 @@ class LeadModel extends FormModel
      * @param int          $reason   Must be a class constant from the DoNotContact class.
      * @param bool         $persist
      *
-     * @return boolean If a DNC entry is added or updated, returns true. If a DNC is already present
+     * @return boolean|DoNotContact If a DNC entry is added or updated, returns the DoNotContact object. If a DNC is already present
      *                 and has the specified reason, nothing is done and this returns false.
      */
     public function addDncForLead(Lead $lead, $channel, $comments = '', $reason = DoNotContact::BOUNCED, $persist = true)
@@ -1197,7 +1197,7 @@ class LeadModel extends FormModel
                 $this->saveEntity($lead);
             }
 
-            return true;
+            return $dnc;
         }
         // Or if the given reason is different than the stated reason
         elseif ($isContactable !== $reason) {
@@ -1223,7 +1223,7 @@ class LeadModel extends FormModel
                         $this->saveEntity($lead);
                     }
 
-                    return true;
+                    return $dnc;
                 }
             }
         }


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2294 
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

This PR fixes an issue with processing callbacks for transports - currently should only affect Mandrill which is the only one that leverages an `email` key in it's webhooks.

It removes the (broken) batch processing due to changes in a previous release with how DNC is handled (persisted through the Lead entity) and being able to catch DNC changes through LeadEvents (we should probably clean that up by dispatching a new DNC event so we can batch persist DNC records rather than going through the Lead entity). 

#### Steps to test this PR:
1. Run the  unit test
2. Or hack test - apply PR, follow instructions in #2294, hack in the array in Mautic\EmailBundle\Controller\PublicController\mailerCallbackAction and force it through `$model->processMailerCallback($array);`

#### Steps to reproduce bug:
1. Follow # 2 above without applying the PR OR setup Mandrill with a webhook, do not setup the hashId metadata, and send an email that will definitely bounce