### PR TITLE
Campaign and Campaign ID columns in reports

### DIFF
--- a/app/bundles/AssetBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/ReportSubscriber.php
@@ -68,7 +68,13 @@ class ReportSubscriber extends CommonSubscriber
                 ],
             ];
 
-            $columns = array_merge($columns, $event->getStandardColumns($prefix, ['name'], 'mautic_asset_action'), $event->getCategoryColumns());
+            $columns = array_merge(
+                $columns,
+                $event->getStandardColumns($prefix, ['name'], 'mautic_asset_action'),
+                $event->getCategoryColumns(),
+                $event->getCampaignByChannelColumns()
+            );
+
             $event->addTable(
                 'assets',
                 [
@@ -135,6 +141,7 @@ class ReportSubscriber extends CommonSubscriber
         if ($context == 'assets') {
             $queryBuilder->from(MAUTIC_TABLE_PREFIX.'assets', 'a');
             $event->addCategoryLeftJoin($queryBuilder, 'a');
+            $event->addCampaignByChannelJoin($queryBuilder, 'a', 'asset');
         } elseif ($context == 'asset.downloads') {
             $event->applyDateFilters($queryBuilder, 'date_download', 'ad');
 
@@ -143,6 +150,7 @@ class ReportSubscriber extends CommonSubscriber
             $event->addCategoryLeftJoin($queryBuilder, 'a');
             $event->addLeadLeftJoin($queryBuilder, 'ad');
             $event->addIpAddressLeftJoin($queryBuilder, 'ad');
+            $event->addCampaignByChannelJoin($queryBuilder, 'a', 'asset');
         }
 
         $event->setQueryBuilder($queryBuilder);

--- a/app/bundles/AssetBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/ReportSubscriber.php
@@ -113,7 +113,13 @@ class ReportSubscriber extends CommonSubscriber
                     'asset.downloads',
                     [
                         'display_name' => 'mautic.asset.report.downloads.table',
-                        'columns'      => array_merge($columns, $downloadColumns, $event->getLeadColumns(), $event->getIpColumn()),
+                        'columns'      => array_merge(
+                            $columns,
+                            $downloadColumns,
+                            $event->getLeadColumns(),
+                            $event->getIpColumn(),
+                            $event->getCampaignByChannelColumns()
+                        ),
                     ],
                     'assets'
                 );

--- a/app/bundles/AssetBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/ReportSubscriber.php
@@ -117,8 +117,7 @@ class ReportSubscriber extends CommonSubscriber
                             $columns,
                             $downloadColumns,
                             $event->getLeadColumns(),
-                            $event->getIpColumn(),
-                            $event->getCampaignByChannelColumns()
+                            $event->getIpColumn()
                         ),
                     ],
                     'assets'

--- a/app/bundles/CampaignBundle/Translations/en_US/messages.ini
+++ b/app/bundles/CampaignBundle/Translations/en_US/messages.ini
@@ -1,5 +1,6 @@
 mautic.campaign.add_new_source="Add a contact source..."
 mautic.campaign.campaign="Campaign"
+mautic.campaign.campaign.id="Campaign ID"
 mautic.campaign.campaign.addremovelead="Add / remove contact"
 mautic.campaign.campaign.description="<strong>Campaign description:</strong> %description%"
 mautic.campaign.campaign.launch.builder="Launch Campaign Builder"

