### PR TITLE
Removed catch that prevented builder from closing without selecting a type or style

### DIFF
--- a/plugins/MauticFocusBundle/Assets/js/focus.js
+++ b/plugins/MauticFocusBundle/Assets/js/focus.js
@@ -372,27 +372,6 @@ Mautic.closeFocusBuilder = function (el) {
 
     mQuery('#websiteUrlPlaceholderInput').prop('disabled', true);
 
-    // Make sure a style and a type are chosen
-    if (!mQuery('#focus_type').val()) {
-        mQuery('.focus-type-header').addClass('text-danger');
-        mQuery('.builder-panel-focus .nav-tabs a[href="#focusType"]').tab('show');
-        mQuery(el).blur();
-
-        return;
-    } else {
-        mQuery('.focus-type-header').removeClass('text-danger');
-    }
-
-    if (!mQuery('#focus_style').val()) {
-        mQuery('.focus-style-header').addClass('text-danger');
-        mQuery('.builder-panel-focus .nav-tabs a[href="#focusStyle"]').tab('show');
-        mQuery(el).blur();
-
-        return;
-    } else {
-        mQuery('.focus-style-header').removeClass('text-danger');
-    }
-
     Mautic.stopIconSpinPostEvent();
 
     // Kill the overlay

--- a/plugins/MauticFocusBundle/Controller/AjaxController.php
+++ b/plugins/MauticFocusBundle/Controller/AjaxController.php
@@ -41,7 +41,7 @@ class AjaxController extends CommonAjaxController
                 $snapshotKey = $this->get('mautic.helper.core_parameters')->getParameter('website_snapshot_key');
 
                 $http     = $this->get('mautic.http.connector');
-                $response = $http->get($snapshotUrl.'?key='.$snapshotKey.'&url='.urlencode($website));
+                $response = $http->get($snapshotUrl.'?url='.urlencode($website).'&key='.$snapshotKey, [], 30);
 
                 if ($response->code === 200) {
                     $package = json_decode($response->body, true);

--- a/plugins/MauticFocusBundle/Translations/en_US/validators.ini
+++ b/plugins/MauticFocusBundle/Translations/en_US/validators.ini
@@ -1,2 +1,2 @@
-mautic.focus.error.select_type = "Use the builder to select a Focus type."
-mautic.focus.error.select_style = "Use the builder to select a Focus style."
+mautic.focus.error.select_type="Use the builder to select what the focus should be."
+mautic.focus.error.select_style="Use the builder to select what style should be used."


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2677 
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If trying to close the focus builder without selecting a style or type, the panel headers highlighted and refused to close the builder. This was not very intuitive so that catch has been removed in favor of just returning a validation error on save instead.

#### Steps to test this PR:
1. Create a new focus item
2. Open the builder and immediately try to close the builder
3. Save the focus and validation errors should be returned regarding the style and type

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Same as above only the builder will not close - instead it will highlight the panel headers
