### PR TITLE
Fix multiselect inputs from forms

### DIFF
--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -290,11 +290,6 @@ class SubmissionModel extends CommonFormModel
             $leadField = $f->getLeadField();
             if (!empty($leadField)) {
                 $leadValue = $value;
-                if (is_array($leadValue)) {
-                    // Multiselect lead fields store the values with bars
-                    $delimeter = ('multiselect' === $leadFields[$leadField]['type']) ? '|' : ', ';
-                    $leadValue = implode($delimeter, $leadValue);
-                }
 
                 $leadFieldMatches[$leadField] = $leadValue;
             }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | ✔️ 
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #3741
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Form inputs on multiselect fields used to only let in contacts with only one matching option from that multiselect selected. This PR fixes that for contacts with multiple options selected.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a multiselect field ![image](https://cloud.githubusercontent.com/assets/18265735/26241369/b037c72e-3c84-11e7-839d-3fa1a95df4db.png)
2. Create a form with a checkbox group or a multiselect input linked to that field 
3. Submit the form selecting more than one value
4. Only the contacts with only a **single** matching option will have that option filled in, those with multiple or all of them will not.

#### Steps to test this PR:
1. Repeat steps 1 to 3 above
2. Check that contacts with multiple or all options selected have these options stored