### PR TITLE
Added support for a temporary directory location for file uploads like file imports

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -716,6 +716,7 @@ return [
         'cache_path'                => '%kernel.root_dir%/cache',
         'log_path'                  => '%kernel.root_dir%/logs',
         'image_path'                => 'media/images',
+        'tmp_path'                  => '%kernel.root_dir%/cache',
         'theme'                     => 'Mauve',
         'db_driver'                 => 'pdo_mysql',
         'db_host'                   => '127.0.0.1',

--- a/app/bundles/CoreBundle/Helper/PathsHelper.php
+++ b/app/bundles/CoreBundle/Helper/PathsHelper.php
@@ -54,6 +54,11 @@ class PathsHelper
     protected $kernelLogsDir;
 
     /**
+     * @var mixed
+     */
+    protected $temporaryDir;
+
+    /**
      * @var User
      */
     protected $user;
@@ -69,11 +74,12 @@ class PathsHelper
         $this->user                   = $userHelper->getUser();
         $this->paths                  = $coreParametersHelper->getParameter('paths');
         $this->theme                  = $coreParametersHelper->getParameter('theme');
-        $this->imagePath              = $coreParametersHelper->getParameter('image_path');
-        $this->dashboardImportDir     = $coreParametersHelper->getParameter('dashboard_import_dir');
-        $this->dashboardImportUserDir = $coreParametersHelper->getParameter('dashboard_import_user_dir');
-        $this->kernelCacheDir         = $coreParametersHelper->getParameter('kernel.cache_dir');
-        $this->kernelLogsDir          = $coreParametersHelper->getParameter('kernel.logs_dir');
+        $this->imagePath              = $this->removeTrailingSlash($coreParametersHelper->getParameter('image_path'));
+        $this->dashboardImportDir     = $this->removeTrailingSlash($coreParametersHelper->getParameter('dashboard_import_dir'));
+        $this->temporaryDir           = $this->removeTrailingSlash($coreParametersHelper->getParameter('tmp_path'));
+        $this->dashboardImportUserDir = $this->removeTrailingSlash($coreParametersHelper->getParameter('dashboard_import_user_dir'));
+        $this->kernelCacheDir         = $this->removeTrailingSlash($coreParametersHelper->getParameter('kernel.cache_dir'));
+        $this->kernelLogsDir          = $this->removeTrailingSlash($coreParametersHelper->getParameter('kernel.logs_dir'));
     }
 
     /**
@@ -89,50 +95,64 @@ class PathsHelper
      */
     public function getSystemPath($name, $fullPath = false)
     {
-        if ($name == 'currentTheme' || $name == 'current_theme') {
-            $path = $this->paths['themes'].'/'.$this->theme;
-        } elseif ($name == 'cache' || $name == 'logs') {
-            //these are absolute regardless as they are configurable
-            return ($name === 'cache') ? $this->kernelCacheDir : $this->kernelLogsDir;
-        } elseif ($name == 'images') {
-            $path = $this->imagePath;
+        switch ($name) {
+            case 'currentTheme':
+            case 'current_theme':
+                $path = $this->paths['themes'].'/'.$this->theme;
+                break;
 
-            if (substr($path, -1) === '/') {
-                $path = substr($path, 0, -1);
-            }
-        } elseif ($name == 'dashboard.user' || $name == 'dashboard.global') {
-            //these are absolute regardless as they are configurable
-            $globalPath = $this->dashboardImportDir;
+            case 'cache':
+            case 'logs':
+            case 'temporary':
+            case 'tmp':
+                //these are absolute regardless as they are configurable
+                if ('cache' === $name) {
+                    return $this->kernelCacheDir;
+                } elseif ('logs' === $name) {
+                    return $this->kernelLogsDir;
+                } else {
+                    if (!is_dir($this->temporaryDir) && !file_exists($this->temporaryDir)) {
+                        mkdir($this->temporaryDir, 0755);
+                    }
 
-            if (substr($globalPath, -1) === '/') {
-                $globalPath = substr($globalPath, 0, -1);
-            }
+                    return $this->temporaryDir;
+                }
 
-            if ($name == 'dashboard.global') {
-                return $globalPath;
-            }
+            case 'images':
+                $path = $this->imagePath;
+                break;
 
-            if (!$userPath = $this->dashboardUserImportDir) {
-                $userPath = $globalPath;
-            } elseif (substr($userPath, -1) === '/') {
-                $userPath = substr($userPath, 0, -1);
-            }
+            case 'dashboard.user':
+            case 'dashboard.global':
+                //these are absolute regardless as they are configurable
+                $globalPath = $this->dashboardImportDir;
 
-            $userPath .= '/'.$this->user->getId();
+                if ($name == 'dashboard.global') {
+                    return $globalPath;
+                }
 
-            // @todo check is_writable
-            if (!is_dir($userPath) && !file_exists($userPath)) {
-                mkdir($userPath, 0755);
-            }
+                if (!$userPath = $this->dashboardUserImportDir) {
+                    $userPath = $globalPath;
+                }
 
-            return $userPath;
-        } elseif (isset($this->paths[$name])) {
-            $path = $this->paths[$name];
-        } elseif (strpos($name, '_root') !== false) {
-            // Assume system root if one is not set specifically
-            $path = $this->paths['root'];
-        } else {
-            throw new \InvalidArgumentException("$name does not exist.");
+                $userPath .= '/'.$this->user->getId();
+
+                // @todo check is_writable
+                if (!is_dir($userPath) && !file_exists($userPath)) {
+                    mkdir($userPath, 0755);
+                }
+
+                return $userPath;
+
+            default:
+                if (isset($this->paths[$name])) {
+                    $path = $this->paths[$name];
+                } elseif (strpos($name, '_root') !== false) {
+                    // Assume system root if one is not set specifically
+                    $path = $this->paths['root'];
+                } else {
+                    throw new \InvalidArgumentException("$name does not exist.");
+                }
         }
 
         if ($fullPath) {
@@ -142,5 +162,19 @@ class PathsHelper
         }
 
         return $path;
+    }
+
+    /**
+     * @param $dir
+     *
+     * @return string
+     */
+    private function removeTrailingSlash($dir)
+    {
+        if (substr($dir, -1) === '/') {
+            $dir = substr($dir, 0, -1);
+        }
+
+        return $dir;
     }
 }

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1316,10 +1316,10 @@ class LeadController extends FormController
         // Move the file to cache and rename it
         $forceStop = $this->request->get('cancel', false);
         $step      = ($forceStop) ? 1 : $session->get('mautic.lead.import.step', 1);
