### PR TITLE
fix when deleting multiple contacts in contact list view

### DIFF
--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -364,7 +364,7 @@ class WebhookModel extends FormModel
                 $payload[$type][] = $queuePayload;
 
                 $this->webhookQueueIdList[] = $queue->getId();
-                $this->em->clear($queue);
+                $this->em->clear('\Mautic\WebhookBundle\Entity\WebhookQueue');
             }
         }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When trying to delete anonymous contacts using the select all checkbox from the list view, then pressing the delete icon, game me a Warning: Illegal offset type in isset or empty error. This PR fixes that.

#### Steps to test this PR:
1. 
2. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### List deprecations along with the new alternative:
1. Apply PR
2. try to delete multiple contacts from the list of contacts, you should not get an error

#### List backwards compatibility breaks:
1. try to delete multiple contacts from the list of contacts, you should get an error.
2. 