### PR TITLE
Fix dynamic filters in reports

### DIFF
--- a/app/bundles/ReportBundle/Form/Type/DynamicFiltersType.php
+++ b/app/bundles/ReportBundle/Form/Type/DynamicFiltersType.php
@@ -27,50 +27,52 @@ class DynamicFiltersType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         foreach ($options['report']->getFilters() as $filter) {
-            $column     = $filter['column'];
-            $definition = $options['filterDefinitions']->definitions[$column];
+            if ($filter['dynamic']) {
+                $column     = $filter['column'];
+                $definition = $options['filterDefinitions']->definitions[$column];
 
-            $args = [
-                'label'      => $definition['label'],
-                'label_attr' => ['class' => 'control-label'],
-                'attr'       => [
-                    'class'    => 'form-control',
-                    'onchange' => "Mautic.filterTableData('report.".$options['report']->getId()."','".$column."',this.value,'list','.report-content');",
-                ],
-                'required' => false,
-            ];
+                $args = [
+                    'label'      => $definition['label'],
+                    'label_attr' => ['class' => 'control-label'],
+                    'attr'       => [
+                        'class'    => 'form-control',
+                        'onchange' => "Mautic.filterTableData('report.".$options['report']->getId()."','".$column."',this.value,'list','.report-content');",
+                    ],
+                    'required' => false,
+                ];
 
-            switch ($definition['type']) {
-                case 'bool':
-                case 'boolean':
-                    $type                      = 'button_group';
-                    $args['choices_as_values'] = true;
-                    $args['choices']           = [
-                        [
-                            'mautic.core.form.no'      => false,
-                            'mautic.core.form.yes'     => true,
-                            'mautic.core.filter.clear' => '',
-                        ],
-                    ];
+                switch ($definition['type']) {
+                    case 'bool':
+                    case 'boolean':
+                        $type                      = 'button_group';
+                        $args['choices_as_values'] = true;
+                        $args['choices']           = [
+                            [
+                                'mautic.core.form.no'      => false,
+                                'mautic.core.form.yes'     => true,
+                                'mautic.core.filter.clear' => '',
+                            ],
+                        ];
 
-                    if (isset($options['data'][$definition['alias']])) {
-                        $args['data'] = ((int) $options['data'][$definition['alias']] == 1);
-                    }
-                    break;
-                case 'datetime':
-                    $type = 'datetime';
-                    break;
-                case 'multiselect':
-                case 'select':
-                    $type            = 'choice';
-                    $args['choices'] = $definition['list'];
-                    break;
-                default:
-                    $type = 'text';
-                    break;
+                        if (isset($options['data'][$definition['alias']])) {
+                            $args['data'] = ((int) $options['data'][$definition['alias']] == 1);
+                        }
+                        break;
+                    case 'datetime':
+                        $type = 'datetime';
+                        break;
+                    case 'multiselect':
+                    case 'select':
+                        $type            = 'choice';
+                        $args['choices'] = $definition['list'];
+                        break;
+                    default:
+                        $type = 'text';
+                        break;
+                }
+
+                $builder->add($definition['alias'], $type, $args);
             }
-
-            $builder->add($definition['alias'], $type, $args);
         }
     }
 

--- a/app/bundles/ReportBundle/Form/Type/FilterSelectorType.php
+++ b/app/bundles/ReportBundle/Form/Type/FilterSelectorType.php
@@ -111,7 +111,6 @@ class FilterSelectorType extends AbstractType
                     'tooltip' => 'mautic.report.report.label.filterdynamic_tooltip',
                 ],
                 'required' => false,
-                'data'     => (!isset($options['data']['dynamic']) || !empty($options['data']['dynamic'])),
             ]
         );
     }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Create/Edit report
2.  Disable Dynamic option in filters
3.  After Apply see still enabled Dynamic option
4.  Close and see report and all dynamic filters are in search area



#### Steps to test this PR:
1.  Apply PR
2.  Create report with 2 filters.  Enable Dynamic in first one, Disable Dynamic option in second one.
3.  Apply and see if works correctly
4. Close and see just one  dynamic filter in report
