### PR TITLE
Stream report downloads incrementally

### DIFF
--- a/app/bundles/ReportBundle/Controller/ReportController.php
+++ b/app/bundles/ReportBundle/Controller/ReportController.php
@@ -785,11 +785,11 @@ class ReportController extends FormController
         $fromDate = $session->get('mautic.report.date.from', (new \DateTime('-30 days'))->format('Y-m-d'));
         $toDate   = $session->get('mautic.report.date.to', (new \DateTime())->format('Y-m-d'));
 
-        $date = (new DateTimeHelper())->toLocalString();
-        $name = str_replace(' ', '_', $date) . '_' . InputHelper::alphanum($entity->getName(), false, '-');
-        $options = array( 'dateFrom' => new \DateTime($fromDate),'dateTo' => new \DateTime($toDate));
+        $date    = (new DateTimeHelper())->toLocalString();
+        $name    = str_replace(' ', '_', $date).'_'.InputHelper::alphanum($entity->getName(), false, '-');
+        $options = ['dateFrom' => new \DateTime($fromDate), 'dateTo' => new \DateTime($toDate)];
 
-        if($format === 'csv') {
+        if ($format === 'csv') {
             $response = new HttpFoundation\StreamedResponse(
                 function () use ($model, $fromDate, $toDate, $entity, $format, $name, $options) {
                     $options['paginate'] = true;
@@ -798,10 +798,10 @@ class ReportController extends FormController
                     $reportData['totalResults'] = 10000;
                     $options['page'] = 1;
                     $handle = fopen('php://output', 'r+');
-                    while ($reportData['totalResults'] >= ($options['page'] - 1) *  $options['limit']) {
+                    while ($reportData['totalResults'] >= ($options['page'] - 1) * $options['limit']) {
                         $reportData = $model->getReportData($entity, null, $options);
                         $model->exportResults($format, $entity, $reportData, $handle, null, $options['page']);
-                        $options['page']++;
+                        ++$options['page'];
                     }
                     fclose($handle);
                 }
@@ -809,7 +809,7 @@ class ReportController extends FormController
 
             $response->headers->set('Content-Type', 'application/force-download');
             $response->headers->set('Content-Type', 'application/octet-stream');
-            $response->headers->set('Content-Disposition', 'attachment; filename="' . $name . '.'.$format.'"');
+            $response->headers->set('Content-Disposition', 'attachment; filename="'.$name.'.'.$format.'"');
             $response->headers->set('Expires', 0);
             $response->headers->set('Cache-Control', 'must-revalidate');
             $response->headers->set('Pragma', 'public');
@@ -818,7 +818,7 @@ class ReportController extends FormController
                 $options['ignoreGraphData'] = true;
             }
             $reportData = $model->getReportData($entity, null, $options);
-            $response = $model->exportResults($format, $entity, $reportData);
+            $response   = $model->exportResults($format, $entity, $reportData);
         }
 
         return $response;

--- a/app/bundles/ReportBundle/Controller/ReportController.php
+++ b/app/bundles/ReportBundle/Controller/ReportController.php
@@ -787,13 +787,6 @@ class ReportController extends FormController
         $name = str_replace(' ', '_', $date) . '_' . InputHelper::alphanum($entity->getName(), false, '-');
         $options = array( 'dateFrom' => new \DateTime($fromDate),'dateTo' => new \DateTime($toDate));
 
-        if($format === 'html') {
-            if ($format === 'xlsx') {
-                $options['ignoreGraphData'] = true;
-            }
-            $reportData = $model->getReportData($entity, null, $options);
-            $response = $model->exportResults($format, $entity, $reportData, null, null);
-        }
         if($format === 'csv') {
             $response = new HttpFoundation\StreamedResponse(
                 function () use ($model, $fromDate, $toDate, $entity, $format, $name, $options) {
@@ -818,6 +811,12 @@ class ReportController extends FormController
             $response->headers->set('Expires', 0);
             $response->headers->set('Cache-Control', 'must-revalidate');
             $response->headers->set('Pragma', 'public');
+        }else{
+            if ($format === 'xlsx') {
+                $options['ignoreGraphData'] = true;
+            }
+            $reportData = $model->getReportData($entity, null, $options);
+            $response = $model->exportResults($format, $entity, $reportData, null, null);
         }
 
         return $response;

--- a/app/bundles/ReportBundle/Controller/ReportController.php
+++ b/app/bundles/ReportBundle/Controller/ReportController.php
@@ -800,7 +800,7 @@ class ReportController extends FormController
                     $handle = fopen('php://output', 'r+');
                     while ($reportData['totalResults'] >= ($options['page'] - 1) * $options['limit']) {
                         $reportData = $model->getReportData($entity, null, $options);
-                        $model->exportResults($format, $entity, $reportData, $handle, null, $options['page']);
+                        $model->exportResults($format, $entity, $reportData, $handle, $options['page']);
                         ++$options['page'];
                     }
                     fclose($handle);

--- a/app/bundles/ReportBundle/Controller/ReportController.php
+++ b/app/bundles/ReportBundle/Controller/ReportController.php
@@ -12,6 +12,8 @@
 namespace Mautic\ReportBundle\Controller;
 
 use Mautic\CoreBundle\Controller\FormController;
+use Mautic\CoreBundle\Helper\DateTimeHelper;
+use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\ReportBundle\Entity\Report;
 use Symfony\Component\HttpFoundation;
 
@@ -811,12 +813,12 @@ class ReportController extends FormController
             $response->headers->set('Expires', 0);
             $response->headers->set('Cache-Control', 'must-revalidate');
             $response->headers->set('Pragma', 'public');
-        }else{
+        } else {
             if ($format === 'xlsx') {
                 $options['ignoreGraphData'] = true;
             }
             $reportData = $model->getReportData($entity, null, $options);
-            $response = $model->exportResults($format, $entity, $reportData, null, null);
+            $response = $model->exportResults($format, $entity, $reportData);
         }
 
         return $response;

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -374,10 +374,9 @@ class ReportModel extends FormModel
                 //build the data rows
                 if (is_null($handle)) {
                     $response = new StreamedResponse(
-                        function () use ($reportData, $report, $formatter) {
+                        function () use ($reportData, $formatter) {
                             $handle = fopen('php://output', 'r+');
-                            $header = [];
-                            $this->exportCSV($formatter, $report, $reportData, $handle, 0);
+                            $this->exportCSV($formatter, $reportData, $handle, 0);
                             fclose($handle);
                         }
                     );
@@ -390,7 +389,7 @@ class ReportModel extends FormModel
 
                     return $response;
                 } else {
-                    $this->exportCSV($formatter, $report, $reportData, $handle, $page);
+                    $this->exportCSV($formatter, $reportData, $handle, $page);
 
                     return;
                 }
@@ -703,12 +702,12 @@ class ReportModel extends FormModel
         return $options;
     }
 
-    private function exportCSV($formatter, $report, $reportData, $handle, $page)
+    private function exportCSV($formatter, $reportData, $handle, $page)
     {
         foreach ($reportData['data'] as $count => $data) {
             $row = [];
             foreach ($data as $k => $v) {
-                if ($count === 0) {
+                if ($count == 0) {
                     //set the header
                     $header[] = $k;
                 }
@@ -716,7 +715,7 @@ class ReportModel extends FormModel
                 $row[] = $formatter->_($v, $reportData['columns'][$reportData['dataColumns'][$k]]['type'], true);
             }
 
-            if ($page === 1 && $count === 0) {
+            if ($page == 1 && $count == 0) {
                 fputcsv($handle, $header);
             }
             fputcsv($handle, $row);

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -715,7 +715,7 @@ class ReportModel extends FormModel
                 $row[] = $formatter->_($v, $reportData['columns'][$reportData['dataColumns'][$k]]['type'], true);
             }
 
-            if ($page == 1 && $count == 0) {
+            if ($page === 1 && $count === 0) {
                 fputcsv($handle, $header);
             }
             fputcsv($handle, $row);

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -372,12 +372,12 @@ class ReportModel extends FormModel
         switch ($format) {
             case 'csv':
                 //build the data rows
-                if(is_null($handle)){
+                if (is_null($handle)) {
                     $response = new StreamedResponse(
                         function () use ($reportData, $report, $formatter) {
                             $handle = fopen('php://output', 'r+');
                             $header = [];
-                            $this->exportCSV($formatter,$report, $reportData, $handle, 0);
+                            $this->exportCSV($formatter, $report, $reportData, $handle, 0);
                             fclose($handle);
                         }
                     );
@@ -387,9 +387,11 @@ class ReportModel extends FormModel
                     $response->headers->set('Expires', 0);
                     $response->headers->set('Cache-Control', 'must-revalidate');
                     $response->headers->set('Pragma', 'public');
+
                     return $response;
                 } else {
-                    $this->exportCSV($formatter,$report, $reportData, $handle, $page);
+                    $this->exportCSV($formatter, $report, $reportData, $handle, $page);
+
                     return;
                 }
             case 'html':
@@ -432,7 +434,6 @@ class ReportModel extends FormModel
                                 if ($count === 0) {
                                     //write the column names row
                                     $objPHPExcel->getActiveSheet()->fromArray($header, null, 'A1');
-
                                 }
                                 //write the row
                                 $rowCount = $count + 2;
@@ -589,7 +590,7 @@ class ReportModel extends FormModel
                 // Build the options array to pass into the query
                 $limit = $this->session->get('mautic.report.'.$entity->getId().'.limit', $this->defaultPageLimit);
                 if (!empty($options['limit'])) {
-                    $limit = $options['limit'];
+                    $limit      = $options['limit'];
                     $reportPage = $options['page'];
                 }
                 $start = ($reportPage === 1) ? 0 : (($reportPage - 1) * $limit);
@@ -702,7 +703,8 @@ class ReportModel extends FormModel
         return $options;
     }
 
-    private function exportCSV($formatter,$report, $reportData, $handle, $page){
+    private function exportCSV($formatter, $report, $reportData, $handle, $page)
+    {
         foreach ($reportData['data'] as $count => $data) {
             $row = [];
             foreach ($data as $k => $v) {

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -577,7 +577,8 @@ public function exportResults($format, $report, $reportData, $handle, $page)
             if ($paginate) {
                 // Build the options array to pass into the query
                 $limit = $this->session->get('mautic.report.'.$entity->getId().'.limit', $this->defaultPageLimit);
-                if (!empty($limit = $options['limit'])) {
+                if (!empty($options['limit'])) {
+                    $limit = $options['limit'];
                     $reportPage = $options['page'];
                 }
                 $start = ($reportPage === 1) ? 0 : (($reportPage - 1) * $limit);

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -366,8 +366,8 @@ class ReportModel extends FormModel
 public function exportResults($format, $report, $reportData, $handle, $page)
     {
         $formatter = $this->formatterHelper;
-        $date = (new DateTimeHelper())->toLocalString();
-        $name = str_replace(' ', '_', $date) . '_' . InputHelper::alphanum($report->getName(), false, '-');
+        $date      = (new DateTimeHelper())->toLocalString();
+        $name      = str_replace(' ', '_', $date).'_'.InputHelper::alphanum($report->getName(), false, '-');
 
         switch ($format) {
             case 'csv':
@@ -393,13 +393,13 @@ public function exportResults($format, $report, $reportData, $handle, $page)
                 $content = $this->templatingHelper->getTemplating()->renderResponse(
                     'MauticReportBundle:Report:export.html.php',
                     [
-                        'data' => $reportData['data'],
-                        'columns' => $reportData['columns'],
+                        'data'      => $reportData['data'],
+                        'columns'   => $reportData['columns'],
                         'pageTitle' => $name,
-                        'graphs' => $reportData['graphs'],
-                        'report' => $report,
-                        'dateFrom' => $reportData['dateFrom'],
-                        'dateTo' => $reportData['dateTo'],
+                        'graphs'    => $reportData['graphs'],
+                        'report'    => $report,
+                        'dateFrom'  => $reportData['dateFrom'],
+                        'dateTo'    => $reportData['dateTo'],
                     ]
                 )->getContent();
 
@@ -411,8 +411,10 @@ public function exportResults($format, $report, $reportData, $handle, $page)
                         function () use ($formatter, $reportData, $report, $name) {
                             $objPHPExcel = new \PHPExcel();
                             $objPHPExcel->getProperties()->setTitle($name);
+
                             $objPHPExcel->createSheet();
                             $header = [];
+
                             //build the data rows
                             foreach ($reportData['data'] as $count => $data) {
                                 $row = [];
@@ -423,9 +425,11 @@ public function exportResults($format, $report, $reportData, $handle, $page)
                                     }
                                     $row[] = $formatter->_($v, $reportData['columns'][$reportData['dataColumns'][$k]]['type'], true);
                                 }
+
                                 if ($count === 0) {
                                     //write the column names row
                                     $objPHPExcel->getActiveSheet()->fromArray($header, null, 'A1');
+
                                 }
                                 //write the row
                                 $rowCount = $count + 2;
@@ -433,17 +437,21 @@ public function exportResults($format, $report, $reportData, $handle, $page)
                                 //free memory
                                 unset($row, $reportData['data'][$count]);
                             }
+
                             $objWriter = \PHPExcel_IOFactory::createWriter($objPHPExcel, 'Excel2007');
                             $objWriter->setPreCalculateFormulas(false);
+
                             $objWriter->save('php://output');
                         }
                     );
+
                     $response->headers->set('Content-Type', 'application/force-download');
                     $response->headers->set('Content-Type', 'application/octet-stream');
                     $response->headers->set('Content-Disposition', 'attachment; filename="'.$name.'.xlsx"');
                     $response->headers->set('Expires', 0);
                     $response->headers->set('Cache-Control', 'must-revalidate');
                     $response->headers->set('Pragma', 'public');
+
                     return $response;
                 }
                 throw new \Exception('PHPExcel is required to export to Excel spreadsheets');


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | ✔️ 
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Exporting reports used to run out of memory quickly. This PR aims to stream the report downloads incrementally so as to be able to export arbitrarily large reports without crashing Mautic.

So far, this has only been done for the CSV exports and a lot of the logic is in the controller.
I would greatly appreciate any feedback and help completing this fix.

BTW, I have no clue how to do the same for the excel export.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Make a big report
2. Try to export it
3. Hopefully make Mautic run out of memory (if not, either try to make your report bigger or lower the PHP memory limit)

#### Steps to test this PR:
1.  Open that same big report
2. Try to export it as a CSV
3. The memory should not run out