### PR TITLE
HTML attributes in the Oxygen theme caused JS error - fix

### DIFF
--- a/themes/oxygen/html/email.html.twig
+++ b/themes/oxygen/html/email.html.twig
@@ -1,11 +1,12 @@
+<!DOCTYPE html>
 <html>
     <head>
         <title>{subject}</title>
     </head>
-    <body style="font-family: 'Oxygen', 'Helvetica Neue', 'Arial', 'sans-serif' !important;-webkit-font-smoothing: antialiased;-webkit-text-size-adjust: none;height: 100%;color: #676767;width: 100% !important;margin: 0 !important;">
-        <div data-section-wrapper align="center" valign="top" width="100%" style="background-color: #f7f7f7;font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 20px 0 30px;" class="content-padding">
+    <body style="font-family: Helvetica, Arial, sans-serif;color: #676767;width: 100%;margin: 0;">
+        <div data-section-wrapper style="width:100%;background-color: #f7f7f7;font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;padding: 20px 0 30px;" class="content-padding">
             <center>
-                <table data-section cellspacing="0" cellpadding="0" width="600" class="w320" style="border-collapse: collapse !important;">
+                <table data-section cellspacing="0" cellpadding="0" width="600" class="w320" style="border-collapse: collapse;">
                     <tr>
                         <td class="header-lg" data-slot-container style="font-family: Helvetica, Arial, sans-serif;font-size: 32px;color: #4d4d4d;text-align: center;line-height: normal;border-collapse: collapse;font-weight: 700;padding: 35px 0 0;">
                             <div data-slot="text">
@@ -14,22 +15,22 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="free-text" data-slot-container style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 10px 60px 0px;width: 100% !important;">
+                        <td class="free-text" data-slot-container style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 10px 60px 0px 60px;width: 100%;">
                             <div data-slot="text">
-                                <span><a href="" style="color: #ff6f6f;font-weight: bold;text-decoration: none !important;">@JaneDoe</a></span> has invited you to join Awesome inc!
+                                <span><a href="" style="color: #ff6f6f;font-weight: bold;text-decoration: none;">@JaneDoe</a></span> has invited you to join Awesome inc!
                             </div>
                         </td>
                     </tr>
                     <tr>
                         <td class="mini-block-container" style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 30px 50px;width: 500px;">
-                            <table cellspacing="0" cellpadding="0" width="100%" style="border-collapse:separate !important;">
+                            <table cellspacing="0" cellpadding="0" width="100%" style="border-collapse:separate;">
                                 <tr>
                                     <td class="mini-block" data-slot-container style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;background-color: #ffffff;width: 498px;border: 1px solid #cccccc;border-radius: 5px;padding: 45px 75px;">
                                         <div class="user-img" data-slot="text" style="text-align: center;border-radius: 100px;color: #ff6f6f;font-weight: 700;">
-                                            <a href="" style="color: #ff6f6f;font-weight: bold;text-decoration: none !important;"><img class="user-img" src="{{ getAssetUrl('themes/'~template~'/img/profile_pic.jpg', null, null, true) }}" alt="user img" style="max-width: 600px;outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;border: 1px solid #cccccc;text-align: center;border-radius: 5px;color: #ff6f6f;font-weight: 700;width: 130px;"></a>
-                                            <br><a href="" style="color: #ff6f6f;font-weight: bold;text-decoration: none !important;">@JaneDoe</a>
+                                            <a href="" style="color: #ff6f6f;font-weight: bold;text-decoration: none;"><img class="user-img" src="{{ getAssetUrl('themes/'~template~'/img/profile_pic.jpg', null, null, true) }}" alt="user img" style="max-width: 600px;outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;border: 1px solid #cccccc;text-align: center;border-radius: 5px;color: #ff6f6f;font-weight: 700;width: 130px;"></a>
+                                            <br><a href="" style="color: #ff6f6f;font-weight: bold;text-decoration: none;">@JaneDoe</a>
                                         </div>
