### PR TITLE
Fix for lastActive date via API not being saved

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -529,8 +529,8 @@ class LeadApiController extends CommonApiController
         }
 
         // Check for lastActive date
-        if (isset($parameters['lastActive'])) {
-            $lastActive = new DateTimeHelper($parameters['lastActive']);
+        if (isset($originalParams['lastActive'])) {
+            $lastActive = new DateTimeHelper($originalParams['lastActive']);
             $entity->setLastActive($lastActive->getDateTime());
         }
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

#### Description:
This PR fixes an issue with setting a contacts lastActive date via the API. Currently the value is not retained and any new contact created via the API will have a null lastActive date.

#### Steps to test this PR:
1. Create a new contact via the API and specify a `lastActive` date in the form: `yyyy-mm-ddThh:mm:ss+00:00`
Prior to the fix, the contact returned will contain a null lastActive date.
After this fix is applied, the data specified will be returned.

#### Steps to reproduce the bug:
1. As above
