### PR TITLE
Fix Social Monitoring firstName, lastName import order

### DIFF
--- a/plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
+++ b/plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
@@ -333,7 +333,7 @@ EOT
     /*
      * handles splitting a string handle into first / last name based on a space
      *
-     * return array($first, $last)
+     * @return array($first, $last)
      */
     private function splitName($name)
     {
@@ -346,7 +346,7 @@ EOT
         // push the rest of the name into first name
         $firstName = implode(' ', $nameParts);
 
-        return [$lastName, $firstName];
+        return [$firstName, $lastName];
     }
 
     /*


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2356
| BC breaks? | No
| Deprecations? | No

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
splitName method was documented to return the name in the order of firstName, lastName, but was returning in the opposite order. Made the return consistent with expected use case.

#### Steps to test this PR:
1. Merge
2. Setup a social monitoring campaign for a #hashtag and then inspect the order of first name last name