### PR TITLE
Broken email/page HTML due to using Froala's Code View fixed

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -935,7 +935,9 @@ Mautic.initSlotListeners = function() {
                 var field = mQuery(e.target);
 
                 // Store the slot settings as attributes
-                clickedSlot.attr('data-param-'+field.attr('data-slot-param'), field.val());
+                if (field.attr('data-slot-param')) {
+                    clickedSlot.attr('data-param-'+field.attr('data-slot-param'), field.val());
+                }
 
                 // Trigger the slot:change event
                 clickedSlot.trigger('slot:change', {slot: clickedSlot, field: field, type: focusType});


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3621
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When editing a text slot in the code view, the JS took the CodeMirror textarea as a new slot configuration parameter and tried to store the HTML code as a HTML parameter which caused invalid HTML if the `"` was used. This PR won't save the param value if the param name is missing.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new email or page.
2. Select any theme.
3. Drop a new text slot somewhere.
4. Edit the text slot in the Froala's Code View.
5. Insert `<h1>I like John. Such a nice guy!</h3>` (right?) to a new line.
6. Close the builder
7. Save the email
8. Preview the email. - You should see broken HTML as in the screenshot in the linked issue.

#### Steps to test this PR:
1. Apply this PR.
2. Refresh production assets or use the dev mode. Clear browser cache
3. Test again - The HTML should not break.