### PR TITLE
Enable new code mode slot

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/app/less/components/builder.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/components/builder.less
@@ -129,10 +129,6 @@
   height: auto;
 }
 
-#slot_codemode .CodeMirror {
-  height: 200px;
-}
-
 .CodeMirror-hints {
   position: absolute;
   z-index: 9999 !important;

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -972,40 +972,15 @@ Mautic.initSlotListeners = function() {
             // initialize code mode slots
             if ('codemode' === type) {
                 Mautic.codeMode = true;
-                var rawTokens = [];
                 var element = focusForm.find('#slot_codemode_content')[0];
                 if (element) {
                     Mautic.builderCodeMirror = CodeMirror.fromTextArea(element, {
-                        //value: slot.find('#codemodeHtmlContainer').html(),
                         lineNumbers: true,
                         mode: 'htmlmixed',
                         extraKeys: {"Ctrl-Space": "autocomplete"},
                         lineWrapping: true,
-                        // hintOptions: {
-                        //     hint: function (editor) {
-                        //         var cursor = editor.getCursor();
-                        //         var currentLine = editor.getLine(cursor.line);
-                        //         var start = cursor.ch;
-                        //         var end = start;
-                        //         while (end < currentLine.length && /[\w|}$]+/.test(currentLine.charAt(end))) ++end;
-                        //         while (start && /[\w|{$]+/.test(currentLine.charAt(start - 1))) --start;
-                        //         var curWord = start != end && currentLine.slice(start, end);
-                        //         var regex = new RegExp('^' + curWord, 'i');
-                        //         return {
-                        //             list: (!curWord ? rawTokens : mQuery(rawTokens).filter(function (idx) {
-                        //                 return (rawTokens[idx].indexOf(curWord) !== -1);
-                        //             })),
-                        //             from: CodeMirror.Pos(cursor.line, start),
-                        //             to: CodeMirror.Pos(cursor.line, end)
-                        //         };
-                        //     }
-                        // }
                     });
                     Mautic.builderCodeMirror.getDoc().setValue(slot.find('#codemodeHtmlContainer').html());
-                    // Mautic.builderCodeMirror.on('mousedown', function(instance, e){
-                    //     console.log(Mautic.builderCodeMirror);
-                    //     instance.focus();
-                    // });
                     Mautic.keepPreviewAlive(null, slot.find('#codemodeHtmlContainer'));
                 }
             }

--- a/app/bundles/CoreBundle/Assets/js/libraries/4j.codemirror.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/4j.codemirror.js
@@ -3586,12 +3586,15 @@
     }
     if (clickInGutter(cm, e)) return;
     var start = posFromMouse(cm, e);
-    window.focus();
+    var codeMode = typeof Mautic != 'undefined' && Mautic.codeMode === true;
+    if (!codeMode) {
+      window.focus();
+    }
 
     switch (e_button(e)) {
     case 1:
       // #3261: make sure, that we're not starting a second selection
-      if (cm.state.selectingText)
+      if (cm.state.selectingText && !codeMode)
         cm.state.selectingText(e);
       else if (start)
         leftButtonDown(cm, e, start);

--- a/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
@@ -184,14 +184,14 @@ class BuilderSubscriber extends CommonSubscriber
                 'slot_socialfollow',
                 600
             );
-//            $event->addSlotType(
-//                'codemode',
-//                'Code Mode',
-//                'code',
-//                'MauticCoreBundle:Slots:codemode.html.php',
-//                'slot_codemode',
-//                500
-//            );
+            $event->addSlotType(
+                'codemode',
+                'Code Mode',
+                'code',
+                'MauticCoreBundle:Slots:codemode.html.php',
+                'slot_codemode',
+                500
+            );
             $event->addSlotType(
                 'separator',
                 'Separator',

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -171,14 +171,14 @@ class BuilderSubscriber extends CommonSubscriber
                 'slot_socialfollow',
                 600
             );
-//            $event->addSlotType(
-//                'codemode',
-//                'Code Mode',
-//                'code',
-//                'MauticCoreBundle:Slots:codemode.html.php',
-//                'slot_codemode',
-//                500
-//            );
+            $event->addSlotType(
+                'codemode',
+                'Code Mode',
+                'code',
+                'MauticCoreBundle:Slots:codemode.html.php',
+                'slot_codemode',
+                500
+            );
             $event->addSlotType(
                 'separator',
                 'Separator',


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR enables a new slot type named "Code Mode" that allows the user to quickly insert pieces of HTML directly in the email or landing page.

![image](https://cloud.githubusercontent.com/assets/2924026/23877924/4cbf063e-080a-11e7-81f0-badb84f16869.png)

![image](https://cloud.githubusercontent.com/assets/2924026/23878061/d84665ee-080a-11e7-81c9-ab6cc1157e5c.png)

![image](https://cloud.githubusercontent.com/assets/2924026/23878081/f52c2c02-080a-11e7-8a84-6553f151d3aa.png)


#### Steps to test this PR:
1. Apply this PR
2. Create a new Email or Landing Page.
3. Select a theme (not code mode)
4. In the slot types area there is a new slot named "Code Mode"


