### PR TITLE
Froala useClasses option removed, imageOutputSize only for emails

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -283,8 +283,6 @@ var Mautic = {
             imageUploadURL: mauticBaseUrl + 's/file/upload',
             imageManagerLoadURL: mauticBaseUrl + 's/file/list',
             imageManagerDeleteURL: mauticBaseUrl + 's/file/delete',
-            useClasses: false,
-            imageOutputSize: true,
             htmlAllowedTags: ['a', 'abbr', 'address', 'area', 'article', 'aside', 'audio', 'b', 'base', 'bdi', 'bdo', 'blockquote', 'br', 'button', 'canvas', 'caption', 'cite', 'code', 'col', 'colgroup', 'datalist', 'dd', 'del', 'details', 'dfn', 'dialog', 'div', 'dl', 'dt', 'em', 'embed', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hgroup', 'hr', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'keygen', 'label', 'legend', 'li', 'link', 'main', 'map', 'mark', 'menu', 'menuitem', 'meter', 'nav', 'noscript', 'object', 'ol', 'optgroup', 'option', 'output', 'p', 'param', 'pre', 'progress', 'queue', 'rp', 'rt', 'ruby', 's', 'samp', 'script', 'style', 'section', 'select', 'small', 'source', 'span', 'strike', 'strong', 'sub', 'summary', 'sup', 'table', 'tbody', 'td', 'textarea', 'tfoot', 'th', 'thead', 'time', 'title', 'tr', 'track', 'u', 'ul', 'var', 'video', 'wbr', 'center'],
             htmlAllowedAttrs: ['data-atwho-at-query', 'data-section', 'data-section-wrapper', 'accept', 'accept-charset', 'accesskey', 'action', 'align', 'allowfullscreen', 'alt', 'async', 'autocomplete', 'autofocus', 'autoplay', 'autosave', 'background', 'bgcolor', 'border', 'charset', 'cellpadding', 'cellspacing', 'checked', 'cite', 'class', 'color', 'cols', 'colspan', 'content', 'contenteditable', 'contextmenu', 'controls', 'coords', 'data', 'data-.*', 'datetime', 'default', 'defer', 'dir', 'dirname', 'disabled', 'download', 'draggable', 'dropzone', 'enctype', 'for', 'form', 'formaction', 'frameborder', 'headers', 'height', 'hidden', 'high', 'href', 'hreflang', 'http-equiv', 'icon', 'id', 'ismap', 'itemprop', 'keytype', 'kind', 'label', 'lang', 'language', 'list', 'loop', 'low', 'max', 'maxlength', 'media', 'method', 'min', 'mozallowfullscreen', 'multiple', 'name', 'novalidate', 'open', 'optimum', 'pattern', 'ping', 'placeholder', 'poster', 'preload', 'pubdate', 'radiogroup', 'readonly', 'rel', 'required', 'reversed', 'rows', 'rowspan', 'sandbox', 'scope', 'scoped', 'scrolling', 'seamless', 'selected', 'shape', 'size', 'sizes', 'span', 'src', 'srcdoc', 'srclang', 'srcset', 'start', 'step', 'summary', 'spellcheck', 'style', 'tabindex', 'target', 'title', 'type', 'translate', 'usemap', 'value', 'valign', 'webkitallowfullscreen', 'width', 'wrap']
         };
@@ -587,6 +585,10 @@ var Mautic = {
                         options.lineBreakerTags = [];
                     }
 
+                    if (textarea.hasClass('editor-email')) {
+                        options.imageOutputSize = true;
+                    }
+                    
                     textarea.on('froalaEditor.focus', function (e, editor) {
                         Mautic.showChangeThemeWarning = true;
                     });

--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -584,7 +584,7 @@ var Mautic = {
                         options.htmlRemoveTags = [];
                         options.lineBreakerTags = [];
                     }
-                    
+
                     textarea.on('froalaEditor.focus', function (e, editor) {
                         Mautic.showChangeThemeWarning = true;
                     });

--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -584,10 +584,6 @@ var Mautic = {
                         options.htmlRemoveTags = [];
                         options.lineBreakerTags = [];
                     }
-
-                    if (textarea.hasClass('editor-email')) {
-                        options.imageOutputSize = true;
-                    }
                     
                     textarea.on('froalaEditor.focus', function (e, editor) {
                         Mautic.showChangeThemeWarning = true;

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -520,7 +520,6 @@ Mautic.initSlotListeners = function() {
                 toolbarButtonsSM: buttons,
                 toolbarButtonsXS: buttons,
                 linkList: [], // TODO push here the list of tokens from Mautic.getPredefinedLinks
-                useClasses: false,
                 imageEditButtons: ['imageReplace', 'imageAlign', 'imageRemove', 'imageAlt', 'imageSize', '|', 'imageLink', 'linkOpen', 'linkEdit', 'linkRemove']
             };
 
@@ -533,7 +532,6 @@ Mautic.initSlotListeners = function() {
             // Init Froala editor
             image.froalaEditor(mQuery.extend(Mautic.basicFroalaOptions, {
                     linkList: [], // TODO push here the list of tokens from Mautic.getPredefinedLinks
-                    useClasses: false,
                     imageEditButtons: ['imageReplace', 'imageAlign', 'imageAlt', 'imageSize', '|', 'imageLink', 'linkOpen', 'linkEdit', 'linkRemove']
                 }
             ));


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2421
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR:

a) removes [useClasses: false](https://www.froala.com/wysiwyg-editor/docs/options#useClasses) option which is [recommended by Froala](https://www.froala.com/blog/styling-emails-with-wysiwyg-html-editors) to use for email editors. But it was modifying themes too much. For example if you try to use this theme:

Testing theme: [useclasses.zip](https://github.com/mautic/mautic/files/452168/useclasses.zip)

For a landing page, after Save&Close it's destroyed.

b) The linked issue suggests to use the [imageOutputSize: true](https://www.froala.com/wysiwyg-editor/docs/options#imageOutputSize) option only for emails because it is not needed for other content. So this PR does just that.
This option was [suggested by Mautic users](https://github.com/mautic/mautic/issues/1959#issuecomment-234005971) and the width and height parameters are needed for Outlook to display images properly. But https://github.com/mautic/mautic/issues/2455 suggests to remove it completely so he could use percentage as image width to make it responsive. Well, let's open a discussion about this one. Should we remove this option completely?

#### Steps to test this PR:
1. Apply this PR or copy-paste the changes to your Mautic.
2. Use the dev mode or run `app/console mautic:assets:generate` command to regenerate the assets.
3. Test again the points 3 and 4 - the landing page should be OK now. If you check the images, they don't have the width and height parameters.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Download the theme above.
2. Install the theme.
3. Build a page from this theme.
4. Save&Close and preview it. The style should be just wrong and when you inspect the code, all the block elements has bunch of inline styles which weren't there originally. If you check the images, they have the width and height parameters.