### PR TITLE
stacked bars on bargraph when multiple bars use the same x-axis

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -3542,7 +3542,11 @@ var Mautic = {
             options: {
                 scales: {
                     xAxes: [{
-                        barPercentage: 35
+                        barPercentage: 35,
+                        stacked: true,
+                    }],
+                    yAxes: [{
+                        stacked: false,
                     }]
                 }
             }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #2384
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When multiple bars on a bar graph use the same x-axis bars are misaligned, this PR stacks them together, a way to look at each one is to hide the ones that fall on top of the others.

#### Steps to test this PR:
1. Apply PR
2. go to a segment email that sends to multiple emails, graph should show stacked bars, click on the labels to look at individual labels


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. go to segment email with multiple segments, bars on graph appear misaligned from its x-axis