### PR TITLE
Append company data when pushing a contact to an integration.

### DIFF
--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -529,8 +529,9 @@ class EventModel extends CommonFormModel
                             ],
                         ],
                     ],
-                    'orderBy'    => 'l.id',
-                    'orderByDir' => 'asc',
+                    'orderBy'            => 'l.id',
+                    'orderByDir'         => 'asc',
+                    'withPrimaryCompany' => true,
                 ]
             );
 
@@ -1106,8 +1107,9 @@ class EventModel extends CommonFormModel
                             ],
                         ],
                     ],
-                    'orderBy'    => 'l.id',
-                    'orderByDir' => 'asc',
+                    'orderBy'            => 'l.id',
+                    'orderByDir'         => 'asc',
+                    'withPrimaryCompany' => true,
                 ]
             );
 
@@ -1392,8 +1394,9 @@ class EventModel extends CommonFormModel
                                     ],
                                 ],
                             ],
-                            'orderBy'    => 'l.id',
-                            'orderByDir' => 'asc',
+                            'orderBy'            => 'l.id',
+                            'orderByDir'         => 'asc',
+                            'withPrimaryCompany' => true,
                         ]
                     );
 

--- a/app/bundles/LeadBundle/Entity/CompanyRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyRepository.php
@@ -316,7 +316,7 @@ class CompanyRepository extends CommonRepository implements CustomFieldRepositor
     public function getCompaniesForContacts(array $contacts)
     {
         $qb = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $qb->select('c.*, l.lead_id')
+        $qb->select('c.*, l.lead_id, l.is_primary')
             ->from(MAUTIC_TABLE_PREFIX.'companies', 'c')
             ->join('c', MAUTIC_TABLE_PREFIX.'companies_leads', 'l', 'l.company_id = c.id')
             ->where(

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -381,9 +381,10 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
         });
 
         if (!empty($args['withPrimaryCompany'])) {
-            $tmpContacts = $args['withTotalCount'] ? $contacts['results'] : $contacts;
-            $contactIds  = array_keys($tmpContacts);
-            $companies   = $this->getEntityManager()->getRepository('MauticLeadBundle:Company')->getCompaniesForContacts($contactIds);
+            $withTotalCount = array_key_exists('withTotalCount', $args);
+            $tmpContacts    = ($withTotalCount && $args['withTotalCount']) ? $contacts['results'] : $contacts;
+            $contactIds     = array_keys($tmpContacts);
+            $companies      = $this->getEntityManager()->getRepository('MauticLeadBundle:Company')->getCompaniesForContacts($contactIds);
 
             foreach ($contactIds as $id) {
                 if (isset($companies[$id]) && !empty($companies[$id])) {
@@ -409,7 +410,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
                 }
             }
 
-            if ($args['withTotalCount']) {
+            if ($withTotalCount && $args['withTotalCount']) {
                 $contacts['results'] = $tmpContacts;
             } else {
                 $contacts = $tmpContacts;

--- a/app/bundles/PluginBundle/Helper/EventHelper.php
+++ b/app/bundles/PluginBundle/Helper/EventHelper.php
@@ -19,12 +19,12 @@ use Mautic\CoreBundle\Factory\MauticFactory;
 class EventHelper
 {
     /**
-     * @param               $contact
+     * @param               $lead
      * @param MauticFactory $factory
      */
-    public static function pushLead($config, $contact, MauticFactory $factory)
+    public static function pushLead($config, $lead, MauticFactory $factory)
     {
-        $contact = $factory->getEntityManager()->getRepository('MauticLeadBundle:Lead')->getEntityWithPrimaryCompany($contact);
+        $contact = $factory->getEntityManager()->getRepository('MauticLeadBundle:Lead')->getEntityWithPrimaryCompany($lead);
 
         /** @var \Mautic\PluginBundle\Helper\IntegrationHelper $integrationHelper */
         $integrationHelper = $factory->getHelper('integration');

--- a/app/bundles/PluginBundle/Helper/EventHelper.php
+++ b/app/bundles/PluginBundle/Helper/EventHelper.php
@@ -19,11 +19,13 @@ use Mautic\CoreBundle\Factory\MauticFactory;
 class EventHelper
 {
     /**
-     * @param               $lead
+     * @param               $contact
      * @param MauticFactory $factory
      */
-    public static function pushLead($config, $lead, MauticFactory $factory)
+    public static function pushLead($config, $contact, MauticFactory $factory)
     {
+        $contact = $factory->getEntityManager()->getRepository('MauticLeadBundle:Lead')->getEntityWithPrimaryCompany($contact);
+
         /** @var \Mautic\PluginBundle\Helper\IntegrationHelper $integrationHelper */
         $integrationHelper = $factory->getHelper('integration');
 
@@ -40,7 +42,7 @@ class EventHelper
             }
 
             if (method_exists($s, 'pushLead')) {
-                if ($s->pushLead($lead, $config)) {
+                if ($s->pushLead($contact, $config)) {
                     $success = true;
                 }
             }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

With the addition of Companies to Mautic and the notion of Primary Company on a contact, we failed to associate that data when pushing contacts out to integrations. This PR adds a `primaryCompany` property to the contact data that can be accessed in your integration code. `primaryCompany` is only available (at the moment) in the methods that push contacts out to integrations.

If your integration uses Form Submit actions or Point actions, the primaryCompany data is added in the `EventHelper::pushLead` method. For Campaign actions, the primaryCompany data is added in one of either `CampaignBundle\EventModel::triggerStartingEvents, triggerNegativeEvents, or triggerScheduledEvents`.

In addition, you can fetch entities with `primaryCompany` populated using `LeadRepository::getEntities($args)`, adding `'withPrimaryCompany' => true` to the `$args` array.