### PR TITLE
Attributes in email <html> tag wrap additional <html> tag with no doctype in webview

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -71,7 +71,7 @@ class PublicController extends CommonFormController
             $analytics = $this->factory->getHelper('template.analytics')->getCode();
 
             // Check for html doc
-            if (strpos($content, '<html>') === false) {
+            if (strpos($content, '<html') === false) {
                 $content = "<html>\n<head>{$analytics}</head>\n<body>{$content}</body>\n</html>";
             } elseif (strpos($content, '<head>') === false) {
                 $content = str_replace('<html>', "<html>\n<head>\n{$analytics}\n</head>", $content);


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | ✔️ 
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

#### Description:

When creating a _Code Mode_ email, putting attributes in the `<html>` tag will wrap it in an additional `<html>` tag with a little boilerplate but no doctype when opening that email's _webview_ url. This is problematic because it may cause emails to look **drastically different** in the _webview_. (You wouldn't believe what tables end up doing in quirks mode!)

Actual code:
![image](https://cloud.githubusercontent.com/assets/18265735/23212225/08f81b92-f906-11e6-83ed-29416e055c32.png)

Text version (for copy pasting):
```html
<!doctype html>
<html lang="en">
  <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <title>Hello there</title>
  </head>
  <body>
    <p>Hello there</p>
  </body>
</html>
```

Webview source:
![image](https://cloud.githubusercontent.com/assets/18265735/23212321/6af46ada-f906-11e6-946e-4ba93947b62d.png)

#### Steps to reproduce the bug:
1. Create a _Code Mode_ email with the code above
2. Send it to yourself
3. Open it in its webview URL (you can get that link in your contact's detailed view)
4. Open the source code

#### Steps to test this PR:
1. Apply the PR
2. Repeat the steps above