### PR TITLE
Theme access fix according to role

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -112,7 +112,7 @@ return [
                 'route'     => 'mautic_themes_index',
                 'iconClass' => 'fa-newspaper-o',
                 'id'        => 'mautic_themes_index',
-                'access'    => 'admin',
+                'access'    => 'core:themes:view',
             ],
         ],
         'extra' => [


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3619

#### Description:
Fix access to theme in right panel

#### Steps to test this PR:

1. With a user with theme view access, icon is not in right panel
2. Apply PR & clear cache
3. Check if icon is in right panel
4. Remove user view theme role
5. Check if icon is no longer in right panel
6. 