### PR TITLE
fix bad merge that readed lines back, and undefined object error

### DIFF
--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -971,10 +971,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 $this->pushContactLink = true;
                 unset($leadFields[$mauticContactLinkField]);
             }
-            $fields          = implode(', l.', $leadFields);
-            $fields          = 'l.'.$fields;
-            $result          = 0;
-            $checkEmailsInSF = [];
+            $fields = implode(', l.', $leadFields);
+            $fields = 'l.'.$fields;
+            $result = 0;
 
             $leadSfFieldsToCreate = $this->cleanSalesForceData($config, array_keys($config['leadFields']), 'Lead');
             $leadSfFields         = array_diff_key($leadSfFieldsToCreate, array_flip($fieldsToUpdateInSf));
@@ -999,7 +998,6 @@ class SalesforceIntegration extends CrmAbstractIntegration
             }
         }
 
-        $checkEmailsInSF = [];
         // Only get the max limit
         if ($limit) {
             $limit -= count($leadsToUpdate);
@@ -1122,7 +1120,6 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 );
             }
         }
-
         $request['allOrNone']        = 'false';
         $request['compositeRequest'] = array_values($mauticData);
 
@@ -1227,6 +1224,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
             $persistEntities = [];
             foreach ($response as $item) {
                 $contactId = $integrationEntityId = null;
+                $object    = 'Lead';
                 if (!empty($item['referenceId'])) {
                     $reference = explode('-', $item['referenceId']);
                     if (3 === count($reference)) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixes a bad merge that readed some lines to the pushLeads method, and an undefined $object variable error.
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. run the SF cronjob
2. Contacts are not updating when pushing to SF

#### Steps to test this PR:
1. rerun the cronjob for SF 
2. Contacts should update

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 