### PR TITLE
Segment filters based on company fields gets populated now

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -46,6 +46,13 @@ class LeadListRepository extends CommonRepository
     protected $dispatcher;
 
     /**
+     * Flag to check if some segment filter on a company field exists.
+     *
+     * @var bool
+     */
+    protected $hasCompanyFilter = false;
+
+    /**
      * {@inheritdoc}
      *
      * @param int $id
@@ -307,48 +314,12 @@ class LeadListRepository extends CommonRepository
                 $filters = [];
             }
 
-            $objectFilters         = $this->arrangeFilters($filters);
-            $includesContactFields = isset($objectFilters['lead']);
-            $includesCompanyFields = isset($objectFilters['company']);
+            $parameters = [];
 
             if ($dynamic && count($filters)) {
-                $q          = $this->getEntityManager()->getConnection()->createQueryBuilder();
-                $parameters = [];
-
-                if ($includesContactFields) {
-                    $expr = $this->getListFilterExpr($objectFilters['lead'], $parameters, $q, false, null, 'lead');
-                }
-                if (empty($expr) || !$expr->count()) {
-                    $nonMembersOnly = true;
-                }
-                if ($includesCompanyFields) {
-                    $this->listFiltersInnerJoinCompany = false;
-                    $exprCompany                       = $this->getListFilterExpr($objectFilters['company'], $parameters, $q, false, null, 'company');
-                }
-
-                foreach ($parameters as $k => $v) {
-                    switch (true) {
-                        case is_bool($v):
-                            $paramType = 'boolean';
-                            break;
-
-                        case is_int($v):
-                            $paramType = 'integer';
-                            break;
-
-                        case is_float($v):
-                            $paramType = 'float';
-                            break;
-
-                        default:
-                            $paramType = null;
-                            break;
-                    }
-                    $q->setParameter($k, $v, $paramType);
-                }
-
+                $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
                 if ($countOnly) {
-                    $count  = ($includesCompanyFields) ? 'count(distinct(l.id))' : 'count(l.id)';
+                    $count  = ($this->hasCompanyFilter) ? 'count(distinct(l.id))' : 'count(l.id)';
                     $select = $count.' as lead_count, max(l.id) as max_id';
                     if ($withMinId) {
                         $select .= ', min(l.id) as min_id';
@@ -376,9 +347,23 @@ class LeadListRepository extends CommonRepository
                     }
                 }
 
-                if ($newOnly && !empty($expr) && $expr->count()) {
-                    if ($includesCompanyFields) {
-                        $this->applyCompanyFieldFilters($q, $exprCompany);
+                if ($newOnly) {
+                    $expr = $this->generateSegmentExpression($filters, $parameters, $q);
+
+                    if (!$this->hasCompanyFilter && !$expr->count()) {
+                        // Treat this as if it has no filters since all the filters are now invalid (fields were deleted)
+                        $return[$id] = [];
+                        if ($countOnly) {
+                            $return[$id] = [
+                                'count' => 0,
+                                'maxId' => 0,
+                            ];
+                            if ($withMinId) {
+                                $return[$id]['minId'] = 0;
+                            }
+                        }
+
+                        continue;
                     }
 
                     // Leads that do not have any record in the lead_lists_leads table for this lead list
@@ -435,21 +420,19 @@ class LeadListRepository extends CommonRepository
                     $sq = $this->getEntityManager()->getConnection()->createQueryBuilder();
                     $sq->select('l.id')
                         ->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
-                    if ($includesContactFields && !empty($expr) && $expr->count()) {
-                        $sq->andWhere($expr);
-                    }
 
-                    if ($includesCompanyFields) {
-                        $this->applyCompanyFieldFilters($sq, $exprCompany);
-                    }
+                    $expr = $this->generateSegmentExpression($filters, $parameters, $sq, $q);
 
-                    $mainExpr->add(
-                        sprintf('l.id NOT IN (%s)', $sq->getSQL())
-                    );
+                    if ($this->hasCompanyFilter || $expr->count()) {
+                        $mainExpr->add(
+                            sprintf('l.id NOT IN (%s)', $sq->getSQL())
+                        );
+                    }
 
                     if ($batchExpr->count()) {
                         $mainExpr->add($batchExpr);
                     }
+
                     if (!empty($mainExpr) && $mainExpr->count() > 0) {
                         $q->andWhere($mainExpr);
                     }
@@ -537,6 +520,62 @@ class LeadListRepository extends CommonRepository
         }
 
         return $return;
+    }
+
+    /**
+     * @param array        $filters
+     * @param array        $parameters
+     * @param QueryBuilder $q
+     *
+     * @return QueryBuilder
+     */
+    protected function generateSegmentExpression(array $filters, array &$parameters, QueryBuilder $q, QueryBuilder $parameterQ = null)
+    {
+        if (null === $parameterQ) {
+            $parameterQ = $q;
+        }
+
+        $objectFilters = $this->arrangeFilters($filters);
+
+        if (isset($objectFilters['lead'])) {
+            $expr = $this->getListFilterExpr($objectFilters['lead'], $parameters, $q, false, null, 'lead');
+        } else {
+            $expr = $q->expr()->andX();
+        }
+
+        $this->hasCompanyFilter = false;
+        if (isset($objectFilters['company'])) {
+            $this->listFiltersInnerJoinCompany = false;
+            $exprCompany                       = $this->getListFilterExpr($objectFilters['company'], $parameters, $q, false, null, 'company');
+
+            if ($exprCompany->count()) {
+                $this->hasCompanyFilter = true;
+                $this->applyCompanyFieldFilters($q, $exprCompany);
+            }
+        }
+
+        foreach ($parameters as $k => $v) {
+            switch (true) {
+                case is_bool($v):
+                    $paramType = 'boolean';
+                    break;
+
+                case is_int($v):
+                    $paramType = 'integer';
+                    break;
+
+                case is_float($v):
+                    $paramType = 'float';
+                    break;
+
+                default:
+                    $paramType = null;
+                    break;
+            }
+            $parameterQ->setParameter($k, $v, $paramType);
+        }
+
+        return $expr;
     }
 
     /**

--- a/app/bundles/LeadBundle/Views/FormTheme/Filter/_leadlist_filters_entry_widget.html.php
+++ b/app/bundles/LeadBundle/Views/FormTheme/Filter/_leadlist_filters_entry_widget.html.php
@@ -13,6 +13,9 @@ $filterType  = $form['field']->vars['value'];
 $inGroup     = $form->vars['data']['glue'] === 'and';
 $object      = (isset($form->vars['data']['object'])) ? $form->vars['data']['object'] : 'lead';
 $class       = (isset($form->vars['data']['object']) && $form->vars['data']['object'] == 'company') ? 'fa-building' : 'fa-user';
+if (!$isPrototype && !isset($fields[$object][$filterType]['label'])) {
+    return;
+}
 ?>
 
 <div class="panel<?php echo ($inGroup && $first === false) ? ' in-group' : ''; ?>">


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4038
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to create a segment with filters based on company field
2. The segment won't populate any contacts

#### Steps to test this PR:
1. Apply this PR
2. Run the segment update command again - it will populate the right contacts
