### PR TITLE
Add support for javascript-based translations.

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -181,6 +181,31 @@ var Mautic = {
     },
 
     /**
+     * Translations
+     *
+     * @param id     string
+     * @param params object
+     */
+    translate: function (id, params) {
+        if (!mauticLang.hasOwnProperty(id)) {
+            return id;
+        }
+
+        var translated = mauticLang[id];
+
+        if (params) {
+            for (var key in params) {
+                if (!params.hasOwnProperty(key)) continue;
+
+                var regEx = new RegExp('%' + key + '%', 'g');
+                translated = translated.replace(regEx, params[key])
+            }
+        }
+
+        return translated;
+    },
+
+    /**
      * Setups browser notifications
      */
     setupBrowserNotifier: function () {

--- a/app/bundles/CoreBundle/Templating/Helper/TranslatorHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/TranslatorHelper.php
@@ -46,4 +46,23 @@ class TranslatorHelper extends BaseHelper
     {
         return $this->translator->transConditional($preferred, $alternative, $parameters, $domain, $locale);
     }
+
+    public function getJsLang()
+    {
+        $this->translator->addResource('mautic', null, $this->translator->getLocale(), 'javascript');
+
+        $messages = $this->translator->getMessages();
+
+        $oldKeys = [
+            "chosenChooseOne" => $this->trans('mautic.core.form.chooseone'),
+            "chosenChooseMore" => $this->trans('mautic.core.form.choosemultiple'),
+            "chosenNoResults" => $this->trans('mautic.core.form.nomatches'),
+            "pleaseWait" => $this->trans('mautic.core.wait'),
+            "popupBlockerMessage" => $this->trans('mautic.core.popupblocked')
+        ];
+
+        $jsLang = array_merge($messages['javascript'], $oldKeys);
+
+        return json_encode($jsLang, JSON_PRETTY_PRINT|JSON_FORCE_OBJECT);
+    }
 }

--- a/app/bundles/CoreBundle/Translations/en_US/javascript.ini
+++ b/app/bundles/CoreBundle/Translations/en_US/javascript.ini
@@ -1,0 +1,6 @@
+mautic.core.dynamicContent="Dynamic Content"
+mautic.core.dynamicContent.new="Dynamic Content %number%"
+mautic.core.dynamicContent.token_name="Name"
+mautic.core.dynamicContent.tab="Variation %number%"
+mautic.core.dynamicContent.default_content="Default Content"
+mautic.core.dynamicContent.alt_content="Content"

--- a/app/bundles/CoreBundle/Views/Default/script.html.php
+++ b/app/bundles/CoreBundle/Views/Default/script.html.php
@@ -15,12 +15,6 @@
     var mauticAssetPrefix = '<?php echo $view['assets']->getAssetPrefix(true); ?>';
     var mauticContent     = '<?php $view['slots']->output('mauticContent',''); ?>';
     var mauticEnv         = '<?php echo $app->getEnvironment(); ?>';
-    var mauticLang        = {
-        chosenChooseOne: '<?php echo $view['translator']->trans('mautic.core.form.chooseone'); ?>',
-        chosenChooseMore: '<?php echo $view['translator']->trans('mautic.core.form.choosemultiple'); ?>',
-        chosenNoResults: '<?php echo $view['translator']->trans('mautic.core.form.nomatches'); ?>',
-        pleaseWait: '<?php echo $view['translator']->trans('mautic.core.wait'); ?>',
-        popupBlockerMessage: '<?php echo $view['translator']->trans('mautic.core.popupblocked'); ?>',
-    };
+    var mauticLang        = <?php echo $view['translator']->getJsLang(); ?>;
 </script>
 <?php $view['assets']->outputSystemScripts(true); ?>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | mautic/developer-documentation#32
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR gives us the ability to translate messages in javascript in a similar fashion as we currently do in PHP. 

To enable javascript translations in your bundle, add a `javascript.ini` file in the `app/bundles/YOURBUNDLE/Translations/LOCALE` directory. The contents of the file should be structured exactly the same as you currently structure them for normal translations.

```ini
mautic.core.dynamicContent="Dynamic Content"
mautic.core.dynamicContent.new="Dynamic Content %number%"
```

Then, in your javascript, you can get the translated message content by passing the key to the `Mautic.translate()` function.

```js
Mautic.translate("mautic.core.dynamicContent");
// outputs "Dynamic Content"
```

String interpolation for messages with variables works with js translations just as you'd expect.

```js
Mautic.translate("mautic.core.dynamicContent.new", {number: 4});
// outputs "Dynamic Content 4"
```

#### Steps to test this PR:
1. Merge PR
2. Log in to Mautic and view your page source. In the head within a `<script>` tag you'll find the `mauticLang` variable, and you'll see translation strings present.
3. Open your browser console and test using some of the examples above to ensure the `Mautic.translate()` method returns the correct values.
