### PR TITLE
Prevent fatal error when executing a command in dev mode

### DIFF
--- a/app/bundles/CoreBundle/Helper/IpLookupHelper.php
+++ b/app/bundles/CoreBundle/Helper/IpLookupHelper.php
@@ -163,7 +163,7 @@ class IpLookupHelper
 
             $ipAddress->setDoNotTrackList($doNotTrack);
 
-            if ($ipAddress->isTrackable()) {
+            if ($ipAddress->isTrackable() && $this->request) {
                 $userAgent = $this->request->headers->get('User-Agent');
                 foreach ($this->doNotTrackBots as $bot) {
                     if (strpos($userAgent, $bot) !== false) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Running commands in dev mode such as the campaign trigger will cause a fatal error due to attempting to get the bot from the request

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. In dev mode, execute mautic:campaign:update
2. 

#### Steps to test this PR:
1. Same as above but no error should occur
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 