### PR TITLE
Fix for Brazilan states

### DIFF
--- a/app/bundles/CoreBundle/Assets/json/regions.json
+++ b/app/bundles/CoreBundle/Assets/json/regions.json
@@ -687,10 +687,10 @@
 		"Alagoas",
 		"Amazonas",
 		"Amapa",
-		"Baia",
+		"Bahia",
 		"Ceara",
+		"Distrito Federal",
 		"Espirito Santo",
-		"Fernando de Noronha",
 		"Goias",
 		"Maranhao",
 		"Minas Gerais",
@@ -709,7 +709,7 @@
 		"Santa Catarina",
 		"Sergipe",
 		"Sao Paulo",
-		"Tocatins"
+		"Tocantins"
 	],
 	"Mexico": [
 		"Distrito Federal",


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Fernando de noronha removed, once it is not a Brazilian state
Bahia and Tocantins changed, it was written wrong
Distrito Federal added