### PR TITLE
Fix mail as owner feature for tokenized transports

### DIFF
--- a/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
@@ -269,15 +269,6 @@ class BuilderSubscriber extends CommonSubscriber
 
         $signatureText = $this->coreParametersHelper->getParameter('default_signature_text');
         $fromName      = $this->coreParametersHelper->getParameter('mailer_from_name');
-
-        if (!empty($lead['owner_id'])) {
-            $owner = $this->factory->getModel('lead')->getRepository()->getLeadOwner($lead['owner_id']);
-            if ($owner && !empty($owner['signature'])) {
-                $fromName      = $owner['first_name'].' '.$owner['last_name'];
-                $signatureText = EmojiHelper::toHtml($owner['signature']);
-            }
-        }
-
         $signatureText = str_replace('|FROM_NAME|', $fromName, nl2br($signatureText));
         $event->addToken('{signature}', EmojiHelper::toHtml($signatureText));
 

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -12,11 +12,47 @@
 namespace Mautic\EmailBundle\Tests\Helper;
 
 use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\EmailBundle\MonitoredEmail\Mailbox;
 use Mautic\EmailBundle\Swiftmailer\Exception\BatchQueueMaxException;
 use Mautic\EmailBundle\Tests\Helper\Transport\BatchTransport;
+use Mautic\EmailBundle\Tests\Helper\Transport\SmtpTransport;
+use Mautic\LeadBundle\Entity\LeadRepository;
+use Mautic\LeadBundle\Model\LeadModel;
+use Monolog\Logger;
 
 class MailHelperTest extends \PHPUnit_Framework_TestCase
 {
+    protected $contacts = [
+        [
+            'id'        => 1,
+            'email'     => 'contact1@somewhere.com',
+            'firstname' => 'Contact',
+            'lastname'  => '1',
+            'owner_id'  => 1,
+        ],
+        [
+            'id'        => 2,
+            'email'     => 'contact2@somewhere.com',
+            'firstname' => 'Contact',
+            'lastname'  => '2',
+            'owner_id'  => 0,
+        ],
+        [
+            'id'        => 3,
+            'email'     => 'contact3@somewhere.com',
+            'firstname' => 'Contact',
+            'lastname'  => '3',
+            'owner_id'  => 2,
+        ],
+        [
+            'id'        => 4,
+            'email'     => 'contact4@somewhere.com',
+            'firstname' => 'Contact',
+            'lastname'  => '4',
+            'owner_id'  => 1,
+        ],
+    ];
+
     /**
      * @expectedException \Mautic\EmailBundle\Swiftmailer\Exception\BatchQueueMaxException
      */
@@ -74,5 +110,152 @@ class MailHelperTest extends \PHPUnit_Framework_TestCase
 
         // Otherwise success
         $this->assertTrue(true);
+    }
+
+    public function testQueuedOwnerAsMailer()
+    {
+        $mockFactory = $this->getMockFactory();
+
+        $transport   = new BatchTransport();
+        $swiftMailer = new \Swift_Mailer($transport);
+
+        $mailer = new \Mautic\EmailBundle\Helper\MailHelper($mockFactory, $swiftMailer, ['nobody@nowhere.com' => 'No Body']);
+
+        foreach ($this->contacts as $contact) {
+            $mailer->setTo($contact['email']);
+            $mailer->setLead($contact);
+            $mailer->queue();
+        }
+
+        $mailer->flushQueue();
+
+        $fromAddresses = $transport->getFromAddresses();
+        $metadatas     = $transport->getMetadatas();
+
+        $this->assertEquals(3, count($fromAddresses));
+        $this->assertEquals(3, count($metadatas));
+        $this->assertEquals(['owner1@owner.com', 'nobody@nowhere.com', 'owner2@owner.com'], $fromAddresses);
+
+        foreach ($metadatas as $key => $metadata) {
+            $this->assertTrue(isset($metadata[$this->contacts[$key]['email']]));
+
+            if (0 === $key) {
+                // Should have two contacts
+                $this->assertEquals(2, count($metadata));
+                $this->assertTrue(isset($metadata['contact4@somewhere.com']));
+            } else {
+                $this->assertEquals(1, count($metadata));
+            }
+
+            // Check that signatures are valid
+            if (1 === $key) {
+                // There should not be a signature token because owner was not set and token events have not been dispatched
+                $this->assertFalse(isset($metadata['tokens']['{signature}']));
+            } else {
+                $this->assertEquals($metadata[$this->contacts[$key]['email']]['tokens']['{signature}'], 'owner '.$this->contacts[$key]['owner_id']);
+
+                if (0 === $key) {
+                    // Ensure the last contact has the correct signature
+                    $this->assertEquals($metadata['contact4@somewhere.com']['tokens']['{signature}'], 'owner '.$this->contacts[$key]['owner_id']);
+                }
+            }
+        }
+    }
+
+    public function testStandardOwnerAsMailer()
+    {
+        $mockFactory = $this->getMockFactory();
+
+        $transport   = new SmtpTransport();
+        $swiftMailer = new \Swift_Mailer($transport);
+
+        $mailer = new \Mautic\EmailBundle\Helper\MailHelper($mockFactory, $swiftMailer, ['nobody@nowhere.com' => 'No Body']);
+        $mailer->setBody('{signature}');
+
+        foreach ($this->contacts as $key => $contact) {
+            $mailer->setTo($contact['email']);
+            $mailer->setLead($contact);
+            $mailer->send();
+
+            $body = $mailer->message->getBody();
+            $from = key($mailer->message->getFrom());
+
+            if ($contact['owner_id']) {
+                $this->assertEquals('owner'.$contact['owner_id'].'@owner.com', $from);
+                $this->assertEquals('owner '.$contact['owner_id'], $body);
+            } else {
+                $this->assertEquals('nobody@nowhere.com', $from);
+                $this->assertEquals('{signature}', $body);
+            }
+        }
+    }
+
+    protected function getMockFactory()
+    {
+        $mockLeadRepository = $this->getMockBuilder(LeadRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockLeadRepository->method('getLeadOwner')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        [1, ['id' => 1, 'email' => 'owner1@owner.com', 'first_name' => '', 'last_name' => '', 'signature' => 'owner 1']],
+                        [2, ['id' => 2, 'email' => 'owner2@owner.com', 'first_name' => '', 'last_name' => '', 'signature' => 'owner 2']],
+                    ]
+                )
+            );
+
+        $mockLeadModel = $this->getMockBuilder(LeadModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockLeadModel->method('getRepository')
+            ->willReturn($mockLeadRepository);
+
+        $mockFactory = $this->getMockBuilder(MauticFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockFactory->method('getParameter')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['mailer_return_path', false, null],
+                        ['mailer_spool_type', false, 'memory'],
+                        ['mailer_is_owner', false, true],
+                    ]
+                )
+            );
+        $mockFactory->method('getModel')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['lead', $mockLeadModel],
+                    ]
+                )
+            );
+
+        $mockLogger = $this->getMockBuilder(Logger::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockFactory->method('getLogger')
+            ->willReturn($mockLogger);
+
+        $mockMailboxHelper = $this->getMockBuilder(Mailbox::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockMailboxHelper->method('isConfigured')
+            ->willReturn(false);
+
+        $mockFactory->method('getHelper')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['mailbox', $mockMailboxHelper],
+                    ]
+                )
+            );
+
+        return $mockFactory;
     }
 }

