### PR TITLE
Citrix Segments Error

### DIFF
--- a/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
+++ b/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
@@ -194,7 +194,8 @@ class LeadSubscriber extends CommonSubscriber
                             'list' => $eventNamesWithAny,
                         ],
                         'operators' => [
-                            'include' => ['in', '!in'],
+                            'in'  => $event->getTranslator()->trans('mautic.core.operator.in'),
+                            '!in' => $event->getTranslator()->trans('mautic.core.operator.notin'),
                         ],
                     ]
                 );
@@ -210,7 +211,8 @@ class LeadSubscriber extends CommonSubscriber
                         'list' => $eventNamesWithAny,
                     ],
                     'operators' => [
-                        'include' => ['in', '!in'],
+                        'in'  => $event->getTranslator()->trans('mautic.core.operator.in'),
+                        '!in' => $event->getTranslator()->trans('mautic.core.operator.notin'),
                     ],
                 ]
             );
@@ -225,7 +227,7 @@ class LeadSubscriber extends CommonSubscriber
                         'list' => $eventNamesWithoutAny,
                     ],
                     'operators' => [
-                        'include' => ['in'],
+                        'in' => $event->getTranslator()->trans('mautic.core.operator.in'),
                     ],
                 ]
             );


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3617
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes the Citrix segments filters issue.

#### Steps to reproduce the bug:
1. See https://github.com/mautic/mautic/issues/3617

#### Steps to test this PR:
1. Apply this PR
2. Make sure the GotoWebinar plugin is activated
3. Goto Segments and try to create one using GotoWebinar (attended) or GotoWebinar (registered) filter.
4. The operators in the combobox will show the correct labels.

