### PR TITLE
Outlook XML v: namespace enabled

### DIFF
--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -393,7 +393,7 @@ class InputHelper
 
             // Slecial handling for XML tags used in Outlook optimized emails <o:*/> and <w:/>
             $value = preg_replace_callback(
-                "/<\/*[o|w]:[^>]*>/is",
+                "/<\/*[o|w|v]:[^>]*>/is",
                 function ($matches) {
                     return '<mencoded>'.htmlspecialchars($matches[0]).'</mencoded>';
                 },


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/pull/3476#issuecomment-284662523
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Outlook uses special XML tags. Sadly, Microsoft doesn't have any documentation about what the special tags are. This PR adds `v:` namespace support. The PR linked above added `o:` and `w:` namespaces support.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to save an email in the Code Mode with this XML in it:
```
<v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="http://litmus.com" style="height:36px;v-text-anchor:middle;width:150px;" arcsize="5%" strokecolor="#EB7035" fillcolor="#EB7035">
</v:roundrect>
```
It will get stripped which it shouldn't.

#### Steps to test this PR:
1. Apply this PR
2. Test again. The testing code will stay after save.