### PR TITLE
Fixed clicked and DNC queries for email details graph

### DIFF
--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -14,6 +14,7 @@ namespace Mautic\EmailBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\PersistentCollection;
 use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\AssetBundle\Entity\Asset;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
@@ -841,7 +842,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
     }
 
     /**
-     * @return mixed
+     * @return PersistentCollection
      */
     public function getLists()
     {

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -617,9 +617,9 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             $sentCounts         = $statRepo->getSentCount($emailIds, true, $query);
             $readCounts         = $statRepo->getReadCount($emailIds, true, $query);
             $failedCounts       = $statRepo->getFailedCount($emailIds, true, $query);
-            $clickCounts        = $trackableRepo->getCount('email', $emailIds, true, $query);
-            $unsubscribedCounts = $dncRepo->getCount('email', $emailIds, DoNotContact::UNSUBSCRIBED, true, $query);
-            $bouncedCounts      = $dncRepo->getCount('email', $emailIds, DoNotContact::BOUNCED, true, $query);
+            $clickCounts        = $trackableRepo->getCount('email', $emailIds, $lists->getKeys(), $query);
+            $unsubscribedCounts = $dncRepo->getCount('email', $emailIds, DoNotContact::UNSUBSCRIBED, $lists->getKeys(), $query);
+            $bouncedCounts      = $dncRepo->getCount('email', $emailIds, DoNotContact::BOUNCED, $lists->getKeys(), $query);
 
             foreach ($lists as $l) {
                 $sentCount = isset($sentCounts[$l->getId()]) ? $sentCounts[$l->getId()] : 0;
@@ -1794,6 +1794,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             }
 
             $data = $query->loadAndBuildTimeData($q);
+
             $chart->setDataset($this->translator->trans('mautic.email.clicked'), $data);
         }
 

--- a/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
+++ b/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
@@ -75,6 +75,12 @@ class DoNotContactRepository extends CommonRepository
             if (true === $listId) {
                 $q->addSelect('cs.leadlist_id')
                     ->groupBy('cs.leadlist_id');
+            } elseif (is_array($listId)) {
+                $q->andWhere(
+                    $q->expr()->in('cs.leadlist_id', array_map('intval', $listId))
+                )
+                    ->addSelect('cs.leadlist_id')
+                    ->groupBy('cs.leadlist_id');
             } else {
                 $q->andWhere('cs.leadlist_id = :list_id')
                     ->setParameter('list_id', $listId);
@@ -87,7 +93,7 @@ class DoNotContactRepository extends CommonRepository
 
         $results = $q->execute()->fetchAll();
 
-        if (true === $listId) {
+        if (true === $listId || is_array($listId)) {
             // Return list group of counts
             $byList = [];
             foreach ($results as $result) {

--- a/app/bundles/PageBundle/Entity/TrackableRepository.php
+++ b/app/bundles/PageBundle/Entity/TrackableRepository.php
@@ -148,7 +148,7 @@ class TrackableRepository extends CommonRepository
     public function getCount($channel, $channelIds, $listId, ChartQuery $chartQuery = null)
     {
         $q = $this->_em->getConnection()->createQueryBuilder()
-            ->select('count(DISTINCT(cut.redirect_id)) as click_count')
+            ->select('count(ph.id) as click_count')
             ->from(MAUTIC_TABLE_PREFIX.'channel_url_trackables', 'cut')
             ->leftJoin('cut', MAUTIC_TABLE_PREFIX.'page_hits', 'ph', 'ph.redirect_id = cut.redirect_id');
 
@@ -160,7 +160,7 @@ class TrackableRepository extends CommonRepository
             if (!is_array($channelIds)) {
                 $channelIds = [(int) $channelIds];
             }
-            $q->where(
+            $q->andWhere(
                 $q->expr()->in('cut.channel_id', $channelIds)
             );
         }
@@ -170,6 +170,12 @@ class TrackableRepository extends CommonRepository
 
             if (true === $listId) {
                 $q->addSelect('cs.leadlist_id')
+                    ->groupBy('cs.leadlist_id');
+            } elseif (is_array($listId)) {
+                $q->andWhere(
+                    $q->expr()->in('cs.leadlist_id', array_map('intval', $listId))
+                )
+                    ->addSelect('cs.leadlist_id')
                     ->groupBy('cs.leadlist_id');
             } else {
                 $q->andWhere('cs.leadlist_id = :list_id')
@@ -183,7 +189,7 @@ class TrackableRepository extends CommonRepository
 
         $results = $q->execute()->fetchAll();
 
-        if (true === $listId) {
+        if (true === $listId || is_array($listId)) {
             // Return array of results
             $byList = [];
             foreach ($results as $result) {


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The clicked count in the overview graph of the email details page did not show the correct click counts. Also it along with the DNC graphs queried for all lists the leads were part of and not just the lists associated with the email. So this PR fixes that. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Send an email to a segment with a link it it.
2. Open the link in an private browser session
3. Note that the click is not in the graph

#### Steps to test this PR:
1. Repeat and it shows
