### PR TITLE
Fixed misnamed method for AssetEvents::ON_CAMPAIGN_TRIGGER_DECISION event

### DIFF
--- a/app/bundles/AssetBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/CampaignSubscriber.php
@@ -32,7 +32,7 @@ class CampaignSubscriber extends CommonSubscriber
         return [
             CampaignEvents::CAMPAIGN_ON_BUILD         => ['onCampaignBuild', 0],
             AssetEvents::ASSET_ON_LOAD                => ['onAssetDownload', 0],
-            AssetEvents::ON_CAMPAIGN_TRIGGER_DECISION => ['onCampaignTrigger', 0]
+            AssetEvents::ON_CAMPAIGN_TRIGGER_DECISION => ['onCampaignTriggerDecision', 0]
         ];
     }
 


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | not reported
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

The method for AssetBundle's AssetEvents::ON_CAMPAIGN_TRIGGER_DECISION was named incorrectly leading to the error ` PHP Warning: call_user_func() expects parameter 1 to be a valid callback, class ‘Mautic\AssetBundle\EventListener\CampaignSubscriber’ does not have a method ‘onCampaignTrigger'`. This PR corrects the name.

#### Steps to test this PR:
1. Review the file changed and note the method name is onCampaignTriggerDecision and not onCampaignTrigger
2. Or create a campaign with an `asset downloaded` decision then download that asset as a contact

### As applicable
#### Steps to reproduce the bug:
1. Repeat the steps above without applying this PR
