### PR TITLE
Add translation string for mautic.campaign.twitter.tweet

### DIFF
--- a/plugins/MauticSocialBundle/Translations/en_US/messages.ini
+++ b/plugins/MauticSocialBundle/Translations/en_US/messages.ini
@@ -177,3 +177,4 @@ mautic.social.twitter.tweet.event.open_desc="Send tweets automatically to contac
 mautic.social.twitter.tweet.count="Count"
 mautic.social.twitter.tweet.handle="Handle"
 mautic.monitoring.form.confirmdelete="Delete the social monitoring, %name%?"
+mautic.campaign.twitter.tweet="Tweet contact"


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Adds a translation string for the `mautic.campaign.twitter.tweet` translation key.

#### Steps to test this PR:
1. Apply the PR
2. Repeat the steps to reproduce the bug. You'll see that the string is translated.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a campaign
2. Add a "Tweet contact" action and save the campaign
3. In the lower section of the campaign details on the "Actions" tab, you'll see a "Tweet contact" row. To the right on that row you'll see the string with a missing translation.
