### PR TITLE
Fixed issue where cookie secure was forced when using https regardless of settings

### DIFF
--- a/app/bundles/CoreBundle/Form/Type/ConfigType.php
+++ b/app/bundles/CoreBundle/Form/Type/ConfigType.php
@@ -665,7 +665,7 @@ class ConfigType extends AbstractType
             array(
                 'label'       => 'mautic.core.config.form.cookie.secure',
                 'empty_value' => 'mautic.core.form.default',
-                'data'        => (array_key_exists('cookie_secure', $options['data']) && !empty($options['data']['cookie_secure'])) ? true : false,
+                'data'        => (array_key_exists('cookie_secure', $options['data'])) ? $options['data']['cookie_secure'] : '',
                 'attr'        => array(
                     'tooltip' => 'mautic.core.config.form.cookie.secure.tooltip'
                 )

--- a/app/bundles/CoreBundle/Helper/CookieHelper.php
+++ b/app/bundles/CoreBundle/Helper/CookieHelper.php
@@ -36,11 +36,12 @@ class CookieHelper
      */
     public function __construct($cookiePath, $cookieDomain, $cookieSecure, $cookieHttp, RequestStack $requestStack)
     {
-        $this->path    = $cookiePath;
-        $this->domain  = $cookieDomain;
-        $this->secure  = $cookieSecure;
-        $this->request = $requestStack->getCurrentRequest();
+        $this->path     = $cookiePath;
+        $this->domain   = $cookieDomain;
+        $this->secure   = $cookieSecure;
+        $this->httponly = $cookieHttp;
 
+        $this->request = $requestStack->getCurrentRequest();
         if (('' === $this->secure || null === $this->secure) && $this->request) {
             $this->secure = filter_var($requestStack->getCurrentRequest()->server->get('HTTPS', false), FILTER_VALIDATE_BOOLEAN);
         }

--- a/app/bundles/CoreBundle/Helper/CookieHelper.php
+++ b/app/bundles/CoreBundle/Helper/CookieHelper.php
@@ -36,16 +36,14 @@ class CookieHelper
      */
     public function __construct($cookiePath, $cookieDomain, $cookieSecure, $cookieHttp, RequestStack $requestStack)
     {
-        $this->path   = $cookiePath;
-        $this->domain = $cookieDomain;
-        $this->secure = $cookieSecure;
+        $this->path    = $cookiePath;
+        $this->domain  = $cookieDomain;
+        $this->secure  = $cookieSecure;
         $this->request = $requestStack->getCurrentRequest();
 
-        if (($this->secure == '' || $this->secure == null) && $this->request) {
-            $this->secure = ($requestStack->getCurrentRequest()->server->get('HTTPS', false));
+        if (('' === $this->secure || null === $this->secure) && $this->request) {
+            $this->secure = filter_var($requestStack->getCurrentRequest()->server->get('HTTPS', false), FILTER_VALIDATE_BOOLEAN);
         }
-
-        $this->httponly = $cookieHttp;
     }
 
     /**
@@ -57,10 +55,10 @@ class CookieHelper
      * @param null $secure
      * @param bool $httponly
      */
-    public function setCookie($name, $value, $expire = 1800, $path = null, $domain = null, $secure = null, $httponly = true)
+    public function setCookie($name, $value, $expire = 1800, $path = null, $domain = null, $secure = null, $httponly = null)
     {
 
-        if($this->request==null){
+        if ($this->request == null) {
             return true;
         }
 
@@ -84,7 +82,7 @@ class CookieHelper
      * @param null      $secure
      * @param bool|true $httponly
      */
-    public function deleteCookie($name, $path = null, $domain = null, $secure = null, $httponly = true)
+    public function deleteCookie($name, $path = null, $domain = null, $secure = null, $httponly = null)
     {
         $this->setCookie($name, '', time() - 3600, $path, $domain, $secure, $httponly);
     }


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #1969 
| BC breaks? | n
| Deprecations? | n 

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

Cookies were always set to httpOnly and secure (if loading Mautic under https) regardless of cookie settings in Configuration. This PR fixes it so that secure is only forced if set to Yes or Default and the site is under https. And sets httpOnly only if set to yes in the configuration.

#### Steps to test this PR:
1. Apply PR
2. Follow steps to reproduce bug - the cookies should match Configuration settings (if secure = default, then browsing via https will result in secure cookies; otherwise yes/no).

### As applicable
#### Steps to reproduce the bug:
1. Browse to Mautic landing page under http and review the cookies. Notice they are httpOnly. Browse under https and notice it is secure and httponly.
2. Change the cookie settings in Configuration so that secure and httponly are set to No. 
3. Delete cookies and repeat # 1 - note that they are still httponly and secure (under https) 
