### PR TITLE
Un/Publishing a Twitter monitoring from monitoring list fixed

### DIFF
--- a/plugins/MauticSocialBundle/Views/Monitoring/list.html.php
+++ b/plugins/MauticSocialBundle/Views/Monitoring/list.html.php
@@ -80,7 +80,7 @@ if ($tmpl == 'index') {
                                 'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                 [
                                     'item'  => $item,
-                                    'model' => 'plugin.mauticSocial.monitoring',
+                                    'model' => 'social.monitoring',
                                 ]
                             ); ?>
                             <a href="<?php echo $view['router']->path(


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Un/Publishing a Social Monitoring from the monitoring list table throws an error that the model does not exist.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create some social monitoring
2. Go to the monitoring table
3. Try to unpublish it - error

#### Steps to test this PR:
1. Apply this PR
2. Repeat the test - unpublishing works.