### PR TITLE
Display errors for authorizing plugins

### DIFF
--- a/app/bundles/PluginBundle/Views/Auth/postauth.html.php
+++ b/app/bundles/PluginBundle/Views/Auth/postauth.html.php
@@ -11,7 +11,6 @@
 $view->extend('MauticCoreBundle:Default:slim.html.php');
 $view['slots']->set('mauticContent', 'social');
 
-if (empty($message)):
 $data = json_encode($data);
 $js   = <<<JS
 function postFormHandler() {
@@ -22,17 +21,23 @@ function postFormHandler() {
         Mautic.refreshIntegrationForm();
     }
     window.close()
-
 }
+JS;
+
+if (empty($message)):
+    $js .= <<<'JS'
+    
 (function() {
    postFormHandler();
 })();
 JS;
+endif;
 ?>
 <script>
     <?php echo $js; ?>
 </script>
-<?php else: ?>
+
+<?php if (!empty($message)): ?>
     <div class="alert alert-<?php echo $alert; ?>">
         <?php echo $message; ?>
     </div>

--- a/app/bundles/PluginBundle/Views/Auth/postauth.html.php
+++ b/app/bundles/PluginBundle/Views/Auth/postauth.html.php
@@ -10,6 +10,8 @@
  */
 $view->extend('MauticCoreBundle:Default:slim.html.php');
 $view['slots']->set('mauticContent', 'social');
+
+if (empty($message)):
 $data = json_encode($data);
 $js   = <<<JS
 function postFormHandler() {
@@ -30,7 +32,7 @@ JS;
 <script>
     <?php echo $js; ?>
 </script>
-<?php if (!empty($message)): ?>
+<?php else: ?>
     <div class="alert alert-<?php echo $alert; ?>">
         <?php echo $message; ?>
     </div>

--- a/app/bundles/PluginBundle/Views/Auth/postauth.html.php
+++ b/app/bundles/PluginBundle/Views/Auth/postauth.html.php
@@ -24,7 +24,7 @@ function postFormHandler() {
 }
 JS;
 
-if (empty($message)):
+if (!empty($message) && 'success' === $alert):
     $js .= <<<'JS'
     
 (function() {

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -12,6 +12,7 @@
 namespace MauticPlugin\MauticCrmBundle\Integration;
 
 use Mautic\CoreBundle\Helper\InputHelper;
+use Mautic\PluginBundle\Exception\ApiErrorException;
 
 /**
  * Class ZohoIntegration.
@@ -139,7 +140,11 @@ class ZohoIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @return array
+     * @param array $settings
+     *
+     * @return array|bool
+     *
+     * @throws ApiErrorException
      */
     public function getAvailableLeadFields($settings = [])
     {
@@ -149,6 +154,7 @@ class ZohoIntegration extends CrmAbstractIntegration
 
         $zohoFields        = [];
         $silenceExceptions = (isset($settings['silence_exceptions'])) ? $settings['silence_exceptions'] : true;
+
         try {
             if ($this->isAuthorized()) {
                 $leadObject = $this->getApiHelper()->getLeadFields();
@@ -178,7 +184,7 @@ class ZohoIntegration extends CrmAbstractIntegration
                     }
                 }
             }
-        } catch (ErrorException $exception) {
+        } catch (ApiErrorException $exception) {
             $this->logIntegrationError($exception);
 
             if (!$silenceExceptions) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If an integration failed authorization, the popup window would close and thus hide whatever error was returned by the integration. This fixes it so that the window only closes if authorization is successful.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Configure the zoho integration using a bad credential to cause it to return with an error
2. Click the authorize button.
3. The popup will close without showing the error

#### Steps to test this PR:
1. The popup should remain open with the error displayed