### PR TITLE
Fixed bad model names that prevented unlock overrides SMS and Notifications

### DIFF
--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -517,7 +517,7 @@ class NotificationController extends FormController
             return $this->accessDenied();
         } elseif ($model->isLocked($entity)) {
             //deny access if the entity is locked
-            return $this->isLocked($postActionVars, $entity, 'email');
+            return $this->isLocked($postActionVars, $entity, 'notification');
         }
 
         //Create the form

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -510,7 +510,7 @@ class SmsController extends FormController
             return $this->accessDenied();
         } elseif ($model->isLocked($entity)) {
             //deny access if the entity is locked
-            return $this->isLocked($postActionVars, $entity, 'email');
+            return $this->isLocked($postActionVars, $entity, 'sms');
         }
 
         //Create the form


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |  #3128
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This fixes an issue where an administrator could not override locks on sms messages and notifications. 

#### Steps to test this PR:
1. Use one user to edit a sms message and leave it open
2. Login as a different administrator in another browser and try to edit the same sms and/or notification
3. You should get a flash with a link to override
4. Click the override link
6. Edit the message and this time it should let you

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Same as above only the unlock link will say success but it remains locked