### PR TITLE
Fixes #2571

### DIFF
--- a/app/bundles/PageBundle/Event/UntrackableUrlsEvent.php
+++ b/app/bundles/PageBundle/Event/UntrackableUrlsEvent.php
@@ -52,7 +52,7 @@ class UntrackableUrlsEvent extends Event
      */
     public function addNonTrackable($url)
     {
-        $this->doNotTrack[$url] = true;
+        $this->doNotTrack[] = $url;
     }
 
     /**

--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -569,7 +569,7 @@ class TrackableModel extends AbstractCommonModel
     {
         // Ensure it's not in the do not track list
         foreach ($this->doNotTrack as $notTrackable) {
-            if (preg_match('/'.preg_quote($notTrackable, '/').'/', $url)) {
+            if (preg_match('~'.$notTrackable.'~', $url)) {
                 return true;
             }
         }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #2571
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When sending an email to a segment with more than one contact, if we have a contact field token with a link, it gets replaced with the first encounter of the link. This PR fixes it by not replacing URL with a tracking link. In theory Mautic will not track contact URL's since each contact url can be different.

Use the below email as your test:

```
<br>

<h2>Hello there!</h2>
<br>We haven't heard from you for a while...
<br>
<br><a href="{contactfield=website}">{contactfield=website}</a>
<br>
<br><a href="http://{contactfield=firstname}.com/foo">http://{contactfield=firstname}.com/foo</a>
<br>
<br><a href="https://google.com/?q={contactfield=firstname}">https://google.com/?q={contactfield=firstname}</a>
<br>
<br>{unsubscribe_text} | {webview_text}
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. add a custom field or use an existing URL field
2. add a contact field token in an email, and send it, this will get replaced by the first encounter of the URL token, and all emails will end up with that same trackable link.

#### Steps to test this PR:
1. Apply PR, follow steps above
2. contact's URLs will be displayed with each contact's respective URL.