### PR TITLE
Skip required validation when field is hidden by 'hide if exist' and has existing value.

### DIFF
--- a/app/bundles/FormBundle/Entity/Field.php
+++ b/app/bundles/FormBundle/Entity/Field.php
@@ -852,7 +852,7 @@ class Field
             }
 
             // Hide the field if the value is already known from the lead profile
-            if ($lead !== null && $this->leadField && $lead->getFieldValue($this->leadField) !== null) {
+            if ($lead !== null && $this->leadField && !empty($lead->getFieldValue($this->leadField))) {
                 return false;
             }
         }

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -214,6 +214,12 @@ class SubmissionModel extends CommonFormModel
             }
 
             if ($f->isRequired() && empty($value)) {
+
+                //field is required, but hidden from form because of 'ShowWhenValueExists'
+                if( null !== $f->getShowWhenValueExists() && $f->getShowWhenValueExists() === false ){
+                    continue;
+                }
+                
                 //somehow the user got passed the JS validation
                 $msg = $f->getValidationMessage();
                 if (empty($msg)) {

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -216,10 +216,10 @@ class SubmissionModel extends CommonFormModel
             if ($f->isRequired() && empty($value)) {
 
                 //field is required, but hidden from form because of 'ShowWhenValueExists'
-                if( null !== $f->getShowWhenValueExists() && $f->getShowWhenValueExists() === false ){
+                if ($f->getShowWhenValueExists() === false && !isset($post[$alias])) {
                     continue;
                 }
-                
+
                 //somehow the user got passed the JS validation
                 $msg = $f->getValidationMessage();
                 if (empty($msg)) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| Issues addressed (#s or URLs) | #2612

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fixes form submit when previously a required field with the behaviour "Hide if value exist" was filled in. Now the form submits without return an error for the required field. 

#### Steps to test this PR:
1. Create a form
2. Add a field that is required
3. Set the option "Hide if value exist"
4. Fill in the form
5. Fill in the form again ( the field should be hidden now )
6. Form should now send without any problems.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form
2. Add a field that is required
3. Set the option "Hide if value exist"
4. Fill in the form
5. Fill in the form again ( the field should be hidden now )
6. When submitting it will not send.