### PR TITLE
Fixed issue where the migration was processed even if it was applied already

### DIFF
--- a/app/migrations/Version20170303000000.php
+++ b/app/migrations/Version20170303000000.php
@@ -27,8 +27,8 @@ class Version20170303000000 extends AbstractMauticMigration
      */
     public function preUp(Schema $schema)
     {
-        $table = $schema->getTable(MAUTIC_TABLE_PREFIX.'leads');
-        if ($table->hasIndex('date_added_country_index')) {
+        $table = $schema->getTable("{$this->prefix}leads");
+        if ($table->hasIndex("{$this->prefix}date_added_country_index")) {
             throw new SkipMigrationException('Schema includes this migration');
         }
     }


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

While testing 2.8.0 - 2.8.1 update with table prefix I was getting this error when I run the upgrade for the second time. I know it's not a normal use case, but it pointed out a problem in the migrations so here's the fix. 

```
mautic.NOTICE: Doctrine\DBAL\Exception\DriverException: An exception occurred while executing 'CREATE INDEX m_date_added_country_index ON m_leads (date_added, country)':  SQLSTATE[42000]: Syntax error or access violation: 1061 Duplicate key name 'm_date_added_country_index' (uncaught exception) at /Users/jan/dev/2.8.0/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php line 115 while running console command `doctrine:migrations:migrate` [] []
[2017-05-12 13:20:50] mautic.ERROR: [UPGRADE ERROR] Exit code 1; Mautic Migrations \ Migrating up to 20170506144649 from 20160225000000 \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ ++ migrating 20160615000000 \ -> DROP INDEX m_email_date_read ON m_email_stats -> CREATE INDEX m_email_date_read ON m_email_stats (date_read) \ ++ migrated (0.84s) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ ++ migrating 20160712000000 \ -> UPDATE m_lead_fields SET properties = 'a:2:{s:9:"roundmode";s:1:"4";s:9:"precision";s:1:"2";}' WHERE alias = 'attribution' \ ++ migrated (0.89s) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ ++ migrating 20160720000000 \ -> DELETE FROM m_lead_utmtags WHERE utm_campaign is null and utm_content is null and utm_medium is null and utm_source is null and utm_term is null \ ++ migrated (0.78s) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ ++ migrating 20160726000001 \ -> ALTER TABLE m_emails DROP FOREIGN KEY FK_612BAAC9091A2FB -> ALTER TABLE m_emails ADD CONSTRAINT FK_612BAAC9091A2FB FOREIGN KEY (translation_parent_id) REFERENCES m_emails (id) ON DELETE CASCADE -> ALTER TABLE m_emails DROP FOREIGN KEY FK_612BAAC91861123 -> ALTER TABLE m_emails ADD CONSTRAINT FK_612BAAC91861123 FOREIGN KEY (variant_parent_id) REFERENCES m_emails (id) ON DELETE CASCADE -> ALTER TABLE m_pages DROP FOREIGN KEY FK_6C835A119091A2FB -> ALTER TABLE m_pages ADD CONSTRAINT FK_6C835A119091A2FB FOREIGN KEY (translation_parent_id) REFERENCES m_pages (id) ON DELETE CASCADE -> ALTER TABLE m_pages DROP FOREIGN KEY FK_6C835A1191861123 -> ALTER TABLE m_pages ADD CONSTRAINT FK_6C835A1191861123 FOREIGN KEY (variant_parent_id) REFERENCES m_pages (id) ON DELETE CASCADE -> ALTER TABLE m_dynamic_content DROP FOREIGN KEY FK_196D77AA9091A2FB -> ALTER TABLE m_dynamic_content ADD CONSTRAINT FK_196D77AA9091A2FB FOREIGN KEY (translation_parent_id) REFERENCES m_dynamic_content (id) ON DELETE CASCADE -> ALTER TABLE m_dynamic_content DROP FOREIGN KEY FK_196D77AA91861123 -> ALTER TABLE m_dynamic_content ADD CONSTRAINT FK_196D77AA91861123 FOREIGN KEY (variant_parent_id) REFERENCES m_dynamic_content (id) ON DELETE CASCADE \ ++ migrated (0.98s) \ SS skipped (Reason: Schema includes this migration) \ ++ migrating 20160731000000 \ -> update m_campaign_lead_event_log log inner join m_campaign_events events on log.event_id = events.id set log.metadata = 'a:0:{}' where events.type = 'email.send' and log.metadata = 'a:2:{s:6:"failed";i:1;s:6:"reason";s:50:"mautic.notification.campaign.failed.not_subscribed";}' \ ++ migrated (0.79s) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ ++ migrating 20160926182807 \ -> insert into m_companies (companyname, is_published) (SELECT DISTINCT TRIM(company), 1 from m_leads l left join m_companies c ON l.company = c.companyname where company IS NOT NULL and company <> '' and c.companyname is null) -> insert into m_companies_leads (company_id, lead_id, date_added, manually_added, manually_removed) SELECT c.id, l.id, '2017-05-12 13:20:34', 0, 0 from m_leads l join m_companies c on c.companyname = l.company ON DUPLICATE KEY UPDATE company_id = c.id; \ ++ migrated (0.8s) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ ++ migrating 20161123225456 \ Migration 20161123225456 was executed but did not result in any SQL statements. \ ++ migrated (1.17s) \ ++ migrating 20161124145649 \ -> ALTER TABLE m_lead_frequencyrules CHANGE `frequency_number` `frequency_number` SMALLINT DEFAULT NULL; -> ALTER TABLE m_lead_frequencyrules CHANGE `frequency_time` `frequency_time` VARCHAR(25) DEFAULT NULL; \ ++ migrated (1.34s) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ ++ migrating 20170108012944 \ -> ALTER TABLE m_push_notifications CHANGE button button LONGTEXT NULL -> ALTER TABLE m_dynamic_content_lead_data DROP FOREIGN KEY FK_92894FD755458D -> ALTER TABLE m_dynamic_content_lead_data CHANGE lead_id lead_id INT NOT NULL -> ALTER TABLE m_dynamic_content_lead_data ADD CONSTRAINT FK_92894FD755458D FOREIGN KEY (lead_id) REFERENCES m_leads (id) ON DELETE CASCADE \ ++ migrated (0.94s) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ SS skipped (Reason: Schema includes this migration) \ ++ migrating 20170303000000 \ -> CREATE INDEX m_date_added_country_index ON m_leads (date_added, country) Migration 20170303000000 failed during Execution. Error An exception occurred while executing 'CREATE INDEX m_date_added_country_index ON m_leads (date_added, country)': \ SQLSTATE[42000]: Syntax error or access violation: 1061 Duplicate key name 'm_date_added_country_index' \ [Doctrine\DBAL\Exception\DriverException] An exception occurred while executing 'CREATE INDEX m_date_added_country_index ON m_leads (date_added, country)': SQLSTATE[42000]: Syntax error or access violation: 1061 Duplicate key name 'm_date_added_country_index' \ [Doctrine\DBAL\Driver\PDOException] SQLSTATE[42000]: Syntax error or access violation: 1061 Duplicate key name 'm_date_added_country_index' \ [PDOException] SQLSTATE[42000]: Syntax error or access violation: 1061 Duplicate key name 'm_date_added_country_index' \ doctrine:migrations:migrate [--write-sql] [--dry-run] [--query-time] [--allow-no-migration] [--configuration [CONFIGURATION]] [--db-configuration [DB-CONFIGURATION]] [--db DB] [--em EM] [--shard SHARD] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-s|--shell] [--process-isolation] [-e|--env ENV] [--no-debug] [--]  [] \ [] []
```
Introduced in https://github.com/mautic/mautic/pull/3580

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. It's a special use case described above

#### Steps to test this PR:
1. Make sure the migrations command work
2. Make sure the upgrade process work