### PR TITLE
If the target class has __call() magic function implemented, then is_…

### DIFF
--- a/app/bundles/EmailBundle/Controller/AjaxController.php
+++ b/app/bundles/EmailBundle/Controller/AjaxController.php
@@ -228,7 +228,7 @@ class AjaxController extends CommonAjaxController
 
             if (!empty($mailer)) {
                 try {
-                    if (is_callable([$mailer, 'setApiKey'])) {
+                    if (method_exists($mailer, 'setApiKey')) {
                         if (empty($settings['api_key'])) {
                             $settings['api_key'] = $this->get('mautic.helper.core_parameters')->getParameter('mailer_api_key');
                         }


### PR DESCRIPTION
…callable will ALWAYS return TRUE for whatever method you call it.

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3383, https://github.com/mautic/mautic/issues/3291, https://github.com/mautic/mautic/issues/3188
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

I’m trying to track down the error reported in above issues:
```
Call to undefined method setApiKey - in file vendor/swiftmailer/swiftmailer/lib/classes/Swift/Transport/EsmtpTransport.php - at line 291
```
I cannot replicate it. But the only place where it can happen is:
```                    
    if (is_callable([$mailer, 'setApiKey'])) {
        // ...
        $mailer->setApiKey($settings['api_key']);
    }
```
One would say that it cannot be called if the method doesn’t exist in the if statement, but then I saw this comment in the PHP docs:

> If the target class has __call() magic function implemented, then is_callable will ALWAYS return TRUE for whatever method you call it.

And the `EsmtpTransport` does have the `__call()` method:
https://github.com/swiftmailer/swiftmailer/blob/5.x/lib/classes/Swift/Transport/EsmtpTransport.php#L274

So hopefully, if we replace `is_callable` with `method_exists`, it will fix the issue.

#### Steps to test this PR:
1. Apply the change form this PR and repeat the test

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to Mautic's configuration
2. Email settings
3. Try to test the connection
4. Try to send the test email
