### PR TITLE
Bitly URL param should be longUrl, not longurl

### DIFF
--- a/app/bundles/CoreBundle/Translations/en_US/messages.ini
+++ b/app/bundles/CoreBundle/Translations/en_US/messages.ini
@@ -101,7 +101,7 @@ mautic.core.config.form.ip.lookup.auth.tooltip="Set authentication credential(s)
 mautic.core.config.form.ip.lookup.service="IP lookup service"
 mautic.core.config.form.ip.lookup.service.tooltip="Set the service to use to lookup geographical information from an IP address. Note that some of the services listed are commercial services. Mautic is not affiliated with the listed services but provide them for convenience."
 mautic.core.config.form.link.shortener="URL Shortener"
-mautic.core.config.form.link.shortener.tooltip="The full URL (including access key) to your url shortener that, when queried, returns a plain text shortened url. For bit.ly users, use `https://api-ssl.bitly.com/v3/shorten?access_token=[ACCESS_TOKEN]&format=txt&longurl=`, replacing [ACCESS_TOKEN] with your bit.ly access token."
+mautic.core.config.form.link.shortener.tooltip="The full URL (including access key) to your url shortener that, when queried, returns a plain text shortened url. For bit.ly users, use `https://api-ssl.bitly.com/v3/shorten?access_token=[ACCESS_TOKEN]&format=txt&longUrl=`, replacing [ACCESS_TOKEN] with your bit.ly access token."
 mautic.core.config.form.locale="Default language"
 mautic.core.config.form.locale.tooltip="Set the site's default language. Users can set their own default language via their profile."
 mautic.core.config.form.log.path="Path to the log directory"


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3542
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
According to the issue, the Bitly URL param `longurl` should be `longUrl` and the same sais the [documentation](https://dev.bitly.com/links.html).

#### Steps to test this PR:
1. Code review is sufficient