### PR TITLE
Fixes ability to save Focus permissions

### DIFF
--- a/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
@@ -248,10 +248,8 @@ class CorePermissions
             $parts = explode(':', $permission);
 
             if ($parts[0] == 'plugin' && count($parts) == 4) {
-                $isPlugin = true;
+                // @deprecated - no longer used; to be removed in 3.0
                 array_shift($parts);
-            } else {
-                $isPlugin = null;
             }
 
             if (count($parts) != 3) {
@@ -270,7 +268,7 @@ class CorePermissions
                 $activePermissions = ($userEntity instanceof User) ? $userEntity->getActivePermissions() : [];
 
                 //check against bundle permissions class
-                $permissionObject = $this->getPermissionObject($parts[0], true, $isPlugin);
+                $permissionObject = $this->getPermissionObject($parts[0]);
 
                 //Is the permission supported?
                 if (!$permissionObject->isSupported($parts[1], $parts[2])) {
@@ -337,17 +335,15 @@ class CorePermissions
             $parts = explode(':', $p);
 
             if ($parts[0] == 'plugin' && count($parts) == 4) {
-                $isPlugin = true;
+                // @deprecated - no longer used; to be removed in 3.0
                 array_shift($parts);
-            } else {
-                $isPlugin = null;
             }
 
             if (count($parts) != 3) {
                 $result[$p] = false;
             } else {
                 //check against bundle permissions class
-                $permissionObject = $this->getPermissionObject($parts[0], false, $isPlugin);
+                $permissionObject = $this->getPermissionObject($parts[0], false);
                 $result[$p]       = $permissionObject && $permissionObject->isSupported($parts[1], $parts[2]);
             }
         }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | todo
| Issues addressed (#s or URLs) | #2674
| BC breaks? | n
| Deprecations? | y

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Saving a role that customizes focus permissions would result in an error. 

#### Steps to test this PR:
1. Create a new role. 
2. Customize Focus Permissions. 
3. Save and note no error

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Same as above only results in error

#### List deprecations along with the new alternative:
1. Permission use of `plugin:somePlugin` is no longer required due to permission class changes introduced in 2.2. This means that it's also no longer required to know track plugin vs core bundle. So, 2.2.1 deprecates this to be removed in 3.0. 