### PR TITLE
Prevent logging 40x exceptions that drastically clutter up logging

### DIFF
--- a/app/bundles/CoreBundle/EventListener/ExceptionListener.php
+++ b/app/bundles/CoreBundle/EventListener/ExceptionListener.php
@@ -16,6 +16,9 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\EventListener\ExceptionListener as KernelExceptionListener;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Router;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -62,14 +65,47 @@ class ExceptionListener extends KernelExceptionListener
         }
 
         // Check for exceptions we don't want to handle
-        if ($exception instanceof AuthenticationException ||
-            $exception instanceof AccessDeniedException ||
-            $exception instanceof LogoutException
+        if ($exception instanceof AuthenticationException || $exception instanceof AccessDeniedException || $exception instanceof LogoutException
         ) {
             return;
         }
 
-        // Let the HttpKernel listener handle the rest
-        parent::onKernelException($event);
+        if (!$exception instanceof AccessDeniedHttpException && !$exception instanceof NotFoundHttpException) {
+            $this->logException($exception, sprintf('Uncaught PHP Exception %s: "%s" at %s line %s', get_class($exception), $exception->getMessage(), $exception->getFile(), $exception->getLine()));
+        }
+
+        $exception = $event->getException();
+        $request   = $event->getRequest();
+        $request   = $this->duplicateRequest($exception, $request);
+        try {
+            $response = $event->getKernel()->handle($request, HttpKernelInterface::SUB_REQUEST, false);
+
+            $event->setResponse($response);
+        } catch (\Exception $e) {
+            $this->logException(
+                $e,
+                sprintf(
+                    'Exception thrown when handling an exception (%s: %s at %s line %s)',
+                    get_class($e),
+                    $e->getMessage(),
+                    $e->getFile(),
+                    $e->getLine()
+                )
+            );
+
+            $wrapper = $e;
+
+            while ($prev = $wrapper->getPrevious()) {
+                if ($exception === $wrapper = $prev) {
+                    throw $e;
+                }
+            }
+
+            $prev = new \ReflectionProperty('Exception', 'previous');
+            $prev->setAccessible(true);
+            $prev->setValue($wrapper, $exception);
+
+            throw $e;
+        }
     }
 }

--- a/app/bundles/CoreBundle/Templating/Helper/TranslatorHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/TranslatorHelper.php
@@ -49,6 +49,9 @@ class TranslatorHelper extends BaseHelper
         return $this->translator->transConditional($preferred, $alternative, $parameters, $domain, $locale);
     }
 
+    /**
+     * @return string
+     */
     public function getJsLang()
     {
         $this->translator->addResource('mautic', null, $this->translator->getLocale(), 'javascript');


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | n
| New feature? | n
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If the API is disabled or 404 is hit, Mautic's logs get cluttered up. These should be logged in the web servers logs so not necessary for Mautic's. 

#### Steps to test this PR:
1. Disable API 
2. Browse to /s/api/contacts
3. Should get a not authorized message
4. Check mautic's logs and it should not be recorded
