### PR TITLE
Add throws annotation for app/bundles/ApiBundle/Model/ClientModel.php

### DIFF
--- a/app/bundles/ApiBundle/Model/ClientModel.php
+++ b/app/bundles/ApiBundle/Model/ClientModel.php
@@ -165,6 +165,8 @@ class ClientModel extends FormModel
 
     /**
      * @param $entity
+     *
+     * @throws MethodNotAllowedHttpException
      */
     public function revokeAccess($entity)
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Yes |
| New feature? | No |
| Related user documentation PR URL | No |
| Related developer documentation PR URL | No |
| Issues addressed (#s or URLs) | No |
| BC breaks? | No |
| Deprecations? | No |
#### Description:

In `app/bundles/ApiBundle/Model/ClientModel.php`, I think the `revokeAccess` function needs `throw` annotation.
#### Steps to test this PR:

See file changed code.
Just add annotation.

Thanks!
