### PR TITLE
Do not trigger assignment rules when updating a Lead

### DIFF
--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -620,9 +620,6 @@ abstract class AbstractIntegration
             $headers    = $event->getHeaders();
             $parameters = $event->getParameters();
         }
-        if (isset($settings['batchSizeSF'])) {
-            $headers[] = 'Sforce-Query-Options: batchSize='.$settings['batchSizeSF'];
-        }
 
         if (!isset($settings['query'])) {
             $settings['query'] = [];

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -52,7 +52,7 @@ class SalesforceApi extends CrmApi
 
         $settings = $this->requestSettings;
         if ($method == 'PATCH') {
-            $settings['headers'] = ['Sforce-Auto-Assign:' => 'FALSE'];
+            $settings['headers'] = ['Sforce-Auto-Assign' => 'FALSE'];
         }
 
         $response = $this->integration->makeRequest($requestUrl, $elementData, $method, $settings);

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -39,6 +39,10 @@ class SalesforceApi extends CrmApi
      */
     public function request($operation, $elementData = [], $method = 'GET', $retry = false, $object = null, $queryUrl = null)
     {
+        $settings = [];
+        if ($method == 'PATCH') {
+            $settings['headers'] = 'Sforce-Auto-Assign: FALSE';
+        }
         if (!$object) {
             $object = $this->object;
         }
@@ -49,8 +53,8 @@ class SalesforceApi extends CrmApi
         } else {
             $requestUrl = sprintf($queryUrl.'/%s', $operation);
         }
-
-        $response = $this->integration->makeRequest($requestUrl, $elementData, $method, $this->requestSettings);
+        $settings = array_merge($settings, $this->requestSettings);
+        $response = $this->integration->makeRequest($requestUrl, $elementData, $method, $settings);
 
         if (!empty($response['errors'])) {
             $notificactionModel->addNotification(implode(', ', $response['errors']), 'Salesforce', false, $this->integration->getName().':');

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -52,7 +52,7 @@ class SalesforceApi extends CrmApi
 
         $settings = $this->requestSettings;
         if ($method == 'PATCH') {
-            $settings['headers'] = 'Sforce-Auto-Assign: FALSE';
+            $settings['headers'] = ['Sforce-Auto-Assign:' => 'FALSE'];
         }
 
         $response = $this->integration->makeRequest($requestUrl, $elementData, $method, $settings);

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -39,10 +39,6 @@ class SalesforceApi extends CrmApi
      */
     public function request($operation, $elementData = [], $method = 'GET', $retry = false, $object = null, $queryUrl = null)
     {
-        $settings = [];
-        if ($method == 'PATCH') {
-            $settings['headers'] = 'Sforce-Auto-Assign: FALSE';
-        }
         if (!$object) {
             $object = $this->object;
         }
@@ -53,7 +49,12 @@ class SalesforceApi extends CrmApi
         } else {
             $requestUrl = sprintf($queryUrl.'/%s', $operation);
         }
-        $settings = array_merge($settings, $this->requestSettings);
+
+        $settings = $this->requestSettings;
+        if ($method == 'PATCH') {
+            $settings['headers'] = 'Sforce-Auto-Assign: FALSE';
+        }
+
         $response = $this->integration->makeRequest($requestUrl, $elementData, $method, $settings);
 
         if (!empty($response['errors'])) {

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -1204,6 +1204,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     'url'         => $url,
                     'referenceId' => $id,
                     'body'        => $body,
+                    'httpHeaders' => [
+                        'Sforce-Auto-Assign' => ($objectId) ? 'FALSE' : 'TRUE',
+                    ],
                 ];
             }
         }
@@ -1633,6 +1636,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     'url'         => $patchurl,
                     'referenceId' => $id,
                     'body'        => $b,
+                    'httpHeaders' => [
+                        'Sforce-Auto-Assign' => 'FALSE',
+                    ],
                 ];
             } elseif (isset($b['LeadId']) and $memberId = array_search($b['LeadId'], $leadIds)) {
                 $id                  = (!empty($lead->getId()) ? $lead->getId() : '').'-CampaignMember'.$b['LeadId'].(!empty($referenceId && $internalLeadId == $lead->getId()) ? '-'.$referenceId : '').$campaignMappingId;
@@ -1644,6 +1650,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     'url'         => $patchurl,
                     'referenceId' => $id,
                     'body'        => $b,
+                    'httpHeaders' => [
+                        'Sforce-Auto-Assign' => 'FALSE',
+                    ],
                 ];
             } else {
                 $id                  = (!empty($lead->getId()) ? $lead->getId() : '').'-CampaignMemberNew-null'.$campaignMappingId;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Salesforce applies assignment rules when a Lead is created or updated. This PR assignment rules are only triggered when a lead is created, but not when it's updated.
[//]: # ( As applicable: )

#### Steps to test this PR:
1. Create an assignment rule on Salesforce
2. Run the CLI to sync contacts from Mautic to SF.
3. If it's a new Contact it should create a Lead and trigger the assignment rule `php app/console mautic:integration:fetchleads --time-interval="2 minutes" --env dev --integration=Salesforce`
4. If a contact is being updated, it should not trigger the assignment rule.