### PR TITLE
Ensure EmailRepository has currentUser set before accessing it.

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -366,8 +366,17 @@ return [
             ],
             'mautic.form.type.leadlist' => [
                 'class'     => 'Mautic\LeadBundle\Form\Type\ListType',
-                'arguments' => ['translator', 'mautic.lead.model.list', 'mautic.email.model.email', 'mautic.security', 'mautic.lead.model.lead', 'mautic.stage.model.stage', 'mautic.category.model.category'],
-                'alias'     => 'leadlist',
+                'arguments' => [
+                    'translator',
+                    'mautic.lead.model.list',
+                    'mautic.email.model.email',
+                    'mautic.security',
+                    'mautic.lead.model.lead',
+                    'mautic.stage.model.stage',
+                    'mautic.category.model.category',
+                    'mautic.helper.user',
+                ],
+                'alias' => 'leadlist',
             ],
             'mautic.form.type.leadlist_choices' => [
                 'class'     => 'Mautic\LeadBundle\Form\Type\LeadListType',

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -163,6 +163,7 @@ class ListController extends FormController
         //set the return URL for post actions
         $returnUrl = $this->generateUrl('mautic_segment_index', ['page' => $page]);
         $action    = $this->generateUrl('mautic_segment_action', ['objectAction' => 'new']);
+
         //get the user form factory
         $form = $model->createForm($list, $this->get('form.factory'),  $action);
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | #2994, #1768 
| BC breaks? | Explained Below
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixes an issue where the `currentUser` property was not populated, and we were trying to access it.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Follow steps to reproduce found on #2994

#### Steps to test this PR:
1. Apply PR, and try to reproduce
2. You should be able to load a new segment as a user with full contact access.

#### List backwards compatibility breaks:
1. This PR adds a required `$userHelper` parameter to the constructor for the ListType. It shouldn't be an issue as the constructors are never called directly by a user, but rather through Symfony's form factory.