### PR TITLE
Focus Js has wrong content-type

### DIFF
--- a/plugins/MauticFocusBundle/Controller/PublicController.php
+++ b/plugins/MauticFocusBundle/Controller/PublicController.php
@@ -34,15 +34,15 @@ class PublicController extends CommonController
 
         if ($focus) {
             if (!$focus->isPublished()) {
-                return new Response('');
+                return new Response('', 200, ['Content-Type' => 'application/javascript']);
             }
 
             $content  = (MAUTIC_ENV == 'dev') ? $model->generateJavascript($focus, false, true) : $model->getContent($focus);
-            $response = new Response($content);
+            $response = new Response($content, 200, ['Content-Type' => 'application/javascript']);
 
             return $response;
         } else {
-            return new Response('');
+            return new Response('', 200, ['Content-Type' => 'application/javascript']);
         }
     }
 


### PR DESCRIPTION
giving me this error on browser : 
```
Refused to execute script from 'https://localhost:20443/focus/1.js' because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.
```