### PR TITLE
Fix string search problem

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -624,7 +624,7 @@ class CommonRepository extends EntityRepository
 
         if (!$filter->strict) {
             if (strpos($string, '%') === false) {
-                $string = "$string%";
+                $string = "%$string%";
             }
         }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #2808
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Global text search was broken. It was only possible to search with begining of words/string, not middle... This fix the problem


#### Steps to test this PR:
1. Create a contact with a name like "golum"
2. Go to contact, and search "olu"
3. The contact is in the results (before, it was not) 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a contact with a name like "golum"
2. Go to contact, and search "olu"
3. The contact is NOT in the results
