### PR TITLE
Fixed issue with special chars in select options for filters

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/FilterType.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterType.php
@@ -220,15 +220,19 @@ class FilterType extends AbstractType
                     if (!is_array($list)) {
                         $parts = explode('||', $list);
                         if (count($parts) > 1) {
-                            $labels  = explode('|', $parts[0]);
-                            $values  = explode('|', $parts[1]);
-                            $choices = array_combine($values, $labels);
+                            $labels = explode('|', $parts[0]);
+                            $values = explode('|', $parts[1]);
+                            $list   = array_combine($values, $labels);
                         } else {
-                            $list    = explode('|', $list);
-                            $choices = array_combine($list, $list);
+                            $list = explode('|', $list);
+                            $list = array_combine($list, $list);
                         }
-                    } else {
-                        $choices = $list;
+                    }
+
+                    $choices = [];
+                    foreach ($list as $value => $label) {
+                        $value           = html_entity_decode($value, ENT_QUOTES);
+                        $choices[$value] = $label;
                     }
 
                     if ($fieldType == 'select') {

--- a/app/bundles/LeadBundle/Form/Type/FilterType.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterType.php
@@ -10,6 +10,7 @@
 namespace Mautic\LeadBundle\Form\Type;
 
 use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\LeadBundle\Helper\FormFieldHelper;
 use Mautic\UserBundle\Form\DataTransformer as Transformers;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -217,23 +218,7 @@ class FilterType extends AbstractType
                     }
 
                     $list = $options['fields'][$fieldName]['properties']['list'];
-                    if (!is_array($list)) {
-                        $parts = explode('||', $list);
-                        if (count($parts) > 1) {
-                            $labels = explode('|', $parts[0]);
-                            $values = explode('|', $parts[1]);
-                            $list   = array_combine($values, $labels);
-                        } else {
-                            $list = explode('|', $list);
-                            $list = array_combine($list, $list);
-                        }
-                    }
-
-                    $choices = [];
-                    foreach ($list as $value => $label) {
-                        $value           = html_entity_decode($value, ENT_QUOTES);
-                        $choices[$value] = $label;
-                    }
+                    $choices = FormFieldHelper::parseListStringIntoArray($list);
 
                     if ($fieldType == 'select') {
                         // array_unshift cannot be used because numeric values get lost as keys

--- a/app/bundles/LeadBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/LeadBundle/Helper/FormFieldHelper.php
@@ -222,4 +222,36 @@ class FormFieldHelper
     {
         return Intl::getLocaleBundle()->getLocaleNames();
     }
+
+    /**
+     * @param $list
+     *
+     * @return array
+     */
+    static function parseListStringIntoArray($list)
+    {
+        if (!is_array($list) && strpos($list, '|') !== false) {
+            $parts = explode('||', $list);
+            if (count($parts) > 1) {
+                $labels = explode('|', $parts[0]);
+                $values = explode('|', $parts[1]);
+                $list   = array_combine($values, $labels);
+            } else {
+                $labels = explode('|', $list);
+                $values = $labels;
+                $list   = array_combine($values, $labels);
+            }
+        }
+        if (!empty($list) && !is_array($list)) {
+            $list = [$list => $list];
+        }
+
+        // Handle special chars so that validation doesn't fail
+        $choices =  [];
+        foreach ($list as $val => $label) {
+            $choices[html_entity_decode($val, ENT_QUOTES)] = $label;
+        }
+
+        return $choices;
+    }
 }

--- a/app/bundles/LeadBundle/Views/List/form.html.php
+++ b/app/bundles/LeadBundle/Views/List/form.html.php
@@ -85,26 +85,7 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
                                     <?php
                                     foreach ($fields as $value => $params):
                                         $list      = (!empty($params['properties']['list'])) ? $params['properties']['list'] : array();
