### PR TITLE
Fixed social monitoring detail chart

### DIFF
--- a/plugins/MauticSocialBundle/Entity/PostCountRepository.php
+++ b/plugins/MauticSocialBundle/Entity/PostCountRepository.php
@@ -46,19 +46,13 @@ class PostCountRepository extends CommonRepository
         $chartQuery = new ChartQuery($this->getEntityManager()->getConnection(), $dateFrom, $dateTo);
 
         // Load points for selected period
-        $q = $this->_em->getConnection()->createQueryBuilder();
-        $q->select('cl.post_count, cl.post_date')
-            ->from(MAUTIC_TABLE_PREFIX.'monitor_post_count', 'cl')
-            ->orderBy('cl.post_date', 'ASC');
-
+        $q = $chartQuery->prepareTimeDataQuery(MAUTIC_TABLE_PREFIX.'monitor_post_count', 'post_date', $options);
         if (isset($options['monitor_id'])) {
-            $q->andwhere($q->expr()->eq('cl.monitor_id', (int) $options['monitor_id']));
+            $q->andwhere($q->expr()->eq('t.monitor_id', (int) $options['monitor_id']));
         }
 
-        $chartQuery->applyDateFilters($q, 'post_date', 'cl');
+        $data = $chartQuery->loadAndBuildTimeData($q);
 
-        $postCount = $q->execute()->fetchAll();
-
-        return $postCount;
+        return $data;
     }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2753
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixes the chart displayed in the social monitoring detail
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. setup social monitoring and create some entries by doing a mention or hashtag and running the cronjob <php app/console mautic:social:monitoring>
2. The chart will not display the number of tweets gleaned

#### Steps to test this PR:
1. Apply this PR and refresh the social monitoring detail page
2. the chart should be displaying the number of tweets