### PR TITLE
Automatic HTTPS for generate.js

### DIFF
--- a/app/bundles/FormBundle/Views/Builder/form.html.php
+++ b/app/bundles/FormBundle/Views/Builder/form.html.php
@@ -20,7 +20,8 @@ $pageCount = 1;
 <div id="mauticform_wrapper<?php echo $formName ?>" class="mauticform_wrapper">
     <form autocomplete="false" role="form" method="post" action="<?php echo $view['router']->url(
         'mautic_form_postresults',
-        ['formId' => $form->getId()]
+        ['formId' => $form->getId()],
+        self:ABSOLUTE_PATH
     ); ?>" id="mauticform<?php echo $formName ?>" data-mautic-form="<?php echo ltrim($formName, '_') ?>">
         <div class="mauticform-error" id="mauticform<?php echo $formName ?>_error"></div>
         <div class="mauticform-message" id="mauticform<?php echo $formName ?>_message"></div>

--- a/plugins/MauticFocusBundle/Views/Builder/form.html.php
+++ b/plugins/MauticFocusBundle/Views/Builder/form.html.php
@@ -109,7 +109,7 @@ if (empty($preview)):
         <form autocomplete="false" role="form" method="post" action="<?php echo $view['router']->url(
             'mautic_form_postresults',
             ['formId' => $form->getId()],
-            true
+            self::ABSOLUTE_PATH
         ); ?>" id="mauticform<?php echo $formName ?>" data-mautic-form="<?php echo $jsFormName; ?>">
             <div class="mauticform-error" id="mauticform<?php echo $formName ?>_error"></div>
             <div class="mauticform-message" id="mauticform<?php echo $formName ?>_message"></div>


### PR DESCRIPTION
#2778 - Automatic HTTPS redirect doesn't work for forms
Solution, call $reference_type = ABSOLUTE_PATH with self::ABSOLUTE_PATH
* http://api.symfony.com/2.7/Symfony/Component/Routing/Generator/UrlGeneratorInterface.html
* “when you call this method with $referenceType = ABSOLUTE_PATH but the route requires the https scheme whereas the current scheme is http, it will instead return an ABSOLUTE_URL with the https scheme and the current host. This makes sure the generated URL matches the route in any case.”

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #2778 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When you have a HTTPS Mautic instance and you embed a form onto another HTTPS site, the generateform.js file does not correctly generate the URL for the form submit as HTTPS. This Pull Request Fixes that. 

This does not fix the Helper Text Window mentioned in #2778, but instead fixes the references in the generateform.js which throw errors for mixed and insecure content once the forms are correctly embedded.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Have a HTTPS Mautic Instance and HTTPS Website
2. Embed a Form to your site using the manual embed JS method.
3. Update the script to correctly reference your HTTPS mautic domain.
4. Try to submit, the nested generate.js will incorrectly reference the HTTP url of the Mautic instance.

#### Steps to test this PR:
1. Have both a HTTPS Mautic instance and a HTTPS Website
2. Embed a Form 
3. You must manually update the form embed to reference the https:// version of your site. See the description above about how the helper Text Window is not fixed.
4. Submit your form, you should no longer receive an error for mixed insecure/secure content.

