### PR TITLE
Contact timeline export

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -75,6 +75,13 @@ return [
                     'leadId' => '\d+',
                 ],
             ],
+            'mautic_contact_timeline_export_action' => [
+                'path'         => '/contacts/timeline/batchExport/{leadId}',
+                'controller'   => 'MauticLeadBundle:Timeline:batchExport',
+                'requirements' => [
+                    'leadId' => '\d+',
+                ],
+            ],
             'mautic_contact_action' => [
                 'path'       => '/contacts/{objectAction}/{objectId}',
                 'controller' => 'MauticLeadBundle:Lead:execute',

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -2388,14 +2388,14 @@ class LeadController extends FormController
             'orderBy'        => $orderBy,
             'orderByDir'     => $orderByDir,
             'withTotalCount' => true,
-            'type'           => $dataType,
-            'filename'       => 'contacts',
         ];
 
         $resultsCallback = function ($contact) {
             return $contact->getProfileFields();
         };
 
-        return $this->exportResultsAs($model, $args, $resultsCallback);
+        $toExport = $this->getDataForExport($model, $args, $resultsCallback);
+
+        return $this->exportResultsAs($toExport, $dataType, 'contacts');
     }
 }

--- a/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
+++ b/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
@@ -186,10 +186,11 @@ trait LeadDetailsTrait
      * @param array|null $filters
      * @param array|null $orderBy
      * @param int        $page
+     * @param int        $limit
      *
      * @return array
      */
-    protected function getEngagements(Lead $lead, array $filters = null, array $orderBy = null, $page = 1)
+    protected function getEngagements(Lead $lead, array $filters = null, array $orderBy = null, $page = 1, $limit = 25)
     {
         $session = $this->get('session');
 
@@ -218,7 +219,7 @@ trait LeadDetailsTrait
         /** @var LeadModel $model */
         $model = $this->getModel('lead');
 
-        return $model->getEngagements($lead, $filters, $orderBy, $page);
+        return $model->getEngagements($lead, $filters, $orderBy, $page, $limit);
     }
 
     /**

--- a/app/bundles/LeadBundle/Controller/TimelineController.php
+++ b/app/bundles/LeadBundle/Controller/TimelineController.php
@@ -179,4 +179,86 @@ class TimelineController extends CommonController
             ]
         );
     }
+
+    /**
+     * @return array|\Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\StreamedResponse
+     */
+    public function batchExportAction(Request $request, $leadId)
+    {
+        if (empty($leadId)) {
+            return $this->accessDenied();
+        }
+
+        $lead = $this->checkLeadAccess($leadId, 'view');
+        if ($lead instanceof Response) {
+            return $lead;
+        }
+
+        $this->setListFilters();
+
+        $session = $this->get('session');
+        if ($request->getMethod() == 'POST' && $request->request->has('search')) {
+            $filters = [
+                'search'        => InputHelper::clean($request->request->get('search')),
+                'includeEvents' => InputHelper::clean($request->request->get('includeEvents', [])),
+                'excludeEvents' => InputHelper::clean($request->request->get('excludeEvents', [])),
+            ];
+            $session->set('mautic.lead.'.$leadId.'.timeline.filters', $filters);
+        } else {
+            $filters = null;
+        }
+
+        $order = [
+            $session->get('mautic.lead.'.$leadId.'.timeline.orderby'),
+            $session->get('mautic.lead.'.$leadId.'.timeline.orderbydir'),
+        ];
+
+        $dataType = $this->request->get('filetype', 'csv');
+
+        $resultsCallback = function ($event) {
+            $eventLabel = (isset($event['eventLabel'])) ? $event['eventLabel'] : $event['eventType'];
+            if (is_array($eventLabel)) {
+                $eventLabel = $eventLabel['label'];
+            }
+
+            return [
+                'eventName'      => $eventLabel,
+                'eventType'      => isset($event['eventType']) ? $event['eventType'] : '',
+                'eventTimestamp' => $this->get('mautic.helper.template.date')->toText($event['timestamp'], 'local', 'Y-m-d H:i:s', true),
+            ];
+        };
+
+        $results    = $this->getEngagements($lead, $filters, $order, 1, 200);
+        $count      = $results['total'];
+        $items      = $results['events'];
+        $iterations = ceil($count / 200);
+        $loop       = 1;
+
+        // Max of 50 iterations for 10K result export
+        if ($iterations > 50) {
+            $iterations = 50;
+        }
+
+        $toExport = [];
+
+        while ($loop <= $iterations) {
+            if (is_callable($resultsCallback)) {
+                foreach ($items as $item) {
+                    $toExport[] = $resultsCallback($item);
+                }
+            } else {
+                foreach ($items as $item) {
+                    $toExport[] = (array) $item;
+                }
+            }
+
+            $items = $this->getEngagements($lead, $filters, $order, $loop + 1, 200);
+
+            $this->getDoctrine()->getManager()->clear();
+
+            ++$loop;
+        }
+
+        return $this->exportResultsAs($toExport, $dataType, 'contact_timeline');
+    }
 }

