### PR TITLE
Fixed graph for unique hits in landing page details

### DIFF
--- a/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
+++ b/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
@@ -195,13 +195,13 @@ class ChartQuery extends AbstractChart
      *
      * @return \Doctrine\DBAL\Query\QueryBuilder
      */
-    public function prepareTimeDataQuery($table, $column, $filters = [])
+    public function prepareTimeDataQuery($table, $column, $filters = [], $countColumn = '*')
     {
         // Convert time unitst to the right form for current database platform
         $query = $this->connection->createQueryBuilder();
         $query->from($this->prepareTable($table), 't');
 
-        $this->modifyTimeDataQuery($query, $column);
+        $this->modifyTimeDataQuery($query, $column, 't', $countColumn);
         $this->applyFilters($query, $filters);
         $this->applyDateFilters($query, $column);
 
@@ -214,8 +214,9 @@ class ChartQuery extends AbstractChart
      * @param QueryBuilder $query
      * @param string       $column      name
      * @param string       $tablePrefix
+     * @param string       $countColumn
      */
-    public function modifyTimeDataQuery(&$query, $column, $tablePrefix = 't')
+    public function modifyTimeDataQuery(&$query, $column, $tablePrefix = 't', $countColumn = '*')
     {
         // Convert time unitst to the right form for current database platform
         $dbUnit  = $this->translateTimeUnit($this->unit);
@@ -227,7 +228,7 @@ class ChartQuery extends AbstractChart
             unset($filters['groupBy']);
         }
         $dateConstruct = 'DATE_FORMAT('.$tablePrefix.'.'.$column.', \''.$dbUnit.'\')';
-        $query->select($dateConstruct.' AS date, COUNT(*) AS count')
+        $query->select($dateConstruct.' AS date, COUNT('.$countColumn.') AS count')
             ->groupBy($dateConstruct.$groupBy);
 
         $query->orderBy($dateConstruct, 'ASC')->setMaxResults($limit);

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -857,8 +857,8 @@ class PageModel extends FormModel
         }
 
         if ($flag == 'unique' || $flag == 'total_and_unique') {
-            $q = $query->prepareTimeDataQuery('page_hits', 'date_hit', $filter);
-            $q->groupBy('t.lead_id, t.date_hit');
+            $q = $query->prepareTimeDataQuery('page_hits', 'date_hit', $filter, 'distinct(t.lead_id)');
+            $q->groupBy('DATE_FORMAT(t.date_hit, \'%Y-%m-%d\')');
 
             if (!$canViewOthers) {
                 $this->limitQueryToCreator($q);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The unique hits line in the landing page details view graph was always 1. This PR fixes it.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Hit a landing page with multiple contacts (may be easier to manipulate the database)
2. View the landing page's details page
3. Note that the unique hits in the graph is always 1 per each day

#### Steps to test this PR:
1. Unique hits should be unique contacts per day
