### PR TITLE
Fix Stat creation from plugins

### DIFF
--- a/app/bundles/EmailBundle/Helper/PointEventHelper.php
+++ b/app/bundles/EmailBundle/Helper/PointEventHelper.php
@@ -27,6 +27,10 @@ class PointEventHelper
      */
     public static function validateEmail($eventDetails, $action)
     {
+        if (null === $eventDetails) {
+            return false;
+        }
+
         $emailId = $eventDetails->getId();
 
         if (isset($action['properties']['emails'])) {

--- a/plugins/MauticClearbitBundle/Integration/ClearbitIntegration.php
+++ b/plugins/MauticClearbitBundle/Integration/ClearbitIntegration.php
@@ -14,6 +14,7 @@ namespace MauticPlugin\MauticClearbitBundle\Integration;
 use Mautic\PluginBundle\Integration\AbstractIntegration;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class ClearbitIntegration extends AbstractIntegration
 {
@@ -68,20 +69,33 @@ class ClearbitIntegration extends AbstractIntegration
         }
     }
 
-    /**
-     * Allows integration to set a custom form template.
-     *
-     * @return string
-     */
-    public function getFormTemplate()
-    {
-        return 'MauticClearbitBundle:Integration:form.html.php';
-    }
-
     public function shouldAutoUpdate()
     {
         $featureSettings = $this->getKeys();
 
         return (isset($featureSettings['auto_update'])) ? (bool) $featureSettings['auto_update'] : false;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param $section
+     *
+     * @return string
+     */
+    public function getFormNotes($section)
+    {
+        if ('custom' === $section) {
+            return [
+                'template'   => 'MauticClearbitBundle:Integration:form.html.php',
+                'parameters' => [
+                    'mauticUrl' => $this->factory->get('router')->generate(
+                        'mautic_plugin_clearbit_index', [], UrlGeneratorInterface::ABSOLUTE_URL
+                    ),
+                ],
+            ];
+        }
+
+        return parent::getFormNotes($section);
     }
 }

--- a/plugins/MauticClearbitBundle/Views/Integration/form.html.php
+++ b/plugins/MauticClearbitBundle/Views/Integration/form.html.php
@@ -9,65 +9,15 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-if (!$hasSupportedFeatures = (isset($form['supportedFeatures']) && count($form['supportedFeatures']))) {
-    if (isset($form['supportedFeatures'])) {
-        $form['supportedFeatures']->setRendered();
-    }
-}
-
-if (!$hasFields = (isset($form['featureSettings']) && count($form['featureSettings']['leadFields']))) {
-    // Unset if set to prevent features tab from showing when there's no feature to show
-    unset($form['featureSettings']['leadFields']);
-}
-if (!$hasFeatureSettings = (isset($form['featureSettings']) && (($hasFields && count(
-                $form['featureSettings']
-            ) > 1) || (!$hasFields && count($form['featureSettings']))))
-) {
-    if (isset($form['featureSettings'])) {
-        $form['featureSettings']->setRendered();
-    }
-}
-
-$fieldHtml     = ($hasFields) ? $view['form']->row($form['featureSettings']['leadFields']) : '';
-$fieldLabel    = ($hasFields) ? $form['featureSettings']['leadFields']->vars['label'] : '';
-$fieldTabClass = ($hasFields) ? '' : ' hide';
-unset($form['featureSettings']['leadFields']);
-
 ?>
 
-<?php if (!empty($description)): ?>
-    <div class="alert alert-info">
-        <?php echo $description; ?>
+<div class="well well-sm" style="margin-bottom:0 !important;">
+    <p>
+        <?php echo $view['translator']->trans('mautic.plugin.clearbit.webhook_info'); ?>
+    </p>
+    <div class="alert alert-warning">
+        <?php echo $view['translator']->trans('mautic.plugin.clearbit.public_info'); ?>
     </div>
-<?php endif; ?>
-<ul class="nav nav-tabs pr-md pl-md">
-    <li class="active" id="details-tab"><a href="#details-container" role="tab"
-                                           data-toggle="tab"><?php echo $view['translator']->trans(
-                'mautic.plugin.integration.tab.details'
-            ); ?></a></li>
-
-</ul>
-
-<?php echo $view['form']->start($form); ?>
-<!--/ tabs controls -->
-<div class="tab-content pa-md bg-white">
-    <div class="tab-pane fade in active bdr-w-0" id="details-container">
-        <?php echo $view['form']->row($form['isPublished']); ?>
-        <?php echo $view['form']->row($form['apiKeys']); ?>
-        <div class="well well-sm" style="margin-bottom:0 !important;">
-            <p>
-                <?php echo $view['translator']->trans('mautic.plugin.clearbit.webhook_info'); ?>
-            </p>
-            <div class="alert alert-warning">
-                <?php echo $view['translator']->trans('mautic.plugin.clearbit.public_info'); ?>
-            </div>
-            <input type="text" readonly="" onclick="this.setSelectionRange(0, this.value.length);"
-                   value="<?php echo $this->container->get('router')->generate(
-                       'mautic_plugin_clearbit_index',
-                       [],
-                       \Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL
-                   ) ?>" class="form-control">
-        </div>
-    </div>
+    <input type="text" readonly="" onclick="this.setSelectionRange(0, this.value.length);"
+           value="<?php echo $mauticUrl ?>" class="form-control">
 </div>
-<?php echo $view['form']->end($form); ?>

