### PR TITLE
Exclude anonymous leads from created contacts widget by default 

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1918,6 +1918,9 @@ class LeadModel extends FormModel
         $chartQuery->applyFilters($q, $filters);
         $chartQuery->applyDateFilters($q, 'date_added');
 
+        if (empty($options['includeAnonymous'])) {
+            $q->andWhere($q->expr()->isNotNull('t.date_identified'));
+        }
         $results = $q->execute()->fetchAll();
 
         if ($results) {


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | n
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | not reported
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

The created contacts widget included anonymous contacts. This mean that it almost always showed just a bunch of "anonymous." This PR excludes anonymous contacts form that list to make it more useful.

#### Steps to test this PR:
1.  Add a Contacts created widget to the dashboard
2. It should show identified contacts and not a list of just `anonymous`
