### PR TITLE
Fixed error happening on filtering the contact events

### DIFF
--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -296,7 +296,7 @@ class LeadTimelineEvent extends Event
         return [
             'leadId' => $this->lead->getId(),
             'limit'  => $this->limit,
-            'start'  => (1 === $this->page) ? 0 : ($this->page - 1) * $this->limit,
+            'start'  => (1 >= $this->page) ? 0 : ($this->page - 1) * $this->limit,
         ];
     }
 


### PR DESCRIPTION
…eline while filtering events.

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3539
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
There is an error while filtering contact's timeline as stated in the linked issue. The reason is that if the page === 0, the formula returns a negative number. The fix I propose is if the page <= 1, return start = 0.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to a contact detail page.
2. Try to filter the timeline by some events.
- error

#### Steps to test this PR:
1. Apply this PR.
2. Test again.
- filtering and pagination works without any issue.
