### PR TITLE
JS tracking encodes values sent via tracking pixel query

### DIFF
--- a/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
@@ -50,7 +50,7 @@ MauticJS.serialize = function(obj) {
     }
 
     return Object.keys(obj).map(function(key) {
-        return key + '=' + obj[key];
+        return key + '=' + encodeURIComponent(obj[key]);
     }).join('&');
 };
 

--- a/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
@@ -50,7 +50,7 @@ MauticJS.serialize = function(obj) {
     }
 
     return Object.keys(obj).map(function(key) {
-        return key + '=' + encodeURIComponent(obj[key]);
+        return encodeURIComponent(key) + '=' + encodeURIComponent(obj[key]);
     }).join('&');
 };
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | /
| Deprecations? | /

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Some users were complaining that their tracking pixel request returns 404 instead of 200. I noticed it's because the page_url is not decoded.

#### Testing HTML page:
```
<html>
    <head>
        <title>Test of the Mautic JS tracking</title>
        <script>
            (function(w,d,t,u,n,a,m){w['MauticTrackingObject']=n;
                w[n]=w[n]||function(){(w[n].q=w[n].q||[]).push(arguments)},a=d.createElement(t),
                m=d.getElementsByTagName(t)[0];a.async=1;a.src=u;m.parentNode.insertBefore(a,m)
            })(window,document,'script','http://[your_mautic]/mtc.js','mt');

            mt(
                'send',
                'pageview',
                {
                    email: 'some+JStracking@gmail.com'
                }
            );
        </script>
    </head>
    <body>
        JS test. Open the JS console to see the results.
    </body>
</html>
```

#### Steps to test this PR:
1. Apply this PR.
2. Refresh the testing HTML page. The ajax request should have encoded values: `mtracking.gif?page_title=Test%20of%20the%20Mautic%20JS%20tracking&page_language=en-US&page_referrer=&page_url=http%3A%2F%2Flocalhost%2Fmauticjstest.html&email=some%2BJStracking%40gmail.com&fingerprint=05071a234bf2c71b3bb4eb21da0c789a&resolution=1920x1080&timezone_offset=-120&platform=Linux%20x86_64&do_not_track=unknown&adblock=false`
3. Check in the contact detail that the values like the page_url are not destroyed byt the encoding.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create the testing HTML page, update the URL in it to link to your instance.
2. Visit the page and check the ajax requests in the dev tools. All values in it are raw:
`mtracking.gif?page_title=Test%20of%20the%20Mautic%20JS%20tracking&page_language=en-US&page_referrer=&page_url=http://localhost/mauticjstest.html&email=some+JStracking@gmail.com&fingerprint=05071a234bf2c71b3bb4eb21da0c789a&resolution=1920x1080&timezone_offset=-120&platform=Linux%20x86_64&do_not_track=unknown&adblock=false`
