### PR TITLE
trigger_error method works only with E_USER family of constants

### DIFF
--- a/app/bundles/CategoryBundle/Helper/MenuHelper.php
+++ b/app/bundles/CategoryBundle/Helper/MenuHelper.php
@@ -26,6 +26,6 @@ class MenuHelper
      */
     public static function addCategoryMenuItems(&$items, $bundleName, CorePermissions $security)
     {
-        @trigger_error('Individual category menu items are no longer used.', E_DEPRECATED);
+        @trigger_error('Individual category menu items are no longer used.', E_USER_DEPRECATED);
     }
 }

--- a/app/bundles/CoreBundle/Event/ChannelBroadcastEvent.php
+++ b/app/bundles/CoreBundle/Event/ChannelBroadcastEvent.php
@@ -11,7 +11,7 @@
 
 namespace Mautic\CoreBundle\Event;
 
-@trigger_error('Mautic\CoreBundle\Event\ChannelBroadcastEvent was deprecated in 2.4 and to be removed in 3.0 Use \Mautic\ChannelBundle\Event\ChannelBroadcastEvent instead', E_DEPRECATED);
+@trigger_error('Mautic\CoreBundle\Event\ChannelBroadcastEvent was deprecated in 2.4 and to be removed in 3.0 Use \Mautic\ChannelBundle\Event\ChannelBroadcastEvent instead', E_USER_DEPRECATED);
 
 /**
  * Class ChannelBroadcastEvent.

--- a/app/bundles/CoreBundle/Event/MessageQueueBatchProcessEvent.php
+++ b/app/bundles/CoreBundle/Event/MessageQueueBatchProcessEvent.php
@@ -11,7 +11,7 @@
 
 namespace Mautic\CoreBundle\Event;
 
-@trigger_error('Mautic\CoreBundle\Event\MessageQueueBatchProcessEvent was deprecated in 2.4 and to be removed in 3.0 Use \Mautic\ChannelBundle\Event\MessageQueueBatchProcessEvent instead', E_DEPRECATED);
+@trigger_error('Mautic\CoreBundle\Event\MessageQueueBatchProcessEvent was deprecated in 2.4 and to be removed in 3.0 Use \Mautic\ChannelBundle\Event\MessageQueueBatchProcessEvent instead', E_USER_DEPRECATED);
 
 /**
  * Class MessageQueueBatchProcessEvent.

--- a/app/bundles/CoreBundle/Event/MessageQueueEvent.php
+++ b/app/bundles/CoreBundle/Event/MessageQueueEvent.php
@@ -11,7 +11,7 @@
 
 namespace Mautic\CoreBundle\Event;
 
-@trigger_error('Mautic\CoreBundle\Event\MessageQueueEvent was deprecated in 2.4 and to be removed in 3.0 Use \Mautic\ChannelBundle\Event\MessageQueueEvent instead', E_DEPRECATED);
+@trigger_error('Mautic\CoreBundle\Event\MessageQueueEvent was deprecated in 2.4 and to be removed in 3.0 Use \Mautic\ChannelBundle\Event\MessageQueueEvent instead', E_USER_DEPRECATED);
 
 /**
  * Class MessageQueueEvent.

--- a/app/bundles/CoreBundle/Event/MessageQueueProcessEvent.php
+++ b/app/bundles/CoreBundle/Event/MessageQueueProcessEvent.php
@@ -11,7 +11,7 @@
 
 namespace Mautic\CoreBundle\Event;
 
-@trigger_error('Mautic\CoreBundle\Event\MessageQueueProcessEvent was deprecated in 2.4 and to be removed in 3.0 Use \Mautic\ChannelBundle\Event\MessageQueueProcessEvent instead', E_DEPRECATED);
+@trigger_error('Mautic\CoreBundle\Event\MessageQueueProcessEvent was deprecated in 2.4 and to be removed in 3.0 Use \Mautic\ChannelBundle\Event\MessageQueueProcessEvent instead', E_USER_DEPRECATED);
 
 /**
  * Class MessageQueueProcessEvent.

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1475,7 +1475,7 @@ class MailHelper
      */
     public function useMailerTokenization($tokenizationEnabled = true)
     {
-        @trigger_error('useMailerTokenization() is now deprecated. Use enableQueue() instead.', E_DEPRECATED);
+        @trigger_error('useMailerTokenization() is now deprecated. Use enableQueue() instead.', E_USER_DEPRECATED);
 
         $this->enableQueue($tokenizationEnabled);
     }

--- a/app/bundles/LeadBundle/Event/ChannelEvent.php
+++ b/app/bundles/LeadBundle/Event/ChannelEvent.php
@@ -11,7 +11,7 @@
 
 namespace Mautic\LeadBundle\Event;
 
-@trigger_error('\Mautic\LeadBundle\Event\ChannelEvent was deprecated in 2.4 and to be removed in 3.0 Use \Mautic\ChannelBundle\Event\ChannelEvent instead', E_DEPRECATED);
+@trigger_error('\Mautic\LeadBundle\Event\ChannelEvent was deprecated in 2.4 and to be removed in 3.0 Use \Mautic\ChannelBundle\Event\ChannelEvent instead', E_USER_DEPRECATED);
 
 /**
  * Class ChannelEvent.


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When sending a segment email I got this PHP warning:
![screen shot 2017-02-28 at 12 18 26](https://cloud.githubusercontent.com/assets/1235442/23403421/58668b6a-fdb0-11e6-9b35-bd2f5bcf1676.png)
From the [PHP docs](http://php.net/manual/en/function.trigger-error.php):

> The designated error type for this error. It only works with the E_USER family of constants

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Not sure, It happened when I was sending a segment email to segments and the error above appeared on the page `s/emails/send/1360`. But I sent a segment email earlier today without any problem.

#### Steps to test this PR:
1. If you cannot replicate it, see the documentation, code review and eiter agree or disagree :)
