### PR TITLE
Fixes a bug that caused labels to be saved as the values for boolean filters

### DIFF
--- a/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryFiltersType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryFiltersType.php
@@ -176,7 +176,7 @@ class DynamicContentFilterEntryFiltersType extends AbstractType
                     }
 
                     $list    = $options['fields'][$fieldObject][$fieldName]['properties']['list'];
-                    $choices = FormFieldHelper::parseListStringIntoArray($list);
+                    $choices = FormFieldHelper::parseList($list, true, ('boolean' === $fieldType));
 
                     if ($fieldType == 'select') {
                         // array_unshift cannot be used because numeric values get lost as keys

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -588,6 +588,11 @@ class LeadListRepository extends CommonRepository
                 $column = isset($companyTable[$details['field']]) ? $companyTable[$details['field']] : false;
             }
 
+            if (!$column) {
+                // Column no longer exists so continue
+                continue;
+            }
+
             //DBAL does not have a not() function so we have to use the opposite
             $func = (!$not)
                 ? $options[$details['operator']]['expr']
@@ -599,32 +604,30 @@ class LeadListRepository extends CommonRepository
                 $field = "comp.{$details['field']}";
             }
             // Format the field based on platform specific functions that DBAL doesn't support natively
-            if ($column) {
-                $formatter  = AbstractFormatter::createFormatter($this->_em->getConnection());
-                $columnType = $column->getType();
+            $formatter  = AbstractFormatter::createFormatter($this->_em->getConnection());
+            $columnType = $column->getType();
 
-                switch ($details['type']) {
-                    case 'datetime':
-                        if (!$columnType instanceof UTCDateTimeType) {
-                            $field = $formatter->toDateTime($field);
-                        }
-                        break;
-                    case 'date':
-                        if (!$columnType instanceof DateType && !$columnType instanceof UTCDateTimeType) {
-                            $field = $formatter->toDate($field);
-                        }
-                        break;
-                    case 'time':
-                        if (!$columnType instanceof TimeType && !$columnType instanceof UTCDateTimeType) {
-                            $field = $formatter->toTime($field);
-                        }
-                        break;
-                    case 'number':
-                        if (!$columnType instanceof IntegerType && !$columnType instanceof FloatType) {
-                            $field = $formatter->toNumeric($field);
-                        }
-                        break;
-                }
+            switch ($details['type']) {
+                case 'datetime':
+                    if (!$columnType instanceof UTCDateTimeType) {
+                        $field = $formatter->toDateTime($field);
+                    }
+                    break;
+                case 'date':
+                    if (!$columnType instanceof DateType && !$columnType instanceof UTCDateTimeType) {
+                        $field = $formatter->toDate($field);
+                    }
+                    break;
+                case 'time':
+                    if (!$columnType instanceof TimeType && !$columnType instanceof UTCDateTimeType) {
+                        $field = $formatter->toTime($field);
+                    }
+                    break;
+                case 'number':
+                    if (!$columnType instanceof IntegerType && !$columnType instanceof FloatType) {
+                        $field = $formatter->toNumeric($field);
+                    }
+                    break;
             }
 
             //the next one will determine the group

--- a/app/bundles/LeadBundle/Form/Type/FilterType.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterType.php
@@ -229,9 +229,9 @@ class FilterType extends AbstractType
                     }
 
                     $list    = $field['properties']['list'];
-                    $choices = FormFieldHelper::parseList($list);
+                    $choices = FormFieldHelper::parseList($list, true, ('boolean' === $fieldType));
 
-                    if ($fieldType == 'select') {
+                    if ('select' == $fieldType) {
                         // array_unshift cannot be used because numeric values get lost as keys
                         $choices     = array_reverse($choices, true);
                         $choices[''] = '';

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -447,8 +447,8 @@ class ListModel extends FormModel
                     ];
                 } else {
                     $properties['callback'] = 'activateLeadFieldTypeahead';
+                    $properties['list']     = (isset($properties['list'])) ? FormFieldHelper::formatList(FormFieldHelper::FORMAT_BAR, FormFieldHelper::parseList($properties['list'])) : '';
                 }
