### PR TITLE
Strip out <script> tag and convert html for error messages for Salesforce

### DIFF
--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -1443,7 +1443,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     $object = 'CampaignMember';
                 }
                 if (isset($item['body'][0]['errorCode'])) {
-                    $exception = new ApiErrorException($item['body'][0]['message']);
+                    $exception = new ApiErrorException($this->cleanErrorMessage($item['body'][0]['message']));
                     if ($object == 'Contact' || $object = 'Lead') {
                         $exception->setContactId($contactId);
                     }
@@ -1494,10 +1494,10 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     $error = 'http status code '.$item['httpStatusCode'];
                     switch (true) {
                         case !empty($item['body'][0]['message']['message']):
-                            $error = $item['body'][0]['message']['message'];
+                            $error = $this->cleanErrorMessage($item['body'][0]['message']['message']);
                             break;
                         case !empty($item['body']['message']):
-                            $error = $item['body']['message'];
+                            $error = $this->cleanErrorMessage($item['body']['message']);
                             break;
                     }
 
@@ -1866,5 +1866,23 @@ class SalesforceIntegration extends CrmAbstractIntegration
         }
 
         return $this->processCompositeResponse($result['compositeResponse'], $salesforceIdMapping);
+    }
+
+    /**
+     * Cleans up the error message for use in the notifications.
+     *
+     * @param string $message
+     *
+     * @return string
+     */
+    protected function cleanErrorMessage($message)
+    {
+        // Strip out <script> tags from the message
+        $message = preg_replace('#<script(.*?)>(.*?)</script>#is', '', $message);
+
+        // Encode Entities
+        $message = htmlentities($message);
+
+        return $message;
     }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| Issues addressed (#s or URLs) |  #4084
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Sometimes Salesforce returns error messages with a <script> tag which has code to redirect you to another page. When this happens it makes Mautic unusable as on every page load the Notification feature loads this error message which redirects you immediately.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Enable the deduper extension of salesforce
2. Try to push a contact which already exists according to deduper criteria
3. Attempt to open mautic

#### Steps to test this PR:

Same as above