### PR TITLE
Fix to add Text or DC slot on Goldstar theme

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/libraries/builder.css
+++ b/app/bundles/CoreBundle/Assets/css/libraries/builder.css
@@ -5385,6 +5385,8 @@ div[data-slot-toolbar] .btn .fa {
 div[data-slot],
 [data-section-wrapper] {
   position: relative;
+  font-size: initial;
+  line-height: initial;
 }
 div[data-slot^="image"] {
   padding-top: 1px;

--- a/app/bundles/CoreBundle/Assets/css/libraries/builder.less
+++ b/app/bundles/CoreBundle/Assets/css/libraries/builder.less
@@ -142,6 +142,8 @@ div[data-slot-toolbar] .btn .fa {
 
 div[data-slot], [data-section-wrapper] {
     position: relative;
+    font-size: initial;
+    line-height: initial;
 }
 
 div[data-slot^="image"] {


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes an issue that prevented to add text or DEC slots in the Goldstar theme.
The problem is that the Goldstar theme has tables in the markup with inline styles like the following:
`font-size:0pt; line-height:0pt`
These styles are inherited by the slots, rendering them virtually invisible. This PR adds a style to the builder style sheet that enables the slots to display their content normally.

#### Steps to reproduce the bug:
1. Create or edit an email
2. Select Goldstar theme
3. Try to add a Text or DEC slot in the editor area
4. The slot will not show

#### Steps to test this PR:
1. Apply this PR
2. Create or edit an email
3. Select Goldstar theme
4. Try to add a Text or DEC slot in the editor area
5. The slot will now be visible

