### PR TITLE
Fixed sorting issue with emails and limits

### DIFF
--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -175,11 +175,12 @@ class EmailController extends FormController
 
         $emails = $model->getEntities(
             [
-                'start'      => $start,
-                'limit'      => $limit,
-                'filter'     => $filter,
-                'orderBy'    => $orderBy,
-                'orderByDir' => $orderByDir
+                'start'          => $start,
+                'limit'          => $limit,
+                'filter'         => $filter,
+                'orderBy'        => $orderBy,
+                'orderByDir'     => $orderByDir,
+                'ignoreListJoin' => true
             ]
         );
 

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -134,7 +134,7 @@ class EmailRepository extends CommonRepository
         if (empty($args['iterator_mode'])) {
             $q->leftJoin('e.category', 'c');
 
-            if (!isset($args['email_type']) || $args['email_type'] == 'list') {
+            if (!isset($args['ignoreListJoin']) && (!isset($args['email_type']) || $args['email_type'] == 'list')) {
                 $q->leftJoin('e.lists', 'l');
             }
         }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2383 
| BC breaks? | n
| Deprecations? | n

[//]: # ( Required: )
#### Description:

Due to Doctrine's way of handling associations and joins, sorting emails may not show the full number as set by the limit because Doctrine counts the associations as part of the limit.

#### Steps to test this PR:
1. Follow the steps in #2383  

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Follow the steps in #2383 
