### PR TITLE
Fixed 500 error when using SAML and a user pre-exists with the given email

### DIFF
--- a/app/bundles/UserBundle/Config/config.php
+++ b/app/bundles/UserBundle/Config/config.php
@@ -192,6 +192,7 @@ return [
                 'alias'     => 'userconfig',
                 'arguments' => [
                     'mautic.helper.core_parameters',
+                    'translator',
                 ],
             ],
         ],

--- a/app/bundles/UserBundle/Form/Type/ConfigType.php
+++ b/app/bundles/UserBundle/Form/Type/ConfigType.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\File;
 
 /**
@@ -32,13 +33,19 @@ class ConfigType extends AbstractType
     protected $parameters;
 
     /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    /**
      * ConfigType constructor.
      *
      * @param CoreParametersHelper $parametersHelper
      */
-    public function __construct(CoreParametersHelper $parametersHelper)
+    public function __construct(CoreParametersHelper $parametersHelper, TranslatorInterface $translator)
     {
         $this->parameters = $parametersHelper;
+        $this->translator = $translator;
     }
 
     /**
@@ -51,9 +58,9 @@ class ConfigType extends AbstractType
             'saml_idp_metadata',
             ConfigFileType::class,
             [
-                'label'      => 'mautic.user.config.form.saml.idp.metadata',
-                'label_attr' => ['class' => 'control-label'],
-                'attr'       => [
+                'label'       => 'mautic.user.config.form.saml.idp.metadata',
+                'label_attr'  => ['class' => 'control-label'],
+                'attr'        => [
                     'class'   => 'form-control',
                     'tooltip' => 'mautic.user.config.form.saml.idp.metadata.tooltip',
                     'rows'    => 10,
@@ -74,9 +81,9 @@ class ConfigType extends AbstractType
             'saml_idp_own_certificate',
             ConfigFileType::class,
             [
-                'label'      => 'mautic.user.config.form.saml.idp.own_certificate',
-                'label_attr' => ['class' => 'control-label'],
-                'attr'       => [
+                'label'       => 'mautic.user.config.form.saml.idp.own_certificate',
+                'label_attr'  => ['class' => 'control-label'],
+                'attr'        => [
                     'class'   => 'form-control',
                     'tooltip' => 'mautic.user.config.form.saml.idp.own_certificate.tooltip',
                 ],
@@ -96,9 +103,9 @@ class ConfigType extends AbstractType
             'saml_idp_own_private_key',
             ConfigFileType::class,
             [
-                'label'      => 'mautic.user.config.form.saml.idp.own_private_key',
-                'label_attr' => ['class' => 'control-label'],
-                'attr'       => [
+                'label'       => 'mautic.user.config.form.saml.idp.own_private_key',
+                'label_attr'  => ['class' => 'control-label'],
+                'attr'        => [
                     'class'   => 'form-control',
                     'tooltip' => 'mautic.user.config.form.saml.idp.own_private_key.tooltip',
                 ],
@@ -124,7 +131,7 @@ class ConfigType extends AbstractType
                     'class'   => 'form-control',
                     'tooltip' => 'mautic.user.config.form.saml.idp.own_password.tooltip',
                 ],
-                'required' => false,
+                'required'   => false,
             ]
         );
 
@@ -150,7 +157,7 @@ class ConfigType extends AbstractType
                 'attr'       => [
                     'class' => 'form-control',
                 ],
-                'required' => false,
+                'required'   => false,
             ]
         );
 
@@ -184,13 +191,15 @@ class ConfigType extends AbstractType
             'saml_idp_default_role',
             'role_list',
             [
-                'label'      => 'mautic.user.config.form.saml.idp.default_role',
-                'label_attr' => ['class' => 'control-label'],
-                'attr'       => [
-                    'class' => 'form-control',
+                'label'       => 'mautic.user.config.form.saml.idp.default_role',
+                'label_attr'  => ['class' => 'control-label'],
+                'attr'        => [
+                    'class'            => 'form-control',
+                    'data-placeholder' => $this->translator->trans('mautic.user.config.form.saml.idp.disable_creation'),
+                    'tooltip'          => 'mautic.user.config.form.saml.idp.default_role.tooltip',
                 ],
-                'required'    => true,
-                'empty_value' => false,
+                'required'    => false,
+                'empty_value' => '',
             ]
         );
     }

--- a/app/bundles/UserBundle/Security/User/UserCreator.php
+++ b/app/bundles/UserBundle/Security/User/UserCreator.php
@@ -77,6 +77,10 @@ class UserCreator implements UserCreatorInterface
      */
     public function createUser(Response $response)
     {
+        if (empty($this->defaultRole)) {
+            throw new BadCredentialsException('User does not exist.');
+        }
+
         $user = $this->userMapper->getUsername($response, true);
         $user->setPassword($this->userModel->checkNewPassword($user, $this->encoder->getEncoder($user), EncryptionHelper::generateKey()));
         $user->setRole($this->entityManager->getReference('MauticUserBundle:Role', $this->defaultRole));

--- a/app/bundles/UserBundle/Security/User/UserMapper.php
+++ b/app/bundles/UserBundle/Security/User/UserMapper.php
@@ -77,7 +77,7 @@ class UserMapper implements UsernameMapperInterface
                 foreach ($assertion->getAllAttributeStatements() as $attributeStatement) {
                     $attribute = $attributeStatement->getFirstAttributeByName($attributeName);
                     if ($attribute && $attribute->getFirstAttributeValue()) {
-                        $attributes[$key] = $assertion->getSubject()->getNameID()->getValue();
+                        $attributes[$key] = $attribute->getFirstAttributeValue();
                     }
                 }
             }

