### PR TITLE
Prevent modal from stacking if it's the same active modal

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/9.modals.js
+++ b/app/bundles/CoreBundle/Assets/js/9.modals.js
@@ -391,7 +391,7 @@ Mautic.showModal = function(target) {
         var activeModal = mQuery('.modal.in .modal-dialog:not(:has(.aside))').parents('.modal').last(),
             targetModal  = mQuery(target);
 
-        if (activeModal.length) {
+        if (activeModal.length && activeModal.attr('id') !== targetModal.attr('id')) {
             targetModal.attr('data-previous-modal', '#'+activeModal.attr('id'));
             activeModal.find('.modal-dialog').addClass('aside');
             var stackedDialogCount = mQuery('.modal.in .modal-dialog.aside').length;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When authorizing a plugin, the modal will be moved to the side as if another modal was opened. 

#### Steps to test this PR:
1. Go to Plugins, choose a plugin that requires authorization (twitter, zoho, etc) and authorize.
2. After a successful authorization, the modal should refresh rather than being pushed to the side

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. After authorization, the modal will be moved to the side as if another modal was opened (stacked modals)

