### PR TITLE
Fixed instances where clicking Apply for a clone would keep creating new copies

### DIFF
--- a/app/bundles/AssetBundle/Controller/AssetController.php
+++ b/app/bundles/AssetBundle/Controller/AssetController.php
@@ -204,10 +204,10 @@ class AssetController extends FormController
                         'total'     => $activeAsset->getDownloadCount(),
                         'unique'    => $activeAsset->getUniqueDownloadCount(),
                         'timeStats' => $model->getDownloadsLineChartData(
-                            null, 
-                            new \DateTime($dateRangeForm->get('date_from')->getData()), 
-                            new \DateTime($dateRangeForm->get('date_to')->getData()), 
-                            null, 
+                            null,
+                            new \DateTime($dateRangeForm->get('date_from')->getData()),
+                            new \DateTime($dateRangeForm->get('date_to')->getData()),
+                            null,
                             ['asset_id' => $activeAsset->getId()]
                         )
                     ]
@@ -259,13 +259,15 @@ class AssetController extends FormController
      *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      */
-    public function newAction ()
+    public function newAction ($entity = null)
     {
         /** @var \Mautic\AssetBundle\Model\AssetModel $model */
         $model = $this->getModel('asset');
 
         /** @var \Mautic\AssetBundle\Entity\Asset $entity */
-        $entity  = $model->getEntity();
+        if (null == $entity) {
+            $entity = $model->getEntity();
+        }
         $entity->setMaxSize(Asset::convertSizeToBytes($this->factory->getParameter('max_size') . 'M')); // convert from MB to B
         $method  = $this->request->getMethod();
         $session = $this->factory->getSession();
@@ -398,10 +400,8 @@ class AssetController extends FormController
     public function editAction ($objectId, $ignorePost = false)
     {
         /** @var \Mautic\AssetBundle\Model\AssetModel $model */
-        $model = $this->getModel('asset');
-
-        /** @var \Mautic\AssetBundle\Entity\Asset $entity */
-        $entity     = $model->getEntity($objectId);
+        $model  = $this->getModel('asset');
+        $entity = $model->getEntity($objectId);
         $entity->setMaxSize(Asset::convertSizeToBytes($this->factory->getParameter('max_size') . 'M')); // convert from MB to B
         $session    = $this->factory->getSession();
         $page       = $this->factory->getSession()->get('mautic.asset.page', 1);
@@ -576,15 +576,13 @@ class AssetController extends FormController
             }
 
             $clone = clone $entity;
-            $clone->setDownloadCounts(0);
-            $clone->setUniqueDownloadCounts(0);
+            $clone->setDownloadCount(0);
+            $clone->setUniqueDownloadCount(0);
             $clone->setRevision(0);
             $clone->setIsPublished(false);
-            $model->saveEntity($clone);
-            $objectId = $clone->getId();
         }
 
-        return $this->editAction($objectId);
+        return $this->newAction($clone);
     }
 
     /**

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -323,7 +323,7 @@ class AssetModel extends FormModel
      * Get a specific entity or generate a new one if id is empty
      *
      * @param $id
-     * @return null|object
+     * @return null|Asset
      */
     public function getEntity($id = null)
     {

--- a/app/bundles/AssetBundle/Views/Asset/details.html.php
+++ b/app/bundles/AssetBundle/Views/Asset/details.html.php
@@ -23,6 +23,7 @@ $view['slots']->set(
                     $permissions['asset:assets:editother'],
                     $activeAsset->getCreatedBy()
                 ),
+                'clone'   => $permissions['asset:assets:create'],
                 'delete' => $security->hasEntityAccess(
                     $permissions['asset:assets:deleteown'],
                     $permissions['asset:assets:deleteother'],

--- a/app/bundles/AssetBundle/Views/Asset/list.html.php
+++ b/app/bundles/AssetBundle/Views/Asset/list.html.php
@@ -61,6 +61,7 @@ $view->extend('MauticAssetBundle:Asset:index.html.php');
                             'templateButtons' => [
                                 'edit'       => $security->hasEntityAccess($permissions['asset:assets:editown'], $permissions['asset:assets:editother'], $item->getCreatedBy()),
                                 'delete'     => $security->hasEntityAccess($permissions['asset:assets:deleteown'], $permissions['asset:assets:deleteother'], $item->getCreatedBy()),
+                                'clone'      => $permissions['asset:assets:create'],
                             ],
                             'routeBase'  => 'asset',
                             'langVar'    => 'asset.asset',

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -704,6 +704,12 @@ class CampaignController extends FormController
             } else {
                 //rebuild everything to include new ids if valid
                 $cleanSlate = $valid;
+
+                if ($valid) {
+                    // Rebuild the form with new action so that apply doesn't keep creating a clone
+                    $action = $this->generateUrl('mautic_campaign_action', ['objectAction' => 'edit', 'objectId' => $entity->getId()]);
+                    $form   = $model->createForm($entity, $this->get('form.factory'), $action);
+                }
             }
         } else {
             $cleanSlate = true;

--- a/app/bundles/CategoryBundle/Model/CategoryModel.php
+++ b/app/bundles/CategoryBundle/Model/CategoryModel.php
@@ -117,7 +117,7 @@ class CategoryModel extends FormModel
      * Get a specific entity or generate a new one if id is empty
      *
      * @param $id
-     * @return null|object
+     * @return Category
      */
     public function getEntity($id = null)
     {

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -656,9 +656,15 @@ class FormController extends CommonFormController
                     )
                 );
             } elseif ($form->get('buttons')->get('apply')->isClicked()) {
-                //rebuild everything to include new ids
+                // Rebuild everything to include new ids
                 $cleanSlate = true;
                 $reorder    = true;
+
+                if ($valid) {
+                    // Rebuild the form with new action so that apply doesn't keep creating a clone
+                    $action = $this->generateUrl('mautic_form_action', ['objectAction' => 'edit', 'objectId' => $entity->getId()]);
+                    $form   = $model->createForm($entity, $this->get('form.factory'), $action);
+                }
             }
         } else {
             $cleanSlate = true;

--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -11,6 +11,7 @@ namespace Mautic\LeadBundle\Controller;
 
 use Mautic\CoreBundle\Controller\FormController;
 use Mautic\LeadBundle\Entity\LeadField;
+use Mautic\LeadBundle\Model\FieldModel;
 use Symfony\Component\Form\FormError;
 
 class FieldController extends FormController
@@ -209,6 +210,7 @@ class FieldController extends FormController
             return $this->accessDenied();
         }
 
+        /** @var FieldModel $model */
         $model   = $this->getModel('lead.field');
         $field   = $model->getEntity($objectId);
 
@@ -288,6 +290,10 @@ class FieldController extends FormController
                         )
                     )
                 );
+            } elseif ($valid) {
+                // Rebuild the form with new action so that apply doesn't keep creating a clone
+                $action = $this->generateUrl('mautic_contactfield_action', ['objectAction' => 'edit', 'objectId' => $field->getId()]);
+                $form   = $model->createForm($field, $this->get('form.factory'), $action);
             }
         } else {
             //lock the entity


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #1931
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

For some entities, using clone along with the apply button would result in new entities getting created each time apply was clicked. This was because the form's action remained the same with the temporary objectId in place. This PR fixes these instances

#### Steps to test this PR:
1. Clone the following objects: asset, campaign, form and contact field and use the apply button to save them.
2. Be sure they cloned correctly and were directed to the correct URL
3. Click apply again and check the URL to ensure it remains the same and doesn't create a new ID on every click

### As applicable
#### Steps to reproduce the bug:
1. Repeat the above before applying the PR - each apply will result in a new ID