### PR TITLE
Fix CampaignExecutionEvent error

### DIFF
--- a/app/bundles/NotificationBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/CampaignSubscriber.php
@@ -181,8 +181,8 @@ class CampaignSubscriber extends CommonSubscriber
             'type'    => 'mautic.notification.notification',
             'id'      => $notification->getId(),
             'name'    => $notification->getName(),
-            'heading' => $event->getHeading(),
-            'content' => $event->getMessage(),
+            'heading' => $sendEvent->getHeading(),
+            'content' => $sendEvent->getMessage(),
         ];
 
         $event->setResult($result);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | n
| Related developer documentation PR URL | n
| Issues addressed (#s or URLs) | n
| BC breaks? | n
| Deprecations? | n

[//]: # ( Required: )
#### Description:
When you send notificitions from  php app/console mautic:campaign:trigger --force there was error:

`Attempted to call an undefined method named "getMessage" of class "Mautic\CampaignBundle\Event\CampaignExecutionEvent"

This PR fixed it.
`
#### Steps to test this PR:
1. Apply PR. 
2. Create campaign with notification
3. Send from console php app/console mautic:campaign:trigger --force 
4. See If error disappeared