### PR TITLE
Added index for faster loading of the email table

### DIFF
--- a/app/bundles/EmailBundle/Entity/Stat.php
+++ b/app/bundles/EmailBundle/Entity/Stat.php
@@ -7,7 +7,6 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
-
 namespace Mautic\EmailBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -131,6 +130,7 @@ class Stat
         $builder->setTable('email_stats')
             ->setCustomRepositoryClass('Mautic\EmailBundle\Entity\StatRepository')
             ->addIndex(['email_id', 'lead_id'], 'stat_email_search')
+            ->addIndex(['lead_id', 'email_id'], 'stat_email_search2')
             ->addIndex(['is_failed'], 'stat_email_failed_search')
             ->addIndex(['is_read'], 'stat_email_read_search')
             ->addIndex(['tracking_hash'], 'stat_email_hash_search')

--- a/app/migrations/Version20161004090629.php
+++ b/app/migrations/Version20161004090629.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Adds new index suggested in GH issue #1671 to speed up the email list table.
+ */
+class Version20161004090629 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        $tagTable = $schema->getTable($this->prefix.'email_stats');
+        if ($tagTable->hasIndex($this->prefix.'stat_email_search2')) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('CREATE INDEX '.$this->prefix.'stat_email_search2 ON '.$this->prefix.'email_stats (lead_id, email_id)');
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/1671
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This index was suggested in the linked issue to speed up the email list table. I wasn't able to notice any difference in the load time with my few email_stat rows, but I believe in our community :)

#### Steps to test this PR:
1. Run `app/console doctrine:migrations:migrate`
2. You should see `-> CREATE INDEX stat_email_search2 ON email_stats (lead_id, email_id)`
3. If you have significant number of rows in the email_stats table, you should see faster loading.

