### PR TITLE
The email isn't available in the EmailSendEvent when previewing in the browser

### DIFF
--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -27,6 +27,12 @@ class EmailSendEvent extends CommonEvent
     private $helper;
 
     /**
+     * @var Mail
+     */
+    private $email;
+
+
+    /**
      * @var string
      */
     private $content = '';
@@ -91,6 +97,10 @@ class EmailSendEvent extends CommonEvent
             $this->subject = $args['subject'];
         }
 
+        if (isset($args['email'])) {
+            $this->email = $args['email'];
+        }
+
         if (!$this->subject && isset($args['email']) && $args['email'] instanceof Email) {
             $this->subject = $args['email']->getSubject();
         }
@@ -149,7 +159,7 @@ class EmailSendEvent extends CommonEvent
      */
     public function getEmail()
     {
-        return ($this->helper !== null) ? $this->helper->getEmail() : null;
+        return ($this->helper !== null) ? $this->helper->getEmail() : $this->email;
     }
 
     /**


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL |  N/A
| Related developer documentation PR URL | N/A 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The email isn't available in the EmailSendEvent when you preview the email in the browser. I have a custom plugin that needs to get some information from the Email when the event triggers. I guess this isn't an uncommon use case for a plugin that extends the email sending process. This pull request just adds the email as a property, and uses that if the send helper isn't available. The calling code is already providing an email argument when the event is created, so everything seems to work smoothly.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a plugin which subscribes to EmailEvents::EMAIL_ON_DISPLAY
2. Fetch the email with getEmail() in the subscriber. The email isn't available since the helper isn't attached to the event.

#### Steps to test this PR:
1. Create a plugin which subscribes to EmailEvents::EMAIL_ON_DISPLAY
2. Fetch the email with getEmail() in the subscriber. The email is now available.
