### PR TITLE
Fix Mautic Helper Extension for Chrome timeline popup view

### DIFF
--- a/app/bundles/LeadBundle/Controller/TimelineController.php
+++ b/app/bundles/LeadBundle/Controller/TimelineController.php
@@ -120,7 +120,7 @@ class TimelineController extends CommonController
                     'mauticContent' => 'pluginTimeline',
                     'timelineCount' => $events['total'],
                 ],
-                'contentTemplate' => 'MauticLeadBundle:Timeline:plugin_list.html.php',
+                'contentTemplate' => ('gmail' === strtolower($integration)) ? 'MauticLeadBundle:Timeline:plugin_list.html.php' : 'MauticLeadBundle:Timeline:plugin_table.html.php',
             ]
         );
     }
@@ -175,7 +175,7 @@ class TimelineController extends CommonController
                     'mauticContent' => 'pluginTimeline',
                     'timelineCount' => $events['total'],
                 ],
-                'contentTemplate' => 'MauticLeadBundle:Timeline:plugin_list.html.php',
+                'contentTemplate' => ('gmail' === strtolower($integration)) ? 'MauticLeadBundle:Timeline:plugin_list.html.php' : 'MauticLeadBundle:Timeline:plugin_table.html.php',
             ]
         );
     }

--- a/app/bundles/LeadBundle/Controller/TimelineController.php
+++ b/app/bundles/LeadBundle/Controller/TimelineController.php
@@ -102,8 +102,15 @@ class TimelineController extends CommonController
         $events = $this->getAllEngagements($leads, $filters, $order, $page, $limit);
 
         $str = $this->request->server->get('QUERY_STRING');
-        $str = substr($str, strpos($str, '?') + 1);
         parse_str($str, $query);
+
+        $tmpl = 'table';
+        if (array_key_exists('from', $query) && 'iframe' === $query['from']) {
+            $tmpl = 'list';
+        }
+        if (array_key_exists('tmpl', $query)) {
+            $tmpl = $query['tmpl'];
+        }
 
         return $this->delegateView(
             [
@@ -120,7 +127,7 @@ class TimelineController extends CommonController
                     'mauticContent' => 'pluginTimeline',
                     'timelineCount' => $events['total'],
                 ],
-                'contentTemplate' => ('gmail' === strtolower($integration)) ? 'MauticLeadBundle:Timeline:plugin_list.html.php' : 'MauticLeadBundle:Timeline:plugin_table.html.php',
+                'contentTemplate' => sprintf('MauticLeadBundle:Timeline:plugin_%s.html.php', $tmpl),
             ]
         );
     }
@@ -158,8 +165,15 @@ class TimelineController extends CommonController
         $events = $this->getEngagements($lead, $filters, $order, $page);
 
         $str = $this->request->server->get('QUERY_STRING');
-        $str = substr($str, strpos($str, '?') + 1);
         parse_str($str, $query);
+
+        $tmpl = 'table';
+        if (array_key_exists('from', $query) && 'iframe' === $query['from']) {
+            $tmpl = 'list';
+        }
+        if (array_key_exists('tmpl', $query)) {
+            $tmpl = $query['tmpl'];
+        }
 
         return $this->delegateView(
             [
@@ -175,7 +189,7 @@ class TimelineController extends CommonController
                     'mauticContent' => 'pluginTimeline',
                     'timelineCount' => $events['total'],
                 ],
-                'contentTemplate' => ('gmail' === strtolower($integration)) ? 'MauticLeadBundle:Timeline:plugin_list.html.php' : 'MauticLeadBundle:Timeline:plugin_table.html.php',
+                'contentTemplate' => sprintf('MauticLeadBundle:Timeline:plugin_%s.html.php', $tmpl),
             ]
         );
     }

--- a/app/bundles/LeadBundle/Views/Timeline/plugin_index.html.php
+++ b/app/bundles/LeadBundle/Views/Timeline/plugin_index.html.php
@@ -10,7 +10,11 @@
  */
 $view->extend('MauticCoreBundle:Default:slim.html.php');
 ?>
-
+<style>
+    .container {
+        margin: auto !important;
+    }
+</style>
 <!-- filter form -->
 <form method="post" action="<?php echo isset($lead) ? $view['router']->path(
     'mautic_plugin_timeline_view', ['leadId' => $lead->getId(), 'integration' => $integration]

