### PR TITLE
Fix #2410: Removed unnecessary output, which breaks setting cookies

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1161,7 +1161,6 @@ class EmailModel extends FormModel
                 $emailSettings[$eid]['limit'] = $count;
             }
         }
-        echo "\n\n";
 
         // Store stat entities
         $errors   = [];


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | #2410 
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Removed unnecessary output, which breaks setting cookies.
It looks completely useless, if the opposite - please let me know.

#### Steps to test this PR:
1. Apply PR.
2. Make sure the mentioned warnings stopped to appear in Mautic logs.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Wait until one of your contacts visits your site. You could do it yourself - just make sure to do it via incognito browser mode.
2. Another such message appears in Mautic logs.
