### PR TITLE
Fixed form field ordering and sortable UI issues

### DIFF
--- a/app/bundles/FormBundle/Assets/css/form.css
+++ b/app/bundles/FormBundle/Assets/css/form.css
@@ -8,6 +8,10 @@
     position: relative;
 }
 
+.form-field-wrapper img {
+    max-width: 100%;
+}
+
 #mauticforms_fields .mauticform-row, #mauticforms_actions .mauticform-row {
     padding: 10px;
 }

--- a/app/bundles/FormBundle/Assets/js/form.js
+++ b/app/bundles/FormBundle/Assets/js/form.js
@@ -3,18 +3,40 @@ Mautic.formOnLoad = function (container) {
     if (mQuery(container + ' #list-search').length) {
         Mautic.activateSearchAutocomplete('list-search', 'form.form');
     }
-
+    var bodyOverflow = {};
     if (mQuery('#mauticforms_fields')) {
         //make the fields sortable
         mQuery('#mauticforms_fields').sortable({
             items: '.panel',
             cancel: '',
-            stop: function(i) {
+            helper: function(e, ui) {
+                ui.children().each(function() {
+                    mQuery(this).width(mQuery(this).width());
+                });
+
+                // Fix body overflow that messes sortable up
+                bodyOverflow.overflowX = mQuery('body').css('overflow-x');
+                bodyOverflow.overflowY = mQuery('body').css('overflow-y');
+                mQuery('body').css({
+                    overflowX: 'visible',
+                    overflowY: 'visible'
+                });
+
+                return ui;
+            },
+            scroll: true,
+            axis: 'y',
+            containment: '#mauticforms_fields .drop-here',
+            stop: function(e, ui) {
+                // Restore original overflow
+                mQuery('body').css(bodyOverflow);
+                mQuery(ui.item).attr('style', '');
+
                 mQuery.ajax({
                     type: "POST",
                     url: mauticAjaxUrl + "?action=form:reorderFields",
                     data: mQuery('#mauticforms_fields').sortable("serialize", {attribute: 'data-sortable-id'}) + "&formId=" + mQuery('#mauticform_sessionId').val()
-                })
+                });
             }
         });
 
@@ -26,7 +48,29 @@ Mautic.formOnLoad = function (container) {
         mQuery('#mauticforms_actions').sortable({
             items: '.panel',
             cancel: '',
-            stop: function(i) {
+            helper: function(e, ui) {
+                ui.children().each(function() {
+                    mQuery(this).width(mQuery(this).width());
+                });
+
+                // Fix body overflow that messes sortable up
+                bodyOverflow.overflowX = mQuery('body').css('overflow-x');
+                bodyOverflow.overflowY = mQuery('body').css('overflow-y');
+                mQuery('body').css({
+                    overflowX: 'visible',
+                    overflowY: 'visible'
+                });
+
+                return ui;
+            },
+            scroll: true,
+            axis: 'y',
+            containment: '#mauticforms_actions .drop-here',
+            stop: function(e, ui) {
+                // Restore original overflow
+                mQuery('body').css(bodyOverflow);
+                mQuery(ui.item).attr('style', '');
+
                 mQuery.ajax({
                     type: "POST",
                     url: mauticAjaxUrl + "?action=form:reorderActions",

--- a/app/bundles/FormBundle/Controller/AjaxController.php
+++ b/app/bundles/FormBundle/Controller/AjaxController.php
@@ -26,7 +26,7 @@ class AjaxController extends CommonAjaxController
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
-    protected function reorderFieldsAction(Request $request, $name = 'fields')
+    protected function reorderFieldsAction(Request $request, $bundle, $name = 'fields')
     {
         $dataArray   = ['success' => 0];
         $sessionId   = InputHelper::clean($request->request->get('formId'));

--- a/app/bundles/FormBundle/Views/Builder/index.html.php
+++ b/app/bundles/FormBundle/Views/Builder/index.html.php
@@ -84,6 +84,7 @@ $formId = $form['sessionId']->vars['data'];
                                     </ul>
                                 </div>
                             </div>
+                            <div class="drop-here">
                             <?php foreach ($formFields as $field): ?>
                                 <?php if (!in_array($field['id'], $deletedFields)) : ?>
                                     <?php if (!empty($field['isCustom'])):
@@ -105,10 +106,11 @@ $formId = $form['sessionId']->vars['data'];
                                     ); ?>
                                 <?php endif; ?>
                             <?php endforeach; ?>
+                            </div>
                             <?php if (!count($formFields)): ?>
-                                <div class="alert alert-info" id="form-field-placeholder">
-                                    <p><?php echo $view['translator']->trans('mautic.form.form.addfield'); ?></p>
-                                </div>
+                            <div class="alert alert-info" id="form-field-placeholder">
+                                <p><?php echo $view['translator']->trans('mautic.form.form.addfield'); ?></p>
+                            </div>
                             <?php endif; ?>
                         </div>
                     </div>
@@ -153,6 +155,7 @@ $formId = $form['sessionId']->vars['data'];
                                     </ul>
                                 </div>
                             </div>
+                            <div class="drop-here">
                             <?php foreach ($formActions as $action): ?>
                                 <?php if (!in_array($action['id'], $deletedActions)) : ?>
                                     <?php $template = (isset($actionSettings[$action['type']]['template']))
@@ -171,10 +174,11 @@ $formId = $form['sessionId']->vars['data'];
                                     ); ?>
                                 <?php endif; ?>
                             <?php endforeach; ?>
+                            </div>
                             <?php if (!count($formActions)): ?>
-                                <div class="alert alert-info" id="form-action-placeholder">
-                                    <p><?php echo $view['translator']->trans('mautic.form.form.addaction'); ?></p>
-                                </div>
+                            <div class="alert alert-info" id="form-action-placeholder">
+                                <p><?php echo $view['translator']->trans('mautic.form.form.addaction'); ?></p>
+                            </div>
                             <?php endif; ?>
                         </div>
                     </div>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | #2745
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Field ordering broke in a recent version. This PR fixes it. It also addresses some UI issues when dragging while scrolled further down the page.

#### Steps to test this PR:
1. In dev mode, re-order the fields and save
2. The field order should persist
3. Add enough fields to cause scrolling
4. Scroll to the bottom and re-order the last field. The clone/field should stay aligned with the cursor.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Same as above but field order doesn't persist
2. Same as above but the dragged element will be aligned above of the cursor