--- a/app/bundles/UserBundle/Security/User/UserMapper.php
+++ b/app/bundles/UserBundle/Security/User/UserMapper.php
@@ -57,32 +57,46 @@ class UserMapper implements UsernameMapperInterface
      */
     private function getValueFromAssertion(Assertion $assertion, User $user)
     {
+        $attributes = [];
         foreach ($this->attributes as $key => $attributeName) {
             if (self::NAME_ID == $attributeName) {
                 // Check for a populated username; default to email if empty
                 if (!$user->getUsername()) {
                     if ($email = $user->getEmail()) {
-                        $user->setUsername($email);
+                        $attributes['email'] = $assertion->getSubject()->getNameID()->getValue();
                     } elseif (
                         $assertion->getSubject() &&
                         $assertion->getSubject()->getNameID() &&
                         $assertion->getSubject()->getNameID()->getValue() &&
                         $assertion->getSubject()->getNameID()->getFormat() != SamlConstants::NAME_ID_FORMAT_TRANSIENT
                     ) {
-                        $user->setUsername($assertion->getSubject()->getNameID()->getValue());
+                        $attributes['username'] = $assertion->getSubject()->getNameID()->getValue();
                     }
                 }
             } else {
                 foreach ($assertion->getAllAttributeStatements() as $attributeStatement) {
                     $attribute = $attributeStatement->getFirstAttributeByName($attributeName);
                     if ($attribute && $attribute->getFirstAttributeValue()) {
-                        $setter = 'set'.ucfirst($key);
-                        $user->$setter($attribute->getFirstAttributeValue());
+                        $attributes[$key] = $assertion->getSubject()->getNameID()->getValue();
                     }
                 }
             }
         }
 
-        return null;
+        // use email as the user by default
+        if (isset($attributes['email'])) {
+            $user->setEmail($attributes['email']);
+            $user->setUsername($attributes['email']);
+        } elseif (isset($attributes['username'])) {
+            $user->setUsername($attributes['email']);
+        }
+
+        if (isset($attributes['firstname'])) {
+            $user->setFirstname($attributes['firstname']);
+        }
+
+        if (isset($attributes['lastname'])) {
+            $user->setLastName($attributes['lastname']);
+        }
     }
 }

--- a/app/bundles/UserBundle/Security/User/UserMapper.php
+++ b/app/bundles/UserBundle/Security/User/UserMapper.php
@@ -88,7 +88,7 @@ class UserMapper implements UsernameMapperInterface
             $user->setEmail($attributes['email']);
             $user->setUsername($attributes['email']);
         } elseif (isset($attributes['username'])) {
-            $user->setUsername($attributes['email']);
+            $user->setUsername($attributes['username']);
         }
 
         if (isset($attributes['firstname'])) {

--- a/app/bundles/UserBundle/Translations/en_US/messages.ini
+++ b/app/bundles/UserBundle/Translations/en_US/messages.ini
@@ -74,6 +74,8 @@ mautic.user.config.form.saml.idp.attribute_firstname="First name"
 mautic.user.config.form.saml.idp.attribute_lastname="Last name"
 mautic.user.config.form.saml.idp_entity_id="Use the following entity ID in the IDP: <code>%entityId%</code>"
 mautic.user.config.form.saml.idp.default_role="Default role for created users"
+mautic.user.config.form.saml.idp.default_role.tooltip="Choose the default role to assign newly created users. To disable creating users, clear the selected role and leave empty."
+mautic.user.config.form.saml.idp.disable_creation="Leave empty to disable user creation"
 mautic.user.config.form.saml.idp.metadata="Identity provider metadata file"
 mautic.user.config.form.saml.idp.metadata.tooltip="Upload the Identity Provider Metadata XML file."
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If a Mautic user exists with a given email, and SAML is setup and provides a username that is different than email, Mautic will give a 500 error because it tries to create a new user that violates the unique index for email. This is because the given username was passed to the method that searches for the user which often does not match between the IDP and Mautic. So it's been changed to pass email when searching if a user exists which Mautic supports. 

This PR also disables user creation by default by leaving the role empty. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a user in Mautic that has an email that exists in the IDP
2. Setup the IPD if necessary (see SAML in the docs)
3. Single sign on with the user that has that email
4. You should see the 500 error.

#### Steps to test this PR:
1. Repeat and the existing Mautic user should be found
2. Now try to disable user creation by clearing the role in Configuration, delete a user with a matching email, and try to SSO. The user should be denied access. 
3. Choose a role and repeat and the user will be created
