### PR TITLE
Fixed the known route/route params for ajax requests that caused mixed behavior for custom buttons

### DIFF
--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -307,6 +307,38 @@ class CommonController extends Controller implements MauticController
             $passthrough['route'] = $args['returnUrl'];
         }
 
+        if (!empty($passthrough['route'])) {
+            //if the URL has a query built into it, breadcrumbs may fail matching
+            //so let's try to find it by the route name which will be the extras["routeName"] of the menu item
+            $baseUrl       = $this->request->getBaseUrl();
+            $routePath     = str_replace($baseUrl, '', $passthrough['route']);
+            $ajaxRouteName = false;
+
+            try {
+                $routeParams   = $this->get('router')->match($routePath);
+                $ajaxRouteName = $routeParams['_route'];
+
+                $this->request->attributes->set('ajaxRoute',
+                    [
+                        '_route'        => $ajaxRouteName,
+                        '_route_params' => $routeParams,
+                    ]
+                );
+            } catch (\Exception $e) {
+                //do nothing
+            }
+
+            //breadcrumbs may fail as it will retrieve the crumb path for currently loaded URI so we must override
+            $this->request->query->set('overrideRouteUri', $passthrough['route']);
+            if ($ajaxRouteName) {
+                if (isset($routeParams['objectAction'])) {
+                    //action urls share same route name so tack on the action to differentiate
+                    $ajaxRouteName .= "|{$routeParams['objectAction']}";
+                }
+                $this->request->query->set('overrideRouteName', $ajaxRouteName);
+            }
+        }
+
         //Ajax call so respond with json
         $newContent = '';
         if ($contentTemplate) {
@@ -341,27 +373,6 @@ class CommonController extends Controller implements MauticController
 
         $tmpl = (isset($parameters['tmpl'])) ? $parameters['tmpl'] : $this->request->get('tmpl', 'index');
         if ($tmpl == 'index') {
-            if (!empty($passthrough['route'])) {
-                //breadcrumbs may fail as it will retrieve the crumb path for currently loaded URI so we must override
-                $this->request->query->set('overrideRouteUri', $passthrough['route']);
-
-                //if the URL has a query built into it, breadcrumbs may fail matching
-                //so let's try to find it by the route name which will be the extras["routeName"] of the menu item
-                $baseUrl   = $this->request->getBaseUrl();
-                $routePath = str_replace($baseUrl, '', $passthrough['route']);
-                try {
-                    $routeParams = $this->get('router')->match($routePath);
-                    $routeName   = $routeParams['_route'];
-                    if (isset($routeParams['objectAction'])) {
-                        //action urls share same route name so tack on the action to differentiate
-                        $routeName .= "|{$routeParams['objectAction']}";
-                    }
-                    $this->request->query->set('overrideRouteName', $routeName);
-                } catch (\Exception $e) {
-                    //do nothing
-                }
-            }
-
             $updatedContent = [];
             if (!empty($newContent)) {
                 $updatedContent['newContent'] = $newContent;

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -308,8 +308,7 @@ class CommonController extends Controller implements MauticController
         }
 
         if (!empty($passthrough['route'])) {
-            //if the URL has a query built into it, breadcrumbs may fail matching
-            //so let's try to find it by the route name which will be the extras["routeName"] of the menu item
+            // Add the ajax route to the request so that the desired route is fed to plugins rather than the current request
             $baseUrl       = $this->request->getBaseUrl();
             $routePath     = str_replace($baseUrl, '', $passthrough['route']);
             $ajaxRouteName = false;

--- a/app/bundles/CoreBundle/Event/CustomButtonEvent.php
+++ b/app/bundles/CoreBundle/Event/CustomButtonEvent.php
@@ -30,6 +30,16 @@ class CustomButtonEvent extends Event
     protected $request;
 
     /**
+     * @var
+     */
+    protected $route;
+
+    /**
+     * @var array
+     */
+    protected $routeParams = [];
+
+    /**
      * @var array
      */
     protected $buttons = [];
@@ -54,8 +64,19 @@ class CustomButtonEvent extends Event
         $this->location = $location;
         $this->item     = $item;
 
-        // The original request will be stored in the subrequest
         $this->request = ($request->isXmlHttpRequest() && $request->query->has('request')) ? $request->query->get('request') : $request;
+        if ($this->request->attributes->has('ajaxRoute')) {
+            $ajaxRoute         = $this->request->attributes->get('ajaxRoute');
+            $this->route       = $ajaxRoute['_route'];
+            $this->routeParams = $ajaxRoute['_route_params'];
+        } else {
+            $this->route       = $this->request->attributes->get('_route');
+            $this->routeParams = $this->request->attributes->get('_route_params');
+        }
+
+        if (null === $this->routeParams) {
+            $this->routeParams = [];
+        }
 
         foreach ($buttons as $button) {
             $this->buttons[$this->generateButtonKey($button)] = $button;
@@ -87,8 +108,7 @@ class CustomButtonEvent extends Event
      */
     public function getRoute($withParams = false)
     {
-        return ($withParams) ? [$this->request->attributes->get('_route'), $this->request->attributes->get('_route_params')]
-            : $this->request->attributes->get('_route');
+        return ($withParams) ? [$this->route, $this->routeParams] : $this->route;
     }
 
     /**
@@ -193,9 +213,8 @@ class CustomButtonEvent extends Event
     {
         if (null !== $route) {
             list($currentRoute, $routeParams) = $this->getRoute(true);
-
-            $givenRoute       = $route;
-            $givenRouteParams = [];
+            $givenRoute                       = $route;
+            $givenRouteParams                 = [];
             if (is_array($route)) {
                 list($givenRoute, $givenRouteParams) = $route;
             }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Ajax requests would have the current request populated in the Request object rather than the route requested by the ajax route. This confused plugins that injected buttons into the UI because the route given may be different than the ajax request (for example, when saving an email, mautic_email_action rather than mautic_email_index would be passed to the plugin). 

#### Steps to test this PR:
1. Extract the EmailBundle.php and add it to the install. Clear the cache. 
2. View an email details page and note the Test button in the page actions.
3. Edit the email then save & close.
4. Note the Test button is still present on the details page.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Repeat the above but after save & close, the test button is gone until a refresh.

[EmailBundle.zip](https://github.com/mautic/mautic/files/632523/EmailBundle.zip)
