### PR TITLE
Timezone property added to the Lead Entity. It fixes the 500 error du…

### DIFF
--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -107,6 +107,11 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
     private $zipcode;
 
     /**
+     * @var string
+     */
+    private $timezone;
+
+    /**
      * @var
      */
     private $country;
@@ -403,6 +408,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
                 'city',
                 'state',
                 'zipcode',
+                'timezone',
                 'country',
             ],
             FieldModel::$coreFields
@@ -436,6 +442,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
                     'city',
                     'state',
                     'zipcode',
+                    'timezone',
                     'country',
                 ]
             )
@@ -1648,6 +1655,27 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
     {
         $this->isChanged('zipcode', $zipcode);
         $this->zipcode = $zipcode;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTimezone()
+    {
+        return $this->timezone;
+    }
+
+    /**
+     * @param string $timezone
+     *
+     * @return Lead
+     */
+    public function setTimezone($timezone)
+    {
+        $this->isChanged('timezone', $timezone);
+        $this->timezone = $timezone;
 
         return $this;
     }


### PR DESCRIPTION
…ring page hit tracking.

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3397
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
A PHP error occurs on JS tracking HTTP request. It was caused by merging 2 PRs together in 2.6.0.

#### Steps to test this PR:
1. Apply this PR.
2. Repeat the test.
3. The HTTP requests will return 200 and the page hit will be recorded to the contact history.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Open a page where the Mautic JS tracking is configured. Or configure one if you don't have such page.
2. Open the dev tools and refresh the page. You'll see the requests are failing.
