### PR TITLE
Prevent exception if no contacts are found with getEntities

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -88,8 +88,8 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
         $col = 'l.'.$field;
 
         $q = $this->getEntityManager()->getConnection()->createQueryBuilder()
-                  ->select('l.id')
-                  ->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
+            ->select('l.id')
+            ->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
 
         if ($field == 'email') {
             // Prevent emails from being case sensitive
@@ -108,7 +108,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
             );
         } else {
             $q->where("$col = :search")
-              ->setParameter('search', $value);
+                ->setParameter('search', $value);
         }
 
         if ($ignoreId) {
@@ -302,8 +302,8 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
                 $contactId = (int) $id['id'];
             } else {
                 $q->select('l, u, i')
-                ->leftJoin('l.ipAddresses', 'i')
-                ->leftJoin('l.owner', 'u');
+                    ->leftJoin('l.ipAddresses', 'i')
+                    ->leftJoin('l.owner', 'u');
                 $contactId = $id;
             }
             $q->andWhere($this->getTableAlias().'.id = '.(int) $contactId);
@@ -386,14 +386,15 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
             }
         );
 
-        if (!empty($args['withPrimaryCompany']) || !empty($args['withChannelRules'])) {
+        $contactCount = isset($contacts['results']) ? count($contacts['results']) : count($contacts);
+        if ($contactCount && (!empty($args['withPrimaryCompany']) || !empty($args['withChannelRules']))) {
+            $withTotalCount = (array_key_exists('withTotalCount', $args) && $args['withTotalCount']);
+            /** @var Lead[] $tmpContacts */
+            $tmpContacts = ($withTotalCount) ? $contacts['results'] : $contacts;
+
             $withCompanies   = !empty($args['withPrimaryCompany']);
             $withPreferences = !empty($args['withChannelRules']);
-
-            $withTotalCount = array_key_exists('withTotalCount', $args);
-            /** @var Lead[] $tmpContacts */
-            $tmpContacts = ($withTotalCount && $args['withTotalCount']) ? $contacts['results'] : $contacts;
-            $contactIds  = array_keys($tmpContacts);
+            $contactIds      = array_keys($tmpContacts);
 
             if ($withCompanies) {
                 $companies = $this->getEntityManager()->getRepository('MauticLeadBundle:Company')->getCompaniesForContacts($contactIds);
@@ -445,7 +446,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
                 }
             }
 
-            if ($withTotalCount && $args['withTotalCount']) {
+            if ($withTotalCount) {
                 $contacts['results'] = $tmpContacts;
             } else {
                 $contacts = $tmpContacts;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If there are not contacts, such as after a contact has been deleted with the campaign action, a SQL error is thrown because it tries to query with an empty in() statement for companies and frequency rules.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a campaign with just the delete contact action
2. Run the campaign

#### Steps to test this PR:
1. No exception should be thrown
2. Send an email with dynamic web content setup using company filters. Ensure that the received emails have appropriate content to the company based filters.