-                $properties['list'] = (isset($properties['list'])) ? FormFieldHelper::formatList(FormFieldHelper::FORMAT_BAR, FormFieldHelper::parseList($properties['list'])) : '';
             }
             $choices[$field->getObject()][$field->getAlias()] = [
                 'label'      => $field->getLabel(),

--- a/app/migrations/Version20161123225456.php
+++ b/app/migrations/Version20161123225456.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20161123225456 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // Fix a bug in dynamic content and segments if there are boolean fields
+
+        // Check if there are even boolean fields to worry about
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('lf.alias, lf.properties')
+           ->from($this->prefix.'lead_fields', 'lf')
+           ->where(
+               $qb->expr()->eq('lf.type', $qb->expr()->literal('boolean'))
+           );
+        $booleanFields = $qb->execute()->fetchAll();
+
+        if (count($booleanFields)) {
+            $fields = [];
+            foreach ($booleanFields as $key => $field) {
+                $fields[$field['alias']] = unserialize($field['properties']);
+            }
+
+            $this->fixEmails($qb, $fields);
+            $this->fixSegments($qb, $fields);
+        }
+    }
+
+    /**
+     * @param $qb
+     * @param $fields
+     */
+    protected function fixEmails(QueryBuilder $qb, $fields)
+    {
+        // Get a list of emails that do not have the default dynamic content
+        $emails = $qb->resetQueryParts()
+                     ->select('e.id, e.dynamic_content')
+                     ->from($this->prefix.'emails', 'e')
+                     ->where(
+                         $qb->expr()->andX(
+                             $qb->expr()->neq(
+                                 'e.dynamic_content',
+                                 $qb->expr()->literal(
+                                     'a:1:{i:0;a:3:{s:9:"tokenName";N;s:7:"content";N;s:7:"filters";a:1:{i:0;a:2:{s:7:"content";N;s:7:"filters";a:1:{i:0;a:7:{s:4:"glue";N;s:5:"field";N;s:6:"object";N;s:4:"type";N;s:8:"operator";N;s:7:"display";N;s:6:"filter";N;}}}}}}'
+                                 )
+                             ),
+                             $qb->expr()->neq(
+                                 'e.dynamic_content',
+                                 $qb->expr()->literal(
+                                     'a:1:{i:0;a:3:{s:9:"tokenName";N;s:7:"content";N;s:7:"filters";a:1:{i:0;a:2:{s:7:"content";N;s:7:"filters";a:0:{}}}}}'
+                                 )
+                             )
+                         )
+                     )
+                     ->execute()
+                     ->fetchAll();
+
+        // Start a transaction
+        if (count($emails)) {
+            foreach ($emails as $email) {
+                $update         = false;
+                $dynamicContent = unserialize($email['dynamic_content']);
+                foreach ($dynamicContent as &$dc) {
+                    foreach ($dc['filters'] as &$filter) {
+                        foreach ($filter['filters'] as &$checkMe) {
+                            $this->fixField($checkMe, $update, $fields);
+                        }
+                    }
+                }
+
+                if ($update) {
+                    $this->fixRow($qb, 'emails', 'dynamic_content', $email['id'], $dynamicContent);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param $qb
+     * @param $fields
+     */
+    protected function fixSegments(QueryBuilder $qb, $fields)
+    {
+        // Now fix segment filters
+        $segments = $qb->resetQueryParts()
+                       ->select('s.id, s.filters')
+                       ->from($this->prefix.'lead_lists', 's')
+                       ->where(
+                           $qb->expr()->neq(
+                               's.filters',
+                               $qb->expr()->literal('a:0:{}')
+                           )
+                       )
+                        ->execute()
+                        ->fetchAll();
+
+        if (count($segments)) {
+            foreach ($segments as $segment) {
+                $update  = false;
+                $filters = unserialize($segment['filters']);
+                foreach ($filters as &$filter) {
+                    $this->fixField($filter, $update, $fields);
+                }
+
+                if ($update) {
+                    $this->fixRow($qb, 'lead_lists', 'filters', $segment['id'], $filters);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param $qb
+     * @param $table
+     * @param $column
+     * @param $value
+     * @param $id
+     */
+    protected function fixRow(QueryBuilder $qb, $table, $column, $id, $value)
+    {
+        $qb->resetQueryParts()
+           ->update($this->prefix.$table)
+           ->set($column, $qb->expr()->literal(serialize($value)))
+           ->where(
+               $qb->expr()->eq('id', $id)
+           )
+           ->execute();
+    }
+
+    /**
+     * @param $checkMe
+     * @param $update
+     * @param $fields
+     */
+    protected function fixField(&$checkMe, &$update, $fields)
+    {
+        if ($checkMe['field'] && array_key_exists($checkMe['field'], $fields)) {
+            // Boolean field found so check to see if the label was used
+            if ($checkMe['filter'] === $fields[$checkMe['field']]['no']) {
+                $update            = true;
+                $checkMe['filter'] = 0;
+            } elseif ($checkMe['filter'] === $fields[$checkMe['field']]['yes']) {
+                $update            = true;
+                $checkMe['filter'] = 1;
+            }
+        }
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #2978
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Filters based on boolean custom fields saved the label to the filter rather than the value leading to filters always being treated as true (due to a string being type casted to boolean). This PR addresses this issue by ensuring that the correct value is saved to the filter. It also includes a migration to fix existing emails and segments. 

#### Steps to test this PR:
1. Before applying the PR create a new boolean custom field if one doesn't exist. 
2. Create an email with dynamic content that  includes a filter based on the boolean field. 
3. Create a segment using the boolean field as a filter.
4. Apply the PR
5. Run `php app/console doctrine:migrations:migrate`
6. View the email and segment - both filters should have the correct boolean value selected. If you look in the database at the serialized array, the filter should be 0 or 1 and not the string label.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Same as above but the label will be persisted to the serialized array.