### PR TITLE
Fixed issue with creating a new sms and notifications through the list view didn't show up in campaigns

### DIFF
--- a/app/bundles/NotificationBundle/Entity/Notification.php
+++ b/app/bundles/NotificationBundle/Entity/Notification.php
@@ -99,7 +99,7 @@ class Notification extends FormEntity
     /**
      * @var string
      */
-    private $notificationType;
+    private $notificationType = 'template';
 
     /**
      *

--- a/app/bundles/NotificationBundle/Form/Type/NotificationListType.php
+++ b/app/bundles/NotificationBundle/Form/Type/NotificationListType.php
@@ -52,7 +52,7 @@ class NotificationListType extends AbstractType
 
                     $choices = [];
 
-                    $notifications = $repo->getNotificationList('', 0, 0, $viewOther, $options['notification_type']);
+                    $notifications = $repo->getNotificationList('', 0, 0, $viewOther);
                     foreach ($notifications as $notification) {
                         $choices[$notification['language']][$notification['id']] = $notification['name'];
                     }

--- a/app/bundles/SmsBundle/Entity/Sms.php
+++ b/app/bundles/SmsBundle/Entity/Sms.php
@@ -84,7 +84,7 @@ class Sms extends FormEntity
     /**
      * @var string
      */
-    private $smsType;
+    private $smsType = 'template';
 
     public function __clone()
     {

--- a/app/bundles/SmsBundle/Form/Type/SmsListType.php
+++ b/app/bundles/SmsBundle/Form/Type/SmsListType.php
@@ -52,7 +52,7 @@ class SmsListType extends AbstractType
 
                     $choices = [];
 
-                    $smses = $repo->getSmsList('', 0, 0, $viewOther, $options['sms_type']);
+                    $smses = $repo->getSmsList('', 0, 0, $viewOther);
                     foreach ($smses as $sms) {
                         $choices[$sms['language']][$sms['id']] = $sms['name'];
                     }

--- a/app/bundles/SmsBundle/Translations/en_US/messages.ini
+++ b/app/bundles/SmsBundle/Translations/en_US/messages.ini
@@ -18,7 +18,7 @@ mautic.sms.sms="Text Message"
 mautic.sms.smses="Text Messages"
 mautic.sms.campaign.send_sms="Send Push Text Message"
 mautic.sms.campaign.send_sms.tooltip="Sends a push sms to the user."
-
+mautic.sms.choose.smss="Select a text message to send."
 mautic.sms.config.form.sms.app_id="Text Messages Provider App ID"
 mautic.sms.config.form.sms.app_id.tooltip="One Signal App ID"
 mautic.sms.config.form.sms.rest_api_key="Text Messages Provider API Key"


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | not reported
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

Creating a new SMS or Notification through the list views do not show up as options in campaigns because the type is not set as template. This PR fixes this. 

#### Steps to test this PR:
1. Create a new SMS and notification using the New button from the list views
2. Create/edit a campaign and inject a send text message/notification and ensure they are displayed in the list

### As applicable
#### Steps to reproduce the bug:
1. Repeat above and the new will not show up in the campaign list