### PR TITLE
Prevent a cloned segment email converted to a template email from being sent by broadcast:send command

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -534,6 +534,10 @@ class EmailRepository extends CommonRepository
         $qb   = $this->createQueryBuilder($this->getTableAlias());
         $expr = $this->getPublishedByDateExpression($qb, null, true, true, false);
 
+        $expr->add(
+            $qb->expr()->eq($this->getTableAlias().'.emailType', $qb->expr()->literal('list'))
+        );
+
         if (!empty($id)) {
             $expr->add(
                 $qb->expr()->eq($this->getTableAlias().'.id', (int) $id)

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -221,6 +221,9 @@ class EmailModel extends FormModel
                 $parentLists = $translationParent->getLists()->toArray();
                 $entity->setLists($parentLists);
             }
+        } else {
+            // Ensure that all lists are been removed in case of a clone
+            $entity->setLists([]);
         }
 
         if (!$this->updatingTranslationChildren) {
@@ -873,6 +876,11 @@ class EmailModel extends FormModel
         //get the leads
         if (empty($lists)) {
             $lists = $email->getLists();
+        }
+
+        // Safety check
+        if ('list' !== $email->getEmailType()) {
+            return [0, 0, []];
         }
 
         $options = [


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | 
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If a published segment email that includes a publish up date, publish down date, is published, and the date is appropriate and then is cloned into a template email; the `mautic:broadcast:send` command would pick up the new template email and send it to the contacts in the original email's segment.

#### Steps to test this PR:
1. Apply the PR.
2. Create a new segment email with publish up and down dates that would be valid for now and publish
3. Clone the email and save as a template email.
4. Run the command `mautic:broadcasts:send` 
5. Note that only the original segment email is sent out.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Same as above but both emails will be sent out by the command