### PR TITLE
Gmail Plugin - tracked emails sent are publicly accessible

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -28,6 +28,11 @@ class PublicController extends CommonFormController
         /** @var \Mautic\EmailBundle\Model\EmailModel $model */
         $model = $this->getModel('email');
         $stat  = $model->getEmailStatus($idHash);
+        
+        if (!$stat->getEmail() && $this->get('mautic.security')->isAnonymous()) {
+            // Anonymous users don't have access to view custom emails
+            return $this->accessDenied();
+        }
 
         if (!empty($stat)) {
             if ($this->get('mautic.security')->isAnonymous()) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? | N |
| Related user documentation PR URL | N |
| Related developer documentation PR URL | N |
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2678 |
| BC breaks? | N |
| Deprecations? | N |
#### Description:

When accessing the new gmail plugin to track an email sent. The notification showing in mautic, has a link to that email. If pressed, you can view the full content of the email that was sent even when the user is signed out. The link looks like this:
http://[Domain-Name]/mautic/email/view/63xxxxxxxxb38
Its fine for marketing campaign perhaps. However for personal direct emails this is quite dangerous.
#### Steps to test this PR:
1. Send an email from Gmail and track it in Mautic with the [Mautic Helper Chrome Extension](https://chrome.google.com/webstore/detail/mautic-helper/glpjomjkomefedfilfhgoijnfkneifje)
2. Open the timeline from the Mautic Helper
3. Click on the link to open the email just sent
4. The email should be visible (leave the window/tab open)
5. Log out from Mautic from another window
6. On the window/tab with the email preview, click refresh to load it again
7. There should be a Forbidden message
#### Steps to reproduce the bug:
1. The same as before but the email content should still be visible even if logged out from Mautic
