### PR TITLE
Set a limit on the number of notifications to query 

### DIFF
--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -689,7 +689,7 @@ class AjaxController extends CommonController
 
         /** @var \Mautic\CoreBundle\Model\NotificationModel $model */
         $model = $this->getModel('core.notification');
-        $model->clearNotification($id);
+        $model->clearNotification($id, 200);
 
         return $this->sendJsonResponse(['success' => 1]);
     }

--- a/app/bundles/CoreBundle/Controller/DefaultController.php
+++ b/app/bundles/CoreBundle/Controller/DefaultController.php
@@ -23,9 +23,9 @@ use Symfony\Component\HttpFoundation\Request;
 class DefaultController extends CommonController
 {
     /**
-     * Generates default index.php.
+     * @param Request $request
      *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\Response
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      */
     public function indexAction(Request $request)
     {
@@ -75,22 +75,24 @@ class DefaultController extends CommonController
     }
 
     /**
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\Response
      */
     public function notificationsAction()
     {
         /** @var \Mautic\CoreBundle\Model\NotificationModel $model */
         $model = $this->getModel('core.notification');
 
-        list($notifications, $showNewIndicator, $updateMessage) = $model->getNotificationContent();
+        list($notifications, $showNewIndicator, $updateMessage) = $model->getNotificationContent(null, false, 200);
 
-        return $this->delegateView([
-            'contentTemplate' => 'MauticCoreBundle:Notification:notifications.html.php',
-            'viewParameters'  => [
-                'showNewIndicator' => $showNewIndicator,
-                'notifications'    => $notifications,
-                'updateMessage'    => $updateMessage,
-            ],
-        ]);
+        return $this->delegateView(
+            [
+                'contentTemplate' => 'MauticCoreBundle:Notification:notifications.html.php',
+                'viewParameters'  => [
+                    'showNewIndicator' => $showNewIndicator,
+                    'notifications'    => $notifications,
+                    'updateMessage'    => $updateMessage,
+                ],
+            ]
+        );
     }
 }

--- a/app/bundles/CoreBundle/Entity/VariantEntityTrait.php
+++ b/app/bundles/CoreBundle/Entity/VariantEntityTrait.php
@@ -256,8 +256,9 @@ trait VariantEntityTrait
     /**
      * Get an array of all IDs for parent/child variants and associated translations if applicable.
      *
-     * @param VariantEntityInterface $entity
-     * @param bool                   $publishedOnly
+     * @param bool $publishedOnly
+     *
+     * @return array
      */
     public function getRelatedEntityIds($publishedOnly = false)
     {

--- a/app/bundles/CoreBundle/Model/NotificationModel.php
+++ b/app/bundles/CoreBundle/Model/NotificationModel.php
@@ -158,21 +158,24 @@ class NotificationModel extends FormModel
     /**
      * Clears a notification for a user.
      *
-     * @param $id Notification to clear; will clear all if empty
+     * @param $id       Notification to clear; will clear all if empty
+     * @param $limit    Maximum number of notifications to clear if $id is empty
      */
-    public function clearNotification($id)
+    public function clearNotification($id, $limit = null)
     {
-        $this->getRepository()->clearNotificationsForUser($this->userHelper->getUser()->getId(), $id);
+        $this->getRepository()->clearNotificationsForUser($this->userHelper->getUser()->getId(), $id, $limit);
     }
 
     /**
      * Get content for notifications.
      *
      * @param null $afterId
+     * @param bool $includeRead
+     * @param int  $limit
      *
      * @return array
      */
-    public function getNotificationContent($afterId = null, $includeRead = false)
+    public function getNotificationContent($afterId = null, $includeRead = false, $limit = null)
     {
         if ($this->userHelper->getUser()->isGuest) {
             return [[], false, ''];
@@ -180,10 +183,10 @@ class NotificationModel extends FormModel
 
         $this->updateUpstreamNotifications();
 
-        $userId        = ($this->userHelper->getUser()) ? $this->userHelper->getUser()->getId() : 0;
-        $notifications = $this->getRepository()->getNotifications($userId, $afterId, $includeRead);
-
         $showNewIndicator = false;
+        $userId           = ($this->userHelper->getUser()) ? $this->userHelper->getUser()->getId() : 0;
+
+        $notifications = $this->getRepository()->getNotifications($userId, $afterId, $includeRead, null, $limit);
 
         //determine if the new message indicator should be shown
         foreach ($notifications as $n) {


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If a user has a lot of unread notifications, it could exhaust PHP's memory. This PR fixes that by limiting the number of notifications displayed at at a time.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create more than 200 notifications for a user in the notifications table (I already had a bunch from standard use so just ran a query to change them all to a single user and changed is_read to 0)
2. You probably won't exhaust the memory with just 200 but all of the notifications will be displayed.

#### Steps to test this PR:
1. Repeat the above but this time only the first 200 will show. Clear, click on on another page and the rest should appear. 