-                                        <div class="user-msg" data-slot="text" style="padding: 10px 0;font-size: 14px;text-align: center;font-style: italic;">
+                                        <div class="user-msg" data-slot="text" style="padding: 10px 0px;font-size: 14px;text-align: center;font-style: italic;">
                                             "Hey Bob,
                                             here's your invite! Come check out my profile page when you have a chance. You'll love it!"
                                         </div>
@@ -47,23 +48,23 @@
                 </table>
             </center>
         </div>
-        <div data-section-wrapper align="center" valign="top" width="100%" style="background-color: #ffffff;border-top: 1px solid #e5e5e5;border-bottom: 1px solid #e5e5e5;font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;">
+        <div data-section-wrapper style="width:100%; background-color: #ffffff;border-top: 1px solid #e5e5e5;border-bottom: 1px solid #e5e5e5;font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;">
             <center>
-                <table data-section cellpadding="0" cellspacing="0" width="600" class="w320" style="border-collapse: collapse !important;">
+                <table data-section cellpadding="0" cellspacing="0" width="600" class="w320" style="border-collapse: collapse;">
                     <tr>
-                        <td class="header-md" data-slot-container style="font-family: Helvetica, Arial, sans-serif;font-size: 24px;color: #4d4d4d;text-align: center;line-height: normal;border-collapse: collapse;font-weight: 700;padding: 35px 0 0;">
+                        <td class="header-md" data-slot-container style="font-family: Helvetica, Arial, sans-serif;font-size: 24px;color: #4d4d4d;text-align: center;line-height: normal;border-collapse: collapse;font-weight: 700;padding: 35px 0px 0px 0px;">
                             <div data-slot="text">
                                 Come check us out!
                             </div>
                         </td>
                     </tr>
                     <tr>
-                        <td class="mini-imgs" style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 25px 0 30px;" data-slot-container>
+                        <td class="mini-imgs" style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 25px 0px 30px 0px;" data-slot-container>
                             <div data-slot="text">
-                            <table cellpadding="0" cellspacing="0" width="0" style="border-collapse:separate !important;">
+                            <table cellpadding="0" cellspacing="0" width="0" style="border-collapse:separate;">
                                 <tr>
                                     <td class="mobile-block" style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;">
-                                        <table cellspacing="0" cellpadding="0" width="100%" style="border-collapse:separate !important;">
+                                        <table cellspacing="0" cellpadding="0" width="100%" style="border-collapse:separate;">
                                             <tr>
                                                 <td class="mini-img" style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 3px;width: 130px;">
                                                     <img src="{{ getAssetUrl('themes/'~template~'/img/bracelet.jpg', null, null, true) }}" alt="product" style="max-width: 600px;outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;border-radius: 3px;width: 130px;">
@@ -83,7 +84,7 @@
                                         </table>
                                     </td>
                                     <td class="mobile-block" style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;">
-                                        <table cellspacing="0" cellpadding="0" width="100%" style="border-collapse:separate !important;">
+                                        <table cellspacing="0" cellpadding="0" width="100%" style="border-collapse:separate;">
                                             <tr>
                                                 <td class="mini-img" style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 3px;width: 130px;">
                                                     <img src="{{ getAssetUrl('themes/'~template~'/img/shoes.jpg', null, null, true) }}" alt="product" style="max-width: 600px;outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;border-radius: 3px;width: 130px;">
@@ -110,9 +111,9 @@
                 </table>
             </center>
         </div>
-        <div data-section-wrapper align="center" valign="top" width="100%" style="background-color: #f7f7f7;font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;">
+        <div data-section-wrapper style="width:100%; background-color: #f7f7f7;font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;">
             <center>
-                <table data-section cellspacing="0" cellpadding="0" width="600" class="w320" style="border-collapse: collapse !important;">
+                <table data-section cellspacing="0" cellpadding="0" width="600" class="w320" style="border-collapse: collapse;">
                     <tr>
                         <td style="padding: 25px 0 25px;font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;" data-slot-container>
                             <div data-slot="text">

