### PR TITLE
Fixed deleting multiple hierarchical campaign events

### DIFF
--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -641,7 +641,7 @@ class CampaignController extends FormController
                             $model->setCanvasSettings($entity, $connections);
 
                             if (!empty($deletedEvents)) {
-                                $this->getModel('campaign.event')->deleteEvents($entity->getEvents(), $modifiedEvents, $deletedEvents);
+                                $this->getModel('campaign.event')->deleteEvents($entity->getEvents()->toArray(), $deletedEvents);
                             }
                         }
 

--- a/app/bundles/CampaignBundle/Entity/EventRepository.php
+++ b/app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -483,4 +483,21 @@ class EventRepository extends CommonRepository
             array('campaign_id' => (int) $campaignId)
         );
     }
+
+    /**
+     * Null event parents in preparation for deleting events from a campaign
+     *
+     * @param $campaignId
+     */
+    public function nullEventRelationships($events)
+    {
+        $qb = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        $qb->update(MAUTIC_TABLE_PREFIX.'campaign_events')
+            ->set('parent_id', ':null')
+            ->setParameter('null', null)
+            ->where(
+                $qb->expr()->in('parent_id', $events)
+            )
+            ->execute();
+    }
 }

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -169,58 +169,30 @@ class EventModel extends CommonFormModel
      * @param $originalEvents
      * @param $deletedEvents
      */
-    public function deleteEvents($currentEvents, $originalEvents, $deletedEvents)
+    public function deleteEvents($currentEvents, $deletedEvents)
     {
-        $orderedDelete = array();
+        $deletedKeys = [];
         foreach ($deletedEvents as $k => $deleteMe) {
             if ($deleteMe instanceof Event) {
                 $deleteMe = $deleteMe->getId();
             }
 
             if (strpos($deleteMe, 'new') === 0) {
-                continue;
+                unset($deletedEvents[$k]);
             }
 
-            if (isset($originalEvents[$deleteMe]) && !in_array($deleteMe, $orderedDelete)) {
-                $this->buildEventHierarchy($originalEvents[$deleteMe], $orderedDelete);
-            }
-        }
-
-        //remove any events that are now part of the current events (i.e. a child moved from a deleted parent)
-        foreach ($orderedDelete as $k => $deleteMe) {
             if (isset($currentEvents[$deleteMe])) {
-                unset($orderedDelete[$k]);
+                unset($deletedEvents[$k]);
             }
+
+            $deletedKeys[] = $deleteMe;
         }
 
-        $this->deleteEntities($orderedDelete);
-    }
+        // wipe out any references to these events to prevent restraint violations
+        $this->getRepository()->nullEventRelationships($deletedKeys);
 
-    /**
-     * Build a hierarchy of children and parent entities for deletion
-     *
-     * @param $entity
-     * @param $hierarchy
-     */
-    public function buildEventHierarchy($entity, &$hierarchy)
-    {
-        if ($entity instanceof Event) {
-            $children = $entity->getChildren();
-            $id       = $entity->getId();
-        } else {
-            $children = (isset($entity['children'])) ? $entity['children'] : array();
-            $id       = $entity['id'];
-        }
-        $hasChildren = count($children) ? true : false;
-
-        if (!$hasChildren) {
-            $hierarchy[] = $id;
-        } else {
-            foreach ($children as $child) {
-                $this->buildEventHierarchy($child, $hierarchy);
-            }
-            $hierarchy[] = $id;
-        }
+        // delete the events
+        $this->deleteEntities($deletedEvents);
     }
 
     /**


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2005
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

When multiple events are deleted from a campaign that were parents of parents, foreign restraints were violated preventing the events from getting deleted. This PR fixes that by nulling parent_id's of the events about to be deleted.

#### Steps to test this PR:
1. Follow the animated gif in #2005

### As applicable
#### Steps to reproduce the bug:
1. Follow the animated gif in #2005
