### PR TITLE
PHP error on focus detail fixed

### DIFF
--- a/app/bundles/CoreBundle/Controller/FormController.php
+++ b/app/bundles/CoreBundle/Controller/FormController.php
@@ -63,16 +63,27 @@ class FormController extends AbstractStandardFormController
     }
 
     /**
+     * @param array $args
+     * @param       $action
+     *
+     * @return array
+     */
+    public function getViewArguments(array $args, $action)
+    {
+        return $this->customizeViewArguments($args, $action);
+    }
+
+    /**
      * @param $args
      * @param $action
      *
-     * @deprecated 2.6.0 to be removed in 3.0
+     * @deprecated 2.6.0 to be removed in 3.0; use getViewArguments instead
      *
      * @return array
      */
     public function customizeViewArguments($args, $action)
     {
-        return $this->getViewArguments($args, $action);
+        return $args;
     }
 
     /**


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | Y

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
There is a PHP error if you try to access the Focus detail page.

#### Steps to test this PR:
1. Pull this PR.
2. Repeat the test - should open the page without any error.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to a Focus detail page.
2. You'll see the error.

#### List deprecations along with the new alternative:
1. `customizeViewArguments` => `getViewArguments`