### PR TITLE
Fix getUrl for Mautic in directory

### DIFF
--- a/app/bundles/CoreBundle/Templating/Helper/AssetsHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/AssetsHelper.php
@@ -122,7 +122,7 @@ class AssetsHelper
             $path        = $assetPrefix.$path;
         }
 
-        $url = $this->packages->getUrl($path, $packageName, $version);
+        $url = ((strpos($path, '/') !== 0)?'/':'').$path;
 
         if ($absolute) {
             $url = $this->getBaseUrl().$url;

--- a/app/bundles/CoreBundle/Templating/Helper/AssetsHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/AssetsHelper.php
@@ -122,10 +122,15 @@ class AssetsHelper
             $path        = $assetPrefix.$path;
         }
 
-        $url = ((strpos($path, '/') !== 0)?'/':'').$path;
+        $url = ((strpos($path, '/') !== 0) ? '/' : '').$path;
 
         if ($absolute) {
             $url = $this->getBaseUrl().$url;
+        }
+
+        // Remove the dev index so the assets work in the dev mode
+        if (strpos($url, '/index_dev.php/')) {
+            $url = str_replace('index_dev.php/', '', $url);
         }
 
         return $url;

--- a/app/bundles/CoreBundle/Tests/Templating/Helper/AssetsHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Templating/Helper/AssetsHelperTest.php
@@ -12,6 +12,7 @@
 namespace Mautic\CoreBundle\Tests\Helper;
 
 use Mautic\CoreBundle\Helper\PathsHelper;
+use Mautic\CoreBundle\Templating\Helper\AssetsHelper;
 use Symfony\Component\Asset\Packages;
 
 class AssetsHelperTest extends \PHPUnit_Framework_TestCase
@@ -34,7 +35,7 @@ class AssetsHelperTest extends \PHPUnit_Framework_TestCase
         $pathsHelper->method('getSystemPath')
             ->willReturn('');
 
-        $assetHelper = new \Mautic\CoreBundle\Templating\Helper\AssetsHelper($packagesMock);
+        $assetHelper = new AssetsHelper($packagesMock);
         $assetHelper->setPathsHelper($pathsHelper);
 
         $assetHelper->addStylesheet('/app.css');
@@ -42,16 +43,106 @@ class AssetsHelperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains('app.css', $head);
 
-        $assetHelper->setContext(\Mautic\CoreBundle\Templating\Helper\AssetsHelper::CONTEXT_BUILDER)
+        $assetHelper->setContext(AssetsHelper::CONTEXT_BUILDER)
             ->addStylesheet('/builder.css')
             ->setContext();
 
         $head = $assetHelper->getHeadDeclarations();
         $this->assertNotContains('builder.css', $head);
 
-        $head = $assetHelper->setContext(\Mautic\CoreBundle\Templating\Helper\AssetsHelper::CONTEXT_BUILDER)
+        $head = $assetHelper->setContext(AssetsHelper::CONTEXT_BUILDER)
             ->getHeadDeclarations();
         $this->assertContains('builder.css', $head);
         $this->assertNotContains('app.css', $head);
+    }
+
+    public function testGetUrlWithAbsolutePath()
+    {
+        $packagesMock = $this->getMockBuilder(Packages::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $assetHelper = new AssetsHelper($packagesMock);
+
+        $this->assertEquals('http://some.absolute/path', $assetHelper->getUrl('http://some.absolute/path'));
+        $this->assertEquals('https://some.absolute/path', $assetHelper->getUrl('https://some.absolute/path'));
+    }
+
+    public function testGetUrlWithRelativePath()
+    {
+        $packagesMock = $this->getMockBuilder(Packages::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $packagesMock->method('getUrl')
+            ->will($this->returnCallback(function () {
+                $args = func_get_args();
+
+                return $args[0];
+            }));
+
+        $pathsHelper = $this->getMockBuilder(PathsHelper::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+
+        $pathsHelper->method('getSystemPath')
+            ->willReturn('http://some.mautic');
+
+        $assetHelper = new AssetsHelper($packagesMock);
+        $assetHelper->setPathsHelper($pathsHelper);
+
+        $this->assertEquals('http://some.mautic/some/path', $assetHelper->getUrl('some/path'));
+    }
+
+    public function testGetUrlWithRelativePathWhenMauticInSubfolder()
+    {
+        $packagesMock = $this->getMockBuilder(Packages::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $packagesMock->method('getUrl')
+            ->will($this->returnCallback(function () {
+                $args = func_get_args();
+
+                return $args[0];
+            }));
+
+        $pathsHelper = $this->getMockBuilder(PathsHelper::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+
+        $pathsHelper->method('getSystemPath')
+            ->willReturn('http://some.mautic/m');
+
+        $assetHelper = new AssetsHelper($packagesMock);
+        $assetHelper->setPathsHelper($pathsHelper);
+
+        $this->assertEquals('http://some.mautic/m/some/path', $assetHelper->getUrl('some/path'));
+    }
+
+    public function testGetUrlWithRelativePathWithDevIndex()
+    {
+        $packagesMock = $this->getMockBuilder(Packages::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $packagesMock->method('getUrl')
+            ->will($this->returnCallback(function () {
+                $args = func_get_args();
+
+                return $args[0];
+            }));
+
+        $pathsHelper = $this->getMockBuilder(PathsHelper::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+
+        $pathsHelper->method('getSystemPath')
+            ->willReturn('http://some.mautic/index_dev.php/');
+
+        $assetHelper = new AssetsHelper($packagesMock);
+        $assetHelper->setPathsHelper($pathsHelper);
+
+        $this->assertEquals('http://some.mautic/some/path', $assetHelper->getUrl('some/path'));
     }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When I used Mautic in directory (for example http://mautic.test/mautic/)  Mautic gave me errors. This should fix it.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Use mautic in directory (http://mautic.test/mautic/)
2.  Create form and use it test page
3. See browser console and 404 error (scritp call non exist http://mautic.test/mautic/mautic/media/js/mautic-form.js)

#### Steps to test this PR:
1. Repeat steps
2. See brower console clear
