### PR TITLE
Use different message in report dynamic filters

### DIFF
--- a/app/bundles/ReportBundle/Form/Type/DynamicFiltersType.php
+++ b/app/bundles/ReportBundle/Form/Type/DynamicFiltersType.php
@@ -47,9 +47,9 @@ class DynamicFiltersType extends AbstractType
                     $args['choices_as_values'] = true;
                     $args['choices']           = [
                         [
-                            'mautic.core.form.no'    => false,
-                            'mautic.core.form.yes'   => true,
-                            'mautic.core.form.reset' => '',
+                            'mautic.core.form.no'      => false,
+                            'mautic.core.form.yes'     => true,
+                            'mautic.core.filter.clear' => '',
                         ],
                     ];
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | ✔️ 
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:

In the reports dynamic filters, one of the options for boolean dynamic filters is _Clear_ using the translation key `mautic.core.form.reset`. However this doesn't translate well into every language such as French where the message becomes _Effacer_ meaning _To delete_ which makes no sense in this context. This PR aims to replace it with the translation key `mautic.core.filter.clear` which is _Clear filter_ in English and _Supprimer le filtre_ in French meaning roughly the same thing so I think it's better to base the translation on that key rather than the previous one which might result in a translation too generic that will lose the original meaning.

![capture d ecran 2017-03-29 a 11 49 50](https://cloud.githubusercontent.com/assets/18265735/24449071/86af2798-1476-11e7-9a4d-137ccb621127.png)

#### Steps to reproduce the bug:
1. Set language to French
2. Open a report with dynamic filters

#### Steps to test this PR:
1. Apply PR
1. Set language to French
2. Open a report with dynamic filters