### PR TITLE
fixed modified date filter not showing operators, changed last_modifi…

### DIFF
--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -256,14 +256,14 @@ class ListModel extends FormModel
             ],
             'last_active' => [
                 'label'      => $this->translator->trans('mautic.lead.list.filter.last_active'),
-                'properties' => ['type' => 'date'],
+                'properties' => ['type' => 'datetime'],
                 'operators'  => $this->getOperatorsForFieldType('default'),
                 'object'     => 'lead',
             ],
             'date_modified' => [
                 'label'      => $this->translator->trans('mautic.lead.list.filter.date_modified'),
-                'properties' => ['type' => 'date'],
-                'operators'  => 'default',
+                'properties' => ['type' => 'datetime'],
+                'operators'  => $this->getOperatorsForFieldType('default'),
                 'object'     => 'lead',
             ],
             'owner_id' => [


### PR DESCRIPTION
…ed and last_active filters to datetime

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y + enhancement
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
on Segment filters the modified date filter was not showing the operators correctly, this was fixed. Also the last modified and last active filters were changed to datetime, in order to filter contacts to a more specific time, this should not affect existing filters using these fields.
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. go to segments and create a new one, pick modified date from the contact dropdown, operators do not have a dropdown

#### Steps to test this PR:
1. modified date should show the operator dropdown
2. modified date and last active date now work with the date part.
3. it should not break your previous filters using these fields