### PR TITLE
Title custom field empty option fixed

### DIFF
--- a/app/bundles/CoreBundle/Form/Type/SortableListType.php
+++ b/app/bundles/CoreBundle/Form/Type/SortableListType.php
@@ -64,6 +64,15 @@ class SortableListType extends AbstractType
             'error_bubbling' => false
         ));
 
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use($options) {
+            // remove empty options
+            $data = $event->getData();
+            if (isset($data['list']) && $options['option_notblank']) {
+                $data['list'] = array_filter($data['list']);
+                $event->setData($data);
+            }
+        });
+
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             //reorder list in case keys were dynamically removed
             $data = $event->getData();

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -31,7 +31,7 @@ class FieldModel extends FormModel
         // Listed according to $order for installation
         'title'     => [
             'type'       => 'lookup',
-            'properties' => ['list' => '|Mr|Mrs|Miss'],
+            'properties' => ['list' => 'Mr|Mrs|Miss'],
             'fixed'      => true,
         ],
         'firstname' => [


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

#### Description:
There is an empty option in the Title custom field which shouldn't be there and it prevents to save this field until you remove it.

This PR:
1) Removes the empty option for the future Mautic installations.
2) Remove the empty option before the form is rendered for current installations.

#### Steps to test this PR:
1. Apply this PR
2. Refresh the Title field edit page
- The empty option should be gone and you should be able to save the field.

#### Steps to reproduce the bug:
1. Edit the Title custom field.
2. Do not change a thing and try to save it.
- You should see the error message about empty option. DO NOT REMOVE IT just yet, this PR does it for you.
