### PR TITLE
Do not crash when the browser refuses to store in local storage

### DIFF
--- a/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
@@ -256,9 +256,11 @@ MauticJS.setTrackedContact = function(response) {
             
         // Set the id in local storage in case cookies are only allowed for sites visited and Mautic is on a different domain
         // than the current page
-        if (window.localStorage) {
+        try {
             localStorage.setItem('mtc_id', response.id);
             localStorage.setItem('mtc_sid', response.sid);
+        } catch (e) {
+            console.warn('Browser does not allow storing in local storage');
         }
     }
 };


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | ✔️ 
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

#### Description:

Viewing a page tracked my Mautic in an private Safari window causes the tracking pixel because Safari refuses to use Web Storage in private windows, throwind a [`QuotaExceededError`](https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-setitem)

#### Steps to reproduce the bug:
1. Open a page tracked by Mautic in a private Safari window
2. Open the developer console to see the uncaught error

#### Steps to test this PR:
1. Apply this PR
1. Open a page tracked by Mautic in a private Safari window
2. Open the developer console to see the warning