### PR TITLE
Non admin roles can unlock entities

### DIFF
--- a/app/bundles/CampaignBundle/Form/Type/ConfigType.php
+++ b/app/bundles/CampaignBundle/Form/Type/ConfigType.php
@@ -1,5 +1,14 @@
 <?php
-// plugins/HelloWorldBundle/Form/Type/ConfigType.php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
 namespace Mautic\CampaignBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;

--- a/app/bundles/CoreBundle/Controller/AbstractFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractFormController.php
@@ -30,8 +30,9 @@ abstract class AbstractFormController extends CommonController
      */
     public function unlockAction($id, $modelName)
     {
-        $model  = $this->getModel($modelName);
-        $entity = $model->getEntity($id);
+        $model                = $this->getModel($modelName);
+        $entity               = $model->getEntity($id);
+        $this->permissionBase = $model->getPermissionBase();
 
         if ($this->canEdit($entity)) {
             if ($entity !== null && $entity->getCheckedOutBy() !== null) {
@@ -190,16 +191,22 @@ abstract class AbstractFormController extends CommonController
     {
         $security = $this->get('mautic.security');
 
-        if ($this->getPermissionBase()) {
-            if ($entity && $security->checkPermissionExists($this->getPermissionBase().':editown')) {
+        if ($this->permissionBase) {
+            $permissionBase = $this->permissionBase;
+        } else {
+            $permissionBase = $this->getPermissionBase();
+        }
+
+        if ($permissionBase) {
+            if ($entity && $security->checkPermissionExists($permissionBase.':editown')) {
                 return $security->hasEntityAccess(
-                    $this->getPermissionBase().':editown',
-                    $this->getPermissionBase().':editother',
+                    $permissionBase.':editown',
+                    $permissionBase.':editother',
                     $entity->getCreatedBy()
                 );
-            } elseif ($security->checkPermissionExists($this->getPermissionBase().':edit')) {
+            } elseif ($security->checkPermissionExists($permissionBase.':edit')) {
                 return $security->isGranted(
-                    $this->getPermissionBase().':edit'
+                    $permissionBase.':edit'
                 );
             }
         }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The unlocking works only for admins because the permissionBase is not defined in this case. The request goes to a controller which doesn't have any specific model assigned. And method [getPermissionBase()](https://github.com/mautic/mautic/blob/staging/app/bundles/CoreBundle/Controller/FormController.php#L150) is deprecated and returns always null.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new role with complete access to campaigns.
2. Create a new user with that role.
3. Open a new incognito browser window and log in with that new user.
4. Open the edit for for a campaign with your admin user.
5. Try to edit that campaign with your new user.
6. A notice will appear where the unlock link is. But if you click it, you get 403 error.

#### Steps to test this PR:
1. Apply this PR
2. Try to unlock the campaign again. It should go smoothly.