### PR TITLE
Twilio integration used in NotificationHelper instead of OneSignal

### DIFF
--- a/app/bundles/NotificationBundle/Helper/NotificationHelper.php
+++ b/app/bundles/NotificationBundle/Helper/NotificationHelper.php
@@ -102,9 +102,9 @@ class NotificationHelper
     public function getScript()
     {
         if ($this->hasScript()) {
-            $integration = $this->integrationHelper->getIntegrationObject('Twilio');
+            $integration = $this->integrationHelper->getIntegrationObject('OneSignal');
 
-            if ($integration === false) {
+            if (!$integration) {
                 return;
             }
 
@@ -147,7 +147,7 @@ scrpt.rel ='manifest';
 scrpt.href ='/manifest.json';
 var head = document.getElementsByTagName('head')[0];
 head.appendChild(scrpt);
-     
+
 OneSignal.push(["init", {
     appId: "{$appId}",
     safari_web_id: "{$safariWebId}",
@@ -184,8 +184,8 @@ OneSignal.push(function() {
         OneSignal.getUserId(function(userId) {
             if (userId) {
                 postUserIdToMautic(userId);
-            }        
-        });    
+            }
+        });
     };
 });
 JS;
@@ -222,9 +222,9 @@ JS;
             $landingPage = false;
         }
 
-        $integration = $this->integrationHelper->getIntegrationObject('Twilio');
+        $integration = $this->integrationHelper->getIntegrationObject('OneSignal');
 
-        if ($integration === false) {
+        if (!$integration) {
             return false;
         }
 

--- a/app/bundles/NotificationBundle/Helper/NotificationHelper.php
+++ b/app/bundles/NotificationBundle/Helper/NotificationHelper.php
@@ -104,7 +104,7 @@ class NotificationHelper
         if ($this->hasScript()) {
             $integration = $this->integrationHelper->getIntegrationObject('OneSignal');
 
-            if (!$integration) {
+            if (!$integration || $integration->getIntegrationSettings()->getIsPublished() === false) {
                 return;
             }
 
@@ -224,7 +224,7 @@ JS;
 
         $integration = $this->integrationHelper->getIntegrationObject('OneSignal');
 
-        if (!$integration) {
+        if (!$integration || $integration->getIntegrationSettings()->getIsPublished() === false) {
             return false;
         }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3959, https://github.com/mautic/mautic/issues/3963, https://github.com/mautic/mautic/issues/3968
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Twilio integration is called in the NotificationHelper where the OneSignal integration should be called instead. This caused that Desktop Notification aren't working at all and if the Twilio plugin is enabled, it will cause PHP notices and JS errors on Mautic landing pages and tracked pages.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to use desktop notifications
2. Try to enable Twilio plugin and go to landing or tracked page. You'll see the JS errors in console and PHP notices in Mautic logs similar to those reported in https://github.com/mautic/mautic/issues/3959

#### Steps to test this PR:
1. Apply this PR
2. The problems should be gone, notifications will work.