### PR TITLE
Reset a failed delete of a directory back to 755 instead of 644 when …

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -1252,8 +1252,8 @@ function remove_mautic_deleted_files(array $status)
                     if (file_exists($dirpath) && !glob($dirpath.'/*')) {
                         @chmod($dirpath, 0777);
                         if (!@unlink($dirpath)) {
-                            // Failed to delete, reset the permissions to 644 for safety
-                            @chmod($dirpath, 0644);
+                            // Failed to delete, reset the permissions to 0755 for safety
+                            @chmod($dirpath, 0755);
                         }
                     }
                 }


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2199
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:
The upgrade script tries to cleanup directories that no longer exist in the release but if that fails it restores safe permissions. In the case of directories, they were getting reset to 644 instead of 755. This PR fixes that.

#### Steps to test this PR:
1. Requires an upgrade with failed directories - hard to replicate so probably just do a code review
