### PR TITLE
Allow font files in themes

### DIFF
--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -370,7 +370,7 @@ class ThemeHelper
             throw new \Exception($this->getExtractError($archive));
         } else {
             $containsConfig    = false;
-            $allowedExtensions = ['', 'json', 'twig', 'css', 'js', 'htm', 'html', 'txt', 'jpg', 'jpeg', 'png', 'gif', 'tiff'];
+            $allowedExtensions = ['', 'json', 'twig', 'css', 'js', 'htm', 'html', 'txt', 'jpg', 'jpeg', 'png', 'gif', 'tiff', 'eot', 'woff'];
             $allowedFiles      = [];
             for ($i = 0; $i < $zipper->numFiles; ++$i) {
                 $entry     = $zipper->getNameIndex($i);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| BC breaks? | no |
#### Description:

Some E-Mail templates require the use of specific fonts. This PR allows the upload of font files in themes.
#### Steps to test this PR:
1. Upload a theme with a .woff file. The request will be answered with a 404, because the file is ignored during the install
2. Apply PR
3. Font file is delivered and font style in theme is correct
