### PR TITLE
Fix untranslated string "Close"

### DIFF
--- a/app/bundles/FormBundle/Views/Form/details.html.php
+++ b/app/bundles/FormBundle/Views/Form/details.html.php
@@ -318,7 +318,7 @@ $isStandalone = $activeForm->isStandalone();
                     <i><?php echo $view['translator']->trans('mautic.form.form.help.automaticcopy.iframe.note'); ?></i>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-default" data-dismiss="modal"><?php echo $view['translator']->trans('mautic.core.close'); ?></button>
                 </div>
             </div>
         </div>
@@ -350,7 +350,7 @@ $isStandalone = $activeForm->isStandalone();
                               onclick="this.setSelectionRange(0, this.value.length);"><?php echo $formContent; ?></textarea>
                 </div>
                 <div class="panel-footer text-right">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-default" data-dismiss="modal"><?php echo $view['translator']->trans('mautic.core.close'); ?></button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? | N

#### Description:

![image](https://cloud.githubusercontent.com/assets/18265735/17764690/4b752bc8-6521-11e6-8099-24feda7725f5.png)

The string "Close" in the form embedding modal box was not being translated.
This PR changes the hardcoded value "Close" to the value at key `mautic.core.close`

#### Steps to test this PR:
1. Switch Mautic to another language
2. Make a form
3. Click on one of the form embedding buttons ![image](https://cloud.githubusercontent.com/assets/18265735/17766942/f9029972-652d-11e6-9194-4e733cb9ac4b.png)
4. Check that the close button is properly internationalized