### PR TITLE
Boolean cotact field values were set to false on every form submit - …

### DIFF
--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -791,8 +791,6 @@ class SubmissionModel extends CommonFormModel
         $getData = function ($currentFields, $uniqueOnly = false) use ($leadFields, $uniqueLeadFields) {
             $uniqueFieldsWithData = $data = [];
             foreach ($leadFields as $alias => $properties) {
-                $data[$alias] = '';
-
                 if (isset($currentFields[$alias])) {
                     $value        = $currentFields[$alias];
                     $data[$alias] = $value;


### PR DESCRIPTION
…fixed

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3489
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The form submission process generates an empty string for every contact field which doesn't exist in the form. I couldn't think of a reason why it's doing that. It is a reason why the  boolean contact fields were set to false on every Mautic form submission (empty string is taken as false). I suggest a fix of providing only the values which exists in the form and are linked with a contact field to be send to the LeadModel to update/create the contact.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a custom boolean field eg fieldBool
2. Edit a contact and set the field to "Yes". Review the contact details to make sure the changes were applied
3. Create a form with only one field for email address
4. Go to the form page, enter the email address from the contact edited in step 2, and submit the form
5. Reload the contact and view the details, fieldBool will now be set to 0

#### Steps to test this PR:
1. Apply this PR
2. Test again
3. Make sure all form submissions, ecpecially the contact merging part, still work correctly. 