### PR TITLE
Fixes a bug where user couldn't edit contacts

### DIFF
--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -267,7 +267,9 @@ trait CustomFieldRepositoryTrait
         $fq->select('f.id, f.label, f.alias, f.type, f.field_group as "group", f.field_order, f.object')
             ->from(MAUTIC_TABLE_PREFIX.'lead_fields', 'f')
             ->where($fq->expr()->eq('f.object', ':object'))
+            ->andWhere('f.is_published = :published')
             ->setParameter('object', $object)
+            ->setParameter('published', true, 'boolean')
             ->orderBy('f.field_order', 'asc');
         $results = $fq->execute()->fetchAll();
 

--- a/app/bundles/LeadBundle/Views/Lead/form.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/form.html.php
@@ -208,9 +208,13 @@ $img = $view['lead_avatar']->getAvatar($lead);
                                     <div class="row">
                                         <?php foreach ($groupFields as $alias => $field): ?>
                                             <?php
-                                            if ($alias == 'company' || !isset($form[$alias]) || $form[$alias]->isRendered()) {
+                                            if ($isCompany = ('company' === $alias) || !isset($form[$alias]) || $form[$alias]->isRendered()):
+                                                // Company rendered so that it doesn't show up at the bottom of the form
+                                                if ($isCompany):
+                                                    $form[$alias]->setRendered();
+                                                endif;
                                                 continue;
-                                            }
+                                            endif;
                                             ?>
                                             <div class="col-sm-8">
                                                 <?php echo $view['form']->row($form[$alias]); ?>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? | N |
| Related user documentation PR URL |  |
| Related developer documentation PR URL |  |
| Issues addressed (#s or URLs) | Probably part of #1398 |
| BC breaks? |  |
| Deprecations? |  |
#### Description:

Fixes a bug where user couldn't edit contacts if there are unpublished fields
#### Steps to test this PR:
1. Unpublish a used field from Custom Fields menu
2. Go to Contacts > Open a contact > Click on Edit button
3.  Loading icon shown forever and error 500 shown on browser console
4. Now apply this PR, clear cache, test again and it should work
#### Steps to reproduce the bug:
1. Unpublish a used field from Custom Fields menu
2. Go to Contacts > Open a contact > Click on Edit button
3. Loading icon shown forever and error 500 shown on browser console
