### PR TITLE
Fix bug for Type-o in the Third Party Tracking Code description

### DIFF
--- a/app/bundles/PageBundle/Translations/en_US/messages.ini
+++ b/app/bundles/PageBundle/Translations/en_US/messages.ini
@@ -169,7 +169,7 @@ mautic.trackable.click_url="URL"
 mautic.trackable.total_clicks="Total Clicks"
 
 mautic.config.tab.pagetracking="3rd party website tracking code"
-mautic.config.tab.pagetracking.info="Insert following code at the end of the web page before ending <code>&lt;body/&gt;</code> tag. Mautic Landing Pages are tracked automatically. Use this only to track 3rd party websites."
+mautic.config.tab.pagetracking.info="Insert following code at the end of the web page before ending <code>&lt;/body&gt;</code> tag. Mautic Landing Pages are tracked automatically. Use this only to track 3rd party websites."
 mautic.report.group.pages="Pages"
 mautic.page.event.videohit="Video View Event"
 mautic.page.time.on.video="Total time viewed"


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | #3280
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The description paragraph on the 3rd party website tracking code settings page has a type-o. It currently reads as 

> Insert following code at the end of the web page before ending ```<body/>``` tag. Mautic Landing Pages are tracked automatically. Use this only to track 3rd party websites

It should read as 

> Insert following code at the end of the web page before ending ```</body>``` tag. Mautic Landing Pages are tracked automatically. Use this only to track 3rd party websites

#### Steps to test this PR:

1. Log in as administrator
2. Navigate to Settings (cog) > Configuration > Landing Page Settings

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Log in as administrator
2. Navigate to Settings (cog) > Configuration > Landing Page Settings

![ending_body_tag](https://cloud.githubusercontent.com/assets/361586/22208875/7b07273a-e152-11e6-8385-5fc70d981960.png)
