### PR TITLE
Fixed width of campaign event panels on mobile

### DIFF
--- a/app/bundles/CampaignBundle/Assets/js/campaign.js
+++ b/app/bundles/CampaignBundle/Assets/js/campaign.js
@@ -1263,6 +1263,9 @@ Mautic.campaignBuilderUpdateEventList = function (groups, hidden, view, active, 
         });
 
         var newWidth = (500 / 3) * groupsEnabled;
+        if (newWidth >= mQuery(window).width()) {
+            newWidth = mQuery(window).width() - 10;
+        }
 
         var leftPos = (forcePosition) ? forcePosition.left : Mautic.campaignBuilderAnchorClickedPosition.left - (newWidth / 2 - 10);
         var topPos  = (forcePosition) ? forcePosition.top : Mautic.campaignBuilderAnchorClickedPosition.top + 25;

--- a/app/bundles/CampaignBundle/Views/Campaign/builder.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/builder.html.php
@@ -68,7 +68,7 @@
                                     </div>
                                     <div class="col-xs-4 col-sm-2 pl-0 pr-0 pt-10 pb-10 text-right">
                                         <i class="hidden-xs fa fa-bullseye fa-lg"></i>
-                                        <button class="visible-xs pull-right btn btn-sm btn-default btn-nospin text-primary" data-type="Decision">
+                                        <button class="visible-xs pull-right btn btn-sm btn-default btn-nospin text-primary" data-type="Action">
                                             <?php echo $view['translator']->trans('mautic.core.select'); ?>
                                         </button>
                                     </div>
@@ -91,7 +91,7 @@
                                     </div>
                                     <div class="col-xs-4 col-sm-2 pl-0 pr-0 pt-10 pb-10 text-right">
                                         <i class="hidden-xs fa fa-filter fa-lg"></i>
-                                        <button class="visible-xs pull-right btn btn-sm btn-default btn-nospin text-danger" data-type="Decision">
+                                        <button class="visible-xs pull-right btn btn-sm btn-default btn-nospin text-danger" data-type="Condition">
                                             <?php echo $view['translator']->trans('mautic.core.select'); ?>
                                         </button>
                                     </div>


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | not reported
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:
When using the campaign builder on mobile and tapping an anchor, the list of the event type panels were too wide for mobile and clicking on the Select button always displayed Decisions. This PR fixes it. 

#### Steps to test this PR:
1. On mobile or a very small width - open the campaign builder
2. Tap/click an anchor to select an Action/Decision/Condition
3. The width should be within the device width
4. Tap/click select of Action or Condition and it should show the appropriate list.

### As applicable
#### Steps to reproduce the bug:
1. Repeat the above - width will be wider than the device width (500px)
2. Tapping/clicking Select on any item will show Decisions.
