### PR TITLE
Fixed mailer callback for when queue is enabled

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -297,7 +297,9 @@ class PublicController extends CommonFormController
         ignore_user_abort(true);
 
         // Use the real transport as the one in Mailer could be SpoolTransport if the system is configured to queue
-        $currentTransport = $this->get('swiftmailer.transport.real');
+        // Can't use swiftmailer.transport.real because it's not set for when queue is disabled
+        $transportParam   = $this->get('mautic.helper.core_parameters')->getParameter(('mailer_transport'));
+        $currentTransport = $this->get('swiftmailer.mailer.transport.'.$transportParam);
 
         if ($currentTransport instanceof InterfaceCallbackTransport && $currentTransport->getCallbackPath() == $transport) {
             $response = $currentTransport->handleCallbackResponse($this->request, $this->factory);

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -296,8 +296,8 @@ class PublicController extends CommonFormController
     {
         ignore_user_abort(true);
 
-        // Check to see if transport matches currently used transport
-        $currentTransport = $this->factory->getMailer()->getTransport();
+        // Use the real transport as the one in Mailer could be SpoolTransport if the system is configured to queue
+        $currentTransport = $this->get('swiftmailer.transport.real');
 
         if ($currentTransport instanceof InterfaceCallbackTransport && $currentTransport->getCallbackPath() == $transport) {
             $response = $currentTransport->handleCallbackResponse($this->request, $this->factory);


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #1800
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

When using a transport that supports mailer callback (Mandrill and Sparkpost) and the system is set to Queue email, the callback fails due to the mailer using `Swift_Transport_SpoolTransport` as the transport. Thus, the callback doesn't know what transport/method to call. This PR fixes it to use the `swiftmailer.transport.real` service which should be the correct transport to process the callback.

#### Steps to test this PR:
1. Apply the PR
2. Configure the mailer to be Mandrill and the `How should email be handled?` to`Queue`
3. Visit the URL /mailer/mandrill/callback
4. Should get `success`

### As applicable
#### Steps to reproduce the bug:
1. Repeat the above without applying the PR
2. Instead of `success` should get a 404

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
