### PR TITLE
Fixed error when the $list was LeadList object instead of array

### DIFF
--- a/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
+++ b/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
@@ -12,6 +12,7 @@
 namespace MauticPlugin\MauticCrmBundle\EventListener;
 
 use Mautic\CoreBundle\EventListener\CommonSubscriber;
+use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Event\LeadListFiltersChoicesEvent;
 use Mautic\LeadBundle\Event\ListPreProcessListEvent;
 use Mautic\LeadBundle\LeadEvents;
@@ -95,6 +96,7 @@ class LeadListSubscriber extends CommonSubscriber
         $integrationObjects = $this->helper->getIntegrationObjects();
         $list               = $event->getList();
         $success            = false;
+        $filters            = ($list instanceof LeadList) ? $list->getFilters() : $list['filters'];
 
         foreach ($integrationObjects as $name => $integrationObject) {
             $settings = $integrationObject->getIntegrationSettings();
@@ -103,7 +105,7 @@ class LeadListSubscriber extends CommonSubscriber
             }
 
             if (method_exists($integrationObject, 'getCampaignMembers')) {
-                foreach ($list['filters'] as $filter) {
+                foreach ($filters as $filter) {
                     if ($filter['field'] == 'integration_campaigns') {
                         if ($integrationObject->getCampaignMembers($filter['filter'], [])) {
                             $success = true;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
I'll push here fixes for error messages from error log of my Mautic. I don't know how the steps to replicate are, but the fixes should logically fix the issue and do not change the functionality. The first commit fixes:
```
Symfony\Component\Debug\Exception\FatalThrowableError: Cannot use object of type Mautic\LeadBundle\Entity\LeadList as array (uncaught exception) at plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php line 106 while running console command
```
The error occurs probably when running the update segments command.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make sure that `app/console mautic:segments:update` still works.