### PR TITLE
reprocess errored leads when the contact in mautic has been updated

### DIFF
--- a/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
+++ b/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
@@ -264,6 +264,18 @@ class IntegrationEntityRepository extends CommonRepository
 
         $q->where('internal_entity_id = :leadId')
             ->andWhere($q->expr()->eq('internal_entity', ':internalEntity'))
+            ->andWhere($q->expr()->isNotNull('integration_entity_id'))
+            ->setParameter('leadId', $leadId)
+            ->setParameter('internalEntity', $internalEntity)
+            ->execute();
+
+        $z = $this->_em->getConnection()->createQueryBuilder()
+            ->delete(MAUTIC_TABLE_PREFIX.'integration_entity')
+            ->from(MAUTIC_TABLE_PREFIX.'integration_entity');
+
+        $z->where('internal_entity_id = :leadId')
+            ->andWhere($q->expr()->like('internal_entity', ':internalEntity'))
+            ->andWhere($q->expr()->isNull('integration_entity_id'))
             ->setParameter('leadId', $leadId)
             ->setParameter('internalEntity', $internalEntity)
             ->execute();

--- a/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
+++ b/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
@@ -253,6 +253,19 @@ class IntegrationEntityRepository extends CommonRepository
             ->andWhere($q->expr()->like('internal_entity', ':internalEntity'))
             ->setParameter('leadId', $leadId)
             ->setParameter('internalEntity', $internalEntity)
-        ->execute();
+            ->execute();
+    }
+
+    public function updateErrorLeads($internalEntity, $leadId)
+    {
+        $q = $this->_em->getConnection()->createQueryBuilder()
+            ->update(MAUTIC_TABLE_PREFIX.'integration_entity')
+            ->set('internal_entity', ':lead')->setParameter('lead', 'lead');
+
+        $q->where('internal_entity_id = :leadId')
+            ->andWhere($q->expr()->eq('internal_entity', ':internalEntity'))
+            ->setParameter('leadId', $leadId)
+            ->setParameter('internalEntity', $internalEntity)
+            ->execute();
     }
 }

--- a/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
+++ b/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
@@ -263,8 +263,8 @@ class IntegrationEntityRepository extends CommonRepository
             ->set('internal_entity', ':lead')->setParameter('lead', 'lead');
 
         $q->where('internal_entity_id = :leadId')
-            ->andWhere($q->expr()->eq('internal_entity', ':internalEntity'))
             ->andWhere($q->expr()->isNotNull('integration_entity_id'))
+            ->andWhere($q->expr()->eq('internal_entity', ':internalEntity'))
             ->setParameter('leadId', $leadId)
             ->setParameter('internalEntity', $internalEntity)
             ->execute();
@@ -274,8 +274,8 @@ class IntegrationEntityRepository extends CommonRepository
             ->from(MAUTIC_TABLE_PREFIX.'integration_entity');
 
         $z->where('internal_entity_id = :leadId')
-            ->andWhere($q->expr()->like('internal_entity', ':internalEntity'))
             ->andWhere($q->expr()->isNull('integration_entity_id'))
+            ->andWhere($q->expr()->like('internal_entity', ':internalEntity'))
             ->setParameter('leadId', $leadId)
             ->setParameter('internalEntity', $internalEntity)
             ->execute();

--- a/app/bundles/PluginBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/LeadSubscriber.php
@@ -42,6 +42,7 @@ class LeadSubscriber extends CommonSubscriber
     {
         return [
             LeadEvents::LEAD_PRE_DELETE => ['onLeadDelete', 0],
+            LeadEvents::LEAD_POST_SAVE  => ['onLeadSave', 0],
         ];
     }
 
@@ -57,5 +58,16 @@ class LeadSubscriber extends CommonSubscriber
         $success = false;
 
         return $success;
+    }
+
+    /*
+    * Change lead event
+    */
+    public function onLeadSave(LeadEvent $event)
+    {
+        /** @var \Mautic\LeadBundle\Entity\Lead $lead */
+        $lead                  = $event->getLead();
+        $integrationEntityRepo = $this->pluginModel->getIntegrationEntityRepository();
+        $integrationEntityRepo->findLeadsToDelete('lead-error', $lead->getId());
     }
 }

--- a/app/bundles/PluginBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/LeadSubscriber.php
@@ -68,6 +68,6 @@ class LeadSubscriber extends CommonSubscriber
         /** @var \Mautic\LeadBundle\Entity\Lead $lead */
         $lead                  = $event->getLead();
         $integrationEntityRepo = $this->pluginModel->getIntegrationEntityRepository();
-        $integrationEntityRepo->findLeadsToDelete('lead-error', $lead->getId());
+        $integrationEntityRepo->updateErrorLeads('lead-error', $lead->getId());
     }
 }

--- a/app/bundles/PluginBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/LeadSubscriber.php
@@ -12,6 +12,7 @@
 namespace Mautic\PluginBundle\EventListener;
 
 use Mautic\CoreBundle\EventListener\CommonSubscriber;
+use Mautic\LeadBundle\Event\CompanyEvent;
 use Mautic\LeadBundle\Event\LeadEvent;
 use Mautic\LeadBundle\LeadEvents;
 use Mautic\PluginBundle\Model\PluginModel;