--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -154,7 +154,8 @@ class ReportSubscriber extends CommonSubscriber
             $columns = array_merge(
                 $columns,
                 $event->getStandardColumns($prefix, [], 'mautic_email_action'),
-                $event->getCategoryColumns()
+                $event->getCategoryColumns(),
+                $event->getCampaignByChannelColumns()
             );
             $data = [
                 'display_name' => 'mautic.email.emails',
@@ -214,7 +215,13 @@ class ReportSubscriber extends CommonSubscriber
 
                 $data = [
                     'display_name' => 'mautic.email.stats.report.table',
-                    'columns'      => array_merge($columns, $statColumns, $event->getLeadColumns(), $event->getIpColumn()),
+                    'columns'      => array_merge(
+                        $columns,
+                        $statColumns,
+                        $event->getLeadColumns(),
+                        $event->getIpColumn(),
+                        $event->getCampaignByChannelColumns()
+                    ),
                 ];
                 $event->addTable('email.stats', $data, 'emails');
 
@@ -272,6 +279,9 @@ class ReportSubscriber extends CommonSubscriber
                         'e.id = dnc.channel_id and dnc.channel=\'email\' and dnc.reason='.DoNotContact::UNSUBSCRIBED
                     );
                 }
+
+                $event->addCampaignByChannelJoin($qb, 'e', 'email');
+
                 break;
             case 'email.stats':
                 $qb->from(MAUTIC_TABLE_PREFIX.'email_stats', 'es')
@@ -305,6 +315,8 @@ class ReportSubscriber extends CommonSubscriber
                         'e.id = dnc.channel_id AND dnc.channel=\'email\' AND dnc.reason='.DoNotContact::UNSUBSCRIBED.' AND es.lead_id = dnc.lead_id'
                     );
                 }
+
+                $event->addCampaignByChannelJoin($qb, 'e', 'email');
 
                 break;
         }

--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -219,8 +219,7 @@ class ReportSubscriber extends CommonSubscriber
                         $columns,
                         $statColumns,
                         $event->getLeadColumns(),
-                        $event->getIpColumn(),
-                        $event->getCampaignByChannelColumns()
+                        $event->getIpColumn()
                     ),
                 ];
                 $event->addTable('email.stats', $data, 'emails');

--- a/app/bundles/FormBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/ReportSubscriber.php
@@ -51,8 +51,13 @@ class ReportSubscriber extends CommonSubscriber
                     'type'  => 'string',
                 ],
             ];
-            $columns = array_merge($columns, $event->getStandardColumns($prefix, [], 'mautic_form_action'), $event->getCategoryColumns());
-            $data    = [
+            $columns = array_merge(
+                $columns,
+                $event->getStandardColumns($prefix, [], 'mautic_form_action'),
+                $event->getCategoryColumns(),
+                $event->getCampaignByChannelColumns()
+            );
+            $data = [
                 'display_name' => 'mautic.form.forms',
                 'columns'      => $columns,
             ];
@@ -109,6 +114,7 @@ class ReportSubscriber extends CommonSubscriber
             case 'forms':
                 $qb->from(MAUTIC_TABLE_PREFIX.'forms', 'f');
                 $event->addCategoryLeftJoin($qb, 'f');
+                $event->addCampaignByChannelJoin($qb, 'f', 'form');
                 break;
             case 'form.submissions':
                 $event->applyDateFilters($qb, 'date_submitted', 'fs');
@@ -119,6 +125,7 @@ class ReportSubscriber extends CommonSubscriber
                 $event->addCategoryLeftJoin($qb, 'f');
                 $event->addLeadLeftJoin($qb, 'fs');
                 $event->addIpAddressLeftJoin($qb, 'fs');
+                $event->addCampaignByChannelJoin($qb, 'f', 'form');
                 break;
         }
 

