### PR TITLE
Fixed filtering by formula field in reports

### DIFF
--- a/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
@@ -306,7 +306,6 @@ class ReportSubscriber extends CommonSubscriber
 
         switch ($context) {
             case 'leads':
-                $event->applyDateFilters($qb, 'date_added', 'l');
                 $qb->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
 
                 if ($event->hasColumn(['u.first_name', 'u.last_name']) || $event->hasFilter(['u.first_name', 'u.last_name'])) {
@@ -320,6 +319,9 @@ class ReportSubscriber extends CommonSubscriber
 
                 if ($event->hasFilter('s.leadlist_id')) {
                     $qb->join('l', MAUTIC_TABLE_PREFIX.'lead_lists_leads', 's', 's.lead_id = l.id AND s.manually_removed = 0');
+                    $event->applyDateFilters($qb, 'date_added', 's');
+                } else {
+                    $event->applyDateFilters($qb, 'date_added', 'l');
                 }
                 break;
 

--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -335,7 +335,12 @@ final class MauticReportBuilder implements ReportBuilderInterface
                         }
 
                         $columnValue = ":$paramName";
-                        switch ($filterDefinitions[$filter['column']]['type']) {
+                        $type        = $filterDefinitions[$filter['column']]['type'];
+                        if (isset($filterDefinitions[$filter['column']]['formula'])) {
+                            $filter['column'] = $filterDefinitions[$filter['column']]['formula'];
+                        }
+
+                        switch ($type) {
                             case 'bool':
                             case 'boolean':
                                 if ((int) $filter['value'] > 1) {
@@ -359,9 +364,9 @@ final class MauticReportBuilder implements ReportBuilderInterface
                                 $queryBuilder->setParameter($paramName, $filter['value']);
                         }
 
-                        $filterExpr->add(
-                            $expr->{$exprFunction}($filter['column'], $columnValue)
-                        );
+                    $filterExpr->add(
+                        $expr->{$exprFunction}($filter['column'], $columnValue)
+                    );
                 }
             }
         }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

A fatal error will occur if filtering a report based on a formula. For example, filter by an email read ratio in the email stats context.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new report based on email stats
2. Add a filter based on read ratio
3. Save and close

#### Steps to test this PR:
1. Same as above but no error
2. 
