### PR TITLE
Show only published, global segments in the Preference Center

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/ContactFrequencyType.php
+++ b/app/bundles/LeadBundle/Form/Type/ContactFrequencyType.php
@@ -181,11 +181,12 @@ class ContactFrequencyType extends AbstractType
                 'lead_lists',
                 'leadlist_choices',
                 [
-                    'label'      => 'mautic.lead.form.list',
-                    'label_attr' => ['class' => 'control-label'],
-                    'multiple'   => true,
-                    'expanded'   => $options['public_view'],
-                    'required'   => false,
+                    'global_only' => true,
+                    'label'       => 'mautic.lead.form.list',
+                    'label_attr'  => ['class' => 'control-label'],
+                    'multiple'    => true,
+                    'expanded'    => $options['public_view'],
+                    'required'    => false,
                 ]
             );
         }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3594
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The Preference Center shows all segments. Even those which are unpublished or private. This PR changes that to show only published global segments.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make sure the preference center with segments section is enabled in the configuration.
2. Send an segment email with unpublish url to your contact.
3. Open the unsubscribe page. The Preference center with all segments should be there.
4. Unpublish some segment and make one more segment private.
5. Refresh the preference center. All the segments are still listed.

#### Steps to test this PR:
1. Apply this PR.
2. Refresh the preference center. Only the published global segments are listed.