--- a/app/bundles/LeadBundle/EventListener/ButtonSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ButtonSubscriber.php
@@ -30,7 +30,7 @@ class ButtonSubscriber extends CommonSubscriber
      */
     public function injectViewButtons(CustomButtonEvent $event)
     {
-        if (0 === strpos($event->getRoute(), 'mautic_contact_')) {
+        if (0 === strpos($event->getRoute(), 'mautic_contact_index')) {
             $exportRoute = $this->router->generate(
                 'mautic_contact_action',
                 ['objectAction' => 'batchExport']

--- a/app/bundles/LeadBundle/Views/Timeline/index.html.php
+++ b/app/bundles/LeadBundle/Views/Timeline/index.html.php
@@ -18,7 +18,7 @@
     </div>
     <?php if (isset($events['types']) && is_array($events['types'])) : ?>
         <div class="history-search panel-footer text-muted">
-            <div class="col-sm-6">
+            <div class="col-sm-5">
                 <select name="includeEvents[]" multiple="multiple" class="form-control bdr-w-0" data-placeholder="<?php echo $view['translator']->trans('mautic.lead.lead.filter.bundles.include.placeholder'); ?>">
                     <?php foreach ($events['types'] as $typeKey => $typeName) : ?>
                         <option value="<?php echo $typeKey; ?>"<?php echo in_array($typeKey, $events['filters']['includeEvents']) ? ' selected' : ''; ?> >
@@ -27,7 +27,7 @@
                     <?php endforeach; ?>
                 </select>
             </div>
-            <div class="col-sm-6">
+            <div class="col-sm-5">
                 <select name="excludeEvents[]" multiple="multiple" class="form-control bdr-w-0" data-placeholder="<?php echo $view['translator']->trans('mautic.lead.lead.filter.bundles.exclude.placeholder'); ?>">
                     <?php foreach ($events['types'] as $typeKey => $typeName) : ?>
                         <option value="<?php echo $typeKey; ?>"<?php echo in_array($typeKey, $events['filters']['excludeEvents']) ? ' selected' : ''; ?> >
@@ -35,6 +35,13 @@
                         </option>
                     <?php endforeach; ?>
                 </select>
+            </div>
+            <div class="col-sm-2">
+                <a class="btn btn-default btn-block" href="<?php echo $view['router']->generate('mautic_contact_timeline_export_action', ['leadId' => $lead->getId()]); ?>" data-toggle="download">
+                    <span>
+                        <i class="fa fa-download"></i> <span class="hidden-xs hidden-sm"><?php echo $view['translator']->trans('mautic.core.export'); ?></span>
+                    </span>
+                </a>
             </div>
         </div>
     <?php endif; ?>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Related user documentation PR URL | Pending
| Related developer documentation PR URL | Pending
| Issues addressed (#s or URLs) | Not found
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR adds support to be able to export a contact's timeline with support for filters.


#### Steps to test this PR:
1. Apply PR
2. Navigate to a contact
3. Click the export button next to the filters on the contact timeline to get up to 10K timeline entries exported
4. Add some filters, and click export again. The filtered timeline events that show on the contact page should mirror what is seen on the page.