### PR TITLE
Fixed lookup custom field options

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -444,6 +444,7 @@ class CommonRepository extends EntityRepository
      */
     protected function addAdvancedSearchWhereClause(&$qb, $filters)
     {
+        $type         = 'and';
         $parseFilters = [];
         if (isset($filters->root)) {
             // Function is determined by the second clause type

--- a/app/bundles/CoreBundle/Form/DataTransformer/SortableListTransformer.php
+++ b/app/bundles/CoreBundle/Form/DataTransformer/SortableListTransformer.php
@@ -19,16 +19,25 @@ use Symfony\Component\Form\DataTransformerInterface;
  */
 class SortableListTransformer implements DataTransformerInterface
 {
+    /**
+     * @var bool
+     */
     private $removeEmpty = true;
+
+    /**
+     * @var bool
+     */
+    private $withLabels = true;
 
     /**
      * SortableListTransformer constructor.
      *
      * @param bool $removeEmpty
      */
-    public function __construct($removeEmpty = true)
+    public function __construct($removeEmpty = true, $withLabels = true)
     {
         $this->removeEmpty = $removeEmpty;
+        $this->withLabels  = $withLabels;
     }
 
     /**
@@ -38,15 +47,7 @@ class SortableListTransformer implements DataTransformerInterface
      */
     public function transform($array)
     {
-        if ($array === null || !isset($array['list'])) {
-            return ['list' => []];
-        }
-
-        $array['list'] = AbstractFormFieldHelper::parseList($array['list'], $this->removeEmpty);
-
-        $array['list'] = AbstractFormFieldHelper::formatList(AbstractFormFieldHelper::FORMAT_ARRAY, $array['list']);
-
-        return $array;
+        return $this->formatList($array);
     }
 
     /**
@@ -56,11 +57,28 @@ class SortableListTransformer implements DataTransformerInterface
      */
     public function reverseTransform($array)
     {
+        return $this->formatList($array);
+    }
+
+    /**
+     * @param $array
+     *
+     * @return mixed
+     */
+    private function formatList($array)
+    {
         if ($array === null || !isset($array['list'])) {
             return ['list' => []];
         }
 
         $array['list'] = AbstractFormFieldHelper::parseList($array['list'], $this->removeEmpty);
+
+        if (!$this->withLabels) {
+            $array['list'] = array_keys($array['list']);
+        }
+
+        $format        = ($this->withLabels) ? AbstractFormFieldHelper::FORMAT_ARRAY : AbstractFormFieldHelper::FORMAT_SIMPLE_ARRAY;
+        $array['list'] = AbstractFormFieldHelper::formatList($format, $array['list']);
 
         return $array;
     }

--- a/app/bundles/CoreBundle/Form/Type/SortableListType.php
+++ b/app/bundles/CoreBundle/Form/Type/SortableListType.php
@@ -76,7 +76,7 @@ class SortableListType extends AbstractType
                     'error_bubbling' => false,
                 ]
             )
-        )->addModelTransformer(new SortableListTransformer($options['option_notblank']));
+        )->addModelTransformer(new SortableListTransformer($options['option_notblank'], $options['with_labels']));
     }
 
     /**

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -515,7 +515,7 @@ Mautic.leadfieldOnLoad = function (container) {
 Mautic.updateLeadFieldProperties = function(selectedVal) {
     var defaultValueField = mQuery('input#leadfield_defaultValue');
 
-    if (selectedVal == 'lookup' || selectedVal == 'multiselect') {
+    if (selectedVal == 'multiselect') {
         // Use select
         selectedVal = 'select';
     }

--- a/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
@@ -214,7 +214,7 @@ trait EntityFieldsBuildFormTrait
                         $attr['data-target'] = $alias;
 
                         if (!empty($properties['list'])) {
-                            $attr['data-options'] = $properties['list'];
+                            $attr['data-options'] = FormFieldHelper::formatList(FormFieldHelper::FORMAT_BAR, array_keys(FormFieldHelper::parseList($properties['list'])));
                         }
                     }
                     $builder->add(

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -122,6 +122,17 @@ class FieldType extends AbstractType
         );
 
         $builder->add(
+            'properties_lookup_template',
+            'sortablelist',
+            [
+                'mapped'          => false,
+                'label'           => 'mautic.lead.field.form.properties.select',
+                'option_required' => false,
+                'with_labels'     => false,
+            ]
+        );
+
+        $builder->add(
             'default_template',
             'text',
             [
@@ -190,7 +201,7 @@ class FieldType extends AbstractType
                             'required'    => false,
                             'label'       => 'mautic.lead.field.form.properties.select',
                             'data'        => $properties,
-                            'with_labels' => true,
+                            'with_labels' => ('lookup' !== $type),
                         ]
                     );
                     break;

--- a/app/bundles/LeadBundle/Views/Field/form.html.php
+++ b/app/bundles/LeadBundle/Views/Field/form.html.php
@@ -22,6 +22,7 @@ if (!empty($userId)) {
 $view['slots']->set('headerTitle', $header);
 
 $selectTemplate      = $view['form']->row($form['properties_select_template']);
+$lookupTemplate      = $view['form']->row($form['properties_lookup_template']);
 $defaultTemplate     = $view['form']->widget($form['default_template']);
 $defaultBoolTemplate = $view['form']->widget($form['default_bool_template']);
 ?>
@@ -81,12 +82,17 @@ $defaultBoolTemplate = $view['form']->widget($form['default_bool_template']);
                             break;
                         case 'select':
                         case 'multiselect':
-                        case 'lookup':
                             echo $view->render('MauticLeadBundle:Field:properties_select.html.php', [
                                 'form'           => $form['properties'],
                                 'selectTemplate' => $selectTemplate,
                             ]);
                             break;
+                        case 'lookup':
+                            echo $view->render('MauticLeadBundle:Field:properties_select.html.php', [
+                                'form'           => $form['properties'],
+                                'selectTemplate' => $lookupTemplate,
+                                'isLookup'       => 'lookup',
+                            ]);
                         endswitch;
                         ?>
                     </div>
@@ -153,6 +159,10 @@ $defaultBoolTemplate = $view['form']->widget($form['default_bool_template']);
     echo $view->render('MauticLeadBundle:Field:properties_boolean.html.php');
     echo $view->render('MauticLeadBundle:Field:properties_select.html.php', [
         'selectTemplate' => $selectTemplate,
+    ]);
+    echo $view->render('MauticLeadBundle:Field:properties_select.html.php', [
+        'selectTemplate' => $lookupTemplate,
+        'isLookup'       => 'lookup',
     ]);
 ?>
 </div>

--- a/app/bundles/LeadBundle/Views/Field/properties_select.html.php
+++ b/app/bundles/LeadBundle/Views/Field/properties_select.html.php
@@ -8,15 +8,16 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
+
+$type  = (!empty($isLookup)) ? 'lookup' : 'select';
 $value = (isset($value)) ? $value : '';
 if (!isset($form) || !$form->vars['value']) {
-    $html = str_replace(['properties_select_template', 'leadfield_properties'], ['properties', 'leadfield_properties_template'], $selectTemplate);
+    $html = str_replace(['properties_'.$type.'_template', 'leadfield_properties'], ['properties', 'leadfield_properties_template'], $selectTemplate);
 } else {
     $html = $view['form']->row($form);
 }
-
 ?>
 
-<div class="select">
+<div class="<?php echo $type; ?>">
     <?php echo $html; ?>
 </div>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | y |
| New feature? |  |
| Related user documentation PR URL |  |
| Related developer documentation PR URL |  |
| Issues addressed (#s or URLs) |  |
| BC breaks? |  |
| Deprecations? |  |
#### Description:

When editing a contact with a lookup field - the options would show up as "Array." This fixes that. It also uses a standard single label options instead of label/value as lookups do not use label/value pairs.
#### Steps to test this PR:
1. Before applying the PR, create a lookup custom field with some options defined (label/value). Save.
2. Apply the PR
3. Create a second custom lookup field with options (note that there should only be a single input for each option now)
4. Edit a contact
5. The first lookup field should suggest the values from the pre-PR created field. The second lookup should suggest the only input values given when creating the field.
6. Edit the first lookup field - the values from before the PR should be listed as the options.
#### Steps to reproduce the bug:
1. Create a lookup field and edit/create a contact. 
2. Start typing in the lookup field and Array will appear.
