### PR TITLE
Prevented JS errors in builder due to undeclared mauticLang variable

### DIFF
--- a/app/bundles/CoreBundle/Controller/BuilderControllerTrait.php
+++ b/app/bundles/CoreBundle/Controller/BuilderControllerTrait.php
@@ -31,6 +31,7 @@ trait BuilderControllerTrait
             ->addScriptDeclaration("var mauticAjaxUrl     = '".$routerHelper->generate('mautic_core_ajax')."';")
             ->addScriptDeclaration("var mauticBaseUrl     = '".$routerHelper->generate('mautic_base_index')."';")
             ->addScriptDeclaration("var mauticAssetPrefix = '".$assetsHelper->getAssetPrefix(true)."';")
+            ->addScriptDeclaration("var mauticLang         = '".$this->get('templating.helper.translator')->getJsLang()."';")
             ->addCustomDeclaration($assetsHelper->getSystemScripts(true, true))
             ->addStylesheet('app/bundles/CoreBundle/Assets/css/libraries/builder.css');
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Using page or email builder will result in a JS error that mauticLang is not defined. This fixes that.

#### Steps to test this PR:
1. Open a builder and look at the console. It should not have any JS errors.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Same as above but will get the JS error.