-        $cacheDir  = $this->get('mautic.helper.paths')->getSystemPath('cache', true);
+        $tmpDir    = $this->get('mautic.helper.paths')->getSystemPath('tmp');
         $username  = $this->get('mautic.helper.user')->getUser()->getUsername();
         $fileName  = $username.'_leadimport.csv';
-        $fullPath  = $cacheDir.'/'.$fileName;
+        $fullPath  = $tmpDir.'/'.$fileName;
         $complete  = false;
         if (!file_exists($fullPath)) {
             // Force step one if the file doesn't exist
@@ -1504,7 +1504,7 @@ class LeadController extends FormController
                                 $errorMessage    = null;
                                 $errorParameters = [];
                                 try {
-                                    $fileData->move($cacheDir, $fileName);
+                                    $fileData->move($tmpDir, $fileName);
 
                                     $file = new \SplFileObject($fullPath);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | n |
| New feature? | n |
| Related user documentation PR URL | na |
| Related developer documentation PR URL | todo |
| Issues addressed (#s or URLs) | na |
| BC breaks? | na |
| Deprecations? | na |
#### Description:

In some cases, it's beneficial to define a unique location outside cache for temporary files such as file uploads. This PR adds this ability.
#### Steps to test this PR:
1. Edit local.php and `'tmp_path' => '%kernel.root_dir%/tmp'`.
2. Go to import contacts and upload a CSV file.
3. Check that the directory was created and the CSV file exists.
4. Continue the import and the CSV file should get deleted after completion.
