### PR TITLE
placeholders for injecting custom content for lead details page

### DIFF
--- a/app/bundles/LeadBundle/Views/Lead/lead.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/lead.html.php
@@ -297,6 +297,8 @@ $view['slots']->set(
                         </a>
                     </li>
                 <?php endif; ?>
+
+                <?php echo $view['content']->getCustomContent('tabs', $mauticTemplateVars); ?>
             </ul>
             <!--/ tabs controls -->
         </div>
@@ -336,6 +338,7 @@ $view['slots']->set(
                 </div>
             <?php endif; ?>
             <!--/ #social-container -->
+          <?php echo $view['content']->getCustomContent('tabs.content', $mauticTemplateVars); ?>
 
             <!-- #place-container -->
             <?php if ($places): ?>


### PR DESCRIPTION
would allow a plugin to listen to the CoreEvents::VIEW_INJECT_CUSTOM_CONTENT
event to inject custom content into those spots.

Directly inspired from the CampaignBundle where those placeholders are similarly present in app/bundles/CampaignBundle/Views/Campaign/details.html.php (lines 168 & 196)

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | No |
| New feature? | related to  |
| Related user documentation PR URL | none|
| Related developer documentation PR URL | none[
| Issues addressed (#s or URLs) | none [
| BC breaks? |  |
| Deprecations? | no | 

[//]: # ( Required: )
#### Description:

Would allow a plugin to listen to the CoreEvents::VIEW_INJECT_CUSTOM_CONTENT event to inject custom content into those spot.

