### PR TITLE
Fix for Wrong numbering on report pages #3330

### DIFF
--- a/app/bundles/ReportBundle/Views/Report/details_data.html.php
+++ b/app/bundles/ReportBundle/Views/Report/details_data.html.php
@@ -15,7 +15,7 @@ if ($tmpl == 'index') {
 $dataCount   = count($data);
 $columnOrder = $report->getColumns();
 $graphOrder  = $report->getGraphs();
-$startCount  = ($dataCount > $limit) ? ($reportPage * $limit) - ($dataCount - 1) : 1;
+$startCount  = ($totalResults > $limit) ? ($reportPage * $limit) - $limit + 1 : 1;
 ?>
 
 <?php if (!empty($columnOrder)): ?>


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3330
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes the issue reported in https://github.com/mautic/mautic/issues/3330

#### Steps to reproduce the bug:
1. See https://github.com/mautic/mautic/issues/3330

#### Steps to test this PR:
1. Apply this PR
2. Try to reproduce the bug
3. The numbering will continue in the correct order for each page of the report.

