### PR TITLE
Prevent emojis in tokens from preventing a stat to be saved

### DIFF
--- a/app/bundles/EmailBundle/Entity/Stat.php
+++ b/app/bundles/EmailBundle/Entity/Stat.php
@@ -405,6 +405,9 @@ class Stat
         $this->retryCount = $retryCount;
     }
 
+    /**
+     * Increase the retry count.
+     */
     public function upRetryCount()
     {
         ++$this->retryCount;

--- a/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
@@ -14,6 +14,7 @@ namespace Mautic\EmailBundle\EventListener;
 use Mautic\CoreBundle\EventListener\CommonSubscriber;
 use Mautic\CoreBundle\Form\Type\SlotTextType;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\EmojiHelper;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Event\EmailBuilderEvent;
 use Mautic\EmailBundle\Event\EmailSendEvent;
@@ -248,7 +249,7 @@ class BuilderSubscriber extends CommonSubscriber
             $unsubscribeText = $this->translator->trans('mautic.email.unsubscribe.text', ['%link%' => '|URL|']);
         }
         $unsubscribeText = str_replace('|URL|', $this->emailModel->buildUrl('mautic_email_unsubscribe', ['idHash' => $idHash]), $unsubscribeText);
-        $event->addToken('{unsubscribe_text}', $unsubscribeText);
+        $event->addToken('{unsubscribe_text}', EmojiHelper::toHtml($unsubscribeText));
 
         $event->addToken('{unsubscribe_url}', $this->emailModel->buildUrl('mautic_email_unsubscribe', ['idHash' => $idHash]));
 
@@ -257,7 +258,7 @@ class BuilderSubscriber extends CommonSubscriber
             $webviewText = $this->translator->trans('mautic.email.webview.text', ['%link%' => '|URL|']);
         }
         $webviewText = str_replace('|URL|', $this->emailModel->buildUrl('mautic_email_webview', ['idHash' => $idHash]), $webviewText);
-        $event->addToken('{webview_text}', $webviewText);
+        $event->addToken('{webview_text}', EmojiHelper::toHtml($webviewText));
 
         // Show public email preview if the lead is not known to prevent 404
         if (empty($lead['id']) && $email) {
@@ -273,14 +274,14 @@ class BuilderSubscriber extends CommonSubscriber
             $owner = $this->factory->getModel('lead')->getRepository()->getLeadOwner($lead['owner_id']);
             if ($owner && !empty($owner['signature'])) {
                 $fromName      = $owner['first_name'].' '.$owner['last_name'];
-                $signatureText = $owner['signature'];
+                $signatureText = EmojiHelper::toHtml($owner['signature']);
             }
         }
 
         $signatureText = str_replace('|FROM_NAME|', $fromName, nl2br($signatureText));
-        $event->addToken('{signature}', $signatureText);
+        $event->addToken('{signature}', EmojiHelper::toHtml($signatureText));
 
-        $event->addToken('{subject}', $event->getSubject());
+        $event->addToken('{subject}', EmojiHelper::toHtml($event->getSubject()));
     }
 
     /**

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -15,14 +15,12 @@ use Mautic\AssetBundle\Entity\Asset;
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Helper\EmojiHelper;
 use Mautic\EmailBundle\EmailEvents;
-use Mautic\EmailBundle\Entity\Copy;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\EmailBundle\Swiftmailer\Exception\BatchQueueMaxException;
 use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
 use Mautic\EmailBundle\Swiftmailer\Transport\InterfaceTokenTransport;
-use Mautic\LeadBundle\Entity\Lead;
 
 /**
  * Class MailHelper.


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When an emoji is in a subject, the stat will fail to save due to the emoji corrupting the tokens array.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a segment email with an emoji in the subject
2. Send the email to some contacts
3. Note that an error will occur

#### Steps to test this PR:
1. Repeat but this time all emails will send and stats recorded
