### PR TITLE
Resubscribe  doesn't work in contact preference settings

### DIFF
--- a/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
+++ b/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
@@ -176,7 +176,7 @@ trait FrequencyRuleTrait
         foreach ($formData['subscribed_channels'] as $contactChannel) {
             if (!isset($leadChannels[$contactChannel])) {
                 $contactable = $model->isContactable($lead, $contactChannel);
-                if ($contactable !== DoNotContact::UNSUBSCRIBED) {
+                if ($contactable == DoNotContact::UNSUBSCRIBED) {
                     // Only resubscribe if the contact did not opt out themselves
                     $model->removeDncForLead($lead, $contactChannel);
                 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Show contact preference settings
2. Open unsubcribe link
3. Uncheck Contact me through email
4. Contact is unsubscribed (ok)
5. Enable Contact me through email on unsubscribe link
6. Contact is still unsubscribed. 


#### Steps to test this PR:
1.  Apply PR
2. Check if Resubscribe   works
