### PR TITLE
Reverting support for PHP 7.1 since the commands are failing on this …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ php:
   #- 5.5
   - 5.6
   - 7.0
-  - 7.1
+
+matrix:
+  allow_failures:
+    - php: 7.0
 
 before_script:
   - composer install

--- a/app/middlewares/VersionCheckMiddleware.php
+++ b/app/middlewares/VersionCheckMiddleware.php
@@ -20,7 +20,7 @@ class VersionCheckMiddleware implements HttpKernelInterface, PrioritizedMiddlewa
     const PRIORITY = 10;
 
     const MAUTIC_MINIMUM_PHP = '5.6.19';
-    const MAUTIC_MAXIMUM_PHP = '7.1.999';
+    const MAUTIC_MAXIMUM_PHP = '7.0.999';
 
     /**
      * @var HttpKernelInterface

--- a/upgrade.php
+++ b/upgrade.php
@@ -12,7 +12,7 @@ ini_set('display_errors', 'Off');
 date_default_timezone_set('UTC');
 
 define('MAUTIC_MINIMUM_PHP', '5.6.19');
-define('MAUTIC_MAXIMUM_PHP', '7.1.999');
+define('MAUTIC_MAXIMUM_PHP', '7.0.999');
 
 // Are we running the minimum version?
 if (version_compare(PHP_VERSION, MAUTIC_MINIMUM_PHP, 'lt')) {


### PR DESCRIPTION
…version

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/pull/3416
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR reverts support for PHP 7.1 added in https://github.com/mautic/mautic/pull/3416, because the commands are failing on this version with error as this one:

```
An error occurred when executing the "'cache:clear --no-warmup'" command:       
                                                                                  
    [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]    
    You have requested a non-existent service "kernel.debug".
```
