### PR TITLE
Fixed instances of checking contact permissions against created by rather than owner

### DIFF
--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -145,7 +145,7 @@ class AjaxController extends CommonAjaxController
             $model = $this->getModel('lead.lead');
             $lead  = $model->getEntity($leadId);
 
-            if ($lead !== null && $this->factory->getSecurity()->hasEntityAccess('lead:leads:editown', 'lead:leads:editown', $lead->getOwner())) {
+            if ($lead !== null && $this->factory->getSecurity()->hasEntityAccess('lead:leads:editown', 'lead:leads:editown', $lead->getPermissionUser())) {
                 $leadFields = $lead->getFields();
                 /** @var IntegrationHelper $integrationHelper */
                 $integrationHelper = $this->factory->getHelper('integration');
@@ -207,7 +207,7 @@ class AjaxController extends CommonAjaxController
             $model = $this->getModel('lead.lead');
             $lead  = $model->getEntity($leadId);
 
-            if ($lead !== null && $this->factory->getSecurity()->hasEntityAccess('lead:leads:editown', 'lead:leads:editown', $lead->getOwner())) {
+            if ($lead !== null && $this->factory->getSecurity()->hasEntityAccess('lead:leads:editown', 'lead:leads:editown', $lead->getPermissionUser())) {
                 $dataArray['success'] = 1;
                 /** @var \Mautic\PluginBundle\Helper\IntegrationHelper $helper */
                 $helper         = $this->factory->getHelper('integration');
@@ -545,7 +545,7 @@ class AjaxController extends CommonAjaxController
         $updatedTags = (!empty($post['tags']) && is_array($post['tags'])) ? $post['tags'] : [];
         $data        = ['success' => 0];
 
-        if ($lead !== null && $this->factory->getSecurity()->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner())) {
+        if ($lead !== null && $this->factory->getSecurity()->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getPermissionUser())) {
 
             $leadModel->setTags($lead, $updatedTags, true);
 

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -162,7 +162,7 @@ class LeadApiController extends CommonApiController
     {
         $entity = $this->model->getEntity($id);
         if ($entity !== null) {
-            if (!$this->factory->getSecurity()->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother', $entity->getOwner())) {
+            if (!$this->factory->getSecurity()->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother', $entity->getPermissionUser())) {
                 return $this->accessDenied();
             }
 
@@ -215,7 +215,7 @@ class LeadApiController extends CommonApiController
     {
         $entity = $this->model->getEntity($id);
         if ($entity !== null) {
-            if (!$this->factory->getSecurity()->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother', $entity->getOwner())) {
+            if (!$this->factory->getSecurity()->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother', $entity->getPermissionUser())) {
                 return $this->accessDenied();
             }
 
@@ -255,7 +255,7 @@ class LeadApiController extends CommonApiController
     {
         $entity = $this->model->getEntity($id);
         if ($entity !== null) {
-            if (!$this->factory->getSecurity()->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother', $entity->getOwner())) {
+            if (!$this->factory->getSecurity()->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother', $entity->getPermissionUser())) {
                 return $this->accessDenied();
             }
 

--- a/app/bundles/LeadBundle/Controller/Api/ListApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/ListApiController.php
@@ -68,7 +68,7 @@ class ListApiController extends CommonApiController
             // Does the lead exist and the user has permission to edit
             if ($lead == null) {
                 return $this->notFound();
-            } elseif (!$this->security->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner())) {
+            } elseif (!$this->security->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getPermissionUser())) {
                 return $this->accessDenied();
             }
 
@@ -107,7 +107,7 @@ class ListApiController extends CommonApiController
             // Does the lead exist and the user has permission to edit
             if ($lead == null) {
                 return $this->notFound();
-            } elseif (!$this->security->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner())) {
+            } elseif (!$this->security->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getPermissionUser())) {
                 return $this->accessDenied();
             }
 

--- a/app/bundles/LeadBundle/Controller/LeadAccessTrait.php
+++ b/app/bundles/LeadBundle/Controller/LeadAccessTrait.php
@@ -55,7 +55,7 @@ trait LeadAccessTrait
         } elseif (!$this->get('mautic.security')->hasEntityAccess(
             'lead:leads:'.$action.'own',
             'lead:leads:'.$action.'other',
-            $lead->getOwner()
+            $lead->getPermissionUser()
         )
         ) {
 

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1806,7 +1806,7 @@ class LeadController extends FormController
 
             $count = 0;
             foreach ($entities as $lead) {
-                if ($this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getCreatedBy())) {
+                if ($this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner())) {
                     $count++;
 
                     if (!empty($data['add'])) {
@@ -1910,7 +1910,7 @@ class LeadController extends FormController
             }
 
             foreach ($entities as $key => $lead) {
-                if (!$this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getCreatedBy())) {
+                if (!$this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner())) {
 
                     unset($entities[$key]);
                 }
@@ -2036,7 +2036,7 @@ class LeadController extends FormController
             if ($count = count($entities)) {
                 $persistEntities = [];
                 foreach ($entities as $lead) {
-                    if ($this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getCreatedBy())) {
+                    if ($this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner())) {
 
                         if ($model->addDncForLead($lead, 'email', $data['reason'], DoNotContact::MANUAL)) {
                             $persistEntities[] = $lead;
@@ -2127,7 +2127,7 @@ class LeadController extends FormController
 
             $count = 0;
             foreach ($entities as $lead) {
-                if ($this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getCreatedBy())) {
+                if ($this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner())) {
                     $count++;
 
                     if (!empty($data['addstage'])) {

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -309,7 +309,7 @@ class LeadController extends FormController
         if (!$this->get('mautic.security')->hasEntityAccess(
             'lead:leads:viewown',
             'lead:leads:viewother',
-            $lead->getOwner()
+            $lead->getPermissionUser()
         )
         ) {
             return $this->accessDenied();
@@ -568,7 +568,7 @@ class LeadController extends FormController
         } elseif (!$this->get('mautic.security')->hasEntityAccess(
             'lead:leads:editown',
             'lead:leads:editother',
-            $lead->getOwner()
+            $lead->getPermissionUser()
         )
         ) {
             return $this->accessDenied();
@@ -834,8 +834,8 @@ class LeadController extends FormController
                             )
                         );
                     } elseif (
-                        !$this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $mainLead->getOwner())
-                        || !$this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $secLead->getOwner())
+                        !$this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $mainLead->getPermissionUser())
+                        || !$this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $secLead->getPermissionUser())
                     ) {
                         return $this->accessDenied();
                     } elseif ($model->isLocked($mainLead)) {
@@ -912,7 +912,7 @@ class LeadController extends FormController
         $model = $this->getModel('lead');
         $lead  = $model->getEntity($objectId);
         $data = [];
-        if ($lead != null && $this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner())) {
+        if ($lead != null && $this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getPermissionUser())) {
             $frequencyRules = $model->getFrequencyRule($lead);
 
             foreach ($frequencyRules as $frequencyRule) {
@@ -1018,7 +1018,7 @@ class LeadController extends FormController
             } elseif (!$this->get('mautic.security')->hasEntityAccess(
                 'lead:leads:deleteown',
                 'lead:leads:deleteother',
-                $entity->getOwner()
+                $entity->getPermissionUser()
             )
             ) {
                 return $this->accessDenied();
@@ -1088,7 +1088,7 @@ class LeadController extends FormController
                 } elseif (!$this->get('mautic.security')->hasEntityAccess(
                     'lead:leads:deleteown',
                     'lead:leads:deleteother',
-                    $entity->getCreatedBy()
+                    $entity->getPermissionUser()
                 )
                 ) {
                     $flashes[] = $this->accessDenied(true);
@@ -1140,7 +1140,7 @@ class LeadController extends FormController
             && $this->get('mautic.security')->hasEntityAccess(
                 'lead:leads:editown',
                 'lead:leads:editother',
-                $lead->getOwner()
+                $lead->getPermissionUser()
             )
         ) {
             /** @var \Mautic\LeadBundle\Model\ListModel $listModel */
@@ -1181,7 +1181,7 @@ class LeadController extends FormController
             && $this->get('mautic.security')->hasEntityAccess(
                 'lead:leads:editown',
                 'lead:leads:editother',
-                $lead->getOwner()
+                $lead->getPermissionUser()
             )
         ) {
             /** @var \Mautic\CampaignBundle\Model\CampaignModel $campaignModel */
@@ -1619,7 +1619,7 @@ class LeadController extends FormController
             || !$this->get('mautic.security')->hasEntityAccess(
                 'lead:leads:viewown',
                 'lead:leads:viewother',
-                $lead->getOwner()
+                $lead->getPermissionUser()
             )
         ) {
             return $this->modalAccessDenied();
@@ -1806,7 +1806,7 @@ class LeadController extends FormController
 
             $count = 0;
             foreach ($entities as $lead) {
-                if ($this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner())) {
+                if ($this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getPermissionUser())) {
                     $count++;
 
                     if (!empty($data['add'])) {
@@ -1910,7 +1910,7 @@ class LeadController extends FormController
             }
 
             foreach ($entities as $key => $lead) {
-                if (!$this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner())) {
+                if (!$this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getPermissionUser())) {
 
                     unset($entities[$key]);
                 }
@@ -2036,7 +2036,7 @@ class LeadController extends FormController
             if ($count = count($entities)) {
                 $persistEntities = [];
                 foreach ($entities as $lead) {
-                    if ($this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner())) {
+                    if ($this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getPermissionUser())) {
 
                         if ($model->addDncForLead($lead, 'email', $data['reason'], DoNotContact::MANUAL)) {
                             $persistEntities[] = $lead;
@@ -2127,7 +2127,7 @@ class LeadController extends FormController
 
             $count = 0;
             foreach ($entities as $lead) {
-                if ($this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner())) {
+                if ($this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getPermissionUser())) {
                     $count++;
 
                     if (!empty($data['addstage'])) {

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -496,7 +496,7 @@ class ListController extends FormController
                     'msgVars' => array('%id%' => $listId)
                 );
             } elseif (!$this->factory->getSecurity()->hasEntityAccess(
-                'lead:leads:editown', 'lead:leads:editother', $lead->getOwner()
+                'lead:leads:editown', 'lead:leads:editother', $lead->getPermissionUser()
             )) {
                 return $this->accessDenied();
             } elseif ($list === null) {

--- a/app/bundles/LeadBundle/Controller/NoteController.php
+++ b/app/bundles/LeadBundle/Controller/NoteController.php
@@ -120,8 +120,8 @@ class NoteController extends FormController
                     'noteTypes'   => $noteTypes,
                     'tmpl'        => $tmpl,
                     'permissions' => [
-                        'edit'   => $security->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner()),
-                        'delete' => $security->hasEntityAccess('lead:leads:deleteown', 'lead:leads:deleteown', $lead->getOwner()),
+                        'edit'   => $security->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getPermissionUser()),
+                        'delete' => $security->hasEntityAccess('lead:leads:deleteown', 'lead:leads:deleteown', $lead->getPermissionUser()),
                     ]
                 ],
                 'passthroughVars' => [
@@ -180,8 +180,8 @@ class NoteController extends FormController
 
         $security    = $this->get('mautic.security');
         $permissions = [
-            'edit'   => $security->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner()),
-            'delete' => $security->hasEntityAccess('lead:leads:deleteown', 'lead:leads:deleteown', $lead->getOwner()),
+            'edit'   => $security->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getPermissionUser()),
+            'delete' => $security->hasEntityAccess('lead:leads:deleteown', 'lead:leads:deleteown', $lead->getPermissionUser()),
         ];
 
         if ($closeModal) {
@@ -243,7 +243,7 @@ class NoteController extends FormController
         $closeModal = false;
         $valid      = false;
 
-        if ($note === null || !$this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner())) {
+        if ($note === null || !$this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getPermissionUser())) {
             return $this->accessDenied();
         }
 
@@ -272,8 +272,8 @@ class NoteController extends FormController
 
         $security    = $this->get('mautic.security');
         $permissions = [
-            'edit'   => $security->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner()),
-            'delete' => $security->hasEntityAccess('lead:leads:deleteown', 'lead:leads:deleteown', $lead->getOwner()),
+            'edit'   => $security->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getPermissionUser()),
+            'delete' => $security->hasEntityAccess('lead:leads:deleteown', 'lead:leads:deleteown', $lead->getPermissionUser()),
         ];
 
         if ($closeModal) {
@@ -331,7 +331,7 @@ class NoteController extends FormController
         $note  = $model->getEntity($objectId);
 
         if (
-            $note === null || !$this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getOwner())
+            $note === null || !$this->get('mautic.security')->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getPermissionUser())
             || $model->isLocked($note)
             || $this->request->getMethod() != 'POST'
         ) {

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -473,6 +473,16 @@ class Lead extends FormEntity
     }
 
     /**
+     * Returns the user to be used for permissions
+     *
+     * @return User|int
+     */
+    public function getPermissionUser()
+    {
+       return (null === $this->getOwner()) ? $this->getCreatedBy() : $this->getOwner();
+    }
+
+    /**
      * Add ipAddress
      *
      * @param IpAddress $ipAddress

--- a/app/bundles/LeadBundle/Views/Lead/lead.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/lead.html.php
@@ -37,7 +37,7 @@ $groups = array_keys($fields);
 $edit   = $view['security']->hasEntityAccess(
     $permissions['lead:leads:editown'],
     $permissions['lead:leads:editother'],
-    $lead->getOwner()
+    $lead->getPermissionUser()
 );
 
 $buttons = [];
@@ -124,7 +124,7 @@ if ($view['security']->isGranted('campaign:campaigns:edit')) {
 if (($view['security']->hasEntityAccess(
         $permissions['lead:leads:deleteown'],
         $permissions['lead:leads:deleteother'],
-        $lead->getOwner()
+        $lead->getPermissionUser()
     ))
     && $edit
 ) {
@@ -162,12 +162,12 @@ $view['slots']->set(
                 'delete' => $view['security']->hasEntityAccess(
                     $permissions['lead:leads:deleteown'],
                     $permissions['lead:leads:deleteother'],
-                    $lead->getOwner()
+                    $lead->getPermissionUser()
                 ),
                 'close'  => $view['security']->hasEntityAccess(
                     $permissions['lead:leads:viewown'],
                     $permissions['lead:leads:viewother'],
-                    $lead->getOwner()
+                    $lead->getPermissionUser()
                 ),
             ],
         ]

--- a/app/bundles/LeadBundle/Views/Lead/lead.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/lead.html.php
@@ -158,11 +158,7 @@ $view['slots']->set(
             'langVar'         => 'lead.lead',
             'customButtons'   => $buttons,
             'templateButtons' => [
-                'edit'   => $view['security']->hasEntityAccess(
-                    $permissions['lead:leads:editown'],
-                    $permissions['lead:leads:editother'],
-                    $lead->getCreatedBy()
-                ),
+                'edit'   => $edit,
                 'delete' => $view['security']->hasEntityAccess(
                     $permissions['lead:leads:deleteown'],
                     $permissions['lead:leads:deleteother'],
@@ -171,7 +167,7 @@ $view['slots']->set(
                 'close'  => $view['security']->hasEntityAccess(
                     $permissions['lead:leads:viewown'],
                     $permissions['lead:leads:viewother'],
-                    $lead->getCreatedBy()
+                    $lead->getOwner()
                 ),
             ],
         ]

--- a/app/bundles/LeadBundle/Views/Lead/list_rows.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/list_rows.html.php
@@ -16,7 +16,7 @@
                     $hasEditAccess = $security->hasEntityAccess(
                         $permissions['lead:leads:editown'],
                         $permissions['lead:leads:editother'],
-                        $item->getOwner()
+                        $item->getPermissionUser()
                     );
 
                     $custom = array();
@@ -54,7 +54,7 @@
                         'item'      => $item,
                         'templateButtons' => array(
                             'edit'      => $hasEditAccess,
-                            'delete'    => $security->hasEntityAccess($permissions['lead:leads:deleteown'], $permissions['lead:leads:deleteother'], $item->getOwner()),
+                            'delete'    => $security->hasEntityAccess($permissions['lead:leads:deleteown'], $permissions['lead:leads:deleteother'], $item->getPermissionUser()),
                         ),
                         'routeBase' => 'contact',
                         'langVar'   => 'lead.lead',


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2387
| BC breaks? | n
| Deprecations? | n

[//]: # ( Required: )
#### Description:

In some places, a contact permission was checked against created by user and in some places owner. It should all be owner so this PR fixes this.

#### Steps to test this PR:
1. Create a role that has contact permissions without edit other.
2. Create/add a user to that role
3. Create a contact and assign that user as the owner
4. Log in as that user and go to the contact details page.
5. Note there should be an edit button at the top - click and you should be able to edit. 
6. Try to perform batch actions on the contact (add dnc, list, campaigns, or delete) which should all be successful

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Repeat the above - but the button should be hidden on the details view and the batch actions will fail with access denied
