### PR TITLE
API - get URL history of specific lead

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -129,7 +129,12 @@ return [
                 'path'       => '/segments/{id}/contact/remove/{leadId}',
                 'controller' => 'MauticLeadBundle:Api\ListApi:removeLead',
                 'method'     => 'POST'
+            ],
+            'mautic_api_getleadhistory_bc' => [
+                'path' => '/contacts/{id}/history',
+                'controller' => 'MauticLeadBundle:Api\LeadApi:getEntityUrlHistory'
             ]
+        		
         ]
     ],
     'menu'     => [

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -119,6 +119,29 @@ class LeadApiController extends CommonApiController
     }
 
     /**
+     * Obtains a specific entity url history of specific contact
+     *
+     * @param int $id contact id
+     *            
+     * @return Response
+     */
+    public function getEntityUrlHistoryAction($id)
+    {
+        $start= $this->request->query->get('start', 0);
+        $limit= $this->request->query->get('limit', 0);
+        
+        $entity = $this->model->getEntityUrlHistory($id,$start,$limit);
+        
+        $this->preSerializeEntity($entity);
+        $view = $this->view(array(
+            $this->entityNameOne => $entity
+        ), Codes::HTTP_OK);
+        $this->setSerializationContext($view);
+        
+        return $this->handleView($view);
+    }
+    
+    /**
      * Obtains a list of custom fields
      *
      * @return \Symfony\Component\HttpFoundation\Response

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -449,6 +449,35 @@ class LeadRepository extends CommonRepository
     }
 
     /**
+     *
+     * {@inheritdoc}
+     *
+     * @param integer $id contact id           
+     * @param integer $start start of pagination
+     * @param integer $limit size of pagination
+     * @return mixed|null
+     */
+    public function getEntityUrlHistory($id = 0, $start = 0, $limit = 0)
+    {
+        $q = $this->_em->getConnection()
+            ->createQueryBuilder()
+            ->select('hits.*')
+            ->from(MAUTIC_TABLE_PREFIX . 'page_hits', 'hits')
+            ->where("lead_id = :id")
+            ->setParameter('id', $id)
+            ->setFirstResult($start);
+        if ($limit !== 0) {
+            $q->setMaxResults($limit);
+        }
+        $result = $q->execute()->fetchAll();
+        if (count($result)) {
+            return $result;
+        } else {
+            return null;
+        }
+    }
+    
+    /**
      * Get a list of leads
      *
      * @param array $args

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -224,6 +224,27 @@ class LeadModel extends FormModel
         return "getPrimaryIdentifier";
     }
 
+
+    /**
+     * Get a specific entity Url history
+     *
+     * @param integer $id contact id           
+     * @param integer $start start of pagination
+     * @param integer $limit size of pagination
+     * @return null|object
+     */
+    public function getEntityUrlHistory($id = null, $start=0, $limit=0)
+    {
+        if (null !== $id) {
+            $repo = $this->getRepository();
+            if (method_exists($repo, 'getEntityUrlHistory')) {
+                return $repo->getEntityUrlHistory($id, $start, $limit);
+            }
+            return $repo->find($id);
+        }
+        return null;
+    }
+    
     /**
      * {@inheritdoc}
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | N |
| New feature? | Y |
| Related user documentation PR URL | N |
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/16 |
| Issues addressed (#s or URLs) | N |
| BC breaks? | N |
| Deprecations? | N |
#### Description:

Feature originaly submited on PR : https://github.com/mautic/mautic/pull/1899
Get the list of all url visited by a contact through API.
#### Steps to test this PR:
1. Apply this PR
2. Use API tester with PR https://github.com/mautic/api-library/pull/56
3. Get URL history with API route contacts/{id}/history
