### PR TITLE
Bug fix: UTM tags were no longer showing on the contact's timeline

### DIFF
--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -434,17 +434,15 @@ class LeadSubscriber extends CommonSubscriber
     {
         $lead    = $event->getLead();
         $utmTags = $this->em->getRepository('MauticLeadBundle:UtmTag')->getUtmTagsByLead($lead, $event->getQueryOptions());
-
         // Add to counter
         $event->addToCounter($eventTypeKey, $utmTags);
 
         if (!$event->isEngagementCount()) {
             // Add the logs to the event array
             foreach ($utmTags['results'] as $utmTag) {
-                if (!empty($utmTag['query'])) {
-                    $icon = 'fa-tag';
-                    if (isset($utmTag['utm_medium'])) {
-                        switch (strtolower($utmTag['utm_medium'])) {
+                $icon = 'fa-tag';
+                if (isset($utmTag['utm_medium'])) {
+                    switch (strtolower($utmTag['utm_medium'])) {
                             case 'social':
                             case 'socialmedia':
                                 $icon = 'fa-'.((isset($utmTag['utm_source'])) ? strtolower($utmTag['utm_source']) : 'share-alt');
@@ -467,13 +465,12 @@ class LeadSubscriber extends CommonSubscriber
                                 $icon = 'fa-'.((isset($utmTag['utm_source'])) ? strtolower($utmTag['utm_source']) : 'tablet');
                                 break;
                         }
-                    }
-
-                    $event->addEvent(
+                }
+                $event->addEvent(
                         [
                             'event'      => $eventTypeKey,
                             'eventType'  => $eventTypeName,
-                            'eventLabel' => !empty($utmTag['utm_campaign']) ? $utmTag['utm_campaign'] : '',
+                            'eventLabel' => !empty($utmTag) ? $utmTag['utm_campaign'] : 'UTM Tags',
                             'timestamp'  => $utmTag['date_added'],
                             'icon'       => $icon,
                             'extra'      => [
@@ -482,7 +479,6 @@ class LeadSubscriber extends CommonSubscriber
                             'contentTemplate' => 'MauticLeadBundle:SubscribedEvents\Timeline:utmadded.html.php',
                         ]
                     );
-                }
             }
         } else {
             // Purposively not including this in engagements graph as the engagement is counted by the page hit

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -538,6 +538,10 @@ class PageModel extends FormModel
         if ($isUnique) {
             // Add UTM tags entry if a UTM tag exist
             $queryHasUtmTags = false;
+            if (!is_array($query)) {
+                parse_str($query, $query);
+            }
+
             foreach ($query as $key => $value) {
                 if (strpos($key, 'utm_') !== false) {
                     $queryHasUtmTags = true;
@@ -577,7 +581,6 @@ class PageModel extends FormModel
                 $this->leadModel->setUtmTags($lead, $utmTags);
             }
         }
-
         //get a list of the languages the user prefers
         $browserLanguages = $request->server->get('HTTP_ACCEPT_LANGUAGE');
         if (!empty($browserLanguages)) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #2505
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
UTM tags were no longer showing in the contact's timeline

#### Steps to test this PR:
1. Apply this PR
2. Follow the steps bellow, but this time UTM tags should be recorded. 

use utm tags like this: 

utm_campaign=campaign&utm_source=source&utm_medium=medium&utm_content=content&utm_term=term

> **NOTE: UTM tags are only recorded once per unique URL.**

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create and email with a link and add the UTM tags.
2. Send that email.
3. Go to your mailbox and click that link.
4. Watch the contact history finding the UTM tag you add in the link.