### PR TITLE
Escape percent character when saving configuration file.

### DIFF
--- a/app/bundles/ConfigBundle/Config/config.php
+++ b/app/bundles/ConfigBundle/Config/config.php
@@ -49,7 +49,10 @@ return [
     'services' => [
         'events' => [
             'mautic.config.subscriber' => [
-                'class' => 'Mautic\ConfigBundle\EventListener\ConfigSubscriber',
+                'class'     => 'Mautic\ConfigBundle\EventListener\ConfigSubscriber',
+                'arguments' => [
+                    'mautic.helper.core_parameters',
+                ],
             ],
         ],
 

--- a/app/bundles/ConfigBundle/Event/ConfigEvent.php
+++ b/app/bundles/ConfigBundle/Event/ConfigEvent.php
@@ -167,29 +167,6 @@ class ConfigEvent extends CommonEvent
     }
 
     /**
-     * @param $value
-     *
-     * @return mixed|string
-     */
-    public function escapeString($value)
-    {
-        // Prevent symfony for failing due to percent signs
-        if (is_string($value) && strpos($value, '%') !== false) {
-            $value = urldecode($value);
-
-            if (preg_match_all('/([^%]|^)(%{1}[^%]+[^%]%{1})([^%]|$)/i', $value, $matches)) {
-                // Encode any left over to prevent Symfony from crashing
-                foreach ($matches[0] as $matchKey => $match) {
-                    $replaceWith = $matches[1][$matchKey].'%'.$matches[2][$matchKey].'%'.$matches[3][$matchKey];
-                    $value       = str_replace($match, $replaceWith, $value);
-                }
-            }
-        }
-
-        return $value;
-    }
-
-    /**
      * @param UploadedFile $file
      *
      * @return string

--- a/app/bundles/ConfigBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/ConfigBundle/EventListener/ConfigSubscriber.php
@@ -12,20 +12,53 @@
 namespace Mautic\ConfigBundle\EventListener;
 
 use Mautic\ConfigBundle\ConfigEvents;
+use Mautic\ConfigBundle\Event\ConfigEvent;
 use Mautic\CoreBundle\EventListener\CommonSubscriber;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 
 /**
  * Class ConfigSubscriber.
  */
 class ConfigSubscriber extends CommonSubscriber
 {
+    protected $paramHelper;
+
+    public function __construct(CoreParametersHelper $paramHelper)
+    {
+        $this->paramHelper = $paramHelper;
+    }
+
     /**
      * @return array
      */
     public static function getSubscribedEvents()
     {
         return [
-            // ConfigEvents::CONFIG_POST_SAVE   => array('onConfigPostSave', 0)
+            ConfigEvents::CONFIG_PRE_SAVE => ['escapePercentCharacters', 1000],
         ];
+    }
+
+    /**
+     * @param ConfigEvent $event
+     */
+    public function escapePercentCharacters(ConfigEvent $event)
+    {
+        $config = $event->getConfig();
+
+        $escapeInvalidReference = function ($reference) {
+            // only escape when the referenced variable doesn't exist
+            if ($this->paramHelper->getParameter($reference[1]) === null) {
+                return '%'.$reference[0].'%';
+            }
+
+            return $reference[0];
+        };
+
+        array_walk_recursive($config, function (&$value) use ($escapeInvalidReference) {
+            if (is_string($value)) {
+                $value = preg_replace_callback('/%(.*?)%/', $escapeInvalidReference, $value);
+            }
+        });
+        $event->setConfig($config);
     }
 }

--- a/app/bundles/EmailBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ConfigSubscriber.php
@@ -97,18 +97,6 @@ class ConfigSubscriber extends CommonSubscriber
             }
         }
 
-        // Ensure that percent signs are decoded in the unsubscribe/webview settings
-        $decode = [
-            'unsubscribe_text',
-            'webview_text',
-            'unsubscribe_message',
-            'resubscribe_message',
-            'default_signature_text',
-        ];
-        foreach ($decode as $key) {
-            $data[$key] = $event->escapeString($data[$key]);
-        }
-
         $event->setConfig($data, 'emailconfig');
     }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Add %value% into google analytics script field and save
2. Mautic crashes on config file load

#### Steps to test this PR:
1. Try to add %value% (or any other value which has two % signs) into google analytics script with the PR applied.
2. No more crashes.
