### PR TITLE
Fixing campaign condition values for state, timezone and nuber contact fields

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/6.forms.js
+++ b/app/bundles/CoreBundle/Assets/js/6.forms.js
@@ -582,7 +582,7 @@ Mautic.updateFieldOperatorValue = function(field, action) {
                 valueField.chosen('destroy');
             }
 
-            if (!mQuery.isEmptyObject(response.options)) {
+            if (!mQuery.isEmptyObject(response.options) && response.fieldType !== 'number') {
                 var newValueField = mQuery('<select/>')
                     .attr('class', valueFieldAttrs['class'])
                     .attr('id', valueFieldAttrs['id'])
@@ -624,11 +624,12 @@ Mautic.updateFieldOperatorValue = function(field, action) {
             }
 
             if (!mQuery.isEmptyObject(response.operators)) {
+                var operatorField = mQuery('#'+fieldPrefix+'operator');
+
                 if (mQuery('#'+fieldPrefix+'operator_chosen').length) {
-                    mQuery('#'+fieldPrefix+'operator').chosen('destroy');
+                    operatorField.chosen('destroy');
                 }
 
-                var operatorField = mQuery('#'+fieldPrefix+'operator');
                 var operatorFieldAttrs = {
                     'class': operatorField.attr('class'),
                     'id': operatorField.attr('id'),
@@ -645,10 +646,7 @@ Mautic.updateFieldOperatorValue = function(field, action) {
                     .attr('value', operatorFieldAttrs['value'])
                     .attr('onchange', 'Mautic.updateLeadFieldValues(this)');
                 mQuery.each(response.operators, function(optionKey, optionVal) {
-                    var option = mQuery("<option/>")
-                        .attr('value', optionKey)
-                        .text(optionVal);
-                    newOperatorField.append(option);
+                    newOperatorField.append(Mautic.createOption(optionKey, optionVal));
                 });
                 operatorField.replaceWith(newOperatorField);
                 Mautic.activateChosenSelect(newOperatorField);

--- a/app/bundles/CoreBundle/Assets/js/6.forms.js
+++ b/app/bundles/CoreBundle/Assets/js/6.forms.js
@@ -535,6 +535,17 @@ Mautic.removeFormListOption = function (el) {
 };
 
 /**
+ * Creates a select option element with a name and label
+ * @param value
+ * @param label
+ */
+Mautic.createOption = function (value, label) {
+    return mQuery('<option/>')
+        .attr('value', value)
+        .text(label);
+}
+
+/**
  * Updates operator select and value input format based on selected field and operator
  *
  * @param field
@@ -568,7 +579,7 @@ Mautic.updateFieldOperatorValue = function(field, action) {
             };
 
             if (mQuery('#'+fieldPrefix+'value_chosen').length) {
-                mQuery('#'+fieldPrefix+'value').chosen('destroy');
+                valueField.chosen('destroy');
             }
 
             if (!mQuery.isEmptyObject(response.options)) {
@@ -578,11 +589,16 @@ Mautic.updateFieldOperatorValue = function(field, action) {
                     .attr('name', valueFieldAttrs['name'])
                     .attr('autocomplete', valueFieldAttrs['autocomplete'])
                     .attr('value', valueFieldAttrs['value']);
-                mQuery.each(response.options, function(optionKey, optionVal) {
-                    var option = mQuery("<option/>")
-                        .attr('value', optionKey)
-                        .text(optionVal);
-                    newValueField.append(option);
+                mQuery.each(response.options, function(value, optgroup) {
+                    if (typeof optgroup === 'object') {
+                        var optgroupEl = mQuery('<optgroup/>').attr('label', value);
+                        mQuery.each(optgroup, function(optVal, label) {
+                            optgroupEl.append(Mautic.createOption(optVal, label))
+                        });
+                        newValueField.append(optgroupEl);
+                    } else {
+                        newValueField.append(Mautic.createOption(value, optgroup));
+                    }
                 });
                 valueField.replaceWith(newValueField);
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2725, https://github.com/mautic/mautic/issues/3493
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
https://github.com/mautic/mautic/issues/3493: If a campaign condition was based on a field with optgroups like state or timezone, the select was not build right. See the screenshot in the linked issue.

https://github.com/mautic/mautic/issues/3493: If the contact field of number was selected, the rounding options was used to build a select from the value field. There should be just a text field instead.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
0. Make sure you have a contact field type of number. If not, create one.
1. Try to create a campaign condition based on a state or timezone contact field. The select options are clearly buggy.
2. Try to create a campaign condition based on a number field. You are not able to fill in the value you want.

#### Steps to test this PR:
1. Apply this PR
2. Build production assets with `app/console mautic:assets:generate` or use the dev environment.
3. Test again. The opt groups with options will load correctly. Normal select fields must still work.