### PR TITLE
Fixing bug where the company/contact relationship was not created aft…

### DIFF
--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -166,6 +166,24 @@ class SubmissionModel extends CommonFormModel
         $ipAddress = $this->ipLookupHelper->getIpAddress();
         $submission->setIpAddress($ipAddress);
 
+        // Create/update lead
+        if (!empty($leadFieldMatches)) {
+            $lead = $this->createLeadFromSubmit($form, $leadFieldMatches, $leadFields);
+            $submission->setLead($lead);
+        }
+
+        // Get updated lead if applicable with tracking ID
+        if ($form->isInKioskMode()) {
+            $lead = $this->leadModel->getCurrentLead();
+        } else {
+            list($lead, $trackingId, $generated) = $this->leadModel->getCurrentLead(true);
+
+            //set tracking ID for stats purposes to determine unique hits
+            $submission->setTrackingId($trackingId);
+        }
+
+        $submission->setLead($lead);
+
         if (!empty($post['return'])) {
             $referer = $post['return'];
         } elseif (!empty($server['HTTP_REFERER'])) {
@@ -296,6 +314,18 @@ class SubmissionModel extends CommonFormModel
                     $leadValue = implode($delimeter, $leadValue);
                 }
 
+                if ('company' === $leadField) {
+                    $company = $this->companyModel->getRepository()->identifyCompany($value);
+                    if (!empty($company['id'])) {
+                        $this->companyModel->addLeadToCompany([$company['id']], $lead);
+                    } else {
+                        $companyEntity = $this->companyModel->getEntity();
+                        $companyEntity->setName($value);
+                        $this->companyModel->saveEntity($companyEntity);
+                        $this->companyModel->addLeadToCompany($companyEntity, $lead);
+                    }
+                }
+
                 $leadFieldMatches[$leadField] = $leadValue;
             }
 
@@ -328,23 +358,6 @@ class SubmissionModel extends CommonFormModel
         if (!empty($validationErrors)) {
             return ['errors' => $validationErrors];
         }
-
-        // Create/update lead
-        if (!empty($leadFieldMatches)) {
-            $lead = $this->createLeadFromSubmit($form, $leadFieldMatches, $leadFields);
-            $submission->setLead($lead);
-        }
-
-        // Get updated lead if applicable with tracking ID
-        if ($form->isInKioskMode()) {
-            $lead = $this->leadModel->getCurrentLead();
-        } else {
-            list($lead, $trackingId, $generated) = $this->leadModel->getCurrentLead(true);
-
-            //set tracking ID for stats purposes to determine unique hits
-            $submission->setTrackingId($trackingId);
-        }
-        $submission->setLead($lead);
 
         // Save the submission
         $this->saveEntity($submission);

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -166,12 +166,6 @@ class SubmissionModel extends CommonFormModel
         $ipAddress = $this->ipLookupHelper->getIpAddress();
         $submission->setIpAddress($ipAddress);
 
-        // Create/update lead
-        if (!empty($leadFieldMatches)) {
-            $lead = $this->createLeadFromSubmit($form, $leadFieldMatches, $leadFields);
-            $submission->setLead($lead);
-        }
-
         // Get updated lead if applicable with tracking ID
         if ($form->isInKioskMode()) {
             $lead = $this->leadModel->getCurrentLead();
@@ -340,6 +334,12 @@ class SubmissionModel extends CommonFormModel
             if ($f->getSaveResult() !== false) {
                 $results[$alias] = $value;
             }
+        }
+
+        // Create/update lead
+        if (!empty($leadFieldMatches)) {
+            $lead = $this->createLeadFromSubmit($form, $leadFieldMatches, $leadFields);
+            $submission->setLead($lead);
         }
 
         // Set the results


### PR DESCRIPTION
…er the submission of a form with the company field

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3425
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The companies weren't created and the relationship with contact was not created on form submission when the form contained the company field.

#### Steps to test this PR:
1. Apply this PR.
2. Repeat the test - the company should be there.
3. Test with existing company - it should only create the relationship with the contact, not create another company.
4. Test with a new company - it should create the company and the relationship with the contact.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form with the company field.
2. Map the form field with the company contact field.
3. Submit the form in a incognito browser window.
4. Open the form results page and click on the date.
5. You should be redirected to the contact who submitted the form.
- The company is not there.
