### PR TITLE
Fix Broken Default Avatar URL in #3382

### DIFF
--- a/app/bundles/LeadBundle/Templating/Helper/AvatarHelper.php
+++ b/app/bundles/LeadBundle/Templating/Helper/AvatarHelper.php
@@ -12,6 +12,7 @@
 namespace Mautic\LeadBundle\Templating\Helper;
 
 use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\CoreBundle\Helper\UrlHelper;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Component\Templating\Helper\Helper;
 
@@ -90,12 +91,9 @@ class AvatarHelper extends Helper
      */
     public function getDefaultAvatar($absolute = false)
     {
-        return $this->factory->getHelper('template.assets')->getUrl(
-            $this->factory->getSystemPath('assets').'/images/avatar.png',
-            null,
-            null,
-            $absolute
-        );
+        $img = $this->factory->getSystemPath('assets').'/images/avatar.png';
+
+        return UrlHelper::rel2abs($this->factory->getHelper('template.assets')->getUrl($img));
     }
 
     /**


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3382
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes the issue reported in https://github.com/mautic/mautic/issues/3382

#### Steps to reproduce the bug:
1. See https://github.com/mautic/mautic/issues/3382

#### Steps to test this PR:
1. Apply this PR
2. Try to reproduce the bug
3. The default avatar will be displayed correctly.

