### PR TITLE
Fixed PHP error if openssl PHP extension is not installed

### DIFF
--- a/app/bundles/EmailBundle/Views/FormTheme/Config/monitored_mailboxes_widget.html.php
+++ b/app/bundles/EmailBundle/Views/FormTheme/Config/monitored_mailboxes_widget.html.php
@@ -55,9 +55,11 @@
         <div class="col-sm-4 col-md-2">
             <?php echo $view['form']->row($form['port']); ?>
         </div>
+        <?php if (extension_loaded('openssl')) : ?>
         <div class="col-sm-8 col-md-4">
             <?php echo $view['form']->row($form['encryption']); ?>
         </div>
+        <?php endif; ?>
     </div>
 
     <div class="row">


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2192
| BC breaks? | N
| Deprecations? | N

#### Description:
Configuration fails to load when openssl isn't installed on the server.

#### Steps to test this PR:
1. Just make sure the configuration loads for you with the Email > Encryption field if you have openssl installed. If not, the option should be hidden, but the configuration should not fail to load because of it.

