### PR TITLE
Yes No button option is not working properly 

### DIFF
--- a/app/bundles/CoreBundle/Views/FormTheme/Custom/yesno_button_group_widget.html.php
+++ b/app/bundles/CoreBundle/Views/FormTheme/Custom/yesno_button_group_widget.html.php
@@ -10,7 +10,7 @@ if (isset($attr['onchange'])) {
 } else {
     $attr['onchange'] = $onchange;
 }
-$attr['style'] = 'width: 100%; height: 100%; top: 0; left: 0; margin-top: 0;';
+$attr['style'] = 'width: 1px; height: 1px; top: 0; left: 0; margin-top: 0;';
 
 ?>
 <div class="btn-group btn-block" data-toggle="buttons">


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X


[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Yes or No options does not save clicked option when the click out of the radio button area.
The option is still unchecked though the Yes or No button group shows as checked in view. So the data is not saved.
The below image shows the region in which the button click works. 
![scr](https://cloud.githubusercontent.com/assets/24408961/22882637/1a1b0cd6-f212-11e6-8e5c-affacfaf3eed.png)


#### Steps to test this PR:
1. Navigate the page which contains the Yes_no_button group (e.g: Form edit, Segment edit etc) 
2. Check whether the click in all areas of Yes or No button group updates exact data.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Navigate the page which contains the Yes_no_button group (e.g: Form edit, Segment edit etc) 
2. Click on the border areas of the Yes or No button group and check. It will not send correct data.
