### PR TITLE
Make installer use pre-configured password as a default.

### DIFF
--- a/app/bundles/InstallBundle/Controller/InstallController.php
+++ b/app/bundles/InstallBundle/Controller/InstallController.php
@@ -100,6 +100,10 @@ class InstallController extends CommonController
 
                         break;
                     case self::DOCTRINE_STEP:
+                        // password field does not retain configured defaults
+                        if (empty($formData->password) && !empty($params['db_password'])) {
+                            $formData->password = $params['db_password'];
+                        }
                         $dbParams = (array) $formData;
                         $this->validateDatabaseParams($form, $dbParams);
                         if (!$form->getErrors(true)->count()) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Installer prefills database connection form with values available in the configuration file with exception of password field (it cannot be prefilled securely in html form). This PR works around the issue by using preconfigured database password if it is available and the user left the password form field empty.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Prefill db connection info into configuration file.
2. Run installer without changing database configuration values
3. Installer fails because it doesn't use preconfigured password (it attempts connection without password)

#### Steps to test this PR:
1. Run installer without preconfiguring anything
2. Run installer and preconfigure database connection info
