### PR TITLE
Out of memory exception on iplookup command

### DIFF
--- a/app/bundles/CoreBundle/IpLookup/AbstractLocalDataLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/AbstractLocalDataLookup.php
@@ -85,6 +85,8 @@ abstract class AbstractLocalDataLookup extends AbstractLookup implements IpLooku
                 case 'gz' == $tempExt:
                     $memLimit = $this->sizeInByte(ini_get('memory_limit'));
                     $freeMem  = $memLimit - memory_get_peak_usage();
+                    //check whether there is enough memory to handle large iplookp DB
+                    // or will throw iplookup exception
                     if (function_exists('gzdecode') && strlen($data->body) < ($freeMem / 3)) {
                         $success = (bool) file_put_contents($localTarget, gzdecode($data->body));
                     } elseif (function_exists('gzopen')) {

--- a/app/bundles/CoreBundle/IpLookup/AbstractLocalDataLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/AbstractLocalDataLookup.php
@@ -83,7 +83,9 @@ abstract class AbstractLocalDataLookup extends AbstractLookup implements IpLooku
                     break;
 
                 case 'gz' == $tempExt:
-                    if (function_exists('gzdecode')) {
+                    $memLimit = $this->sizeInByte(ini_get('memory_limit'));
+                    $freeMem  = $memLimit - memory_get_peak_usage();
+                    if (function_exists('gzdecode') && strlen($data->body) < ($freeMem / 3)) {
                         $success = (bool) file_put_contents($localTarget, gzdecode($data->body));
                     } elseif (function_exists('gzopen')) {
                         if (file_put_contents($tempTarget, $data->body)) {
@@ -139,5 +141,18 @@ abstract class AbstractLocalDataLookup extends AbstractLookup implements IpLooku
         }
 
         return null;
+    }
+
+    protected function sizeInByte($size)
+    {
+        $data = (int) substr($size, 0, -1);
+        switch (strtoupper(substr($size, -1))) {
+            case 'K':
+                return $data * 1024;
+            case 'M':
+                return $data * 1024 * 1024;
+            case 'G':
+                return $data * 1024 * 1024 * 1024;
+        }
     }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N


[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Ip lookup command (mastic:iplookup:download) with IP lookup service 'MaxMind - GeoLite2 City Download' throw an error OutOfMemoryException on gzdecode as the Max mind ip lookup db size is more than 50 mb. This PR will resolve the issue by checking the file size and remaining memory available. And use gzopen instead of gzdecode function.

php memory_limit = 128M 

#### Steps to test this PR:
1. Go to configuration page
2. Select 'MaxMind - GeoLite2 City Download' option in 'IP lookup service' in General Settings
3. Apply the changes.
4. Go to the command line and execute the command 'php app/console mautic:iplookup:download'


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to configuration page
2. Select 'MaxMind - GeoLite2 City Download' option in 'IP lookup service' in General Settings
3. Apply the changes.
4. Go to the command line and execute the command 'php app/console mautic:iplookup:download'