### PR TITLE
Channel Names added to API responses for MM

### DIFF
--- a/app/bundles/ChannelBundle/Entity/Channel.php
+++ b/app/bundles/ChannelBundle/Entity/Channel.php
@@ -34,6 +34,11 @@ class Channel extends CommonEntity
     private $channelId;
 
     /**
+     * @var string
+     */
+    private $channelName;
+
+    /**
      * @var Message
      */
     private $message;
@@ -47,13 +52,6 @@ class Channel extends CommonEntity
      * @var bool
      */
     private $isEnabled = false;
-
-    /**
-     * Channel constructor.
-     */
-    public function __construct()
-    {
-    }
 
     /**
      * @param ClassMetadata $metadata
@@ -95,6 +93,7 @@ class Channel extends CommonEntity
                     'id',
                     'channel',
                     'channelId',
+                    'channelName',
                     'isEnabled',
                 ]
             )
@@ -155,6 +154,26 @@ class Channel extends CommonEntity
         }
 
         $this->channelId = $channelId;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getChannelName()
+    {
+        return $this->channelName;
+    }
+
+    /**
+     * @param string $channelName
+     *
+     * @return Channel
+     */
+    public function setChannelName($channelName)
+    {
+        $this->channelName = $channelName;
 
         return $this;
     }

--- a/app/bundles/ChannelBundle/Event/ChannelEvent.php
+++ b/app/bundles/ChannelBundle/Event/ChannelEvent.php
@@ -70,9 +70,11 @@ class ChannelEvent extends CommonEvent
     }
 
     /**
-     * Returns repository name for the provided channel. Null if not found.
+     * Returns repository name for the provided channel. Defaults to classic naming convention.
      *
-     * @return string|null
+     * @param string $channel
+     *
+     * @return string
      */
     public function getRepositoryName($channel)
     {
@@ -80,13 +82,18 @@ class ChannelEvent extends CommonEvent
             return $this->channels[$channel][MessageModel::CHANNEL_FEATURE]['repository'];
         }
 
