### PR TITLE
Allow google cloud deploy to send emails

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
@@ -30,7 +30,7 @@ class AmazonTransport extends \Swift_SmtpTransport implements InterfaceCallbackT
      */
     public function __construct($host, Http $httpClient)
     {
-        parent::__construct($host, 587, 'tls');
+        parent::__construct($host, 2587, 'tls');
         $this->setAuthMode('login');
         $this->httpClient = $httpClient;
     }


### PR DESCRIPTION
Google cloud blocks 587 port.
This would fix it.

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 

#### Steps to test this PR:
1. deploy on google cloud
2. configure ses
3. send email

#### List backwards compatibility breaks:
1. if a user has a strict exit firewall rule, he can't send emails any more (I'm not sure it concerns a lot of users

Alternatively, we could make this configurable?