--- a/app/bundles/PageBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/ReportSubscriber.php
@@ -102,7 +102,8 @@ class ReportSubscriber extends CommonSubscriber
             $columns = array_merge(
                 $columns,
                 $event->getStandardColumns('p.', ['name', 'description'], 'mautic_page_action'),
-                $event->getCategoryColumns()
+                $event->getCategoryColumns(),
+                $event->getCampaignByChannelColumns()
             );
             $data = [
                 'display_name' => 'mautic.page.pages',
@@ -257,6 +258,7 @@ class ReportSubscriber extends CommonSubscriber
                     ->leftJoin('p', MAUTIC_TABLE_PREFIX.'pages', 'tp', 'p.id = tp.id')
                     ->leftJoin('p', MAUTIC_TABLE_PREFIX.'pages', 'vp', 'p.id = vp.id');
                 $event->addCategoryLeftJoin($qb, 'p');
+                $event->addCampaignByChannelJoin($qb, 'p', 'page');
                 break;
             case 'page.hits':
                 $event->applyDateFilters($qb, 'date_hit', 'ph');
@@ -271,6 +273,7 @@ class ReportSubscriber extends CommonSubscriber
                 $event->addIpAddressLeftJoin($qb, 'ph');
                 $event->addCategoryLeftJoin($qb, 'p');
                 $event->addLeadLeftJoin($qb, 'ph');
+                $event->addCampaignByChannelJoin($qb, 'p', 'page');
                 break;
         }
 

--- a/app/bundles/ReportBundle/Event/ReportBuilderEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportBuilderEvent.php
@@ -332,6 +332,25 @@ class ReportBuilderEvent extends AbstractReportEvent
         ];
     }
 
