### PR TITLE
Fixed error when user have only permission to create/edit own emails

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -2037,7 +2037,9 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         $results = [];
         switch ($type) {
             case 'email':
-                $emails = $this->getRepository()->getEmailList(
+                $emailRepo = $this->getRepository();
+                $emailRepo->setCurrentUser($this->userHelper->getUser());
+                $emails = $emailRepo->getEmailList(
                     $filter,
                     $limit,
                     $start,


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3554
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If a user have only permission to create/edit own email, he cannot create any email because the EmailRepository is not aware of current user.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
Nicely described in https://github.com/mautic/mautic/issues/3554

#### Steps to test this PR:
Retest