### PR TITLE
Fix chart timezone

### DIFF
--- a/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
+++ b/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
@@ -219,10 +219,10 @@ class ChartQuery extends AbstractChart
             unset($filters['groupBy']);
         }
 
-        $query->select($this->getLocalDateExpression($column, $tablePrefix).' AS local_date, COUNT(*) AS `count`')
-            ->groupBy('local_date'.$groupBy);
+        $query->select($this->getLocalDateExpression($column, $tablePrefix).' AS `date`, COUNT(*) AS `count`')
+            ->groupBy('`date`'.$groupBy);
 
-        $query->orderBy('local_date', 'ASC')->setMaxResults($limit);
+        $query->orderBy('`date`', 'ASC')->setMaxResults($limit);
     }
 
     public function getLocalDateExpression($column, $tablePrefix = 't')

--- a/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
+++ b/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
@@ -136,31 +136,29 @@ class ChartQuery extends AbstractChart
             // Can't rely on alias in "where" - so have to repeat.
             $dateExpression = $this->getLocalDateExpression($dateColumn, $tablePrefix);
 
+            if ($this->dateFrom && $this->dateTo) {
+                // Between is faster so if we know both dates...
+                $query->andWhere($dateExpression.' BETWEEN :dateFrom AND :dateTo');
+            } elseif ($this->dateFrom) {
+                // Apply the start date/time if set
+                $query->andWhere($dateExpression.' >= :dateFrom');
+            } elseif ($this->dateTo) {
+                // Apply the end date/time if set
+                $query->andWhere($dateExpression.' <= :dateTo');
+            }
+
             if ($this->dateFrom) {
                 $dateFrom = clone $this->dateFrom;
                 if ($this->isTimeUnit) {
                     $dateFrom->setTimeZone(new \DateTimeZone('UTC'));
                 }
+                $query->setParameter('dateFrom', $dateFrom->format('Y-m-d H:i:s'));
             }
             if ($this->dateTo) {
                 $dateTo = clone $this->dateTo;
                 if ($this->isTimeUnit) {
                     $dateTo->setTimeZone(new \DateTimeZone('UTC'));
                 }
-            }
-
-            if ($this->dateFrom && $this->dateTo) {
-                // Between is faster so if we know both dates...
-                $query->andWhere($dateExpression.' BETWEEN :dateFrom AND :dateTo');
-                $query->setParameter('dateFrom', $dateFrom->format('Y-m-d H:i:s'));
-                $query->setParameter('dateTo', $dateTo->format('Y-m-d H:i:s'));
-            } elseif ($this->dateFrom) {
-                // Apply the start date/time if set
-                $query->andWhere($dateExpression.' >= :dateFrom');
-                $query->setParameter('dateFrom', $dateFrom->format('Y-m-d H:i:s'));
-            } elseif ($this->dateTo) {
-                // Apply the end date/time if set
-                $query->andWhere($dateExpression.' <= :dateTo');
                 $query->setParameter('dateTo', $dateTo->format('Y-m-d H:i:s'));
             }
         }

--- a/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
+++ b/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
@@ -226,11 +226,13 @@ class ChartQuery extends AbstractChart
             $groupBy = ', '.$tablePrefix.'.'.$filters['groupBy'];
             unset($filters['groupBy']);
         }
-        $dateConstruct = 'DATE_FORMAT('.$tablePrefix.'.'.$column.', \''.$dbUnit.'\')';
-        $query->select($dateConstruct.' AS date, COUNT(*) AS count')
-            ->groupBy($dateConstruct.$groupBy);
+        $localDateConstruct = 'CONVERT_TZ('.$tablePrefix.'.'.$column.',\'UTC\',\''.date_default_timezone_get().'\')';
+        $dateConstruct      = 'DATE_FORMAT('.$localDateConstruct.', \''.$dbUnit.'\')';
 
