### PR TITLE
No need to encode '{}' because visual tokens are not used anymore

### DIFF
--- a/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
+++ b/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
@@ -7,7 +7,6 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
-
 namespace Mautic\CoreBundle\Helper;
 
 use Doctrine\ORM\Query\Expr;
@@ -230,20 +229,16 @@ class BuilderTokenHelper
         if (is_array($content)) {
             foreach ($content as &$slot) {
                 self::replaceVisualPlaceholdersWithTokens($slot);
-                if ($encodeTokensInUrls) {
-                    self::encodeUrlTokens($slot, $encodeTokensInUrls);
-                }
             }
         } else {
             $content = preg_replace('/'.self::getVisualTokenHtml(null, null, true).'/smi', '$1', $content);
-            if ($encodeTokensInUrls) {
-                self::encodeUrlTokens($content, $encodeTokensInUrls);
-            }
         }
     }
 
     /**
      * Prevent tokens in URLs from being converted to visual tokens by encoding the brackets.
+     *
+     * @deprecated 2.2.1 - to be removed in 3.0
      *
      * @param string $content
      * @param array  $tokenKeys


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2447
| BC breaks? | N
| Deprecations? | Y

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
In certain content the curly brackets in the tokens were encoded. The reason was from the time when Mautic used visual tokens.

#### Steps to test this PR:
1. Apply this PR.
2. Test again. `{}` will not be replaced.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to create a new email with the content published here: https://github.com/mautic/mautic/issues/2447#issuecomment-251057016
2. Check that `{}` were encoded after Save&Close or Apply+refresh.

#### List deprecations along with the new alternative:
1. `BuilderTokenHelper::replaceVisualPlaceholdersWithTokens()` is deprecated


