### PR TITLE
Don't use like for the segment search command as it may display wrong contacts

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -696,6 +696,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
                         )
                     )
                 );
+                $filter->strict  = true;
                 $returnParameter = true;
 
                 break;

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -689,7 +689,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
                         ],
                     ],
                     $innerJoinTables,
-                    $this->generateFilterExpression($q, 'list.alias', $likeExpr, $unique, ($filter->not) ? true : null,
+                    $this->generateFilterExpression($q, 'list.alias', $eqExpr, $unique, ($filter->not) ? true : null,
                         // orX for filter->not either manuall removed or is null
                         $q->expr()->$xExpr(
                             $q->expr()->$eqExpr('list_lead.manually_removed', 0)

--- a/app/bundles/LeadBundle/Views/List/list.html.php
+++ b/app/bundles/LeadBundle/Views/List/list.html.php
@@ -75,7 +75,8 @@ $listCommand = $view['translator']->trans('mautic.lead.lead.searchcommand.list')
                             [
                                 'item'            => $item,
                                 'templateButtons' => [
-                                    'delete' => $security->hasEntityAccess(true, $permissions['lead:lists:deleteother'], $item->getCreatedBy()),
+                                    'edit'   => $view['security']->hasEntityAccess(true, $permissions['lead:lists:editother'], $item->getCreatedBy()),
+                                    'delete' => $view['security']->hasEntityAccess(true, $permissions['lead:lists:deleteother'], $item->getCreatedBy()),
                                 ],
                                 'routeBase' => 'segment',
                                 'langVar'   => 'lead.list',
@@ -104,7 +105,7 @@ $listCommand = $view['translator']->trans('mautic.lead.lead.searchcommand.list')
                                 'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                 ['item' => $item, 'model' => 'lead.list']
                             ); ?>
-                            <?php if ($security->hasEntityAccess(true, $permissions['lead:lists:editother'], $item->getCreatedBy())) : ?>
+                            <?php if ($view['security']->hasEntityAccess(true, $permissions['lead:lists:editother'], $item->getCreatedBy())) : ?>
                                 <a href="<?php echo $view['router']->path(
                                     'mautic_segment_action',
                                     ['objectAction' => 'edit', 'objectId' => $item->getId()]


### PR DESCRIPTION
…cts not part of the expected segment

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If there are segments that start with the same alias as a segment, contacts in all the segments will show up when using the search command for the one segment. For example, all contacts belonging to `test`, `test-one`, and `test-two` will be displayed if using `segment:test` as the search command (also used when clicking on the contacts button in the segment view. This PR replaces the like comparison with an equals.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create two segments with an alias of `test` and `test-two`. 
2. Add a contact to `test-two`
3. Go to the segment list and click on the contacts button for `test` and note that the contact in `test-two` will show up.

#### Steps to test this PR:
1. Repeat the above but this time no one should be displayed.