### PR TITLE
check if .git is exist before copy pre-commit hook

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,12 +127,12 @@
         "post-install-cmd": [
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
-            "cp ./build/hooks/pre-commit ./.git/hooks/pre-commit"
+            "if [ -d ./.git ]; then cp ./build/hooks/pre-commit ./.git/hooks/pre-commit; fi"
         ],
         "post-update-cmd": [
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
-            "cp ./build/hooks/pre-commit ./.git/hooks/pre-commit"
+            "if [ -d ./.git ]; then cp ./build/hooks/pre-commit ./.git/hooks/pre-commit; fi"
         ]
     },
     "config": {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

After ad992c2f27cbef554e262bfa8c55e20f3bab7f87 , post-install-cmd and post-update-cmd always expect to .git dir is exist.
But .git dir does not always exist (for example, we'll not have that when we follow [gettings-started](https://github.com/mautic/mautic#getting-started) instruction).
This is not a serious problem in most cases, but we need to handle errors when install with provisioning tool such as Ansible.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. download release archive and then extract it. 
2. "composer install; echo $?"
3. you can see "1" as return code of "composer install"

#### Steps to test this PR:
1. remove .git dir
2. "composer install; echo $?"
3. you can see "0" as return code of "composer install"

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 