### PR TITLE
Make default value appropriate to the type and properties defined

### DIFF
--- a/app/bundles/CoreBundle/Controller/FormController.php
+++ b/app/bundles/CoreBundle/Controller/FormController.php
@@ -925,4 +925,23 @@ class FormController extends CommonController
             )
         );
     }
+
+    /**
+     * @param Form $copyFrom
+     * @param Form $copyTo
+     */
+    protected function copyErrorsRecursively(Form $copyFrom, Form $copyTo)
+    {
+        /** @var $error FormError */
+        foreach ($copyFrom->getErrors() as $error) {
+            $copyTo->addError($error);
+        }
+
+        foreach ($copyFrom->all() as $key => $child) {
+            if ($child instanceof Form && $copyTo->has($key)) {
+                $childTo = $copyTo->get($key);
+                $this->copyErrorsRecursively($child, $childTo);
+            }
+        }
+    }
 }

--- a/app/bundles/CoreBundle/Views/FormTheme/Custom/sortablelist_row.html.php
+++ b/app/bundles/CoreBundle/Views/FormTheme/Custom/sortablelist_row.html.php
@@ -1,5 +1,11 @@
 <?php
-$list          = $form->children['list'];
+$list            = $form->children['list'];
+$parentHasErrors = $view['form']->containsErrors($form->parent);
+if ($parentHasErrors && empty($list->vars['value'])) {
+    // Work around for Symfony bug not repopulating values
+    $list = $form->parent->children['properties']['list'];
+}
+
 $hasErrors     = count($list->vars['errors']);
 $feedbackClass = (!empty($hasErrors)) ? ' has-error' : '';
 $datePrototype = (isset($list->vars['prototype'])) ?

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -241,18 +241,9 @@ Mautic.leadlistOnLoad = function(container) {
     }
 };
 
-Mautic.leadlistPopulateChoices = function(el) {
-
-    Mautic.ajaxActionRequest('lead:getLeadFieldsPerObject', {'object': mQuery(el).val()},
-       function (response) {
-            console.log(response);
-        }
-    );
-};
-
 Mautic.convertLeadFilterInput = function(el) {
     var operator = mQuery(el).val();
-    console.log(el);
+
     // Extract the filter number
     var regExp    = /leadlist_filters_(\d+)_operator/;
     var matches   = regExp.exec(mQuery(el).attr('id'));
@@ -511,32 +502,63 @@ Mautic.leadfieldOnLoad = function (container) {
     }
 
     if (mQuery(container + ' form[name="leadfield"]').length) {
-        Mautic.updateLeadFieldProperties(mQuery('#leadfield_type').val());
+        Mautic.updateLeadFieldProperties(mQuery('#leadfield_type').val(), true);
     }
 
 };
 
