### PR TITLE
Fixed malformed delete button on form results page

### DIFF
--- a/app/bundles/CoreBundle/Templating/Helper/ButtonHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/ButtonHelper.php
@@ -236,15 +236,15 @@ class ButtonHelper extends Helper
         $content              = '';
         $dropdownHtmlAppended = false;
         if (!empty($this->buttons)) {
-            $buttonCount = 1;
+            $buttonCount = 0;
 
             foreach ($this->buttons as $button) {
-                $content .= $this->buildButton($button, $buttonCount);
                 ++$buttonCount;
 
-                if ($this->groupType == self::TYPE_BUTTON_DROPDOWN && $buttonCount === $this->listMarker
-                    && $this->buttonCount !== $this->listMarker
-                ) {
+                $content .= $this->buildButton($button, $buttonCount);
+
+                $nextButton = $buttonCount + 1;
+                if ($this->groupType == self::TYPE_BUTTON_DROPDOWN && $nextButton === $this->listMarker && $buttonCount !== $this->buttonCount) {
                     $content .= $dropdownHtml;
                     $dropdownHtmlAppended = true;
                 }
@@ -323,7 +323,7 @@ class ButtonHelper extends Helper
         $buttons = '';
 
         //Wrap links in a tag
-        if ($this->groupType == self::TYPE_DROPDOWN || ($this->groupType == self::TYPE_BUTTON_DROPDOWN && $buttonCount >= $this->listMarker && $this->buttonCount != $this->listMarker)) {
+        if ($this->groupType == self::TYPE_DROPDOWN || ($this->groupType == self::TYPE_BUTTON_DROPDOWN && $buttonCount >= $this->listMarker)) {
             $this->wrapOpeningTag = "<li>\n";
             $this->wrapClosingTag = "</li>\n";
         }
@@ -332,7 +332,7 @@ class ButtonHelper extends Helper
             $button['attr'] = [];
         }
 
-        if (($this->groupType == self::TYPE_GROUP || ($this->groupType == self::TYPE_BUTTON_DROPDOWN && $buttonCount < $this->listMarker || ($this->buttonCount === $this->listMarker && $buttonCount == $this->buttonCount)))) {
+        if ($this->groupType == self::TYPE_GROUP || ($this->groupType == self::TYPE_BUTTON_DROPDOWN && $buttonCount < $this->listMarker)) {
             $this->addButtonClasses($button);
         } elseif (in_array($this->groupType, [self::TYPE_BUTTON_DROPDOWN, self::TYPE_DROPDOWN])) {
             $this->removeButtonClasses($button);
@@ -430,16 +430,12 @@ class ButtonHelper extends Helper
 
                 if (empty($button['primary'])) {
                     $this->listMarker = $counter;
+
                     break;
                 }
             }
 
-            if ($this->buttonCount <= 3 && $this->listMarker <= 3) {
-                // If the last button is a delete button, hide it; otherwise show all buttons
-                $lastButton       = end($this->buttons);
-                $this->listMarker = (!empty($lastButton['confirm']['template']) && 'delete' == $lastButton['confirm']['template']) ? 2 : 3;
-                reset($this->buttons);
-            } elseif ($this->listMarker <= 1 && $this->buttonCount) {
+            if ($this->listMarker <= 1 && $this->buttonCount) {
                 // Show at least one button
                 $this->listMarker = 2;
             }

--- a/app/bundles/FormBundle/Views/Result/index.html.php
+++ b/app/bundles/FormBundle/Views/Result/index.html.php
@@ -25,6 +25,7 @@ $buttons[] = [
     ],
     'btnText'   => $view['translator']->trans('mautic.form.result.export.html'),
     'iconClass' => 'fa fa-file-code-o',
+    'primary'   => true,
 ];
 
 $buttons[] = [
@@ -36,6 +37,7 @@ $buttons[] = [
     ],
     'btnText'   => $view['translator']->trans('mautic.form.result.export.csv'),
     'iconClass' => 'fa fa-file-text-o',
+    'primary'   => true,
 ];
 
 if (class_exists('PHPExcel')) {
@@ -48,6 +50,7 @@ if (class_exists('PHPExcel')) {
         ],
         'btnText'   => $view['translator']->trans('mautic.form.result.export.xlsx'),
         'iconClass' => 'fa fa-file-excel-o',
+        'primary'   => true,
     ];
 }
 
@@ -58,7 +61,6 @@ $buttons[] = [
         'confirmAction' => $view['router']->path('mautic_form_results_delete', array_merge(['formId' => $form->getId()])),
         'iconClass'     => 'fa fa-trash-o text-danger',
         'btnText'       => $view['translator']->trans('mautic.core.form.delete'),
-        'btnClass'      => false,
     ],
 ];
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

2.3.0 introduced a bad UI on the form results page where the delete button is not formatted. 
![2016-11-30_11-17-22](https://cloud.githubusercontent.com/assets/63312/20764515/208e3222-b6f4-11e6-99ca-005979f6197d.png)

#### Steps to test this PR:
1. View results of a form and note the buttons
2. Look through other pages to ensure buttons are still formatted correctly (list dropdowns, batch drop down, page buttons with dropdowns)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. View results of a form and note the buttons as per the screenshot above