### PR TITLE
Export the first row as well as the header row

### DIFF
--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -7,7 +7,6 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
-
 namespace Mautic\ReportBundle\Model;
 
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
@@ -372,9 +371,9 @@ class ReportModel extends FormModel
                             if ($count === 0) {
                                 //write the row
                                 fputcsv($handle, $header);
-                            } else {
-                                fputcsv($handle, $row);
                             }
+
+                            fputcsv($handle, $row);
 
                             //free memory
                             unset($row, $reportData['data'][$count]);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2590
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When exporting a CSV from reports, the first row you see in the report is replaced by the CSV header. This PR adds the header row as well as the first row.

#### Steps to test this PR:
1. Apply this PR.
2. Test again - the first row should be present.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to a report, make sure there are some rows in the report table.
2. Export the report to CSV.
3. Compare the CSV with the report table - the first row is missing.

