### PR TITLE
Fix Issue #3306 Bad font in segment filter dropdown

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/libraries/libraries.css
+++ b/app/bundles/CoreBundle/Assets/css/libraries/libraries.css
@@ -6371,9 +6371,9 @@ button.close {
   font-weight: normal;
   font-style: normal;
 }
-.fa {
+.fa { 
   display: inline-block;
-  font: normal normal normal 14px/1 FontAwesome;
+  font: normal normal normal 14px/1 FontAwesome,sans-serif;
   font-size: inherit;
   text-rendering: auto;
   -webkit-font-smoothing: antialiased;

--- a/app/bundles/FormBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/ReportSubscriber.php
@@ -75,7 +75,7 @@ class ReportSubscriber extends CommonSubscriber
                         'type'  => 'int',
                         'link'  => 'mautic_page_action',
                     ],
-                    $pagePrefix.'name' => [
+                    $pagePrefix.'title' => [
                         'label' => 'mautic.form.report.page_name',
                         'type'  => 'string',
                     ],


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | NA
| Related developer documentation PR URL | NA
| Issues addressed (#s or URLs) | #3066
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fix Font issue in Segment Filter Style

#### Steps to test this PR:
1. Go to Segments in Menu
2. New Segment
3. Filters Tab
4. Open Fields Dropdown
5. List Items must appears with San-Serif Font

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. In Chrome press F12
2. Disable go to Network Tab
3.  Click Disable Cache
4. Follow PR Instructions
