### PR TITLE
Fixed category searches for campaigns

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -434,7 +434,7 @@ class CommonRepository extends EntityRepository
     {
         return array(
             false,
-            array()
+            array(),
         );
     }
 
@@ -620,7 +620,7 @@ class CommonRepository extends EntityRepository
 
         return array(
             $expr,
-            array("$unique" => $string)
+            array("$unique" => $string),
         );
     }
 
@@ -659,7 +659,25 @@ class CommonRepository extends EntityRepository
                 $returnParameter = false;
                 break;
             case $this->translator->trans('mautic.core.searchcommand.category'):
-                $expr           = $q->expr()->like("c.alias", ":$unique");
+                // Find the category prefix
+                $joins     = $q->getDQLPart('join');
+                $catPrefix = false;
+                foreach ($joins as $joinPrefix => $joinStatements) {
+                    /** @var Query\Expr\Join $join */
+                    foreach ($joinStatements as $join) {
+                        if (strpos($join->getJoin(), '.category') !== false) {
+                            $catPrefix = $join->getAlias();
+                            break;
+                        }
+                    }
+                    if ($catPrefix !== false) {
+                        break;
+                    }
+                }
+                if (false === $catPrefix) {
+                    $catPrefix = 'c';
+                }
+                $expr           = $q->expr()->like("{$catPrefix}.alias", ":$unique");
                 $filter->strict = true;
                 break;
         }
@@ -690,7 +708,7 @@ class CommonRepository extends EntityRepository
             'mautic.core.searchcommand.isunpublished',
             'mautic.core.searchcommand.isuncategorized',
             'mautic.core.searchcommand.ismine',
-            'mautic.core.searchcommand.category'
+            'mautic.core.searchcommand.category',
         );
     }
 


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #1858
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

Category and campaigns both used `c` as the prefix which caused a sql error when searching by `category:` in the campaign list. This PR resolves that by dynamically finding the prefix for category.

#### Steps to test this PR:
1. Apply the PR
2. Go to Campaigns
3. Filter with `category:test` - no error should occur (or use an actual category alias)

### As applicable
#### Steps to reproduce the bug:
1. Repeat the steps above without applying the PR and you should get a SQL error
