### PR TITLE
SPA Javascript error on second page

### DIFF
--- a/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
@@ -362,17 +362,19 @@ if (typeof window[window.MauticTrackingObject] !== 'undefined') {
     MauticJS.inputQueue = MauticJS.input.q;
 
     // Dispatch the queue event when an event is added to the queue
-    Object.defineProperty(MauticJS.inputQueue, 'push', {
-        configurable: false,
-        enumerable: false,
-        writable: false,
-        value: function () {
-            for (var i = 0, n = this.length, l = arguments.length; i < l; i++, n++) {
-                MauticJS.dispatchEvent('eventAddedToMauticQueue', arguments[i]);
+    if (!MauticJS.inputQueue.hasOwnProperty('push')) {
+        Object.defineProperty(MauticJS.inputQueue, 'push', {
+            configurable: false,
+            enumerable: false,
+            writable: false,
+            value: function () {
+                for (var i = 0, n = this.length, l = arguments.length; i < l; i++, n++) {
+                    MauticJS.dispatchEvent('eventAddedToMauticQueue', arguments[i]);
+                }
+                return n;
             }
-            return n;
-        }
-    });
+        });
+    }
 
     MauticJS.getInput = function(task, type) {
         var matches = [];


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? |  N
| Related user documentation PR URL | n/a
| Related developer documentation PR URL | n/a
| Issues addressed (#s or URLs) | n/a
| BC breaks? | No
| Deprecations? | No

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
In a SPA like application, the object MauticJS is already defined since the javascript is already loaded.
I'm using this on my app : https://github.com/youtube/spfjs but I think there will be also the bug with alternative ([TurboLinks](https://github.com/turbolinks/turbolinks) , [Barba.js](http://barbajs.org/))

It raise this error  
```
Uncaught TypeError: Cannot redefine property: push
    at Function.defineProperty (<anonymous>)
    at mtc.js:226
```
I only add hasOwnProperty test and everything seems to be working

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Load a page with 1 off this spa library & mautic js code
2. browse a 2 second page and an error happen