### PR TITLE
removed two lines of code conflicting with saving fields

### DIFF
--- a/app/bundles/PluginBundle/Controller/AjaxController.php
+++ b/app/bundles/PluginBundle/Controller/AjaxController.php
@@ -342,7 +342,7 @@ class AjaxController extends CommonAjaxController
         $integration_object = $helper->getIntegrationObject($integration);
         $entity             = $integration_object->getIntegrationSettings();
         $featureSettings    = $entity->getFeatureSettings();
-        $doNotMatchField    = ($mautic_field === '-1');
+        $doNotMatchField    = ($mautic_field === '-1' || $mautic_field === '');
         if ($object == 'lead') {
             $fields       = 'leadFields';
             $updateFields = 'update_mautic';
@@ -363,12 +363,13 @@ class AjaxController extends CommonAjaxController
             $newFeatureSettings[$integration_field] = $update_mautic;
             if (isset($featureSettings[$updateFields])) {
                 $featureSettings[$updateFields] = array_merge($featureSettings[$updateFields], $newFeatureSettings);
+            } else {
+                $featureSettings[$updateFields] = $newFeatureSettings;
             }
             $newFeatureSettings[$integration_field] = $mautic_field;
             if (isset($featureSettings[$fields])) {
                 $featureSettings[$fields] = array_merge($featureSettings[$fields], $newFeatureSettings);
-            }
-            if (empty($featureSettings[$fields])) {
+            } else {
                 $featureSettings[$fields] = $newFeatureSettings;
             }
 

--- a/app/bundles/PluginBundle/Controller/AjaxController.php
+++ b/app/bundles/PluginBundle/Controller/AjaxController.php
@@ -342,8 +342,7 @@ class AjaxController extends CommonAjaxController
         $integration_object = $helper->getIntegrationObject($integration);
         $entity             = $integration_object->getIntegrationSettings();
         $featureSettings    = $entity->getFeatureSettings();
-
-        $doNotMatchField = ($mautic_field === '-1');
+        $doNotMatchField    = ($mautic_field === '-1');
         if ($object == 'lead') {
             $fields       = 'leadFields';
             $updateFields = 'update_mautic';
@@ -369,10 +368,12 @@ class AjaxController extends CommonAjaxController
             if (isset($featureSettings[$fields])) {
                 $featureSettings[$fields] = array_merge($featureSettings[$fields], $newFeatureSettings);
             }
+            if (empty($featureSettings[$fields])) {
+                $featureSettings[$fields] = $newFeatureSettings;
+            }
 
             $dataArray = ['success' => 1];
         }
-
         $entity->setFeatureSettings($featureSettings);
 
         $this->getModel('plugin')->saveFeatureSettings($entity);

--- a/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
+++ b/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
@@ -128,6 +128,8 @@ class FeatureSettingsType extends AbstractType
 
             $enableDataPriority = !empty($formSettings['enable_data_priority']);
 
+            $leadFields['-1'] = '';
+
             $leadFields['mauticContactTimelineLink'] = $this->translator->trans('mautic.plugin.integration.contact.timeline.link');
 
             $form->add(

--- a/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
+++ b/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
@@ -128,11 +128,7 @@ class FeatureSettingsType extends AbstractType
 
             $enableDataPriority = !empty($formSettings['enable_data_priority']);
 
-            $leadFields['-1'] = '';
-
             $leadFields['mauticContactTimelineLink'] = $this->translator->trans('mautic.plugin.integration.contact.timeline.link');
-
-            $leadFields['-1'] = '';
 
             $form->add(
                 'leadFields',

--- a/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
+++ b/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
@@ -47,7 +47,6 @@ trait FieldsTypeTrait
                 $optionalFields = [];
                 $group = [];
                 $fieldData = $event->getData();
-
                 // First loop to build options
                 foreach ($integrationFields as $field => $details) {
                     $groupName = '0default';
@@ -111,15 +110,14 @@ trait FieldsTypeTrait
                 }
 
                 // Ensure that fields aren't hidden
-                if ($start > count($fields)) {
+                if ($start > count($fields) || $options['page'] == 0) {
                     $start = 0;
                 }
-                $paginatedFields = array_slice($fields, $start, $limit);
 
+                $paginatedFields = array_slice($fields, $start, $limit);
                 foreach ($paginatedFields as $field => $details) {
                     $matched = isset($fieldData[$field]);
                     $required = (int) !empty($integrationFields[$field]['required']);
-
                     ++$index;
                     $form->add(
                         'label_'.$index,

--- a/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
+++ b/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
@@ -57,8 +57,12 @@ class LeadListSubscriber extends CommonSubscriber
     public function onFilterChoiceFieldsGenerate(LeadListFiltersChoicesEvent $event)
     {
         $integration = $this->helper->getIntegrationObject('Salesforce');
-        $choices     = [];
-        $campaigns   = $integration->getCampaigns();
+        if (!$integration || !$integration->getIntegrationSettings()->isPublished()) {
+            return;
+        }
+
+        $choices   = [];
+        $campaigns = $integration->getCampaigns();
         if (isset($campaigns['records']) && !empty($campaigns['records'])) {
             foreach ($campaigns['records'] as $campaign) {
                 $choices[$campaign['Id']] = $campaign['Name'];


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixes being able to save field from a first config on plugins that have direction enabled
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. try to save integration fields for the first time in a plugin that has data priority enabled, it will not save.
2. 

#### Steps to test this PR:
1. Apply PR it should save.
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 