### PR TITLE
Disconnect from imap when switching mailbox to ensure new settings are used

### DIFF
--- a/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -239,6 +239,9 @@ class Mailbox
             $this->settings           = (!empty($this->mailboxes[$key]['override_settings'])) ? $this->mailboxes[$key] : $this->mailboxes['general'];
             $this->imapFolder         = $this->mailboxes[$key]['folder'];
             $this->settings['folder'] = $this->mailboxes[$key]['folder'];
+            // Disconnect so that new mailbox settings are used
+            $this->disconnect();
+            // Setup new connection
             $this->setImapPath();
         } else {
             throw new MailboxException($key.' not found');


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2405
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When both the bounce and unsubscribe monitored inboxes are configured - the unsubscribe imap checking will still use the connection to the bounce folder. This PR fixes this. 

#### Steps to test this PR:
1. Setup bounce and unsubscribe monitored inboxes - use a different folder for each and ensure one unread message is in each inbox.
2. Run the command `php app/console mautic:email:fetch`
3. The emails in both folders should be marked read.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Repeat the above but the emails in the unsubscribe folder will remain marked as read.

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
…e used