### PR TITLE
Dynamic Content permissions can be saved

### DIFF
--- a/app/bundles/DynamicContentBundle/Config/config.php
+++ b/app/bundles/DynamicContentBundle/Config/config.php
@@ -15,7 +15,7 @@ return [
             'items' => [
                 'mautic.dynamicContent.dynamicContent' => [
                     'route'    => 'mautic_dynamicContent_index',
-                    'access'   => ['dynamicContent:dynamicContents:viewown', 'dynamicContent:dynamicContents:viewother'],
+                    'access'   => ['dynamiccontent:dynamiccontents:viewown', 'dynamiccontent:dynamiccontents:viewother'],
                     'parent'   => 'mautic.core.components',
                     'priority' => 90,
                 ],

--- a/app/bundles/DynamicContentBundle/Controller/Api/DynamicContentApiController.php
+++ b/app/bundles/DynamicContentBundle/Controller/Api/DynamicContentApiController.php
@@ -29,6 +29,6 @@ class DynamicContentApiController extends CommonApiController
         $this->entityClass     = 'Mautic\DynamicContentBundle\Entity\DynamicContent';
         $this->entityNameOne   = 'dynamicContent';
         $this->entityNameMulti = 'dynamicContents';
-        $this->permissionBase  = 'dynamicContent:dynamicContents';
+        $this->permissionBase  = 'dynamiccontent:dynamiccontents';
     }
 }

