### PR TITLE
Prevent misplacing orphans across menus on login

### DIFF
--- a/app/bundles/CoreBundle/Event/MenuEvent.php
+++ b/app/bundles/CoreBundle/Event/MenuEvent.php
@@ -68,7 +68,7 @@ class MenuEvent extends Event
 
         $isRoot = isset($items['name']) && ($items['name'] == 'root' || $items['name'] == $items['name']);
         if (!$isRoot) {
-            $this->helper->createMenuStructure($items, 0, $defaultPriority);
+            $this->helper->createMenuStructure($items, 0, $defaultPriority, $this->type);
 
             $this->menuItems['children'] = array_merge_recursive($this->menuItems['children'], $items);
         } else {
@@ -92,9 +92,9 @@ class MenuEvent extends Event
      */
     public function getMenuItems()
     {
-        $this->helper->placeOrphans($this->menuItems['children'], true);
+        $this->helper->placeOrphans($this->menuItems['children'], true, 1, $this->type);
         $this->helper->sortByPriority($this->menuItems['children']);
-        $this->helper->resetOrphans();
+        $this->helper->resetOrphans($this->type);
 
         return $this->menuItems;
     }

--- a/app/bundles/CoreBundle/Menu/MenuBuilder.php
+++ b/app/bundles/CoreBundle/Menu/MenuBuilder.php
@@ -16,7 +16,6 @@ use Knp\Menu\Loader\ArrayLoader;
 use Knp\Menu\Matcher\MatcherInterface;
 use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\MenuEvent;
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -45,9 +44,12 @@ class MenuBuilder
     private $menuHelper;
 
     /**
-     * @param FactoryInterface $knpFactory
-     * @param MatcherInterface $matcher
-     * @param MauticFactory    $factory
+     * MenuBuilder constructor.
+     *
+     * @param FactoryInterface         $knpFactory
+     * @param MatcherInterface         $matcher
+     * @param EventDispatcherInterface $dispatcher
+     * @param MenuHelper               $menuHelper
      */
     public function __construct(FactoryInterface $knpFactory, MatcherInterface $matcher, EventDispatcherInterface $dispatcher, MenuHelper $menuHelper)
     {

--- a/app/bundles/CoreBundle/Menu/MenuHelper.php
+++ b/app/bundles/CoreBundle/Menu/MenuHelper.php
@@ -59,11 +59,12 @@ class MenuHelper
     /**
      * Converts menu config into something KNP menus expects.
      *
-     * @param     $items
-     * @param int $depth
-     * @param int $defaultPriority
+     * @param        $items
+     * @param int    $depth
+     * @param int    $defaultPriority
+     * @param string $type
      */
-    public function createMenuStructure(&$items, $depth = 0, $defaultPriority = 9999)
+    public function createMenuStructure(&$items, $depth = 0, $defaultPriority = 9999, $type = 'main')
     {
         foreach ($items as $k => &$i) {
             if (!is_array($i) || empty($i)) {
@@ -169,11 +170,15 @@ class MenuHelper
 
             // Determine if this item needs to be listed in a bundle outside it's own
             if (isset($i['parent'])) {
-                if (!isset($this->orphans[$i['parent']])) {
-                    $this->orphans[$i['parent']] = [];
+                if (!isset($this->orphans[$type])) {
+                    $this->orphans[$type] = [];
                 }
 
-                $this->orphans[$i['parent']][$k] = $i;
+                if (!isset($this->orphans[$type][$i['parent']])) {
+                    $this->orphans[$type][$i['parent']] = [];
+                }
+
+                $this->orphans[$type][$i['parent']][$k] = $i;
 
                 unset($items[$k]);
 
@@ -188,12 +193,14 @@ class MenuHelper
     /**
      * Get and reset orphaned menu items.
      *
-     * @return array
+     * @param string $type
+     *
+     * @return mixed
      */
-    public function resetOrphans()
+    public function resetOrphans($type = 'main')
     {
-        $orphans       = $this->orphans;
-        $this->orphans = [];
+        $orphans              = (isset($this->orphans[$type])) ? $this->orphans[$type] : [];
+        $this->orphans[$type] = [];
 
         return $orphans;
     }
@@ -205,12 +212,12 @@ class MenuHelper
      * @param bool  $appendOrphans
      * @param int   $depth
      */
-    public function placeOrphans(array &$menuItems, $appendOrphans = false, $depth = 1)
+    public function placeOrphans(array &$menuItems, $appendOrphans = false, $depth = 1, $type = 'main')
     {
         foreach ($menuItems as $key => &$items) {
-            if (isset($this->orphans[$key])) {
+            if (isset($this->orphans[$type]) && isset($this->orphans[$type][$key])) {
                 $priority = (isset($items['priority'])) ? $items['priority'] : 9999;
-                foreach ($this->orphans[$key] as &$orphan) {
+                foreach ($this->orphans[$type][$key] as &$orphan) {
                     if (!isset($orphan['extras'])) {
                         $orphan['extras'] = [];
                     }
@@ -220,23 +227,24 @@ class MenuHelper
                     }
                 }
 
-                $items['children'] = (!isset($items['children']))
+                $items['children'] =
+                    (!isset($items['children']))
                     ?
-                    $this->orphans[$key]
+                    $this->orphans[$type][$key]
                     :
-                    $items['children'] = array_merge($items['children'], $this->orphans[$key]);
-                unset($this->orphans[$key]);
+                    array_merge($items['children'], $this->orphans[$type][$key]);
+                unset($this->orphans[$type][$key]);
             } elseif (isset($items['children'])) {
                 foreach ($items['children'] as $subKey => $subItems) {
-                    $this->placeOrphans($subItems, false, $depth + 1);
+                    $this->placeOrphans($subItems, false, $depth + 1, $type);
                 }
             }
         }
 
         // Append orphans that couldn't find a home
-        if ($appendOrphans && count($this->orphans)) {
-            $menuItems     = array_merge($menuItems, $this->orphans);
-            $this->orphans = [];
+        if ($appendOrphans && !empty($this->orphans[$type])) {
+            $menuItems            = array_merge($menuItems, $this->orphans[$type]);
+            $this->orphans[$type] = [];
         }
     }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | na
| Related developer documentation PR URL | na
| Issues addressed (#s or URLs) | na
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When one first logs in, the extra menu in the upper left may appear with "Components" and "Channels" in it. A refresh causes it to disappear. This PR fixes that. 

#### Steps to test this PR:
1. Apply the PR
2. Logout and back in
3. Note the extra menu does not show up (top left to the right of the Mautic logo)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Same as above but immediately after logging in, the extra menu appears with those two useless items.