### PR TITLE
Enhance the Top Segments Dashboard widget to link to Segment's Contacts

### DIFF
--- a/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
@@ -167,8 +167,9 @@ class DashboardSubscriber extends MainDashboardSubscriber
                 // Build table rows with links
                 if ($lists) {
                     foreach ($lists as &$list) {
-                        $listUrl = $this->router->generate('mautic_segment_action', ['objectAction' => 'edit', 'objectId' => $list['id']]);
-                        $row     = [
+                        $listUrl    = $this->router->generate('mautic_segment_action', ['objectAction' => 'edit', 'objectId' => $list['id']]);
+                        $contactUrl = $this->router->generate('mautic_contact_index', ['search' => 'segment:'.$list['alias']]);
+                        $row        = [
                             [
                                 'value' => $list['name'],
                                 'type'  => 'link',
@@ -176,6 +177,8 @@ class DashboardSubscriber extends MainDashboardSubscriber
                             ],
                             [
                                 'value' => $list['leads'],
+                                'type'  => 'link',
+                                'link'  => $contactUrl,
                             ],
                         ];
                         $items[] = $row;

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -1022,7 +1022,7 @@ class ListModel extends FormModel
     public function getTopLists($limit = 10, $dateFrom = null, $dateTo = null, $filters = [])
     {
         $q = $this->em->getConnection()->createQueryBuilder();
-        $q->select('COUNT(t.date_added) AS leads, ll.id, ll.name')
+        $q->select('COUNT(t.date_added) AS leads, ll.id, ll.name, ll.alias')
             ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 't')
             ->join('t', MAUTIC_TABLE_PREFIX.'lead_lists', 'll', 'll.id = t.leadlist_id')
             ->orderBy('leads', 'DESC')


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Related user documentation PR URL | None Needed
| Related developer documentation PR URL | None Needed
| Issues addressed (#s or URLs) | #3229 
| BC breaks? | N
| Deprecations? | N

#### Description:

Currently a default dashboard is `Top Lists` which uses the `Contact Widgets: Top Segments` type. This dashboard shows the names of the top segments with a count of `Contacts` within the `Segment`.

Currently clicking on the name of the segment is a link to edit the segment while the number of contacts is just plain text. If you go to the Segments page it shows a number of contacts with it being a link to the contacts page filtered by segments.

I would argue that seeing the contacts within a segment is much more useful then being able to edit the Segment.

This is solved bychanging the number of Contacts from plain text to be a link to the Contacts page filtered by segment.

#### Steps to test this PR:
1. Go to the homepage and make sure you have the _Top Segments_ widget on the _Dashboard_
2. Click on the _Name_ of the `Segment`
  * You will **still** be taken to the edit of page of the `Segment`
3. Go back to the homepage
4. Click on the _Number_ of `Contacts` in the `Segment`
  * You will **now** be taken to the list page of `Contact` being filtered by the `Segment`