--- a/app/bundles/EmailBundle/Tests/Helper/Transport/BatchTransport.php
+++ b/app/bundles/EmailBundle/Tests/Helper/Transport/BatchTransport.php
@@ -13,17 +13,54 @@ use Mautic\EmailBundle\Swiftmailer\Transport\AbstractTokenArrayTransport;
 
 class BatchTransport extends AbstractTokenArrayTransport implements \Swift_Transport
 {
+    private $fromAddresses = [];
+    private $metadatas     = [];
+
+    /**
+     * @param \Swift_Mime_Message $message
+     * @param null                $failedRecipients
+     */
     public function send(\Swift_Mime_Message $message, &$failedRecipients = null)
     {
+        $this->message = $message;
+
+        $this->fromAddresses[] = key($message->getFrom());
+        $this->metadatas[]     = $this->getMetadata();
     }
 
+    /**
+     * @return int
+     */
     public function getMaxBatchLimit()
     {
         return 1;
     }
 
+    /**
+     * @param \Swift_Message $message
+     * @param int            $toBeAdded
+     * @param string         $type
+     *
+     * @return int
+     */
     public function getBatchRecipientCount(\Swift_Message $message, $toBeAdded = 1, $type = 'to')
     {
         return count($message->getTo()) + $toBeAdded;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFromAddresses()
+    {
+        return $this->fromAddresses;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMetadatas()
+    {
+        return $this->metadatas;
     }
 }

--- a/app/bundles/EmailBundle/Tests/Helper/Transport/SmtpTransport.php
+++ b/app/bundles/EmailBundle/Tests/Helper/Transport/SmtpTransport.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Helper\Transport;
+
+use Swift_Mime_Message;
+
+class SmtpTransport implements \Swift_Transport
+{
+    public function send(Swift_Mime_Message $message, &$failedRecipients = null)
+    {
+    }
+
+    /**
+     * Test if this Transport mechanism has started.
+     *
+     * @return bool
+     */
+    public function isStarted()
+    {
+        return true;
+    }
+
+    /**
+     * Start this Transport mechanism.
+     */
+    public function start()
+    {
+        return true;
+    }
+
+    /**
+     * Stop this Transport mechanism.
+     */
+    public function stop()
+    {
+        return true;
+    }
+
+    /**
+     * Register a plugin in the Transport.
+     *
+     * @param \Swift_Events_EventListener $plugin
+     */
+    public function registerPlugin(\Swift_Events_EventListener $plugin)
+    {
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Using the contact owner as the from address did not work for transports that utilized batch sends/tokenized emails (sparkpost, mandrill). This fixes that.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Configure sparkpost as the mailer
2. Set configuration to enable owner as mailer
3. Set yourself as the owner of a contact
4. Update your signature in your profile
5. Email that contact (include {signature} in the body)
6. Note that the from will be the system default and the signature will be the system defaults

#### Steps to test this PR:
1. Repeat the above but the from will be you and the body will include your signature