### PR TITLE
Fixed testing mailer with API key

### DIFF
--- a/app/bundles/EmailBundle/Controller/AjaxController.php
+++ b/app/bundles/EmailBundle/Controller/AjaxController.php
@@ -228,7 +228,7 @@ class AjaxController extends CommonAjaxController
             }
 
             if (!empty($mailer)) {
-                if (is_callable($mailer, 'setApiKey')) {
+                if (is_callable([$mailer, 'setApiKey'])) {
                     if (empty($settings['api_key'])) {
                         $settings['api_key'] = $this->get('mautic.helper.core_parameters')->getParameter('mailer_api_key');
                     }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2535
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
`is_callable` had the mailer and method set as arguments rather than array and thus didn't properly check if `setApiKey` was callable leading to the `Cannot create instance of \SparkPost\SparkPost while API key is NULL Log data: !! Cannot create instance of \SparkPost\SparkPost while API key is NULL (code: 0)` error. Although some instances seem to still return successful tests. 

#### Steps to test this PR:
1. Use sparkpost transport in Email Configuration
2. Add api key
3. Click test connection

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Repeat above and may get the error noted
