### PR TITLE
Plugin dataflow arrows

### DIFF
--- a/app/bundles/PluginBundle/Views/FormTheme/Integration/fields_row.html.php
+++ b/app/bundles/PluginBundle/Views/FormTheme/Integration/fields_row.html.php
@@ -87,7 +87,6 @@ $indexCount = 1;
                                     <input type="radio"
                                            id="<?php echo $child->vars['id']; ?>_0"
                                            name="<?php echo $child->vars['full_name']; ?>"
-                                           data-toggle="tooltip"
                                            title=""
                                            autocomplete="false"
                                            value="0"
@@ -99,7 +98,6 @@ $indexCount = 1;
                                 <label class="btn btn-default<?php if ($checked): echo ' active'; endif; ?>">
                                     <input type="radio" id="<?php echo $child->vars['id']; ?>_1"
                                            name="<?php echo $child->vars['full_name']; ?>"
-                                           data-toggle="tooltip"
                                            title=""
                                            autocomplete="false"
                                            value="1"

--- a/plugins/MauticSocialBundle/Integration/FacebookIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/FacebookIntegration.php
@@ -61,7 +61,7 @@ class FacebookIntegration extends SocialIntegration
     {
         return 'https://graph.facebook.com/oauth/access_token';
     }
-	
+
     /**
      * @return string
      */


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
with latest changes arrows for data flow in plugins had a change in format
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. go to a CRM plugin with data priority enabled
2. arrows have a question mark next to them

#### Steps to test this PR:
1. this PR removes that
