### PR TITLE
Fixed query for filtering by tags

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -811,7 +811,7 @@ class LeadRepository extends CommonRepository
                     ->where(
                         $sq->expr()->andX(
                             $sq->expr()->eq('l.id', 'x.lead_id'),
-                            $sq->expr()->$eqFunc('t.tag', ":$unique")
+                            $sq->expr()->$likeFunc('t.tag', ":$unique")
                         )
                     );
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2512 
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This fixes the issue where filtering contacts by `tag:` did not work.

#### Steps to test this PR:
1. Tag some contacts, go to Contacts, and filter by `tag:$theTag` (replace `$theTag` with the tag you want to filter by)
2. List should return appropriate results.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Filter by `tag:$theTag` and it should return empty results