--- a/themes/oxygen/html/page.html.twig
+++ b/themes/oxygen/html/page.html.twig
@@ -1,9 +1,9 @@
 {% extends ":"~template~":base.html.twig" %}
 
 {% block content %}
-<div data-section-wrapper align="center" valign="top" width="100%" style="background-color: #f7f7f7;font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 20px 0 30px;" class="content-padding">
+<div data-section-wrapper style="width:100%;background-color: #f7f7f7;font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 20px 0 30px;" class="content-padding">
     <center>
-        <table data-section cellspacing="0" cellpadding="0" width="600" class="w320" style="border-collapse: collapse !important;">
+        <table data-section cellspacing="0" cellpadding="0" width="600" class="w320" style="border-collapse: collapse;">
             <tr>
                 <td class="header-lg" data-slot-container style="font-family: Helvetica, Arial, sans-serif;font-size: 32px;color: #4d4d4d;text-align: center;line-height: normal;border-collapse: collapse;font-weight: 700;padding: 35px 0 0;">
                     <div data-slot="text">
@@ -12,20 +12,20 @@
                 </td>
             </tr>
             <tr>
-                <td class="free-text" data-slot-container style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 10px 60px 0px;width: 100% !important;">
+                <td class="free-text" data-slot-container style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 10px 60px 0px;width: 100%;">
                     <div data-slot="text">
-                        <span><a href="" style="color: #ff6f6f;font-weight: bold;text-decoration: none !important;">@JaneDoe</a></span> has invited you to join Awesome inc!
+                        <span><a href="" style="color: #ff6f6f;font-weight: bold;text-decoration: none;">@JaneDoe</a></span> has invited you to join Awesome inc!
                     </div>
                 </td>
             </tr>
             <tr>
                 <td class="mini-block-container" style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 30px 50px;width: 500px;">
-                    <table cellspacing="0" cellpadding="0" width="100%" style="border-collapse:separate !important;">
+                    <table cellspacing="0" cellpadding="0" width="100%" style="border-collapse:separate;">
                         <tr>
                             <td class="mini-block" data-slot-container style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;background-color: #ffffff;width: 498px;border: 1px solid #cccccc;border-radius: 5px;padding: 45px 75px;">
                                 <div class="user-img" data-slot="text" style="text-align: center;border-radius: 100px;color: #ff6f6f;font-weight: 700;">
-                                    <a href="" style="color: #ff6f6f;font-weight: bold;text-decoration: none !important;"><img class="user-img" src="{{ getAssetUrl('themes/'~template~'/img/profile_pic.jpg', null, null, true) }}" alt="user img" style="max-width: 600px;outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;border: 1px solid #cccccc;text-align: center;border-radius: 5px;color: #ff6f6f;font-weight: 700;width: 130px;"></a>
-                                    <br><a href="" style="color: #ff6f6f;font-weight: bold;text-decoration: none !important;">@JaneDoe</a>
+                                    <a href="" style="color: #ff6f6f;font-weight: bold;text-decoration: none;"><img class="user-img" src="{{ getAssetUrl('themes/'~template~'/img/profile_pic.jpg', null, null, true) }}" alt="user img" style="max-width: 600px;outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;border: 1px solid #cccccc;text-align: center;border-radius: 5px;color: #ff6f6f;font-weight: 700;width: 130px;"></a>
+                                    <br><a href="" style="color: #ff6f6f;font-weight: bold;text-decoration: none;">@JaneDoe</a>
                                 </div>
                                 <div class="user-msg" data-slot="text" style="padding: 10px 0;font-size: 14px;text-align: center;font-style: italic;">
                                     "Hey Bob,
@@ -45,9 +45,9 @@
         </table>
     </center>
 </div>
