### PR TITLE
Change EventType form to handle choice type fields with non-value conditions

### DIFF
--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -824,7 +824,12 @@ class AjaxController extends CommonAjaxController
             switch ($operator) {
                 case 'empty':
                 case '!empty':
-                    $disabled = true;
+                    $disabled             = true;
+                    $dataArray['options'] = null;
+                    break;
+                case 'regexp':
+                case '!regexp':
+                    $dataArray['options'] = null;
                     break;
             }
             $dataArray['disabled'] = $disabled;

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
@@ -125,10 +125,11 @@ class CampaignEventLeadFieldValueType extends AbstractType
                 }
             }
 
-            $supportsValue = !in_array($operator, ['empty', '!empty']);
+            $supportsValue   = !in_array($operator, ['empty', '!empty']);
+            $supportsChoices = !in_array($operator, ['empty', '!empty', 'regexp', '!regexp']);
 
             // Display selectbox for a field with choices, textbox for others
-            if (!empty($fieldValues)) {
+            if (!empty($fieldValues) && $supportsChoices) {
                 $form->add(
                     'value',
                     'choice',


### PR DESCRIPTION
If the condition is regex we want to use a plain text box for value.
if the condition is empty or not empty we don't want a value at all

for #3924

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| Issues addressed (#s or URLs) | #3494 #3924
| BC breaks? | Not sure

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This allows for using "empty" and "not empty" as well as "regex" and "not regex" with fields which are of the type "select".  I don't represent this as being a good solution - I find it quite ugly and hacky; however, it works and I'm hoping it spurs someone to do fix this up and make it cleaner.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Add a Cusotom Field of type "Select" with choices
2. Attempt to use it in a condition in the campaign builder with "not empty" or "empty".

#### Steps to test this PR:
1. Checkout branch
2. user dev or generate assets