### PR TITLE
Bugfix for #4042: FB deprecated the „bio“ Field

### DIFF
--- a/plugins/MauticSocialBundle/Integration/FacebookIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/FacebookIntegration.php
@@ -155,7 +155,6 @@ class FacebookIntegration extends SocialIntegration
     {
         return [
             'about'       => ['type' => 'string'],
-            'bio'         => ['type' => 'string'],
             'birthday'    => ['type' => 'string'],
             'email'       => ['type' => 'string'],
             'first_name'  => ['type' => 'string'],


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #4042
| BC breaks? | 
| Deprecations? | dropping "bio" field

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
In the **MauticPlugin\MauticSocialBundle\Integration\FacebookIntegration::getUserData()**, I'm getting following Error returned by FB Graph API:
`{"error":{"message":"(#12) bio field is deprecated for versions v2.8 and higher","type":"OAuthException","code":12,"fbtrace_id":"XXXXXXXXXX"}}`

The effect of this is that I don't get any User data saved in my Contact. The Contact is in the System as Anonymous.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup FB Integration
2. Build a Form with Social Login Field
3. Login via this Button
4. Error is not displayed/logged anywhere BUT the return value of "$this->makeRequest()"  on line 122 of FacebookIntegration will return the error message

#### Steps to test this PR:
1. Setup FB Integration
2. Build a Form with Social Login Field
3. Login via this Button
4. See the User Data in the Contact

#### List deprecations along with the new alternative:
1. we lose the "bio" field

#### List backwards compatibility breaks:
1. breaks mapping, if FB Plugin was configured to use this field. (it's not really a BC break since everybody who is using the bio field doesn't get any user data ATM)