### PR TITLE
Fixed bug where company may not be selected upon editing a contat

### DIFF
--- a/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
+++ b/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
@@ -160,12 +160,17 @@ class EntityLookupChoiceLoader implements ChoiceLoaderInterface
             // Build choice list in case of different formats
             $choices = $this->fetchChoices($modelName, $data);
 
+            if ($choices) {
+                $this->formatChoices($choices);
+            }
+
             if ($includeNew && !empty($data)) {
                 // Fetch some extra choices
                 $extraChoices = $this->fetchChoices($modelName);
 
                 // Test if grouped
                 if ($extraChoices) {
+                    $this->formatChoices($extraChoices);
                     foreach ($extraChoices as $k => $v) {
                         if (is_array($v)) {
                             if (!isset($choices[$k])) {
@@ -179,10 +184,6 @@ class EntityLookupChoiceLoader implements ChoiceLoaderInterface
                     }
                 }
                 unset($extraChoices);
-            }
-
-            if (!empty($choices)) {
-                $this->formatChoices($choices);
             }
 
             $this->choices[$modelName] = $choices;


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #3687 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR fixes #3687. The issue is that companies returned a choice list in the format of [['label' => '', 'value' => '']] however when merging these results with the actual selected, the key became overwritten. The fix included ensuring both $choices and $extraChoices are in the same format before merging. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Hack https://github.com/mautic/mautic/blob/3c9e19f3d689e3cff3ddc906f90ac976056c2594/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php#L280-L280 to be 2
2. Edit a contact that has a company selected and notice it should be empty

#### Steps to test this PR:
1. Repeat the above but this time the company should be selected
