### PR TITLE
#3938 - Gmail popup error

### DIFF
--- a/app/bundles/CampaignBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/CampaignBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -43,7 +43,7 @@ if ($cancelled) {
                 <?php echo $view['translator']->trans('mautic.campaign.event.cancelled.time', ['%date%' => $dateSpan, '%event%' => $event['eventLabel']]); ?>
             </span>
         </span>
-        <?php if ($view['security']->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getPermissionUser())): ?>
+        <?php if ($lead != null && $view['security']->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $lead->getPermissionUser())): ?>
         <span class="form-buttons btn-group btn-group-xs mb-3" role="group" aria-label="Field options">
             <button type="button" class="btn btn-default btn-edit btn-nospin" onclick="Mautic.updateScheduledCampaignEvent(<?php echo $item['event_id']; ?>, <?php echo $lead->getId(); ?>)" data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.campaign.event.reschedule'); ?>">
                 <i class="fa fa-clock-o text-primary"></i>


### PR DESCRIPTION
When opening the popup under gmail extension there's an error displayed
the lead variable is null and not tested before use

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | #3938
| BC breaks? | No
| Deprecations? | No

#### Description:
Fixed an error when opening the gmail integration popup where as the lead variable is null but not tested before use displaying a fatal error within the iframe.
