### PR TITLE
Optimize dashboad widgets query

### DIFF
--- a/app/bundles/CoreBundle/Entity/AuditLog.php
+++ b/app/bundles/CoreBundle/Entity/AuditLog.php
@@ -79,7 +79,8 @@ class AuditLog
         $builder->setTable('audit_log')
             ->setCustomRepositoryClass('Mautic\CoreBundle\Entity\AuditLogRepository')
             ->addIndex(['object', 'object_id'], 'object_search')
-            ->addIndex(['bundle', 'object', 'action', 'object_id'], 'timeline_search');
+            ->addIndex(['bundle', 'object', 'action', 'object_id'], 'timeline_search')
+            ->addIndex(['date_added'], 'date_added_index');
 
         $builder->addId();
 

--- a/app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
+++ b/app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
@@ -115,6 +115,8 @@ class LeadFieldData extends AbstractFixture implements OrderedFixtureInterface, 
             if ($object == 'lead') {
                 // Add an attribution index
                 $indexHelper->addIndex(['attribution', 'attribution_date'], 'contact_attribution');
+                //Add date added and country index
+                $indexHelper->addIndex(['date_added', 'country'], 'date_added_country_index');
             } else {
                 $indexHelper->addIndex(['companyname', 'companyemail'], 'company_filter');
                 $indexHelper->addIndex(['companyname', 'companycity', 'companycountry', 'companystate'], 'company_match');

--- a/app/bundles/LeadBundle/EventListener/DoctrineSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/DoctrineSubscriber.php
@@ -116,6 +116,7 @@ class DoctrineSubscriber implements \Doctrine\Common\EventSubscriber
                 switch ($object) {
                     case 'lead':
                         $table->addIndex(['attribution', 'attribution_date'], MAUTIC_TABLE_PREFIX.'contact_attribution');
+                        $table->addIndex(['date_added', 'country'], MAUTIC_TABLE_PREFIX.'date_added_country_index');
                         break;
                     case 'company':
                         $table->addIndex(['companyname', 'companyemail'], MAUTIC_TABLE_PREFIX.'company_filter');

--- a/app/bundles/PageBundle/Entity/Hit.php
+++ b/app/bundles/PageBundle/Entity/Hit.php
@@ -163,7 +163,8 @@ class Hit
             ->addIndex(['tracking_id'], 'page_hit_tracking_search')
             ->addIndex(['code'], 'page_hit_code_search')
             ->addIndex(['source', 'source_id'], 'page_hit_source_search')
-            ->addIndex(['date_hit'], 'page_date_hit');
+            ->addIndex(['date_hit'], 'page_date_hit')
+            ->addIndex(['date_hit', 'date_left'], 'date_hit_left_index');
 
         $builder->addId();
 

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -906,19 +906,23 @@ class PageModel extends FormModel
      */
     public function getNewVsReturningPieChartData($dateFrom, $dateTo, $filters = [], $canViewOthers = true)
     {
-        $chart   = new PieChart();
-        $query   = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);
-        $allQ    = $query->getCountQuery('page_hits', 'id', 'date_hit', $filters);
-        $uniqueQ = $query->getCountQuery('page_hits', 'lead_id', 'date_hit', $filters, ['getUnique' => true, 'selectAlso' => ['t.page_id']]);
+        $chart              = new PieChart();
+        $query              = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);
+        $allQ               = $query->getCountQuery('page_hits', 'id', 'date_hit', $filters);
+        $filters['lead_id'] = [
+            'expression' => 'isNull',
+        ];
+        $returnQ = $query->getCountQuery('page_hits', 'id', 'date_hit', $filters);
 
         if (!$canViewOthers) {
             $this->limitQueryToCreator($allQ);
-            $this->limitQueryToCreator($uniqueQ);
+            $this->limitQueryToCreator($returnQ);
         }
 
-        $all       = $query->fetchCount($allQ);
-        $unique    = $query->fetchCount($uniqueQ);
-        $returning = $all - $unique;
+        $all = $query->fetchCount($allQ);
+//        $unique    = $query->fetchCount($uniqueQ);
+        $returning = $query->fetchCount($returnQ);
+        $unique    = $all - $returning;
         $chart->setDataset($this->translator->trans('mautic.page.unique'), $unique);
         $chart->setDataset($this->translator->trans('mautic.page.graph.pie.new.vs.returning.returning'), $returning);
 

--- a/app/migrations/Version20170303000000.php
+++ b/app/migrations/Version20170303000000.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170303000000 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        $table = $schema->getTable(MAUTIC_TABLE_PREFIX.'leads');
+        if ($table->hasIndex('date_added_country_index')) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql("CREATE INDEX {$this->prefix}date_added_country_index ON {$this->prefix}leads (date_added, country)");
+        $this->addSql("CREATE INDEX {$this->prefix}date_added_index ON {$this->prefix}audit_log (date_added)");
+        $this->addSql("CREATE INDEX {$this->prefix}date_hit_left_index ON {$this->prefix}page_hits (date_hit, date_left)");
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3523

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Some dashboard wigets requires MySQL queries that can take really long time with large data (about million dataset), is leads to timeout. This PR add some indexes to speed up the data fetching. 

#### Steps to test this PR:
1. Apply this PR 
2. Navigate to Dashboard Page 
3. Check whether the page speed is increased