-Mautic.updateLeadFieldProperties = function(selectedVal) {
-    var defaultValueField = mQuery('input#leadfield_defaultValue');
-
+Mautic.updateLeadFieldProperties = function(selectedVal, onload) {
     if (selectedVal == 'multiselect') {
         // Use select
         selectedVal = 'select';
     }
 
-    if (mQuery('#field-templates .'+selectedVal).length) {
-        mQuery('#leadfield_properties').html('');
-        mQuery('#leadfield_properties')
-            .append(
-                mQuery(
-                    mQuery('#field-templates .'+selectedVal).html()
-                        .replace(/leadfield_properties_template/g, 'leadfield_properties')
-                )
-            );
+    if (mQuery('#field-templates .' + selectedVal).length) {
+        mQuery('#leadfield_properties').html(
+            mQuery('#field-templates .' + selectedVal).html()
+                .replace(/leadfield_properties_template/g, 'leadfield_properties')
+        );
         mQuery("#leadfield_properties *[data-toggle='sortablelist']").each(function (index) {
+            var sortableList = mQuery(this);
             Mautic.activateSortable(this);
+            // Using an interval so removing, adding, updating and reordering are accounted for
+            var contactFieldListOptions = mQuery('#leadfield_properties').find('input').map(function() {
+                return mQuery(this).val();
+            }).get().join();
+            var updateDefaultValuesetInterval = setInterval(function() {
+                var evalListOptions = mQuery('#leadfield_properties').find('input').map(function() {
+                    return mQuery(this).val();
+                }).get().join();
+                if (mQuery('#leadfield_properties_itemcount').length) {
+                    if (contactFieldListOptions != evalListOptions) {
+                        contactFieldListOptions = evalListOptions;
+                        var selected = mQuery('#leadfield_defaultValue').val();
+                        mQuery('#leadfield_defaultValue').html('<option value=""></option>');
+                        var labels = mQuery('#leadfield_properties').find('input.sortable-label');
+                        if (labels.length) {
+                            labels.each(function () {
+                                // label/value pairs
+                                var label = mQuery(this).val();
+                                var val = mQuery(this).closest('.row').find('input.sortable-value').first().val();
+                                mQuery('<option value="' + val + '">' + label + '</option>').appendTo(mQuery('#leadfield_defaultValue'));
+                            });
+                        } else {
+                            mQuery('#leadfield_properties .list-sortable').find('input').each(function () {
+                                var val = mQuery(this).val();
+                                mQuery('<option value="' + val + '">' + val + '</option>').appendTo(mQuery('#leadfield_defaultValue'));
+                            });
+                        }
+
+                        mQuery('#leadfield_defaultValue').val(selected);
+                        mQuery('#leadfield_defaultValue').trigger('chosen:updated');
+                    }
+                } else {
+                    clearInterval(updateDefaultValuesetInterval);
+                    delete contactFieldListOptions;
+                }
+            }, 500);
         });
-    } else if (!mQuery('#leadfield_properties .'+selectedVal).length) {
+    } else if (!mQuery('#leadfield_properties .' + selectedVal).length) {
         mQuery('#leadfield_properties').html('');
     }
 
@@ -547,29 +569,67 @@ Mautic.updateLeadFieldProperties = function(selectedVal) {
     }
 
     // Switch default field if applicable
+    var defaultValueField = mQuery('#leadfield_defaultValue');
+    if (defaultValueField.hasClass('calendar-activated')) {
+        defaultValueField.datetimepicker('destroy').removeClass('calendar-activated');
+    } else if (mQuery('#leadfield_defaultValue_chosen').length) {
+        mQuery('#leadfield_defaultValue').chosen('destroy');
+    }
+
     var defaultFieldType = mQuery('input[name="leadfield[defaultValue]"]').attr('type');
-    if (selectedVal == 'boolean') {
-        if (defaultFieldType == 'text') {
-            // Convert to a select
-            var newDiv      = mQuery('<div id="leadfield_defaultValue"></div>');
-            var defaultBool = mQuery('#field-templates .default_bool').html();
-            defaultBool     = defaultBool.replace(/default_bool_template/g, 'defaultValue');
+    var tempType = selectedVal;
+    var html = '';
+    var isSelect = false;
+    var defaultVal = defaultValueField.val();
+    switch (selectedVal) {
+        case 'boolean':
+            if (defaultFieldType != 'radio') {
+                // Convert to a boolean type
+                html = '<div id="leadfield_default_template_boolean">' + mQuery('#field-templates .default_template_boolean').html() + '</div>';
+            }
+            break;
+        case 'country':
+        case 'region':
+        case 'locale':
+        case 'timezone':
+            html = mQuery('#field-templates .default_template_' + selectedVal).html();
+            isSelect = true;
+            break;
+        case 'select':
+        case 'multiselect':
+        case 'lookup':
+            html = mQuery('#field-templates .default_template_select').html();
+            tempType = 'select';
+            isSelect = true;
+            break;
+        case 'textarea':
+            html = mQuery('#field-templates .default_template_textarea').html();
+            break;
+        default:
+            html = mQuery('#field-templates .default_template_text').html();
+            tempType = 'text';
 
-            mQuery(defaultBool).appendTo(newDiv);
+            if (selectedVal == 'number' || selectedVal == 'tel' || selectedVal == 'url' || selectedVal == 'email') {
+                var replace = 'type="text"';
+                var regex = new RegExp(replace, "g");
+                html = html.replace(regex, 'type="' + selectedVal + '"');
+            }
 
-            defaultValueField.replaceWith(newDiv);
-        }
-    } else if (defaultFieldType == 'radio') {
-        // Convert to input
-        var html = mQuery('#field-templates .default').html();
-        html     = html.replace(/default_template/g, 'defaultValue');
-        defaultValueField.replaceWith(html);
+            break;
+    }
+
+    if (html && !onload) {
+        var replace = 'default_template_' + tempType;
+        var regex = new RegExp(replace, "g");
+        html = html.replace(regex, 'defaultValue')
+        defaultValueField.replaceWith(mQuery(html));
+        mQuery('#leadfield_defaultValue').val(defaultVal);
     }
 
     if (selectedVal === 'datetime' || selectedVal === 'date' || selectedVal === 'time') {
-        Mautic.activateDateTimeInputs(defaultValueField, selectedVal);
-    } else if (defaultValueField.hasClass('calendar-activated')) {
-        defaultValueField.datetimepicker('destroy').removeClass('calendar-activated');
+        Mautic.activateDateTimeInputs('#leadfield_defaultValue', selectedVal);
+    } else if (isSelect) {
+       Mautic.activateChosenSelect('#leadfield_defaultValue');
     }
 };
 

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -808,38 +808,6 @@ class AjaxController extends CommonAjaxController
 
         return $this->sendJsonResponse($dataArray);
     }
-    /**
-     * @param Request $request
-     *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse
-     */
-    protected function getLeadFieldsPerObjectAction(Request $request)
-    {
-        $dataArray = ['success' => 1];
-
-        //$object = $request->request->get('object');
-
-        $fields = $this->getModel('lead.field')->getEntities(
-            [
-                 'filter' => [
-                     'force' => [
-                        'column' => 'f.isPublished',
-                        'expr'   => 'eq',
-                        'value'  => true,
-                    ],
-                    ],
-                'hydration_mode' => 'HYDRATE_ARRAY',
-          ]
-        );
-
-        if (is_object($fields)) {
-            $fields = $fields->getIterator()->getArrayCopy();
-        }
-
-        $dataArray['fields'] = json_encode($fields);
-
-        return $this->sendJsonResponse($fields);
-    }
 
     /**
      * @param Request $request

--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -197,6 +197,12 @@ class FieldController extends FormController
                 );
             } elseif ($valid && !$cancelled) {
                 return $this->editAction($field->getId(), true);
+            } elseif (!$valid) {
+                // some bug in Symfony prevents repopulating list options on errors
+                $field   = $form->getData();
+                $newForm = $model->createForm($field, $this->get('form.factory'), $action);
+                $this->copyErrorsRecursively($form, $newForm);
+                $form = $newForm;
             }
         }
 
@@ -313,6 +319,12 @@ class FieldController extends FormController
                 // Rebuild the form with new action so that apply doesn't keep creating a clone
                 $action = $this->generateUrl('mautic_contactfield_action', ['objectAction' => 'edit', 'objectId' => $field->getId()]);
                 $form   = $model->createForm($field, $this->get('form.factory'), $action);
+            } else {
+                // some bug in Symfony prevents repopulating list options on errors
+                $field   = $form->getData();
+                $newForm = $model->createForm($field, $this->get('form.factory'), $action);
+                $this->copyErrorsRecursively($form, $newForm);
+                $form = $newForm;
             }
         } else {
             //lock the entity

--- a/app/bundles/LeadBundle/Views/Field/form.html.php
+++ b/app/bundles/LeadBundle/Views/Field/form.html.php
@@ -21,10 +21,17 @@ if (!empty($userId)) {
 }
 $view['slots']->set('headerTitle', $header);
 
-$selectTemplate      = $view['form']->row($form['properties_select_template']);
-$lookupTemplate      = $view['form']->row($form['properties_lookup_template']);
-$defaultTemplate     = $view['form']->widget($form['default_template']);
-$defaultBoolTemplate = $view['form']->widget($form['default_bool_template']);
+// Render the templates so they don't get rendered automatically
+$selectTemplate          = $view['form']->row($form['properties_select_template']);
+$lookupTemplate          = $view['form']->row($form['properties_lookup_template']);
+$defaultTextTemplate     = $view['form']->widget($form['default_template_text']);
+$defaultTextareaTemplate = $view['form']->widget($form['default_template_textarea']);
+$defaultLocaleTemplate   = $view['form']->widget($form['default_template_locale']);
+$defaultSelectTemplate   = $view['form']->widget($form['default_template_select']);
+$defaultBoolTemplate     = $view['form']->widget($form['default_template_boolean']);
+$defaultCountryTemplate  = $view['form']->widget($form['default_template_country']);
+$defaultRegionTemplate   = $view['form']->widget($form['default_template_region']);
+$defaultTimezoneTemplate = $view['form']->widget($form['default_template_timezone']);
 ?>
 
 <?php echo $view['form']->start($form); ?>
@@ -42,29 +49,29 @@ $defaultBoolTemplate = $view['form']->widget($form['default_bool_template']);
             </div>
             <div class="row">
                 <div class="col-md-6">
+                    <?php echo $view['form']->row($form['object']); ?>
+                </div>
+                <div class="col-md-6">
+                    <?php echo $view['form']->row($form['group']); ?>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-6">
                     <?php echo $view['form']->row($form['type']); ?>
                 </div>
                 <div class="col-md-6">
                     <?php echo $view['form']->row($form['defaultValue']); ?>
                 </div>
             </div>
-            <div class="row">
-                <div class="col-md-6">
-                    <?php echo $view['form']->row($form['group']); ?>
-                </div>
-                <div class="col-md-6">
-                    <?php echo $view['form']->row($form['order']); ?>
-                </div>
-            </div>
+
             <?php
             $type          = $form['type']->vars['data'];
             $properties    = $form['properties']->vars['data'];
             $errors        = count($form['properties']->vars['errors']);
             $feedbackClass = (!empty($errors)) ? ' has-error' : '';
             ?>
-
             <div class="row">
-                <div class="form-group  col-xs-12 col-sm-8 col-md-6<?php echo $feedbackClass; ?>">
+                <div class="form-group col-md-6<?php echo $feedbackClass; ?>">
                     <div id="leadfield_properties">
                         <?php
                         switch ($type):
@@ -105,6 +112,11 @@ $defaultBoolTemplate = $view['form']->widget($form['default_bool_template']);
     <div class="col-md-4 bg-white height-auto">
         <div class="pr-lg pl-lg pt-md pb-md">
             <div class="row">
+                <div class="col-md-12">
+                    <?php echo $view['form']->row($form['order']); ?>
+                </div>
+            </div>
+            <div class="row">
                 <div class="col-md-6">
                     <?php echo $view['form']->row($form['isPublished']); ?>
                 </div>
@@ -132,9 +144,9 @@ $defaultBoolTemplate = $view['form']->widget($form['default_bool_template']);
                 <div class="col-md-6">
                     <?php echo $view['form']->row($form['isUniqueIdentifer']); ?>
                 </div>
-                <div class="unique-identifier-warning col-md-6" style="<?php if (!$form['isUniqueIdentifer']->vars['data']) {
-                            echo 'display:none;';
-                        } ?>">
+            </div>
+            <div class="row unique-identifier-warning" style="<?php if (!$form['isUniqueIdentifer']->vars['data']): echo 'display:none;'; endif; ?>">
+                <div class="col-md-12">
                     <div class="alert alert-danger">
                         <?php echo $view['translator']->trans('mautic.lead.field.form.isuniqueidentifer.warning'); ?>
                     </div>
@@ -148,11 +160,29 @@ $defaultBoolTemplate = $view['form']->widget($form['default_bool_template']);
 
 <?php if ($isNew): ?>
 <div id="field-templates" class="hide">
-    <div class="default">
-        <?php echo $defaultTemplate; ?>
+    <div class="default_template_text">
+        <?php echo $defaultTextTemplate; ?>
     </div>
-    <div class="default_bool">
+    <div class="default_template_textarea">
+        <?php echo $defaultTextareaTemplate; ?>
+    </div>
+    <div class="default_template_boolean">
         <?php echo $defaultBoolTemplate; ?>
+    </div>
+    <div class="default_template_country">
+        <?php echo $defaultCountryTemplate; ?>
+    </div>
+    <div class="default_template_region">
+        <?php echo $defaultRegionTemplate; ?>
+    </div>
+    <div class="default_template_locale">
+        <?php echo $defaultLocaleTemplate; ?>
+    </div>
+    <div class="default_template_timezone">
+        <?php echo $defaultTimezoneTemplate; ?>
+    </div>
+    <div class="default_template_select">
+        <?php echo $defaultSelectTemplate; ?>
     </div>
 <?php
     echo $view->render('MauticLeadBundle:Field:properties_number.html.php');


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Before, the default field was not forced to match the field type if it was a select. This meant that creating new leads could fail because the form rejected the default value as an option and thus invalidate the form. 

#### Steps to test this PR:
1. Create a new custom field. Choose multiple types and notice the default value input will convert to match the field type. If it's a select, multiselect, or lookup, the default field will update dynamically to match new options added. 


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new custom field and choose a select and add options. Set the default field to something not in the choice list. Save. 
2. Use the API to create a new contact. Validation should fail.
