### PR TITLE
Default values imported, boolean values can be true/false/yes/no

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1515,20 +1515,12 @@ class LeadModel extends FormModel
             );
         }
 
-        $booleanTrue  = ['1', 'true', 'yes'];
-        $booleanFalse = ['0', 'false', 'no'];
-
         foreach ($leadFields as $leadField) {
             if (isset($fieldData[$leadField['alias']])) {
 
                 // Adjust the boolean values from text to boolean
                 if ($leadField['type'] == 'boolean') {
-                    $value = strtolower($fieldData[$leadField['alias']]);
-                    if (in_array($value, $booleanTrue)) {
-                        $fieldData[$leadField['alias']] = 1;
-                    } elseif (in_array($value, $booleanFalse)) {
-                        $fieldData[$leadField['alias']] = 0;
-                    }
+                    $fieldData[$leadField['alias']] = (int) filter_var($fieldData[$leadField['alias']], FILTER_VALIDATE_BOOLEAN);
                 }
 
                 // Skip if the value is in the CSV row

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -7,7 +7,6 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
-
 namespace Mautic\LeadBundle\Model;
 
 use Mautic\CoreBundle\Entity\IpAddress;
@@ -1514,6 +1513,31 @@ class LeadModel extends FormModel
                     'hydration_mode' => 'HYDRATE_ARRAY',
                 ]
             );
+        }
+
+        $booleanTrue  = ['1', 'true', 'yes'];
+        $booleanFalse = ['0', 'false', 'no'];
+
+        foreach ($leadFields as $leadField) {
+            if (isset($fieldData[$leadField['alias']])) {
+
+                // Adjust the boolean values from text to boolean
+                if ($leadField['type'] == 'boolean') {
+                    $value = strtolower($fieldData[$leadField['alias']]);
+                    if (in_array($value, $booleanTrue)) {
+                        $fieldData[$leadField['alias']] = 1;
+                    } elseif (in_array($value, $booleanFalse)) {
+                        $fieldData[$leadField['alias']] = 0;
+                    }
+                }
+
+                // Skip if the value is in the CSV row
+                continue;
+            } elseif ($leadField['defaultValue']) {
+
+                // Fill in the default value if any
+                $fieldData[$leadField['alias']] = $leadField['defaultValue'];
+            }
         }
 
         $form = $this->createForm($lead, $this->formFactory, null, ['fields' => $leadFields, 'csrf_protection' => false]);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | Y
| Related user documentation PR URL | https://github.com/mautic/documentation/pull/115
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/1863, https://github.com/mautic/mautic/issues/2502
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR does 2 things:
1) It imports also default values if the contact fields have any
2) It allows to import yes/no/true/false as Boolean values.

#### Steps to test this PR:
1. Apply this PR.
2. Test again.

Notice:
1. All 8 contacts were imported with correct Boolean values.
2. All contact have the default value in the Phone field.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make sure you have at least one contact field with default value. For example Phone field.
2. Create a new contact field called "Boolean Test" and is type of Boolean.
3. Try to import the following CSV:

```
"email", "stage", "company", "boolean_test"
"john2@doe.com", "test", "Google", "No"
"john1@doe.com", "test", "Google", 0
"john3@doe.com", "test", "Google", "false"
"john4@doe.com", "test", "Google", "FALSE"
"johana1@doana.com", "stage A", "Apple", 1
"johana2@doana.com", "stage A", "Apple", "Yes"
"johana3@doana.com", "stage A", "Apple", "true"
"johana4@doana.com", "stage A", "Apple", "TRUE"
```

Notice:
1. It will import only 2 out of 8 contacts. The reason is that text Boolean values are not valid.
2. The default Phone value wasn't imported to the contacts who got saved.