### PR TITLE
Do not clean data in code mode

### DIFF
--- a/app/bundles/CoreBundle/Form/EventListener/CleanFormSubscriber.php
+++ b/app/bundles/CoreBundle/Form/EventListener/CleanFormSubscriber.php
@@ -53,10 +53,8 @@ class CleanFormSubscriber implements EventSubscriberInterface
     {
         $data = $event->getData();
 
-        // clean the data unless in code mode
-        if ($data['template'] !== 'mautic_code_mode') {
-            $data = InputHelper::_($data, $this->masks);
-        }
+        // clean the data
+        $data = InputHelper::_($data, $this->masks);
 
         $event->setData($data);
     }

--- a/app/bundles/CoreBundle/Form/EventListener/CleanFormSubscriber.php
+++ b/app/bundles/CoreBundle/Form/EventListener/CleanFormSubscriber.php
@@ -53,8 +53,10 @@ class CleanFormSubscriber implements EventSubscriberInterface
     {
         $data = $event->getData();
 
-        //clean the data
-        $data = InputHelper::_($data, $this->masks);
+        // clean the data unless in code mode
+        if ($data['template'] !== 'mautic_code_mode') {
+            $data = InputHelper::_($data, $this->masks);
+        }
 
         $event->setData($data);
     }

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -399,6 +399,14 @@ class InputHelper
                 },
                 $value, -1, $needsDecoding);
 
+            // Slecial handling for script tags
+            $value = preg_replace_callback(
+                "/<script>(.*?)<\/script>/is",
+                function ($matches) {
+                    return '<mscript>'.base64_encode($matches[0]).'</mscript>';
+                },
+                $value, -1, $needsScriptDecoding);
+
             // Special handling for HTML comments
             $value = str_replace(['<!--', '-->'], ['<mcomment>', '</mcomment>'], $value, $commentCount);
 
@@ -422,12 +430,23 @@ class InputHelper
                 $value = str_replace(['<mcomment>', '</mcomment>'], ['<!--', '-->'], $value);
             }
 
-            $value = preg_replace_callback(
-                "/<mencoded>(.*?)<\/mencoded>/is",
-                function ($matches) {
-                    return htmlspecialchars_decode($matches[1]);
-                },
-                $value);
+            if ($needsDecoding) {
+                $value = preg_replace_callback(
+                    "/<mencoded>(.*?)<\/mencoded>/is",
+                    function ($matches) {
+                        return htmlspecialchars_decode($matches[1]);
+                    },
+                    $value);
+            }
+
+            if ($needsScriptDecoding) {
+                $value = preg_replace_callback(
+                    "/<mscript>(.*?)<\/mscript>/is",
+                    function ($matches) {
+                        return base64_decode($matches[1]);
+                    },
+                    $value);
+            }
         }
 
         return $value;

--- a/app/bundles/CoreBundle/Tests/Helper/InputHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Helper/InputHelperTest.php
@@ -19,9 +19,9 @@ use Mautic\CoreBundle\Helper\InputHelper;
 class InputHelperTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @testdox The guessTimezoneFromOffset returns correct values
+     * @testdox The html returns correct values
      *
-     * @covers \Mautic\CoreBundle\Helper\InputHelperTest::guessTimezoneFromOffset
+     * @covers \Mautic\CoreBundle\Helper\InputHelper::html
      */
     public function testHtmlFilter()
     {
@@ -38,7 +38,8 @@ class InputHelperTest extends \PHPUnit_Framework_TestCase
         $xhtml1Doctype = '<!DOCTYPE html PUBLIC
   "-//W3C//DTD XHTML 1.0 Transitional//EN"
   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">';
-        $cdata = '<![CDATA[content]]>';
+        $cdata  = '<![CDATA[content]]>';
+        $script = '<script>for (let i = 0; i < 10; i += 1) {console.log(i);}</script>';
 
         $samples = [
             $outlookXML                => $outlookXML,
@@ -46,6 +47,7 @@ class InputHelperTest extends \PHPUnit_Framework_TestCase
             $html5DoctypeWithContent   => $html5DoctypeWithContent,
             $xhtml1Doctype             => $xhtml1Doctype,
             $cdata                     => $cdata,
+            $script                    => $script,
             '<applet>content</applet>' => 'content',
         ];
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | I guess
| New feature? | Maybe
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3899 https://github.com/mautic/mautic/issues/3650
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Creating a landing page with the following code strips some of the Javascript starting with the `<` in the `for` loop.
```html
<!DOCTYPE html>
<html>
    <head>
        <meta charset="utf-8">
        <title>Test</title>
    </head>
    <body>
        <script>
            for (let i = 0; i < 10; i += 1) {
                console.log(i)
            }
        </script>
    </body>
</html>
```

I see that the way things currently work is that they go through the _InputHelper_ which then replaces every _non-html_ element with **fake** html tags such as `<mcomment>` which seems like it would become very complicated for things like JavaScript.
I suggest we simply forgo the _cleaning_ process when using the code mode. Maybe this should be extended to the new code mode blocks in landing pages using themes.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new landing page in code mode with the code supplied above
2. Save and close
3. Preview
4. View source code
5. Notice the error in the `for` loop

#### Steps to test this PR:
1. Repeat steps 1 through 4 above
2. Notice the `for` loop remains untouched