### PR TITLE
IpLookupHelper fix static array check

### DIFF
--- a/app/bundles/CoreBundle/Helper/IpLookupHelper.php
+++ b/app/bundles/CoreBundle/Helper/IpLookupHelper.php
@@ -126,7 +126,7 @@ class IpLookupHelper
             $ip = '127.0.0.1';
         }
 
-        if (empty($ipAddress[$ip])) {
+        if (empty($ipAddresses[$ip])) {
             $repo      = $this->em->getRepository('MauticCoreBundle:IpAddress');
             $ipAddress = $repo->findOneByIpAddress($ip);
             $saveIp    = ($ipAddress === null);


### PR DESCRIPTION
I guees We should check static array  $ipAddresses not $ipAddress, because $ipAddress is object.

Nothing for test :)