### PR TITLE
Prevent potential HTML ID collision if form name is the same as the field alias

### DIFF
--- a/app/bundles/FormBundle/Model/FieldModel.php
+++ b/app/bundles/FormBundle/Model/FieldModel.php
@@ -89,13 +89,19 @@ class FieldModel extends CommonFormModel
         //make sure alias is not already taken
         $testAlias = $alias;
 
-        $count     = (int) in_array($alias, $aliases);
-        $aliasTag  = $count;
+        $count    = (int) in_array($alias, $aliases);
+        $aliasTag = $count;
 
         while ($count) {
-            $testAlias = $alias . $aliasTag;
+            $testAlias = $alias.$aliasTag;
             $count     = (int) in_array($testAlias, $aliases);
             $aliasTag++;
+        }
+
+        // Prevent internally used identifiers in the form HTML from colliding with the generated field's ID
+        $internalUse = ['message', 'error', 'id', 'return', 'name', 'messenger'];
+        if (in_array($testAlias, $internalUse)) {
+            $testAlias = 'f_'.$testAlias;
         }
 
         $aliases[] = $testAlias;

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -186,7 +186,7 @@ class FormModel extends CommonFormModel
     {
         $order          = 1;
         $existingFields = $entity->getFields()->toArray();
-
+        $formName       = $entity->generateFormName();
         foreach ($sessionFields as $key => $properties) {
             $isNew = (!empty($properties['id']) && isset($existingFields[$properties['id']])) ? false : true;
             $field = !$isNew ? $existingFields[$properties['id']] : new Field();
@@ -198,6 +198,11 @@ class FormModel extends CommonFormModel
                 if (empty($properties['label'])) {
                     $properties['label'] = $field->getLabel();
                 }
+            }
+
+            if ($formName === $properties['alias']) {
+                // Change the alias to prevent potential ID collisions in the rendered HTML
+                $properties['alias'] = 'f_'.$properties['alias'];
             }
 
             foreach ($properties as $f => $v) {
@@ -572,8 +577,7 @@ class FormModel extends CommonFormModel
     public function populateValuesWithGetParameters(Form $form, &$formHtml)
     {
         $fieldHelper = new FormFieldHelper($this->translator);
-        $request  = $this->factory->getRequest();
-        $formName = $form->generateFormName();
+        $formName    = $form->generateFormName();
 
         $fields = $form->getFields()->toArray();
         /** @var \Mautic\FormBundle\Entity\Field $f */
@@ -604,7 +608,7 @@ class FormModel extends CommonFormModel
 
             if (isset($leadField) && $isAutoFill) {
                 $value = $lead->getFieldValue($leadField);
-                
+
 		        if (!empty($value)) {
 		            $fieldHelper->populateField($f, $value, $formName, $formHtml);
 		        }


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2279 
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

If the generated form name is the same as the generated field alias, there is a risk that the same HTML ID may be generated in the DOM. This becomes apparent when `Message` is used for both form name and field label as is in #2279. This PR simply does a check and prefixes the field if it's found to be the same as the form name.

#### Steps to test this PR:
1. Apply PR, follow steps in #2279 but ensure the name of the form is "Message"

### As applicable
#### Steps to reproduce the bug:
1. See #2279  but ensure the name of the form is "Message"