### PR TITLE
Search contact by IP fixed

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -794,7 +794,7 @@ class LeadRepository extends CommonRepository
                     ->join('lip', MAUTIC_TABLE_PREFIX.'ip_addresses', 'ip', 'lip.ip_id = ip.id')
                     ->where(
                         $sq->expr()->andX(
-                            $sq->expr->andX('l.id', 'lip.lead_id'),
+                            $sq->expr()->eq('l.id', 'lip.lead_id'),
                             $sq->expr()->$likeFunc('ip.ip_address', ":$unique")
                         )
                     );


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | [reported via FB](https://www.facebook.com/groups/953588998063936/permalink/1076555922433909/)
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Searching for a contact by IP caused a PHP error and didn't work. This PR fixes it.

#### Steps to test this PR:
1. Apply this PR.
2. Go to a contact which has a IP in his timeline. Copy it.
3. Go to the contact list and try to search for it like `ip:[paste the IP here]`

- The contact you copied the IP from should appear in the search results.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to a contact which has a IP in his timeline. Copy it.
2. Go to the contact list and try to search for it like `ip:[paste the IP here]`

- You will see an error in the logs.

