### PR TITLE
Display:none removed form the email tracking pixel because GMail didn't render it

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -877,7 +877,7 @@ class MailHelper
 
         if (!$ignoreTrackingPixel && $this->factory->getParameter('mailer_append_tracking_pixel')) {
             // Append tracking pixel
-            $trackingImg = '<img style="display: none;" height="1" width="1" src="{tracking_pixel}" alt="" />';
+            $trackingImg = '<img height="1" width="1" src="{tracking_pixel}" alt="" />';
             if (strpos($content, '</body>') !== false) {
                 $content = str_replace('</body>', $trackingImg.'</body>', $content);
             } else {


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2193
| BC breaks? | N
| Deprecations? | N

#### Description:
GMail didn't render the tracking pixel because of `style="display: none;"` attribute. This PR removes it.

There [are discussions](http://stackoverflow.com/questions/4013670/gmail-is-ignoring-displaynone) that GMail doesn't ignore `style="display:none !important;"`, but I think that it's just a matter of time before it does as well.

#### Steps to test this PR:
This PR can be tested only with a Mautic on publicly accessible URL.
1. Apply this PR.
2. Send a segment or campaign email to a lead.
3. Open it in GMail in a incognito window.
4. If GMail disables the images for this email, enable it.
5. Check if the email open was tracked.

