### PR TITLE
Fixed where a user preferred locale and timezone were not applied

### DIFF
--- a/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
@@ -38,7 +38,8 @@ class CoreSubscriber extends CommonSubscriber
         return array(
             KernelEvents::CONTROLLER          => array('onKernelController', 0),
             KernelEvents::REQUEST             => [
-                ['onKernelRequest', 0],
+                ['onKernelRequestSetTimezone', 9999],
+                ['onKernelRequestSetLocale', 15], // Must be 15 to load after Symfony's default Locale listener
                 ['onKernelRequestAddGlobalJS', 0]
             ],
             CoreEvents::BUILD_MENU            => array('onBuildMenu', 9999),
@@ -49,43 +50,19 @@ class CoreSubscriber extends CommonSubscriber
     }
 
     /**
-     * Set default timezone/locale
+     * Set timezone
      *
      * @param GetResponseEvent $event
-     *
-     * @return void
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequestSetTimezone(GetResponseEvent $event)
     {
-        // Set the user's default locale
         $request = $event->getRequest();
         if (!$request->hasPreviousSession()) {
             return;
         }
 
-        $currentUser = $this->factory->getUser();
-
-        //set the user's timezone
-        if (is_object($currentUser)) {
-            $tz = $currentUser->getTimezone();
-        }
-
-        if (empty($tz)) {
-            $tz = $this->params['default_timezone'];
-        }
-
-        date_default_timezone_set($tz);
-
-        if (!$locale = $request->attributes->get('_locale')) {
-            if (is_object($currentUser)) {
-                $locale = $currentUser->getLocale();
-            }
-            if (empty($locale)) {
-                $locale = $this->params['locale'];
-            }
-        }
-
-        $request->setLocale($locale);
+        // Set date/time
+        date_default_timezone_set($request->getSession()->get('_timezone', $this->params['default_timezone']));
 
         // Set a cookie with session name for filemanager
         $sessionName = $request->cookies->get('mautic_session_name');
@@ -93,6 +70,29 @@ class CoreSubscriber extends CommonSubscriber
             /** @var \Mautic\CoreBundle\Helper\CookieHelper $cookieHelper */
             $cookieHelper = $this->factory->getHelper('cookie');
             $cookieHelper->setCookie('mautic_session_name', session_name(), null);
+        }
+    }
+
+    /**
+     * Set default locale
+     *
+     * @param GetResponseEvent $event
+     *
+     * @return void
+     */
+    public function onKernelRequestSetLocale(GetResponseEvent $event)
+    {
+        // Set the user's default locale
+        $request = $event->getRequest();
+        if (!$request->hasPreviousSession()) {
+            return;
+        }
+
+        // Set locale
+        if ($locale = $request->attributes->get('_locale')) {
+            $request->getSession()->set('_locale', $locale);
+        } else {
+            $request->setLocale($request->getSession()->get('_locale', $this->params['locale']));
         }
     }
 
@@ -144,6 +144,20 @@ class CoreSubscriber extends CommonSubscriber
                 $userModel->setOnlineStatus('online');
 
                 $userModel->getRepository()->setLastLogin($user);
+
+                // Set the timezone and locale in session while we have it since Symfony dispatches the onKernelRequest prior to the
+                // firewall setting the known user
+                $tz = $user->getTimezone();
+                if (empty($tz)) {
+                    $tz = $this->params['default_timezone'];
+                }
+                $session->set('_timezone', $tz);
+
+                $locale = $user->getLocale();
+                if (empty($locale)) {
+                    $locale = $this->params['locale'];
+                }
+                $session->set('_locale', $locale);
             }
 
             //dispatch on login events

--- a/app/bundles/UserBundle/Controller/ProfileController.php
+++ b/app/bundles/UserBundle/Controller/ProfileController.php
@@ -22,14 +22,14 @@ class ProfileController extends FormController
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\Response
      */
