### PR TITLE
Fixed group IDs when InputHelper::alphanum() that caused multiple options to have same ID

### DIFF
--- a/app/bundles/FormBundle/Views/Field/group.html.php
+++ b/app/bundles/FormBundle/Views/Field/group.html.php
@@ -7,6 +7,7 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
+use \Mautic\CoreBundle\Helper\InputHelper;
 
 $containerType     = "{$type}grp";
 $defaultInputClass = "{$containerType}-{$type}";
@@ -29,7 +30,7 @@ if (stripos($optionLabelAttr, 'class') === false) {
 }
 
 $count   = 0;
-$firstId = 'mauticform_' . $containerType . '_' . $type . '_'.$field['alias'].'_'.\Mautic\CoreBundle\Helper\InputHelper::alphanum($list[0]);
+$firstId = 'mauticform_' . $containerType . '_' . $type . '_'.$field['alias'].'_'.InputHelper::alphanum(InputHelper::transliterate($list[0])).'1';
 
 $formButtons = (!empty($inForm)) ? $view->render('MauticFormBundle:Builder:actions.html.php',
     [
@@ -49,9 +50,9 @@ $help = (empty($field['helpMessage'])) ? '' : <<<HTML
 HTML;
 
 $options = [];
-foreach ($list as $l):
+foreach ($list as $counter => $l):
 
-$id               = $field['alias'].'_'.\Mautic\CoreBundle\Helper\InputHelper::alphanum($l);
+$id               = $field['alias'].'_'.InputHelper::alphanum(InputHelper::transliterate($l)).$counter;
 $checked          = ($field['defaultValue'] == $l) ? 'checked="checked"' : '';
 $checkboxBrackets = ($type == 'checkbox') ? '[]' : '';
 


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2251
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

When a checkbox group has values that when cleaned result in the same ID, clicking the label will result in another item getting checked because multiple IDs are present. This PR appends a number to prevent this. It also passes the value through InputHelper::transliterate so that #2333 will allow proper handling of Chinese and other similar languages.

#### Steps to test this PR:
1. Create a new checkbox group for a field
2. Add the options `C` and `C++`
3. Save and preview the form
4. Click the label for `C++` and the correct box should be checked

### As applicable
#### Steps to reproduce the bug:
1. Repeat the above but `C` will get checked instead of `C++`