-                                        if (!is_array($list) && strpos($list, '|') !== false):
-                                            $parts = explode('||', $list);
-                                            if (count($parts) > 1):
-                                                $labels = explode('|', $parts[0]);
-                                                $values = explode('|', $parts[1]);
-                                                $list = array_combine($values, $labels);
-                                            else:
-                                                $labels = explode('|', $list);
-                                                $values = $labels;
-                                                $list = array_combine($values, $labels);
-                                            endif;
-                                        endif;
-                                        if (!is_array($list)):
-                                            $list = [$list => $list];
-                                        endif;
-                                        // Handle special chars so that validation doesn't fail
-                                        $choices =  [];
-                                        foreach ($list as $val => $label):
-                                            $choices[html_entity_decode($val, ENT_QUOTES)] = $label;
-                                        endforeach;
+                                        $choices   = \Mautic\LeadBundle\Helper\FormFieldHelper::parseListStringIntoArray($list);
                                         $list      = json_encode($choices);
                                         $callback  = (!empty($params['properties']['callback'])) ? $params['properties']['callback'] : '';
                                         $operators = (!empty($params['operators'])) ? $view->escape(json_encode($params['operators'])) : '{}';

--- a/app/bundles/LeadBundle/Views/List/form.html.php
+++ b/app/bundles/LeadBundle/Views/List/form.html.php
@@ -90,11 +90,23 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
                                             if (count($parts) > 1):
                                                 $labels = explode('|', $parts[0]);
                                                 $values = explode('|', $parts[1]);
+                                                // Handle special chars so that validation doesn't fail
+                                                foreach ($values as &$val):
+                                                    $val = htmlspecialchars($val);
+                                                endforeach;
                                                 $list = array_combine($values, $labels);
                                             else:
-                                                $list = explode('|', $list);
-                                                $list = array_combine($list, $list);
+                                                $labels = explode('|', $list);
+                                                $values = $labels;
+                                                // Handle special chars so that validation doesn't fail
+                                                foreach ($values as &$val):
+                                                    $val = htmlspecialchars($val);
+                                                endforeach;
+                                                $list = array_combine($values, $labels);
                                             endif;
+                                        endif;
+                                        if (!is_array($list)):
+                                            $list = [htmlspecialchars($list) => $list];
                                         endif;
                                         $list      = json_encode($list);
                                         $callback  = (!empty($params['properties']['callback'])) ? $params['properties']['callback'] : '';

--- a/app/bundles/LeadBundle/Views/List/form.html.php
+++ b/app/bundles/LeadBundle/Views/List/form.html.php
@@ -90,25 +90,22 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
                                             if (count($parts) > 1):
                                                 $labels = explode('|', $parts[0]);
                                                 $values = explode('|', $parts[1]);
-                                                // Handle special chars so that validation doesn't fail
-                                                foreach ($values as &$val):
-                                                    $val = htmlspecialchars($val);
-                                                endforeach;
                                                 $list = array_combine($values, $labels);
                                             else:
                                                 $labels = explode('|', $list);
                                                 $values = $labels;
-                                                // Handle special chars so that validation doesn't fail
-                                                foreach ($values as &$val):
-                                                    $val = htmlspecialchars($val);
-                                                endforeach;
                                                 $list = array_combine($values, $labels);
                                             endif;
                                         endif;
                                         if (!is_array($list)):
-                                            $list = [htmlspecialchars($list) => $list];
+                                            $list = [$list => $list];
                                         endif;
-                                        $list      = json_encode($list);
+                                        // Handle special chars so that validation doesn't fail
+                                        $choices =  [];
+                                        foreach ($list as $val => $label):
+                                            $choices[html_entity_decode($val, ENT_QUOTES)] = $label;
+                                        endforeach;
+                                        $list      = json_encode($choices);
                                         $callback  = (!empty($params['properties']['callback'])) ? $params['properties']['callback'] : '';
                                         $operators = (!empty($params['operators'])) ? $view->escape(json_encode($params['operators'])) : '{}';
                                         ?>


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2077
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

Special chars in choice values would cause Symfony to invalidate a segment filter option because it didn't match the encoded version it was expecting. Also - values are saved to the lead's column decoded so this should make sure filters match.

#### Steps to test this PR:
1. Create a custom select contact field with `aujourd'hui` as an option.
2. Create a new segment and select the above field as a filter.
3. Select `aujourd'hui` and save - should save without validation issues

### As applicable
#### Steps to reproduce the bug:
1. Repeat above without this PR - should get a validation violation
