### PR TITLE
Fix adding a contact to a company which does not exist

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -2425,6 +2425,11 @@ class LeadModel extends FormModel
             $company = $this->companyModel->getEntity($company);
         }
 
+        // company does not exist anymore
+        if ($company === null) {
+            return false;
+        }
+
         $companyLead = $this->companyModel->getCompanyLeadRepository()->getCompaniesByLeadId($lead->getId(), $company->getId());
 
         if (empty($companyLead)) {


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
I got this error when I run the `app/console mautic:campaign:trigger` command:
```
Symfony\Component\Debug\Exception\FatalThrowableError: Call to a member function getId() on null (uncaught exception) at /Users/jan/dev/mautic/app/bundles/LeadBundle/Model/LeadModel.php line 2419 while running console command `mautic:campaigns:trigger`
```
The error happened on this campaign:
![screen shot 2017-04-20 at 15 59 34](https://cloud.githubusercontent.com/assets/1235442/25234477/6ffc764a-25e2-11e7-9825-3b7697ab0049.png)

Based on the error and the code, the problem occurs when we try to add a contact to a company which does not exist and therefor the `$company` is `null`.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a campaign with __Add to company__ action
2. Remove the company you selected in the action
3. Run `app/console mautic:campaing:update` and `app/console mautic:campaing:trigger`
- You should get the error

#### Steps to test this PR:
1. Apply this PR
2. Run the command again. No error is thrown and all the campaigns are processed.