--- a/app/bundles/LeadBundle/Views/Timeline/plugin_list.html.php
+++ b/app/bundles/LeadBundle/Views/Timeline/plugin_list.html.php
@@ -8,9 +8,16 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
-$leadId = isset($lead) ? $lead->getId() : null;
 
-$view->extend('MauticLeadBundle:Timeline:plugin_index.html.php');
+/*
+ * THIS PAGE IS USED AND FORMATTED TO FIT THE GMAIL EXTENSION TIMELINE POPUP.
+ * WHEN MAKING CHANGES TO THIS PAGE, MAKE SURE THE TIMELINE STILL LOOKS GOOD.
+ */
+
+$leadId = isset($lead) ? $lead->getId() : null;
+if (isset($tmpl) && $tmpl == 'index') {
+    $view->extend('MauticLeadBundle:Timeline:plugin_index.html.php');
+}
 
 $baseUrl = isset($lead) ? $view['router']->path(
     'mautic_plugin_timeline_view',
@@ -18,101 +25,164 @@ $baseUrl = isset($lead) ? $view['router']->path(
 ) :
     $view['router']->path('mautic_plugin_timeline_index', ['integration' => $integration]);
 ?>
-<div class="table-responsive">
-    <div class="tl-header">
-        <?php echo $view['translator']->trans('mautic.lead.timeline.displaying_events', ['%total%' => $events['total']]); ?>
-        <?php if (isset($lead)) {
+<style>
+    .col-xs-6 {
+        padding-left: 2px;
+        padding-right: 2px;
+    }
+
+    span.timeline-icon {
+        float: right;
+        margin-top: -5px;
+    }
+
+    span.timeline-lead {
+        font-weight: bold;
+    }
+
+    .timeline-row {
+        padding: 15px;
+        border: 1px solid lightblue;
+        margin: 10px;
+    }
+
+    .timeline-row span {
+        display: inline-block;
+        vertical-align: middle;
+    }
+
+    span.timeline-name {
+        display: block;
+    }
+
+    div.timeline-details {
+        border-top: 1px solid lightgray;
+        margin-top: 10px;
+        padding-top: 10px;
+    }
+
+    div.tl-header {
+        color: #333;
+        background: #eee;
+        padding: 5px 10px;
+    }
+
+    div.tl-header .tl-new {
+        font-weight: bold;
+        color #300;
+    }
+
+    .timeline-row-highlighted {
+        background-color: #fafafa;
+    }
+
+    .timeline-row.timeline-featured {
+        background: #eee;
+    }
+
+    .timeline-row.tr-new {
+        background: #FFF2D4;
+    }
+
+    span.timeline-icon {
+        width: 25px;
+    }
+
+</style>
+<div class="tl-header">
+    <?php echo $view['translator']->trans('mautic.lead.timeline.displaying_events', ['%total%' => $events['total']]); ?>
+    <?php if (isset($lead)) {
     echo $view['translator']->trans('mautic.lead.timeline.displaying_events_for_contact', ['%contact%' => $lead->getName(), '%id%' => $lead->getId()]);
 } ?>
-        (<span class="tl-new"><?php echo $newCount; ?></span> <?php echo $view['translator']->trans(
-            'mautic.lead.timeline.events_new'
-        ); ?>)
-    </div>
-    <table class="table table-hover table-bordered" id="contact-timeline">
-        <thead>
-        <tr>
-            <th class="timeline-icon">
-                <a class="btn btn-sm btn-nospin btn-default" data-activate-details="all" data-toggle="tooltip" title="<?php echo $view['translator']->trans(
-                    'mautic.lead.timeline.toggle_all_details'
-                ); ?>">
-                    <span class="fa fa-fw fa-level-down"></span>
-                </a>
-            </th>
-            <?php
-            echo $view->render('MauticCoreBundle:Helper:tableheader.html.php', [
-                'orderBy'    => 'eventLabel',
-                'text'       => 'mautic.lead.timeline.event_name',
-                'class'      => 'timeline-name',
-                'sessionVar' => 'lead.'.$leadId.'.timeline',
-                'baseUrl'    => $baseUrl,
-                'target'     => '#timeline-table',
-            ]);
+    (<span class="tl-new"><?php echo $newCount; ?></span> <?php echo $view['translator']->trans(
+        'mautic.lead.timeline.events_new'
+    ); ?>)
+</div>
+<!-- timeline -->
+<div class="event-list" id="timeline-container">
 
-            echo $view->render('MauticCoreBundle:Helper:tableheader.html.php', [
-                'orderBy'    => 'eventType',
-                'text'       => 'mautic.lead.timeline.event_type',
-                'class'      => 'visible-md visible-lg timeline-type',
-                'sessionVar' => 'lead.'.$leadId.'.timeline',
-                'baseUrl'    => $baseUrl,
-                'target'     => '#timeline-table',
-            ]);
+    <?php foreach ($events['events'] as $counter => $event): ?>
+        <?php
+        $counter += 1; // prevent 0
+        $icon       = (isset($event['icon'])) ? $event['icon'] : 'fa-history';
+        $eventLabel = (isset($event['eventLabel'])) ? $event['eventLabel'] : $event['eventType'];
+        if (is_array($eventLabel)):
+            $linkType   = empty($eventLabel['isExternal']) ? 'data-toggle="ajax"' : 'target="_new"';
+            $eventLabel = "<a href=\"{$eventLabel['href']}\" $linkType>{$eventLabel['label']}</a>";
+        endif;
+        $eventLabel = preg_replace('/a\s+href/', 'a target="_new" href', $eventLabel);
+        $eventLabel = preg_replace('/data-toggle="ajax"/', '', $eventLabel);
 
-            echo $view->render('MauticCoreBundle:Helper:tableheader.html.php', [
-                'orderBy'    => 'timestamp',
-                'text'       => 'mautic.lead.timeline.event_timestamp',
-                'class'      => 'visible-md visible-lg timeline-timestamp',
-                'sessionVar' => 'lead.'.$leadId.'.timeline',
-                'baseUrl'    => $baseUrl,
-                'target'     => '#timeline-table',
-            ]);
-            ?>
-        </tr>
-        <tbody>
-        <?php foreach ($events['events'] as $counter => $event): ?>
-            <?php
-            $counter += 1; // prevent 0
-            $icon       = (isset($event['icon'])) ? $event['icon'] : 'fa-history';
-            $eventLabel = (isset($event['eventLabel'])) ? $event['eventLabel'] : $event['eventType'];
-            if (is_array($eventLabel)):
-                $linkType   = empty($eventLabel['isExternal']) ? 'data-toggle="ajax"' : 'target="_new"';
-                $eventLabel = "<a href=\"{$eventLabel['href']}\" $linkType>{$eventLabel['label']}</a>";
-            endif;
+        $details = '';
+        if (isset($event['contentTemplate']) && $view->exists($event['contentTemplate'])):
+            $details = trim($view->render($event['contentTemplate'], ['event' => $event]));
+        endif;
 
-            $details = '';
-            if (isset($event['contentTemplate']) && $view->exists($event['contentTemplate'])):
-                $details = trim($view->render($event['contentTemplate'], ['event' => $event, 'lead' => $lead]));
-            endif;
+        $details = preg_replace('/a\s+href/', 'a target="_new" href', $details);
+        $details = preg_replace('/data-toggle="ajax"/', '', $details);
 
-            $rowStripe = ($counter % 2 === 0) ? ' timeline-row-highlighted' : '';
-            ?>
-            <tr class="timeline-row<?php echo $rowStripe; ?><?php if (!empty($event['featured'])) {
-                echo ' timeline-featured';
-            } ?>">
-                <td class="timeline-icon">
-                    <a data-activate-details="<?php echo $counter; ?>" class="btn btn-sm btn-nospin btn-default<?php if (empty($details)) {
-                echo ' disabled';
-            } ?>" data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.lead.timeline.toggle_details'); ?>" data-target="timeline-details-<?php echo $counter; ?>">
+        $rowStripe = ($counter % 2 === 0) ? ' timeline-row-highlighted' : '';
+        ?>
+        <div class="timeline-row<?php echo $rowStripe; ?><?php if (!empty($event['featured'])) {
+            echo ' timeline-featured';
+        }
+        if ($newCount-- > 0) {
+            echo ' tr-new';
+        }
+        ?>">
+            <span class="timeline-row-id hide"><?php echo $view['date']->toText($event['timestamp']); ?>
+                on <?php echo $event['timestamp']->format('Y-m-d H:i:s'); ?></span>
+            <span class="timeline-row-lead-id hide"><?php echo isset($event['leadId']) ? $event['leadId'] : ''; ?></span>
+            <div class="btn-group" role="group" style="float: right;">
+                <span class="timeline-icon">
+                    <a href="javascript:void(0);"
+                       onclick="mQuery('#timeline-details-<?php echo $counter; ?>').toggleClass('hide')"
+                       data-activate-details="<?php echo $counter; ?>"
+                       class="btn btn-xs btn-nospin btn-default<?php if (empty($details)) {
+            echo ' disabled';
+        } ?>" data-toggle="tooltip"
+                       title="<?php echo $view['translator']->trans('mautic.lead.timeline.toggle_details'); ?>">
                         <span class="fa fa-fw <?php echo $icon ?>"></span>
                     </a>
