### PR TITLE
Excel export in reports removed the first row - fixed

### DIFF
--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -389,10 +389,11 @@ class ReportModel extends FormModel
                             }
 
                             if ($count === 0) {
-                                //write the row
+                                //write the column names row
                                 fputcsv($handle, $header);
                             }
 
+                            //write the row
                             fputcsv($handle, $row);
 
                             //free memory
@@ -447,13 +448,14 @@ class ReportModel extends FormModel
                                     $row[] = $formatter->_($v, $reportData['columns'][$reportData['dataColumns'][$k]]['type'], true);
                                 }
 
-                                //write the row
                                 if ($count === 0) {
+                                    //write the column names row
                                     $objPHPExcel->getActiveSheet()->fromArray($header, null, 'A1');
-                                } else {
-                                    $rowCount = $count + 1;
-                                    $objPHPExcel->getActiveSheet()->fromArray($row, null, "A{$rowCount}");
                                 }
+
+                                //write the row
+                                $rowCount = $count + 2;
+                                $objPHPExcel->getActiveSheet()->fromArray($row, null, "A{$rowCount}");
 
                                 //free memory
                                 unset($row, $reportData['data'][$count]);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3474
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The export to Excel sheet in Reports removed the first row because of collision with the column name row.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create 3 leads
2. Make a report on all contacts
3. Export to excel
4. Notice the first one is missing

#### Steps to test this PR:
1. Apply the PR
2. Test again
- All rows should be there
