### PR TITLE
Minor in TranslationModelTrait.php

### DIFF
--- a/app/bundles/CoreBundle/Model/TranslationModelTrait.php
+++ b/app/bundles/CoreBundle/Model/TranslationModelTrait.php
@@ -36,6 +36,7 @@ trait TranslationModelTrait
     {
         list($translationParent, $translationChildren) = $entity->getTranslations();
 
+        $chosenLanguage = null;
         if (count($translationChildren)) {
             if ($translationParent) {
                 $translationChildren = $translationParent->getTranslationChildren();
@@ -94,7 +95,6 @@ trait TranslationModelTrait
 
             $matchFound     = false;
             $preferredCore  = false;
-            $chosenLanguage = null;
             foreach ($languageList as $language) {
                 $core = $this->getTranslationLocaleCore($language);
                 if (isset($translationList[$core])) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | n
| Related developer documentation PR URL | n
| Issues addressed (#s or URLs) | n
| BC breaks? | n
| Deprecations? | n

[//]: # ( Required: )
#### Description:

PHP did return notice  on line 126 because variable doesn't exist

`if (!$leadPreference && $chosenLanguage && $lead instanceof Lead) {`