-        $query->orderBy($dateConstruct, 'ASC')->setMaxResults($limit);
+        $query->select($dateConstruct.' AS date, COUNT(*) AS count')
+            ->groupBy('date'.$groupBy);
+
+        $query->orderBy('date', 'ASC')->setMaxResults($limit);
     }
 
     /**

--- a/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
+++ b/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
@@ -135,39 +135,33 @@ class ChartQuery extends AbstractChart
         if ($dateColumn) {
             // Can't rely on alias in "where" - so have to repeat.
             $dateExpression = $this->getLocalDateExpression($dateColumn, $tablePrefix);
-            if ($this->dateFrom && $this->dateTo) {
-                // Between is faster so if we know both dates...
+
+            if ($this->dateFrom) {
                 $dateFrom = clone $this->dateFrom;
-                $dateTo   = clone $this->dateTo;
                 if ($this->isTimeUnit) {
                     $dateFrom->setTimeZone(new \DateTimeZone('UTC'));
                 }
+            }
+            if ($this->dateTo) {
+                $dateTo = clone $this->dateTo;
                 if ($this->isTimeUnit) {
                     $dateTo->setTimeZone(new \DateTimeZone('UTC'));
                 }
+            }
+
+            if ($this->dateFrom && $this->dateTo) {
+                // Between is faster so if we know both dates...
                 $query->andWhere($dateExpression.' BETWEEN :dateFrom AND :dateTo');
                 $query->setParameter('dateFrom', $dateFrom->format('Y-m-d H:i:s'));
                 $query->setParameter('dateTo', $dateTo->format('Y-m-d H:i:s'));
-            } else {
+            } elseif ($this->dateFrom) {
                 // Apply the start date/time if set
-                if ($this->dateFrom) {
-                    $dateFrom = clone $this->dateFrom;
-                    if ($this->isTimeUnit) {
-                        $dateFrom->setTimeZone(new \DateTimeZone('UTC'));
-                    }
-                    $query->andWhere($dateExpression.' >= :dateFrom');
-                    $query->setParameter('dateFrom', $dateFrom->format('Y-m-d H:i:s'));
-                }
-
+                $query->andWhere($dateExpression.' >= :dateFrom');
+                $query->setParameter('dateFrom', $dateFrom->format('Y-m-d H:i:s'));
+            } elseif ($this->dateTo) {
                 // Apply the end date/time if set
-                if ($this->dateTo) {
-                    $dateTo = clone $this->dateTo;
-                    if ($this->isTimeUnit) {
-                        $dateTo->setTimeZone(new \DateTimeZone('UTC'));
-                    }
-                    $query->andWhere($dateExpression.' <= :dateTo');
-                    $query->setParameter('dateTo', $dateTo->format('Y-m-d H:i:s'));
-                }
+                $query->andWhere($dateExpression.' <= :dateTo');
+                $query->setParameter('dateTo', $dateTo->format('Y-m-d H:i:s'));
             }
         }
     }

--- a/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
+++ b/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
@@ -219,10 +219,10 @@ class ChartQuery extends AbstractChart
             unset($filters['groupBy']);
         }
 
-        $query->select($this->getLocalDateExpression($column, $tablePrefix).' AS date, COUNT(*) AS count')
-            ->groupBy('date'.$groupBy);
+        $query->select($this->getLocalDateExpression($column, $tablePrefix).' AS local_date, COUNT(*) AS `count`')
+            ->groupBy('local_date'.$groupBy);
 
-        $query->orderBy('date', 'ASC')->setMaxResults($limit);
+        $query->orderBy('local_date', 'ASC')->setMaxResults($limit);
     }
 
     public function getLocalDateExpression($column, $tablePrefix = 't')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | y |
| New feature? | n |
| Related user documentation PR URL | - |
| Related developer documentation PR URL | - |
| Issues addressed (#s or URLs) | - |
| BC breaks? | - |
| Deprecations? | - |
#### Description:

Fixes chart timezone: now all stats are displayed in user timezone - not UTC as before.
#### Steps to test this PR:
1. Compare form results count for particular date (calculated manually) with chart data: they are the same because charts now are react on user timezone.
#### Steps to reproduce the bug:
1. Compare form results count for particular date (calculated manually) with chart data: they differ because of timezone difference.