### PR TITLE
Fixed a couple cases where filter strings did not work as expected with contacts

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -321,19 +321,22 @@ class CommonRepository extends EntityRepository
                     list($expressions, $parameters) = $this->addAdvancedSearchWhereClause($q, $filter);
 
                     if (!empty($forceExpressions)) {
-                        $expressions->add($forceExpressions);
                         $parameters = array_merge($parameters, $forceParameters);
                     }
                 } elseif (!empty($forceExpressions)) {
-                    //We do not have a user search but have some required filters
-                    $expressions = $forceExpressions;
                     $parameters  = $forceParameters;
                 }
 
-                $filterCount = ($expressions instanceof \Countable) ? count($expressions) : count($expressions->getParts());
-
-                if (!empty($filterCount)) {
+                $filterCount = 0;
+                if (!empty($expressions) && $filterCount = ($expressions instanceof \Countable) ? count($expressions) : count($expressions->getParts())) {
                     $q->andWhere($expressions);
+                }
+
+                if (!empty($forceExpressions) &&  $forcedFilterCount = ($forceExpressions instanceof \Countable) ? count($forceExpressions) : count($forceExpressions->getParts())) {
+                    $q->andWhere($forceExpressions);
+                }
+
+                if (!empty($filterCount) || !empty($forceExpressions)) {
                     foreach ($parameters as $k => $v) {
                         if ($v === true || $v === false) {
                             $q->setParameter($k, $v, 'boolean');

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -665,7 +665,6 @@ class LeadRepository extends CommonRepository
         } else {
             $xFunc    = 'orX';
             $exprFunc = 'like';
-
         }
 
         $expr = $q->expr()->$xFunc(
@@ -713,13 +712,13 @@ class LeadRepository extends CommonRepository
         //DBAL QueryBuilder does not have an expr()->not() function; boo!!
         if ($filter->not) {
             $xFunc = "orX";
-            $xSubFunc = "andX";
+            $existsFunc = "NOT EXISTS";
             $eqFunc   = "neq";
             $nullFunc = "isNotNull";
             $likeFunc = "notLike";
         } else {
             $xFunc = "andX";
-            $xSubFunc = "orX";
+            $existsFunc = "EXISTS";
             $eqFunc   = "eq";
             $nullFunc = "isNull";
             $likeFunc = "like";
@@ -767,70 +766,57 @@ class LeadRepository extends CommonRepository
                 }
 
                 $sq = $this->_em->getConnection()->createQueryBuilder()
-                    ->select('ll.lead_id')
+                    ->select('null')
                     ->from(MAUTIC_TABLE_PREFIX . 'lead_lists_leads', 'll');
 
                 $sq->where(
                     $sq->expr()->andX(
+                        $sq->expr()->eq('l.id', 'll.lead_id'),
                         $sq->expr()->eq('ll.leadlist_id', $listId),
                         $sq->expr()->orX(
                             $sq->expr()->isNull('ll.manually_removed'),
-                            $sq->expr()->eq('ll.manually_removed', ':false')
+                            $sq->expr()->eq('ll.manually_removed', ":$unique")
                         )
                     )
-                )
-                    ->setParameter('false', false, 'boolean');
-                $results = $sq->execute()->fetchAll();
+                );
 
-                $leadIds = array();
-                foreach ($results as $row) {
-                    $leadIds[] = $row['lead_id'];
-                }
-                if (!count($leadIds)) {
-                    $leadIds[] = 0;
-                }
-                $expr = $q->expr()->in('l.id', $leadIds);
+                $filter->string = false;
+                $filter->strict = false;
+
+                $expr = $q->expr()->andX(sprintf('%s (%s)', $existsFunc, $sq->getSQL()));
 
                 break;
             case $this->translator->trans('mautic.core.searchcommand.ip'):
                 // search by IP
                 $sq = $this->_em->getConnection()->createQueryBuilder();
-                $sq->select('lip.lead_id')
+                $sq->select('null')
                     ->from(MAUTIC_TABLE_PREFIX.'lead_ips_xref', 'lip')
                     ->join('lip', MAUTIC_TABLE_PREFIX.'ip_addresses', 'ip', 'lip.ip_id = ip.id')
                     ->where(
-                        $sq->expr()->$likeFunc('ip.ip_address', ":$unique")
-                    )
-                    ->setParameter($unique, $string);
-                $results = $sq->execute()->fetchAll();
-                $leadIds = array();
-                foreach ($results as $row) {
-                    $leadIds[] = $row['lead_id'];
-                }
-                if (!count($leadIds)) {
-                    $leadIds[] = 0;
-                }
-                $expr = $q->expr()->in('l.id', $leadIds);
+                        $sq->expr()->andX(
+                            $sq->expr->andX('l.id', 'lip.lead_id'),
+                            $sq->expr()->$likeFunc('ip.ip_address', ":$unique")
+                        )
+                    );
+
+                $expr = $q->expr()->andX(sprintf('%s (%s)', $existsFunc, $sq->getSQL()));
+
                 break;
             case $this->translator->trans('mautic.lead.lead.searchcommand.tag'):
                 // search by tag
                 $sq = $this->_em->getConnection()->createQueryBuilder();
-                $sq->select('x.lead_id')
+                $sq->select('null')
                     ->from(MAUTIC_TABLE_PREFIX.'lead_tags_xref', 'x')
                     ->join('x', MAUTIC_TABLE_PREFIX.'lead_tags', 't', 'x.tag_id = t.id')
                     ->where(
-                        $sq->expr()->$eqFunc('t.tag', ":$unique")
-                    )
-                    ->setParameter($unique, $string);
-                $results = $sq->execute()->fetchAll();
-                $leadIds = array();
-                foreach ($results as $row) {
-                    $leadIds[] = $row['lead_id'];
-                }
-                if (!count($leadIds)) {
-                    $leadIds[] = 0;
-                }
-                $expr = $q->expr()->in('l.id', $leadIds);
+                        $sq->expr()->andX(
+                            $sq->expr()->eq('l.id', 'x.lead_id'),
+                            $sq->expr()->$eqFunc('t.tag', ":$unique")
+                        )
+                    );
+
+                $expr = $q->expr()->andX(sprintf('%s (%s)', $existsFunc, $sq->getSQL()));
+
                 break;
             case $this->translator->trans('mautic.core.searchcommand.email'):
                 $expr = $q->expr()->$likeFunc('LOWER(l.email)', ":$unique");
@@ -846,10 +832,7 @@ class LeadRepository extends CommonRepository
         }
 
         $string = ($filter->strict) ? $filter->string : "%{$filter->string}%";
-
-        if ($command != $this->translator->trans('mautic.lead.lead.searchcommand.list')) {
-            $parameters[$unique] = $string;
-        }
+        $parameters[$unique] = $string;
 
         return array(
             $expr,


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #1593
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

This PR fixes the following two search scenarios for contacts:

1. `!segment:alias` (would return the segment's contacts because the queries weren't written to accommodate the NOT)
2. `foo@bar.com OR bar@foo.com` (would return all identified leads because the auto-appended "is not anonymous" was added as an OR instead of AND)

#### Steps to test this PR:
1. Search the two examples above and the results should be appropriate.

### As applicable
#### Steps to reproduce the bug:
1. Search the two examples above and the results will not be appropriate