-        return null;
+        // if not defined, try the classic naming convention
+        $channel = ucfirst($channel);
+
+        return "Mautic{$channel}Bundle:{$channel}";
     }
 
     /**
      * Returns the name of the column holding the channel name for the provided channel. Defaults to 'name'.
      *
-     * @return string|null
+     * @param string $channel
+     *
+     * @return string
      */
     public function getNameColumn($channel)
     {

--- a/app/bundles/ChannelBundle/Event/ChannelEvent.php
+++ b/app/bundles/ChannelBundle/Event/ChannelEvent.php
@@ -11,7 +11,9 @@
 
 namespace Mautic\ChannelBundle\Event;
 
+use Mautic\ChannelBundle\Model\MessageModel;
 use Mautic\CoreBundle\Event\CommonEvent;
+use Mautic\LeadBundle\Model\LeadModel;
 
 /**
  * Class ChannelEvent.
@@ -68,6 +70,34 @@ class ChannelEvent extends CommonEvent
     }
 
     /**
+     * Returns repository name for the provided channel. Null if not found.
+     *
+     * @return string|null
+     */
+    public function getRepositoryName($channel)
+    {
+        if (isset($this->channels[$channel][MessageModel::CHANNEL_FEATURE]['repository'])) {
+            return $this->channels[$channel][MessageModel::CHANNEL_FEATURE]['repository'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the name of the column holding the channel name for the provided channel. Defaults to 'name'.
+     *
+     * @return string|null
+     */
+    public function getNameColumn($channel)
+    {
+        if (isset($this->channels[$channel][MessageModel::CHANNEL_FEATURE]['nameColumn'])) {
+            return $this->channels[$channel][MessageModel::CHANNEL_FEATURE]['nameColumn'];
+        }
+
+        return 'name';
+    }
+
+    /**
      * @param $feature
      *
      * @return array
@@ -86,7 +116,7 @@ class ChannelEvent extends CommonEvent
      */
     public function setChannel($channel)
     {
-        $this->addChannel($channel, [\Mautic\LeadBundle\Model\LeadModel::CHANNEL_FEATURE => []]);
+        $this->addChannel($channel, [LeadModel::CHANNEL_FEATURE => []]);
     }
 
     /**

--- a/app/bundles/ChannelBundle/Model/MessageModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageModel.php
@@ -228,6 +228,35 @@ class MessageModel extends FormModel implements AjaxLookupModelInterface
     }
 
     /**
+     * Get the channel name from the database.
+     *
+     * @param int    $id
+     * @param string $entityName
+     * @param string $nameColumn
+     *
+     * @return string|null
+     */
+    public function getChannelName($id, $entityName, $nameColumn = 'name')
+    {
+        if (!$id || !$entityName || !$nameColumn) {
+            return null;
+        }
+
+        $repo = $this->em->getRepository($entityName);
+        $qb   = $repo->createQueryBuilder('e')
+            ->select('e.'.$nameColumn)
+            ->where('e.id = :id')
+            ->setParameter('id', (int) $id);
+        $result = $qb->getQuery()->getOneOrNullResult();
+
+        if (isset($result[$nameColumn])) {
+            return $result[$nameColumn];
+        }
+
+        return null;
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @throws MethodNotAllowedHttpException

--- a/app/bundles/EmailBundle/EventListener/ChannelSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ChannelSubscriber.php
@@ -57,6 +57,7 @@ class ChannelSubscriber extends CommonSubscriber
                         'form.submit',
                     ],
                     'lookupFormType' => 'email_list',
+                    'repository'     => 'MauticEmailBundle:Email',
                 ],
                 LeadModel::CHANNEL_FEATURE   => [],
                 ReportModel::CHANNEL_FEATURE => [

--- a/app/bundles/EmailBundle/EventListener/ChannelSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ChannelSubscriber.php
@@ -57,7 +57,6 @@ class ChannelSubscriber extends CommonSubscriber
                         'form.submit',
                     ],
                     'lookupFormType' => 'email_list',
-                    'repository'     => 'MauticEmailBundle:Email',
                 ],
                 LeadModel::CHANNEL_FEATURE   => [],
                 ReportModel::CHANNEL_FEATURE => [

--- a/app/bundles/NotificationBundle/EventListener/ChannelSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/ChannelSubscriber.php
@@ -49,6 +49,7 @@ class ChannelSubscriber extends CommonSubscriber
                             'form.submit',
                         ],
                         'lookupFormType' => 'notification_list',
+                        'repository'     => 'MauticNotificationBundle:Notification',
                     ],
                     ReportModel::CHANNEL_FEATURE => [
                         'table' => 'push_notifications',

--- a/app/bundles/SmsBundle/EventListener/ChannelSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/ChannelSubscriber.php
@@ -50,6 +50,7 @@ class ChannelSubscriber extends CommonSubscriber
                             'form.submit',
                         ],
                         'lookupFormType' => 'sms_list',
+                        'repository'     => 'MauticSmsBundle:Sms',
                     ],
                     LeadModel::CHANNEL_FEATURE   => [],
                     ReportModel::CHANNEL_FEATURE => [


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/50
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR adds the `channelName` attribute to the Marketing Messages API endpoint. It won't work for Twitter channel since the tweets aren't entities, but channel params. So Twitter channel will always have channelId and channelName = null. Example response:

```
{
    "message": {
        "isPublished": true,
        "dateAdded": "2017-02-03T17:51:58+01:00",
        "dateModified": "2017-02-23T15:39:40+01:00",
        "createdBy": 1,
        "createdByUser": "John Doe",
        "modifiedBy": 1,
        "modifiedByUser": "John Doe",
        "id": 1,
        "name": "The first MM",
        "description": null,
        "publishUp": null,
        "publishDown": null,
        "channels": [
            {
                "id": 1,
                "channel": "email",
                "channelId": 44,
                "channelName": "Email A", <-- here
                "isEnabled": true
            },
            {
                "id": 3,
                "channel": "notification",
                "channelId": 75,
                "channelName": "fvgdasfa", <-- here
                "isEnabled": false
            },
            {
                "id": 2,
                "channel": "sms",
                "channelId": 1,
                "channelName": "test", <-- here
                "isEnabled": true
            }
        ]
    }
}
```

#### Steps to test this PR:
1. Try to get/update/create MM via API. The names should be in the response.
2. Run the API Library unit tests.
