### PR TITLE
Fix contact segment filter SQL

### DIFF
--- a/app/bundles/LeadBundle/Assets/css/lead.css
+++ b/app/bundles/LeadBundle/Assets/css/lead.css
@@ -48,6 +48,22 @@
     overflow: auto;
 }
 
+.selected-filters .in-group {
+    margin-left:20px;
+}
+
+.selected-filters .panel {
+    margin-bottom:0;
+    margin-top:20px;
+}
+
+.selected-filters .panel.in-group {
+    margin-top:0;
+    border-top:0;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}
+
 .col-leadpoints-date {
     width: 175px;
 }

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -1103,4 +1103,15 @@ Mautic.initUniqueIdentifierFields = function() {
             });
         });
     }
-}
+};
+
+Mautic.updateFilterPositioning = function (el) {
+    var $el = mQuery(el);
+    var $parentEl = $el.closest('.panel');
+
+    if ($el.val() == 'and') {
+        $parentEl.addClass('in-group');
+    } else {
+        $parentEl.removeClass('in-group');
+    }
+};

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -517,9 +517,7 @@ class LeadListRepository extends CommonRepository
             }
 
             //the next one will determine the group
-            $glue = (isset($filters[$k + 1])) ? $filters[$k + 1]['glue'] : $details['glue'];
-
-            if ($glue == "or" || $details['glue'] == 'or') {
+            if ($details['glue'] == 'or') {
                 // Create a new group of andX expressions
                 if ($groupExpr->count()) {
                     $groups[]  = $groupExpr;

--- a/app/bundles/LeadBundle/Form/Type/FilterType.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterType.php
@@ -67,7 +67,8 @@ class FilterType extends AbstractType
                     'or'  => 'mautic.lead.list.form.glue.or'
                 ),
                 'attr'    => array(
-                    'class' => 'form-control not-chosen'
+                    'class' => 'form-control not-chosen glue-select',
+                    'onchange' => 'Mautic.updateFilterPositioning(this)'
                 )
             )
         );

--- a/app/bundles/LeadBundle/Views/FormTheme/Filter/_leadlist_filters_entry_widget.html.php
+++ b/app/bundles/LeadBundle/Views/FormTheme/Filter/_leadlist_filters_entry_widget.html.php
@@ -9,9 +9,10 @@
 
 $isPrototype = ($form->vars['name'] == '__name__');
 $filterType  = $form['field']->vars['value'];
+$inGroup     = $form->vars['data']['glue'] === 'and';
 ?>
 
-<div class="panel">
+<div class="panel<?php echo ($inGroup && $first === false) ? ' in-group' : ''; ?>">
     <div class="panel-footer<?php if (!$isPrototype && $form->vars['name'] === '0') echo " hide"; ?>">
         <div class="col-sm-2 pl-0">
             <?php echo $view['form']->widget($form['glue']); ?>

--- a/app/bundles/LeadBundle/Views/FormTheme/Filter/_leadlist_filters_widget.html.php
+++ b/app/bundles/LeadBundle/Views/FormTheme/Filter/_leadlist_filters_widget.html.php
@@ -7,10 +7,10 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-foreach ($form as $filter) {
+foreach ($form as $i => $filter) {
     $isPrototype = ($filter->vars['name'] == '__name__');
     $filterType  = $filter['field']->vars['value'];
     if ($isPrototype || isset($form->parent->vars['fields'][$filter->vars['value']['field']])) {
-        echo $view['form']->widget($filter);
+        echo $view['form']->widget($filter, ['first' => ($i === 0)]);
     }
 }


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | #1367, #1374 
| BC breaks? | N
| Deprecations? | N

#### Description:
When processed, Mautic segment filters weren't building the SQL string to correctly represent the filter setup. This PR addresses that, as well as adds better visual cue's about how the query will be structured when processed.

#### Steps to test this PR:
1. Apply the PR and clear the cache (rebuild production assets as well, or access via index_dev.php)
2. After following the steps below to reproduce the bug, run `app/console mautic:segments:update` again, and you'll see the lead removed.

#### Steps to reproduce the bug:
1. Create a new segment.
2. Add the following filters
    - Country = United States
    - AND Company = Mautic
    - OR Country is empty
    - AND Company = Mautic
3. Save the filter. Then add a new lead with Company = Github and Country is empty
4. From the command line, run `app/console mautic:segments:update`
5. You'll see that the created lead is added to that segment when it meets none of the criteria.

Preview of (non-final) visual changes is included below. The main difference here is that AND blocks are indented slightly and bottom margin's removed to show that they are part of the parent OR item (or in part of the very first filter item).
<img width="895" alt="screen shot 2016-08-17 at 5 06 48 pm" src="https://cloud.githubusercontent.com/assets/718028/17753607/95ced620-649e-11e6-954e-a617c6b4d462.png">