### PR TITLE
Suppress PHP warning when transliterator_transliterate cannot be created

### DIFF
--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -7,7 +7,6 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
-
 namespace Mautic\CoreBundle\Helper;
 
 use Joomla\Filter\InputFilter;
@@ -440,9 +439,10 @@ class InputHelper
      */
     public static function transliterate($value)
     {
-        if (function_exists('transliterator_transliterate')) {
+        $transId = 'Any-Latin; Latin-ASCII';
+        if (function_exists('transliterator_transliterate') && $trans = \Transliterator::create($transId)) {
             // Use intl by default
-            return transliterator_transliterate('Any-Latin; Latin-ASCII', $value);
+            return $trans->transliterate($value);
         }
 
         return \URLify::transliterate($value);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2448
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
In the linked issue was reported a PHP warning:
```
PHP Warning: transliterator_transliterate(): Could not create transliterator with ID "Any-Latin; Latin-ASCII" (transliterator_create: unable to open ICU transliterator with id "Any-Latin; Latin-ASCII": U_INVALID_ID) - in file .../app/bundles/CoreBundle/Helper/InputHelper.php - at line 397
```
I borrowed solution from [Faker](https://github.com/fzaninotto/Faker/pull/541/files)

#### Steps to test this PR:
1. The transliterate method is used for example when generating a form alias. So try to create a form with name containing non-ascii characters. For example `ščřžřýřážíůú日本人`
2. Check that alias of the created form contains ascii replacement.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
No idea how to reproduce the bug. In this [conversation](https://bugs.php.net/bug.php?id=69120) the issue was caused by:
> I checked my PATH today and found another icu54 in directory of latest Poedit.
> Removed it from path and it works!