### PR TITLE
Bug email address apostrophe

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1256,15 +1256,14 @@ class MailHelper
 
         if ($invalidChar !== false) {
             throw new \Swift_RfcComplianceException(
-                'Address in mailbox given ['.$address.
-                '] contains the invalid character: '.substr($invalidChar, 0, 1)
+                'Email address ['.$address.
+                '] contains this invalid character: '.substr($invalidChar, 0, 1)
             );
         }
 
         if (!filter_var($address, FILTER_VALIDATE_EMAIL)) {
             throw new \Swift_RfcComplianceException(
-                'Address in mailbox given ['.$address.
-                '] does not comply with RFC 882'
+                'Email address ['.$address.'] is invalid'
             );
         }
     }

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -55,9 +55,6 @@ class MailHelperTest extends \PHPUnit_Framework_TestCase
         ],
     ];
 
-    /**
-     *
-     */
     public function setUp()
     {
         defined('MAUTIC_ENV') or define('MAUTIC_ENV', 'test');
@@ -282,7 +279,7 @@ class MailHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testValidateValidEmails()
     {
-        $helper = $this->mockEmptyMailHelper();
+        $helper    = $this->mockEmptyMailHelper();
         $addresses = [
             'john@doe.com',
             'john@doe.email',
@@ -299,56 +296,63 @@ class MailHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testValidateEmailWithoutTld()
     {
+        $heper = $this->mockEmptyMailHelper();
         $this->setExpectedException(\Swift_RfcComplianceException::class);
-        $this->mockEmptyMailHelper()::validateEmail('john@doe');
+        $heper::validateEmail('john@doe');
     }
 
     public function testValidateEmailWithSpaceInIt()
     {
+        $heper = $this->mockEmptyMailHelper();
         $this->setExpectedException(\Swift_RfcComplianceException::class);
-        $this->mockEmptyMailHelper()::validateEmail('jo hn@doe.email');
+        $heper::validateEmail('jo hn@doe.email');
     }
 
     public function testValidateEmailWithCaretInIt()
     {
+        $heper = $this->mockEmptyMailHelper();
         $this->setExpectedException(\Swift_RfcComplianceException::class);
-        $this->mockEmptyMailHelper()::validateEmail('jo^hn@doe.email');
+        $heper::validateEmail('jo^hn@doe.email');
     }
 
     public function testValidateEmailWithApostropheInIt()
     {
+        $heper = $this->mockEmptyMailHelper();
         $this->setExpectedException(\Swift_RfcComplianceException::class);
-        $this->mockEmptyMailHelper()::validateEmail('jo\'hn@doe.email');
+        $heper::validateEmail('jo\'hn@doe.email');
     }
 
     public function testValidateEmailWithSemicolonInIt()
     {
+        $heper = $this->mockEmptyMailHelper();
         $this->setExpectedException(\Swift_RfcComplianceException::class);
-        $this->mockEmptyMailHelper()::validateEmail('jo;hn@doe.email');
+        $heper::validateEmail('jo;hn@doe.email');
     }
 
     public function testValidateEmailWithAmpersandInIt()
     {
+        $heper = $this->mockEmptyMailHelper();
         $this->setExpectedException(\Swift_RfcComplianceException::class);
-        $this->mockEmptyMailHelper()::validateEmail('jo&hn@doe.email');
+        $heper::validateEmail('jo&hn@doe.email');
     }
 
     public function testValidateEmailWithStarInIt()
     {
+        $heper = $this->mockEmptyMailHelper();
         $this->setExpectedException(\Swift_RfcComplianceException::class);
-        $this->mockEmptyMailHelper()::validateEmail('jo*hn@doe.email');
+        $heper::validateEmail('jo*hn@doe.email');
     }
 
     public function testValidateEmailWithPercentInIt()
     {
+        $heper = $this->mockEmptyMailHelper();
         $this->setExpectedException(\Swift_RfcComplianceException::class);
-        $this->mockEmptyMailHelper()::validateEmail('jo%hn@doe.email');
+        $heper::validateEmail('jo%hn@doe.email');
     }
 
     protected function mockEmptyMailHelper()
     {
         $mockFactory = $this->getMockFactory();
-
         $transport   = new SmtpTransport();
         $swiftMailer = new \Swift_Mailer($transport);
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | https://github.com/mautic/mautic/issues/3865
| Issues addressed (#s or URLs) | 
| BC breaks? | /
| Deprecations? | /

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
It was possible to create contacts with email address like `mike.o'neal@gmail.com` which then caused troubles in email sending. This PR changes the method which validates the email address to the default PHP email validation and it's adding also some special chars which will make the email address invalid like the apostrophe.

The original validation method stated that it follows RFC 2822, 3.6.2. The default PHP validation states in the docs that it follows RFC 882 with some exceptions.

Testing CSV:
```
email
mike.o'neal@gmail.com
mike.o^neal@gmail.com
"mike.o neal@gmail.com"
mike@gmail.com;
mike.@gmail.com
mike@oneal.email
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to import a CSV with the content above.
2. The contacts with email addresses with the characters which shouldn't be in the email address will be created.

#### Steps to test this PR:
1. Apply this PR
2. Remove the contacts created in the previous test.
3. Import again - the import will show you that all the rows have invalid email address except the last one. No contact with invalid email address will be created.
4. Run `composer test` cuz that validation method has been covered with unit tests.
