### PR TITLE
Removed ellipses class that caused timeline table to extend beyond it…

### DIFF
--- a/app/bundles/LeadBundle/Views/Timeline/list.html.php
+++ b/app/bundles/LeadBundle/Views/Timeline/list.html.php
@@ -88,7 +88,7 @@ $baseUrl = $view['router']->path(
                         <span class="fa fa-fw <?php echo $icon ?>"></span>
                     </a>
                 </td>
-                <td class="timeline-name"><span class="ellipsis"><?php echo $eventLabel; ?></span></td>
+                <td class="timeline-name"><?php echo $eventLabel; ?></td>
                 <td class="timeline-type"><?php if (isset($event['eventType'])) {
                         echo $event['eventType'];
                     } ?></td>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | na
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If a page hit URL title or any event name took up more than the given width of the browser view port, it would push the timeline table out of it's constraints.

![](http://alan.direct/drop/2016-09-26_11-49-06.png)

This PR simply removes the ellipses class that caused this which was remnants from the old layout.


#### Steps to test this PR:
1. Create a page hit entry for a contact that has a really long title and view the contact's timeline. The timeline table should remain within it's constraints.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Repeat above but the table will extend out of it's constraints and into the right column.
