### PR TITLE
Add point field to several places in the app

### DIFF
--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -129,6 +129,11 @@ class FieldModel extends FormModel
             'listable' => true,
             'object'   => 'lead',
         ],
+        'points' => [
+            'type'   => 'number',
+            'fixed'  => true,
+            'object' => 'lead',
+        ],
         'facebook' => [
             'listable' => true,
             'group'    => 'social',

--- a/app/migrations/Version20170516000000.php
+++ b/app/migrations/Version20170516000000.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+use Mautic\LeadBundle\Entity\LeadField;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170516000000 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        $em        = $this->container->get('doctrine')->getManager();
+        $leadField = $em->getRepository(LeadField::class)->findOneByAlias('points');
+
+        if ($leadField) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $sql = <<<SQL
+INSERT INTO `{$this->prefix}lead_fields` (`is_published`, `label`, `alias`, `type`, `field_group`, `default_value`, `is_required`, `is_fixed`, `is_visible`, `is_short_visible`, `is_listable`, `is_publicly_updatable`, `is_unique_identifer`, `field_order`, `properties`, `object`) 
+VALUES (1, 'Points', 'points', 'number', 'core', '0', 0, 1, 1, 0, 0, 0, 0, 29, 'a:0:{}', 'lead');
+SQL;
+        $this->addSql($sql);
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | x
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3822 https://github.com/mautic/mautic/issues/3533 https://github.com/mautic/mautic/issues/967 and a little bit of https://github.com/mautic/mautic/issues/124
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
# Description:
**We globally added the ability to modify the point contact field everywhere in the application.**

## Contact point management
You can now edit the points of a contact while modifying its contact page. Answers to issue https://github.com/mautic/mautic/issues/967

## Campaign point decision & update action
You can now find the contact point field in 2 places in the campaign builder to answer to the need of the issue https://github.com/mautic/mautic/issues/124
* Action: update contact field
* Condition on contact field value

## Synchronize point in CRM plugins
You will now find the point contact field in the CRM field mapping tab. Answers to issue https://github.com/mautic/mautic/issues/3822.
Then you can take action in your CRM depending on the score. Salesmen will be now very happy :)

## Use point in emails as token
Answers to issue https://github.com/mautic/mautic/issues/3533.

## Points in forms
You can now find the contact point field in the form field mapping tab.

---------

⚠️ @alanhartless how could we make it so doctrine is aware of this change, so that we can fix this for all existing instances using the standard doctrine migrations / schema update processes ?