### PR TITLE
Fix ratio and add decimal to reports

### DIFF
--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -82,7 +82,7 @@ class ReportSubscriber extends CommonSubscriber
                     'alias'   => 'read_ratio',
                     'label'   => 'mautic.email.report.read_ratio',
                     'type'    => 'string',
-                    'formula' => 'CONCAT(ROUND(('.$prefix.'read_count/'.$prefix.'sent_count)*100),\'%\')',
+                    'formula' => 'CONCAT(ROUND(('.$prefix.'read_count/'.$prefix.'sent_count)*100, 1),\'%\')',
                 ],
                 $prefix.'sent_count' => [
                     'label' => 'mautic.email.report.sent_count',

--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -104,15 +104,13 @@ class ReportSubscriber extends CommonSubscriber
                     'alias'   => 'hits_ratio',
                     'label'   => 'mautic.email.report.hits_ratio',
                     'type'    => 'string',
-                    'formula' => 'CONCAT(ROUND('.$channelUrlTrackables.'hits/('.$prefix.'sent_count * '.$channelUrlTrackables
-                        .'trackable_count)*100),\'%\')',
+                    'formula' => 'CONCAT(ROUND('.$channelUrlTrackables.'hits/('.$prefix.'sent_count)*100, 1),\'%\')',
                 ],
                 'unique_ratio' => [
                     'alias'   => 'unique_ratio',
                     'label'   => 'mautic.email.report.unique_ratio',
                     'type'    => 'string',
-                    'formula' => 'CONCAT(ROUND('.$channelUrlTrackables.'unique_hits/('.$prefix.'sent_count * '.$channelUrlTrackables
-                        .'trackable_count)*100),\'%\')',
+                    'formula' => 'CONCAT(ROUND('.$channelUrlTrackables.'unique_hits/('.$prefix.'sent_count)*100, 1),\'%\')',
                 ],
                 'unsubscribed' => [
                     'alias'   => 'unsubscribed',
@@ -124,7 +122,7 @@ class ReportSubscriber extends CommonSubscriber
                     'alias'   => 'unsubscribed_ratio',
                     'label'   => 'mautic.email.report.unsubscribed_ratio',
                     'type'    => 'string',
-                    'formula' => 'CONCAT(ROUND((COUNT(DISTINCT '.$doNotContact.'id)/'.$prefix.'sent_count)*100),\'%\')',
+                    'formula' => 'CONCAT(ROUND((COUNT(DISTINCT '.$doNotContact.'id)/'.$prefix.'sent_count)*100, 1),\'%\')',
                 ],
                 $prefix.'revision' => [
                     'label' => 'mautic.email.report.revision',


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3461
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Clicks ratio and Unique clicks ratio returns wrong data for emails
This PR also add decimal for all ratio columns.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Create email report
2.  See wrong data for Clicks ratio and Unique clicks  ratio

#### Steps to test this PR:
1.  Check  fixed Clicks ratio and Unique clicks  ratio
2.  Check round with decimal for all ratio columns. 
