### PR TITLE
Campaign API tests fail. This adds the BC campaign structure.

### DIFF
--- a/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
+++ b/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
@@ -159,7 +159,7 @@ class CampaignApiController extends CommonApiController
 
             foreach ($entity->getLists() as $currentSegment) {
                 if (!in_array($currentSegment->getId(), $requestSegmentIds)) {
-                    $deletedSources['lists'][] = $currentSegment->getId();
+                    $deletedSources['lists'][$currentSegment->getId()] = 'ignore';
                 }
             }
 
@@ -174,7 +174,7 @@ class CampaignApiController extends CommonApiController
 
             foreach ($entity->getForms() as $currentForm) {
                 if (!in_array($currentForm->getId(), $requestFormIds)) {
-                    $deletedSources['forms'][] = $currentForm->getId();
+                    $deletedSources['forms'][$currentForm->getId()] = 'ignore';
                 }
             }
         }

--- a/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
+++ b/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
@@ -125,8 +125,8 @@ class CampaignApiController extends CommonApiController
         $deletedSources = ['lists' => [], 'forms' => []];
         $deletedEvents  = [];
         $currentSources = [
-            'lists' => isset($parameters['lists']) ? $parameters['lists'] : [],
-            'forms' => isset($parameters['forms']) ? $parameters['forms'] : [],
+            'lists' => isset($parameters['lists']) ? $this->modifyCampaignEventArray($parameters['lists']) : [],
+            'forms' => isset($parameters['forms']) ? $this->modifyCampaignEventArray($parameters['forms']) : [],
         ];
 
         // delete events and sources which does not exist in the PUT request
@@ -198,6 +198,28 @@ class CampaignApiController extends CommonApiController
         if ($method === 'PUT' && !empty($deletedEvents)) {
             $this->getModel('campaign.event')->deleteEvents($entity->getEvents()->toArray(), $deletedEvents);
         }
+    }
+
+    /**
+     * Change the array structure.
+     *
+     * @param array $events
+     *
+     * @return array
+     */
+    public function modifyCampaignEventArray($events)
+    {
+        $updatedEvents = [];
+
+        if ($events && is_array($events)) {
+            foreach ($events as $event) {
+                if (!empty($event['id'])) {
+                    $updatedEvents[$event['id']] = 'ignore';
+                }
+            }
+        }
+
+        return $updatedEvents;
     }
 
     /**

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -121,8 +121,9 @@ class EmailApiController extends CommonApiController
                 return $lead;
             }
 
-            $post   = $this->request->request->all();
-            $tokens = (!empty($post['tokens'])) ? $post['tokens'] : [];
+            $post     = $this->request->request->all();
+            $tokens   = (!empty($post['tokens'])) ? $post['tokens'] : [];
+            $response = ['success' => false];
 
             $cleantokens = array_map(
                 function ($v) {
@@ -133,7 +134,7 @@ class EmailApiController extends CommonApiController
 
             $leadFields = array_merge(['id' => $leadId], $lead->getProfileFields());
 
-            $errors = $this->model->sendEmail(
+            $result = $this->model->sendEmail(
                 $entity,
                 $leadFields,
                 [
@@ -143,13 +144,10 @@ class EmailApiController extends CommonApiController
                 ]
             );
 
-            $success  = empty($errors);
-            $response = [
-                'success' => $success,
-            ];
-
-            if (!$success) {
-                $response['failed'] = $errors;
+            if (is_bool($result)) {
+                $response['success'] = $result;
+            } else {
+                $response['failed'] = $result;
             }
 
             $view = $this->view($response, Codes::HTTP_OK);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The API Library unit tests fail with error
```
Entity of type 'Mautic\LeadBundle\Entity\LeadList' for IDs id(0) was not found
```

#### Steps to test this PR:
1. Run the API Library tests
2. The campaign tests will pass

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run the API Library tests
2. The Campaign tests will fail