### PR TITLE
Prevent :office: in Outlook email <html> tag from getting converted to emoji

### DIFF
--- a/app/bundles/CoreBundle/Helper/EmojiHelper.php
+++ b/app/bundles/CoreBundle/Helper/EmojiHelper.php
@@ -106,6 +106,10 @@ class EmojiHelper
         foreach ($maps as $useMap) {
             $mapClass = "Mautic\\CoreBundle\\Helper\\EmojiMap\\{$useMap}EmojiMap";
             $text     = str_replace(array_keys($mapClass::$map), $mapClass::$map, $text);
+
+            if (isset($mapClass::$exceptions)) {
+                $text = str_replace(array_keys($mapClass::$exceptions), $mapClass::$exceptions, $text);
+            }
         }
 
         if ($to !== 'emoji') {

--- a/app/bundles/CoreBundle/Helper/EmojiMap/ShortToUnicodeEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/ShortToUnicodeEmojiMap.php
@@ -1358,4 +1358,9 @@ class ShortToUnicodeEmojiMap
             ':woman-heart-woman:'                                      => "\xf0\x9f\x91\xa9\xe2\x80\x8d\xe2\x9d\xa4\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x91\xa9",
             ':woman-kiss-woman:'                                       => "\xf0\x9f\x91\xa9\xe2\x80\x8d\xe2\x9d\xa4\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x92\x8b\xe2\x80\x8d\xf0\x9f\x91\xa9",
       ];
+
+    public static $exceptions = [
+            // Outlook email rendering
+            "microsoft-com\xf0\x9f\x8f\xa2office" => 'microsoft-com:office:office',
+      ];
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2440
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Because `:office` was in an Outlook's email html tag, it was converted to the emoji equivalent of the short tag. This PR adds support to define exceptions which basically just reverts such cases that were converted to emoji's to begin with. 

#### Steps to test this PR:
1. Create/edit an email and update the source with `<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">`
2. Preview the email and view the source. `:office:` should remain intact. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Repeat the above only `:office` should have been converted to an office emoji
