### PR TITLE
Fixed issue where a campaign's progress bars/percentages exceeded 100…

### DIFF
--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -12,6 +12,7 @@
 namespace Mautic\CampaignBundle\Controller;
 
 use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CoreBundle\Controller\FormController;
 use Mautic\LeadBundle\Controller\EntityContactsTrait;
 use Symfony\Component\Form\FormError;
@@ -258,6 +259,7 @@ class CampaignController extends FormController
         $action          = $this->generateUrl('mautic_campaign_action', ['objectAction' => 'view', 'objectId' => $objectId]);
         $dateRangeForm   = $this->get('form.factory')->create('daterange', $dateRangeValues, ['action' => $action]);
 
+        /** @var LeadEventLogRepository $eventLogRepo */
         $eventLogRepo = $this->getDoctrine()->getManager()->getRepository('MauticCampaignBundle:LeadEventLog');
         $events       = $model->getEventRepository()->getCampaignEvents($entity->getId());
         $leadCount    = $model->getRepository()->getCampaignLeadCount($entity->getId());

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -165,7 +165,8 @@ class LeadEventLogRepository extends CommonRepository
     {
         $q = $this->_em->getConnection()->createQueryBuilder()
             ->select('o.event_id, count(o.lead_id) as lead_count')
-            ->from(MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'o');
+            ->from(MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'o')
+            ->innerJoin('o', MAUTIC_TABLE_PREFIX.'campaign_leads', 'l', 'o.lead_id = l.lead_id and l.campaign_id = '.(int) $campaignId.' and l.manually_removed = 0');
 
         $expr = $q->expr()->andX(
             $q->expr()->eq('o.campaign_id', (int) $campaignId),

--- a/app/bundles/NotificationBundle/Translations/en_US/messages.ini
+++ b/app/bundles/NotificationBundle/Translations/en_US/messages.ini
@@ -1,3 +1,5 @@
+mautic.campaign.notification.send_notification="Send Notification"
+
 mautic.notification.notification="Web Notification"
 mautic.notification.notifications="Web Notifications"
 mautic.notification.campaign.send_notification="Send web notification"


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This fixes a math/UI issue for viewing campaigns due to the event log entries for contacts no longer part of the campaign were included in the equation.

#### Steps to test this PR:
1. Add a couple contacts to a campaign and execute it so that there is 100% completion of an action.
2. Remove one of the contacts from the campaign
3. View the details of the campaign and the progress bar for the action should still be at 100%

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Repeat the above but the progress bar will be more than 100%

![2016-12-01_16-35-20](https://cloud.githubusercontent.com/assets/63312/20815669/6a28d43c-b7e4-11e6-86d0-f028a84af841.png)