### PR TITLE
fixing generation of SQL query with AND (()) if the segment only contains a campaign filter

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -423,7 +423,7 @@ class LeadListRepository extends CommonRepository
 
                     $expr = $this->generateSegmentExpression($filters, $parameters, $sq, $q);
 
-                    if ($this->hasCompanyFilter || $expr->count()) {
+                    if ($this->hasCompanyFilter && $expr->count()) {
                         $sq->andWhere($expr);
                         $mainExpr->add(
                             sprintf('l.id NOT IN (%s)', $sq->getSQL())

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -423,8 +423,11 @@ class LeadListRepository extends CommonRepository
 
                     $expr = $this->generateSegmentExpression($filters, $parameters, $sq, $q);
 
-                    if ($this->hasCompanyFilter && $expr->count()) {
-                        $sq->andWhere($expr);
+                    if ($this->hasCompanyFilter || $expr->count()) {
+                        if ($expr->count()) {
+                            $sq->andWhere($expr);
+                        }
+
                         $mainExpr->add(
                             sprintf('l.id NOT IN (%s)', $sq->getSQL())
                         );

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -556,27 +556,40 @@ class LeadListRepository extends CommonRepository
         }
 
         foreach ($parameters as $k => $v) {
-            switch (true) {
-                case is_bool($v):
-                    $paramType = 'boolean';
-                    break;
-
-                case is_int($v):
-                    $paramType = 'integer';
-                    break;
-
-                case is_float($v):
-                    $paramType = 'float';
-                    break;
-
-                default:
-                    $paramType = null;
-                    break;
-            }
-            $parameterQ->setParameter($k, $v, $paramType);
+            $parameterQ->setParameter($k, $v, $this->getTypeNameFromValue($v));
         }
 
         return $expr;
+    }
+
+    /**
+     * Returns string name of the value type.
+     *
+     * @param mixed $value
+     *
+     * @return string|null
+     */
+    public function getTypeNameFromValue($value)
+    {
+        switch (true) {
+            case is_bool($value):
+                $type = 'boolean';
+                break;
+
+            case is_int($value):
+                $type = 'integer';
+                break;
+
+            case is_float($value):
+                $type = 'float';
+                break;
+
+            default:
+                $type = null;
+                break;
+        }
+
+        return $type;
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Repository/LeadListRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Repository/LeadListRepositoryTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Mautic\LeadBundle\Repository\Tests;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Mautic\LeadBundle\Entity\LeadListRepository;
+
+class LeadListRepositoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetTypeNameFromValue()
+    {
+        $repo     = $this->initRepo();
+        $testData = [
+            [
+                'val' => 'string',
+                'res' => null,
+            ],
+            [
+                'val' => '324',
+                'res' => null,
+            ],
+            [
+                'val' => '324.87',
+                'res' => null,
+            ],
+            [
+                'val' => null,
+                'res' => null,
+            ],
+            [
+                'val' => false,
+                'res' => 'boolean',
+            ],
+            [
+                'val' => 45,
+                'res' => 'integer',
+            ],
+            [
+                'val' => 0,
+                'res' => 'integer',
+            ],
+            [
+                'val' => 2323.343,
+                'res' => 'float',
+            ],
+            [
+                'val' => -453.00,
+                'res' => 'float',
+            ],
+        ];
+
+        foreach ($testData as $td) {
+            $res = $repo->getTypeNameFromValue($td['val']);
+            $this->assertSame($td['res'], $res, 'test failed for row '.print_r($td, true));
+        }
+    }
+
+    protected function initRepo()
+    {
+        $entityManager = $this
+            ->getMockBuilder(EntityManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $classMetadata = $this
+            ->getMockBuilder(ClassMetadata::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return new LeadListRepository($entityManager, $classMetadata);
+    }
+}


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
I was getting this error when executing `app/console mautic:segments:update`:

```
[Doctrine\DBAL\Exception\SyntaxErrorException]
  An exception occurred while executing 'SELECT count(distinct(l.id)) as lead_count, max(l.id) as max_id FROM leads l INNER JOIN lead_lists_leads ll ON l.id = ll.lead_id WHERE (ll.date_added <= '2017
  -06-05 09:43:54') AND (ll.manually_added = ?) AND (ll.leadlist_id = 17) AND (l.id NOT IN (SELECT l.id FROM leads l INNER JOIN companies_leads cl ON l.id = cl.lead_id INNER JOIN companies comp ON cl
  .company_id = comp.id WHERE (comp.companyname = ?) AND (()) GROUP BY l.id))' with params [0, "Delta"]:
  SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')) G
  ROUP BY l.id))' at line 1
```

This PR fixes that.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new segment with filter `company name = Something`
2. Run `app/console mautic:segments:update` - you should get the error

#### Steps to test this PR:
1. Apply this PR
2. Repeat the test - it should execute successfully and add the right contacts to the segment.