-<div data-section-wrapper align="center" valign="top" width="100%" style="background-color: #ffffff;border-top: 1px solid #e5e5e5;border-bottom: 1px solid #e5e5e5;font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;">
+<div data-section-wrapper style="width:100%;background-color: #ffffff;border-top: 1px solid #e5e5e5;border-bottom: 1px solid #e5e5e5;font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;">
     <center>
-        <table data-section cellpadding="0" cellspacing="0" width="600" class="w320" style="border-collapse: collapse !important;">
+        <table data-section cellpadding="0" cellspacing="0" width="600" class="w320" style="border-collapse: collapse;">
             <tr>
                 <td class="header-md" data-slot-container style="font-family: Helvetica, Arial, sans-serif;font-size: 24px;color: #4d4d4d;text-align: center;line-height: normal;border-collapse: collapse;font-weight: 700;padding: 35px 0 0;">
                     <div data-slot="text">
@@ -58,10 +58,10 @@
             <tr>
                 <td class="mini-imgs" style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 25px 0 30px;" data-slot-container>
                     <div data-slot="text">
-                    <table cellpadding="0" cellspacing="0" width="0" style="border-collapse:separate !important;">
+                    <table cellpadding="0" cellspacing="0" width="0" style="border-collapse:separate;margin: 0 auto;">
                         <tr>
                             <td class="mobile-block" style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;">
-                                <table cellspacing="0" cellpadding="0" width="100%" style="border-collapse:separate !important;">
+                                <table cellspacing="0" cellpadding="0" width="100%" style="border-collapse:separate;">
                                     <tr>
                                         <td class="mini-img" style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 3px;width: 130px;">
                                             <img src="{{ getAssetUrl('themes/'~template~'/img/bracelet.jpg', null, null, true) }}" alt="product" style="max-width: 600px;outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;border-radius: 3px;width: 130px;">
@@ -81,7 +81,7 @@
                                 </table>
                             </td>
                             <td class="mobile-block" style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;">
-                                <table cellspacing="0" cellpadding="0" width="100%" style="border-collapse:separate !important;">
+                                <table cellspacing="0" cellpadding="0" width="100%" style="border-collapse:separate;">
                                     <tr>
                                         <td class="mini-img" style="font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;padding: 3px;width: 130px;">
                                             <img src="{{ getAssetUrl('themes/'~template~'/img/shoes.jpg', null, null, true) }}" alt="product" style="max-width: 600px;outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;border-radius: 3px;width: 130px;">
@@ -108,9 +108,9 @@
         </table>
     </center>
 </div>
-<div data-section-wrapper align="center" valign="top" width="100%" style="background-color: #f7f7f7;font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;">
+<div data-section-wrapper style="width:100%;background-color: #f7f7f7;font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;">
     <center>
-        <table data-section cellspacing="0" cellpadding="0" width="600" class="w320" style="border-collapse: collapse !important;">
+        <table data-section cellspacing="0" cellpadding="0" width="600" class="w320" style="border-collapse: collapse;">
             <tr>
                 <td style="padding: 25px 0 25px;font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;border-collapse: collapse;" data-slot-container>
                     <div data-slot="text">


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2436
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
`!important`, `-webkit-font-smoothing` and `'Oxygen', 'Helvetica Neue', 'Arial', 'sans-serif'` attributes caused JS errors when editing an email based on the Oxygen theme.

Those can be removed, because
- `!important` - not really important when used in an inline style.
- `-webkit-font-smoothing` - Probably not supported by most of the email clients
- `'Oxygen'` - external fong was not loaded anyway
- `'Oxygen', 'Helvetica Neue', 'Arial', 'sans-serif'` changed to font names without apostrophes.

This PR contains more small fixes to the Oxygen theme markup I noticed when fixing the bug.

#### Steps to test this PR:
1. Apply the PR
2. Test again - the editor is loaded and you can edit it.
3. Make sure the Oxygen email and page theme still looks good.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. create new email
2. select oxygen template and add a character to the headline
3. Save and Close
4. open again for editing - the editor won't even load.

