### PR TITLE
Added DoNotContact API Endpoint, for viewing, setting and removing DN…

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -68,6 +68,15 @@ return [
                 'path'       => '/contacts',
                 'controller' => 'MauticLeadBundle:Api\LeadApi:getEntities'
             ],
+            'mautic_api_getdonotcontact'   => array(
+                'path'       => '/contacts/{id}/donotcontact',
+                'controller' => 'MauticLeadBundle:Api\LeadApi:getDoNotEmail'
+            ),
+            'mautic_api_editdonotcontact'  => array(
+                'path'       => '/contacts/{id}/donotcontact',
+                'controller' => 'MauticLeadBundle:Api\LeadApi:editDoNotEmail',
+                'method'     => 'POST'
+            ),
             'mautic_api_newcontact'           => [
                 'path'       => '/contacts/new',
                 'controller' => 'MauticLeadBundle:Api\LeadApi:newEntity',

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -205,6 +205,106 @@ class LeadApiController extends CommonApiController
     }
 
     /**
+     * Obtains DonotContact status on a specific Contact
+     *
+     * @param $id
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function getDoNotEmailAction($id)
+    {
+        $entity = $this->model->getEntity($id);
+        if ($entity !== null) {
+            if (!$this->factory->getSecurity()->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother', $entity->getOwner())) {
+                return $this->accessDenied();
+            }
+            $doNotEmailStatus = $this->factory->getEntityManager()->getRepository('MauticLeadBundle:Lead')->getDoNotEmail($id);
+            list($doNots, $count) = $this->prepareEntitiesForView($doNotEmailStatus);
+            if (!empty($doNotEmailStatus)){
+                $view = $this->view(
+                    array(
+
+                        'doNotContactStatus' => $doNotEmailStatus
+
+                    ),
+                    Codes::HTTP_OK
+                );
+            }
+            else
+            {
+                $doNotEmailStatus = array(
+                                         );
+                $view = $this->view(
+                    array(
+
+                        'doNotContactStatus' => $doNotEmailStatus
+
+                    ),
+                    Codes::HTTP_OK
+                );
+            }
+
+            $context = SerializationContext::create()->setGroups(array('leadNoteDetails'));
+            $view->setSerializationContext($context);
+
+            return $this->handleView($view);
+        }
+
+        return $this->notFound();
+    }
+
+    /**
+     * sets  DonotContact status on a specific Contact
+
+     *
+     * @param $id
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function editDoNotEmailAction($id)
+    {
+        $entity = $this->model->getEntity($id);
+        $parameters = $this->request->request->all();
+        if ($entity !== null) {
+            if (!$this->factory->getSecurity()->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother', $entity->getOwner())) {
+                return $this->accessDenied();
+            }
+            $currentStatus = $this->factory->getEntityManager()->getRepository('MauticLeadBundle:Lead')->getDoNotEmail($id);
+
+            if ($currentStatus){
+                $this->model->removeDncForLead($entity, $parameters['channel']);
+            }
+            else{
+                $this->model->addDncForLead($entity, $parameters['channel'], $parameters['comments'], $parameters['reason']);
+            }
+
+            $doNotEmailStatus = $this->factory->getEntityManager()->getRepository('MauticLeadBundle:Lead')->getDoNotEmail($id);
+            if (empty($doNotEmailStatus)){
+
+                $doNotEmailStatus = array(
+                                         );
+            }
+
+            list($doNots, $count) = $this->prepareEntitiesForView($doNotEmailStatus);
+            $view = $this->view(
+                array(
+
+                    'doNotContactStatus' => $doNotEmailStatus
+
+                ),
+                Codes::HTTP_OK
+            );
+
+            $context = SerializationContext::create()->setGroups(array('leadNoteDetails'));
+            $view->setSerializationContext($context);
+
+            return $this->handleView($view);
+        }
+
+        return $this->notFound();
+    }
+
+    /**
      * Obtains a list of lead lists the lead is in
      *
      * @param $id

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -937,4 +937,22 @@ class LeadRepository extends CommonRepository
 
         return $result;
     }
+
+    /**
+     * Gets Do Not Contact Status for Specified Contact
+     *
+     * @param  integer $id
+     *
+     * @return array|false
+     */
+    public function getDoNotEmail($id)
+    {
+        $q = $this->_em->getConnection()->createQueryBuilder();
+        $q->select('date_added','reason','channel','channel_id','comments')
+            ->from(MAUTIC_TABLE_PREFIX.'lead_donotcontact', 'e')
+            ->where('lead_id = :id')
+            ->setParameter('id', $id);
+        $results = $q->execute()->fetchAll();
+        return $results;
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | No |
| New feature? | Yes |
| Related user documentation PR URL |  |
| Related developer documentation PR URL |  |
| Issues addressed (#s or URLs) | #770 #1826 |
| BC breaks? |  |
| Deprecations? |  |
#### Description:

This PR will add API Endpoint for DoNotContact. For viewing,setting and removing for a Contact.
#### Steps to test this PR:
1. use api endpoint /api/contacts/{id}/donotcontact
2. get request will give you the status. if empty means no do not contact status for the contact.
3. post will give you the ability to set DNC. if DNC present on contact it will remove the DNC. if not it will add the DNC.
   Parameters:

```
"date_added" : "2016-09-03 15:36:57"
"reason" : 3 
"channel" : "Email"
"comments" : "User unsubscribed"
```

Reason can be 1 or 2 or 3 for unsubscribe, bounce and manual.