### PR TITLE
Add cookie with contact ID on the domain being tracked

### DIFF
--- a/app/bundles/PageBundle/Config/config.php
+++ b/app/bundles/PageBundle/Config/config.php
@@ -28,6 +28,10 @@ return [
                 'path'       => '/mtracking.gif',
                 'controller' => 'MauticPageBundle:Public:trackingImage'
             ],
+            'mautic_page_tracker_getcontact'  => [
+                'path'       => '/mtc',
+                'controller' => 'MauticPageBundle:Public:getContactId'
+            ],
             'mautic_url_redirect' => [
                 'path'       => '/r/{redirectId}',
                 'controller' => 'MauticPageBundle:Public:redirect'

--- a/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
@@ -43,6 +43,8 @@ class BuildJsSubscriber extends CommonSubscriber
             $router->generate('mautic_page_tracker', array(), UrlGeneratorInterface::ABSOLUTE_URL)
         );
 
+        $contactIdUrl = $router->generate('mautic_page_tracker_getcontact', array(), UrlGeneratorInterface::ABSOLUTE_URL);
+
         $js = <<<JS
 (function(m, l, n, d) {
     m.pageTrackingUrl = (l.protocol == 'https:' ? 'https:' : 'http:') + '//{$pageTrackingUrl}';
@@ -105,6 +107,17 @@ class BuildJsSubscriber extends CommonSubscriber
     }
 
 })(MauticJS, location, navigator, document);
+
+MauticJS.getTrackedContact = function () {
+    var url = '$contactIdUrl';
+    MauticJS.makeCORSRequest('GET', url, {}, function(response, xhr) {
+        if (response.id) {
+            document.cookie = "mtc_id="+response.id+";";
+        }
+    });
+};
+
+MauticJS.pixelLoaded(MauticJS.getTrackedContact);
 JS;
 
         $event->appendJs($js, 'Mautic Tracking Pixel');

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -386,6 +386,8 @@ class PageModel extends FormModel
      * @param Lead|null $lead
      * @param array     $query
      *
+     *
+     * @return Hit $hit
      * @throws \Exception
      */
     public function hitPage($page, Request $request, $code = '200', Lead $lead = null, $query = [])
@@ -641,6 +643,8 @@ class PageModel extends FormModel
 
         //save hit to the cookie to use to update the exit time
         $this->cookieHelper->setCookie('mautic_referer_id', $hit->getId());
+
+        return $hit;
     }
 
     /**


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | y
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | 
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This uses the new CORS support to simply do a call to Mautic after the tracking pixel has been loaded to retrieve the ID of the contact and creates it as a cookie on the domain being tracked - making the contact ID accessible to the server tracking the contact to be used with the REST API.

#### Steps to test this PR:
1. Embed the JS tracking code into a 3rd party site
2. Ensure you are not logged into Mautic or use an anonymous browser session
3. Hit up the page and view your cookies
4. mtc_id should exist with the contact's ID
