### PR TITLE
json headers added to the webhhok requests

### DIFF
--- a/app/bundles/WebhookBundle/Controller/AjaxController.php
+++ b/app/bundles/WebhookBundle/Controller/AjaxController.php
@@ -44,11 +44,14 @@ class AjaxController extends CommonAjaxController
 
         $payloads['timestamp'] = $now->format('c');
 
+        // Set up custom headers
+        $headers = ['Content-Type' => 'application/json'];
+
         // instantiate new http class
         $http = new Http();
 
         // set the response
-        $response = $http->post($url, json_encode($payloads));
+        $response = $http->post($url, json_encode($payloads), $headers);
 
         // default to an error message
         $dataArray = array(

--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -258,10 +258,13 @@ class WebhookModel extends FormModel
             return;
         }
 
+        // Set up custom headers
+        $headers = ['Content-Type' => 'application/json'];
+
         /** @var \Mautic\WebhookBundle\Entity\Webhook $webhook */
         try {
             /** @var \Joomla\Http\Http $http */
-            $response = $http->post($webhook->getWebhookUrl(), json_encode($payload));
+            $response = $http->post($webhook->getWebhookUrl(), json_encode($payload), $headers);
             $this->addLog($webhook, $response);
             // throw an error exception if we don't get a 200 back
             if ($response->code != 200) {


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/1782
| BC breaks? | N
| Deprecations? | N

#### Description:
The webhook sends a JSON content, but with `[Content-Type] => application/x-www-form-urlencoded; charset=utf-8` header. This PR changes it to `[Content-Type] => application/json`.

Here is a logging script I used for testing:
https://gist.github.com/escopecz/0d9adba753300b88326d

#### Steps to test this PR:
1. Apply this PR and test again.
2. Maybe test also a real webhook since the test payload use different code.

The new header should be like this:

```
Array
(
    [Host] => localhost
    [Accept] => */*
    [Content-Type] => application/json
    [Content-Length] => 5371
)
```

#### Steps to reproduce the bug:
1. Create a webhook which triggers the script above.
2. Click the Send Test Payload button.
3. Check the log file `webhookLog_headers.log` created in the directory next to the PHP script. It should say:

```
Array
(
    [Host] => localhost
    [Accept] => */*
    [Content-Type] => application/x-www-form-urlencoded; charset=utf-8
    [Content-Length] => 5371
)
```

