### PR TITLE
Fixed issue with campaign canvas losing connections/sources

### DIFF
--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -29,14 +29,17 @@ class CampaignController extends AbstractStandardFormController
      * @var array
      */
     protected $addedSources = [];
+
     /**
      * @var array
      */
     protected $campaignEvents = [];
+
     /**
      * @var array
      */
     protected $campaignSources = [];
+
     /**
      * @var array
      */
@@ -46,14 +49,17 @@ class CampaignController extends AbstractStandardFormController
      * @var array
      */
     protected $deletedEvents = [];
+
     /**
      * @var array
      */
     protected $deletedSources = [];
+
     /**
      * @var array
      */
     protected $listFilters = [];
+
     /**
      * @var array
      */
@@ -278,7 +284,7 @@ class CampaignController extends AbstractStandardFormController
 
         if ($isPost) {
             $this->getCampaignModel()->setCanvasSettings($entity, $this->connections, false, $this->modifiedEvents);
-            $this->prepareCampaignSourcesForEdit($sessionId, $campaignSources);
+            $this->prepareCampaignSourcesForEdit($sessionId, $campaignSources, true);
         } else {
             if (!$isClone) {
                 //clear out existing fields in case the form was refreshed, browser closed, etc
@@ -764,7 +770,7 @@ class CampaignController extends AbstractStandardFormController
      * @param   $objectId
      * @param   $campaignSources
      */
-    protected function prepareCampaignSourcesForEdit($objectId, $campaignSources)
+    protected function prepareCampaignSourcesForEdit($objectId, $campaignSources, $isPost = false)
     {
         $this->campaignSources = [];
         if (is_array($campaignSources)) {
@@ -780,9 +786,11 @@ class CampaignController extends AbstractStandardFormController
             }
         }
 
-        $session = $this->get('session');
-        $session->set('mautic.campaign.'.$objectId.'.leadsources.current', $campaignSources);
-        $session->set('mautic.campaign.'.$objectId.'.leadsources.modified', $campaignSources);
+        if (!$isPost) {
+            $session = $this->get('session');
+            $session->set('mautic.campaign.'.$objectId.'.leadsources.current', $campaignSources);
+            $session->set('mautic.campaign.'.$objectId.'.leadsources.modified', $campaignSources);
+        }
     }
 
     /**

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -294,6 +294,8 @@ class CampaignController extends AbstractStandardFormController
                 if ($entity->getId()) {
                     $campaignSources = $this->getCampaignModel()->getLeadSources($entity->getId());
                     $this->prepareCampaignSourcesForEdit($sessionId, $campaignSources);
+
+                    $this->setSessionCanvasSettings($sessionId, $entity->getCanvasSettings());
                 }
             }
 

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -912,8 +912,6 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
         $messageRepository = $this->getMockBuilder(MessageRepository::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $messageRepository->method('findMessage')
-            ->will($this->returnValue(null));
 
         // Setup the EntityManager
         $entityManager = $this

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -12,10 +12,12 @@
 namespace Mautic\EmailBundle\Tests;
 
 use Doctrine\ORM\EntityManager;
+use Mautic\ChannelBundle\Entity\MessageRepository;
 use Mautic\ChannelBundle\Model\MessageQueueModel;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Helper\ThemeHelper;
+use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Translation\Translator;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\EmailRepository;
@@ -31,6 +33,7 @@ use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PageBundle\Model\TrackableModel;
 use Mautic\UserBundle\Model\UserModel;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class EmailModelTest extends \PHPUnit_Framework_TestCase
 {
@@ -282,6 +285,8 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
         $mailHelper->method('queue')
             ->will($this->returnValue(true));
+        $mailHelper->method('setEmail')
+            ->will($this->returnValue(true));
 
         $leadModel = $this->getMockBuilder(LeadModel::class)
             ->disableOriginalConstructor()
@@ -292,10 +297,6 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $userModel = $this->getMockBuilder(UserModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $coreParametersHelper = $this->getMockBuilder(CoreParametersHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -434,14 +435,14 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $companyModel,
             $trackableModel,
             $userModel,
-            $coreParametersHelper,
             $messageModel
         );
 
         $emailModel->setTranslator($translator);
         $emailModel->setEntityManager($entityManager);
 
-        $count = 12;
+        $count   = 12;
+        $results = [];
         while ($count > 0) {
             $contact = [
                 'id'        => $count,
@@ -451,7 +452,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ];
             --$count;
 
-            $emailModel->sendEmail($emailEntity, [$contact]);
+            $results[] = $emailModel->sendEmail($emailEntity, [$contact]);
         }
 
         $emailSettings = $emailModel->getEmailSettings($emailEntity);
@@ -508,10 +509,6 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $userModel = $this->getMockBuilder(UserModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $coreParametersHelper = $this->getMockBuilder(CoreParametersHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -593,7 +590,6 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $companyModel,
             $trackableModel,
             $userModel,
-            $coreParametersHelper,
             $messageModel
         );
 
@@ -645,10 +641,6 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $userModel = $this->getMockBuilder(UserModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $coreParametersHelper = $this->getMockBuilder(CoreParametersHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -733,7 +725,6 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $companyModel,
             $trackableModel,
             $userModel,
-            $coreParametersHelper,
             $messageModel
         );
 
@@ -785,10 +776,6 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $userModel = $this->getMockBuilder(UserModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $coreParametersHelper = $this->getMockBuilder(CoreParametersHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -851,7 +838,6 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $companyModel,
             $trackableModel,
             $userModel,
-            $coreParametersHelper,
             $messageModel
         );
 
@@ -901,10 +887,6 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $coreParametersHelper = $this->getMockBuilder(CoreParametersHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         // Setup the translator
         $translator = $this->getMockBuilder(Translator::class)
             ->disableOriginalConstructor()
@@ -927,6 +909,11 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $frequencyRepository->method('getAppliedFrequencyRules')
             ->will($this->returnValue([['lead_id' => 1, 'frequency_number' => 1, 'frequency_time' => 'DAY']]));
+        $messageRepository = $this->getMockBuilder(MessageRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $messageRepository->method('findMessage')
+            ->will($this->returnValue(null));
 
         // Setup the EntityManager
         $entityManager = $this
@@ -942,19 +929,38 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
                         ['MauticEmailBundle:Email', $emailRepository],
                         ['MauticEmailBundle:Stat', $statRepository],
                         ['MauticLeadBundle:FrequencyRule', $frequencyRepository],
+                        ['MauticChannelBundle:MessageQueue', $messageRepository],
                     ]
                 )
             );
+        $leadEntity = (new Lead())
+            ->setEmail('someone@domain.com');
 
-        $messageModel = $this->getMockBuilder(MessageQueueModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $messageModel->expects($this->exactly(1))
-            ->method('addToQueue');
+        $entityManager->expects($this->any())
+            ->method('getReference')
+            ->will(
+                $this->returnValue($leadEntity)
+            );
 
         $companyModel = $this->getMockBuilder(CompanyModel::class)
             ->disableOriginalConstructor()
             ->getMock();
+
+        $coreParametersHelper = $this->getMockBuilder(CoreParametersHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $userHelper = $this->getMockBuilder(UserHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $dispatcher = $this->getMockBuilder(EventDispatcher::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $messageModel = new MessageQueueModel($leadModel, $companyModel, $coreParametersHelper);
+        $messageModel->setEntityManager($entityManager);
+        $messageModel->setUserHelper($userHelper);
+        $messageModel->setDispatcher($dispatcher);
 
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,
@@ -965,7 +971,6 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $companyModel,
             $trackableModel,
             $userModel,
-            $coreParametersHelper,
             $messageModel
         );
 
@@ -978,7 +983,18 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
         $emailEntity->method('getId')
             ->will($this->returnValue(1));
 
-        $result = $emailModel->sendEmail($emailEntity, [1 => ['id' => 1, 'email' => 'someone@domain.com']], ['email_type' => 'marketing']);
-        $this->assertTrue(count($result) === 0);
+        $result = $emailModel->sendEmail(
+            $emailEntity,
+            [
+                1 => [
+                    'id'        => 1,
+                    'email'     => 'someone@domain.com',
+                    'firstname' => 'someone',
+                    'lastname'  => 'someone',
+                ],
+            ],
+            ['email_type' => 'marketing']
+        );
+        $this->assertTrue(count($result) === 0, print_r($result, true));
     }
 }

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -1785,10 +1785,11 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
      */
     public static function generateChannelRules(array $frequencyRules, array $dncRules)
     {
-        $rules = [];
+        $rules             = [];
+        $dncFrequencyRules = [];
         foreach ($frequencyRules as $rule) {
             if ($rule instanceof FrequencyRule) {
-                $rules[$rule->getChannel()] = [
+                $ruleArray = [
                     'channel'           => $rule->getChannel(),
                     'pause_from_date'   => $rule->getPauseFromDate(),
                     'pause_to_date'     => $rule->getPauseToDate(),
@@ -1796,11 +1797,18 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
                     'frequency_time'    => $rule->getFrequencyTime(),
                     'frequency_number'  => $rule->getFrequencyNumber(),
                 ];
+
+                if (array_key_exists($rule->getChannel(), $dncRules)) {
+                    $dncFrequencyRules[$rule->getChannel()] = $ruleArray;
+                } else {
+                    $rules[$rule->getChannel()] = $ruleArray;
+                }
             } else {
                 // Already an array
                 break;
             }
         }
+
         if (count($rules)) {
             $frequencyRules = $rules;
         }
@@ -1808,12 +1816,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
         /* @var FrequencyRule $rule */
         usort(
             $frequencyRules,
-            function ($a, $b) use ($dncRules) {
-                if (array_key_exists($a['channel'], $dncRules)) {
-                    // Channel in DNC so give lower preference
-                    return 1;
-                }
-
+            function ($a, $b) {
                 if ($a['pause_from_date'] && $a['pause_to_date']) {
                     $now = new \DateTime();
                     if ($now >= $a['pause_from_date'] && $now <= $a['pause_to_date']) {
@@ -1871,15 +1874,14 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
             $rules[$rule['channel']] =
                 [
                     'frequency' => $rule,
-                    'dnc'       => array_key_exists($rule['channel'], $dncRules) ? $dncRules[$rule['channel']] : DoNotContact::IS_CONTACTABLE,
+                    'dnc'       => DoNotContact::IS_CONTACTABLE,
                 ];
-            unset($dncRules[$rule['channel']]);
         }
 
         if (count($dncRules)) {
             foreach ($dncRules as $channel => $reason) {
                 $rules[$channel] = [
-                    'frequency' => null,
+                    'frequency' => (isset($dncFrequencyRules[$channel])) ? $dncFrequencyRules[$channel] : null,
                     'dnc'       => $reason,
                 ];
             }

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -515,7 +515,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
                     $this->changes['utmtags'] = ['utm_source', $val->getUtmSource()];
                 }
             }
-        } elseif ($prop == 'frequencyRule') {
+        } elseif ($prop == 'frequencyRules') {
             if (!isset($this->changes['frequencyRules'])) {
                 $this->changes['frequencyRules'] = [];
             }
@@ -1022,7 +1022,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
         }
         $this->changes['dnc_status'] = [$type, $doNotContact->getComments()];
 
-        $this->doNotContact[] = $doNotContact;
+        $this->doNotContact[$doNotContact->getChannel()] = $doNotContact;
 
         return $this;
     }
@@ -1357,7 +1357,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
      */
     public function removeFrequencyRule(FrequencyRule $frequencyRule)
     {
-        $this->isChanged('frequencyRules', $frequencyRule->getId());
+        $this->isChanged('frequencyRules', $frequencyRule->getId(), false);
         $this->frequencyRules->removeElement($frequencyRule);
     }
 
@@ -1368,7 +1368,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
      */
     public function addFrequencyRule(FrequencyRule $frequencyRule)
     {
-        $this->isChanged('frequencyRule', $frequencyRule);
+        $this->isChanged('frequencyRules', $frequencyRule, false);
         $this->frequencyRules[] = $frequencyRule;
     }
 
@@ -1788,7 +1788,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
         $rules = [];
         foreach ($frequencyRules as $rule) {
             if ($rule instanceof FrequencyRule) {
-                $rules[$rule->getChannel] = [
+                $rules[$rule->getChannel()] = [
                     'channel'           => $rule->getChannel(),
                     'pause_from_date'   => $rule->getPauseFromDate(),
                     'pause_to_date'     => $rule->getPauseToDate(),
@@ -1809,7 +1809,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
         usort(
             $frequencyRules,
             function ($a, $b) use ($dncRules) {
-                if (in_array($a['channel'], $dncRules)) {
+                if (array_key_exists($a['channel'], $dncRules)) {
                     // Channel in DNC so give lower preference
                     return 1;
                 }

--- a/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
@@ -80,8 +80,7 @@ class LeadTest extends \PHPUnit_Framework_TestCase
         $dnc = (new DoNotContact())->setChannel('channel4');
         $lead->addDoNotContactEntry($dnc);
 
-        $preferredChannels = $lead->getPreferredChannels();
-
-        $this->assertEquals(['channel2', 'channel3', 'channel5', 'channel6', 'channel4', 'channel1'], array_keys($preferredChannels));
+        $channelRules = Lead::generateChannelRules($lead->getFrequencyRules()->toArray(), $lead->getDoNotContact()->toArray());
+        $this->assertEquals(['channel2', 'channel3', 'channel5', 'channel6', 'channel4', 'channel1'], array_keys($channelRules));
     }
 }

--- a/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
@@ -68,6 +68,7 @@ class LeadTest extends \PHPUnit_Framework_TestCase
 
         foreach ($frequencyRules as $channel => $rule) {
             $frequencyRule = (new FrequencyRule())
+                ->setPreferredChannel($rule['preferredChannel'])
                 ->setFrequencyNumber($rule['frequencyNumber'])
                 ->setFrequencyTime($rule['frequencyTime'])
                 ->setChannel($channel)
@@ -81,6 +82,6 @@ class LeadTest extends \PHPUnit_Framework_TestCase
         $lead->addDoNotContactEntry($dnc);
 
         $channelRules = Lead::generateChannelRules($lead->getFrequencyRules()->toArray(), $lead->getDoNotContact()->toArray());
-        $this->assertEquals(['channel2', 'channel3', 'channel5', 'channel6', 'channel4', 'channel1'], array_keys($channelRules));
+        $this->assertEquals(['channel2', 'channel3', 'channel5', 'channel6', 'channel1', 'channel4'], array_keys($channelRules));
     }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When creating a campaign that fails validation, the sources are lost. Or if saving the campaign without opening the builder, the connections are lost.

#### Steps to test this PR:
1. Create a new campaign
2. Leave name empty and build a simple campaign
3. Click apply and should get a validation error
4. View the builder - all looks good
5. Add a name and save and close
6. Edit the campaign and go to the builder
7. Everything should remain intact
8. Save and close
9. Edit again
10. Click apply twice in a row
11. View the builder and everything should remain intact

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Same as above but on step 7, source is lost and on step 11, all connections are lost
