### PR TITLE
Adding back the email type selection

### DIFF
--- a/app/bundles/EmailBundle/Views/Email/form.html.php
+++ b/app/bundles/EmailBundle/Views/Email/form.html.php
@@ -251,7 +251,7 @@ $isCodeMode = ($email->getTemplate() === 'mautic_code_mode');
 
 <?php
 $type = $email->getEmailType();
-if (empty($type) || !empty($forceTypeSelection)):
+if (!$isExisting || empty($type) || !empty($forceTypeSelection)):
     echo $view->render('MauticCoreBundle:Helper:form_selecttype.html.php',
         [
             'item'       => $email,


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The email type selection when creating a new email disappeared because it was defaulted to 'template' to force this type for API calls which won't contain it. This PR adds the popup back for new emails.

#### Steps to test this PR:
1. Apply the PR.
2. Test again.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to create a segment email
2. There is no popup with the choice.
