### PR TITLE
Fix of "Use of undefined constant MAUTIC_TEST_ENV"

### DIFF
--- a/app/bundles/CoreBundle/Command/InstallDataCommand.php
+++ b/app/bundles/CoreBundle/Command/InstallDataCommand.php
@@ -155,7 +155,7 @@ EOT
 
             $testFixturesDir = $bundle['directory'].'/Tests/DataFixtures/ORM';
 
-            if (MAUTIC_TEST_ENV && file_exists($testFixturesDir)) {
+            if (defined('MAUTIC_TEST_ENV') && MAUTIC_TEST_ENV && file_exists($testFixturesDir)) {
                 $classPrefix = 'Mautic\\'.$bundle['bundle'].'\\Tests\\DataFixtures\\ORM\\';
                 $this->populateFixturesFromDirectory($testFixturesDir, $fixtures, $classPrefix, $returnClassNames);
             }

--- a/app/bundles/CoreBundle/Helper/CookieHelper.php
+++ b/app/bundles/CoreBundle/Helper/CookieHelper.php
@@ -57,7 +57,7 @@ class CookieHelper
      */
     public function setCookie($name, $value, $expire = 1800, $path = null, $domain = null, $secure = null, $httponly = null)
     {
-        if ($this->request == null || MAUTIC_TEST_ENV) {
+        if ($this->request == null || (defined('MAUTIC_TEST_ENV') && MAUTIC_TEST_ENV)) {
             return true;
         }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Changes in 2.8.2 PRs caused this PHP notice: `Use of undefined constant MAUTIC_TEST_ENV - assumed 'MAUTIC_TEST_ENV'`. This notice was causing the Forms API endpoints to fail. This PR ensures that the constant is defined before it is used.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run `phpunit --filter FormsTest` on current API Library connected to current Mautic on staging branch.
2. You should see that the tests fail or at least the notice is recorded in the logs.

#### Steps to test this PR:
1. Apply this PR
2. Repeat the test - all API Library tests should pass.
