### PR TITLE
Fix memory explosion on segment leads display

### DIFF
--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -549,10 +549,11 @@ class AjaxController extends CommonAjaxController
                 $dataArray['leads'] = $this->factory->getTemplating()->render(
                     "MauticLeadBundle:Lead:{$template}.html.php",
                     [
-                        'items'       => $results['results'],
-                        'permissions' => $permissions,
-                        'security'    => $this->get('mautic.security'),
-                        'highlight'   => true,
+                        'items'         => $results['results'],
+                        'noContactList' => $emailRepo->getDoNotEmailList(array_keys($results['results'])),
+                        'permissions'   => $permissions,
+                        'security'      => $this->get('mautic.security'),
+                        'highlight'     => true,
                     ]
                 );
                 $dataArray['indexMode'] = $indexMode;

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -549,11 +549,10 @@ class AjaxController extends CommonAjaxController
                 $dataArray['leads'] = $this->factory->getTemplating()->render(
                     "MauticLeadBundle:Lead:{$template}.html.php",
                     [
-                        'items'         => $results['results'],
-                        'noContactList' => $emailRepo->getDoNotEmailList(),
-                        'permissions'   => $permissions,
-                        'security'      => $this->get('mautic.security'),
-                        'highlight'     => true,
+                        'items'       => $results['results'],
+                        'permissions' => $permissions,
+                        'security'    => $this->get('mautic.security'),
+                        'highlight'   => true,
                     ]
                 );
                 $dataArray['indexMode'] = $indexMode;

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -184,6 +184,7 @@ class LeadController extends FormController
                     'currentList'      => $list,
                     'security'         => $this->get('mautic.security'),
                     'inSingleList'     => $inSingleList,
+                    'noContactList'    => $emailRepo->getDoNotEmailList(array_keys($leads)),
                     'maxLeadId'        => $maxLeadId,
                     'anonymousShowing' => $anonymousShowing,
                 ],

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -184,7 +184,6 @@ class LeadController extends FormController
                     'currentList'      => $list,
                     'security'         => $this->get('mautic.security'),
                     'inSingleList'     => $inSingleList,
-                    'noContactList'    => $emailRepo->getDoNotEmailList(),
                     'maxLeadId'        => $maxLeadId,
                     'anonymousShowing' => $anonymousShowing,
                 ],

--- a/app/bundles/LeadBundle/Views/Lead/grid_card.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/grid_card.html.php
@@ -30,8 +30,8 @@ $img = $view['lead_avatar']->getAvatar($contact);
             </div>
             <div class="col-xs-8 va-t">
                 <div class="panel-body">
-                    <?php if (in_array($contact->getId(), $noContactList)) : ?>
-                    <div class="pull-right label label-danger"><i class="fa fa-ban"> </i></div>
+                    <?php if (!$contact->getDoNotContact()->isEmpty()) : ?>
+                        <div class="pull-right label label-danger"><i class="fa fa-ban"> </i></div>
                     <?php endif; ?>
                     <h4 class="fw-sb mb-xs ellipsis">
                         <a href="<?php echo $view['router']->path('mautic_contact_action',

--- a/app/bundles/LeadBundle/Views/Lead/grid_card.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/grid_card.html.php
@@ -30,7 +30,7 @@ $img = $view['lead_avatar']->getAvatar($contact);
             </div>
             <div class="col-xs-8 va-t">
                 <div class="panel-body">
-                    <?php if (!$contact->getDoNotContact()->isEmpty()) : ?>
+                    <?php if (in_array($contact->getId(), array_keys($noContactList)))  : ?>
                         <div class="pull-right label label-danger"><i class="fa fa-ban"> </i></div>
                     <?php endif; ?>
                     <h4 class="fw-sb mb-xs ellipsis">

--- a/app/bundles/LeadBundle/Views/Lead/list_rows.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/list_rows.html.php
@@ -66,7 +66,7 @@
                 </td>
                 <td>
                     <a href="<?php echo $view['router']->path('mautic_contact_action', ['objectAction' => 'view', 'objectId' => $item->getId()]); ?>" data-toggle="ajax">
-                        <?php if (!$item->getDoNotContact()->isEmpty()) : ?>
+                        <?php if (in_array($item->getId(), array_keys($noContactList)))  : ?>
                             <div class="pull-right label label-danger"><i class="fa fa-ban"> </i></div>
                         <?php endif; ?>
                         <div><?php echo ($item->isAnonymous()) ? $view['translator']->trans($item->getPrimaryIdentifier()) : $item->getPrimaryIdentifier(); ?></div>

--- a/app/bundles/LeadBundle/Views/Lead/list_rows.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/list_rows.html.php
@@ -66,7 +66,7 @@
                 </td>
                 <td>
                     <a href="<?php echo $view['router']->path('mautic_contact_action', ['objectAction' => 'view', 'objectId' => $item->getId()]); ?>" data-toggle="ajax">
-                        <?php if (in_array($item->getId(), $noContactList)) : ?>
+                        <?php if (!$item->getDoNotContact()->isEmpty()) : ?>
                             <div class="pull-right label label-danger"><i class="fa fa-ban"> </i></div>
                         <?php endif; ?>
                         <div><?php echo ($item->isAnonymous()) ? $view['translator']->trans($item->getPrimaryIdentifier()) : $item->getPrimaryIdentifier(); ?></div>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:

Getting the list of segment leads used to do a redundant query to later check if the lead was unsubscribed or not that would easily consume too much memory.

That query did not seem to work anyway as with our fix, we now have an icon displayed next to unsubscribed leads.

We've removed  the call to that query and now simply check if the lead is unsubscribed directly through its entity. This avoids running out of memory on an instance with many unsubscribed leads.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Have an instance with many unsubscribed leads
2.  Make a dynamic segment
3. Click on the view x leads button
4. The instance should run out of memory and crash
5. If not, lowering the memory limit to 128M or below can help reproduce

#### Steps to test this PR:
1. Repeat steps 1 to 3 above
2. The instance should be fine as the do not contact records are loaded by need and can be collected by the GC