### PR TITLE
Prevent bad translation files from crashing Mautic

### DIFF
--- a/app/bundles/CoreBundle/Loader/TranslationLoader.php
+++ b/app/bundles/CoreBundle/Loader/TranslationLoader.php
@@ -103,8 +103,53 @@ class TranslationLoader extends ArrayLoader implements LoaderInterface
     {
         $iniFile  = $file->getRealpath();
         $messages = parse_ini_file($iniFile, true);
-        $domain   = substr($file->getFilename(), 0, -4);
+        if (false === $messages) {
+            // Likely a bad INI file; let's try encoding double quotes within double quotes then just ignore this file if it happens again
+            $iniString = file_get_contents($iniFile);
+            $quoteMap  = [
+                "\xC2\x82"     => "'", // U+0082⇒U+201A single low-9 quotation mark
+                "\xC2\x84"     => '"', // U+0084⇒U+201E double low-9 quotation mark
+                "\xC2\x8B"     => "'", // U+008B⇒U+2039 single left-pointing angle quotation mark
+                "\xC2\x91"     => "'", // U+0091⇒U+2018 left single quotation mark
+                "\xC2\x92"     => "'", // U+0092⇒U+2019 right single quotation mark
+                "\xC2\x93"     => '"', // U+0093⇒U+201C left double quotation mark
+                "\xC2\x94"     => '"', // U+0094⇒U+201D right double quotation mark
+                "\xC2\x9B"     => "'", // U+009B⇒U+203A single right-pointing angle quotation mark
+                "\xC2\xAB"     => '"', // U+00AB left-pointing double angle quotation mark
+                "\xC2\xBB"     => '"', // U+00BB right-pointing double angle quotation mark
+                "\xE2\x80\x98" => "'", // U+2018 left single quotation mark
+                "\xE2\x80\x99" => "'", // U+2019 right single quotation mark
+                "\xE2\x80\x9A" => "'", // U+201A single low-9 quotation mark
+                "\xE2\x80\x9B" => "'", // U+201B single high-reversed-9 quotation mark
+                "\xE2\x80\x9C" => '"', // U+201C left double quotation mark
+                "\xE2\x80\x9D" => '"', // U+201D right double quotation mark
+                "\xE2\x80\x9E" => '"', // U+201E double low-9 quotation mark
+                "\xE2\x80\x9F" => '"', // U+201F double high-reversed-9 quotation mark
+                "\xE2\x80\xB9" => "'", // U+2039 single left-pointing angle quotation mark
+                "\xE2\x80\xBA" => "'", // U+203A single right-pointing angle quotation mark
+            ];
+            $search    = array_keys($quoteMap); // but: for efficiency you should
+            $replace   = array_values($quoteMap); // pre-calculate these two arrays
+            $iniString = str_replace($search, $replace, $iniString);
 
+            if (preg_match_all('/^(.*?)="((.*?)?["]+(.*?)?)"$/m', $iniString, $matches)) {
+                $search = $replace = [];
+                foreach ($matches[2] as $hasQuotes) {
+                    $search[]  = $hasQuotes;
+                    $replace[] = str_replace('"', '&quot;', $hasQuotes);
+                }
+                $iniString = str_replace($search, $replace, $iniString);
+            }
+            $messages = parse_ini_string($iniString, true);
+
+            if (false === $messages) {
+                // prevent from crashing Mautic
+
+                return;
+            }
+        }
+
+        $domain        = substr($file->getFilename(), 0, -4);
         $thisCatalogue = parent::load($messages, $locale, $domain);
         $catalogue->addCatalogue($thisCatalogue);
     }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Hack a translation file to include an unescaped double quote in a language string
2. Go into prod and it will crash

#### Steps to test this PR:
1. Repeat and it won't crash (the file just wont' be translated)