-                </td>
-                <td class="timeline-name"><?php echo $eventLabel; ?></td>
-                <td class="timeline-type"><?php if (isset($event['eventType'])) {
-                echo $event['eventType'];
-            } ?></td>
-                <td class="timeline-timestamp"><?php echo $view['date']->toText($event['timestamp'], 'local', 'Y-m-d H:i:s', true); ?></td>
-            </tr>
-            <?php if (!empty($details)): ?>
-                <tr class="timeline-row<?php echo $rowStripe; ?> timeline-details hide" id="timeline-details-<?php echo $counter; ?>">
-                    <td colspan="4">
-                        <?php echo $details ?>
-                    </td>
-                </tr>
+                </span>
+
+                <span class="timeline-icon">
+                    <a href="javascript:void(0);" class="btn btn-xs btn-nospin btn-default" data-toggle="tooltip"
+                       onclick="mQuery(this).toggleClass('btn-warning')"
+                       title="Mute notifications">
+                        <span class="fa fa-fw fa-bell-slash-o"></span>
+                    </a>
+                </span>
+            </div>
+            <?php if (isset($event['leadEmail'])):?>
+                <span class="timeline-lead ellipsis"><a href="mailto:<?php echo $event['leadEmail']; ?>"
+                                                        title="<?php echo $event['leadEmail']; ?>"
+                                                        target="_new"><?php echo $event['leadName']; ?></a></span>
+
+                <span class="timeline-timestamp"> <?php echo $view['date']->toText($event['timestamp']); ?>
+                    on <?php echo $event['timestamp']->format('Y-m-d H:i:s'); ?></span>
             <?php endif; ?>
