### PR TITLE
Add class attribute to button slot in builder to distinguish between regular link

### DIFF
--- a/app/bundles/CoreBundle/Views/Slots/button.html.php
+++ b/app/bundles/CoreBundle/Views/Slots/button.html.php
@@ -9,7 +9,7 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 ?>
-<a href="#" target="_blank" style="font-size: 16px; color: #ffffff; text-decoration: none; text-decoration: none; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px; padding: 12px 18px; background-color: #4e5e9e; display: inline-block;">
+<a href="#" target="_blank" class="button" style="font-size: 16px; color: #ffffff; text-decoration: none; text-decoration: none; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px; padding: 12px 18px; background-color: #4e5e9e; display: inline-block;">
     I want this!
 </a>
 <div style="clear:both"></div>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Y


[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Now there is no possibility to distinguish between regular links (in content) and buttons in builder to write some of default styles for button. This PR will add class attribute ('button') in created button HTML in builder in email theming. This will help to add custom CSS for all buttons added using builder.

#### Steps to test this PR:
1. Create new email in channels section.
2. Select one theme and click builder
3. Add button slot, this will create anchor tag with class attribute 'button' 
4. This will help to add custom style for all buttons using that class name.

