### PR TITLE
Add api route to create User. Correct CSRF token protection

### DIFF
--- a/app/bundles/UserBundle/Config/config.php
+++ b/app/bundles/UserBundle/Config/config.php
@@ -83,6 +83,11 @@ return array(
                 'controller'   => 'MauticUserBundle:Api\UserApi:isGranted',
                 'method'       => 'POST'
             ),
+            'mautic_api_adduser'        => array(
+                'path'       => '/users/add',
+                'controller' => 'MauticUserBundle:Api\UserApi:newEntity',
+                'method'       => 'POST'
+            ),
             'mautic_api_getuserroles'    => array(
                 'path'       => '/users/list/roles',
                 'controller' => 'MauticUserBundle:Api\UserApi:getRoles',

--- a/app/bundles/UserBundle/Controller/Api/UserApiController.php
+++ b/app/bundles/UserBundle/Controller/Api/UserApiController.php
@@ -203,4 +203,16 @@ class UserApiController extends CommonApiController
 
         return $this->handleView($view);
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param $entity
+     *
+     * @return mixed|void
+     */
+    protected function createEntityForm($entity)
+    {
+        return $this->model->createForm($entity, $this->get('form.factory'), null, ['csrf_protection' => false]);
+    }
 }

--- a/app/bundles/UserBundle/Controller/Api/UserApiController.php
+++ b/app/bundles/UserBundle/Controller/Api/UserApiController.php
@@ -78,8 +78,8 @@ class UserApiController extends CommonApiController
 
         $parameters = $this->request->request->all();
 
-        if (isset($parameters['plainPassword']['password'])) {
-            $submittedPassword = $parameters['plainPassword']['password'];
+        if (isset($parameters['plainPassword'])) {
+            $submittedPassword = $parameters['plainPassword'];
             $encoder           = $this->get('security.encoder_factory')->getEncoder($entity);
             $entity->setPassword($this->model->checkNewPassword($entity, $encoder, $submittedPassword));
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Yes |
| New feature? | Yes |
| Related user documentation PR URL | none |
| Related developer documentation PR URL | See PR mautic/developer-documentation/pull/35 |
| Issues addressed (#s or URLs) | none |
| BC breaks? | NO |
| Deprecations? | NO |
#### Description:

Correction on User Creation through API
#### Steps to test this PR:
1. Use Api-library
2. use sample data below
3. try to connect with new user

![capture_create_user_api_library](https://cloud.githubusercontent.com/assets/14073284/18920250/1aa7e706-85a1-11e6-968a-dfe435342e8c.JPG)
