### PR TITLE
Fix bug with escaping multiline configuration strings. 

### DIFF
--- a/app/bundles/ConfigBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/ConfigBundle/EventListener/ConfigSubscriber.php
@@ -56,7 +56,7 @@ class ConfigSubscriber extends CommonSubscriber
 
         array_walk_recursive($config, function (&$value) use ($escapeInvalidReference) {
             if (is_string($value)) {
-                $value = preg_replace_callback('/%(.*?)%/', $escapeInvalidReference, $value);
+                $value = preg_replace_callback('/%(.*?)%/s', $escapeInvalidReference, $value);
             }
         });
         $event->setConfig($config);

--- a/app/bundles/ConfigBundle/Tests/EventListener/ConfigSubscriberTest.php
+++ b/app/bundles/ConfigBundle/Tests/EventListener/ConfigSubscriberTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Mautic\ConfigBundle\Tests\EventListener;
+
+use Mautic\ConfigBundle\EventListener\ConfigSubscriber;
+use Mautic\ConfigBundle\Event\ConfigEvent;
+
+class ConfigSubscriberTest extends \PHPUnit_Framework_TestCase {
+
+    public function testEscapePercentCharacters() {
+        $config = [
+            'regularValue' => 'Nothing to do here',
+            'single percent' => 'Still nothing % to do here',
+            'simple escape' => 'This will be %escaped%',
+            'do not escape valid vars' => 'this is cool var %kernel.root_dir%',
+            'escape complex string' => "
+                trk_tit = trk_tit.replace(/\\%u00a0/g, '');
+                trk_tit = trk_tit.replace(/\\%u2122/g, '');
+                trk_tit = trk_tit.replace(/\\%u[0-9][0-9][0-9][0-9]/g, '');
+            "
+        ];
+        $configEscaped = [
+            'regularValue' => 'Nothing to do here',
+            'single percent' => 'Still nothing % to do here',
+            'simple escape' => 'This will be %%escaped%%',
+            'do not escape valid vars' => 'this is cool var %kernel.root_dir%',
+            'escape complex string' => "
+                trk_tit = trk_tit.replace(/\\%%u00a0/g, '');
+                trk_tit = trk_tit.replace(/\\%%u2122/g, '');
+                trk_tit = trk_tit.replace(/\\%u[0-9][0-9][0-9][0-9]/g, '');
+            "
+        ];
+
+        $event = new ConfigEvent($config, $this->getMockBuilder('\Symfony\Component\HttpFoundation\ParameterBag')->getMock());
+        $paramHelper = $this->getMockBuilder('\Mautic\CoreBundle\Helper\CoreParametersHelper')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $paramHelper->method('getParameter')->will($this->returnCallback(function ($param) {
+            if($param === 'kernel.root_dir') {
+                return '/some/path';
+            }
+            return null;
+        }));
+
+        $configSubscriber = new ConfigSubscriber($paramHelper);
+
+        $configSubscriber->escapePercentCharacters($event);
+
+        $this->assertEquals($configEscaped, $event->getConfig());
+    }
+}


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fix escaping of multiline strings containing percent signs.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to store a multiline value containing more then one percent sign in configuration (in analytics field for example)

#### Steps to test this PR:
1. Try to store a multiline value containing more then one percent sign in configuration (in analytics field for example)