### PR TITLE
Fixing error when trying to get nameSpace Plugin

### DIFF
--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -378,10 +378,10 @@ class PluginController extends FormController
 
         /** @var \Doctrine\ORM\Mapping\ClassMetadata $meta */
         foreach ($allMetadata as $meta) {
-            $namespace = $meta->fullyQualifiedClassName('');
+            $namespace = $meta->fullyQualifiedClassName($meta->getName());
 
             if (strpos($namespace, 'MauticPlugin') !== false) {
-                $bundleName = str_replace('\Entity\\', '', $namespace);
+                $bundleName = strstr($namespace, '\Entity', true);
                 if (!isset($pluginMetadata[$bundleName])) {
                     $pluginMetadata[$bundleName] = [];
                 }


### PR DESCRIPTION
Every time the plugin had to update your schema, the changes were completely ignored by the realodAction because the method "fullyQualifiedClassName" was being called with a empty string. And at line 384, was getting the incorrect bundleName.

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N 
| Related user documentation PR URL | N 
| Related developer documentation PR URL | N 
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Every time the plugin had to update your schema, the changes were completely ignored by the realodAction because the method "fullyQualifiedClassName" was being called with a empty string. And at line 384, was getting the incorrect bundleName.

#### Steps to test this PR:
1.
2.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.Try to update a plugin schema and update your plugins 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 