### PR TITLE
Campaign condition to action fix

### DIFF
--- a/app/bundles/CampaignBundle/Assets/js/campaign.js
+++ b/app/bundles/CampaignBundle/Assets/js/campaign.js
@@ -76,7 +76,7 @@ Mautic.campaignOnLoad = function (container) {
             var option  = mQuery('#'+thisId+' option[value="' + mQuery(this).val() + '"]');
 
             if (option.attr('data-href') && Mautic.campaignBuilderAnchorNameClicked) {
-                var updatedUrl = option.attr('data-href').replace(/anchor=(.*?)$/, "anchor=" + Mautic.campaignBuilderAnchorNameClicked);
+                var updatedUrl = option.attr('data-href').replace(/anchor=(.*?)$/, "anchor=" + Mautic.campaignBuilderAnchorNameClicked + "&anchorEventType=" + Mautic.campaignBuilderAnchorEventTypeClicked);
                 // Replace the anchor in the URL with that clicked
                 option.attr('data-href', updatedUrl);
             }
@@ -423,11 +423,19 @@ Mautic.launchCampaignEditor = function() {
             var epDetails          = Mautic.campaignBuilderGetEndpointDetails(info.sourceEndpoint);
             var targetElementId    = info.targetEndpoint.elementId;
             var previousConnection = mQuery('#'+targetElementId).attr('data-connected')
-            if (previousConnection && previousConnection != epDetails.anchorName && (previousConnection == 'no' || epDetails.anchorName == 'no')) {
-                var editButton = mQuery('#'+targetElementId).find('a.btn-edit');
-                editButton.attr('data-prevent-dismiss', true);
-                var updatedUrl = editButton.attr('data-href', editButton.attr('href')+'&anchor=' + epDetails.anchorName);
+            var editButton         = mQuery('#'+targetElementId).find('a.btn-edit');
+            var editUrl            = editButton.attr('href');
 
+            var anchorQueryParams  = '&anchor=' + epDetails.anchorName + "&anchorEventType=" + epDetails.eventType;
+            if (editUrl.search('anchor=') !== -1) {
+                editUrl.replace(/anchor=(.*?)$/, anchorQueryParams);
+            } else {
+                editUrl = editUrl + anchorQueryParams;
+            }
+            editButton.attr('data-href', editUrl);
+
+            if (previousConnection && previousConnection != epDetails.anchorName && (previousConnection == 'no' || epDetails.anchorName == 'no')) {
+                editButton.attr('data-prevent-dismiss', true);
                 Mautic.campaignBuilderConnectionRequiresUpdate = true;
 
                 editButton.trigger('click');
@@ -1015,6 +1023,7 @@ Mautic.campaignBuilderRegisterAnchors = function(names, el) {
             var clickedAnchorName = epDetails.anchorName;
             Mautic.campaignBuilderAnchorClicked = endpoint.elementId+'_'+clickedAnchorName;
             Mautic.campaignBuilderAnchorNameClicked = clickedAnchorName;
+            Mautic.campaignBuilderAnchorEventTypeClicked = epDetails.eventType;
 
             // Get the position of the event
             var elPos = Mautic.campaignBuilderGetEventPosition(endpoint.element)

--- a/app/bundles/CampaignBundle/Controller/EventController.php
+++ b/app/bundles/CampaignBundle/Controller/EventController.php
@@ -43,10 +43,11 @@ class EventController extends CommonFormController
             $campaignId = $this->request->query->get('campaignId');
             $anchorName = $this->request->query->get('anchor', '');
             $event      = [
-                'type'       => $type,
-                'eventType'  => $eventType,
-                'campaignId' => $campaignId,
-                'anchor'     => $anchorName,
+                'type'            => $type,
+                'eventType'       => $eventType,
+                'campaignId'      => $campaignId,
+                'anchor'          => $anchorName,
+                'anchorEventType' => $this->request->query->get('anchorEventType', ''),
             ];
         }
 
@@ -225,7 +226,8 @@ class EventController extends CommonFormController
         $event          = (array_key_exists($objectId, $modifiedEvents)) ? $modifiedEvents[$objectId] : null;
 
         if ($method == 'POST') {
-            $event['anchor'] = $this->request->request->get('campaignevent[anchor]', '', true);
+            $event['anchor']          = $this->request->request->get('campaignevent[anchor]', '', true);
+            $event['anchorEventType'] = $this->request->request->get('campaignevent[anchorEventType]', '', true);
         } else {
             if (!isset($event['anchor'])) {
                 // Used to generate label
@@ -235,6 +237,11 @@ class EventController extends CommonFormController
             if ($this->request->query->has('anchor')) {
                 // Override the anchor
                 $event['anchor'] = $this->request->get('anchor');
+            }
+
+            if ($this->request->query->has('anchorEventType')) {
+                // Override the anchorEventType
+                $event['anchorEventType'] = $this->request->get('anchorEventType');
             }
         }
 

--- a/app/bundles/CampaignBundle/Form/Type/EventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/EventType.php
@@ -57,7 +57,9 @@ class EventType extends AbstractType
                 'date'      => 'mautic.campaign.form.type.date',
             ];
 
-            if ('no' == $options['data']['anchor'] && 'condition' != $options['data']['eventType']) {
+            if ('no' == $options['data']['anchor'] && 'condition' != $options['data']['anchorEventType']
+                && 'condition' != $options['data']['eventType']
+            ) {
                 $label .= '_inaction';
 
                 unset($choices['immediate']);
@@ -159,6 +161,14 @@ class EventType extends AbstractType
 
         $builder->add('type', 'hidden');
         $builder->add('eventType', 'hidden');
+        $builder->add(
+            'anchorEventType',
+            'hidden',
+            [
+                'mapped' => false,
+                'data'   => (isset($options['data']['anchorEventType'])) ? $options['data']['anchorEventType'] : '',
+            ]
+        );
 
         $builder->add(
             'canvasSettings',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? |  |
| Related user documentation PR URL |  |
| Related developer documentation PR URL |  |
| Issues addressed (#s or URLs) |  |
| BC breaks? |  |
| Deprecations? |  |
#### Description:

This fixes an issue that does not allow immediate execution for actions connected to the "false" path of a condition.
#### Steps to test this PR:
1. Edit/create a campaign and add a condition. 
2. Click on the red/false anchor
3. Add any action - notice that "immediately" is available for when to execute the event
4. Add a decision, click on the red/false anchor, add an action. Notice that "immediately" is not available for execution.
#### Steps to reproduce the bug:
1. Repeat the above but the action connected to the condition does not allow immediate execution
