### PR TITLE
Fix test failures

### DIFF
--- a/app/bundles/CoreBundle/Tests/Helper/IpLookupHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Helper/IpLookupHelperTest.php
@@ -92,8 +92,9 @@ class IpLookupHelperTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $mockRepository->expects($this->any())
-            ->method('findOneByIpAddress')
-            ->will($this->returnValue(null));
+            ->method('__call')
+            ->with($this->equalTo('findOneByIpAddress'))
+            ->willReturn(null);
 
         $mockEm = $this
             ->getMockBuilder(EntityManager::class)

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -85,7 +85,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $translator->expects($this->any())
-            ->method('has')
+            ->method('hasId')
             ->will($this->returnValue(false));
 
         // Setup an email variant email
@@ -307,7 +307,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $translator->expects($this->any())
-            ->method('has')
+            ->method('hasId')
             ->will($this->returnValue(false));
 
         // Setup an email variant email
@@ -523,7 +523,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $translator->expects($this->any())
-            ->method('has')
+            ->method('hasId')
             ->will($this->returnValue(false));
 
         // Setup the StatRepository
@@ -660,7 +660,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $translator->expects($this->any())
-            ->method('has')
+            ->method('hasId')
             ->will($this->returnValue(false));
 
         // Setup the StatRepository
@@ -800,7 +800,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $translator->expects($this->any())
-            ->method('has')
+            ->method('hasId')
             ->will($this->returnValue(false));
 
         // Setup the repositories
@@ -913,7 +913,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $translator->expects($this->any())
-            ->method('has')
+            ->method('hasId')
             ->will($this->returnValue(false));
 
         // Setup the repositories


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? | N/A

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixes the test failures that were introduced with the SAML SSO feature in 2.5. It adds required configuration parameters to the security_test.php

#### Steps to test this PR:
1. Apply PR & clear cache
2. Run `phpunit` from the app directory to see test failures are gone.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Be on 2.5 branch
2. Run `phpunit` from the app directory, and see test failures due to `InvalidConfigurationException: The child node "own" at path "light_saml_symfony_bridge" must be configured.`