--- a/plugins/MauticFullContactBundle/Integration/FullContactIntegration.php
+++ b/plugins/MauticFullContactBundle/Integration/FullContactIntegration.php
@@ -14,6 +14,7 @@ namespace MauticPlugin\MauticFullContactBundle\Integration;
 use Mautic\PluginBundle\Integration\AbstractIntegration;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class FullContactIntegration extends AbstractIntegration
 {
@@ -96,20 +97,31 @@ class FullContactIntegration extends AbstractIntegration
         }
     }
 
-    /**
-     * Allows integration to set a custom form template.
-     *
-     * @return string
-     */
-    public function getFormTemplate()
-    {
-        return 'MauticFullContactBundle:Integration:form.html.php';
-    }
-
     public function shouldAutoUpdate()
     {
         $featureSettings = $this->getKeys();
 
         return (isset($featureSettings['auto_update'])) ? (bool) $featureSettings['auto_update'] : false;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param $section
+     *
+     * @return string
+     */
+    public function getFormNotes($section)
+    {
+        if ('custom' === $section) {
+            return [
+                'template'   => 'MauticFullContactBundle:Integration:form.html.php',
+                'parameters' => [
+                    'mauticUrl' => $this->factory->get('router')->generate('mautic_plugin_fullcontact_index', [], UrlGeneratorInterface::ABSOLUTE_URL),
+                ],
+            ];
+        }
+
+        return parent::getFormNotes($section);
     }
 }

--- a/plugins/MauticFullContactBundle/Views/Integration/form.html.php
+++ b/plugins/MauticFullContactBundle/Views/Integration/form.html.php
@@ -9,57 +9,14 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-
-if (!$hasSupportedFeatures = (isset($form['supportedFeatures']) && count($form['supportedFeatures']))) {
-    if (isset($form['supportedFeatures'])) {
-        $form['supportedFeatures']->setRendered();
-    }
-}
-
-if (!$hasFields = (isset($form['featureSettings']) && count($form['featureSettings']['leadFields']))) {
-    // Unset if set to prevent features tab from showing when there's no feature to show
-    unset($form['featureSettings']['leadFields']);
-}
-if (!$hasFeatureSettings = (isset($form['featureSettings']) && (($hasFields && count($form['featureSettings']) > 1) || (!$hasFields && count($form['featureSettings']))))) {
-    if (isset($form['featureSettings'])) {
-        $form['featureSettings']->setRendered();
-    }
-}
-
-$fieldHtml     = ($hasFields) ? $view['form']->row($form['featureSettings']['leadFields']) : '';
-$fieldLabel    = ($hasFields) ? $form['featureSettings']['leadFields']->vars['label'] : '';
-$fieldTabClass = ($hasFields) ? '' : ' hide';
-unset($form['featureSettings']['leadFields']);
-
 echo $view['assets']->includeScript('plugins/MauticFullContactBundle/Assets/js/fullcontact.js');
 
 ?>
 
-<?php if (!empty($description)): ?>
-    <div class="alert alert-info">
-        <?php echo $description; ?>
+<div class="well well-sm" style="margin-bottom:0 !important;">
+    <p><?php echo $view['translator']->trans('mautic.plugin.fullcontact.webhook'); ?></p>
+    <div class="alert alert-warning">
+        <?php echo $view['translator']->trans('mautic.plugin.fullcontact.public_info'); ?>
     </div>
-<?php endif; ?>
-<ul class="nav nav-tabs pr-md pl-md">
-    <li class="active" id="details-tab"><a href="#details-container" role="tab" data-toggle="tab"><?php echo $view['translator']->trans('mautic.plugin.integration.tab.details'); ?></a></li>
-
-</ul>
-
-<?php echo $view['form']->start($form); ?>
-<!--/ tabs controls -->
-<div class="tab-content pa-md bg-white">
-    <div class="tab-pane fade in active bdr-w-0" id="details-container">
-        <?php echo $view['form']->row($form['isPublished']); ?>
-        <?php echo $view['form']->row($form['apiKeys']); ?>
-        <div class="well well-sm" style="margin-bottom:0 !important;">
-            <p><?php echo $view['translator']->trans('mautic.plugin.fullcontact.webhook'); ?></p>
-            <div class="alert alert-warning">
-                <?php echo $view['translator']->trans('mautic.plugin.fullcontact.public_info'); ?>
-            </div>
-            <input type="text" readonly="readonly" value="<?php echo $this->container->get('router')->generate('mautic_plugin_fullcontact_index', [], UrlGeneratorInterface::ABSOLUTE_URL)?>" class="form-control">
-        </div>
-    </div>
-
+    <input type="text" readonly="readonly" value="<?php echo $mauticUrl?>" class="form-control" title="url"/>
 </div>
-<?php echo $view['form']->end($form); ?>


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? |Y 
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes an issue with Gmail and Outlook plugin that prevented the tracking of emails sent from those systems.

NOTE: Make sure your Mautic instance is publicly accessible on the internet. If not, the tracking will not work.

#### Steps to reproduce the bug:
1. Enable the Outlook or Gmail plugin
2. Send an email from either system and enable tracking.
3. Go to Mautic and open the contact the email was sent to.
4. Notice there is no timeline event about the email being read.

#### Steps to test this PR:
1. Apply this PR
2. Follow the steps to test the PR
3. Now there will be timeline events showing when the email was read.
