### PR TITLE
Fix point triggers

### DIFF
--- a/app/bundles/EmailBundle/Helper/PointEventHelper.php
+++ b/app/bundles/EmailBundle/Helper/PointEventHelper.php
@@ -64,9 +64,13 @@ class PointEventHelper
                 $leadCredentials       = $leadModel->flattenFields($leadFields);
                 $leadCredentials['id'] = $lead->getId();
 
-                $options = ['source' => ['trigger', $event['id']]];
-                $model->sendEmail($email, $leadCredentials, $options);
+                $options   = ['source' => ['trigger', $event['id']]];
+                $emailSent = $model->sendEmail($email, $leadCredentials, $options);
+
+                return is_array($emailSent) ? false : true;
             }
         }
+
+        return false;
     }
 }

--- a/app/bundles/EmailBundle/Helper/PointEventHelper.php
+++ b/app/bundles/EmailBundle/Helper/PointEventHelper.php
@@ -45,6 +45,8 @@ class PointEventHelper
      * @param               $event
      * @param Lead          $lead
      * @param MauticFactory $factory
+     *
+     * @return bool
      */
     public static function sendEmail($event, Lead $lead, MauticFactory $factory)
     {

--- a/app/bundles/EmailBundle/Tests/Helper/PointEventHelper.php
+++ b/app/bundles/EmailBundle/Tests/Helper/PointEventHelper.php
@@ -43,8 +43,8 @@ class PointEventHelperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param string $queueMode
-     *
+     * @param bool $published
+     * @param bool $success
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
     private function getMockMauticFactory($published = true, $success = true)
@@ -88,6 +88,8 @@ class PointEventHelperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @param bool $published
+     * @param bool $success
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
     private function getMockEmail($published = true, $success = true)

--- a/app/bundles/EmailBundle/Tests/Helper/PointEventHelper.php
+++ b/app/bundles/EmailBundle/Tests/Helper/PointEventHelper.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Mautic\EmailBundle\Tests\Helper;
+
+use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Helper\PointEventHelper;
+use Mautic\EmailBundle\Model\EmailModel;
+use Mautic\LeadBundle\Model\LeadModel;
+
+class PointEventHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSendEmail()
+    {
+        $helper = new PointEventHelper();
+        $lead = new Lead();
+        $lead->setFields([
+            'core' => [
+                'email' => [
+                    'value' => 'test@test.com'
+                ]
+            ]
+        ]);
+        $event = [
+            'id' => 1,
+            'properties' => [
+                'email' => 1
+            ]
+        ];
+
+        $result = $helper->sendEmail($event, $lead, $this->getMockMauticFactory());
+        $this->assertEquals(true, $result);
+
+        $result = $helper->sendEmail($event, $lead, $this->getMockMauticFactory(false));
+        $this->assertEquals(false, $result);
+
+        $result = $helper->sendEmail($event, $lead, $this->getMockMauticFactory(true, false));
+        $this->assertEquals(false, $result);
+
+        $result = $helper->sendEmail($event, new Lead(), $this->getMockMauticFactory(true, false));
+        $this->assertEquals(false, $result);
+    }
+
+    /**
+     * @param string $queueMode
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getMockMauticFactory($published = true, $success = true)
+    {
+        $mock = $this->getMockBuilder(MauticFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getModel'])
+            ->getMock()
+        ;
+
+        $mock->expects($this->any())
+            ->method('getModel')
+            ->willReturnCallback(function ($model) use ($published, $success){
+                switch ($model) {
+                    case 'email':
+                        return $this->getMockEmail($published, $success);
+                    case 'lead':
+                        return $this->getMockLead();
+                }
+            });
+
+        return $mock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getMockLead()
+    {
+        $mock = $this->getMockBuilder(LeadModel::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['flattenFields'])
+            ->getMock()
+        ;
+
+        $mock->expects($this->any())
+            ->method('flattenFields')
+            ->willReturn([]);
+
+        return $mock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getMockEmail($published = true, $success = true)
+    {
+        $sendEmail = $success ? true : ['error' => 1];
+
+        $mock = $this->getMockBuilder(EmailModel::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getEntity', 'sendEmail'])
+            ->getMock()
+        ;
+
+        $mock->expects($this->any())
+            ->method('getEntity')
+            ->willReturnCallback(function ($id) use ($published) {
+                $email = new Email();
+                $email->setIsPublished($published);
+
+                return $email;
+            });
+
+        $mock->expects($this->any())
+            ->method('sendEmail')
+            ->willReturn($sendEmail);
+
+        return $mock;
+    }
+
+}

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -480,7 +480,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
     protected function isChanged($prop, $val, $oldValue = null)
     {
         $getter  = 'get'.ucfirst($prop);
-        $current = ($oldValue) ? $oldValue : $this->$getter();
+        $current = $oldValue !== null ? $oldValue : $this->$getter();
         if ($prop == 'owner') {
             if ($current && !$val) {
                 $this->changes['owner'] = [$current->getId(), $val];

--- a/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
@@ -84,4 +84,18 @@ class LeadTest extends \PHPUnit_Framework_TestCase
         $channelRules = Lead::generateChannelRules($lead->getFrequencyRules()->toArray(), $lead->getDoNotContact()->toArray());
         $this->assertEquals(['channel2', 'channel3', 'channel5', 'channel6', 'channel1', 'channel4'], array_keys($channelRules));
     }
+
+    public function testAdjustPoints()
+    {
+        $points = 501;
+        $lead   = new Lead();
+        $lead->adjustPoints($points);
+
+        $this->assertEquals([
+            'points' => [
+                0 => 0,
+                1 => $points,
+            ],
+        ], $lead->getChanges());
+    }
 }

--- a/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
@@ -87,15 +87,53 @@ class LeadTest extends \PHPUnit_Framework_TestCase
 
     public function testAdjustPoints()
     {
-        $points = 501;
-        $lead   = new Lead();
-        $lead->adjustPoints($points);
+        // new lead
+        $this->adjustPointsTest(5, $this->getLeadChangedArray(0, 5), new Lead());
+        $this->adjustPointsTest(5, $this->getLeadChangedArray(0, 5), new Lead(), 'plus');
+        $this->adjustPointsTest(5, $this->getLeadChangedArray(0, -5), new Lead(), 'minus');
+        $this->adjustPointsTest(5, [], new Lead(), 'times');
+        $this->adjustPointsTest(5, [], new Lead(), 'divide');
 
-        $this->assertEquals([
+        // existing lead
+        $lead = new Lead();
+        $lead->setPoints(5);
+
+        $this->adjustPointsTest(5, $this->getLeadChangedArray(5, 10), $lead);
+        $this->adjustPointsTest(5, $this->getLeadChangedArray(10, 15), $lead);
+        $this->adjustPointsTest(10, $this->getLeadChangedArray(15, 150), $lead, 'times');
+        $this->adjustPointsTest(10, $this->getLeadChangedArray(150, 15), $lead, 'divide');
+    }
+
+    /**
+     * @param $points
+     * @param $expected
+     * @param Lead $lead
+     * @param bool $operator
+     */
+    private function adjustPointsTest($points, $expected, Lead $lead, $operator = false)
+    {
+        if ($operator) {
+            $lead->adjustPoints($points, $operator);
+        } else {
+            $lead->adjustPoints($points);
+        }
+
+        $this->assertEquals($expected, $lead->getChanges());
+    }
+
+    /**
+     * @param int $oldValue
+     * @param int $newValue
+     *
+     * @return array
+     */
+    private function getLeadChangedArray($oldValue = 0, $newValue = 0)
+    {
+        return [
             'points' => [
-                0 => 0,
-                1 => $points,
+                0 => $oldValue,
+                1 => $newValue,
             ],
-        ], $lead->getChanges());
+        ];
     }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | --
| Related user documentation PR URL | --
| Related developer documentation PR URL | --
| Issues addressed (#s or URLs) | --
| BC breaks? | --
| Deprecations? | --

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
1. Point Triggers are not working for new users.
2. "Send Email" event will be triggered each time system will change Lead points. (Event if email was sent before)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create new user 
2. Add user to segment
3. Build campaign that will only adjust points to users.
4. Add Point Trigger with "Send Emal" event.
5. Trigger campaign. Email wont be send for new user.
6. Create same campaign and trigger. You will get email.
7. Create same campaign and trigger. You will get email again.Each time system will trigger "change points" event on Lead, he will receive email.

#### Steps to test this PR:
1. Same steps as above. Point triggers event will be fired for new users and only once.
2. Run phpunit tests