### PR TITLE
Content builder sections responsiveness improved

### DIFF
--- a/app/bundles/CoreBundle/Views/Sections/three-column.html.php
+++ b/app/bundles/CoreBundle/Views/Sections/three-column.html.php
@@ -11,22 +11,36 @@
 ?>
 <div data-section-wrapper="1">
     <center>
-        <table data-section="1" style="margin: 0 auto;border-collapse: collapse !important;width: 600px;" class="w320" cellpadding="0" cellspacing="0" width="600">
+        <table data-section="1" style="margin: 0 auto;border-collapse: collapse !important;width: 600px;" class="w320" border="0" cellpadding="0" cellspacing="0" width="600">
             <tr>
-                <td data-slot-container="1" valign="top" class="mobile-block" style="padding-left: 5px; padding-right: 5px;">
-                    <div data-slot="text">
-                        <p>Lorem ipsum dolor sit amet, alterum definitiones eu est. Eos no scripta voluptatum necessitatibus, ea his case movet. Porro vivendo delicatissimi ea qui, in usu aliquam consulatu conclusionemque. Eu vel mazim periculis consequat, quo fastidii salutandi eu, et sed nibh exerci consequuntur. Cu diam efficiendi eum, pri eu delenit insolens. Usu nihil oporteat an, et stet mucius vix, ex nostro assueverit mel.</p>
-                    </div>
-                </td>
-                <td data-slot-container="1" valign="top" class="mobile-block" style="padding-left: 5px; padding-right: 5px;">
-                    <div data-slot="text">
-                        <p>Lorem ipsum dolor sit amet, alterum definitiones eu est. Eos no scripta voluptatum necessitatibus, ea his case movet. Porro vivendo delicatissimi ea qui, in usu aliquam consulatu conclusionemque. Eu vel mazim periculis consequat, quo fastidii salutandi eu, et sed nibh exerci consequuntur. Cu diam efficiendi eum, pri eu delenit insolens. Usu nihil oporteat an, et stet mucius vix, ex nostro assueverit mel.</p>
-                    </div>
-                </td>
-                <td data-slot-container="1" valign="top" class="mobile-block" style="padding-left: 5px; padding-right: 5px;">
-                    <div data-slot="text">
-                        <p>Lorem ipsum dolor sit amet, alterum definitiones eu est. Eos no scripta voluptatum necessitatibus, ea his case movet. Porro vivendo delicatissimi ea qui, in usu aliquam consulatu conclusionemque. Eu vel mazim periculis consequat, quo fastidii salutandi eu, et sed nibh exerci consequuntur. Cu diam efficiendi eum, pri eu delenit insolens. Usu nihil oporteat an, et stet mucius vix, ex nostro assueverit mel.</p>
-                    </div>
+                <td align="center" valign="top">
+                    <table align="left" border="0" cellpadding="10" cellspacing="0" width="200" class="mobile-block">
+                        <tr>
+                            <td data-slot-container="1" valign="top" style="padding-left: 5px; padding-right: 5px;">
+                                <div data-slot="text">
+                                    <p>Lorem ipsum dolor sit amet, alterum definitiones eu est. Eos no scripta voluptatum necessitatibus, ea his case movet. Porro vivendo delicatissimi ea qui, in usu aliquam consulatu conclusionemque. Eu vel mazim periculis consequat, quo fastidii salutandi eu, et sed nibh exerci consequuntur. Cu diam efficiendi eum, pri eu delenit insolens. Usu nihil oporteat an, et stet mucius vix, ex nostro assueverit mel.</p>
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                    <table align="left" border="0" cellpadding="10" cellspacing="0" width="200" class="mobile-block">
+                        <tr>
+                            <td data-slot-container="1" valign="top" style="padding-left: 5px; padding-right: 5px;">
+                                <div data-slot="text">
+                                    <p>Lorem ipsum dolor sit amet, alterum definitiones eu est. Eos no scripta voluptatum necessitatibus, ea his case movet. Porro vivendo delicatissimi ea qui, in usu aliquam consulatu conclusionemque. Eu vel mazim periculis consequat, quo fastidii salutandi eu, et sed nibh exerci consequuntur. Cu diam efficiendi eum, pri eu delenit insolens. Usu nihil oporteat an, et stet mucius vix, ex nostro assueverit mel.</p>
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                    <table align="right" border="0" cellpadding="10" cellspacing="0" width="200" class="mobile-block">
+                        <tr>
+                            <td data-slot-container="1" valign="top" style="padding-left: 5px; padding-right: 5px;">
+                                <div data-slot="text">
+                                    <p>Lorem ipsum dolor sit amet, alterum definitiones eu est. Eos no scripta voluptatum necessitatibus, ea his case movet. Porro vivendo delicatissimi ea qui, in usu aliquam consulatu conclusionemque. Eu vel mazim periculis consequat, quo fastidii salutandi eu, et sed nibh exerci consequuntur. Cu diam efficiendi eum, pri eu delenit insolens. Usu nihil oporteat an, et stet mucius vix, ex nostro assueverit mel.</p>
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
                 </td>
             </tr>
         </table>

