### PR TITLE
fixed updating integration entity id

### DIFF
--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -1062,6 +1062,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                                 $lead['id']
                             );
                             $integrationEntities[] = $integrationEntity->setInternalEntity('lead-converted');
+                            $checkEmailsInSF[$key] = $lead;
                         } else {
                             $checkEmailsInSF[$key] = $lead;
                         }
@@ -1211,6 +1212,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
                         $key = mb_strtolower($sfContactRecord['Email']);
                         if (isset($checkEmailsInSF[$key])) {
                             $salesforceIdMapping[$checkEmailsInSF[$key]['internal_entity_id']] = $sfContactRecord['Id'];
+                            if ($checkEmailsInSF[$key]['integration_entity_id'] != $sfContactRecord['Id'] && $checkEmailsInSF[$key]['integration_entity'] == 'Lead') {
+                                $checkEmailsInSF[$key]['id'] = null;
+                            }
                             if ($this->buildCompositeBody(
                                 $mauticData,
                                 $availableFields,

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -1140,17 +1140,6 @@ class SalesforceIntegration extends CrmAbstractIntegration
                                     );
                                     $integrationEntity->setIntegrationEntityId($sfLeadRecord['Id']);
                                     $integrationEntities[] = $integrationEntity->setInternalEntity('lead-converted');
-                                } else {
-                                    $integrationEntities[] = $this->createIntegrationEntity(
-                                        'Lead',
-                                        $sfLeadRecord['Id'],
-                                        'lead-converted',
-                                        $checkEmailsInSF[$key]['internal_entity_id'],
-                                        [],
-                                        false
-                                    );
-
-                                    $this->logger->debug('SALESFORCE: Converted lead '.$sfLeadRecord['Email']);
                                 }
 
                                 continue;
@@ -1212,7 +1201,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                         $key = mb_strtolower($sfContactRecord['Email']);
                         if (isset($checkEmailsInSF[$key])) {
                             $salesforceIdMapping[$checkEmailsInSF[$key]['internal_entity_id']] = $sfContactRecord['Id'];
-                            if ($checkEmailsInSF[$key]['integration_entity_id'] != $sfContactRecord['Id'] && $checkEmailsInSF[$key]['integration_entity'] == 'Lead') {
+                            if (isset($checkEmailsInSF[$key]['integration_entity_id']) && $checkEmailsInSF[$key]['integration_entity_id'] != $sfContactRecord['Id'] && $checkEmailsInSF[$key]['integration_entity'] == 'Lead') {
                                 $checkEmailsInSF[$key]['id'] = null;
                             }
                             if ($this->buildCompositeBody(
@@ -1478,7 +1467,6 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 } elseif (204 === $item['httpStatusCode']) {
                     // Record was updated
                     if ($integrationEntityId) {
-                        $salesforceIdMapping[$contactId] = $integrationEntityId;
                         /** @var IntegrationEntity $integrationEntity */
                         $integrationEntity = $this->em->getReference('MauticPluginBundle:IntegrationEntity', $integrationEntityId);
 


### PR DESCRIPTION
…Salesforce

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixes an issue encountered when the sync to salesforce would encounter a converted lead and the way we are tracking those internally. the Salesforce id was not being updated for the newly found Contact
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try the SF sync for the first time it should populate the integration_entity table with SF data matched with the contact id in mautic. 
2. Convert any of those synced Leads from salesforce to a Contact in Salesforce
3. on second sync, update the Mautic contact associated to the converted lead so that it will try to push data to SF. 
4. look into the integration table, it should mark that Lead to 'converted-lead' but then it will create a new entry with the id column from the converted lead on that table and write it to the integration_entity_id column. Because of this the sync on the 3rd sync will try to create a new lead in SF.
#### Steps to test this PR:
1. Apply this PR and follow the steps above
2. A new entry for the Contact and correct integration_entity_id will be created in the integration table.

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 