### PR TITLE
Fixed campaign conditions connected to the passive path

### DIFF
--- a/app/bundles/CampaignBundle/Form/Type/EventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/EventType.php
@@ -49,23 +49,26 @@ class EventType extends AbstractType
             ]
         );
 
-        if ($options['data']['eventType'] == 'action' || $options['data']['eventType'] == 'condition') {
+        if (in_array($options['data']['eventType'], ['action', 'condition'])) {
             $label = 'mautic.campaign.form.type';
-            if ('no' == $options['data']['anchor']) {
+
+            $choices = [
+                'immediate' => 'mautic.campaign.form.type.immediate',
+                'interval'  => 'mautic.campaign.form.type.interval',
+                'date'      => 'mautic.campaign.form.type.date'
+            ];
+
+            if ('no' == $options['data']['anchor'] && 'condition' != $options['data']['eventType']) {
                 $label .= '_inaction';
-                $choices = [
-                    'interval' => 'mautic.campaign.form.type.interval_inaction',
-                    'date'     => 'mautic.campaign.form.type.date_inaction'
-                ];
-                $default = 'interval';
-            } else {
-                $choices = [
-                    'immediate' => 'mautic.campaign.form.type.immediate',
-                    'interval'  => 'mautic.campaign.form.type.interval',
-                    'date'      => 'mautic.campaign.form.type.date'
-                ];
-                $default = 'immediate';
+
+                unset($choices['immediate']);
+                $choices['interval'] = $choices['interval'].'_inaction';
+                $choices['date'] = $choices['date'].'_inaction';
             }
+
+            reset($choices);
+            $default = key($choices);
+
             $triggerMode = (empty($options['data']['triggerMode'])) ? $default : $options['data']['triggerMode'];
             $builder->add(
                 'triggerMode',


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2396
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

With the campaign builder change in 2.0, a bug was introduced that did not allow a condition connected to a the red/passive/inaction anchors to be executed immediately. This particularly becomes an issue for Dynamic Web Content. This PR fixes this.

#### Steps to test this PR:
1. Edit/create a campaign. 
2. Add a new decision and click on the red anchor.
3. Select condition and select a condition.
4. Notice the form should have "immediate" available as an option.
5. Now do the same but choose an action - "immediate" should not be an option.
6. Repeat both a condition and action for the green anchor. Both should have "immediate"

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Repeat the steps above and notice that a condition connected to a red anchor will not have immediate as an option
