### PR TITLE
Language on unsubscribe page based on contact preferred locale

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -167,6 +167,11 @@ class PublicController extends CommonFormController
                 $leadModel->setCurrentLead($lead);
             }
 
+            // Set lead lang
+            if ($lead->getPreferredLocale()) {
+                $translator->setLocale($lead->getPreferredLocale());
+            }
+
             if (!$this->get('mautic.helper.core_parameters')->getParameter('show_contact_preferences')) {
                 $model->setDoNotContact($stat, $translator->trans('mautic.email.dnc.unsubscribed'), DoNotContact::UNSUBSCRIBED);
 

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -166,7 +166,6 @@ class PublicController extends CommonFormController
                 // Set the lead as current lead
                 $leadModel->setCurrentLead($lead);
             }
-
             // Set lead lang
             if ($lead->getPreferredLocale()) {
                 $translator->setLocale($lead->getPreferredLocale());
@@ -290,6 +289,11 @@ class PublicController extends CommonFormController
                 $leadModel->setCurrentLead($lead);
             }
 
+            // Set lead lang
+            if ($lead->getPreferredLocale()) {
+                $this->translator->setLocale($lead->getPreferredLocale());
+            }
+
             $model->removeDoNotContact($stat->getEmailAddress());
 
             $message = $this->coreParametersHelper->getParameter('resubscribe_message');
@@ -297,8 +301,8 @@ class PublicController extends CommonFormController
                 $message = $this->translator->trans(
                     'mautic.email.resubscribed.success',
                     [
-                        '%unsubscribedUrl%' => '|URL|',
-                        '%email%'           => '|EMAIL|',
+                        '%unsubscribeUrl%' => '|URL|',
+                        '%email%'          => '|EMAIL|',
                     ]
                 );
             }

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -195,7 +195,6 @@ class PublicController extends CommonFormController
                     ],
                     $message
                 );
-                $message = '<h2>'.$message.'</h2>';
             } elseif ($lead) {
                 $action = $this->generateUrl('mautic_email_unsubscribe', ['idHash' => $idHash]);
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | n
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Unsubscribe page didn't apply contact preferred locale from profile.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to configuration set default lang to german (this step download german translations to translations direcotry)
2. Set default lang back to english 
3. Create contact with german preferred locale
4. Send email to contact with unsubscribe tag 
5. Open email and click to unsubscribe link
6. Unsubscribe page is in english language

#### Steps to test this PR:
1. Repeat  all steps
2. Check step 6 and german language on unsubscribe page