### PR TITLE
Prevent contacts from getting prematurely removed from a segment

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -342,14 +342,15 @@ class LeadListRepository extends CommonRepository
                 $q->select($select)
                     ->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
 
+                $batchExpr = $q->expr()->andX();
                 // Only leads that existed at the time of count
                 if ($batchLimiters) {
                     if (!empty($batchLimiters['minId']) && !empty($batchLimiters['maxId'])) {
-                        $expr->add(
+                        $batchExpr->add(
                             $q->expr()->comparison('l.id', 'BETWEEN', "{$batchLimiters['minId']} and {$batchLimiters['maxId']}")
                         );
                     } elseif (!empty($batchLimiters['maxId'])) {
-                        $expr->add(
+                        $batchExpr->add(
                             $q->expr()->lte('l.id', $batchLimiters['maxId'])
                         );
                     }
@@ -363,16 +364,29 @@ class LeadListRepository extends CommonRepository
                     // Leads that do not have any record in the lead_lists_leads table for this lead list
                     // For non null fields - it's apparently better to use left join over not exists due to not using nullable
                     // fields - https://explainextended.com/2009/09/18/not-in-vs-not-exists-vs-left-join-is-null-mysql/
+                    $listOnExpr = $q->expr()->andX(
+                        $q->expr()->eq('ll.leadlist_id', $id),
+                        $q->expr()->eq('ll.lead_id', 'l.id')
+                    );
+
+                    if (!empty($batchLimiters['dateTime'])) {
+                        // Only leads in the list at the time of count
+                        $listOnExpr->add(
+                            $q->expr()->lte('ll.date_added', $q->expr()->literal($batchLimiters['dateTime']))
+                        );
+                    }
+
                     $q->leftJoin(
                         'l',
                         MAUTIC_TABLE_PREFIX.'lead_lists_leads',
                         'll',
-                        $q->expr()->andX(
-                            $q->expr()->eq('ll.leadlist_id', $id),
-                            $q->expr()->eq('ll.lead_id', 'l.id')
-                        )
+                        $listOnExpr
                     );
                     $expr->add($q->expr()->isNull('ll.lead_id'));
+
+                    if ($batchExpr->count()) {
+                        $expr->add($batchExpr);
+                    }
 
                     $q->andWhere($expr);
                 } elseif ($nonMembersOnly) {
@@ -412,6 +426,11 @@ class LeadListRepository extends CommonRepository
                     $mainExpr->add(
                         sprintf('l.id NOT IN (%s)', $sq->getSQL())
                     );
+
+                    if ($batchExpr->count()) {
+                        $mainExpr->add($batchExpr);
+                    }
+
                     $q->andWhere($mainExpr);
                 }
 

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -640,6 +640,9 @@ class ListModel extends FormModel
             }
         }
 
+        // Unset max ID to prevent capping at newly added max ID
+        unset($batchLimiters['maxId']);
+
         // Get a count of leads to be removed
         $removeLeadCount = $this->getLeadsByList(
             $list,
@@ -650,6 +653,9 @@ class ListModel extends FormModel
                 'batchLimiters'  => $batchLimiters,
             ]
         );
+
+        // Ensure the same list is used each batch
+        $batchLimiters['maxId'] = (int) $removeLeadCount[$id]['maxId'];
 
         // Restart batching
         $start     = $lastRoundPercentage     = 0;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2461 possibly #2419
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If a contact with an ID between existing IDs of a segment is added to the segment, IDs greater than that of the contact just added will be prematurely removed from the segment - then added right back on the next run.

#### Steps to test this PR:

Take the steps below and note that the higher contact IDs should not be removed.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
Taken from #2461 

To duplicate the error:
1. create a segment which adds people based on some criteria, like visiting a page (my specific issue) or having a particular field value set should also work to simulate the effect.
2. get a handful of leads to do whatever they need to qualify for this segment & run cron to get them in.
3. pick a lead who has a leadid somewhere in between the group that was previously added and then do the thing to this lead that will make it qualify for the segment.
4. When you run cron next time you will see that this latest lead (it ain't new) gets added into the segment, and then ANYONE whose leadid > than the one you just entered (this is where maxId comes in) gets removed from the segment.
5. When you run cron again, then the removed people get re-qualified and re-added to the segment, but now their date-added is newer, which will cause problems with campaigns that starts with qualifying into a segment and relies on waiting time before another step, the people keep re-qualifying and restarting the campaign, never getting to trigger the next step...