--- a/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
+++ b/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
@@ -25,15 +25,15 @@ class DynamicContentController extends FormController
     {
         return (array) $this->get('mautic.security')->isGranted(
             [
-                'dynamicContent:dynamicContents:viewown',
-                'dynamicContent:dynamicContents:viewother',
-                'dynamicContent:dynamicContents:create',
-                'dynamicContent:dynamicContents:editown',
-                'dynamicContent:dynamicContents:editother',
-                'dynamicContent:dynamicContents:deleteown',
-                'dynamicContent:dynamicContents:deleteother',
-                'dynamicContent:dynamicContents:publishown',
-                'dynamicContent:dynamicContents:publishother',
+                'dynamiccontent:dynamiccontents:viewown',
+                'dynamiccontent:dynamiccontents:viewother',
+                'dynamiccontent:dynamiccontents:create',
+                'dynamiccontent:dynamiccontents:editown',
+                'dynamiccontent:dynamiccontents:editother',
+                'dynamiccontent:dynamiccontents:deleteown',
+                'dynamiccontent:dynamiccontents:deleteother',
+                'dynamiccontent:dynamiccontents:publishown',
+                'dynamiccontent:dynamiccontents:publishother',
             ],
             'RETURN_ARRAY'
         );
@@ -48,7 +48,7 @@ class DynamicContentController extends FormController
 
         $permissions = $this->getPermissions();
 
-        if (!$permissions['dynamicContent:dynamicContents:viewown'] && !$permissions['dynamicContent:dynamicContents:viewother']) {
+        if (!$permissions['dynamiccontent:dynamiccontents:viewown'] && !$permissions['dynamiccontent:dynamiccontents:viewother']) {
             return $this->accessDenied();
         }
 
@@ -118,7 +118,7 @@ class DynamicContentController extends FormController
      */
     public function newAction($entity = null)
     {
-        if (!$this->accessGranted('dynamicContent:dynamicContents:viewown')) {
+        if (!$this->accessGranted('dynamiccontent:dynamiccontents:viewown')) {
             return $this->accessDenied();
         }
 
@@ -265,7 +265,7 @@ class DynamicContentController extends FormController
                     ]
                 )
             );
-        } elseif (!$this->get('mautic.security')->hasEntityAccess(true, 'dynamicContent:dynamicContents:editother', $entity->getCreatedBy())) {
+        } elseif (!$this->get('mautic.security')->hasEntityAccess(true, 'dynamiccontent:dynamiccontents:editother', $entity->getCreatedBy())) {
             return $this->accessDenied();
         } elseif ($model->isLocked($entity)) {
             //deny access if the entity is locked
@@ -373,8 +373,8 @@ class DynamicContentController extends FormController
                 ]
             );
         } elseif (!$security->hasEntityAccess(
-            'dynamicContent:dynamicContents:viewown',
-            'dynamicContent:dynamicContents:viewother',
+            'dynamiccontent:dynamiccontents:viewown',
+            'dynamiccontent:dynamiccontents:viewother',
             $entity->getCreatedBy()
         )
         ) {
@@ -439,10 +439,10 @@ class DynamicContentController extends FormController
         $entity = $model->getEntity($objectId);
 
         if ($entity != null) {
-            if (!$this->get('mautic.security')->isGranted('dynamicContent:dynamicContents:create')
+            if (!$this->get('mautic.security')->isGranted('dynamiccontent:dynamiccontents:create')
                 || !$this->get('mautic.security')->hasEntityAccess(
-                    'dynamicContent:dynamicContents:viewown',
-                    'dynamicContent:dynamicContents:viewother',
+                    'dynamiccontent:dynamiccontents:viewown',
+                    'dynamiccontent:dynamiccontents:viewother',
                     $entity->getCreatedBy()
                 )
             ) {
@@ -489,8 +489,8 @@ class DynamicContentController extends FormController
                     'msgVars' => ['%id%' => $objectId],
                 ];
             } elseif (!$this->get('mautic.security')->hasEntityAccess(
-                'dynamicContent:dynamicContents:deleteown',
-                'dynamicContent:dynamicContents:deleteother',
+                'dynamiccontent:dynamiccontents:deleteown',
+                'dynamiccontent:dynamiccontents:deleteother',
                 $entity->getCreatedBy()
             )
             ) {
@@ -552,8 +552,8 @@ class DynamicContentController extends FormController
                         'msgVars' => ['%id%' => $objectId],
                     ];
                 } elseif (!$this->get('mautic.security')->hasEntityAccess(
-                    'dynamicContent:dynamicContents:viewown',
-                    'dynamicContent:dynamicContents:viewother',
+                    'dynamiccontent:dynamiccontents:viewown',
+                    'dynamiccontent:dynamiccontents:viewother',
                     $entity->getCreatedBy()
                 )
                 ) {

--- a/app/bundles/DynamicContentBundle/Entity/StatRepository.php
+++ b/app/bundles/DynamicContentBundle/Entity/StatRepository.php
@@ -101,7 +101,7 @@ class StatRepository extends CommonRepository
         }
         $q->groupBy('e.dynamic_content_id');
 
-        //get a total number of sent emails first
+        //get a total number of sent DC stats first
         $results = $q->execute()->fetchAll();
 
         $counts = [];

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentListType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentListType.php
@@ -33,7 +33,7 @@ class DynamicContentListType extends AbstractType
      */
     public function __construct(MauticFactory $factory)
     {
-        $this->viewOther = $factory->getSecurity()->isGranted('dynamicContent:dynamicContents:viewother');
+        $this->viewOther = $factory->getSecurity()->isGranted('dynamiccontent:dynamiccontents:viewother');
         $this->repo      = $factory->getModel('dynamicContent')->getRepository();
 
         $this->repo->setCurrentUser($factory->getUser());

--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -38,7 +38,7 @@ class DynamicContentModel extends FormModel
      */
     public function getPermissionBase()
     {
-        return 'dynamicContent:dynamicContents';
+        return 'dynamiccontent:dynamiccontents';
     }
 
     /**

--- a/app/bundles/DynamicContentBundle/Security/Permissions/DynamicContentPermissions.php
+++ b/app/bundles/DynamicContentBundle/Security/Permissions/DynamicContentPermissions.php
@@ -27,7 +27,7 @@ class DynamicContentPermissions extends AbstractPermissions
         parent::__construct($params);
 
         $this->addStandardPermissions('categories');
-        $this->addExtendedPermissions('dynamicContents');
+        $this->addExtendedPermissions('dynamiccontents');
     }
 
     /**
@@ -37,7 +37,7 @@ class DynamicContentPermissions extends AbstractPermissions
      */
     public function getName()
     {
-        return 'dynamicContent';
+        return 'dynamiccontent';
     }
 
     /**
@@ -48,7 +48,7 @@ class DynamicContentPermissions extends AbstractPermissions
      */
     public function buildForm(FormBuilderInterface &$builder, array $options, array $data)
     {
-        $this->addStandardFormFields('dynamicContent', 'categories', $builder, $data);
-        $this->addExtendedFormFields('dynamicContent', 'dynamicContents', $builder, $data);
+        $this->addStandardFormFields('dynamiccontent', 'categories', $builder, $data);
+        $this->addExtendedFormFields('dynamiccontent', 'dynamiccontents', $builder, $data);
     }
 }

--- a/app/bundles/DynamicContentBundle/Translations/en_US/messages.ini
+++ b/app/bundles/DynamicContentBundle/Translations/en_US/messages.ini
@@ -33,8 +33,8 @@ mautic.dynamicContent.help.searchcommands="<strong>Search commands</strong><br /
 mautic.dynamicContent.menu.edit="Edit Page"
 mautic.dynamicContent.menu.view="View Page"
 
-mautic.dynamicContent.permissions.header="Dynamic Content Permissions"
-mautic.dynamicContent.permissions.dynamicContents="Dynamic Content - User has access to"
+mautic.dynamiccontent.permissions.header="Dynamic Content Permissions"
+mautic.dynamiccontent.permissions.dynamiccontents="Dynamic Content - User has access to"
 mautic.dynamicContent.publish.down="Publish Down"
 mautic.dynamicContent.publish.up="Publish Up"
 mautic.dynamicContent.report.revision="Revision"

--- a/app/bundles/DynamicContentBundle/Views/DynamicContent/details.html.php
+++ b/app/bundles/DynamicContentBundle/Views/DynamicContent/details.html.php
@@ -36,19 +36,19 @@ $view['slots']->set(
             'customButtons'   => (isset($customButtons)) ? $customButtons : [],
             'templateButtons' => [
                 'edit' => $view['security']->hasEntityAccess(
-                    $permissions['dynamicContent:dynamicContents:editown'],
-                    $permissions['dynamicContent:dynamicContents:editother'],
+                    $permissions['dynamiccontent:dynamiccontents:editown'],
+                    $permissions['dynamiccontent:dynamiccontents:editother'],
                     $entity->getCreatedBy()
                 ),
-                'clone'  => $permissions['dynamicContent:dynamicContents:create'],
+                'clone'  => $permissions['dynamiccontent:dynamiccontents:create'],
                 'delete' => $view['security']->hasEntityAccess(
-                    $permissions['dynamicContent:dynamicContents:deleteown'],
-                    $permissions['dynamicContent:dynamicContents:deleteother'],
+                    $permissions['dynamiccontent:dynamiccontents:deleteown'],
+                    $permissions['dynamiccontent:dynamiccontents:deleteother'],
                     $entity->getCreatedBy()
                 ),
                 'close' => $view['security']->hasEntityAccess(
-                    $permissions['dynamicContent:dynamicContents:viewown'],
-                    $permissions['dynamicContent:dynamicContents:viewother'],
+                    $permissions['dynamiccontent:dynamiccontents:viewown'],
+                    $permissions['dynamiccontent:dynamiccontents:viewother'],
                     $entity->getCreatedBy()
                 ),
             ],

--- a/app/bundles/DynamicContentBundle/Views/DynamicContent/index.html.php
+++ b/app/bundles/DynamicContentBundle/Views/DynamicContent/index.html.php
@@ -19,7 +19,7 @@ $view['slots']->set(
         'MauticCoreBundle:Helper:page_actions.html.php',
         [
             'templateButtons' => [
-                'new' => $permissions['dynamicContent:dynamicContents:create'],
+                'new' => $permissions['dynamiccontent:dynamiccontents:create'],
             ],
             'routeBase' => 'dynamicContent',
         ]

--- a/app/bundles/DynamicContentBundle/Views/DynamicContent/list.html.php
+++ b/app/bundles/DynamicContentBundle/Views/DynamicContent/list.html.php
@@ -27,8 +27,8 @@ if ($tmpl == 'index') {
                         'target'          => '#dwcTable',
                         'routeBase'       => 'dynamicContent',
                         'templateButtons' => [
-                            'delete' => $permissions['dynamicContent:dynamicContents:deleteown']
-                                || $permissions['dynamicContent:dynamicContents:deleteother'],
+                            'delete' => $permissions['dynamiccontent:dynamiccontents:deleteown']
+                                || $permissions['dynamiccontent:dynamiccontents:deleteother'],
                         ],
                     ]
                 );
@@ -77,14 +77,14 @@ if ($tmpl == 'index') {
                                 'item'            => $item,
                                 'templateButtons' => [
                                     'edit' => $view['security']->hasEntityAccess(
-                                        $permissions['dynamicContent:dynamicContents:editown'],
-                                        $permissions['dynamicContent:dynamicContents:editother'],
+                                        $permissions['dynamiccontent:dynamiccontents:editown'],
+                                        $permissions['dynamiccontent:dynamiccontents:editother'],
                                         $item->getCreatedBy()
                                     ),
-                                    'clone'  => $permissions['dynamicContent:dynamicContents:create'],
+                                    'clone'  => $permissions['dynamiccontent:dynamiccontents:create'],
                                     'delete' => $view['security']->hasEntityAccess(
-                                        $permissions['dynamicContent:dynamicContents:deleteown'],
-                                        $permissions['dynamicContent:dynamicContents:deleteother'],
+                                        $permissions['dynamiccontent:dynamiccontents:deleteown'],
+                                        $permissions['dynamiccontent:dynamiccontents:deleteother'],
                                         $item->getCreatedBy()
                                     ),
                                 ],


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3088
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Dynamic Content permissions could not be saved. Well, they were saved, but the values weren't checked when the role permission form was loaded again because `'dynamiccontents' != 'dynamicContents'`. Quick fix was to get rid of the capital "C" in the permission name.

#### Steps to test this PR:
1. Apply this PR
2. Clear cache
3. Repeat the test. The permissions should stick after apply.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create/edit a role and try to add some permission to Dynamic Content
2. Apply and see again - the selected options are gone
