### PR TITLE
Throw 404 instead of PHP error if email was not found

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -7,7 +7,6 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
-
 namespace Mautic\EmailBundle\Controller;
 
 use Mautic\CoreBundle\Controller\FormController as CommonFormController;
@@ -331,6 +330,10 @@ class PublicController extends CommonFormController
         /** @var \Mautic\EmailBundle\Model\EmailModel $model */
         $model       = $this->getModel('email');
         $emailEntity = $model->getEntity($objectId);
+
+        if ($emailEntity === null) {
+            return $this->notFound();
+        }
 
         if (
             ($this->get('mautic.security')->isAnonymous() && !$emailEntity->isPublished())


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2382
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The linked issue reported a PHP error that was caused by trying to access an email preview on email which did not exist. This PR adds a check if the email exists and throws 404 if not.

#### Steps to test this PR:
1. Apply this PR and test again.
2. You should get 404.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to open some non-existing email preview. For example /email/preview/2499999
2. You should get `Call to a member function isPublished() on null` in dev mode or it should be logged if using prod.

