### PR TITLE
Fix for issue with draggable slots and DEC tokens

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -795,6 +795,8 @@ Mautic.initSlots = function(slotContainers) {
             mQuery('#builder-template-content', Mautic.parentDocument).attr('scrolling', 'yes');
             // check if it is initialized first to prevent error
             if (slotContainers.data('sortable')) slotContainers.sortable('option', 'scroll', true);
+            // this fixes an issue where after reopening the builder and trying to drag a slot, it leaves a clone behind
+            parent.mQuery('.ui-draggable-dragging').remove();
         }
     }).disableSelection();
 
@@ -1550,7 +1552,6 @@ Mautic.convertDynamicContentSlotsToTokens = function (builderHtml) {
     if (dynConSlots.length) {
         dynConSlots.each(function(i) {
             var $this    = mQuery(this);
-            // if ($this.parents('[data-slot]').length == 0) return; // prevent affecting standalone DEC slots
             var dynConId = $this.attr('data-param-dec-id');
 
             dynConId = '#emailform_dynamicContent_'+dynConId;
@@ -1558,6 +1559,11 @@ Mautic.convertDynamicContentSlotsToTokens = function (builderHtml) {
             var dynConTarget = mQuery(dynConId);
             var dynConName   = dynConTarget.find(dynConId+'_tokenName').val();
             var dynConToken  = '{dynamiccontent="'+dynConName+'"}';
+
+            // Add the dynamic content tokens
+            if (!Mautic.builderTokens.hasOwnProperty(dynConToken)) {
+                Mautic.builderTokens[dynConToken] = dynConName;
+            }
 
             builderHtml = builderHtml.replace(this.outerHTML, dynConToken);
 

--- a/app/bundles/CoreBundle/Assets/js/libraries/2.jquery.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/2.jquery.js
@@ -8967,9 +8967,11 @@
                 box = elem.getBoundingClientRect();
             }
             win = getWindow(doc);
+            var pageYOffset = win ? win.pageYOffset : 0;
+            var pageXOffset = win ? win.pageXOffset : 0;
             return {
-                top: box.top + win.pageYOffset - docElem.clientTop,
-                left: box.left + win.pageXOffset - docElem.clientLeft
+                top: box.top + pageYOffset - docElem.clientTop,
+                left: box.left + pageXOffset - docElem.clientLeft
             };
         },
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes a couple of issues with the email editor that occur when the builder is closed and reopened again.

#### Steps to reproduce the bug:
1. Create or edit an email
2. Open the builder
3. Insert a dynamic content slot
4. Add some text to the DEC slot
5. Close the builder
6. Open the builder again
7. The DEC slot is converted to a token
8. Try to drag any slot type button and drop it near the slot types area
9. The button will leave a clone behind

![image](https://cloud.githubusercontent.com/assets/2924026/25771875/6e2ba5ea-321a-11e7-9181-8cd44b20734c.png)

#### Steps to test this PR:
1. Apply this PR
2. Follow the steps to reproduce the bug.
3. Now the DEC slot will not be converted to token and the slot type buttons will not leave behind a clone.

