### PR TITLE
Add contact owner to contact view page

### DIFF
--- a/app/bundles/LeadBundle/Views/Lead/lead.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/lead.html.php
@@ -445,6 +445,9 @@ $view['slots']->set(
                 </div>
             </div>
             <div class="panel-body pt-sm">
+                <h6 class="fw-sb"><?php echo $view['translator']->trans('mautic.lead.lead.field.owner'); ?></h6>
+                <p class="text-muted"><?php echo $lead->getOwner()->getName(); ?></p>
+
                 <h6 class="fw-sb">
                     <?php echo $view['translator']->trans('mautic.lead.field.address'); ?>
                 </h6>


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | No
| New feature? | Barely
| Related user documentation PR URL | None
| Related developer documentation PR URL | None
| Issues addressed (#s or URLs) | None found
| BC breaks? | No
| Deprecations? | No

#### Description:

This PR adds the contact owner to the contact view page

![image](https://cloud.githubusercontent.com/assets/18265735/18317849/a8287628-751f-11e6-95df-20a72f5038a0.png)

#### Steps to test this PR:
1. Apply the PR
2. View a contact
3. See the contact owner