### PR TITLE
Improving bounce filter for Final-Recipient: rfc822

### DIFF
--- a/app/bundles/EmailBundle/Helper/MessageHelper.php
+++ b/app/bundles/EmailBundle/Helper/MessageHelper.php
@@ -916,7 +916,7 @@ class MessageHelper
         if (
             preg_match('/Original-Recipient: rfc822;(.*)/i', $dsn_report, $match)
             ||
-            preg_match('/Final-Recipient: rfc822;(.*)/i', $dsn_report, $match)
+            preg_match('/Final-Recipient:\s?rfc822;(.*)/i', $dsn_report, $match)
         ) {
             if ($parsedAddressList = self::parseAddressList($match[1])) {
                 $result['email'] = key($parsedAddressList);


### PR DESCRIPTION
What type of report is this: Bug report

## Description:
For some reason email with such content:

Final-Recipient: rfc822;abc@example.com
Action: failed
Status: 5.4.317
Diagnostic-Code: smtp;550 5.4.317 Message expired, cannot connect to remote server

does not go to bounce

## If a bug:

| Q   | A
| --- | ---
| Mautic version |  2.4.0
| PHP version |  PHP Version 7.0.8-3ubuntu3