### PR TITLE
Company select list fixes

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/3b.chosen.ajax.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/3b.chosen.ajax.js
@@ -28,7 +28,11 @@
         }
 
         return this.each(function () {
-            return $(this).next('.chosen-container').find(".search-field > input, .chosen-search > input").bind('keyup', function () {
+            return $(this).next('.chosen-container').find(".search-field > input, .chosen-search > input").bind('keyup', function (event) {
+                if (event.which === 8 || event.which === 93 || event.which === 17 || event.which === 18) {
+                    return false;
+                }
+
                 var field, msg, success, untrimmed_val, val, search_field;
                 untrimmed_val = $(this).val();
                 val = $.trim($(this).val());
@@ -113,6 +117,13 @@
                             hasNew.prependTo(select);
                         }
                         select.trigger("chosen:updated");
+
+                        setTimeout( function() {
+                            // Hack to force chosen to hide already selected values from the list
+                            var e = $.Event("keyup.chosen");
+                            e.which = 93; // Windows/Command
+                            field.trigger(e);
+                        }, 5);
                     } else {
                         select.data().chosen.no_results_clear();
                         select.data().chosen.no_results(field.val());

--- a/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
+++ b/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Form\ChoiceLoader;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
+use Mautic\CoreBundle\Factory\ModelFactory;
+use Mautic\CoreBundle\Model\AjaxLookupModelInterface;
+use Mautic\CoreBundle\Translation\Translator;
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Class EntityLookupChoiceLoader.
+ */
+class EntityLookupChoiceLoader implements ChoiceLoaderInterface
+{
+    /**
+     * @var array
+     */
+    protected $selected;
+
+    /**
+     * @var array
+     */
+    protected $choices = [];
+
+    /**
+     * @var Options
+     */
+    protected $options;
+
+    /**
+     * @var ModelFactory
+     */
+    protected $modelFactory;
+
+    /**
+     * @var Translator
+     */
+    protected $translator;
+
+    /**
+     * @var Connection
+     */
+    protected $connection;
+
+    /**
+     * EntityLookupChoiceLoader constructor.
+     *
+     * @param ModelFactory        $modelFactory
+     * @param TranslatorInterface $translator
+     * @param Connection          $connection
+     */
+    public function __construct(ModelFactory $modelFactory, TranslatorInterface $translator, Connection $connection)
+    {
+        $this->modelFactory = $modelFactory;
+        $this->translator   = $translator;
+        $this->connection   = $connection;
+    }
+
+    /**
+     * @param $options
+     */
+    public function setOptions(Options $options)
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * @param null $value
+     *
+     * @return ArrayChoiceList
+     */
+    public function loadChoiceList($value = null)
+    {
+        return new ArrayChoiceList($this->getChoices(null, true));
+    }
+
+    /**
+     * Validate submitted values.
+     *
+     * Convert to other data types to strings - we're already working with IDs so just return $values
+     *
+     * @param array $values
+     * @param null  $value
+     *
+     * @return array
+     */
+    public function loadChoicesForValues(array $values, $value = null)
+    {
+        return $values;
+    }
+
+    /**
+     * Convert to other data types to strings - we're already working with IDs so just return $choices.
+     *
+     * @param array $choices
+     * @param null  $value
+     *
+     * @return array
+     */
+    public function loadValuesForChoices(array $choices, $value = null)
+    {
+        return $choices;
+    }
+
+    /**
+     * Take note of the selected values for loadChoiceList.
+     *
+     * @param FormEvent $event
+     */
+    public function onFormPostSetData(FormEvent $event)
+    {
+        $this->selected = $event->getData();
+    }
+
+    /**
+     * @param $data
+     * @param $options
+     *
+     * @return array
+     */
+    protected function getChoices($data = null, $includeNew = false)
+    {
+        if (null == $data) {
+            $data = $this->selected;
+        }
+
+        $labelColumn = $this->options['entity_label_column'];
+        $idColumn    = $this->options['entity_id_column'];
+        $modelName   = $this->options['model'];
+        $modalRoute  = $this->options['modal_route'];
+
+        // Check if we've already f the choices
+        if (!isset($this->choices[$modelName]) || count(array_diff($data, array_keys($this->choices[$modelName]))) !== count($data)) {
+            $this->choices[$modelName] = [];
+
+            if ($data) {
+                $data = array_map(
+                    function ($v) {
+                        return (int) $v;
+                    },
+                    (array) $data
+                );
+
+                if (!$this->modelFactory->hasModel($modelName)) {
+                    throw new \InvalidArgumentException("$modelName not found as a registered model service.");
+                }
+                $model = $this->modelFactory->getModel($modelName);
+                if (!$model instanceof AjaxLookupModelInterface) {
+                    throw new \InvalidArgumentException(get_class($model).' must implement '.AjaxLookupModelInterface::class);
+                }
+
+                $alias     = $model->getRepository()->getTableAlias();
+                $expr      = new ExpressionBuilder($this->connection);
+                $composite = $expr->andX();
+                $composite->add(
+                    $expr->in($alias.'.id', $data)
+                );
+
+                $validChoices = $model->getRepository()->getSimpleList($composite, [], $labelColumn, $idColumn);
+                $choices      = [];
+                foreach ($validChoices as $choice) {
+                    $choices[$choice['value']] = $choice['label'];
+                }
+
+                $this->choices[$modelName] = $choices;
+            }
+        }
+
+        $choices = ($includeNew && $modalRoute) ? array_replace(['new' => $this->translator->trans('mautic.core.createnew')], $this->choices[$modelName]) : $this->choices[$modelName];
+
+        // must be [$label => $id]
+        return array_flip($choices);
+    }
+}

--- a/app/bundles/CoreBundle/Form/Type/EntityLookupType.php
+++ b/app/bundles/CoreBundle/Form/Type/EntityLookupType.php
@@ -11,12 +11,10 @@
 namespace Mautic\CoreBundle\Form\Type;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Model\AjaxLookupModelInterface;
+use Mautic\CoreBundle\Form\ChoiceLoader\EntityLookupChoiceLoader;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -29,24 +27,19 @@ use Symfony\Component\Translation\TranslatorInterface;
 class EntityLookupType extends AbstractType
 {
     /**
-     * @var ModelFactory
-     */
-    private $modelFactory;
-
-    /**
      * @var TranslatorInterface
      */
     private $translator;
 
     /**
-     * @var Connection
-     */
-    private $connection;
-
-    /**
      * @var Router
      */
     private $router;
+
+    /**
+     * @var EntityLookupChoiceLoader
+     */
+    private $choiceLoader;
 
     /**
      * EntityLookupType constructor.
@@ -58,10 +51,9 @@ class EntityLookupType extends AbstractType
      */
     public function __construct(ModelFactory $modelFactory, TranslatorInterface $translator, Connection $connection, Router $router)
     {
-        $this->modelFactory = $modelFactory;
         $this->translator   = $translator;
-        $this->connection   = $connection;
         $this->router       = $router;
+        $this->choiceLoader = new EntityLookupChoiceLoader($modelFactory, $translator, $connection);
     }
 
     /**
@@ -70,25 +62,15 @@ class EntityLookupType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        // Let the form builder notify us about initial/submitted choices
         $builder->addEventListener(
-            FormEvents::PRE_SUBMIT,
-            function (FormEvent $event) {
-                $data = $event->getData();
-                $form = $event->getForm();
+            FormEvents::POST_SET_DATA,
+            [$this->choiceLoader, 'onFormPostSetData']
+        );
 
-                if (!$data) {
-                    return;
-                }
-
-                $options = $form->getConfig()->getOptions();
-                $options['choices'] = $this->getChoices($data, $options);
-
-                $form->getParent()->add(
-                    $form->getName(),
-                    $form->getConfig()->getType()->getName(),
-                    $options
-                );
-            }
+        $builder->addEventListener(
+            FormEvents::POST_SUBMIT,
+            [$this->choiceLoader, 'onFormPostSetData']
         );
     }
 
@@ -105,10 +87,10 @@ class EntityLookupType extends AbstractType
                 'entity_label_column'    => 'name',
                 'entity_id_column'       => 'id',
                 'modal_route_parameters' => ['objectAction' => 'new'],
-                'choices'                => function (Options $options) {
-                    $data = (isset($options['data'])) ? $options['data'] : [];
+                'choice_loader'          => function (Options $options) {
+                    $this->choiceLoader->setOptions($options);
 
-                    return $this->getChoices($data, $options);
+                    return $this->choiceLoader;
                 },
                 'expanded'    => false,
                 'multiple'    => false,
@@ -150,53 +132,5 @@ class EntityLookupType extends AbstractType
     public function getParent()
     {
         return 'choice';
-    }
-
-    /**
-     * @param $data
-     * @param $options
-     *
-     * @return array
-     */
-    protected function getChoices($data, $options)
-    {
-        $labelColumn = $options['entity_label_column'];
-        $idColumn    = $options['entity_id_column'];
-        $model       = $options['model'];
-        $modalRoute  = (!empty($options['modal_route'])) ? $options['modal_route'] : false;
-
-        if (empty($data)) {
-            return ($modalRoute) ? ['new' => $this->translator->trans('mautic.core.createnew')] : [];
-        }
-
-        $data = array_map(
-            function ($v) {
-                return (int) $v;
-            },
-            $data
-        );
-
-        if (!$this->modelFactory->hasModel($model)) {
-            throw new \InvalidArgumentException("$model not found as a registered model service.");
-        }
-        $model = $this->modelFactory->getModel($model);
-        if (!$model instanceof AjaxLookupModelInterface) {
-            throw new \InvalidArgumentException(get_class($model).' must implement '.AjaxLookupModelInterface::class);
-        }
-
-        $alias     = $model->getRepository()->getTableAlias();
-        $expr      = new ExpressionBuilder($this->connection);
-        $composite = $expr->andX();
-        $composite->add(
-            $expr->in($alias.'.id', $data)
-        );
-
-        $validChoices = $model->getRepository()->getSimpleList($composite, [], $labelColumn, $idColumn);
-        $choices      = [];
-        foreach ($validChoices as $choice) {
-            $choices[$choice['value']] = $choice['label'];
-        }
-
-        return ($modalRoute) ? array_replace(['new' => $this->translator->trans('mautic.core.createnew')], $choices) : $choices;
     }
 }

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -456,6 +456,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
                 ]);
 
             if ($companyLead == null) {
+
                 // Lead is not part of this list
                 continue;
             }
@@ -474,11 +475,11 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
             unset($companyLead);
         }
 
-        if (!empty($persistcompany)) {
-            $this->getRepository()->saveEntities($persistCompany);
+        if (!empty($persistCompany)) {
+            $this->getCompanyLeadRepository()->saveEntities($persistCompany);
         }
         if (!empty($deleteCompanyLead)) {
-            $this->getRepository()->deleteEntities($deleteCompanyLead);
+            $this->getCompanyLeadRepository()->deleteEntities($deleteCompanyLead);
         }
 
         // Clear CompanyLead entities from Doctrine memory


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2649 #2683
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixes 
1. #2649 where a company couldn't be removed
2. Company was not repopulated when editing the campaign set company action

#### Steps to test this PR:
1. Apply the PR
2. Edit a contact and assign a couple companies and save. Delete one save, then delete the second, save. On refresh each time, the company deleted should be gone with finally no companies are left. 
3. Add a "add to company" campaign action. Choose a company and save. Edit the action and the company should be repopulated. Change the company, save, and edit. The new company should be populated.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Same as above only for contact edit page, the one or more companies may not get deleted. 
2. For campaign, the company will not prefill when editing the action. 
