### PR TITLE
Emails read on emails sent line graph bad data fix from #3379

### DIFF
--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -336,9 +336,10 @@ class ReportSubscriber extends CommonSubscriber
 
             switch ($g) {
                 case 'mautic.email.graph.line.stats':
-                    $chart       = new LineChart(null, $options['dateFrom'], $options['dateTo']);
-                    $sendQuery   = clone $queryBuilder;
-                    $readQuery   = clone $origQuery;
+                    $chart     = new LineChart(null, $options['dateFrom'], $options['dateTo']);
+                    $sendQuery = clone $queryBuilder;
+                    $readQuery = clone $origQuery;
+                    $readQuery->andWhere($qb->expr()->isNotNull('date_read'));
                     $failedQuery = clone $queryBuilder;
                     $failedQuery->andWhere($qb->expr()->eq('es.is_failed', ':true'));
                     $failedQuery->setParameter('true', true, 'boolean');


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3379
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes the issue reported in https://github.com/mautic/mautic/issues/3379

#### Steps to reproduce the bug:
1. See https://github.com/mautic/mautic/issues/3379

#### Steps to test this PR:
1. Apply this PR
2. Follow the previous steps
3. The line graph for Emails Read in the reports will show the correct data.

