### PR TITLE
Don’t merge contacts with the same public ip address

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -697,28 +697,20 @@ class LeadModel extends FormModel
             $leadId = $this->request->cookies->get($trackingId);
             $ip     = $this->ipLookupHelper->getIpAddress();
 
-            if (empty($leadId)) {
-                //this lead is not tracked yet so get leads by IP and track that lead or create a new one
-                $leads = $this->getLeadsByIp($ip->getIpAddress());
+          // if no trackingId cookkie set the lead is not tracked yet so create a new one
+          if (empty($leadId)) {
 
-                if (count($leads)) {
-                    //just create a tracking cookie for the newest lead
-                    $lead   = $leads[0];
-                    $leadId = $lead->getId();
-                    $this->logger->addDebug("LEAD: Existing lead found with ID# $leadId.");
-                } else {
-                    //let's create a lead
-                    $lead = new Lead();
-                    $lead->addIpAddress($ip);
-                    $lead->setNewlyCreated(true);
+                //let's create a lead
+                $lead = new Lead();
+                $lead->addIpAddress($ip);
+                $lead->setNewlyCreated(true);
 
-                    // Set to prevent loops
-                    $this->currentLead = $lead;
+                // Set to prevent loops
+                $this->currentLead = $lead;
 
-                    $this->saveEntity($lead, false);
-                    $leadId = $lead->getId();
-                    $this->logger->addDebug("LEAD: New lead created with ID# $leadId.");
-                }
+                $this->saveEntity($lead, false);
+                $leadId = $lead->getId();
+                $this->logger->addDebug("LEAD: New lead created with ID# $leadId.");
 
                 $fields = $this->getLeadDetails($lead);
                 $lead->setFields($fields);
@@ -953,8 +945,8 @@ class LeadModel extends FormModel
             $oldTrackingId = $this->request->cookies->get('mautic_session_id');
             $trackingId    = hash('sha1', uniqid(mt_rand()));
 
-            //create a tracking cookie
-            $this->cookieHelper->setCookie('mautic_session_id', $trackingId);
+            //create a tracking cookie with a expire of two years
+            $this->cookieHelper->setCookie('mautic_session_id', $trackingId, 31536000);
 
             return [$trackingId, $oldTrackingId];
         }
@@ -968,8 +960,8 @@ class LeadModel extends FormModel
                 $generated  = true;
             }
 
-            //create a tracking cookie
-            $this->cookieHelper->setCookie('mautic_session_id', $trackingId);
+            //create a tracking cookie with a expire of two years
+            $this->cookieHelper->setCookie('mautic_session_id', $trackingId, 31536000);
         }
 
         return [$trackingId, $generated];
@@ -990,7 +982,8 @@ class LeadModel extends FormModel
             $this->cookieHelper->setCookie($oldTrackingId, null, -3600);
         }
 
-        $this->cookieHelper->setCookie($trackingId, $leadId);
+        // Create a cookie with a expire of two years
+        $this->cookieHelper->setCookie($trackingId, $leadId, 31536000);
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -697,8 +697,8 @@ class LeadModel extends FormModel
             $leadId = $this->request->cookies->get($trackingId);
             $ip     = $this->ipLookupHelper->getIpAddress();
 
-          // if no trackingId cookkie set the lead is not tracked yet so create a new one
-          if (empty($leadId)) {
+            // if no trackingId cookkie set the lead is not tracked yet so create a new one
+            if (empty($leadId)) {
 
                 //let's create a lead
                 $lead = new Lead();


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #2406, #1030
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Fist of all: This PR is very similar to #1030. 

All people from one company, with the same public ip address, are identify as the same lead in Mautic. User A on computer A (no cookies from mautic) opens the page. Mautic creates a new anonymous lead. User B on computer B (no cookies from mautic) opens the same page. The activity from both merge into one lead.

If user A filled out a form then the whole activity from all other user of the company is merged to user A.

To fix this issue I remove the section in wich mautic is looking for existing ip addresses and take the last user with this ip address and add the activity from the new user to an existing user.

To track the contacts for a longer time I increase the cookie lifetime (2 years). If the user has an mautic cookie the activity is add to this user. If the user has no mautic cookie mautic creates a new user.

#### Steps to test this PR:
1. User A and B have the same public ip address
2. User A opens the website
3. User B opens the website
4. Check the lists of anonymous user and known users; Mautic had create two users and don't merge the users from the same public ip address