### PR TITLE
[WIP] Contacts structure overhaul

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -360,7 +360,7 @@ class LeadController extends FormController
                     'places'            => $this->getPlaces($lead),
                     'permissions'       => $permissions,
                     'events'            => $this->getEngagements($lead),
-                    'upcomingEvents'    => $this->getScheduledCampaignEvents($lead),
+                    'upcomingEvents'    => [], // $this->getScheduledCampaignEvents($lead)
                     'engagementData'    => $this->getEngagementData($lead),
                     'noteCount'         => $this->getModel('lead.note')->getNoteCount($lead, true),
                     'doNotContact'      => $emailRepo->checkDoNotEmail($fields['core']['email']['value']),

--- a/app/bundles/LeadBundle/Entity/CharLeadField.php
+++ b/app/bundles/LeadBundle/Entity/CharLeadField.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadField;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+/**
+ * Class CharLeadField.
+ */
+class CharLeadField
+{
+    /**
+     * @var Lead
+     */
+    private $lead;
+
+    /**
+     * @var LeadField
+     */
+    private $leadField;
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param ORM\ClassMetadata $metadata
+     */
+    public static function loadMetadata(ORM\ClassMetadata $metadata)
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('char_lead_fields_leads_xref');
+
+        $builder->createManyToOne('lead', 'Mautic\LeadBundle\Entity\Lead')
+                ->cascadePersist()
+                ->cascadeMerge()
+                ->addJoinColumn('lead_id', 'id')
+                ->makePrimaryKey()
+                ->build();
+
+        $builder->createManyToOne('leadField', 'Mautic\LeadBundle\Entity\LeadField')
+                ->cascadePersist()
+                ->cascadeMerge()
+                ->addJoinColumn('lead_field_id', 'id')
+                ->makePrimaryKey()
+                ->build();
+
+        $builder->createField('value', 'string')
+                ->columnName('value')
+                ->build();
+    }
+
+    /**
+     * @return Lead
+     */
+    public function getLead() {
+        return $this->lead;
+    }
+
+    /**
+     * @param Lead
+     *
+     * @return CharLeadField
+     */
+    public function setLead($lead) {
+        $this->lead = $lead;
+        return $this;
+    }
+
+    /**
+     * @return LeadField
+     */
+    public function getLeadField() {
+        return $this->leadField;
+    }
+
+    /**
+     * @param LeadField
+     *
+     * @return CharLeadField
+     */
+    public function setLeadField($leadField) {
+        $this->leadField = $leadField;
+        return $this;
+    }
+
+    /**
+     * @return Value
+     */
+    public function getValue() {
+        return $this->value;
+    }
+
+    /**
+     * @param Value
+     *
+     * @return CharLeadField
+     */
+    public function setValue($value) {
+        $this->value = $value;
+        return $this;
+    }
+
+}

--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -175,6 +175,19 @@ trait CustomFieldRepositoryTrait
         $values = $q->execute()->fetch();
         $this->removeNonFieldColumns($values, $fixedFields);
 
+        $charValues = $this->getEntityManager()->getConnection()->createQueryBuilder()
+            ->select('lf.alias, clf.value')
+            ->from('char_lead_fields_leads_xref', 'clf')
+            ->join('clf', 'lead_fields', 'lf', 'clf.lead_field_id = lf.id')
+            ->execute()->fetchAll();
+
+        $charValues = array_map(function ($charValue) {
+            return [$charValue["alias"] => $charValue["value"]];
+        }, $charValues);
+
+        $values = array_replace($values, ...$charValues);
+
+
         // Reorder leadValues based on field order
         $values = array_merge(array_flip(array_keys($fields)), $values);
 

--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -318,13 +318,15 @@ trait CustomFieldRepositoryTrait
             $em = $this->getEntityManager();
             foreach ($entity->getCharLeadFields() as $charLeadField) {
                 $alias = $charLeadField->getLeadField()->getAlias();
-                if (isset($fields[$alias])) {
-                    $charLeadField->setValue($fields[$alias]);
+                $value = $entity->{'get'.ucfirst($alias)}();
+                if ($value === null || $value === '') {
+                    $em->remove($charLeadField);
+                } else {
+                    $charLeadField->setValue($value);
                     $em->persist($charLeadField);
                 }
             }
             $em->flush();
-            //$this->getEntityManager()->getConnection()->update($table, $fields, ['id' => $entity->getId()]);
         }
     }
 

--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -175,11 +175,9 @@ trait CustomFieldRepositoryTrait
         $values = $q->execute()->fetch();
         $this->removeNonFieldColumns($values, $fixedFields);
 
