### PR TITLE
Embedded form theme styles

### DIFF
--- a/app/bundles/CoreBundle/Templating/TemplateReference.php
+++ b/app/bundles/CoreBundle/Templating/TemplateReference.php
@@ -124,4 +124,18 @@ class TemplateReference extends BaseTemplateReference
 
         return $template;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLogicalName()
+    {
+        $logicalName = parent::getLogicalName();
+
+        if (!empty($this->themeOverride)) {
+            $logicalName = $this->themeOverride.'|'.$logicalName;
+        }
+
+        return $logicalName;
+    }
 }

--- a/app/bundles/FormBundle/Config/config.php
+++ b/app/bundles/FormBundle/Config/config.php
@@ -223,6 +223,7 @@ return [
                 'arguments' => [
                     'request_stack',
                     'mautic.helper.templating',
+                    'mautic.helper.theme',
                     'mautic.schema.helper.factory',
                     'mautic.form.model.action',
                     'mautic.form.model.field',

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -12,6 +12,7 @@ namespace Mautic\FormBundle\Model;
 use Mautic\CoreBundle\Doctrine\Helper\SchemaHelperFactory;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Helper\TemplatingHelper;
+use Mautic\CoreBundle\Helper\ThemeHelper;
 use Mautic\CoreBundle\Model\FormModel as CommonFormModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\FormBundle\Entity\Action;
@@ -42,6 +43,11 @@ class FormModel extends CommonFormModel
     protected $templatingHelper;
 
     /**
+     * @var ThemeHelper
+     */
+    protected $themeHelper;
+
+    /**
      * @var SchemaHelperFactory
      */
     protected $schemaHelperFactory;
@@ -64,12 +70,18 @@ class FormModel extends CommonFormModel
     /**
      * FormModel constructor.
      *
+     * @param RequestStack $requestStack
+     * @param TemplatingHelper $templatingHelper
+     * @param ThemeHelper $themeHelper
+     * @param SchemaHelperFactory $schemaHelperFactory
      * @param ActionModel $formActionModel
      * @param FieldModel $formFieldModel
+     * @param LeadModel $leadModel
      */
     public function __construct(
         RequestStack $requestStack,
         TemplatingHelper $templatingHelper,
+        ThemeHelper $themeHelper,
         SchemaHelperFactory $schemaHelperFactory,
         ActionModel $formActionModel,
         FieldModel $formFieldModel,
@@ -78,6 +90,7 @@ class FormModel extends CommonFormModel
     {
         $this->request = $requestStack->getCurrentRequest();
         $this->templatingHelper = $templatingHelper;
+        $this->themeHelper = $themeHelper;
         $this->schemaHelperFactory = $schemaHelperFactory;
         $this->formActionModel = $formActionModel;
         $this->formFieldModel = $formFieldModel;
@@ -368,6 +381,7 @@ class FormModel extends CommonFormModel
         $theme = $entity->getTemplate();
         $submissions = null;
         $lead = $this->leadModel->getCurrentLead();
+        $style = '';
 
         if (!empty($theme)) {
             $theme .= '|';
@@ -383,13 +397,20 @@ class FormModel extends CommonFormModel
             );
         }
 
+        if ($entity->getRenderStyle()) {
+            $templating = $this->templatingHelper->getTemplating();
+            $styleTheme = $theme.'MauticFormBundle:Builder:style.html.php';
+            $style = $templating->render($this->themeHelper->checkForTwigTemplate($styleTheme));
+        }
+
         $html = $this->templatingHelper->getTemplating()->render(
             $theme.'MauticFormBundle:Builder:form.html.php',
             [
                 'form'        => $entity,
                 'theme'       => $theme,
                 'submissions' => $submissions,
-                'lead'        => $lead
+                'lead'        => $lead,
+                'style'       => $style
             ]
         );
 

--- a/app/bundles/FormBundle/Views/Builder/form.html.php
+++ b/app/bundles/FormBundle/Views/Builder/form.html.php
@@ -11,7 +11,7 @@ $formName = '_' . $form->generateFormName();
 $fields   = $form->getFields();
 ?>
 
-<?php if ($form->getRenderStyle()) echo $view->render($theme.'MauticFormBundle:Builder:style.html.php', array('form' => $form, 'formName' => $formName)); ?>
+<?php echo $style; ?>
 
 <div id="mauticform_wrapper<?php echo $formName ?>" class="mauticform_wrapper">
     <form autocomplete="false" role="form" method="post" action="<?php echo $view['router']->url('mautic_form_postresults', array('formId' => $form->getId())); ?>" id="mauticform<?php echo $formName ?>" data-mautic-form="<?php echo ltrim($formName, '_') ?>">

--- a/themes/coffee/html/MauticFormBundle/Builder/style.html.twig
+++ b/themes/coffee/html/MauticFormBundle/Builder/style.html.twig
@@ -1,0 +1,24 @@
+<style type="text/css" scoped>
+    .mauticform_wrapper { max-width: 600px; margin: 10px auto; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; font-size: 14px; color: #333333;}
+    .mauticform-innerform {}
+    .mauticform-post-success {}
+    .mauticform-name { font-weight: bold; font-size: 1.5em; margin-bottom: 3px; }
+    .mauticform-description { margin-top: 2px; margin-bottom: 10px; }
+    .mauticform-error { margin-bottom: 10px; color: red; }
+    .mauticform-message { margin-bottom: 10px;color: green; }
+    .mauticform-row { display: block; margin-bottom: 20px; }
+    .mauticform-label { font-size: 1.1em; display: block; font-weight: bold; margin-bottom: 5px; }
+    .mauticform-row.mauticform-required .mauticform-label:after { color: #e32; content: " *"; display: inline; }
+    .mauticform-helpmessage { display: block; font-size: 0.9em; margin-bottom: 3px; }
+    .mauticform-errormsg { display: block; color: red; margin-top: 2px; }
+    .mauticform-selectbox, .mauticform-input, .mauticform-textarea { width: 100%; padding: 0.5em 0.5em; border: 1px solid #CCC; background: #fff; box-shadow: 0px 0px 0px #fff inset; border-radius: 4px; box-sizing: border-box; }
+    .mauticform-checkboxgrp-row {}
+    .mauticform-checkboxgrp-label { font-weight: normal; }
+    .mauticform-checkboxgrp-checkbox {}
+    .mauticform-radiogrp-row {}
+    .mauticform-radiogrp-label { font-weight: normal; }
+    .mauticform-radiogrp-radio {}
+    .mauticform-button-wrapper .mauticform-button.btn-default { color: #5d6c7c;background-color: #ffffff;border-color: #dddddd;}
+    .mauticform-button-wrapper .mauticform-button { display: inline-block;margin-bottom: 0;font-weight: 600;text-align: center;vertical-align: middle;cursor: pointer;background-image: none;border: 1px solid transparent;white-space: nowrap;padding: 6px 12px;font-size: 13px;line-height: 1.3856;border-radius: 3px;-webkit-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;}
+    .mauticform-button-wrapper .mauticform-button.btn-default[disabled] { background-color: #ffffff; border-color: #dddddd;}
+</style>

--- a/themes/neopolitan/html/MauticFormBundle/Builder/style.html.twig
+++ b/themes/neopolitan/html/MauticFormBundle/Builder/style.html.twig
@@ -1,0 +1,25 @@
+<style type="text/css" scoped>
+    @import url(https://fonts.googleapis.com/css?family=Droid+Sans);
+    .mauticform_wrapper { max-width: 600px; margin: 10px auto; font-family: 'Droid Sans', 'Helvetica Neue', 'Arial', 'sans-serif' !important; color: #37302d;}
+    .mauticform-innerform {}
+    .mauticform-post-success {}
+    .mauticform-name { font-weight: bold; font-size: 1.5em; margin-bottom: 3px; }
+    .mauticform-description { margin-top: 2px; margin-bottom: 10px; }
+    .mauticform-error { margin-bottom: 10px; color: red; }
+    .mauticform-message { margin-bottom: 10px;color: green; }
+    .mauticform-row { display: block; margin-bottom: 20px; }
+    .mauticform-label { font-size: 1.1em; display: block; font-weight: bold; margin-bottom: 5px; }
+    .mauticform-row.mauticform-required .mauticform-label:after { color: #e32; content: " *"; display: inline; }
+    .mauticform-helpmessage { display: block; font-size: 0.9em; margin-bottom: 3px; }
+    .mauticform-errormsg { display: block; color: red; margin-top: 2px; }
+    .mauticform-selectbox, .mauticform-input, .mauticform-textarea { width: 100%; padding: 0.5em 0.5em; border: 1px solid #CCC; background: #fff; box-shadow: 0px 0px 0px #fff inset; box-sizing: border-box; }
+    .mauticform-checkboxgrp-row {}
+    .mauticform-checkboxgrp-label { font-weight: normal; }
+    .mauticform-checkboxgrp-checkbox {}
+    .mauticform-radiogrp-row {}
+    .mauticform-radiogrp-label { font-weight: normal; }
+    .mauticform-radiogrp-radio {}
+    .mauticform-button-wrapper .mauticform-button.btn-default { color: #fff;background-color: #4dbfbf;border-color: #4dbfbf;}
+    .mauticform-button-wrapper .mauticform-button { display: inline-block;margin-bottom: 0;font-weight: 600;text-align: center;vertical-align: middle;cursor: pointer;background-image: none;border: 1px solid transparent;white-space: nowrap;padding: 8px 16px;font-size: 18px;line-height: 1.3856;-webkit-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;}
+    .mauticform-button-wrapper .mauticform-button.btn-default[disabled] { background-color: #ffffff; border-color: #dddddd;}
+</style>

--- a/themes/oxygen/html/MauticFormBundle/Builder/style.html.twig
+++ b/themes/oxygen/html/MauticFormBundle/Builder/style.html.twig
@@ -1,0 +1,24 @@
+<style type="text/css" scoped>
+    .mauticform_wrapper { max-width: 600px; margin: 10px auto; font-family: Helvetica, Arial, sans-serif; color: #676767;}
+    .mauticform-innerform {}
+    .mauticform-post-success {}
+    .mauticform-name { font-weight: bold; font-size: 1.5em; margin-bottom: 3px; }
+    .mauticform-description { margin-top: 2px; margin-bottom: 10px; }
+    .mauticform-error { margin-bottom: 10px; color: red; }
+    .mauticform-message { margin-bottom: 10px;color: green; }
+    .mauticform-row { display: block; margin-bottom: 20px; }
+    .mauticform-label { font-size: 1.1em; display: block; font-weight: bold; margin-bottom: 5px; }
+    .mauticform-row.mauticform-required .mauticform-label:after { color: #e32; content: " *"; display: inline; }
+    .mauticform-helpmessage { display: block; font-size: 0.9em; margin-bottom: 3px; }
+    .mauticform-errormsg { display: block; color: red; margin-top: 2px; }
+    .mauticform-selectbox, .mauticform-input, .mauticform-textarea { width: 100%; padding: 0.5em 0.5em; border: 1px solid #CCC; background: #fff; box-shadow: 0px 0px 0px #fff inset; border-radius: 4px; box-sizing: border-box; }
+    .mauticform-checkboxgrp-row {}
+    .mauticform-checkboxgrp-label { font-weight: normal; }
+    .mauticform-checkboxgrp-checkbox {}
+    .mauticform-radiogrp-row {}
+    .mauticform-radiogrp-label { font-weight: normal; }
+    .mauticform-radiogrp-radio {}
+    .mauticform-button-wrapper .mauticform-button.btn-default { color: #5d6c7c;background-color: #ffffff;border-color: #dddddd;}
+    .mauticform-button-wrapper .mauticform-button { display: inline-block;margin-bottom: 0;font-weight: 600;text-align: center;vertical-align: middle;cursor: pointer;background-image: none;border: 1px solid transparent;white-space: nowrap;padding: 6px 12px;font-size: 13px;line-height: 1.3856;border-radius: 3px;-webkit-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;}
+    .mauticform-button-wrapper .mauticform-button.btn-default[disabled] { background-color: #ffffff; border-color: #dddddd;}
+</style>

--- a/themes/skyline/html/MauticFormBundle/Builder/style.html.twig
+++ b/themes/skyline/html/MauticFormBundle/Builder/style.html.twig
@@ -1,0 +1,24 @@
+<style type="text/css" scoped>
+    .mauticform_wrapper { max-width: 600px; margin: 10px auto; color: #6f6f6f; font-weight: 400; font-family: 'Source Sans Pro', 'Helvetica Neue', 'Arial', 'sans-serif';font-size: 18px;}
+    .mauticform-innerform {}
+    .mauticform-post-success {}
+    .mauticform-name { font-weight: bold; font-size: 1.5em; margin-bottom: 3px; }
+    .mauticform-description { margin-top: 2px; margin-bottom: 10px; }
+    .mauticform-error { margin-bottom: 10px; color: red; }
+    .mauticform-message { margin-bottom: 10px;color: green; }
+    .mauticform-row { display: block; margin-bottom: 20px; }
+    .mauticform-label { font-size: 1.1em; display: block; font-weight: bold; margin-bottom: 5px; color: #21c5ba; }
+    .mauticform-row.mauticform-required .mauticform-label:after { color: #e32; content: " *"; display: inline; }
+    .mauticform-helpmessage { display: block; font-size: 0.9em; margin-bottom: 3px; }
+    .mauticform-errormsg { display: block; color: red; margin-top: 2px; }
+    .mauticform-selectbox, .mauticform-input, .mauticform-textarea { width: 100%; padding: 0.5em 0.5em; border: 0; border-bottom: 1px solid #21c5ba; background: #fff; box-sizing: border-box; }
+    .mauticform-checkboxgrp-row {}
+    .mauticform-checkboxgrp-label { font-weight: normal; }
+    .mauticform-checkboxgrp-checkbox {}
+    .mauticform-radiogrp-row {}
+    .mauticform-radiogrp-label { font-weight: normal; }
+    .mauticform-radiogrp-radio {}
+    .mauticform-button-wrapper .mauticform-button.btn-default { color: #21c5ba;background-color: #ffffff;border-color: #21c5ba;}
+    .mauticform-button-wrapper .mauticform-button { display: inline-block;margin-bottom: 0;font-weight: 600;text-align: center;vertical-align: middle;cursor: pointer;background-image: none;border: 1px solid transparent;white-space: nowrap;padding: 6px 12px;font-size: 18px;line-height: 1.3856;-webkit-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;}
+    .mauticform-button-wrapper .mauticform-button.btn-default[disabled] { background-color: #ffffff; border-color: #dddddd;}
+</style>

--- a/themes/sunday/html/MauticFormBundle/Builder/style.html.twig
+++ b/themes/sunday/html/MauticFormBundle/Builder/style.html.twig
@@ -1,0 +1,24 @@
+<style type="text/css" scoped>
+    .mauticform_wrapper { max-width: 600px; margin: 10px auto; color: #6f6f6f; font-weight: 400; font-family: 'Source Sans Pro', 'Helvetica Neue', 'Arial', 'sans-serif';font-size: 18px;}
+    .mauticform-innerform {}
+    .mauticform-post-success {}
+    .mauticform-name { font-weight: bold; font-size: 1.5em; margin-bottom: 3px; }
+    .mauticform-description { margin-top: 2px; margin-bottom: 10px; }
+    .mauticform-error { margin-bottom: 10px; color: red; }
+    .mauticform-message { margin-bottom: 10px;color: green; }
+    .mauticform-row { display: block; margin-bottom: 20px; }
+    .mauticform-label { font-size: 1.1em; display: block; font-weight: bold; margin-bottom: 5px; }
+    .mauticform-row.mauticform-required .mauticform-label:after { color: #e32; content: " *"; display: inline; }
+    .mauticform-helpmessage { display: block; font-size: 0.9em; margin-bottom: 3px; }
+    .mauticform-errormsg { display: block; color: red; margin-top: 2px; }
+    .mauticform-selectbox, .mauticform-input, .mauticform-textarea { width: 100%; padding: 0.5em 0.5em; border: 1px solid #CCC; background: #fff; box-shadow: 0px 0px 0px #fff inset; border-radius: 4px; box-sizing: border-box; }
+    .mauticform-checkboxgrp-row {}
+    .mauticform-checkboxgrp-label { font-weight: normal; }
+    .mauticform-checkboxgrp-checkbox {}
+    .mauticform-radiogrp-row {}
+    .mauticform-radiogrp-label { font-weight: normal; }
+    .mauticform-radiogrp-radio {}
+    .mauticform-button-wrapper .mauticform-button.btn-default { color: #5d6c7c;background-color: #ffffff;border-color: #dddddd;}
+    .mauticform-button-wrapper .mauticform-button { display: inline-block;margin-bottom: 0;font-weight: 600;text-align: center;vertical-align: middle;cursor: pointer;background-image: none;border: 1px solid transparent;white-space: nowrap;padding: 6px 12px;font-size: 13px;line-height: 1.3856;border-radius: 3px;-webkit-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;}
+    .mauticform-button-wrapper .mauticform-button.btn-default[disabled] { background-color: #ffffff; border-color: #dddddd;}
+</style>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | Y
| Related user documentation PR URL | https://github.com/mautic/documentation/pull/85
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/30
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2096
| BC breaks? | Some embedded forms will be styled differently than till now. 
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
In the form edit form it is possible to select a theme of the form. But this theme styled only the form preview. If the form was embedded to a website via JS or other method, the theme styling was gone and only the default Mautic styles applied.

It isn't possible to use the styles from the form preview, because those styles are based on the full page HTML. But the embedded form cannot contain the `<head/>` because it could mess up the parent website. And iframe is not cool even though it's one option Mautic provides as an embed method.

So the solution this PR adds is the possibility to override the default __style.html.php__ file with custom CSS styles. Such styles were applied to those themes: coffee, neopolitan, oxygen, skyline, sunday.

#### Steps to test this PR:
1. Apply this PR.
2. Clear the cache.
3. Refresh the website with the form. - it should be styled. Check the font type, color. Some themes will have rounded corners, some not, some use different button styles.
4. Change the form theme, save and check if the form style changed in the website.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Embed a form with as many field types as possible to a 3rd party website.
2. Set "Show when value exists" to No for at least one field so your form HTML won't be cached and you'll be able to see the changes without re-saving the form.
3. Select some theme from the themes listed above for the form. Save it.
4. Refresh the website where the form is embedded. - The styles does not change.
