### PR TITLE
Check if a contact has any owner before trying to read his name

### DIFF
--- a/app/bundles/LeadBundle/Views/Lead/lead.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/lead.html.php
@@ -445,8 +445,10 @@ $view['slots']->set(
                 </div>
             </div>
             <div class="panel-body pt-sm">
+            <?php if ($lead->getOwner()) : ?>
                 <h6 class="fw-sb"><?php echo $view['translator']->trans('mautic.lead.lead.field.owner'); ?></h6>
                 <p class="text-muted"><?php echo $lead->getOwner()->getName(); ?></p>
+            <?php endif; ?>
 
                 <h6 class="fw-sb">
                     <?php echo $view['translator']->trans('mautic.lead.field.address'); ?>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If a contact doesn't have any owner assigned, the detail page throws an error. This issue was introduced in https://github.com/mautic/mautic/pull/2493

#### Steps to test this PR:
1. Visit a contact detail page of a detail who doesn't have any owner.
2. The owner information will not be visible.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Visit a contact detail page of a detail who doesn't have any owner.
2. The page will be corrupted by an error message.

