### PR TITLE
Fixes menu structure on php 7.1 when in dev mode

### DIFF
--- a/app/bundles/CoreBundle/Views/Menu/main.html.php
+++ b/app/bundles/CoreBundle/Views/Menu/main.html.php
@@ -71,8 +71,8 @@ if ($item->hasChildren() && $options['depth'] !== 0 && $item->getDisplayChildren
 
         /* Submenu items start */
         if ($showChildren) {
-            $options['depth']         = ($options['depth']) ? $options['depth']-- : '';
-            $options['matchingDepth'] = ($options['matchingDepth']) ? $options['matchingDepth']-- : '';
+            $options['depth']         = ($options['depth']) ? $options['depth']-- : null;
+            $options['matchingDepth'] = ($options['matchingDepth']) ? $options['matchingDepth']-- : null;
 
             $levelClass = $isAncestor ? 'nav-submenu collapse in' : 'nav-submenu collapse';
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

PHP 7.1 added notices/errors when doing arithmetic on invalid strings.
http://php.net/manual/en/migration71.other-changes.php

This PR fixes an error in our menu rendering that resulted in arithmetic on invalid strings.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Load up `index_dev.php` in a PHP 7.1 environment
2. See that the main menu renders an error.

#### Steps to test this PR:
1. Apply PR
2. Redo reproduction tests, see that menu renders
