### PR TITLE
Facebook Integration does not return email field on social login

### DIFF
--- a/plugins/MauticSocialBundle/Integration/FacebookIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/FacebookIntegration.php
@@ -61,6 +61,14 @@ class FacebookIntegration extends SocialIntegration
     {
         return 'https://graph.facebook.com/oauth/access_token';
     }
+	
+    /**
+     * @return string
+     */
+    public function getAuthScope()
+    {
+        return 'email';
+    }
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
…ield on social login

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #4007 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Add and configure the plugin Facebook Integration
2. Create a form with social login and the fields that you need to show, in this case email
3. Put this form in a Landing Page
4. Click in the social login button of Facebook
5. The email **does not** return in the callback response of Facebook

#### Steps to test this PR:
1. Add and configure the plugin Facebook Integration
2. Create a form with social login and the fields that you need to show, in this case email
3. Put this form in a Landing Page
4. Click in the social login button of Facebook
5. The email **will returned** in the callback response of Facebook