### PR TITLE
Fixed issue that caused boolean filters to fail on first save

### DIFF
--- a/app/bundles/EmailBundle/Views/FormTheme/Email/dynamic_content_filter_entry_widget.html.php
+++ b/app/bundles/EmailBundle/Views/FormTheme/Email/dynamic_content_filter_entry_widget.html.php
@@ -38,7 +38,7 @@
                             <optgroup label="<?php echo $view['translator']->trans('mautic.lead.'.$header); ?>">
                                 <?php foreach ($field as $value => $params):
                                     $list      = (!empty($params['properties']['list'])) ? $params['properties']['list'] : [];
-                                    $choices   = \Mautic\LeadBundle\Helper\FormFieldHelper::parseListStringIntoArray($list);
+                                    $choices   = \Mautic\LeadBundle\Helper\FormFieldHelper::parseList($list, true, ('boolean' === $value));
                                     $list      = json_encode($choices);
                                     $callback  = (!empty($params['properties']['callback'])) ? $params['properties']['callback'] : '';
                                     $operators = (!empty($params['operators'])) ? $view->escape(json_encode($params['operators'])) : '{}';

--- a/app/bundles/EmailBundle/Views/FormTheme/Email/dynamic_content_filter_entry_widget.html.php
+++ b/app/bundles/EmailBundle/Views/FormTheme/Email/dynamic_content_filter_entry_widget.html.php
@@ -38,7 +38,7 @@
                             <optgroup label="<?php echo $view['translator']->trans('mautic.lead.'.$header); ?>">
                                 <?php foreach ($field as $value => $params):
                                     $list      = (!empty($params['properties']['list'])) ? $params['properties']['list'] : [];
-                                    $choices   = \Mautic\LeadBundle\Helper\FormFieldHelper::parseList($list, true, ('boolean' === $value));
+                                    $choices   = \Mautic\LeadBundle\Helper\FormFieldHelper::parseList($list, true, ('boolean' === $params['properties']['type']));
                                     $list      = json_encode($choices);
                                     $callback  = (!empty($params['properties']['callback'])) ? $params['properties']['callback'] : '';
                                     $operators = (!empty($params['operators'])) ? $view->escape(json_encode($params['operators'])) : '{}';

--- a/app/bundles/LeadBundle/Views/List/form.html.php
+++ b/app/bundles/LeadBundle/Views/List/form.html.php
@@ -93,8 +93,7 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
                                     <optgroup label="<?php echo $view['translator']->trans('mautic.lead.'.$header); ?>">
                                         <?php foreach ($field as $value => $params):
                                             $list      = (!empty($params['properties']['list'])) ? $params['properties']['list'] : [];
-                                            $choices   = \Mautic\LeadBundle\Helper\FormFieldHelper::parseList($list);
-                                            $object    = $object;
+                                            $choices   = \Mautic\LeadBundle\Helper\FormFieldHelper::parseList($list, true, ('boolean' === $value));
                                             $list      = json_encode($choices);
                                             $callback  = (!empty($params['properties']['callback'])) ? $params['properties']['callback'] : '';
                                             $operators = (!empty($params['operators'])) ? $view->escape(json_encode($params['operators'])) : '{}';

--- a/app/bundles/LeadBundle/Views/List/form.html.php
+++ b/app/bundles/LeadBundle/Views/List/form.html.php
@@ -93,7 +93,7 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
                                     <optgroup label="<?php echo $view['translator']->trans('mautic.lead.'.$header); ?>">
                                         <?php foreach ($field as $value => $params):
                                             $list      = (!empty($params['properties']['list'])) ? $params['properties']['list'] : [];
-                                            $choices   = \Mautic\LeadBundle\Helper\FormFieldHelper::parseList($list, true, ('boolean' === $value));
+                                            $choices   = \Mautic\LeadBundle\Helper\FormFieldHelper::parseList($list, true, ('boolean' === $params['properties']['type']));
                                             $list      = json_encode($choices);
                                             $callback  = (!empty($params['properties']['callback'])) ? $params['properties']['callback'] : '';
                                             $operators = (!empty($params['operators'])) ? $view->escape(json_encode($params['operators'])) : '{}';


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When adding a new boolean filter to a segment, it fails to validate on first save due to the values still being the label. A second save is successful.

#### Steps to test this PR:
1. Create a new segment and add a boolean filter. Select a value and save. You should not get a validation message.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new segment and add a boolean filter. Select a value and save. You'll get a value is not valid message. Save again and it should go through.