--- a/app/bundles/CoreBundle/Views/Sections/two-column.html.php
+++ b/app/bundles/CoreBundle/Views/Sections/two-column.html.php
@@ -11,17 +11,27 @@
 ?>
 <div data-section-wrapper="1">
     <center>
-        <table data-section="1" style="margin: 0 auto;border-collapse: collapse !important;width: 600px;" class="w320" cellpadding="0" cellspacing="0" width="600">
+        <table data-section="1" style="margin: 0 auto;border-collapse: collapse !important;width: 600px;" class="w320" border="0" cellpadding="0" cellspacing="0" width="600">
             <tr>
-                <td data-slot-container="1" valign="top" class="mobile-block" style="padding-left: 5px; padding-right: 5px;">
-                    <div data-slot="text">
-                        <p>Lorem ipsum dolor sit amet, alterum definitiones eu est. Eos no scripta voluptatum necessitatibus, ea his case movet. Porro vivendo delicatissimi ea qui, in usu aliquam consulatu conclusionemque. Eu vel mazim periculis consequat, quo fastidii salutandi eu, et sed nibh exerci consequuntur. Cu diam efficiendi eum, pri eu delenit insolens. Usu nihil oporteat an, et stet mucius vix, ex nostro assueverit mel.</p>
-                    </div>
-                </td>
-                <td data-slot-container="1" valign="top" class="mobile-block" style="padding-left: 5px; padding-right: 5px;">
-                    <div data-slot="text">
-                        <p>Lorem ipsum dolor sit amet, alterum definitiones eu est. Eos no scripta voluptatum necessitatibus, ea his case movet. Porro vivendo delicatissimi ea qui, in usu aliquam consulatu conclusionemque. Eu vel mazim periculis consequat, quo fastidii salutandi eu, et sed nibh exerci consequuntur. Cu diam efficiendi eum, pri eu delenit insolens. Usu nihil oporteat an, et stet mucius vix, ex nostro assueverit mel.</p>
-                    </div>
+                <td align="center" valign="top">
+                    <table align="left" border="0" cellpadding="10" cellspacing="0" width="300" class="mobile-block">
+                        <tr>
+                            <td data-slot-container="1" valign="top" style="padding-left: 5px; padding-right: 5px;">
+                                <div data-slot="text">
+                                    <p>Lorem ipsum dolor sit amet, alterum definitiones eu est. Eos no scripta voluptatum necessitatibus, ea his case movet. Porro vivendo delicatissimi ea qui, in usu aliquam consulatu conclusionemque. Eu vel mazim periculis consequat, quo fastidii salutandi eu, et sed nibh exerci consequuntur. Cu diam efficiendi eum, pri eu delenit insolens. Usu nihil oporteat an, et stet mucius vix, ex nostro assueverit mel.</p>
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                    <table align="right" border="0" cellpadding="10" cellspacing="0" width="300" class="mobile-block">
+                        <tr>
+                            <td data-slot-container="1" valign="top" style="padding-left: 5px; padding-right: 5px;">
+                                <div data-slot="text">
+                                    <p>Lorem ipsum dolor sit amet, alterum definitiones eu est. Eos no scripta voluptatum necessitatibus, ea his case movet. Porro vivendo delicatissimi ea qui, in usu aliquam consulatu conclusionemque. Eu vel mazim periculis consequat, quo fastidii salutandi eu, et sed nibh exerci consequuntur. Cu diam efficiendi eum, pri eu delenit insolens. Usu nihil oporteat an, et stet mucius vix, ex nostro assueverit mel.</p>
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
                 </td>
             </tr>
         </table>

