### PR TITLE
Builder sidebar scrolling issue fixed

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -4284,7 +4284,7 @@ lesshat-selector { -lh-property: 0 ;
   z-index: 1030;
 }
 .builder-panel {
-  position: absolute;
+  position: fixed;
   top: 0;
   bottom: 0;
   right: 0;

--- a/app/bundles/CoreBundle/Assets/css/app/less/components/builder.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/components/builder.less
@@ -37,7 +37,7 @@
 }
 
 .builder-panel {
-  position: absolute;
+  position: fixed;
   top: 0;
   bottom: 0;
   right: 0;

--- a/plugins/MauticFocusBundle/Assets/css/focus.css
+++ b/plugins/MauticFocusBundle/Assets/css/focus.css
@@ -41,10 +41,6 @@
     overflow-y: scroll;
 }
 
-.builder-panel-focus .builder-panel-top {
-    -webkit-transform: translateZ(0);
-}
-
 .builder-panel-focus #focusFormContent {
     min-height: 1000px;
 }

--- a/plugins/MauticFocusBundle/Assets/css/focus.less
+++ b/plugins/MauticFocusBundle/Assets/css/focus.less
@@ -45,11 +45,6 @@
 .builder-panel-focus {
   overflow-y: scroll;
 
-  .builder-panel-top {
-    // Fix for jumping in Chrome
-    -webkit-transform: translateZ(0);
-  }
-
   #focusFormContent {
     min-height: 1000px;
   }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The Page or Email builder's sidebar was not scrollable if it contains more content than it can vertically fit.

#### Steps to test this PR:
1. Apply this PR
2. Re-generate prod assets if not in dev environment.
3. Test again. You should be able to scroll down.
4. Test also on mobile
5. Test that the Focus Builder Sidebar is working correctly.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Open the Email Builder and click at some slot. Edit options should appear in the right hand side bar.
2. If they fit on your screen, try to make the browser window smaller.
3. You should not be able to scroll down to options at the bottom.
