### PR TITLE
Fixed a bad merge with fields in segments

### DIFF
--- a/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryFiltersType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryFiltersType.php
@@ -274,7 +274,7 @@ class DynamicContentFilterEntryFiltersType extends AbstractType
                     'choices' => $choices,
                     'attr'    => [
                         'class'    => 'form-control not-chosen',
-                        'onchange' => 'Mautic.convertLeadFilterInput(this)',
+                        'onchange' => 'Mautic.convertDynamicContentFilterInput(this)',
                     ],
                 ]
             );

--- a/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryFiltersType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryFiltersType.php
@@ -154,6 +154,7 @@ class DynamicContentFilterEntryFiltersType extends AbstractType
 
                     break;
                 case 'select':
+                case 'multiselect':
                 case 'boolean':
                     $type = 'choice';
                     $attr = array_merge(

--- a/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryFiltersType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryFiltersType.php
@@ -77,8 +77,9 @@ class DynamicContentFilterEntryFiltersType extends AbstractType
             $form    = $event->getForm();
             $options = $form->getConfig()->getOptions();
 
-            $fieldType = $data['type'];
-            $fieldName = $data['field'];
+            $fieldType   = $data['type'];
+            $fieldName   = $data['field'];
+            $fieldObject = $data['object'];
 
             $type = 'text';
             $attr = [
@@ -148,7 +149,7 @@ class DynamicContentFilterEntryFiltersType extends AbstractType
                         ]
                     );
 
-                    if (isset($options['fields'][$fieldName]['properties']['list'])) {
+                    if (isset($options['fields'][$fieldObject][$fieldName]['properties']['list'])) {
                         $displayAttr['data-options'] = $options['fields'][$fieldName]['properties']['list'];
                     }
 
@@ -173,7 +174,7 @@ class DynamicContentFilterEntryFiltersType extends AbstractType
                         }
                     }
 
-                    $list    = $options['fields'][$fieldName]['properties']['list'];
+                    $list    = $options['fields'][$fieldObject][$fieldName]['properties']['list'];
                     $choices = FormFieldHelper::parseListStringIntoArray($list);
 
                     if ($fieldType == 'select') {
@@ -197,7 +198,7 @@ class DynamicContentFilterEntryFiltersType extends AbstractType
                         ]
                     );
 
-                    if (isset($options['fields'][$fieldName]['properties']['list'])) {
+                    if (isset($options['fields'][$fieldObject][$fieldName]['properties']['list'])) {
                         $attr['data-options'] = $options['fields'][$fieldName]['properties']['list'];
                     }
 
@@ -258,12 +259,12 @@ class DynamicContentFilterEntryFiltersType extends AbstractType
             );
 
             $choices = $operatorChoices;
-            if (isset($options['fields'][$fieldName]['operators']['include'])) {
+            if (isset($options['fields'][$fieldObject][$fieldName]['operators']['include'])) {
                 // Inclusive operators
-                $choices = array_intersect_key($choices, array_flip($options['fields'][$fieldName]['operators']['include']));
-            } elseif (isset($options['fields'][$fieldName]['operators']['exclude'])) {
+                $choices = array_intersect_key($choices, array_flip($options['fields'][$fieldObject][$fieldName]['operators']['include']));
+            } elseif (isset($options['fields'][$fieldObject][$fieldName]['operators']['exclude'])) {
                 // Inclusive operators
-                $choices = array_diff_key($choices, array_flip($options['fields'][$fieldName]['operators']['exclude']));
+                $choices = array_diff_key($choices, array_flip($options['fields'][$fieldObject][$fieldName]['operators']['exclude']));
             }
 
             $form->add(
@@ -315,6 +316,7 @@ class DynamicContentFilterEntryFiltersType extends AbstractType
                 'timezones',
                 'stages',
                 'locales',
+                'fields',
             ]
         );
 

--- a/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryType.php
@@ -88,6 +88,7 @@ class DynamicContentFilterEntryType extends AbstractType
                         'timezones' => $this->timezoneChoices,
                         'stages'    => $this->stageChoices,
                         'locales'   => $this->localeChoices,
+                        'fields'    => $this->fieldChoices,
                     ],
                     'error_bubbling' => false,
                     'mapped'         => true,