--- a/themes/blank/html/email.html.twig
+++ b/themes/blank/html/email.html.twig
@@ -1,6 +1,21 @@
+<!DOCTYPE html>
 <html>
     <head>
         <title>{subject}</title>
+        <style type="text/css" media="only screen and (max-width: 480px)">
+            /* Mobile styles */
+            @media only screen and (max-width: 480px) {
+
+                [class="w320"] {
+                    width: 320px !important;
+                }
+
+                [class="mobile-block"] {
+                    width: 100% !important;
+                    display: block !important;
+                }
+            }
+        </style>
     </head>
     <body style="margin:0">
         <div data-section-wrapper="1">

--- a/themes/goldstar/html/email.html.twig
+++ b/themes/goldstar/html/email.html.twig
@@ -56,6 +56,20 @@
             div[class='h2'] { font-size: 44px !important; line-height: 48px !important; }
         } 
     </style>
+    <style type="text/css" media="only screen and (max-width: 480px)">
+        /* Mobile styles */
+        @media only screen and (max-width: 480px) {
+
+            [class="w320"] {
+                width: 320px !important;
+            }
+
+            [class="mobile-block"] {
+                width: 100% !important;
+                display: block !important;
+            }
+        }
+    </style>
 </head>
 <body class="body" style="padding:0 !important; margin:0 !important; display:block !important; background:#1e1e1e; -webkit-text-size-adjust:none">
     <div data-section-wrapper="1"  width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#161616">

--- a/themes/neopolitan/html/email.html.twig
+++ b/themes/neopolitan/html/email.html.twig
@@ -79,15 +79,14 @@
         /* Mobile styles */
         @media only screen and (max-width: 480px) {
 
-            table[class="w320"] {
+            [class="w320"] {
                 width: 320px !important;
             }
 
-            td[class="mobile-block"] {
+            [class="mobile-block"] {
                 width: 100% !important;
                 display: block !important;
             }
-
         }
     </style>
 </head>

--- a/themes/oxygen/html/email.html.twig
+++ b/themes/oxygen/html/email.html.twig
@@ -2,6 +2,20 @@
 <html>
     <head>
         <title>{subject}</title>
+        <style type="text/css" media="only screen and (max-width: 480px)">
+            /* Mobile styles */
+            @media only screen and (max-width: 480px) {
+
+                [class="w320"] {
+                    width: 320px !important;
+                }
+
+                [class="mobile-block"] {
+                    width: 100% !important;
+                    display: block !important;
+                }
+            }
+        </style>
     </head>
     <body style="font-family: Helvetica, Arial, sans-serif;color: #676767;width: 100%;margin: 0;">
         <div data-section-wrapper="1" style="width:100%;background-color: #f7f7f7;font-family: Helvetica, Arial, sans-serif;font-size: 14px;color: #777777;text-align: center;line-height: 21px;padding: 20px 0 30px;" class="content-padding">

--- a/themes/skyline/html/email.html.twig
+++ b/themes/skyline/html/email.html.twig
@@ -93,6 +93,11 @@
                 padding-right: 20px !important;
                 padding-bottom: 20px !important;
             }
+
+            [class="mobile-block"] {
+                width: 100% !important;
+                display: block !important;
+            }
         }
     </style>
 </head>

--- a/themes/sunday/html/email.html.twig
+++ b/themes/sunday/html/email.html.twig
@@ -128,6 +128,11 @@
                 padding-top: 20px !important;
             }
 
+            [class="mobile-block"] {
+                width: 100% !important;
+                display: block !important;
+            }
+
         }
     </style>
 </head>


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Current sections are responsive only for modern browsers. They have problems with email clients. This PR updates the section HTML according to this tutorial: https://templates.mailchimp.com/development/responsive-email/responsive-column-layouts/

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Add a 2 and 3 column section to a stock theme.
2. Send it to yourself.
3. Open the sent email in your mobile device.
- The columns does not wrap into one column, the layout stays to be 2, 3 column.

#### Steps to test this PR:
1. Apply this PR
2. Create a new email with new 2 and 3 column sections
3. Send it to yourself.
4. Open the sent email in your mobile device.
- The columns should wrap into one column.