### PR TITLE
Fix DEC tab for code mode

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -840,7 +840,6 @@ Mautic.cloneFocusForm = function(decId, removeFroala) {
     // reattach DEC
     if (typeof Mautic.activeDEC !== 'undefined') {
         var element = Mautic.activeDEC.detach();
-        element.hide();
         Mautic.activeDECParent.append(element);
     }
     var focusForm = parent.mQuery('#emailform_dynamicContent_' + decId);
@@ -850,7 +849,6 @@ Mautic.cloneFocusForm = function(decId, removeFroala) {
     // remove delete default button
     focusForm.find('.tab-pane:first').find('.remove-item').hide();
     var element =focusForm.detach();
-    element.show();
     Mautic.activeDEC = element;
     return element;
 };
@@ -888,7 +886,6 @@ Mautic.removeAddVariantButton = function() {
     // reattach DEC
     if (typeof Mautic.activeDEC !== 'undefined') {
         var element = Mautic.activeDEC.detach();
-        element.hide();
         Mautic.activeDECParent.append(element);
     }
 };

--- a/app/bundles/CoreBundle/Views/Helper/theme_select.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/theme_select.html.php
@@ -20,7 +20,7 @@ $isCodeMode = ($active == $codeMode);
                 <div class="panel-body text-center" style="height: 250px">
                     <i class="fa fa-code fa-5x text-muted" aria-hidden="true" style="padding-top: 75px; color: #E4E4E4;"></i>
                 </div>
-                <a href="#" type="button" data-theme="<?php echo $codeMode; ?>" class="select-theme-link btn btn-default <?php echo $isCodeMode ? 'hide' : '' ?>">
+                <a href="#" type="button" data-theme="<?php echo $codeMode; ?>" class="select-theme-link btn btn-default <?php echo $isCodeMode ? 'hide' : '' ?>" onclick="mQuery('#dynamic-content-tab').removeClass('hidden')">
                     Select
                 </a>
                 <button type="button" class="select-theme-selected btn btn-default <?php echo $isCodeMode ? '' : 'hide' ?>" disabled="disabled">
@@ -60,7 +60,7 @@ $isCodeMode = ($active == $codeMode);
                             <i class="fa fa-file-image-o fa-5x text-muted" aria-hidden="true" style="padding-top: 75px; color: #E4E4E4;"></i>
                         </div>
                     <?php endif; ?>
-                    <a href="#" type="button" data-theme="<?php echo $themeKey; ?>" class="select-theme-link btn btn-default <?php echo $isSelected ? 'hide' : '' ?>">
+                    <a href="#" type="button" data-theme="<?php echo $themeKey; ?>" class="select-theme-link btn btn-default <?php echo $isSelected ? 'hide' : '' ?>" onclick="mQuery('#dynamic-content-tab').addClass('hidden')">
                         Select
                     </a>
                     <button type="button" class="select-theme-selected btn btn-default <?php echo $isSelected ? '' : 'hide' ?>" disabled="disabled">

--- a/app/bundles/EmailBundle/Views/Email/form.html.php
+++ b/app/bundles/EmailBundle/Views/Email/form.html.php
@@ -68,7 +68,7 @@ $isCodeMode = ($email->getTemplate() === 'mautic_code_mode');
                             <?php echo $view['translator']->trans('mautic.core.advanced'); ?>
                         </a>
                     </li>
-                    <li id="dynamic-content-tab" class="hidden">
+                    <li id="dynamic-content-tab" <?php echo (!$isCodeMode) ? 'class="hidden"' : ''; ?>>
                         <a href="#dynamic-content-container" role="tab" data-toggle="tab">
                             <?php echo $view['translator']->trans('mautic.core.dynamicContent'); ?>
                         </a>


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes an issue where the Dynamic Email Content Tab is not visible when selecting the Code Mode Template.

#### Steps to reproduce the bug:
1. Create or Edit an Email
2. Select Code Mode Template
3. The DEC tab is not visible and there is no way to edit dynamic content

#### Steps to test this PR:
1. Apply this PR
2. Create or Edit an Email
3. Select Code Mode Template
4. The DEC tab is now visible and the dynamic content can be edited

