### PR TITLE
Image slot editor fixed

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/libraries/builder.css
+++ b/app/bundles/CoreBundle/Assets/css/libraries/builder.css
@@ -4588,6 +4588,7 @@ div[data-slot],
 }
 div[data-slot="image"] img {
   z-index: 1;
+  position: relative;
 }
 .slot-placeholder {
   border-top: 1px solid #4e5e9e;

--- a/app/bundles/CoreBundle/Assets/css/libraries/builder.less
+++ b/app/bundles/CoreBundle/Assets/css/libraries/builder.less
@@ -127,6 +127,7 @@ div[data-slot], [data-section-wrapper] {
 
 div[data-slot="image"] img {
     z-index: 1;
+    position: relative;
 }
 
 .slot-placeholder {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2756
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Image slot could be dropped in the theme, but not updated anyhow.

#### Steps to test this PR:
1. Apply this PR and try again
2. It will show up the image editor.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to edit an image in the image slot in the Email or Page Builder.
- It won't show up the editor.
