### PR TITLE
Summarizing the total click of website links

### DIFF
--- a/app/bundles/PageBundle/Translations/en_US/messages.ini
+++ b/app/bundles/PageBundle/Translations/en_US/messages.ini
@@ -164,6 +164,7 @@ mautic.trackable.click_counts.none="There are no URLs currently being tracked fo
 mautic.trackable.click_track_id="Tracking ID"
 mautic.trackable.click_unique_count="Unique Clicks"
 mautic.trackable.click_url="URL"
+mautic.trackable.total_clicks="Total Clicks"
 
 mautic.config.tab.pagetracking="3rd party website tracking code"
 mautic.config.tab.pagetracking.info="Insert following code at the end of the web page before ending <code>&lt;body/&gt;</code> tag. Mautic Landing Pages are tracked automatically. Use this only to track 3rd party websites."

--- a/app/bundles/PageBundle/Views/Trackable/click_counts.html.php
+++ b/app/bundles/PageBundle/Views/Trackable/click_counts.html.php
@@ -13,26 +13,25 @@
                 <?php 
                     $totalClicks = 0;
                     $totalUniqueClicks = 0;
-                    foreach ($trackables as $link):
-                            $totalClicks +=  $link['hits'];
-                            $totalUniqueClicks +=  $link['unique_hits'];
-                    endforeach;
-                ?>
+                    foreach ($trackables as $link): 
+                        $totalClicks +=  $link['hits'];
+                        $totalUniqueClicks +=  $link['unique_hits'];
+                        ?>
+                        <tr>
+                            <td class="long-text"><a href="<?php echo $link['url']; ?>"><?php echo $link['url']; ?></a></td>
+                            <td class="text-center"><?php echo $link['hits']; ?></td>
+                            <td class="text-center"><?php echo $link['unique_hits']; ?></td>
+                            <td><?php echo $link['redirect_id']; ?></td>
+                        </tr>
+                <?php endforeach; ?>
+
                 <tr>
-                    <td class="long-text">Total Clicks</td>
+                    <td class="long-text"><?php echo $view['translator']->trans('mautic.trackable.total_clicks'); ?></td>
                     <td class="text-center"><?php echo $totalClicks; ?></td>
                     <td class="text-center"><?php echo $totalUniqueClicks; ?></td>
                     <td></td>
                 </tr>
-                
-                <?php foreach ($trackables as $link): ?>
-                    <tr>
-                        <td class="long-text"><a href="<?php echo $link['url']; ?>"><?php echo $link['url']; ?></a></td>
-                        <td class="text-center"><?php echo $link['hits']; ?></td>
-                        <td class="text-center"><?php echo $link['unique_hits']; ?></td>
-                        <td><?php echo $link['redirect_id']; ?></td>
-                    </tr>
-                <?php endforeach; ?>
+
             </tbody>
         </table>
     </div>

--- a/app/bundles/PageBundle/Views/Trackable/click_counts.html.php
+++ b/app/bundles/PageBundle/Views/Trackable/click_counts.html.php
@@ -10,14 +10,29 @@
             </tr>
             </thead>
             <tbody>
-            <?php foreach ($trackables as $link): ?>
+                <?php 
+                    $totalClicks = 0;
+                    $totalUniqueClicks = 0;
+                    foreach ($trackables as $link):
+                            $totalClicks +=  $link['hits'];
+                            $totalUniqueClicks +=  $link['unique_hits'];
+                    endforeach;
+                ?>
                 <tr>
-                    <td class="long-text"><a href="<?php echo $link['url']; ?>"><?php echo $link['url']; ?></a></td>
-                    <td class="text-center"><?php echo $link['hits']; ?></td>
-                    <td class="text-center"><?php echo $link['unique_hits']; ?></td>
-                    <td><?php echo $link['redirect_id']; ?></td>
+                    <td class="long-text">Total Clicks</td>
+                    <td class="text-center"><?php echo $totalClicks; ?></td>
+                    <td class="text-center"><?php echo $totalUniqueClicks; ?></td>
+                    <td></td>
                 </tr>
-            <?php endforeach; ?>
+                
+                <?php foreach ($trackables as $link): ?>
+                    <tr>
+                        <td class="long-text"><a href="<?php echo $link['url']; ?>"><?php echo $link['url']; ?></a></td>
+                        <td class="text-center"><?php echo $link['hits']; ?></td>
+                        <td class="text-center"><?php echo $link['unique_hits']; ?></td>
+                        <td><?php echo $link['redirect_id']; ?></td>
+                    </tr>
+                <?php endforeach; ?>
             </tbody>
         </table>
     </div>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | No
| New feature? | Yes
| Related user documentation PR URL |  https://github.com/mautic/documentation/pull/95
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | NA
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Here we are summarizing click statistics in each email

#### Steps to test this PR:
1.  Select Email from the Channel menu
2.  Select any one of the email's detail view
3. At the bottom of the page, we will have a click count table for each links in that email
4. The new feature is, now we can see a total clicks column which displays the sum of all the clicks 
 
[//]: # ( As applicable: )

