### PR TITLE
Fixed campaign reports table for web notifications

### DIFF
--- a/app/bundles/NotificationBundle/EventListener/ChannelSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/ChannelSubscriber.php
@@ -51,7 +51,7 @@ class ChannelSubscriber extends CommonSubscriber
                         'lookupFormType' => 'notification_list',
                     ],
                     ReportModel::CHANNEL_FEATURE => [
-                        'table' => 'push_notification_stats',
+                        'table' => 'push_notifications',
                     ],
                 ]
             );


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If web notifications are enabled, the new campaign report will fail with a SQL error due to the push_notifications_stats table not having a name column. Fixed the table to be push_notifications instead

#### Steps to test this PR:
1. Enable web push notifications (doesn't have to be setup)
2. Create a new campaign events report
3. View it and it should not error.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Same as above but will give SQL error
