### PR TITLE
Feature/sample mail send immediately

### DIFF
--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -508,4 +508,18 @@ class MauticFactory
     {
         return $this->container->has($service);
     }
+
+    /**
+     * @param $service
+     *
+     * @return bool
+     */
+    public function get($service)
+    {
+        if ($this->serviceExists($service)) {
+            return $this->container->get($service);
+        }
+
+        return false;
+    }
 }

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1304,7 +1304,7 @@ class EmailController extends FormController
         ];
 
         // Send to current user
-        $errors = $model->sendEmailToUser($entity, $users, $fields, [], [], false);
+        $errors = $model->sendSampleEmailToUser($entity, $users, $fields, [], [], false);
         if (count($errors)) {
             $this->addFlash(implode('; ', $errors));
         } else {

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -264,6 +264,26 @@ class MailHelper
     }
 
     /**
+     * Mirrors previous MauticFactory functionality.
+     *
+     * @param bool $cleanSlate
+     *
+     * @return $this
+     */
+    public function getSampleMailer($cleanSlate = true)
+    {
+        $queueMode = $this->factory->getParameter('mailer_spool_type');
+        if ($queueMode != 'file') {
+            return $this->getMailer($cleanSlate);
+        }
+        $transport  = $this->factory->get('swiftmailer.transport.real');
+        $mailer     = new \Swift_Mailer($transport);
+        $mailHelper = new self($this->factory, $mailer, $this->from);
+
+        return $mailHelper->getMailer($cleanSlate);
+    }
+
+    /**
      * Send the message.
      *
      * @param bool $dispatchSendEvent
@@ -401,7 +421,7 @@ class MailHelper
                 if (!$this->transport->isStarted()) {
                     $this->transportStartTime = time();
                 }
-
+//                var_dump($this->mailer);die;
                 $this->mailer->send($this->message, $failures);
 
                 if (!empty($failures)) {

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -421,7 +421,6 @@ class MailHelper
                 if (!$this->transport->isStarted()) {
                     $this->transportStartTime = time();
                 }
-//                var_dump($this->mailer);die;
                 $this->mailer->send($this->message, $failures);
 
                 if (!empty($failures)) {

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -276,6 +276,9 @@ class MailHelper
         if ($queueMode != 'file') {
             return $this->getMailer($cleanSlate);
         }
+        // @todo - need a creative way to pass this service to this helper when factory use is removed
+        // the service is only available when queue mode is enabled so likely we'll need to use a cache compiler
+        // pass to ensure it is set regardless
         $transport  = $this->factory->get('swiftmailer.transport.real');
         $mailer     = new \Swift_Mailer($transport);
         $mailHelper = new self($this->factory, $mailer, $this->from);

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -2066,7 +2066,7 @@ class EmailModel extends FormModel
      *
      * @param       $email
      * @param       $users
-     * @param mixed $lead
+     * @param mixed $leadFields
      * @param array $tokens
      * @param array $assetAttachments
      * @param bool  $saveStat
@@ -2075,7 +2075,7 @@ class EmailModel extends FormModel
      *
      * @throws \Doctrine\ORM\ORMException
      */
-    public function sendSampleEmailToUser($email, $users, $lead = null, $tokens = [], $assetAttachments = [], $saveStat = true)
+    public function sendSampleEmailToUser($email, $users, $leadFields = null, $tokens = [], $assetAttachments = [], $saveStat = true)
     {
         if (!$emailId = $email->getId()) {
             return false;
@@ -2095,7 +2095,7 @@ class EmailModel extends FormModel
         }
 
         $mailer = $this->mailHelper->getSampleMailer();
-        $mailer->setLead($lead, true);
+        $mailer->setLead($leadFields, true);
         $mailer->setTokens($tokens);
         $mailer->setEmail($email, false, $emailSettings[$emailId]['slots'], $assetAttachments, (!$saveStat));
 

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -2060,4 +2060,93 @@ class EmailModel extends FormModel
             }
         }
     }
+
+    /**
+     * Send an email to lead(s).
+     *
+     * @param       $email
+     * @param       $users
+     * @param mixed $lead
+     * @param array $tokens
+     * @param array $assetAttachments
+     * @param bool  $saveStat
+     *
+     * @return mixed
+     *
+     * @throws \Doctrine\ORM\ORMException
+     */
+    public function sendSampleEmailToUser($email, $users, $lead = null, $tokens = [], $assetAttachments = [], $saveStat = true)
+    {
+        if (!$emailId = $email->getId()) {
+            return false;
+        }
+
+        if (!is_array($users)) {
+            $user  = ['id' => $users];
+            $users = [$user];
+        }
+
+        //get email settings
+        $emailSettings = &$this->getEmailSettings($email, false);
+
+        //noone to send to so bail
+        if (empty($users)) {
+            return false;
+        }
+
+        $mailer = $this->mailHelper->getSampleMailer();
+        $mailer->setLead($lead, true);
+        $mailer->setTokens($tokens);
+        $mailer->setEmail($email, false, $emailSettings[$emailId]['slots'], $assetAttachments, (!$saveStat));
+
+        $errors = [];
+        foreach ($users as $user) {
+            $idHash = uniqid();
+            $mailer->setIdHash($idHash);
+
+            if (!is_array($user)) {
+                $id   = $user;
+                $user = ['id' => $id];
+            } else {
+                $id = $user['id'];
+            }
+
+            if (!isset($user['email'])) {
+                $userEntity        = $this->userModel->getEntity($id);
+                $user['email']     = $userEntity->getEmail();
+                $user['firstname'] = $userEntity->getFirstName();
+                $user['lastname']  = $userEntity->getLastName();
+            }
+
+            if (!$mailer->setTo($user['email'], $user['firstname'].' '.$user['lastname'])) {
+                $errors[] = "{$user['email']}: ".$this->translator->trans('mautic.email.bounce.reason.bad_email');
+            } else {
+                if (!$mailer->queue(true)) {
+                    $errorArray = $mailer->getErrors();
+                    unset($errorArray['failures']);
+                    $errors[] = "{$user['email']}: ".implode('; ', $errorArray);
+                }
+
+                if ($saveStat) {
+                    $saveEntities[] = $mailer->createEmailStat(false, $user['email']);
+                }
+            }
+        }
+
+        //flush the message
+        if (!$mailer->flushQueue()) {
+            $errorArray = $mailer->getErrors();
+            unset($errorArray['failures']);
+            $errors[] = implode('; ', $errorArray);
+        }
+
+        if (isset($saveEntities)) {
+            $this->getStatRepository()->saveEntities($saveEntities);
+        }
+
+        //save some memory
+        unset($mailer);
+
+        return $errors;
+    }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/1376
| BC breaks? | No
| Deprecations? | No

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Sample message will not added in queue and it will be directly delivered even if queue was enabled.

#### Steps to test this PR:
1. Enable the queue in Email setting in configuration instead of send immediately.
2. Create new email in channels section.
3. Click Send Examples button.
4. Check whether the mail is delivered. 
5. The sample mail send will not be added in queue though queue is enabled.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Enable the queue in Email setting in configuration instead of send immediately.
2. Create new email in channels section.
3. Click Send Examples button.
4. Check whether the mail is delivered. 
5. Mail will not be send until cron job triggered.
