### PR TITLE
fix for deleted fields filters in segments

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -318,7 +318,7 @@ class LeadListRepository extends CommonRepository
                 if ($includesContactFields) {
                     $expr = $this->getListFilterExpr($objectFilters['lead'], $parameters, $q, false, null, 'lead');
                 }
-                if (!$expr->count()) {
+                if (empty($expr) || !$expr->count()) {
                     $nonMembersOnly = true;
                 }
                 if ($includesCompanyFields) {
@@ -376,7 +376,7 @@ class LeadListRepository extends CommonRepository
                     }
                 }
 
-                if ($newOnly && $expr->count()) {
+                if ($newOnly && !empty($expr) && $expr->count()) {
                     if ($includesCompanyFields) {
                         $this->applyCompanyFieldFilters($q, $exprCompany);
                     }
@@ -435,7 +435,7 @@ class LeadListRepository extends CommonRepository
                     $sq = $this->getEntityManager()->getConnection()->createQueryBuilder();
                     $sq->select('l.id')
                         ->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
-                    if ($includesContactFields and $expr->count()) {
+                    if ($includesContactFields && !empty($expr) && $expr->count()) {
                         $sq->andWhere($expr);
                     }
 

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -401,9 +401,12 @@ class LeadListRepository extends CommonRepository
                         'll',
                         $listOnExpr
                     );
-                    $expr->add($q->expr()->isNull('ll.lead_id'));
-
-                    if ($batchExpr->count()) {
+                    if ($expr) {
+                        $expr->add($q->expr()->isNull('ll.lead_id'));
+                    } else {
+                        $expr = $q->expr()->andX($q->expr()->isNull('ll.lead_id'));
+                    }
+                    if ($batchExpr->count() and count($expr)) {
                         $expr->add($batchExpr);
                     }
 
@@ -434,7 +437,7 @@ class LeadListRepository extends CommonRepository
                     $sq->select('l.id')
                         ->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
 
-                    if ($includesContactFields) {
+                    if ($includesContactFields and $expr) {
                         $sq->andWhere($expr);
                     }
 
@@ -1113,7 +1116,7 @@ class LeadListRepository extends CommonRepository
                             $groupExpr->add(
                                 $this->generateFilterExpression($q, $field, $func, $details['filter'], null)
                             );
-
+                            echo 'hola';
                             $ignoreAutoFilter = true;
                             break;
 
@@ -1176,11 +1179,10 @@ class LeadListRepository extends CommonRepository
         if ($groupExpr->count()) {
             $groups[] = $groupExpr;
         }
-
         if (count($groups) === 1) {
             // Only one andX expression
             $expr = $groups[0];
-        } else {
+        } elseif (count($groups) > 1) {
             // Sets of expressions grouped by OR
             $orX = $q->expr()->orX();
             $orX->addMultiple($groups);

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -409,8 +409,9 @@ class LeadListRepository extends CommonRepository
                     if ($batchExpr->count() and count($expr)) {
                         $expr->add($batchExpr);
                     }
-
-                    $q->andWhere($expr);
+                    if (!empty($expr) && $expr->count() > 0) {
+                        $q->andWhere($expr);
+                    }
                 } elseif ($nonMembersOnly) {
                     // Only leads that are part of the list that no longer match filters and have not been manually removed
                     $q->join('l', MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'll', 'l.id = ll.lead_id');
@@ -436,8 +437,7 @@ class LeadListRepository extends CommonRepository
                     $sq = $this->getEntityManager()->getConnection()->createQueryBuilder();
                     $sq->select('l.id')
                         ->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
-
-                    if ($includesContactFields and $expr) {
+                    if ($includesContactFields && $expr && $expr->count() > 0) {
                         $sq->andWhere($expr);
                     }
 
@@ -452,8 +452,9 @@ class LeadListRepository extends CommonRepository
                     if ($batchExpr->count()) {
                         $mainExpr->add($batchExpr);
                     }
-
-                    $q->andWhere($mainExpr);
+                    if (!empty($mainExpr) && $mainExpr->count() > 0) {
+                        $q->andWhere($mainExpr);
+                    }
                 }
 
                 // Set limits if applied
@@ -512,8 +513,9 @@ class LeadListRepository extends CommonRepository
                     $q->setFirstResult($start)
                         ->setMaxResults($limit);
                 }
-
-                $q->where($expr);
+                if (!empty($expr) && $expr->count() > 0) {
+                    $q->where($expr);
+                }
 
                 $results = $q->execute()->fetchAll();
 
@@ -1188,6 +1190,8 @@ class LeadListRepository extends CommonRepository
 
             // Wrap in a andX for other functions to append
             $expr = $q->expr()->andX($orX);
+        } else {
+            $expr = $groupExpr;
         }
 
         return $expr;

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -1116,7 +1116,6 @@ class LeadListRepository extends CommonRepository
                             $groupExpr->add(
                                 $this->generateFilterExpression($q, $field, $func, $details['filter'], null)
                             );
-                            echo 'hola';
                             $ignoreAutoFilter = true;
                             break;
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #2582
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixes bug when a custom field that is used in a segment filter is deleted
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. create a custom field
2. use it in a segment filter and update the segment
3. there should be an error

#### Steps to test this PR:
1. same as above, but the error is gone when updating segments