### PR TITLE
Escaped JS mauticLang strings to prevent UI breakdown for French and other languages

### DIFF
--- a/app/bundles/CoreBundle/Views/Default/script.html.php
+++ b/app/bundles/CoreBundle/Views/Default/script.html.php
@@ -16,11 +16,11 @@
     var mauticContent     = '<?php $view['slots']->output('mauticContent',''); ?>';
     var mauticEnv         = '<?php echo $app->getEnvironment(); ?>';
     var mauticLang        = {
-        chosenChooseOne: '<?php echo $view->escape($view['translator']->trans('mautic.core.form.chooseone')); ?>',
-        chosenChooseMore: '<?php echo $view->escape($view['translator']->trans('mautic.core.form.choosemultiple')); ?>',
-        chosenNoResults: '<?php echo $view->escape($view['translator']->trans('mautic.core.form.nomatches')); ?>',
-        pleaseWait: '<?php echo$view->escape($view['translator']->trans('mautic.core.wait')); ?>',
-        popupBlockerMessage: '<?php echo $view->escape($view['translator']->trans('mautic.core.popupblocked')); ?>',
+        chosenChooseOne: "<?php echo $view->escape($view['translator']->trans('mautic.core.form.chooseone')); ?>",
+        chosenChooseMore: "<?php echo $view->escape($view['translator']->trans('mautic.core.form.choosemultiple')); ?>",
+        chosenNoResults: "<?php echo $view->escape($view['translator']->trans('mautic.core.form.nomatches')); ?>",
+        pleaseWait: "<?php echo$view->escape($view['translator']->trans('mautic.core.wait')); ?>",
+        popupBlockerMessage: "<?php echo $view->escape($view['translator']->trans('mautic.core.popupblocked')); ?>",
     };
 </script>
 <?php $view['assets']->outputSystemScripts(true); ?>

--- a/app/bundles/CoreBundle/Views/Default/script.html.php
+++ b/app/bundles/CoreBundle/Views/Default/script.html.php
@@ -16,11 +16,11 @@
     var mauticContent     = '<?php $view['slots']->output('mauticContent',''); ?>';
     var mauticEnv         = '<?php echo $app->getEnvironment(); ?>';
     var mauticLang        = {
-        chosenChooseOne: '<?php echo $view['translator']->trans('mautic.core.form.chooseone'); ?>',
-        chosenChooseMore: '<?php echo $view['translator']->trans('mautic.core.form.choosemultiple'); ?>',
-        chosenNoResults: '<?php echo $view['translator']->trans('mautic.core.form.nomatches'); ?>',
-        pleaseWait: '<?php echo $view['translator']->trans('mautic.core.wait'); ?>',
-        popupBlockerMessage: '<?php echo $view['translator']->trans('mautic.core.popupblocked'); ?>',
+        chosenChooseOne: '<?php echo $view->escape($view['translator']->trans('mautic.core.form.chooseone')); ?>',
+        chosenChooseMore: '<?php echo $view->escape($view['translator']->trans('mautic.core.form.choosemultiple')); ?>',
+        chosenNoResults: '<?php echo $view->escape($view['translator']->trans('mautic.core.form.nomatches')); ?>',
+        pleaseWait: '<?php echo$view->escape($view['translator']->trans('mautic.core.wait')); ?>',
+        popupBlockerMessage: '<?php echo $view->escape($view['translator']->trans('mautic.core.popupblocked')); ?>',
     };
 </script>
 <?php $view['assets']->outputSystemScripts(true); ?>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | not reported that I know of
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When using the French translation, the single quote in the translated string breaks the javascript due to the single quote not being escaped and the use of single quotes for the language strings. This caused JS errors that prevent Mautic's UI from even functioning. This PR fixes this.

#### Steps to test this PR:
1. Configure Mautic to use the French language. 
2. Browse around Mautic and all should work. 
3. View browser console and there should be no errors.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Repeat the above before applying this PR
2. Mautic's UI will not work and there will be errors in the console
