### PR TITLE
Prepopulate select and country fields on custom forms.

### DIFF
--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -249,6 +249,20 @@ class FormFieldHelper extends AbstractFormFieldHelper
                     $formHtml = str_replace($match[0], $replace, $formHtml);
                 }
                 break;
+            case 'select':
+            case 'country':
+                $regex = '/<select\s*id="mauticform_input_'.$formName.'_'.$alias.'"(.*?)<\/select>/is';
+                if (preg_match($regex, $formHtml, $match)) {
+                    $origText = $match[0];
+                    $replace  = str_replace(
+                        '<option value="'.urldecode($value).'">',
+                        '<option value="'.urldecode($value).'" selected="selected">',
+                        $origText
+                    );
+                    $formHtml = str_replace($origText, $replace, $formHtml);
+                }
+
+                break;
         }
     }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | No
| Deprecations? | No

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: Fix a bug where select and country fields on Forms would not auto fill.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form with an email field, and also a select or country field
2. Set contact field for that field (ex. Preferred Locale or Country)
3. Set `Auto fill data` to `Yes` for that field
4. Publish the form
5. Create a contact with the field filled in
6. Go to the form with the contact's email in the URL as a get param (ex. http://mautic-url/this-form?email=foo%40example.com)
7. The select or country field will not be auto filled

#### Steps to test this PR:
1. Create a form with an email field, and also a select or country field
2. Set contact field for that field (ex. Preferred Locale or Country)
3. Set `Auto fill data` to `Yes` for that field
4. Publish the form
5. Create a contact with the field filled in
6. Go to the form with the contact's email in the URL as a get param (ex. http://mautic-url/this-form?email=foo%40example.com)
7. The select or country field will be auto filled
