### PR TITLE
This adds PHP 5.4+ support for transliterator_transliterate (if it exists) for transliteration support of Chinese/Japanese characters

### DIFF
--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -392,6 +392,11 @@ class InputHelper
      */
     public static function transliterate($value)
     {
+        if (function_exists('transliterator_transliterate')) {
+            // Use intl by default
+            return transliterator_transliterate('Any-Latin', $value);
+        }
+
         return \URLify::transliterate($value);
     }
 }

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -394,7 +394,7 @@ class InputHelper
     {
         if (function_exists('transliterator_transliterate')) {
             // Use intl by default
-            return transliterator_transliterate('Any-Latin', $value);
+            return transliterator_transliterate('Any-Latin; Latin-ASCII', $value);
         }
 
         return \URLify::transliterate($value);

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -160,7 +160,8 @@ class ZohoIntegration extends CrmAbstractIntegration
                         if (!(bool)$field['isreadonly'] || in_array($field['type'], array('Lookup', 'OwnerLookup', 'Boolean'))) {
                             continue;
                         }
-                        $key              = InputHelper::alphanum($field['dv']);
+
+                        $key              = InputHelper::alphanum(InputHelper::transliterate($field['dv']));
                         $zohoFields[$key] = array(
                             'type'     => 'string',
                             'label'    => $field['label'],


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #1233
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

This changes InputHelper::transliterate() to transliterator_transliterate by default if the function exists so that there's some support for Chinese/Japanese characters. This affects things like Zoho where fields in Chinese result in empty keys (after being passed through InputHelper::alphanum)  leading to a fatal error.

#### Steps to test this PR:
1. Create a zoho CRM account and change the language to Chinese. 
2. Configure the Zoho plugin in Mautic and notice the fields. No fatal error. 

### As applicable
#### Steps to reproduce the bug:
1. Repeat the above without this PR and will get a fatal error on opening the Zoho config form.
