### PR TITLE
Save custom field default values for new leads and companies created …

### DIFF
--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -30,6 +30,8 @@ use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
  */
 class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
 {
+    use DefaultValueTrait;
+
     /**
      * @var Session
      */
@@ -50,6 +52,17 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
     {
         $this->leadFieldModel = $leadFieldModel;
         $this->session        = $session;
+    }
+
+    /**
+     * @param Company $entity
+     * @param bool    $unlock
+     */
+    public function saveEntity($entity, $unlock = true)
+    {
+        $this->setEntityDefaultValues($entity, 'company');
+
+        parent::saveEntity($entity, $unlock);
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/DefaultValueTrait.php
+++ b/app/bundles/LeadBundle/Model/DefaultValueTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Model;
+
+trait DefaultValueTrait
+{
+    /**
+     * @param        $entity
+     * @param string $object
+     */
+    protected function setEntityDefaultValues($entity, $object = 'lead')
+    {
+        if (!$entity->getId()) {
+            // New contact so default values if not already set
+            $updatedFields = $entity->getUpdatedFields();
+
+            /** @var FieldModel $fieldModel */
+            $fields = $this->leadFieldModel->getFieldListWithProperties($object);
+            foreach ($fields as $alias => $field) {
+                if (!isset($updatedFields[$alias]) && '' !== $field['defaultValue'] && null !== $field['defaultValue']) {
+                    $entity->addUpdatedField($alias, $field['defaultValue']);
+                }
+            }
+        }
+    }
+}

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -57,6 +57,8 @@ use Symfony\Component\Intl\Intl;
  */
 class LeadModel extends FormModel
 {
+    use DefaultValueTrait;
+
     private $currentLead       = null;
     private $systemCurrentLead = null;
 
@@ -399,6 +401,8 @@ class LeadModel extends FormModel
             }
             unset($updatedFields['company']);
         }
+
+        $this->setEntityDefaultValues($entity);
 
         parent::saveEntity($entity, $unlock);
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When a contact or company is created outside of the form, the default values are not applied. For example contacts created through form submissions or tracking pixels. This fixes that by applying default values for new contacts if they do not already have the given field defined.

#### Steps to test this PR:
1. Create a custom field that has a default value.
2. Create a new form with an email field and map it to the contact's email
3. Submit the form with a new email address not already in Mautic
4. Find the new contact and view the details - the value should be defaulted
5. Edit the contact and change the value of the defaulted field and save
6. The value should be updated appropriately (not to the default)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Same as above but when viewing the contact's details, the default value will not be defined. Editing the contact will then default the value in the form itself.
