### PR TITLE
Do not validate fields which are hidded due to progressive profiling

### DIFF
--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -418,6 +418,26 @@ class FormModel extends CommonFormModel
     }
 
     /**
+     * Get results for a form and lead.
+     *
+     * @param Form $form
+     * @param int  $leadId
+     * @param int  $limit
+     *
+     * @return array
+     */
+    public function getLeadSubmissions(Form $form, $leadId, $limit = 200)
+    {
+        return $this->getRepository()->getFormResults(
+            $form,
+            [
+                'leadId' => $leadId,
+                'limit'  => $limit,
+            ]
+        );
+    }
+
+    /**
      * Generate the form's html.
      *
      * @param Form $entity
@@ -438,13 +458,7 @@ class FormModel extends CommonFormModel
         }
 
         if ($entity->usesProgressiveProfiling()) {
-            $submissions = $this->getRepository()->getFormResults(
-                $entity,
-                [
-                    'leadId' => $lead->getId(),
-                    'limit'  => 200,
-                ]
-            );
+            $submissions = $this->getLeadSubmissions($entity, $lead->getId());
         }
 
         if ($entity->getRenderStyle()) {

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -324,11 +324,6 @@ class SubmissionModel extends CommonFormModel
         // @deprecated - BC support; to be removed in 3.0 - be sure to remove the validator option from addSubmitAction as well
         $this->validateActionCallbacks($submissionEvent, $validationErrors, $alias);
 
-        //return errors if there any - this should be moved to right after foreach($fields) once validateActionCallbacks support is dropped
-        if (!empty($validationErrors)) {
-            return ['errors' => $validationErrors];
-        }
-
         // Create/update lead
         if (!empty($leadFieldMatches)) {
             $lead = $this->createLeadFromSubmit($form, $leadFieldMatches, $leadFields);
@@ -345,6 +340,22 @@ class SubmissionModel extends CommonFormModel
             $submission->setTrackingId($trackingId);
         }
         $submission->setLead($lead);
+
+        // Remove validation errors if the field is not visible
+        if ($form->usesProgressiveProfiling()) {
+            $leadSubmissions = $this->formModel->getLeadSubmissions($form, $lead->getId());
+
+            foreach ($fields as $field) {
+                if (isset($validationErrors[$field->getAlias()]) && !$field->showForContact($leadSubmissions, $lead, $form)) {
+                    unset($validationErrors[$field->getAlias()]);
+                }
+            }
+        }
+
+        //return errors if there any
+        if (!empty($validationErrors)) {
+            return ['errors' => $validationErrors];
+        }
 
         // Save the submission
         $this->saveEntity($submission);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3316
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
There were issues with form validation if the form field was hidden because of some progressive profiling rule. This PR should resolve it for good.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form withe an email field.
2. Add another field to the form. For example type of text, called Name. Important is to add Behaviour - Show after X submissions = 1.
3. Save the form.
4. Access the form in a incognito window somehow. For example on a public page on URL `http://yourmautic.com/form/FORM_ID` or embed it to a landing page.
5. If you try to submit the form, the submit button stays disabled which is caused by the validation error on a field which is not visible.


#### Steps to test this PR:
1. Apply this PR
2. Repeat the test. After the point 5 the submit goes well.
6. Refresh the page.
7. You should see both, the email field and the name field.