### PR TITLE
Use unknown instead of empty label for devices

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1904,7 +1904,10 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         }
 
         foreach ($deviceStats as $device) {
-            $chart->setDataset($device['device'], $device['count']);
+            $chart->setDataset(
+                ($device['device']) ? $device['device'] : $this->translator->trans('mautic.core.unknown'),
+                $device['count']
+            );
         }
 
         return $chart->render();


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #3355 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If an email read stat device comes back as empty, this shows empty on the email devices dashboard widget. This PR replaces that empty value with unknown in the graph

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Send an email to a contact and open it so that there is a device logged.
2. Edit the lead_devices table and update the device to be empty
3. Create a email devices dashboard widget
4. It'll be like the image in the issue report. 

#### Steps to test this PR:
1. Same as above but instead of an empty label, Unknown will show.
