### PR TITLE
Fix of "Undefined index: properties" when saving a select field with no options

### DIFF
--- a/app/bundles/CoreBundle/Views/FormTheme/Custom/sortablelist_row.html.php
+++ b/app/bundles/CoreBundle/Views/FormTheme/Custom/sortablelist_row.html.php
@@ -1,7 +1,7 @@
 <?php
 $list            = $form->children['list'];
 $parentHasErrors = $view['form']->containsErrors($form->parent);
-if ($parentHasErrors && empty($list->vars['value'])) {
+if ($parentHasErrors && empty($list->vars['value']) && isset($form->parent->children['properties']['list'])) {
     // Work around for Symfony bug not repopulating values
     $list = $form->parent->children['properties']['list'];
 }


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3803
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When saving a select or checkbox field with no options, it throws a PHP warning before the validation catch that.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form
2. Add a select field or checkbox field - do not add any option
3. You'll get the PHP warning on field save.

#### Steps to test this PR:
1. Repeat the test steps
2. It will show a validation error message, no PHP warning shows up.
