### PR TITLE
Fix equals sql operation for stage contact field

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -1239,7 +1239,7 @@ class LeadListRepository extends CommonRepository
 
                     break;
                 case 'stage':
-                    $operand = in_array($func, ['eq', 'neq']) ? 'EXISTS' : 'NOT EXISTS';
+                    $operand = ($func === 'eq') ? 'EXISTS' : 'NOT EXISTS';
 
                     $subQb = $this->_em->getConnection()
                         ->createQueryBuilder()


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
This PR fixes `equals` and `not equals` operators in segment filters for stage contact field.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a segment
2. Add filter different on stage field
3. Launch mautic:segment:update
4. See contacts **equals** to the stage field choosen in the segment

#### Steps to test this PR:
1. Apply this fix
2. Add filter different on stage field
3. Launch mautic:segment:update
4. See contacts **different** to the stage field choosen in the segment
