### PR TITLE
Don't block resources in robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -2,7 +2,9 @@ User-agent: *
 Disallow: /addons/
 Disallow: /plugins/
 Disallow: /app/
-Disallow: /media/
+Disallow: /media/dashboard/
+Disallow: /media/files/
+Disallow: /media/js/mautic-form-src.js
 Disallow: /themes/
 Disallow: /translations/
 Disallow: /vendor/


### PR DESCRIPTION
Modification of the PR #3211

| Q  | A
| --- | ---
| Bug fix? |  More or less, it depends on whether you care about SEO or not.
| New feature? | No
| Related user documentation PR URL |  N/A
| Related developer documentation PR URL |  N/A
| Issues addressed (#s or URLs) |  N/A
| BC breaks? | No
| Deprecations? |  No

#### Description:
We include mautic resources on public websites (to insert mautic forms for instance). Search engines need these resources.

You can find more explanation in this blog post : https://varvy.com/mobile/external-resource-blocking.html

#### Steps to test this PR:
1. Have a website with a mautic form in a page
2. Check your page with the Google Search Console tool : https://www.google.com/webmasters/tools/home

#### List deprecations along with the new alternative:
None

#### List backwards compatibility breaks:
None