### PR TITLE
Segment filter font

### DIFF
--- a/app/bundles/LeadBundle/Assets/css/lead.css
+++ b/app/bundles/LeadBundle/Assets/css/lead.css
@@ -234,6 +234,13 @@ ul.tag-cloud li {
 .panel-companies .primary {
     color: #fdb933;
 }
-.bg-building{
-'\f1ad' : '\f007';
+.building::before{
+    content: "\f1ad";
+    font-family: "FontAwesome";
+    padding-right: 3px;
+}
+.user::before{
+    content: "\f007";
+    font-family: "FontAwesome";
+    padding-right: 3px;
 }

--- a/app/bundles/LeadBundle/Assets/css/lead.css
+++ b/app/bundles/LeadBundle/Assets/css/lead.css
@@ -234,12 +234,12 @@ ul.tag-cloud li {
 .panel-companies .primary {
     color: #fdb933;
 }
-.building::before{
+.building::before {
     content: "\f1ad";
     font-family: "FontAwesome";
     padding-right: 3px;
 }
-.user::before{
+.user::before {
     content: "\f007";
     font-family: "FontAwesome";
     padding-right: 3px;

--- a/app/bundles/LeadBundle/Assets/css/lead.css
+++ b/app/bundles/LeadBundle/Assets/css/lead.css
@@ -234,3 +234,6 @@ ul.tag-cloud li {
 .panel-companies .primary {
     color: #fdb933;
 }
+.bg-building{
+'\f1ad' : '\f007';
+}

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -57,7 +57,7 @@ class FieldType extends AbstractType
             [
                 'label'      => 'mautic.lead.field.label',
                 'label_attr' => ['class' => 'control-label'],
-                'attr'       => ['class' => 'form-control', 'length' => 50],
+                'attr'       => ['class' => 'form-control', 'length' => 50, 'data-placeholder' => 'abc'],
             ]
         );
 

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -57,7 +57,7 @@ class FieldType extends AbstractType
             [
                 'label'      => 'mautic.lead.field.label',
                 'label_attr' => ['class' => 'control-label'],
-                'attr'       => ['class' => 'form-control', 'length' => 50, 'data-placeholder' => 'abc'],
+                'attr'       => ['class' => 'form-control', 'length' => 50],
             ]
         );
 

--- a/app/bundles/LeadBundle/Views/List/form.html.php
+++ b/app/bundles/LeadBundle/Views/List/form.html.php
@@ -106,7 +106,7 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
                                                     data-field-callback="<?php echo $callback; ?>"
                                                     data-field-operators="<?php echo $operators; ?>"
                                                     class="segment-filter fa <?php echo $icon; ?>">
-                                                <?php echo $view['translator']->trans($params['label']); ?>
+                                                    <?php echo $view['translator']->trans($params['label']); ?>
                                             </option>
                                         <?php endforeach; ?>
                                     </optgroup>

--- a/app/bundles/LeadBundle/Views/List/form.html.php
+++ b/app/bundles/LeadBundle/Views/List/form.html.php
@@ -88,7 +88,7 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
                                     <?php
                                     foreach ($fields as $object => $field):
                                         $header = $object;
-                                        $icon   = ($object == 'company') ? 'fa-building' : 'fa-user';
+                                        $icon   = ($object == 'company') ? 'building' : 'user';
                                     ?>
                                     <optgroup label="<?php echo $view['translator']->trans('mautic.lead.'.$header); ?>">
                                         <?php foreach ($field as $value => $params):
@@ -105,7 +105,7 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
                                                     data-field-list="<?php echo $view->escape($list); ?>"
                                                     data-field-callback="<?php echo $callback; ?>"
                                                     data-field-operators="<?php echo $operators; ?>"
-                                                    class="segment-filter fa <?php echo $icon; ?>">
+                                                    class="segment-filter <?php echo $icon; ?>">
                                                     <?php echo $view['translator']->trans($params['label']); ?>
                                             </option>
                                         <?php endforeach; ?>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #3066
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The segment filter dropdown has a different font from everything else in Mautic. This PR fixes that.
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. go to filters in segments, see font

#### Steps to test this PR:
1. Apply this PR, see segment filters dropdown again. font should be the same as all dropdowns