### PR TITLE
filtered lead matchup fields in forms, search company names with more…

### DIFF
--- a/app/bundles/CoreBundle/Views/Helper/search.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/search.html.php
@@ -24,7 +24,7 @@ $tmpl           = (empty($tmpl)) ? 'list' : $tmpl;
     </div>
     <?php endif; ?>
 
-    <input type="search" class="form-control search" id="<?php echo $id; ?>" name="search" placeholder="<?php echo $view['translator']->trans('mautic.core.search.placeholder'); ?>" value="<?php echo $searchValue; ?>" autocomplete="false" data-toggle="livesearch" data-target="<?php echo $target; ?>" data-tmpl="<?php echo $tmpl; ?>" data-action="<?php echo $action; ?>" data-overlay="<?php echo $overlayEnabled; ?>" data-overlay-text="<?php echo $view['translator']->trans('mautic.core.search.livesearch'); ?>" data-overlay-target="<?php echo $overlayTarget; ?>" />
+    <input type="search" class="form-control search" id="<?php echo $id; ?>" name="search" placeholder="<?php echo $view['translator']->trans('mautic.core.search.placeholder'); ?>" value="<?php echo $view->escape($searchValue); ?>" autocomplete="false" data-toggle="livesearch" data-target="<?php echo $target; ?>" data-tmpl="<?php echo $tmpl; ?>" data-action="<?php echo $action; ?>" data-overlay="<?php echo $overlayEnabled; ?>" data-overlay-text="<?php echo $view['translator']->trans('mautic.core.search.livesearch'); ?>" data-overlay-target="<?php echo $overlayTarget; ?>" />
     <div class="input-group-btn">
         <button type="button" class="btn btn-default btn-search btn-nospin" id="btn-filter" data-livesearch-parent="<?php echo $id; ?>">
             <i class="fa fa-search fa-fw"></i>

--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -454,7 +454,7 @@ class CompanyController extends FormController
             } elseif ($valid) {
                 // Refetch and recreate the form in order to populate data manipulated in the entity itself
                 $company = $model->getEntity($objectId);
-                $form    = $model->createForm($company, $this->get('form.factory'), $action, ['fields' => $fields]);
+                $form    = $model->createForm($company, $this->get('form.factory'), $action, ['fields' => $fields, 'update_select' => $updateSelect]);
             }
         } else {
             //lock the entity

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -685,9 +685,16 @@ class FieldModel extends FormModel
      */
     public function getFieldListWithProperties($object = 'lead')
     {
+        $forceFilters[] = [
+            'column' => 'f.object',
+            'expr'   => 'eq',
+            'value'  => $object,
+        ];
         $contactFields = $this->getEntities(
             [
-                'object'           => $object,
+                'filter' => [
+                    'force' => $forceFilters,
+                ],
                 'ignore_paginator' => true,
                 'hydration_mode'   => 'hydrate_array',
             ]

--- a/app/bundles/LeadBundle/Views/Company/list.html.php
+++ b/app/bundles/LeadBundle/Views/Company/list.html.php
@@ -117,7 +117,7 @@ if ($tmpl == 'index') {
                         <?php   endif; ?>
                     </td>
                     <td class="visible-md visible-lg">
-                        <a class="label label-primary" href="<?php echo $view['router']->path('mautic_contact_index', ['search' => $view['translator']->trans('mautic.lead.lead.searchcommand.company').':'.$fields['core']['companyname']['value']]); ?>" data-toggle="ajax"<?php echo ($leadCounts[$item->getId()] == 0) ? 'disabled=disabled' : ''; ?>>
+                        <a class="label label-primary" href="<?php echo $view['router']->path('mautic_contact_index', ['search' => $view['translator']->trans('mautic.lead.lead.searchcommand.company').':"'.$fields['core']['companyname']['value'].'"']); ?>" data-toggle="ajax"<?php echo ($leadCounts[$item->getId()] == 0) ? 'disabled=disabled' : ''; ?>>
                             <?php echo $view['translator']->transChoice('mautic.lead.company.viewleads_count', $leadCounts[$item->getId()], ['%count%' => $leadCounts[$item->getId()]]); ?>
                         </a>
                     </td>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #2695 #2717
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Company fields were being mixed up in the lead match fields for forms, when clicking on number of contacts on a company name that was made up of more than one word, filter did not work. Also fixed missing update_select missing option error that came up when clicking on Apply button in the company editing screen.

#### Steps to test this PR:
1. Go to forms and insert a text field or any other field, try to match it to a lead field. Only lead fields should appear
2. go to your list of companies find one that is more than two words and that it has contacts assigned, click on the link to view contacts, contacts assigned to that company should show on the list of contacts

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. In step one above company fields were appearing.
2. in step two above, no contacts were showing for the company.