-        $charValues = $this->getEntityManager()->getConnection()->createQueryBuilder()
-            ->select('lf.alias, clf.value')
-            ->from('char_lead_fields_leads_xref', 'clf')
-            ->join('clf', 'lead_fields', 'lf', 'clf.lead_field_id = lf.id')
-            ->execute()->fetchAll();
+        //use DBAL to get entity fields
+        $q = $this->getLeadFieldsDbalQueryBuilder();
+        $charValues = $q->execute()->fetchAll();
 
         $charValues = array_map(function ($charValue) {
             return [$charValue["alias"] => $charValue["value"]];

--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -203,7 +203,9 @@ trait CustomFieldRepositoryTrait
         $values = array_replace($values, ...$charValues);
 
         // Reorder leadValues based on field order
-        $values = array_merge(array_flip(array_keys($fields)), $values);
+        $values = array_merge(array_map(function ($_) {
+            return null; // Remove the indices from the flipped array keys
+        }, array_flip(array_keys($fields))), $values);
 
         $fieldValues = [];
 

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -238,6 +238,11 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
     private $channelRules = [];
 
     /**
+     * @var ArrayCollection
+     */
+    private $charLeadFields;
+
+    /**
      * Constructor.
      */
     public function __construct()
@@ -392,12 +397,19 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
                 ->fetchExtraLazy()
                 ->build();
 
+        $builder->createOneToMany('charLeadFields', 'Mautic\LeadBundle\Entity\CharLeadField')
+                ->orphanRemoval()
+                ->mappedBy('lead')
+                ->cascadeAll()
+                ->fetchExtraLazy()
+                ->build();
+
         self::loadFixedFieldMetadata(
             $builder,
             [
                 'title',
-                'firstname',
-                'lastname',
+                // 'firstname',
+                // 'lastname',
                 'company',
                 'position',
                 'email',
@@ -1753,6 +1765,27 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
     {
         $this->isChanged('email', $email);
         $this->email = $email;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCharLeadFields()
+    {
+        return $this->charLeadFields;
+    }
+
+    /**
+     * @param mixed $charLeadFields
+     *
+     * @return Lead
+     */
+    public function setCharLeadFields($charLeadFields)
+    {
+        $this->isChanged('charLeadFields', $charLeadFields);
+        $this->charLeadFields = $charLeadFields;
 
         return $this;
     }

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -511,10 +511,11 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
     {
         $alias = $this->getTableAlias();
         $q     = $this->getEntityManager()->createQueryBuilder();
-        $q->select($alias.', u, i,'.$order)
+        $q->select($alias.', u, i, clf,'.$order)
             ->from('MauticLeadBundle:Lead', $alias, $alias.'.id')
             ->leftJoin($alias.'.ipAddresses', 'i')
             ->leftJoin($alias.'.owner', 'u')
+            ->leftJoin($alias.'.charLeadFields', 'clf')
             ->indexBy($alias, $alias.'.id');
 
         return $q;

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -490,6 +490,19 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
     }
 
     /**
+     * @return \Doctrine\DBAL\Query\QueryBuilder
+     */
+    public function getLeadFieldsDbalQueryBuilder()
+    {
+        $dq = $this->getEntityManager()->getConnection()->createQueryBuilder()
+            ->select('lf.alias, clf.value')
+            ->from('char_lead_fields_leads_xref', 'clf')
+            ->join('clf', 'lead_fields', 'lf', 'clf.lead_field_id = lf.id');
+
+        return $dq;
+    }
+
+    /**
      * @param $order
      *
      * @return \Doctrine\ORM\QueryBuilder

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -314,7 +314,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
             }
             $q->andWhere($this->getTableAlias().'.id = '.(int) $contactId);
             $entity = $q->getQuery()->getSingleResult();
-        } catch (\Exception $e) {
+        } catch (\Exception $e) { // What is this supposed to catch? (T_T)
             $entity = null;
         }
 
@@ -324,6 +324,34 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
             }
 
             $fieldValues = $this->getFieldValues($id);
+
+            $charLeadFieldValues = [];
+
+            foreach ($entity->getCharLeadFields() as $charLeadField) {
+                $leadField = $charLeadField->getLeadField();
+                $group = $leadField->getGroup();
+                $id = (string) $leadField->getId();
+                $alias = $leadField->getAlias();
+                $label = $leadField->getLabel();
+                $type = $leadField->getType();
+                $object = $leadField->getObject();
+                $isFixed = $leadField->getIsFixed() ? '1' : '0';
+                $value = $charLeadField->getValue();
+
+                $charLeadFieldValues[$group][$alias] = [
+                    "id" => $id,
+                    "label" => $label,
+                    "alias" => $alias,
+                    "type" => $type,
+                    "group" => $group,
+                    "object" => $object,
+                    "is_fixed" => $isFixed,
+                    "value" => $value
+                ];
+            }
+
+            $fieldValues = array_replace_recursive($fieldValues, $charLeadFieldValues);
+
             $entity->setFields($fieldValues);
 
             foreach ($entity->getCharLeadFields() as $charLeadField) {

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -326,8 +326,11 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
             $fieldValues = $this->getFieldValues($id);
             $entity->setFields($fieldValues);
 
-            $entity->setFirstname($entity->getCharLeadFields()[0]->getValue());
-            $entity->setLastname($entity->getCharLeadFields()[1]->getValue());
+            foreach ($entity->getCharLeadFields() as $charLeadField) {
+                $alias = $charLeadField->getLeadField()->getAlias();
+                $value = $charLeadField->getValue();
+                $entity->{'set' . ucfirst($alias)}($value);
+            }
 
             $entity->setAvailableSocialFields($this->availableSocialFields);
         }

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -306,9 +306,10 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
                 $this->buildSelectClause($q, $id);
                 $contactId = (int) $id['id'];
             } else {
-                $q->select('l, u, i')
+                $q->select('l, u, i, clf')
                     ->leftJoin('l.ipAddresses', 'i')
-                    ->leftJoin('l.owner', 'u');
+                    ->leftJoin('l.owner', 'u')
+                    ->leftJoin('l.charLeadFields', 'clf');
                 $contactId = $id;
             }
             $q->andWhere($this->getTableAlias().'.id = '.(int) $contactId);
@@ -324,6 +325,9 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
 
             $fieldValues = $this->getFieldValues($id);
             $entity->setFields($fieldValues);
+
+            $entity->setFirstname($entity->getCharLeadFields()[0]->getValue());
+            $entity->setLastname($entity->getCharLeadFields()[1]->getValue());
 
             $entity->setAvailableSocialFields($this->availableSocialFields);
         }

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -324,34 +324,6 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
             }
 
             $fieldValues = $this->getFieldValues($id);
-
-            $charLeadFieldValues = [];
-
-            foreach ($entity->getCharLeadFields() as $charLeadField) {
-                $leadField = $charLeadField->getLeadField();
-                $group = $leadField->getGroup();
-                $id = (string) $leadField->getId();
-                $alias = $leadField->getAlias();
-                $label = $leadField->getLabel();
-                $type = $leadField->getType();
-                $object = $leadField->getObject();
-                $isFixed = $leadField->getIsFixed() ? '1' : '0';
-                $value = $charLeadField->getValue();
-
-                $charLeadFieldValues[$group][$alias] = [
-                    "id" => $id,
-                    "label" => $label,
-                    "alias" => $alias,
-                    "type" => $type,
-                    "group" => $group,
-                    "object" => $object,
-                    "is_fixed" => $isFixed,
-                    "value" => $value
-                ];
-            }
-
-            $fieldValues = array_replace_recursive($fieldValues, $charLeadFieldValues);
-
             $entity->setFields($fieldValues);
 
             foreach ($entity->getCharLeadFields() as $charLeadField) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

**⚠️ This is a WIP**

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | ✓
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4139
| BC breaks? | Doing our best not to
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

#### Progress:

Done so far:
- [x] Modify database to match imagined structure for first name and last name only
- [x] Modify Doctrine schema to match database for first name and last name only
- [x] Display a contact's page with the new structure for first name and last name only
---
- [ ] Modify database to match imagined structure
- [ ] Modify Doctrine schema to match database
- [ ] Display a contact's page with the new structure
- [ ] Change generic methods (such as `getEntity`) to return BC contacts
- [ ] Test segments
- [ ] Test emails
- [ ] Test campaigns
- [ ] Test stages
- [ ] Test point actions
- [ ] Test forms
- [ ] Test social monitoring
- [ ] Test contact reports
- [ ] Test plugins
- [ ] Test custom fields menu
- [ ] Migration script

[//]: # ( Required: )
#### Description:

The current contact field structure is limited by the number of column MySQL is willing to create in the same table. This PR aims to restructure the contact fields so as to allow "limitless" custom fields.

More details in https://github.com/mautic/mautic/issues/4139

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 