-        <?php endforeach; ?>
-        </tbody>
-    </table>
-</div>
+            <br/>
+
+            <span class="timeline-type"><?php if (isset($event['eventType'])) {
+            echo $event['eventType'];
+        } ?>: </span>
+
+            <br/>
+
+            <?php if ($eventLabel !== $event['eventType']): ?>
+                <span class="timeline-name ellipsis"><?php echo $eventLabel; ?></span>
+            <?php endif; ?>
+
+            <?php if (!empty($details)): ?>
+                <div class="timeline-details hide" id="timeline-details-<?php echo $counter; ?>">
+                    <?php echo $details ?>
+                </div>
+            <?php endif; ?>
+        </div>
+    <?php endforeach; ?>
 
 </div>
+
 <!--/ timeline -->
 

--- a/app/bundles/LeadBundle/Views/Timeline/plugin_table.html.php
+++ b/app/bundles/LeadBundle/Views/Timeline/plugin_table.html.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+$leadId = isset($lead) ? $lead->getId() : null;
+
+$view->extend('MauticLeadBundle:Timeline:plugin_index.html.php');
+
+$baseUrl = isset($lead) ? $view['router']->path(
+    'mautic_plugin_timeline_view',
+    ['leadId' => $lead->getId(), 'integration' => $integration]
+) :
+    $view['router']->path('mautic_plugin_timeline_index', ['integration' => $integration]);
+?>
+<div class="table-responsive">
+    <div class="tl-header">
+        <?php echo $view['translator']->trans('mautic.lead.timeline.displaying_events', ['%total%' => $events['total']]); ?>
+        <?php if (isset($lead)) {
+    echo $view['translator']->trans('mautic.lead.timeline.displaying_events_for_contact', ['%contact%' => $lead->getName(), '%id%' => $lead->getId()]);
+} ?>
+        (<span class="tl-new"><?php echo $newCount; ?></span> <?php echo $view['translator']->trans(
+            'mautic.lead.timeline.events_new'
+        ); ?>)
+    </div>
+    <table class="table table-hover table-bordered" id="contact-timeline">
+        <thead>
+        <tr>
+            <th class="timeline-icon">
+                <a class="btn btn-sm btn-nospin btn-default" data-activate-details="all" data-toggle="tooltip" title="<?php echo $view['translator']->trans(
+                    'mautic.lead.timeline.toggle_all_details'
+                ); ?>">
+                    <span class="fa fa-fw fa-level-down"></span>
+                </a>
+            </th>
+            <?php
+            echo $view->render('MauticCoreBundle:Helper:tableheader.html.php', [
+                'orderBy'    => 'eventLabel',
+                'text'       => 'mautic.lead.timeline.event_name',
+                'class'      => 'timeline-name',
+                'sessionVar' => 'lead.'.$leadId.'.timeline',
+                'baseUrl'    => $baseUrl,
+                'target'     => '#timeline-table',
+            ]);
+
+            echo $view->render('MauticCoreBundle:Helper:tableheader.html.php', [
+                'orderBy'    => 'eventType',
+                'text'       => 'mautic.lead.timeline.event_type',
+                'class'      => 'visible-md visible-lg timeline-type',
+                'sessionVar' => 'lead.'.$leadId.'.timeline',
+                'baseUrl'    => $baseUrl,
+                'target'     => '#timeline-table',
+            ]);
+
+            echo $view->render('MauticCoreBundle:Helper:tableheader.html.php', [
+                'orderBy'    => 'timestamp',
+                'text'       => 'mautic.lead.timeline.event_timestamp',
+                'class'      => 'visible-md visible-lg timeline-timestamp',
+                'sessionVar' => 'lead.'.$leadId.'.timeline',
+                'baseUrl'    => $baseUrl,
+                'target'     => '#timeline-table',
+            ]);
+            ?>
+        </tr>
+        <tbody>
+        <?php foreach ($events['events'] as $counter => $event): ?>
+            <?php
+            $counter += 1; // prevent 0
+            $icon       = (isset($event['icon'])) ? $event['icon'] : 'fa-history';
+            $eventLabel = (isset($event['eventLabel'])) ? $event['eventLabel'] : $event['eventType'];
+            if (is_array($eventLabel)):
+                $linkType   = empty($eventLabel['isExternal']) ? 'data-toggle="ajax"' : 'target="_new"';
+                $eventLabel = "<a href=\"{$eventLabel['href']}\" $linkType>{$eventLabel['label']}</a>";
+            endif;
+
+            $details = '';
+            if (isset($lead) && isset($event['contentTemplate']) && $view->exists($event['contentTemplate'])):
+                $details = trim($view->render($event['contentTemplate'], ['event' => $event, 'lead' => $lead]));
+            endif;
+
+            $rowStripe = ($counter % 2 === 0) ? ' timeline-row-highlighted' : '';
+            ?>
+            <tr class="timeline-row<?php echo $rowStripe; ?><?php if (!empty($event['featured'])) {
+                echo ' timeline-featured';
+            } ?>">
+                <td class="timeline-icon">
+                    <a data-activate-details="<?php echo $counter; ?>" class="btn btn-sm btn-nospin btn-default<?php if (empty($details)) {
+                echo ' disabled';
+            } ?>" data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.lead.timeline.toggle_details'); ?>" data-target="timeline-details-<?php echo $counter; ?>">
+                        <span class="fa fa-fw <?php echo $icon ?>"></span>
+                    </a>
+                </td>
+                <td class="timeline-name"><?php echo $eventLabel; ?></td>
+                <td class="timeline-type"><?php if (isset($event['eventType'])) {
+                echo $event['eventType'];
+            } ?></td>
+                <td class="timeline-timestamp"><?php echo $view['date']->toText($event['timestamp'], 'local', 'Y-m-d H:i:s', true); ?></td>
+            </tr>
+            <?php if (!empty($details)): ?>
+                <tr class="timeline-row<?php echo $rowStripe; ?> timeline-details hide" id="timeline-details-<?php echo $counter; ?>">
+                    <td colspan="4">
+                        <?php echo $details ?>
+                    </td>
+                </tr>
+            <?php endif; ?>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+
+</div>
+<!--/ timeline -->
+


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3938
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes an issue with the timeline view in the Mautic Helper Extension for Chrome: The formatting was broken and it didn't look good. Now the timeline looks as before.

![image](https://cloud.githubusercontent.com/assets/2924026/25903715/3c6c343a-356b-11e7-9eee-404b60e049f5.png)


#### Steps to reproduce the bug:
1. See https://github.com/mautic/mautic/issues/3938

#### Steps to test this PR:
1. Apply this PR
2. Try to reproduce the bug
3. The timeline will display correctly
