### PR TITLE
fix fullContact plugin

### DIFF
--- a/plugins/MauticFullContactBundle/Controller/PublicController.php
+++ b/plugins/MauticFullContactBundle/Controller/PublicController.php
@@ -46,7 +46,7 @@ class PublicController extends FormController
             return new Response('ERROR');
         }
 
-        $result           = $this->request->request->get('result', []);
+        $result           = json_decode($this->request->request->get('result', []), true);
         $oid              = $this->request->request->get('webhookId', '');
         $validatedRequest = $this->get('mautic.plugin.fullcontact.lookup_helper')->validateRequest($oid);
 


### PR DESCRIPTION
Based on changes recommended in 
https://www.mautic.org/community/index.php/6263-fullcontact-pluign-don-t-callback/0

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Using the Mautic FullContact plugin to pull data from FullContact is not working. No data is returned.

See thread for full detail: https://www.mautic.org/community/index.php/6263-fullcontact-pluign-don-t-callback/0

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Install and configure Fullcontact plugin
2. Save a contact to pull data in from Fullcontact

#### Steps to test this PR:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 