### PR TITLE
Referer database schema column length increased to avoid SQL error

### DIFF
--- a/app/bundles/AssetBundle/Entity/Download.php
+++ b/app/bundles/AssetBundle/Entity/Download.php
@@ -7,7 +7,6 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
-
 namespace Mautic\AssetBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -106,7 +105,7 @@ class Download
 
         $builder->addField('code', 'integer');
 
-        $builder->createField('referer', 'string')
+        $builder->createField('referer', 'text')
             ->nullable()
             ->build();
 

--- a/app/bundles/FormBundle/Entity/Submission.php
+++ b/app/bundles/FormBundle/Entity/Submission.php
@@ -7,7 +7,6 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
-
 namespace Mautic\FormBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -97,7 +96,7 @@ class Submission
             ->columnName('date_submitted')
             ->build();
 
-        $builder->addField('referer', 'string');
+        $builder->addField('referer', 'text');
 
         $builder->createManyToOne('page', 'Mautic\PageBundle\Entity\Page')
             ->addJoinColumn('page_id', 'id', true, false, 'SET NULL')

--- a/app/bundles/LeadBundle/Entity/UtmTag.php
+++ b/app/bundles/LeadBundle/Entity/UtmTag.php
@@ -7,7 +7,6 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
-
 namespace Mautic\LeadBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -99,7 +98,7 @@ class UtmTag
 
         $builder->addNullableField('query', 'array');
 
-        $builder->addNullableField('referer', 'string');
+        $builder->addNullableField('referer', 'text');
 
         $builder->addNullableField('remoteHost', 'string', 'remote_host');
 

--- a/app/migrations/Version20161004080958.php
+++ b/app/migrations/Version20161004080958.php
@@ -15,7 +15,9 @@ use Doctrine\DBAL\Types\StringType;
 use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
 
 /**
- * Auto-generated Migration: Please modify to your needs!
+ * Change referer columns from varchar to longtext because of SQL error:
+ * "Data too long for column 'referer'"
+ * (GH issue #2187).
  */
 class Version20161004080958 extends AbstractMauticMigration
 {

--- a/app/migrations/Version20161004080958.php
+++ b/app/migrations/Version20161004080958.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\StringType;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20161004080958 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        $table                   = $schema->getTable($this->prefix.'form_submissions');
+        $submissionRefererColumn = $table->getColumn('referer');
+
+        if (!($submissionRefererColumn->getType() instanceof StringType)) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE '.$this->prefix.'asset_downloads CHANGE referer referer LONGTEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE '.$this->prefix.'form_submissions CHANGE referer referer LONGTEXT NOT NULL');
+        $this->addSql('ALTER TABLE '.$this->prefix.'lead_utmtags CHANGE referer referer LONGTEXT DEFAULT NULL');
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2187
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Change referer columns from varchar to longtext because of SQL error "Data too long for column 'referer'". It's luck that the page hit table doesn't need this change.

#### Steps to test this PR:
1. Run `app/console doctrine:migrations:migrate` command
2. The output should be:

```
++ migrating 20161004080958

     -> ALTER TABLE asset_downloads CHANGE referer referer LONGTEXT DEFAULT NULL
     -> ALTER TABLE form_submissions CHANGE referer referer LONGTEXT NOT NULL
     -> ALTER TABLE lead_utmtags CHANGE referer referer LONGTEXT DEFAULT NULL
```