### PR TITLE
Hide missing plugins from plugin list and fixed updating the is missing flag

### DIFF
--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -41,6 +41,15 @@ class PluginController extends FormController
         // List of plugins for filter and to show as a single integration
         $plugins = $pluginModel->getEntities(
             [
+                'filter' => [
+                    'force' => [
+                        [
+                            'column' => 'p.isMissing',
+                            'expr'   => 'eq',
+                            'value'  => 0,
+                        ],
+                    ],
+                ],
                 'hydration_mode' => 'hydrate_array',
             ]
         );
@@ -56,17 +65,20 @@ class PluginController extends FormController
         $integrations       = $foundPlugins       = [];
 
         foreach ($integrationObjects as $name => $object) {
-            $settings            = $object->getIntegrationSettings();
-            $integrations[$name] = [
-                'name'     => $object->getName(),
-                'display'  => $object->getDisplayName(),
-                'icon'     => $integrationHelper->getIconPath($object),
-                'enabled'  => $settings->isPublished(),
-                'plugin'   => $settings->getPlugin()->getId(),
-                'isBundle' => false,
-            ];
+            $settings = $object->getIntegrationSettings();
+            $pluginId = $settings->getPlugin()->getId();
+            if (isset($plugins[$pluginId])) {
+                $integrations[$name] = [
+                    'name'     => $object->getName(),
+                    'display'  => $object->getDisplayName(),
+                    'icon'     => $integrationHelper->getIconPath($object),
+                    'enabled'  => $settings->isPublished(),
+                    'plugin'   => $settings->getPlugin()->getId(),
+                    'isBundle' => false,
+                ];
+            }
 
-            $foundPlugins[$settings->getPlugin()->getId()] = true;
+            $foundPlugins[$pluginId] = true;
         }
 
         $nonIntegrationPlugins = array_diff_key($plugins, $foundPlugins);
@@ -403,6 +415,7 @@ class PluginController extends FormController
                 if (!$plugin->getIsMissing()) {
                     //files are no longer found
                     $plugin->setIsMissing(true);
+                    $persistUpdate = true;
                     ++$disabled;
                 }
             } else {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #1118
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When a plugin is marked as missing (uninstalled), it still showed in the plugin list. This PR hides them instead.

#### Steps to test this PR:
1. Manually update the is_missing flag for a plugin the plugins table.
2. View the Plugins - the one marked as missing should not be visible

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Same as above only this time it should be visible regardless of the is missing flag
