### PR TITLE
Direct email tokens aren't converted to visible tokens anymore

### DIFF
--- a/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
+++ b/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
@@ -280,48 +280,6 @@ class BuilderTokenHelper
     }
 
     /**
-     * @param $tokens
-     * @param $content
-     */
-    static public function replaceTokensWithVisualPlaceholders($tokens, &$content)
-    {
-        if (is_array($content)) {
-            foreach ($content as &$slot) {
-                self::replaceTokensWithVisualPlaceholders($tokens, $slot);
-            }
-        } else {
-            if (isset($tokens['visualTokens'])) {
-                // Get all the tokens in the content
-                $replacedTokens = array();
-                if (preg_match_all('/{(.*?)}/', $content, $matches)) {
-                    $search = $replace = array();
-
-                    foreach ($matches[0] as $tokenMatch) {
-                        if (!in_array($tokenMatch, $replacedTokens)) {
-                            $replacedTokens[] = $tokenMatch;
-
-                            if (strstr($tokenMatch, '|')) {
-                                // This token has been customized
-                                $tokenParts = explode('|', $tokenMatch);
-                                $token      = $tokenParts[0].'}';
-                            } else {
-                                $token = $tokenMatch;
-                            }
-
-                            if (in_array($token, $tokens['visualTokens'])) {
-                                $search[]  = $tokenMatch;
-                                $replace[] = self::getVisualTokenHtml($tokenMatch, $tokens['tokens'][$token]);
-                            }
-                        }
-                    }
-
-                    $content = str_ireplace($search, $replace, $content);
-                }
-            }
-        }
-    }
-
-    /**
      * @param $token
      * @param $description
      * @param $forPregReplace

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -777,7 +777,6 @@ class EmailController extends FormController
             $template = $entity->getTemplate();
             if (empty($template)) {
                 $content = $entity->getCustomHtml();
-                BuilderTokenHelper::replaceTokensWithVisualPlaceholders($tokens, $content);
                 $form['customHtml']->setData($content);
             }
         }
@@ -960,9 +959,6 @@ class EmailController extends FormController
         //merge any existing changes
         $newContent = $this->factory->getSession()->get('mautic.emailbuilder.'.$objectId.'.content', []);
         $content    = $entity->getContent();
-
-        $tokens = $model->getBuilderComponents($entity, ['tokens', 'visualTokens']);
-        BuilderTokenHelper::replaceTokensWithVisualPlaceholders($tokens, $content);
 
         if (is_array($newContent)) {
             $content = array_merge($content, $newContent);

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -522,17 +522,11 @@ class AjaxController extends CommonAjaxController
                 $email->getCreatedBy()
             )
         ) {
-
             $mailer = $this->factory->getMailer();
             $mailer->setEmail($email, true, [], [], true);
 
             $data['body']    = $mailer->getBody();
             $data['subject'] = $mailer->getSubject();
-
-            // Parse tokens into view data
-            $tokens = $model->getBuilderComponents($email, ['tokens', 'visualTokens']);
-
-            BuilderTokenHelper::replaceTokensWithVisualPlaceholders($tokens, $data['body']);
         }
 
         return $this->sendJsonResponse($data);

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -14,7 +14,6 @@ use Mautic\LeadBundle\Entity\UtmTag;
 use Mautic\LeadBundle\Helper\FormFieldHelper;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\CoreBundle\Controller\AjaxController as CommonAjaxController;
-use Mautic\CoreBundle\Helper\BuilderTokenHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Mautic\LeadBundle\LeadEvents;

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -552,7 +552,6 @@ class PageController extends FormController
             $template = $entity->getTemplate();
             if (empty($template)) {
                 $content = $entity->getCustomHtml();
-                BuilderTokenHelper::replaceTokensWithVisualPlaceholders($tokens, $content);
                 $form['customHtml']->setData($content);
             }
         }
@@ -785,9 +784,6 @@ class PageController extends FormController
         //merge any existing changes
         $newContent = $this->factory->getSession()->get('mautic.pagebuilder.'.$objectId.'.content', array());
         $content    = $entity->getContent();
-
-        $tokens = $model->getBuilderComponents($entity, array('tokens', 'visualTokens'));
-        BuilderTokenHelper::replaceTokensWithVisualPlaceholders($tokens, $content);
 
         if (is_array($newContent)) {
             $content = array_merge($content, $newContent);

--- a/app/bundles/PageBundle/Controller/SubscribedEvents/BuilderTokenController.php
+++ b/app/bundles/PageBundle/Controller/SubscribedEvents/BuilderTokenController.php
@@ -9,8 +9,6 @@
 
 namespace Mautic\PageBundle\Controller\SubscribedEvents;
 
-use Mautic\PageBundle\Helper\BuilderTokenHelper;
-
 /**
  * Class BuilderTokenController
  */


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2280
| BC breaks? | N
| Deprecations? | N

#### Description:
The direct emails to contact still replaces {tokens} with **tokens** and it breaks the email after send.

#### Steps to test this PR:
1. Apply this PR and test again.
2. Also test that normal emails with tokens can be sent normally.

There is another issue which cause a SQL error on first send after refresh (https://github.com/mautic/mautic/issues/1948). If you get it, close the modal window and try to send again.

#### Steps to reproduce the bug:
1. Create a simple template email with content `Hi {contactfield=firstname}‍`
2. Go to a contact detail
3. Open the modal to send a direct message
4. Select the email you just created
5. The email should replace the tokens to bold font
6. Sending this email results in broken HTML

