### PR TITLE
placeholders for custom content on lead details page

### DIFF
--- a/app/bundles/LeadBundle/Views/Lead/lead.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/lead.html.php
@@ -297,6 +297,8 @@ $view['slots']->set(
                         </a>
                     </li>
                 <?php endif; ?>
+                
+                <?php echo $view['content']->getCustomContent('tabs', $mauticTemplateVars); ?>
             </ul>
             <!--/ tabs controls -->
         </div>
@@ -336,7 +338,11 @@ $view['slots']->set(
                 </div>
             <?php endif; ?>
             <!--/ #social-container -->
-
+            
+            <!-- custom content -->
+            <?php echo $view['content']->getCustomContent('tabs.content', $mauticTemplateVars); ?>
+            <!-- end: custom content -->
+            
             <!-- #place-container -->
             <?php if ($places): ?>
                 <div class="tab-pane fade bdr-w-0" id="place-container">


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | No
| New feature? | Expansion of new feature 


[//]: # ( Required: )
#### Description:

would allow a plugin to listen to the CoreEvents::VIEW_INJECT_CUSTOM_CONTENT
event to inject custom content into those spots.

PR #4098 was reverted as it was associated with another non related commit, so here it a new PR for this.