+    /**
+     * Add campaign columns joined by the campaign lead event log table.
+     *
+     * @return array
+     */
+    public function getCampaignByChannelColumns()
+    {
+        return [
+            'clel.campaign_id' => [
+                'label' => 'mautic.campaign.campaign.id',
+                'type'  => 'string',
+            ],
+            'cmp.name' => [
+                'label' => 'mautic.campaign.campaign',
+                'type'  => 'string',
+            ],
+        ];
+    }
+
     public function getChannelColumns()
     {
         $channelColumns = [

--- a/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
@@ -254,38 +254,15 @@ class ReportGeneratorEvent extends AbstractReportEvent
      */
     public function addCampaignByChannelJoin(QueryBuilder $queryBuilder, $prefix, $channel)
     {
-        $selectedColumns = $this->report->getColumns();
-
-        if (in_array('cmp.name', $selectedColumns)
-            || in_array('clel.campaign_id', $selectedColumns)
-            || $this->columnsExistInFilter(['cmp.name', 'clel.campaign_id'])) {
-            $queryBuilder->innerJoin('a', MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'clel', $prefix.'.id = clel.channel_id AND clel.channel="'.$channel.'"')
-                    ->innerJoin('clel', MAUTIC_TABLE_PREFIX.'campaigns', 'cmp', 'cmp.id = clel.campaign_id');
+        if ($this->hasColumn('cmp.name')
+            || $this->hasFilter('cmp.name')
+            || $this->hasColumn('clel.campaign_id')
+            || $this->hasFilter('clel.campaign_id')) {
+            $queryBuilder->leftJoin('a', MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'clel', $prefix.'.id = clel.channel_id AND clel.channel="'.$channel.'"')
+                    ->leftJoin('clel', MAUTIC_TABLE_PREFIX.'campaigns', 'cmp', 'cmp.id = clel.campaign_id');
         }
 
         return $this;
-    }
-
-    /**
-     * Go through the used filters and let me know if the columns I provided exist in it.
-     *
-     * @param array $columns
-     *
-     * @return bool
-     */
-    public function columnsExistInFilter(array $columns)
-    {
-        $usedFilters = $this->report->getFilters();
-
-        if ($usedFilters) {
-            foreach ($usedFilters as $usedFilter) {
-                if (in_array($usedFilter['column'], $columns)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
@@ -244,6 +244,51 @@ class ReportGeneratorEvent extends AbstractReportEvent
     }
 
     /**
+     * Add IP left join.
+     *
+     * @param QueryBuilder $queryBuilder
+     * @param              $prefix
+     * @param string       $ipPrefix
+     *
+     * @return $this
+     */
+    public function addCampaignByChannelJoin(QueryBuilder $queryBuilder, $prefix, $channel)
+    {
+        $selectedColumns = $this->report->getColumns();
+
+        if (in_array('cmp.name', $selectedColumns)
+            || in_array('clel.campaign_id', $selectedColumns)
+            || $this->columnsExistInFilter(['cmp.name', 'clel.campaign_id'])) {
+            $queryBuilder->innerJoin('a', MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'clel', $prefix.'.id = clel.channel_id AND clel.channel="'.$channel.'"')
+                    ->innerJoin('clel', MAUTIC_TABLE_PREFIX.'campaigns', 'cmp', 'cmp.id = clel.campaign_id');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Go through the used filters and let me know if the columns I provided exist in it.
+     *
+     * @param array $columns
+     *
+     * @return bool
+     */
+    public function columnsExistInFilter(array $columns)
+    {
+        $usedFilters = $this->report->getFilters();
+
+        if ($usedFilters) {
+            foreach ($usedFilters as $usedFilter) {
+                if (in_array($usedFilter['column'], $columns)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Join channel columns.
      *
      * @param QueryBuilder $queryBuilder

--- a/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
@@ -254,10 +254,17 @@ class ReportGeneratorEvent extends AbstractReportEvent
      */
     public function addCampaignByChannelJoin(QueryBuilder $queryBuilder, $prefix, $channel)
     {
-        if ($this->hasColumn('cmp.name')
-            || $this->hasFilter('cmp.name')
-            || $this->hasColumn('clel.campaign_id')
-            || $this->hasFilter('clel.campaign_id')) {
+        $options = $this->getOptions();
+        $cmpName = 'cmp.name';
+        $cmpId   = 'clel.campaign_id';
+
+        if ($this->hasColumn($cmpName)
+            || $this->hasFilter($cmpName)
+            || $this->hasColumn($cmpId)
+            || $this->hasFilter($cmpId)
+            || (!empty($options['order'][0]
+                    && ($options['order'][0] === $cmpName
+                        || $options['order'][0] === $cmpId)))) {
             $queryBuilder->leftJoin($prefix, MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'clel', $prefix.'.id = clel.channel_id AND clel.channel="'.$channel.'"')
                     ->leftJoin('clel', MAUTIC_TABLE_PREFIX.'campaigns', 'cmp', 'cmp.id = clel.campaign_id');
         }

--- a/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
@@ -258,7 +258,7 @@ class ReportGeneratorEvent extends AbstractReportEvent
             || $this->hasFilter('cmp.name')
             || $this->hasColumn('clel.campaign_id')
             || $this->hasFilter('clel.campaign_id')) {
-            $queryBuilder->leftJoin('a', MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'clel', $prefix.'.id = clel.channel_id AND clel.channel="'.$channel.'"')
+            $queryBuilder->leftJoin($prefix, MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'clel', $prefix.'.id = clel.channel_id AND clel.channel="'.$channel.'"')
                     ->leftJoin('clel', MAUTIC_TABLE_PREFIX.'campaigns', 'cmp', 'cmp.id = clel.campaign_id');
         }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR adds __Campaign__ and __Campaign ID__ columns to reports so users can see what Page, Asset, Form, ... was used in a campaign or filter by campaign.

The campaign columns were added to reports with source of:
- [x] Asset
- [x] Asset Downloads      
- [x] Emails
- [x] Emails Sent        
- [x] Forms
- [x] Form Submissions        
- [x] Landing Pages
- [x] Page hits

#### Known issues:

If there are more records in the campaign_lead_event_log table for (for example) one page, the page will get displayed multiple times. The solution would be to add `groupBy('p.id')`, but @mqueme is working on adding the aggregations for reports in parallel PR, so I don't want to cause troubles when both PRs will be merged.

#### Steps to test this PR:
1. Apply this PR
2. Try to add the campaign columns or filter by campaign columns in the reports from the list above.
    2.1. If you don't have any data in your reports, create a related campaign event in some campaign. For example for Forms, create some Form Submitted decision.
    2.2 Run the campaign. There must be some row in the campaign_lead_event_log table so the campaign value to show up in the reports.