--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -467,7 +467,7 @@ Mautic.addDynamicContentFilter = function (selectedFilter) {
 
     if (isSpecial) {
         var templateField = fieldType;
-        if (fieldType == 'boolean') {
+        if (fieldType == 'boolean' || fieldType == 'multiselect') {
             templateField = 'select';
         }
         var template = mQuery('#templates .' + templateField + '-template').clone();
@@ -505,7 +505,7 @@ Mautic.addDynamicContentFilter = function (selectedFilter) {
     var fieldOptions = fieldCallback = '';
     //activate fields
     if (isSpecial) {
-        if (fieldType == 'select' || fieldType == 'boolean') {
+        if (fieldType == 'select' || fieldType == 'boolean' || fieldType == 'multiselect') {
             // Generate the options
             fieldOptions = selectedOption.data("field-list");
 
@@ -617,6 +617,7 @@ Mautic.convertDynamicContentFilterInput = function(el) {
     }
 
     var newName = '';
+    var lastPos;
 
     if (filterEl.is('select')) {
         var isMultiple  = filterEl.attr('multiple');
@@ -635,7 +636,10 @@ Mautic.convertDynamicContentFilterInput = function(el) {
             filterEl.removeAttr('multiple');
 
             // Update the name
-            newName =  filterEl.attr('name').replace(/[\[\]']+/g, '');
+            newName = filterEl.attr('name');
+            lastPos = newName.lastIndexOf('[]');
+            newName = newName.substring(0, lastPos);
+
             filterEl.attr('name', newName);
 
             placeholder = mauticLang['chosenChooseOne'];

--- a/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
@@ -173,6 +173,12 @@ class TokenSubscriber extends CommonSubscriber
                 case '!like':
                     $groups[$groupNum] = strpos($leadVal, $filterVal) === false;
                     break;
+                case 'in':
+                    $groups[$groupNum] = in_array($leadVal, $filterVal) !== false;
+                    break;
+                case '!in':
+                    $groups[$groupNum] = in_array($leadVal, $filterVal) === false;
+                    break;
             }
         }
 

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -261,23 +261,26 @@ Mautic.convertLeadFilterInput = function(el) {
         mQuery(filterId).parent().removeClass('has-error');
     }
 
-    var disabled = (operator == 'empty' || operator == '!empty') ? true : false;
+    var disabled = (operator == 'empty' || operator == '!empty');
     mQuery(filterId).prop('disabled', disabled);
 
     if (disabled) {
         mQuery(filterId).val('');
     }
 
+    var newName = '';
+    var lastPos;
+
     if (mQuery(filterId).is('select')) {
         var isMultiple  = mQuery(filterId).attr('multiple');
-        var multiple    = (operator == 'in' || operator == '!in') ? true : false;
+        var multiple    = (operator == 'in' || operator == '!in');
         var placeholder = mQuery(filterId).attr('data-placeholder');
 
         if (multiple && !isMultiple) {
             mQuery(filterId).attr('multiple', 'multiple');
 
             // Update the name
-            var newName =  mQuery(filterId).attr('name') + '[]';
+            newName =  mQuery(filterId).attr('name') + '[]';
             mQuery(filterId).attr('name', newName);
 
             placeholder = mauticLang['chosenChooseMore'];
@@ -285,7 +288,10 @@ Mautic.convertLeadFilterInput = function(el) {
             mQuery(filterId).removeAttr('multiple');
 
             // Update the name
-            var newName =  mQuery(filterId).attr('name').replace(/[\[\]']+/g,'')
+            newName = filterEl.attr('name');
+            lastPos = newName.lastIndexOf('[]');
+            newName = newName.substring(0, lastPos);
+
             mQuery(filterId).attr('name', newName);
 
             placeholder = mauticLang['chosenChooseOne'];

--- a/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
@@ -157,7 +157,8 @@ trait EntityFieldsBuildFormTrait
                             $value = (int) $value;
                         }
                     }
-                    $typeProperties['data']        = $value;
+
+                    $typeProperties['data']        = $type === 'multiselect' ? FormFieldHelper::parseList($value) : $value;
                     $typeProperties['empty_value'] = $emptyValue;
                     $builder->add(
                         $alias,

--- a/app/bundles/LeadBundle/Form/Type/FilterType.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterType.php
@@ -151,6 +151,7 @@ class FilterType extends AbstractType
                 case 'timezone':
                 case 'country':
                 case 'region':
+                case 'locale':
                     switch ($fieldType) {
                         case 'timezone':
                             $choiceKey = 'timezones';
@@ -160,6 +161,9 @@ class FilterType extends AbstractType
                             break;
                         case 'region':
                             $choiceKey = 'regions';
+                            break;
+                        case 'locale':
+                            $choiceKey = 'locales';
                             break;
                     }
 
@@ -204,6 +208,7 @@ class FilterType extends AbstractType
 
                     break;
                 case 'select':
+                case 'multiselect':
                 case 'boolean':
                     $type = 'choice';
                     $attr = array_merge(
@@ -369,6 +374,7 @@ class FilterType extends AbstractType
                 'emails',
                 'tags',
                 'stage',
+                'locales',
             ]
         );
 

--- a/app/bundles/LeadBundle/Form/Type/ListType.php
+++ b/app/bundles/LeadBundle/Form/Type/ListType.php
@@ -155,6 +155,7 @@ class ListType extends AbstractType
                         'emails'    => $this->emailChoices,
                         'tags'      => $this->tagChoices,
                         'stage'     => $this->stageChoices,
+                        'locales'   => $this->localeChoices,
                     ],
                     'error_bubbling' => false,
                     'mapped'         => true,

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -458,7 +458,7 @@ class ListModel extends FormModel
             // Set operators allowed
             if ($type == 'boolean') {
                 $choices[$field->getObject()][$field->getAlias()]['operators'] = 'bool';
-            } elseif (in_array($type, ['select', 'multiselect', 'country', 'timezone', 'region'])) {
+            } elseif (in_array($type, ['select', 'multiselect', 'country', 'timezone', 'region', 'locale'])) {
                 $choices[$field->getObject()][$field->getAlias()]['operators'] = 'select';
             } elseif (in_array($type, ['lookup', 'lookup_id',  'text', 'email', 'url', 'email', 'tel'])) {
                 $choices[$field->getObject()][$field->getAlias()]['operators'] = 'text';

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -458,10 +458,8 @@ class ListModel extends FormModel
             // Set operators allowed
             if ($type == 'boolean') {
                 $choices[$field->getObject()][$field->getAlias()]['operators'] = 'bool';
-            } elseif (in_array($type, ['select', 'country', 'timezone', 'region'])) {
-                $choices[$field->getObject()][$field->getAlias()]['operators'] = 'select';
             } elseif (in_array($type, ['select', 'multiselect', 'country', 'timezone', 'region'])) {
-                $choices[$field->getAlias()]['operators'] = 'select';
+                $choices[$field->getObject()][$field->getAlias()]['operators'] = 'select';
             } elseif (in_array($type, ['lookup', 'lookup_id',  'text', 'email', 'url', 'email', 'tel'])) {
                 $choices[$field->getObject()][$field->getAlias()]['operators'] = 'text';
             } else {

--- a/app/bundles/LeadBundle/Views/Lead/lead.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/lead.html.php
@@ -218,7 +218,7 @@ $view['slots']->set(
                                                     <img class="mr-sm" src="<?php echo $flag; ?>" alt="" style="max-height: 24px;"/>
                                                     <span class="mt-1"><?php echo $field['value']; ?>
                                                     <?php else: ?>
-                                                        <?php if (!empty($field['value']) && 'multiselect' === $field['type']): ?>
+                                                        <?php if (is_array($field['value']) && 'multiselect' === $field['type']): ?>
                                                             <?php echo implode(', ', $field['value']); ?>
                                                         <?php else: ?>
                                                             <?php echo $field['value']; ?>

--- a/app/bundles/LeadBundle/Views/Lead/lead.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/lead.html.php
@@ -218,7 +218,7 @@ $view['slots']->set(
                                                     <img class="mr-sm" src="<?php echo $flag; ?>" alt="" style="max-height: 24px;"/>
                                                     <span class="mt-1"><?php echo $field['value']; ?>
                                                     <?php else: ?>
-                                                        <?php if ('multiselect' === $field['type']): ?>
+                                                        <?php if (!empty($field['value']) && 'multiselect' === $field['type']): ?>
                                                             <?php echo implode(', ', $field['value']); ?>
                                                         <?php else: ?>
                                                             <?php echo $field['value']; ?>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | na
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Found a bad merge with the multiselect when determining the operators for a segment's filter.

#### Steps to test this PR:
1. Create a new multiselect custom field
2. Create a new segment and use that multiselect as the filter
3. Save and view - no notices or warnings should generate
4. Add a preferred locale as a filter - and the operator list should not include greater than, et al.
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Repeat the above - should get a warning about array_key_exists expecting an array as argument 2

