### PR TITLE
Show 404 page without logging exception

### DIFF
--- a/app/bundles/AssetBundle/Controller/PublicController.php
+++ b/app/bundles/AssetBundle/Controller/PublicController.php
@@ -105,6 +105,6 @@ class PublicController extends CommonFormController
 
         $model->trackDownload($entity, $this->request, 404);
 
-        $this->notFound();
+        return $this->notFound();
     }
 }

--- a/app/bundles/CoreBundle/Controller/DefaultController.php
+++ b/app/bundles/CoreBundle/Controller/DefaultController.php
@@ -39,7 +39,7 @@ class DefaultController extends CommonController
             $page      = $pageModel->getEntity($root);
 
             if (empty($page)) {
-                $this->notFound();
+                return $this->notFound();
             }
 
             $slug = $pageModel->generateSlug($page);

--- a/app/bundles/CoreBundle/Controller/ExceptionController.php
+++ b/app/bundles/CoreBundle/Controller/ExceptionController.php
@@ -41,7 +41,12 @@ class ExceptionController extends CommonController
             }
 
             // Special handling for oauth and api urls
-            if ((strpos($request->getUri(), '/oauth') !== false && strpos($request->getUri(), 'authorize') === false) || strpos($request->getUri(), '/api') !== false) {
+            if ((strpos($request->getUri(), '/oauth') !== false && strpos($request->getUri(), 'authorize') === false)
+                || strpos(
+                    $request->getUri(),
+                    '/api'
+                ) !== false
+            ) {
                 $dataArray = [
                     'error' => [
                         'message' => $exception->getMessage(),
@@ -99,6 +104,7 @@ class ExceptionController extends CommonController
                         ],
                         'route' => $urlParts['path'],
                     ],
+                    'responseCode' => $code,
                 ]
             );
         }

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -83,7 +83,7 @@ class PublicController extends CommonFormController
             return new Response($content);
         }
 
-        $this->notFound();
+        return $this->notFound();
     }
 
     /**
@@ -317,7 +317,7 @@ class PublicController extends CommonFormController
             return new Response('success');
         }
 
-        $this->notFound();
+        return $this->notFound();
     }
 
     /**

--- a/app/bundles/FormBundle/Controller/PublicController.php
+++ b/app/bundles/FormBundle/Controller/PublicController.php
@@ -332,7 +332,7 @@ class PublicController extends CommonFormController
         $template          = null;
 
         if ($form === null || !$form->isPublished()) {
-            $this->notFound();
+            return $this->notFound();
         } else {
             $html = $model->getContent($form);
 

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -276,7 +276,7 @@ class PublicController extends CommonFormController
 
         $model->hitPage($entity, $this->request, 404);
 
-        $this->notFound();
+        return $this->notFound();
     }
 
     /**
@@ -293,7 +293,7 @@ class PublicController extends CommonFormController
         $entity = $model->getEntity($id);
 
         if ($entity === null) {
-            $this->notFound();
+            return $this->notFound();
         }
 
         $analytics = $this->factory->getHelper('template.analytics')->getCode();


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | n
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | 
| BC breaks? | n
| Deprecations? |n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This simply prevents logging 404's as exceptions in Mautic's logs (they are already recording in the web server logs). 

#### Steps to test this PR:
1. Apply PR, go to a non-existent page, note the 404 page but check the logs and no 404 exception should be logged.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Repeat the above and view the log