### PR TITLE
Adding multi-thumbnails support

### DIFF
--- a/app/bundles/CoreBundle/Views/Helper/theme_select.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/theme_select.html.php
@@ -37,8 +37,15 @@ $isCodeMode = ($active == $codeMode);
         <?php if (isset($themeInfo['config']['features']) && !in_array($type, $themeInfo['config']['features'])) {
     continue;
 } ?>
-        <?php $thumbnailUrl = $view['assets']->getUrl('themes/'.$themeKey.'/thumbnail.png'); ?>
+        <?php $thumbnailName = 'thumbnail.png'; ?>
         <?php $hasThumbnail = file_exists($themeInfo['dir'].'/thumbnail.png'); ?>
+        <?php
+        if (file_exists($themeInfo['dir'].'/thumbnail_'.$type.'.png')) {
+            $thumbnailName = 'thumbnail_'.$type.'.png';
+            $hasThumbnail = true;
+        }
+        ?>
+        <?php $thumbnailUrl = $view['assets']->getUrl('themes/'.$themeKey.'/'.$thumbnailName); ?>
         <div class="col-md-3 theme-list">
             <div class="panel panel-default <?php echo $isSelected ? 'theme-selected' : ''; ?>">
                 <div class="panel-body text-center">


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/52
| Issues addressed (#s or URLs) |  #3307 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Add multiple thumbnail to mautic theme
the mixture for the thumbnail name is thumbnail_feature.png [Ex. thumbnail_email.png]
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Added a thumnail with name thumbnail_email.phg
2. Go to Channels -> Emails
3. Check if the thumbnails change

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. Default thumbnails still work if you dont want that much details
2. 