### PR TITLE
Unable to set isUniqueIdentifier for field via api

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/FieldApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/FieldApiController.php
@@ -56,6 +56,10 @@ class FieldApiController extends CommonApiController
     protected function prepareParametersForBinding($parameters, $entity, $action)
     {
         $parameters['object'] = $this->fieldObject;
+        // Workaround for mispelled isUniqueIdentifer.
+        if (isset($parameters['isUniqueIdentifier'])) {
+            $parameters['isUniqueIdentifer'] = $parameters['isUniqueIdentifier'];
+        }
 
         return $parameters;
     }


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3315
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes the issue reported in https://github.com/mautic/mautic/issues/3315

The other workaround is to set `isUniqueIdentifer` (misspelled) to true instead. It will work too.

#### Steps to reproduce the bug:
1. See https://github.com/mautic/mautic/issues/3315

#### Steps to test this PR:
1. Apply this PR
2. Repeat the previous steps.
3.  `isUniqueIdentifier` will be set to true.


