### PR TITLE
Lines gets wrapped in the code mode

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -37,6 +37,7 @@ Mautic.launchBuilder = function (formName, actionName) {
             lineNumbers: true,
             mode: 'htmlmixed',
             extraKeys: {"Ctrl-Space": "autocomplete"},
+            lineWrapping: true,
             hintOptions: {
                 hint: function (editor) {
                     var cursor = editor.getCursor();


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N (just enhancement)
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Long lines in the code view are hard to view and edit. This PR adds configuration to CodeMirror editor to wrap them like this:
![code-mode-line-wrap](https://cloud.githubusercontent.com/assets/1235442/20762777/d2c7676e-b727-11e6-849a-7aacc2787eae.png)


#### Steps to test this PR:
1. Apply this PR
2. Rebuild assets if not in the dev env
3. Try again
- The long lines should be wrapped

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Visit a page or email with some long HTML line in the Code Mode 
- You'll have to scroll to the right to edit the end of it