### PR TITLE
Company SocialCache

### DIFF
--- a/app/bundles/LeadBundle/Entity/Company.php
+++ b/app/bundles/LeadBundle/Entity/Company.php
@@ -34,11 +34,36 @@ class Company extends FormEntity implements CustomFieldEntityInterface
      */
     private $owner;
 
+    /**
+     * @var array
+     */
+    private $socialCache = [];
+
     public function __clone()
     {
         $this->id = null;
 
         parent::__clone();
+    }
+
+    /**
+     * Get social cache.
+     *
+     * @return mixed
+     */
+    public function getSocialCache()
+    {
+        return $this->socialCache;
+    }
+
+    /**
+     * Set social cache.
+     *
+     * @param $cache
+     */
+    public function setSocialCache($cache)
+    {
+        $this->socialCache = $cache;
     }
 
     /**
@@ -53,6 +78,11 @@ class Company extends FormEntity implements CustomFieldEntityInterface
         $builder->createField('id', 'integer')
             ->isPrimaryKey()
             ->generatedValue()
+            ->build();
+
+        $builder->createField('socialCache', 'array')
+            ->columnName('social_cache')
+            ->nullable()
             ->build();
 
         $builder->createManyToOne('owner', 'Mautic\UserBundle\Entity\User')

--- a/app/migrations/Version20161116195435.php
+++ b/app/migrations/Version20161116195435.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2016 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20161116195435 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        $table = $schema->getTable($this->prefix.'companies');
+        if ($table->hasColumn('social_cache')) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql("ALTER TABLE {$this->prefix}companies ADD social_cache LONGTEXT DEFAULT NULL COMMENT '(DC2Type:array)';");
+
+    }
+}


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | No
| New feature? | Yes
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR addresses the need to have a SocialCache field in the Company entity to store temporary objects and right now this is only possible with the Lead entity.

#### Steps to test this PR:
1. Apply this PR
2. Follow the instructions in the developer's documentation to update the database schema:
	
~~~~
  app/console doctrine:schema:update --dump-sql
  app/console mautic:migrations:generate
  app/console doctrine:migrations:execute
~~~~

Now the SocialCache field is ready to be used:

~~~~
  $cache = $company->getSocialCache();
  $cache[$key] = $value;
  $company->setSocialCache($cache);
  $model->saveEntity($company);
~~~~
