### PR TITLE
Only put OneSignal JS in to mtc.js if OneSignal integration is enabled.

### DIFF
--- a/app/bundles/NotificationBundle/Config/config.php
+++ b/app/bundles/NotificationBundle/Config/config.php
@@ -32,6 +32,7 @@ return [
                 'class'     => 'Mautic\NotificationBundle\EventListener\BuildJsSubscriber',
                 'arguments' => [
                     'mautic.helper.notification',
+                    'mautic.helper.integration',
                 ],
             ],
             'mautic.notification.notificationbundle.subscriber' => [

--- a/app/bundles/NotificationBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/BuildJsSubscriber.php
@@ -15,6 +15,7 @@ use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\BuildJsEvent;
 use Mautic\CoreBundle\EventListener\CommonSubscriber;
 use Mautic\NotificationBundle\Helper\NotificationHelper;
+use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -28,13 +29,20 @@ class BuildJsSubscriber extends CommonSubscriber
     protected $notificationHelper;
 
     /**
-     * PageSubscriber constructor.
+     * @var IntegrationHelper
+     */
+    protected $integrationHelper;
+
+    /**
+     * BuildJsSubscriber constructor.
      *
      * @param NotificationHelper $notificationHelper
+     * @param IntegrationHelper  $integrationHelper
      */
-    public function __construct(NotificationHelper $notificationHelper)
+    public function __construct(NotificationHelper $notificationHelper, IntegrationHelper $integrationHelper)
     {
         $this->notificationHelper = $notificationHelper;
+        $this->integrationHelper  = $integrationHelper;
     }
 
     /**
@@ -52,6 +60,12 @@ class BuildJsSubscriber extends CommonSubscriber
      */
     public function onBuildJs(BuildJsEvent $event)
     {
+        $integration = $this->integrationHelper->getIntegrationObject('OneSignal');
+
+        if (!$integration || $integration->getIntegrationSettings()->getIsPublished() === false) {
+            return;
+        }
+
         $subscribeUrl   = $this->router->generate('mautic_notification_popup', [], UrlGeneratorInterface::ABSOLUTE_URL);
         $subscribeTitle = 'Subscribe To Notifications';
         $width          = 450;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

OneSignal JS was being loaded via mtc.js even though the OneSignal integration was disabled.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Disable the OneSignal integration if you have it enabled.
2. Load your Mautic's `mtc.js` file. 
3. Search for `onesignal.com` and see that it is loading in the script.

#### Steps to test this PR:
1. Apply PR, clear cache, and redo the reproduction steps
2. You'll see that a search for `onesignal.com` fails because it's no longer loading it in if the integration is disabled.