### PR TITLE
Allow the CORS list to contain shell patterns of valid domains

### DIFF
--- a/app/middlewares/CORSMiddleware.php
+++ b/app/middlewares/CORSMiddleware.php
@@ -120,6 +120,17 @@ class CORSMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterf
             return $origin;
         }
 
+        // Check the domains using shell wildcard patterns
+        $validCorsDomainFilter = function ($validCorsDomain) use ($origin) {
+            return fnmatch($validCorsDomain, $origin, FNM_CASEFOLD);
+        };
+        if (array_filter($this->validCORSDomains, $validCorsDomainFilter)) {
+            $this->requestOriginIsValid = true;
+            $this->corsHeaders['Vary']  = 'Origin';
+
+            return $origin;
+        }
+
         $this->requestOriginIsValid = false;
 
         return null;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Related user documentation PR URL | mautic/documentation#159
| Related developer documentation PR URL | None Needed
| Issues addressed (#s or URLs) | None
| BC breaks? | None
| Deprecations? | None

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Sometimes you can't control or prepare for all of the subdomains which should be vaild for CORS but don't want to open it up to the world. This patch allows you to specify a wildcard using shell notation.

Example: https://*.example.org will match https://us.example.org and https://uk.example.org

#### Steps to test this PR:
1. Navigate to System Settings > CORS Settings
2. Enable "Restict Domains"
3. Add a domain with a wildcard (e.g. https://*.example.localhost)
4. Attempt to have your website with a tracking token track from two different domains (e.g. https://test1.example.localhost and https://test2.example.localhost)
5. Validate that neither website had a CORS error
6. Check that data from both websites made it into mautic.
