### PR TITLE
New filters added to reports would not save 

### DIFF
--- a/app/bundles/ReportBundle/Assets/js/report.js
+++ b/app/bundles/ReportBundle/Assets/js/report.js
@@ -7,9 +7,8 @@ Mautic.reportOnLoad = function (container) {
 
     // Append an index of the number of filters on the edit form
     if (mQuery('div[id=report_filters]').length) {
-        mQuery('div[id=report_filters]').data('index', mQuery('#report_filters > div').length);
-
-        mQuery('div[id=report_tableOrder]').data('index', mQuery('#report_tableOrder > div').length);
+        mQuery('div[id=report_filters]').attr('data-index', mQuery('#report_filters > div').length + 1);
+        mQuery('div[id=report_tableOrder]').attr('data-index', mQuery('#report_tableOrder > div').length + 1);
 
         if (mQuery('.filter-columns').length) {
             mQuery('.filter-columns').each(function () {

--- a/app/bundles/ReportBundle/Views/Report/form.html.php
+++ b/app/bundles/ReportBundle/Views/Report/form.html.php
@@ -34,9 +34,7 @@ $showGraphTab = count($form['graphs']->vars['choices']);
                     <li class="">
                         <a href="#data-container" role="tab" data-toggle="tab"><?php echo $view['translator']->trans('mautic.report.tab.data'); ?></a>
                     </li>
-                    <li class="<?php if (!$showGraphTab) {
-    echo 'hide';
-} ?>" id="graphs-tab">
+                    <li class="<?php if (!$showGraphTab): echo 'hide'; endif; ?>" id="graphs-tab">
                         <a href="#graphs-container" role="tab" data-toggle="tab"><?php echo $view['translator']->trans('mautic.report.tab.graphs'); ?></a>
                     </li>
                 </ul>
@@ -95,9 +93,7 @@ $showGraphTab = count($form['graphs']->vars['choices']);
                         </div>
                     </div>
 
-                    <div class="tab-pane fade bdr-w-0<?php if (!$showGraphTab) {
-    echo 'hide';
-} ?>" id="graphs-container">
+                    <div class="tab-pane fade bdr-w-0<?php if (!$showGraphTab): echo 'hide'; endif; ?>" id="graphs-container">
                         <div class="row">
                             <div class="col-md-6">
                                 <div class="pa-md">


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #3547
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

 Editing a report and adding new filters failed because the index count wasn't noted from the beginning causing the new filters to override the existing.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Edit a contact report and add two new segment filters
2. Note that the segment value is not populated
3. Save and the filters are gone

#### Steps to test this PR:
1. Repeat above but new filter rows should work and save
