### PR TITLE
Ending head tag typo fixed. Closes #3280

### DIFF
--- a/app/bundles/PageBundle/Translations/en_US/messages.ini
+++ b/app/bundles/PageBundle/Translations/en_US/messages.ini
@@ -169,7 +169,7 @@ mautic.trackable.click_url="URL"
 mautic.trackable.total_clicks="Total Clicks"
 
 mautic.config.tab.pagetracking="3rd party website tracking code"
-mautic.config.tab.pagetracking.info="Insert following code at the end of the web page before ending <code>&lt;body/&gt;</code> tag. Mautic Landing Pages are tracked automatically. Use this only to track 3rd party websites."
+mautic.config.tab.pagetracking.info="Insert following code at the end of the web page before ending <code>&lt;/body&gt;</code> tag. Mautic Landing Pages are tracked automatically. Use this only to track 3rd party websites."
 mautic.report.group.pages="Pages"
 mautic.page.event.videohit="Video View Event"
 mautic.page.time.on.video="Total time viewed"


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3280
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
There is a typo in the Page Setting. `<body/>` instead of `</body>`. Described in detail in the linked issue.

#### Steps to test this PR:
1. Apply this PR
2. Clear the cache if not using the dev mode
3. Check the Page Settings that the body tag is correct.
