### PR TITLE
Fixed issue that caused emails to not be editable if all DC items were deleted

### DIFF
--- a/app/bundles/CoreBundle/Entity/DynamicContentEntityTrait.php
+++ b/app/bundles/CoreBundle/Entity/DynamicContentEntityTrait.php
@@ -82,4 +82,12 @@ trait DynamicContentEntityTrait
 
         return $this;
     }
+
+    /**
+     * @return array
+     */
+    public function getDefaultDynamicContent()
+    {
+        return $this->defaultDynamicContent;
+    }
 }

--- a/app/bundles/CoreBundle/Entity/DynamicContentEntityTrait.php
+++ b/app/bundles/CoreBundle/Entity/DynamicContentEntityTrait.php
@@ -16,9 +16,11 @@ use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 trait DynamicContentEntityTrait
 {
     /**
+     * Keep the default content set outside of $dynamicContent so that it can be used if $dynamicContent is emptied.
+     *
      * @var array
      */
-    private $dynamicContent = [
+    private $defaultDynamicContent = [
         [
             'tokenName' => null,
             'content'   => null,
@@ -42,6 +44,11 @@ trait DynamicContentEntityTrait
     ];
 
     /**
+     * @var array
+     */
+    private $dynamicContent = [];
+
+    /**
      * @param ClassMetadataBuilder $builder
      */
     protected static function addDynamicContentMetadata(ClassMetadataBuilder $builder)
@@ -57,14 +64,22 @@ trait DynamicContentEntityTrait
      */
     public function getDynamicContent()
     {
-        return $this->dynamicContent;
+        return (empty($this->dynamicContent)) ? $this->defaultDynamicContent : $this->dynamicContent;
     }
 
     /**
-     * @param array $dynamicContent
+     * @param $dynamicContent
+     *
+     * @return $this
      */
     public function setDynamicContent($dynamicContent)
     {
+        if (empty($dynamicContent)) {
+            $dynamicContent = $this->defaultDynamicContent;
+        }
+
         $this->dynamicContent = $dynamicContent;
+
+        return $this;
     }
 }

--- a/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryFiltersType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryFiltersType.php
@@ -208,7 +208,7 @@ class DynamicContentFilterEntryFiltersType extends AbstractType
 
             if (in_array($data['operator'], ['empty', '!empty'])) {
                 $attr['disabled'] = 'disabled';
-            } else {
+            } elseif (null !== $data['filter']) {
                 $customOptions['constraints'] = [
                     new NotBlank(
                         [

--- a/app/bundles/CoreBundle/Form/Type/DynamicContentFilterType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentFilterType.php
@@ -13,7 +13,7 @@ namespace Mautic\CoreBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class DynamicContentFilterType.
@@ -68,9 +68,9 @@ class DynamicContentFilterType extends AbstractType
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             [

--- a/app/bundles/CoreBundle/Form/Type/DynamicContentTrait.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentTrait.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Form\Type;
+
+use Mautic\CoreBundle\Entity\DynamicContentEntityTrait;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+trait DynamicContentTrait
+{
+    protected function addDynamicContentField(FormBuilderInterface $builder)
+    {
+        $builder->add(
+            'dynamicContent',
+            CollectionType::class,
+            [
+                'entry_type'   => DynamicContentFilterType::class,
+                'allow_add'    => true,
+                'allow_delete' => true,
+                'label'        => false,
+                'options'      => [
+                    'label' => false,
+                ],
+            ]
+        );
+
+        $builder->addEventListener(
+            FormEvents::PRE_SUBMIT,
+            function (FormEvent $event) {
+                $data = $event->getData();
+                /** @var DynamicContentEntityTrait $entity */
+                $entity = $event->getForm()->getData();
+
+                if (empty($data['dynamicContent'])) {
+                    $data['dynamicContent'] = $entity->getDefaultDynamicContent();
+                    unset($data['dynamicContent'][0]['filters']['filter']);
+                    $event->setData($data);
+                }
+            }
+        );
+    }
+}

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -761,6 +761,9 @@ class EmailController extends FormController
                         ]
                     )
                 );
+            } elseif ($valid && $form->get('buttons')->get('apply')->isClicked()) {
+                // Rebuild the form in the case apply is clicked so that DEC content is properly populated if all were removed
+                $form = $model->createForm($entity, $this->get('form.factory'), $action, ['update_select' => $updateSelect]);
             }
         } else {
             //lock the entity

--- a/app/bundles/EmailBundle/Form/Type/EmailType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailType.php
@@ -16,10 +16,9 @@ use Mautic\CoreBundle\Form\DataTransformer\EmojiToShortTransformer;
 use Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
-use Mautic\CoreBundle\Form\Type\DynamicContentFilterType;
+use Mautic\CoreBundle\Form\Type\DynamicContentTrait;
 use Mautic\LeadBundle\Helper\FormFieldHelper;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -32,6 +31,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class EmailType extends AbstractType
 {
+    use DynamicContentTrait;
+
     private $translator;
     private $defaultTheme;
     private $em;
@@ -476,19 +477,7 @@ class EmailType extends AbstractType
             );
         }
 
-        $builder->add(
-            'dynamicContent',
-            CollectionType::class,
-            [
-                'entry_type'   => DynamicContentFilterType::class,
-                'allow_add'    => true,
-                'allow_delete' => true,
-                'label'        => false,
-                'options'      => [
-                    'label' => false,
-                ],
-            ]
-        );
+        $this->addDynamicContentField($builder);
 
         if (!empty($options['action'])) {
             $builder->setAction($options['action']);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | y |
| New feature? |  |
| Related user documentation PR URL |  |
| Related developer documentation PR URL |  |
| Issues addressed (#s or URLs) |  |
| BC breaks? |  |
| Deprecations? |  |
#### Description:

If all dynamic content items were deleted from an email, the email became uneditable.
#### Steps to test this PR:
1. Edit an email and delete all default dynamic content items and save
2. Edit the email and notice the empty default should have returned
#### Steps to reproduce the bug:
1. Repeat the above. But editing will result in an error.