-    public function indexAction ()
+    public function indexAction()
     {
         //get current user
         $me    = $this->get('security.token_storage')->getToken()->getUser();
         $model = $this->getModel('user');
 
         //set some permissions
-        $permissions = array(
+        $permissions = [
             'apiAccess'    => ($this->get('mautic.helper.core_parameters')->getParameter('api_enabled')) ?
                 $this->get('mautic.security')->isGranted('api:access:full')
                 : 0,
@@ -37,17 +37,18 @@ class ProfileController extends FormController
             'editUsername' => $this->get('mautic.security')->isGranted('user:profile:editusername'),
             'editPosition' => $this->get('mautic.security')->isGranted('user:profile:editposition'),
             'editEmail'    => $this->get('mautic.security')->isGranted('user:profile:editemail')
-        );
+        ];
 
         $action = $this->generateUrl('mautic_user_account');
-        $form   = $model->createForm($me, $this->get('form.factory'), $action, array('in_profile' => true));
+        $form   = $model->createForm($me, $this->get('form.factory'), $action, ['in_profile' => true]);
 
-        $overrides = array();
+        $overrides = [];
 
         //make sure this user has access to edit privileged fields
         foreach ($permissions as $permName => $hasAccess) {
-            if ($permName == 'apiAccess')
+            if ($permName == 'apiAccess') {
                 continue;
+            }
 
             if (!$hasAccess) {
                 //set the value to its original
@@ -56,66 +57,86 @@ class ProfileController extends FormController
                         $overrides['firstName'] = $me->getFirstName();
                         $overrides['lastName']  = $me->getLastName();
                         $form->remove('firstName');
-                        $form->add('firstName_unbound', 'text', array(
-                            'label'      => 'mautic.core.firstname',
-                            'label_attr' => array('class' => 'control-label'),
-                            'attr'       => array('class' => 'form-control'),
-                            'mapped'     => false,
-                            'disabled'   => true,
-                            'data'       => $me->getFirstName(),
-                            'required'   => false
-                        ));
+                        $form->add(
+                            'firstName_unbound',
+                            'text',
+                            [
+                                'label'      => 'mautic.core.firstname',
+                                'label_attr' => ['class' => 'control-label'],
+                                'attr'       => ['class' => 'form-control'],
+                                'mapped'     => false,
+                                'disabled'   => true,
+                                'data'       => $me->getFirstName(),
+                                'required'   => false
+                            ]
+                        );
 
                         $form->remove('lastName');
-                        $form->add('lastName_unbound', 'text', array(
-                            'label'      => 'mautic.core.lastname',
-                            'label_attr' => array('class' => 'control-label'),
-                            'attr'       => array('class' => 'form-control'),
-                            'mapped'     => false,
-                            'disabled'   => true,
-                            'data'       => $me->getLastName(),
-                            'required'   => false
-                        ));
+                        $form->add(
+                            'lastName_unbound',
+                            'text',
+                            [
+                                'label'      => 'mautic.core.lastname',
+                                'label_attr' => ['class' => 'control-label'],
+                                'attr'       => ['class' => 'form-control'],
+                                'mapped'     => false,
+                                'disabled'   => true,
+                                'data'       => $me->getLastName(),
+                                'required'   => false
+                            ]
+                        );
                         break;
 
                     case 'editUsername':
                         $overrides['username'] = $me->getUsername();
                         $form->remove('username');
-                        $form->add('username_unbound', 'text', array(
-                            'label'      => 'mautic.core.username',
-                            'label_attr' => array('class' => 'control-label'),
-                            'attr'       => array('class' => 'form-control'),
-                            'mapped'     => false,
-                            'disabled'   => true,
-                            'data'       => $me->getUsername(),
-                            'required'   => false
-                        ));
+                        $form->add(
+                            'username_unbound',
+                            'text',
+                            [
+                                'label'      => 'mautic.core.username',
+                                'label_attr' => ['class' => 'control-label'],
+                                'attr'       => ['class' => 'form-control'],
+                                'mapped'     => false,
+                                'disabled'   => true,
+                                'data'       => $me->getUsername(),
+                                'required'   => false
+                            ]
+                        );
                         break;
                     case 'editPosition':
                         $overrides['position'] = $me->getPosition();
                         $form->remove('position');
-                        $form->add('position_unbound', 'text', array(
-                            'label'      => 'mautic.core.position',
-                            'label_attr' => array('class' => 'control-label'),
-                            'attr'       => array('class' => 'form-control'),
-                            'mapped'     => false,
-                            'disabled'   => true,
-                            'data'       => $me->getPosition(),
-                            'required'   => false
-                        ));
+                        $form->add(
+                            'position_unbound',
+                            'text',
+                            [
+                                'label'      => 'mautic.core.position',
+                                'label_attr' => ['class' => 'control-label'],
+                                'attr'       => ['class' => 'form-control'],
+                                'mapped'     => false,
+                                'disabled'   => true,
+                                'data'       => $me->getPosition(),
+                                'required'   => false
+                            ]
+                        );
                         break;
                     case 'editEmail':
                         $overrides['email'] = $me->getEmail();
                         $form->remove('email');
-                        $form->add('email_unbound', 'text', array(
-                            'label'      => 'mautic.core.type.email',
-                            'label_attr' => array('class' => 'control-label'),
-                            'attr'       => array('class' => 'form-control'),
-                            'mapped'     => false,
-                            'disabled'   => true,
-                            'data'       => $me->getEmail(),
-                            'required'   => false
-                        ));
+                        $form->add(
+                            'email_unbound',
+                            'text',
+                            [
+                                'label'      => 'mautic.core.type.email',
+                                'label_attr' => ['class' => 'control-label'],
+                                'attr'       => ['class' => 'form-control'],
+                                'mapped'     => false,
+                                'disabled'   => true,
+                                'data'       => $me->getEmail(),
+                                'required'   => false
+                            ]
+                        );
                         break;
 
                 }
@@ -134,7 +155,7 @@ class ProfileController extends FormController
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($this->isFormValid($form)) {
                     foreach ($overrides as $k => $v) {
-                        $func = 'set' . ucfirst($k);
+                        $func = 'set'.ucfirst($k);
                         $me->$func($v);
                     }
 
@@ -146,7 +167,7 @@ class ProfileController extends FormController
 
                     if ($me->getLocale() && !array_key_exists($me->getLocale(), $installedLanguages)) {
                         /** @var \Mautic\CoreBundle\Helper\LanguageHelper $languageHelper */
-                        $languageHelper = $this->factory->getHelper('language');
+                        $languageHelper = $this->get('mautic.helper.language');
 
                         $fetchLanguage = $languageHelper->extractLanguagePackage($me->getLocale());
 
@@ -154,8 +175,8 @@ class ProfileController extends FormController
                         if ($fetchLanguage['error']) {
                             $me->setLocale(null);
                             $model->saveEntity($me);
-                            $message = 'mautic.core.could.not.set.language';
-                            $messageVars = array();
+                            $message     = 'mautic.core.could.not.set.language';
+                            $messageVars = [];
 
                             if (isset($fetchLanguage['message'])) {
                                 $message = $fetchLanguage['message'];
@@ -169,31 +190,36 @@ class ProfileController extends FormController
                         }
                     }
 
-
                     // Update timezone and locale
-                    if ($tz = $me->getTimezone()) {
-                        $this->get('session')->set('_timezone', $tz);
+                    $tz = $me->getTimezone();
+                    if (empty($tz)) {
+                        $tz = $this->get('mautic.helper.core_parameters')->getParameter('default_timezone');
                     }
+                    $this->get('session')->set('_timezone', $tz);
 
-                    if ($locale = $me->getLocale()) {
-                        $this->get('session')->set('_locale', $locale);
+                    $locale = $me->getLocale();
+                    if (empty($locale)) {
+                        $locale = $this->get('mautic.helper.core_parameters')->getParameter('locale');
                     }
+                    $this->get('session')->set('_locale', $locale);
 
                     $returnUrl = $this->generateUrl('mautic_user_account');
 
-                    return $this->postActionRedirect(array(
-                        'returnUrl'       => $returnUrl,
-                        'contentTemplate' => 'MauticUserBundle:Profile:index',
-                        'passthroughVars' => array(
-                            'mauticContent' => 'user'
-                        ),
-                        'flashes'         => array( //success
-                            array(
-                                'type' => 'notice',
-                                'msg'  => 'mautic.user.account.notice.updated'
-                            )
-                        )
-                    ));
+                    return $this->postActionRedirect(
+                        [
+                            'returnUrl'       => $returnUrl,
+                            'contentTemplate' => 'MauticUserBundle:Profile:index',
+                            'passthroughVars' => [
+                                'mauticContent' => 'user'
+                            ],
+                            'flashes'         => [ //success
+                                [
+                                    'type' => 'notice',
+                                    'msg'  => 'mautic.user.account.notice.updated'
+                                ]
+                            ]
+                        ]
+                    );
                 }
             } else {
                 return $this->redirect($this->generateUrl('mautic_dashboard_index'));
@@ -201,20 +227,22 @@ class ProfileController extends FormController
         }
         $this->get('session')->set('formProcessed', 0);
 
-        $parameters = array(
+        $parameters = [
             'permissions'       => $permissions,
             'me'                => $me,
             'userForm'          => $form->createView(),
             'authorizedClients' => $this->forward('MauticApiBundle:Client:authorizedClients')->getContent()
-        );
+        ];
 
-        return $this->delegateView(array(
-            'viewParameters'  => $parameters,
-            'contentTemplate' => 'MauticUserBundle:Profile:index.html.php',
-            'passthroughVars' => array(
-                'route'         => $this->generateUrl('mautic_user_account'),
-                'mauticContent' => 'user'
-            )
-        ));
+        return $this->delegateView(
+            [
+                'viewParameters'  => $parameters,
+                'contentTemplate' => 'MauticUserBundle:Profile:index.html.php',
+                'passthroughVars' => [
+                    'route'         => $this->generateUrl('mautic_user_account'),
+                    'mauticContent' => 'user'
+                ]
+            ]
+        );
     }
 }


### PR DESCRIPTION
Please answer the following questions. 

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | not reported
| BC breaks? | n
| Deprecations? | n

**Note that all new features should have a related user and/or developer documentation PR in their respective repositories.** 

### Required
#### Description:

Likely due to the deprecation of MauticFactory which hid some circular dependencies - user preferred locale and timezone settings were not getting applied. This PR fixes that.

#### Steps to test this PR:
1. Edit your user preferences to a locale different from the system default
2. Go to the dashboard and note that it's in that language

### As applicable
#### Steps to reproduce the bug:
1. Repeat the above before applying the PR - note that if you refresh on the accounts page, the language has been applied - this is because of a subrequest made to generating the authorization tokens
2. Go to the dashboard and refresh - it reverts back to the system default