### PR TITLE
Render dates in emails using custom format

### DIFF
--- a/app/bundles/LeadBundle/Helper/TokenHelper.php
+++ b/app/bundles/LeadBundle/Helper/TokenHelper.php
@@ -62,7 +62,16 @@ class TokenHelper
                         $alias = $match;
                     }
 
-                    $value             = (!empty($lead[$alias])) ? $lead[$alias] : $fallback;
+                    $value = (!empty($lead[$alias])) ? $lead[$alias] : $fallback;
+
+                    // Is it a datetime?
+                    if (($datetime = \DateTime::createFromFormat('Y-m-d H:i:s', $value)) !== false) {
+                        $value = $datetime->format('j/m/Y G:i');
+                    // Or just a date?
+                    } elseif (($datetime = \DateTime::createFromFormat('Y-m-d', $value)) !== false) {
+                        $value = $datetime->format('j/m/Y');
+                    }
+
                     $tokenList[$token] = ($urlencode) ? urlencode($value) : $value;
                 }
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | :heavy_check_mark: 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

#### Description:

Today, date custom fields are rendered in emails using the SQL format.
Here's a quick way to format them using the french format.
What would be nice is a way to customize that formating.
What would be even better would be to automatically set it according to the email language.

Let's discuss how we can improve this PR

#### Steps to test this PR:

1. Create a date and datetime custom field
2. Create a contact with both set
3. Create a segment containing that contact
4. Create an segment email using these custom fields targeting that segment.
5. Check that the format is adequate.