### PR TITLE
Format date fields prior to contact import

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1549,13 +1549,13 @@ class LeadModel extends FormModel
                             break;
                         // Ensure date/time entries match what symfony expects
                         case 'datetime':
-                            $fieldData[$leadField['alias']] = (new \DateTime($fieldData[$leadField['alias']]))->format('Y-m-d H:i:s');
+                            $fieldData[$leadField['alias']] = (new \DateTime($fieldData[$leadField['alias']]))->format('Y-m-d H:i');
                             break;
                         case 'date':
                             $fieldData[$leadField['alias']] = (new \DateTime($fieldData[$leadField['alias']]))->format('Y-m-d');
                             break;
                         case 'time':
-                            $fieldData[$leadField['alias']] = (new \DateTime($fieldData[$leadField['alias']]))->format('H:i:s');
+                            $fieldData[$leadField['alias']] = (new \DateTime($fieldData[$leadField['alias']]))->format('H:i');
                             break;
                     }
                 } catch (\Exception $exception) {

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1541,10 +1541,25 @@ class LeadModel extends FormModel
 
         foreach ($leadFields as $leadField) {
             if (isset($fieldData[$leadField['alias']])) {
-
-                // Adjust the boolean values from text to boolean
-                if ($leadField['type'] == 'boolean') {
-                    $fieldData[$leadField['alias']] = (int) filter_var($fieldData[$leadField['alias']], FILTER_VALIDATE_BOOLEAN);
+                try {
+                    switch ($leadField['type']) {
+                        // Adjust the boolean values from text to boolean
+                        case 'boolean':
+                            $fieldData[$leadField['alias']] = (int) filter_var($fieldData[$leadField['alias']], FILTER_VALIDATE_BOOLEAN);
+                            break;
+                        // Ensure date/time entries match what symfony expects
+                        case 'datetime':
+                            $fieldData[$leadField['alias']] = (new \DateTime($fieldData[$leadField['alias']]))->format('Y-m-d H:i:s');
+                            break;
+                        case 'date':
+                            $fieldData[$leadField['alias']] = (new \DateTime($fieldData[$leadField['alias']]))->format('Y-m-d');
+                            break;
+                        case 'time':
+                            $fieldData[$leadField['alias']] = (new \DateTime($fieldData[$leadField['alias']]))->format('H:i:s');
+                            break;
+                    }
+                } catch (\Exception $exception) {
+                    // We tried; let the form handle the mal-formed data
                 }
 
                 // Skip if the value is in the CSV row

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1549,13 +1549,27 @@ class LeadModel extends FormModel
                             break;
                         // Ensure date/time entries match what symfony expects
                         case 'datetime':
-                            $fieldData[$leadField['alias']] = (new \DateTime($fieldData[$leadField['alias']]))->format('Y-m-d H:i');
-                            break;
                         case 'date':
-                            $fieldData[$leadField['alias']] = (new \DateTime($fieldData[$leadField['alias']]))->format('Y-m-d');
-                            break;
                         case 'time':
-                            $fieldData[$leadField['alias']] = (new \DateTime($fieldData[$leadField['alias']]))->format('H:i');
+                            // Prevent zero based date placeholders
+                            $dateTest = (int) str_replace(['/', '-', ' '], '', $fieldData[$leadField['alias']]);
+
+                            if (!$dateTest) {
+                                // Date placeholder was used so just ignore it to allow import of the field
+                                unset($fieldData[$leadField['alias']]);
+                            } else {
+                                switch ($leadField['type']) {
+                                    case 'datetime':
+                                        $fieldData[$leadField['alias']] = (new \DateTime($fieldData[$leadField['alias']]))->format('Y-m-d H:i');
+                                        break;
+                                    case 'date':
+                                        $fieldData[$leadField['alias']] = (new \DateTime($fieldData[$leadField['alias']]))->format('Y-m-d');
+                                        break;
+                                    case 'time':
+                                        $fieldData[$leadField['alias']] = (new \DateTime($fieldData[$leadField['alias']]))->format('H:i');
+                                        break;
+                                }
+                            }
                             break;
                     }
                 } catch (\Exception $exception) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | 
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

A contact will fail to import if a date field's value does not match the expected format for the Symfony form. For example, if the date value is `11/1/16` instead of `2016-11-01`. 

#### Steps to test this PR:
1. Create a custom date/time field, date field and time fields.
2. Import the CSV below
```
firstname,lastname,datetime,date,time
datetime,test1,"11/1/16 3pm","11/1/16","3:10 pm"
```
Go to contacts and search for `datetime`. View the profile and check the values for the date/time fields. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Import the above CSV before applying the PR and the contact will fail to import