### PR TITLE
Bug email apitransport fix

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1464,8 +1464,9 @@ class MailHelper
     
     /**
      * Enables queue mode if the transport supports tokenization
-     * @param bool $enabled 
      *
+     * @param bool $enabled 
+     */
     public function enableQueue($enabled = true)
     {
         if ($this->tokenizationEnabled) {

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -125,6 +125,13 @@ class MailHelper
      * @var bool
      */
     protected $tokenizationEnabled = false;
+    
+    /**
+     * Use queue mode when sending email through this mailer; this requires a transport that supports tokenization and the use of queue/flushQueue
+     *
+     * @var bool
+     */
+    protected $queueEnabled = false;
 
     /**
      * @var array
@@ -1083,7 +1090,7 @@ class MailHelper
      */
     protected function checkBatchMaxRecipients($toBeAdded = 1, $type = 'to')
     {
-        if ($this->tokenizationEnabled) {
+        if ($this->queueEnabled) {
             // Check if max batching has been hit
             $maxAllowed = $this->transport->getMaxBatchLimit();
 
@@ -1442,7 +1449,7 @@ class MailHelper
     /**
      * Tell the mailer to use batching/tokenized emails if available.  It's up to the function calling to execute flushQueue to send the mail.
      *
-     * @deprecated 2.1.1 - to be removed in 3.0
+     * @deprecated 2.1.1 - to be removed in 3.0; use enableQueue() instead
      *
      * @param bool $tokenizationEnabled
      *
@@ -1450,7 +1457,20 @@ class MailHelper
      */
     public function useMailerTokenization($tokenizationEnabled = true)
     {
-        trigger_error('useMailerTokenization is no longer used as it is automatically handled based on what the transport supports.', E_DEPRECATED);
+        @trigger_error('useMailerTokenization is no longer used as it is automatically handled based on what the transport supports.', E_DEPRECATED);
+        
+        $this->enableQueue($tokenizationEnabled);
+    }
+    
+    /**
+     * Enables queue mode if the transport supports tokenization
+     * @param bool $enabled 
+     *
+    public function enableQueue($enabled = true)
+    {
+        if ($this->tokenizationEnabled) {
+    	    $this->queueEnabled = $enabled;
+    	}
     }
 
     /**

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1457,7 +1457,7 @@ class MailHelper
      */
     public function useMailerTokenization($tokenizationEnabled = true)
     {
-        @trigger_error('useMailerTokenization is no longer used as it is automatically handled based on what the transport supports.', E_DEPRECATED);
+        @trigger_error('useMailerTokenization() is now deprecated. Use enableQueue() instead.', E_DEPRECATED);
         
         $this->enableQueue($tokenizationEnabled);
     }

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1170,7 +1170,7 @@ class EmailModel extends FormModel
 
         // Setup the mailer
         $mailer = $this->mailHelper->getMailer(!$sendBatchMail);
-		$mailer->enableQueue();
+        $mailer->enableQueue();
 		
         // Flushes the batch in case of using API mailers
         $flushQueue = function ($reset = true) use (&$mailer, &$saveEntities, &$errors, &$emailSentCounts, $sendBatchMail) {

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1170,7 +1170,8 @@ class EmailModel extends FormModel
 
         // Setup the mailer
         $mailer = $this->mailHelper->getMailer(!$sendBatchMail);
-
+		$mailer->enableQueue();
+		
         // Flushes the batch in case of using API mailers
         $flushQueue = function ($reset = true) use (&$mailer, &$saveEntities, &$errors, &$emailSentCounts, $sendBatchMail) {
 

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelper.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2016 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Helper;
+
+
+use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\EmailBundle\Swiftmailer\Exception\BatchQueueMaxException;
+use Mautic\EmailBundle\Tests\Helper\Transport\BatchTransport;
+
+class MailHelper extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \Mautic\EmailBundle\Swiftmailer\Exception\BatchQueueMaxException
+     */
+    public function testQueueModeThrowsExceptionWhenBatchLimitHit()
+    {
+        $mockFactory = $this->getMockBuilder(MauticFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockFactory->method('getParameter')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['mailer_return_path', false, null],
+                        ['mailer_spool_type', false, 'memory']
+                    ]
+                )
+            );
+
+        $swiftMailer = new \Swift_Mailer(new BatchTransport());
+
+        $mailer = new \Mautic\EmailBundle\Helper\MailHelper($mockFactory, $swiftMailer, ['nobody@nowhere.com' => 'No Body']);
+
+        // Enable queue mode
+        $mailer->enableQueue();
+        $mailer->addTo('somebody@somewhere.com');
+        $mailer->addTo('somebodyelse@somewhere.com');
+    }
+
+    public function testQueueModeDisabledDoesNotThrowsExceptionWhenBatchLimitHit()
+    {
+        $mockFactory = $this->getMockBuilder(MauticFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockFactory->method('getParameter')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['mailer_return_path', false, null],
+                        ['mailer_spool_type', false, 'memory']
+                    ]
+                )
+            );
+
+        $swiftMailer = new \Swift_Mailer(new BatchTransport());
+
+        $mailer = new \Mautic\EmailBundle\Helper\MailHelper($mockFactory, $swiftMailer, ['nobody@nowhere.com' => 'No Body']);
+
+        // Enable queue mode
+        try {
+            $mailer->addTo('somebody@somewhere.com');
+            $mailer->addTo('somebodyelse@somewhere.com');
+        } catch (BatchQueueMaxException $exception) {
+            $this->fail('BatchQueueMaxException thrown');
+        }
+
+        // Otherwise success
+        $this->assertTrue(true);
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -14,7 +14,7 @@ use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\EmailBundle\Swiftmailer\Exception\BatchQueueMaxException;
 use Mautic\EmailBundle\Tests\Helper\Transport\BatchTransport;
 
-class MailHelper extends \PHPUnit_Framework_TestCase
+class MailHelperTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException \Mautic\EmailBundle\Swiftmailer\Exception\BatchQueueMaxException

--- a/app/bundles/EmailBundle/Tests/Helper/Transport/BatchTransport.php
+++ b/app/bundles/EmailBundle/Tests/Helper/Transport/BatchTransport.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alan
+ * Date: 9/14/16
+ * Time: 5:42 PM
+ */
+
+namespace Mautic\EmailBundle\Tests\Helper\Transport;
+
+use Mautic\EmailBundle\Swiftmailer\Transport\AbstractTokenArrayTransport;
+
+class BatchTransport extends AbstractTokenArrayTransport implements \Swift_Transport
+{
+    public function send(\Swift_Mime_Message $message, &$failedRecipients = null)
+    {
+
+    }
+
+    public function getMaxBatchLimit()
+    {
+        return 1;
+    }
+
+    public function getBatchRecipientCount(\Swift_Message $message, $toBeAdded = 1, $type = 'to')
+    {
+        return count($message->getTo()) + $toBeAdded;
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -27,7 +27,7 @@ use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PageBundle\Model\TrackableModel;
 use Mautic\UserBundle\Model\UserModel;
 
-class EmailModel extends \PHPUnit_Framework_TestCase
+class EmailModelTest extends \PHPUnit_Framework_TestCase
 {
 
     /**

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/MailboxTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/MailboxTest.php
@@ -15,7 +15,7 @@ use Mautic\CoreBundle\Helper\PathsHelper;
 /**
  * Class Mailbox
  */
-class Mailbox extends \PHPUnit_Framework_TestCase
+class MailboxTest extends \PHPUnit_Framework_TestCase
 {
 
     public function testSettingsForMonitoredEmailWithoutOverride()


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | todo
| Issues addressed (#s or URLs) | na
| BC breaks? | n
| Deprecations? | y

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

There's a bug with InterfaceTokenTransport transports that have a lower batch getMaxBatchLimit() than the number of recipients in the message. It was thought MailHelper::useMailerTokenization was no longer needed as the mail helper was updated to auto handle flushing the queue for these mailers that need access to the metadata of a contact to work. (See #2284). But in the case of transports that sets a low max batch limit (say 1) and a form email had two recipients, the BatchQueueMaxException exception was thrown. The original useMailerTokenization() purpose was for when processing a batch of recipients with unique metadata to each to receive the same email. Thus a new MailHelper::enableQueue() was added to replace useMailerTokenization() to restore it's old functionality and follow the same naming scheme as queue() and flushQueue().

#### Steps to test this PR:
1. See unit tests

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Requires a custom transport or something hacked. See unit tests.
2. 

#### List deprecations along with the new alternative:
1. MailHelper::useMailerTokenization was already deprecated and was planned to be removed but this reimplements it's purpose with enableQueue(). 