### PR TITLE
Windows line breaks in forms

### DIFF
--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -692,8 +692,8 @@ class FormModel extends CommonFormModel
         $html = $this->getContent($form);
 
         //replace line breaks with literal symbol and escape quotations
-        $search  = ["\n", '"'];
-        $replace = ['\n', '\"'];
+        $search  = ["\r\n", "\n", '"'];
+        $replace = ['\n', '\n', '\"'];
         $html    = str_replace($search, $replace, $html);
 
         return 'document.write("'.$html.'");';

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -693,7 +693,7 @@ class FormModel extends CommonFormModel
 
         //replace line breaks with literal symbol and escape quotations
         $search  = ["\r\n", "\n", '"'];
-        $replace = ['\n', '\n', '\"'];
+        $replace = ['', '', '\"'];
         $html    = str_replace($search, $replace, $html);
 
         return 'document.write("'.$html.'");';


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Added windows line break to remove for generate form script
More info about line breaks:
https://stackoverflow.com/questions/15433188/r-n-r-n-what-is-the-difference-between-them


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Open on windows app\bundles\FormBundle\Views\Builder\script.html.php and save
2. Create form and add it to test page
3. See browser console for js error

#### Steps to test this PR:
1.Steps to reproduce the bug:
2. See browser console without errors