### PR TITLE
Added code to allow stream and download from asset preview

### DIFF
--- a/app/bundles/CoreBundle/Controller/Api/FileApiController.php
+++ b/app/bundles/CoreBundle/Controller/Api/FileApiController.php
@@ -52,8 +52,9 @@ class FileApiController extends CommonApiController
         $response = [$this->entityNameOne => []];
         if ($this->request->files) {
             foreach ($this->request->files as $file) {
-                if (in_array($file->guessExtension(), $this->allowedExtensions)) {
-                    $fileName = md5(uniqid()).'.'.$file->guessExtension();
+                $extension = $file->guessExtension() ? $file->guessExtension() : $file->getClientOriginalExtension();
+                if (in_array($extension, $this->allowedExtensions)) {
+                    $fileName = md5(uniqid()).'.'.$extension;
                     $moved    = $file->move($path, $fileName);
 
                     if (substr($dir, 0, 6) === 'images') {


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This fix allows to stream and download an asset from the preview action without enclosing it in html markup.

#### Steps to test this PR:
1. Apply this PR
2. Preview the asset using the preview action and add the URL parameters: stream=1 or download=1.
ie. http://MAUTIC_URL/s/assets/preview/1?stream=1

