### PR TITLE
Fixed issue where tokens couldn't be deleted

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/4i.jquery.at.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/4i.jquery.at.js
@@ -1,3 +1,5 @@
+// Mautic hack: reverted https://github.com/ichord/At.js/pull/423
+
 /**
  * at.js - 1.5.1
  * Copyright (c) 2016 chord.luo <chord.luo@gmail.com>;
@@ -832,13 +834,13 @@
       } else {
         suffix = (suffix = this.getOpt('suffix')) === "" ? suffix : suffix || "\u00A0";
         data = $li.data('item-data');
-        this.query.el.removeClass('atwho-query').addClass('atwho-inserted').html(content).attr('data-atwho-at-query', "" + data['atwho-at'] + this.query.text).attr('contenteditable', "false");
+        this.query.el.removeClass('atwho-query').addClass('atwho-inserted').html(content).attr('data-atwho-at-query', "" + data['atwho-at'] + this.query.text);
         if (range = this._getRange()) {
           if (this.query.el.length) {
             range.setEndAfter(this.query.el[0]);
           }
           range.collapse(false);
-          range.insertNode(suffixNode = this.app.document.createTextNode("\u200D" + suffix));
+          range.insertNode(suffixNode = this.app.document.createTextNode("" + suffix));
           this._setRange('after', suffixNode, range);
         }
         if (!this.$inputor.is(':focus')) {


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3940
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Because of issue reported in https://github.com/ichord/At.js/issues/463 the tokens cannot be deleted in Froala editors. This PR hacks the At.js library and reverts the PR which caused the issue.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create/Edit and email or landing page
2. Edit some text slot and add a token by typing `{` and selecting some option.
3. Try to delete the token - cannot be done unless you do it via code view.

#### Steps to test this PR:
1. Apply this PR
2. Use the dev env or run `app/console mautic:assets:generate` command to regenerate assets
3. Test again - the token can be removed easily.
