### PR TITLE
Fixed error when no pages were selected for page hit point action

### DIFF
--- a/app/bundles/PageBundle/Helper/PointActionHelper.php
+++ b/app/bundles/PageBundle/Helper/PointActionHelper.php
@@ -40,7 +40,10 @@ class PointActionHelper
             $pageHitId = 0;
         }
 
-        $limitToPages = $action['properties']['pages'];
+        // If no pages are selected, the pages array does not exist
+        if (isset($action['properties']['pages'])) {
+            $limitToPages = $action['properties']['pages'];
+        }
 
         if (!empty($limitToPages) && !in_array($pageHitId, $limitToPages)) {
             //no points change


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Landing pages threw an error if a point action - page it with no pages selected existed.

#### Steps to test this PR:
1. Apply this PR and refresh the page. Error should be gone.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a point action Page Hit and do not select any specific pages. Save it.
2. Go to some existing landing page and open the public link in an incognito browser. You should see the error directly or it will be in the logs.