### PR TITLE
Fix creating country index in migration

### DIFF
--- a/app/migrations/Version20170303000000.php
+++ b/app/migrations/Version20170303000000.php
@@ -28,7 +28,7 @@ class Version20170303000000 extends AbstractMauticMigration
     public function preUp(Schema $schema)
     {
         $table = $schema->getTable(MAUTIC_TABLE_PREFIX.'leads');
-        if ($table->hasIndex('date_added_country_index')) {
+        if ($table->hasIndex(MAUTIC_TABLE_PREFIX.'date_added_country_index')) {
             throw new SkipMigrationException('Schema includes this migration');
         }
     }
@@ -38,7 +38,7 @@ class Version20170303000000 extends AbstractMauticMigration
      */
     public function up(Schema $schema)
     {
-        $this->addSql("CREATE INDEX {$this->prefix}date_added_country_index ON {$this->prefix}leads (date_added, country)");
+        $this->addSql("CREATE INDEX {$this->prefix}date_added_country_index ON {$this->prefix}leads (date_added, country(50))");
         $this->addSql("CREATE INDEX {$this->prefix}date_added_index ON {$this->prefix}audit_log (date_added)");
         $this->addSql("CREATE INDEX {$this->prefix}date_hit_left_index ON {$this->prefix}page_hits (date_hit, date_left)");
     }


### PR DESCRIPTION
Longtext field needs to have a fixed length.

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: I upgraded from 2.7.1 to 2.8.1 and got the following during migration:
"1170 BLOB/TEXT column 'country' used in key specification without a key length"

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run the upgrade script

#### Steps to test this PR:
1. Run the upgrade script (tested from 2.7.1 to 2.8.1)
