### PR TITLE
Notification stat date_read must be nullable to create fresh stats

### DIFF
--- a/app/bundles/NotificationBundle/Entity/Stat.php
+++ b/app/bundles/NotificationBundle/Entity/Stat.php
@@ -142,6 +142,7 @@ class Stat
 
         $builder->createField('dateRead', 'datetime')
             ->columnName('date_read')
+            ->nullable()
             ->build();
 
         $builder->createField('isClicked', 'boolean')

--- a/app/migrations/Version20170503143650.php
+++ b/app/migrations/Version20170503143650.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * @package     Mautic
+ * @copyright   2017 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170503143650 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        $table = $schema->getTable($this->prefix.'push_notification_stats');
+
+        if ($table->hasColumn('date_read') && $table->getColumn('date_read')->getNotNull() === false) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE '.$this->prefix.'push_notification_stats CHANGE date_read date_read DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime)\'');
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3973
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Date Read for notification stats is not nullable which cause issues like in the linked issue. This PR adds the nullable option for that column and migration which changes that during Mautic update.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
_Copied from the issue:_
1. Create an campaign Action to send web notification
2. See log

#### Steps to test this PR:
1. Apply this PR
2. Just to check, run `app/console doctrine:schema:update --dump-sql | grep date_read`. It should return `ALTER TABLE push_notification_stats CHANGE date_read date_read DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime)';`
3. Run `app/console doctrine:migrations:migrate`
4. Repeat step 2 and the output should be empty. That means the column is nullable after migration which should fix the reported issue.
