### PR TITLE
Fixing updater when php_uname function is disabled

### DIFF
--- a/app/bundles/CoreBundle/Helper/UpdateHelper.php
+++ b/app/bundles/CoreBundle/Helper/UpdateHelper.php
@@ -80,6 +80,22 @@ class UpdateHelper
     }
 
     /**
+     * Tries to get server OS
+     *
+     * @return string
+     */
+    public function getServerOs()
+    {
+        if (function_exists('php_uname')) {
+            return php_uname('s') . ' ' . php_uname('r');
+        } elseif (defined('PHP_OS')) {
+            return PHP_OS;
+        }
+
+        return 'N/A';
+    }
+
+    /**
      * Retrieves the update data from our home server
      *
      * @param bool $overrideCache
@@ -113,7 +129,7 @@ class UpdateHelper
                 'version'       => $this->factory->getVersion(),
                 'phpVersion'    => PHP_VERSION,
                 'dbDriver'      => $this->factory->getParameter('db_driver'),
-                'serverOs'      => php_uname('s') . ' ' . php_uname('r'),
+                'serverOs'      => $this->getServerOs(),
                 'instanceId'    => $instanceId,
                 'installSource' => $this->factory->getParameter('install_source', 'Mautic')
             );


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2376
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
php_uname function which gets info about the server can be disabled on some servers as dangerous method. The update process fails because of it. This PR check if the method exists, if not it tries to get the server info from PHP_OS constant and if that's not defined either, it returns N/A.

#### Steps to test this PR:
1. If you don't want to mess with your development Mautic, pull this branch to another folder, composer install and install Mautic.
2. Update app/version.txt to some older version number.
3. Try to upgrade Mautic.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. You'd have to disable the php_uname function and try to upgrade Mautic.
