### PR TITLE
Fix limit for notification

### DIFF
--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -617,7 +617,7 @@ class CommonController extends Controller implements MauticController
         /** @var \Mautic\CoreBundle\Model\NotificationModel $model */
         $model = $this->getModel('core.notification');
 
-        list($notifications, $showNewIndicator, $updateMessage) = $model->getNotificationContent($afterId);
+        list($notifications, $showNewIndicator, $updateMessage) = $model->getNotificationContent($afterId, false, 200);
 
         $lastNotification = reset($notifications);
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
When you have too many notification (more ~20000), a limit of  200 notifications is display but a second request load all notifications without limit. So it difficult to load page and it's possible to attain the memory limit.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Create 20000 notifications (in database for example)
2. Assign all notifications to one user
3. Connect with this user
4. See the limit of 200 notifications in notifications box
5. Try to change page
6. See the loading is very low and it's possible to get a code return 500 for memory limit.

#### Steps to test this PR:
1. Apply this PR.
2. Create 20000 notifications (in database for example)
3. Assign all notifications to one user
4. Connect with this user
5. See the limit of 200 notifications in notifications box
6. Try to change page
7. See the loading is ordinary