### PR TITLE
Fixed the atwho tokens for the landing page builder

### DIFF
--- a/app/bundles/PageBundle/Controller/AjaxController.php
+++ b/app/bundles/PageBundle/Controller/AjaxController.php
@@ -119,6 +119,6 @@ class AjaxController extends CommonAjaxController
         /** @var \Mautic\PageBundle\Model\PageModel $model */
         $model = $this->getModel('page');
 
-        return $model->getBuilderComponents(null, 'tokens', $query);
+        return $model->getBuilderComponents(null, ['tokens'], $query);
     }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The atwho does not activate when typing `{` for the page builder. This fixes that. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to the landing page editor. Click on a text field and start typing `{` in the wysiwyg. Notice that the token list is not activated. 

#### Steps to test this PR:
1. Same as above but the list should display
