### PR TITLE
Prevent menus from cross-pollinating

### DIFF
--- a/app/bundles/CoreBundle/Event/MenuEvent.php
+++ b/app/bundles/CoreBundle/Event/MenuEvent.php
@@ -21,7 +21,7 @@ class MenuEvent extends Event
     /**
      * @var array
      */
-    protected $menuItems = array('children' => array());
+    protected $menuItems = ['children' => []];
 
     /**
      * @var
@@ -95,7 +95,8 @@ class MenuEvent extends Event
     {
         $this->helper->placeOrphans($this->menuItems['children'], true);
         $this->helper->sortByPriority($this->menuItems['children']);
-        
+        $this->helper->resetOrphans();
+
         return $this->menuItems;
     }
 
@@ -106,4 +107,5 @@ class MenuEvent extends Event
     {
         return $this->type;
     }
+
 }

--- a/app/bundles/CoreBundle/EventListener/CommonSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CommonSubscriber.php
@@ -113,30 +113,18 @@ class CommonSubscriber implements EventSubscriberInterface
      */
     protected function buildMenu (MauticEvents\MenuEvent $event)
     {
-        $name      = $event->getType();
-        $session   = $this->factory->getSession();
-        $allItems  = $session->get('mautic.menu.items', array());
-
-        if (empty($allItems[$name])) {
-            $bundles = $this->factory->getMauticBundles(true);
-            $menuItems = array();
-            foreach ($bundles as $bundle) {
-                if (!empty($bundle['config']['menu'][$name])) {
-                    $menu = $bundle['config']['menu'][$name];
-                    $event->addMenuItems(
-                        array(
-                            'priority' => !isset($menu['priority']) ? 9999 : $menu['priority'],
-                            'items'    => !isset($menu['items']) ? $menu : $menu['items']
-                        )
-                    );
-                }
+        $name = $event->getType();
+        $bundles = $this->factory->getMauticBundles(true);
+        foreach ($bundles as $bundle) {
+            if (!empty($bundle['config']['menu'][$name])) {
+                $menu = $bundle['config']['menu'][$name];
+                $event->addMenuItems(
+                    array(
+                        'priority' => !isset($menu['priority']) ? 9999 : $menu['priority'],
+                        'items'    => !isset($menu['items']) ? $menu : $menu['items']
+                    )
+                );
             }
-
-            $allItems[$name] = $event->getMenuItems();
-
-            unset($bundles, $menuItems);
-        } else {
-            $event->setMenuItems($allItems[$name]);
         }
     }
 

--- a/app/bundles/CoreBundle/Menu/MenuHelper.php
+++ b/app/bundles/CoreBundle/Menu/MenuHelper.php
@@ -41,7 +41,7 @@ class MenuHelper
      *
      * @var array
      */
-    private $orphans = array();
+    private $orphans = [];
 
     /**
      * @var array
@@ -69,7 +69,7 @@ class MenuHelper
      *
      * @param      $items
      * @param int  $depth
-     * @param int $defaultPriority
+     * @param int  $defaultPriority
      */
     public function createMenuStructure(&$items, $depth = 0, $defaultPriority = 9999)
     {
@@ -81,12 +81,12 @@ class MenuHelper
             if (isset($i['bundle'])) {
                 // Category shortcut
                 $bundleName = $i['bundle'];
-                $i          = array(
+                $i          = [
                     'access'          => $bundleName.':categories:view',
                     'route'           => 'mautic_category_index',
                     'id'              => 'mautic_'.$bundleName.'category_index',
-                    'routeParameters' => array('bundle' => $bundleName),
-                );
+                    'routeParameters' => ['bundle' => $bundleName],
+                ];
             }
 
             // Check to see if menu is restricted
@@ -136,10 +136,10 @@ class MenuHelper
 
             //Set link attributes
             if (!isset($i['linkAttributes'])) {
-                $i['linkAttributes'] = array(
+                $i['linkAttributes'] = [
                     'data-menu-link' => $i['id'],
                     'id'             => $i['id']
-                );
+                ];
             } elseif (!isset($i['linkAttributes']['id'])) {
                 $i['linkAttributes']['id']             = $i['id'];
                 $i['linkAttributes']['data-menu-link'] = $i['id'];
@@ -147,7 +147,7 @@ class MenuHelper
                 $i['linkAttributes']['data-menu-link'] = $i['id'];
             }
 
-            $i['extras']          = array();
+            $i['extras']          = [];
             $i['extras']['depth'] = $depth;
 
             // Note a divider
@@ -178,7 +178,7 @@ class MenuHelper
             // Determine if this item needs to be listed in a bundle outside it's own
             if (isset($i['parent'])) {
                 if (!isset($this->orphans[$i['parent']])) {
-                    $this->orphans[$i['parent']] = array();
+                    $this->orphans[$i['parent']] = [];
                 }
 
                 $this->orphans[$i['parent']][$k] = $i;
@@ -194,14 +194,14 @@ class MenuHelper
     }
 
     /**
-     * Get orphaned menu items
+     * Get and reset orphaned menu items
      *
      * @return array
      */
-    public function getOrphans()
+    public function resetOrphans()
     {
-        $orphans = $this->orphans;
-        $this->orphans = array();
+        $orphans       = $this->orphans;
+        $this->orphans = [];
 
         return $orphans;
     }
@@ -220,16 +220,18 @@ class MenuHelper
                 $priority = (isset($items['priority'])) ? $items['priority'] : 9999;
                 foreach ($this->orphans[$key] as &$orphan) {
                     if (!isset($orphan['extras'])) {
-                        $orphan['extras'] = array();
+                        $orphan['extras'] = [];
                     }
                     $orphan['extras']['depth'] = $depth;
                     if (!isset($orphan['priority'])) {
-                        $orphan['priority']  = $priority;
+                        $orphan['priority'] = $priority;
                     }
                 }
 
-                $items['children'] = (!isset($items['children'])) ?
-                    $this->orphans[$key] :
+                $items['children'] = (!isset($items['children']))
+                    ?
+                    $this->orphans[$key]
+                    :
                     $items['children'] = array_merge($items['children'], $this->orphans[$key]);
                 unset($this->orphans[$key]);
             } elseif (isset($items['children'])) {
@@ -241,8 +243,8 @@ class MenuHelper
 
         // Append orphans that couldn't find a home
         if ($appendOrphans && count($this->orphans)) {
-            $menuItems = array_merge($menuItems, $this->orphans);
-            $this->orphans = array();
+            $menuItems     = array_merge($menuItems, $this->orphans);
+            $this->orphans = [];
         }
     }
 


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #1995
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

Sometimes and randomly, Components and Channels show up in the extra menu. Assuming it has to do with variable order Symfony executes events on different installations. But hopefully this will help prevent that from happening. 

#### Steps to test this PR:
1. Ensure menus still work
