### PR TITLE
Fix Company edit form when `companyemail` is unpublished

### DIFF
--- a/app/bundles/LeadBundle/Views/Company/form_fields.html.php
+++ b/app/bundles/LeadBundle/Views/Company/form_fields.html.php
@@ -37,9 +37,11 @@ foreach ($groups as $key => $group):
                                         <?php echo $view['form']->row($form['companyname']); ?>
                                     </div>
                                 <?php endif; ?>
-                                <div class="col-sm-<?php echo $halfSize; ?>">
-                                    <?php echo $view['form']->row($form['companyemail']); ?>
-                                </div>
+                                <?php if (isset($form['companyemail'])): ?>
+                                    <div class="col-sm-<?php echo $halfSize; ?>">
+                                        <?php echo $view['form']->row($form['companyemail']); ?>
+                                    </div>
+                                <?php endif; ?>
                             </div>
                         </div>
                         <hr class="mnr-md mnl-md">

--- a/app/bundles/LeadBundle/Views/Company/list.html.php
+++ b/app/bundles/LeadBundle/Views/Company/list.html.php
@@ -120,11 +120,13 @@ if ($tmpl == 'index') {
                         </div>
                     </td>
                     <td>
+                        <?php if (isset($fields['core']['companyeail'])): ?>
                         <div class="text-muted mt-4">
                             <small>
                                 <?php echo $fields['core']['companyemail']['value']; ?>
                             </small>
                         </div>
+                        <?php endif; ?>
                     </td>
 
                     <td class="visible-md visible-lg">


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR fixes an issue where if you unpublish the `companyemail` field, the company edit form would throw a 500 error.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Unpublish `companyemail`
2. Edit a company, and see that Mautic gives a 500 error.

#### Steps to test this PR:
1. Apply PR
2. Redo steps to reproduce. The error is gone and the form loads.