### PR TITLE
Fix for "Duplicate entry for key 'campaign_rotation'"

### DIFF
--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -1698,26 +1698,27 @@ class EventModel extends CommonFormModel
                         $log->setMetadata($response);
                     }
                     $debug .= ' thus placed on hold '.$this->scheduleTimeForFailedEvents;
+
+                    $metadata = $log->getMetadata();
+                    if (is_array($response)) {
+                        $metadata = array_merge($metadata, $response);
+                    }
+
+                    $reason = null;
+                    if (isset($metadata['errors'])) {
+                        $reason = (is_array($metadata['errors'])) ? implode('<br />', $metadata['errors']) : $metadata['errors'];
+                    } elseif (isset($metadata['reason'])) {
+                        $reason = $metadata['reason'];
+                    }
+                    $this->setEventStatus($log, false, $reason);
                 } else {
                     // Remove
                     $debug .= ' thus deleted';
                     $repo->deleteEntity($log);
+                    unset($log);
                 }
 
-                $metadata = $log->getMetadata();
-                if (is_array($response)) {
-                    $metadata = array_merge($metadata, $response);
-                }
-
-                $reason = null;
-                if (isset($metadata['errors'])) {
-                    $reason = (is_array($metadata['errors'])) ? implode('<br />', $metadata['errors']) : $metadata['errors'];
-                } elseif (isset($metadata['reason'])) {
-                    $reason = $metadata['reason'];
-                }
-                $this->setEventStatus($log, false, $reason);
                 $this->notifyOfFailure($lead, $campaign->getCreatedBy(), $campaign->getName().' / '.$event['name']);
-
                 $this->logger->debug($debug);
             } else {
                 $this->setEventStatus($log, true);

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -1665,11 +1665,10 @@ class EventModel extends CommonFormModel
 
             $eventTriggered = false;
             if ($response instanceof LeadEventLog) {
-                // Listener handled the event and returned a log entry
-                $this->campaignModel->setChannelFromEventProperties($response, $event, $thisEventSettings);
+                $log = $response;
 
-                $repo->saveEntity($response);
-                $this->em->detach($response);
+                // Listener handled the event and returned a log entry
+                $this->campaignModel->setChannelFromEventProperties($log, $event, $thisEventSettings);
 
                 ++$executedEventCount;
 
@@ -1677,7 +1676,7 @@ class EventModel extends CommonFormModel
                     'CAMPAIGN: Listener handled event for '.ucfirst($event['eventType']).' ID# '.$event['id'].' for contact ID# '.$lead->getId()
                 );
 
-                if (!$response->getIsScheduled()) {
+                if (!$log->getIsScheduled()) {
                     $eventTriggered = true;
                 }
             } elseif (($response === false || (is_array($response) && isset($response['result']) && false === $response['result']))


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3749
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
I got this error when running the `mautic:campaigns:trigger` command:
```
[Doctrine\DBAL\Exception\UniqueConstraintViolationException]
  An exception occurred while executing 'INSERT INTO campaign_lead_event_log (rotation, date_triggered, is_scheduled, trigger_date, system_triggered, metadata, channel, channel_id, non_action_path_ta
  ken, event_id, lead_id, campaign_id, ip_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params [1, "2017-05-10 14:32:26", 1, "2017-05-10 15:02:26", 1, "a:0:{}", null, null, 0, 971, 800, 39
  3, 8]:
  SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '971-800-1' for key 'campaign_rotation'
```

It's inserting instead of updating because the detach was called prematurely.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Not really sure

#### Steps to test this PR:
1. Make sure that when you run `app/console mautic:campaigns:trigger` it works and it won't throw the error above.

