### PR TITLE
Fix theme thumbnail dir 

### DIFF
--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -283,6 +283,7 @@ class ThemeHelper
                     $this->themesInfo[$specificFeature][$theme->getBasename()]['key']    = $theme->getBasename();
                     $this->themesInfo[$specificFeature][$theme->getBasename()]['dir']    = $theme->getRealPath();
                     $this->themesInfo[$specificFeature][$theme->getBasename()]['config'] = $config;
+                    $this->themesInfo[$specificFeature][$theme->getBasename()]['themesLocalDir'] = $this->pathsHelper->getSystemPath('themes', false);
                 }
             }
         }

--- a/app/bundles/CoreBundle/Views/Helper/theme_select.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/theme_select.html.php
@@ -37,7 +37,7 @@ $isCodeMode = ($active == $codeMode);
         <?php if (isset($themeInfo['config']['features']) && !in_array($type, $themeInfo['config']['features'])) {
     continue;
 } ?>
-        <?php $thumbnailUrl = $view['assets']->getUrl('themes/'.$themeKey.'/thumbnail.png'); ?>
+        <?php $thumbnailUrl = $view['assets']->getUrl($themeInfo['themesLocalDir'].'/'.$themeKey.'/thumbnail.png'); ?>
         <?php $hasThumbnail = file_exists($themeInfo['dir'].'/thumbnail.png'); ?>
         <div class="col-md-3 theme-list">
             <div class="panel panel-default <?php echo $isSelected ? 'theme-selected' : ''; ?>">


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | n
| Related developer documentation PR URL | n
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/pull/3468
| BC breaks? | n
| Deprecations? | n

PR related to https://github.com/mautic/mautic/pull/3468

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:



[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Add to app/config/paths_local.php 
`$paths = [
    'themes' => 'themes_test'
];
2. Copy themes to themes_test and clear cache
3. Create new template with thumbnail to themes_test
4. Create new email, see themes tab
5. Before PR, thumbnail is located to themes dir, after PR is located to themes_test

#### Steps to test this PR:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 