### PR TITLE
Use set_time_limit function only if it's enabled

### DIFF
--- a/app/console
+++ b/app/console
@@ -8,7 +8,9 @@ date_default_timezone_set('UTC');
 // read http://symfony.com/doc/current/book/installation.html#configuration-and-setup for more information
 //umask(0000);
 
-set_time_limit(0);
+if (function_exists('set_time_limit')) {
+    set_time_limit(0);
+}
 
 defined('IN_MAUTIC_CONSOLE') or define('IN_MAUTIC_CONSOLE', 1);
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | true
| New feature? | false
| Related user documentation PR URL | null
| Related developer documentation PR URL | null
| Issues addressed (#s or URLs) | [Issue described in Mautic CZ group](https://www.facebook.com/groups/953588998063936/permalink/1194215080667992/)
| BC breaks? | false
| Deprecations? | false

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Some web hostings have function `set_time_limit` disabled for security reasons and so every cron job writes warning to a log which may cause disk space issues.

#### Steps to test this PR:
1. Apply this PR
2. Make sure the Mautic commands still work as before.