@@ -41,8 +42,9 @@ class LeadSubscriber extends CommonSubscriber
     public static function getSubscribedEvents()
     {
         return [
-            LeadEvents::LEAD_PRE_DELETE => ['onLeadDelete', 0],
-            LeadEvents::LEAD_POST_SAVE  => ['onLeadSave', 0],
+            LeadEvents::LEAD_PRE_DELETE    => ['onLeadDelete', 0],
+            LeadEvents::LEAD_POST_SAVE     => ['onLeadSave', 0],
+            LeadEvents::COMPANY_PRE_DELETE => ['onCompanyDelete', 0],
         ];
     }
 
@@ -55,6 +57,20 @@ class LeadSubscriber extends CommonSubscriber
         $lead                  = $event->getLead();
         $integrationEntityRepo = $this->pluginModel->getIntegrationEntityRepository();
         $integrationEntityRepo->findLeadsToDelete('lead%', $lead->getId());
+        $success = false;
+
+        return $success;
+    }
+
+    /*
+     * Delete company event
+     */
+    public function onCompanyDelete(CompanyEvent $event)
+    {
+        /** @var \Mautic\LeadBundle\Entity\Company $company */
+        $company               = $event->getCompany();
+        $integrationEntityRepo = $this->pluginModel->getIntegrationEntityRepository();
+        $integrationEntityRepo->findLeadsToDelete('company%', $company->getId());
         $success = false;
 
         return $success;

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -585,6 +585,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
             $lead,
             ['leadFields' => $leadFields, 'object' => $object, 'feature_settings' => ['objects' => $config['objects']]]
         );
+        if (isset($mappedData[$object]['Id'])) {
+            unset($mappedData[$object]['Id']);
+        }
         $this->amendLeadDataBeforePush($mappedData[$object]);
 
         if (isset($config['objects']) && array_search('Contact', $config['objects'])) {
@@ -967,10 +970,13 @@ class SalesforceIntegration extends CrmAbstractIntegration
         $config                = $this->mergeConfigToFeatureSettings();
         $integrationEntityRepo = $this->em->getRepository('MauticPluginBundle:IntegrationEntity');
         $fieldsToUpdateInSf    = isset($config['update_mautic']) ? array_keys($config['update_mautic'], 1) : [];
-        $leadFields            = array_unique(array_values($config['leadFields']));
-        $totalUpdated          = $totalCreated          = $totalErrors          = 0;
-        $leadModel             = $this->leadModel;
-        $companyModel          = $this->companyModel;
+        if (isset($fieldsToUpdateInSf['Id'])) {
+            unset($fieldsToUpdateInSf['Id']);
+        }
+        $leadFields   = array_unique(array_values($config['leadFields']));
+        $totalUpdated = $totalCreated = $totalErrors = 0;
+        $leadModel    = $this->leadModel;
+        $companyModel = $this->companyModel;
 
         if ($mauticContactLinkField = array_search('mauticContactTimelineLink', $leadFields)) {
             $this->pushContactLink = true;
@@ -984,10 +990,14 @@ class SalesforceIntegration extends CrmAbstractIntegration
         $fields               = implode(', l.', $leadFields);
         $fields               = 'l.'.$fields;
         $leadSfFieldsToCreate = $this->cleanSalesForceData($config, array_keys($config['leadFields']), 'Lead');
-        $leadSfFields         = array_diff_key($leadSfFieldsToCreate, array_flip($fieldsToUpdateInSf));
-        $contactSfFields      = $this->cleanSalesForceData($config, array_keys($config['leadFields']), 'Contact');
-        $contactSfFields      = array_diff_key($contactSfFields, array_flip($fieldsToUpdateInSf));
-        $availableFields      = $this->getAvailableLeadFields(['feature_settings' => ['objects' => ['Lead', 'Contact']]]);
+
+        if (isset($leadSfFieldsToCreate['Id'])) {
+            unset($leadSfFieldsToCreate['Id']);
+        }
+        $leadSfFields    = array_diff_key($leadSfFieldsToCreate, array_flip($fieldsToUpdateInSf));
+        $contactSfFields = $this->cleanSalesForceData($config, array_keys($config['leadFields']), 'Contact');
+        $contactSfFields = array_diff_key($contactSfFields, array_flip($fieldsToUpdateInSf));
+        $availableFields = $this->getAvailableLeadFields(['feature_settings' => ['objects' => ['Lead', 'Contact']]]);
 
         $salesforceIdMapping = [];
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If a contact fails to push to the Salesforce integration it doesn't get reprocessed if the cause for that error was fixed in the contact record. This bug fix allows for that updated contact to be reprocessed

There was a bug also when trying to map the contact Id or Lead Id, when creating new leads it sends all fields to SF and SF query doesn't allow the Id to come in the query

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. run the Salesforce from the CLI, try to have a lead that will error the sync
2. you should see a record in the integration table marked as lead-error
3. try to update the lead to fix the erroring issue, the contact doesn't get updated
4. mapp Lead Id or Contact Id you should get an error when trying to run the CLI command or creating a Lead through the push through integration actions 

#### Steps to test this PR:
1. Run this PR and follow steps above...
2. after the contact gets updated it should be reprocessed when running the CLI command again.
3. With this PR the Id bug in the query should not continue to happen
#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 