### PR TITLE
Convert quotes to unicodes for dropdown options in multiselect field

### DIFF
--- a/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
+++ b/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
@@ -152,7 +152,7 @@ abstract class AbstractFormFieldHelper
                     $label = $val;
                 }
 
-                $choices[trim(html_entity_decode($val, ENT_QUOTES))] = trim($label);
+                $choices[trim(html_entity_decode($val, ENT_QUOTES))] = trim(html_entity_decode($val, ENT_QUOTES));
             }
         }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  Yes
| New feature? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL |
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4165
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: Segment filter page breaks because of quotes characters in the multiselect option values.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Merge the code
2. Create Multiselect custom field with quotes characters in option values. For example: "sample" or ""sample""
3. Create new segment filter with multiselect field. Now dropdown values are visible and doesn't break the page.

