### PR TITLE
Fixed issue where cloning an email lost content on opening builder

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -3927,7 +3927,9 @@ var Mautic = {
             Mautic.showChangeThemeWarning = false;
 
             // Populate default content
-            Mautic.setThemeHtml(Mautic.builderTheme);
+            if (!customHtml.length || !customHtml.val().length) {
+                Mautic.setThemeHtml(Mautic.builderTheme);
+            }
         }
 
         if (customHtml.length) {

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -829,7 +829,8 @@ class EmailController extends FormController
      */
     public function cloneAction($objectId)
     {
-        $model  = $this->getModel('email');
+        $model = $this->getModel('email');
+        /** @var Email $entity */
         $entity = $model->getEntity($objectId);
 
         if ($entity != null) {
@@ -847,7 +848,7 @@ class EmailController extends FormController
             $session     = $this->get('session');
             $contentName = 'mautic.emailbuilder.'.$entity->getSessionId().'.content';
 
-            $session->set($contentName, $entity->getContent());
+            $session->set($contentName, $entity->getCustomHtml());
         }
 
         return $this->newAction($entity);

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -612,6 +612,11 @@ class PageController extends FormController
             $entity->setVariantStartDate(null);
             $entity->setVariantHits(0);
             $entity->setIsPublished(false);
+
+            $session     = $this->get('session');
+            $contentName = 'mautic.pagebuilder.'.$entity->getSessionId().'.content';
+
+            $session->set($contentName, $entity->getCustomHtml());
         }
 
         return $this->newAction($entity);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This fixes the issue where content was lost on cloning an email and opening the builder.

#### Steps to test this PR:
1. Create a new email, open the builder, and edit the content
2. Clone, edit, and click the builder - the changed content should be present
3. Create a new email and open the builder and the default blank content should display

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Repeat the above but the cloned content will default to the selected template's default content