### PR TITLE
Email Integration bug fixes

### DIFF
--- a/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
+++ b/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
@@ -121,6 +121,10 @@ trait FieldsTypeTrait
                 if ($fieldObject) {
                     $fieldsName = $fieldObject.'Fields';
                 }
+                if (isset($fieldData[$fieldsName])) {
+                    $fieldData[$fieldsName] = $options['integration_object']->formatMatchedFields($fieldData[$fieldsName]);
+                }
+
                 foreach ($paginatedFields as $field => $details) {
                     $matched = isset($fieldData[$fieldsName][$field]);
                     $required = (int) (!empty($integrationFields[$field]['required']) || $choices[$field] == 'Email');

--- a/app/bundles/PluginBundle/Form/Type/IntegrationsListType.php
+++ b/app/bundles/PluginBundle/Form/Type/IntegrationsListType.php
@@ -118,7 +118,8 @@ class IntegrationsListType extends AbstractType
                     'data'        => (isset($data['config'])) ? $data['config'] : [],
                 ]
             );
-            $hideClass = (isset($data['campaign_member_status'])) ? '' : ' hide';
+
+            $hideClass = (isset($data['campaign_member_status']) && !empty($data['campaign_member_status']['campaign_member_status'])) ? '' : ' hide';
             $form->add(
                 'campaign_member_status',
                 'integration_campaign_status',

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -2395,4 +2395,34 @@ abstract class AbstractIntegration
     {
         return $this->logger;
     }
+
+    /**
+     * Function used to format unformated fields coming from FieldsTypeTrait
+     * (usually used in campaign actions).
+     *
+     * @param $fields
+     *
+     * @return array
+     */
+    public function formatMatchedFields($fields)
+    {
+        $formattedFields = [];
+
+        if (isset($fields['m_1'])) {
+            $xfields = count($fields) / 3;
+            for ($i = 1; $i < $xfields; ++$i) {
+                if (isset($fields['i_'.$i]) && isset($fields['m_'.$i])) {
+                    $formattedFields[$fields['i_'.$i]] = $fields['m_'.$i];
+                } else {
+                    break;
+                }
+            }
+        }
+
+        if (!empty($formattedFields)) {
+            $fields = $formattedFields;
+        }
+
+        return $fields;
+    }
 }

--- a/plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
+++ b/plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
@@ -15,7 +15,7 @@ use Mautic\PluginBundle\Exception\ApiErrorException;
 
 class MailchimpApi extends EmailMarketingApi
 {
-    private $version = '2.0';
+    private $version = '3.0';
 
     /**
      * @param        $endpoint
@@ -62,7 +62,7 @@ class MailchimpApi extends EmailMarketingApi
 
     public function getLists()
     {
-        return $this->request('lists/list', ['limit' => 100]);
+        return $this->request('lists', ['limit' => 100]);
     }
 
     /**
@@ -74,7 +74,7 @@ class MailchimpApi extends EmailMarketingApi
      */
     public function getCustomFields($listId)
     {
-        return $this->request('lists/merge-vars', ['id' => [$listId]]);
+        return $this->request('lists/'.$listId.'/merge-fields');
     }
 
     /**
@@ -92,14 +92,13 @@ class MailchimpApi extends EmailMarketingApi
         $emailStruct        = new \stdClass();
         $emailStruct->email = $email;
 
-        print_r($email);
-
         $parameters = array_merge($config, [
-            'id'         => $listId,
-            'merge_vars' => $fields,
+            'id'           => $listId,
+            'merge_fields' => $fields,
         ]);
-        $parameters['email'] = $emailStruct;
+        $parameters['email_address'] = $email;
+        $parameters['status']        = 'subscribed';
 
-        return $this->request('lists/subscribe', $parameters, 'POST');
+        return $this->request('lists/'.$listId.'/members', $parameters, 'POST');
     }
 }

--- a/plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
+++ b/plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
@@ -92,6 +92,8 @@ class MailchimpApi extends EmailMarketingApi
         $emailStruct        = new \stdClass();
         $emailStruct->email = $email;
 
+        print_r($email);
+
         $parameters = array_merge($config, [
             'id'         => $listId,
             'merge_vars' => $fields,

--- a/plugins/MauticEmailMarketingBundle/Config/config.php
+++ b/plugins/MauticEmailMarketingBundle/Config/config.php
@@ -24,12 +24,12 @@ return [
             ],
             'mautic.form.type.emailmarketing.constantcontact' => [
                 'class'     => 'MauticPlugin\MauticEmailMarketingBundle\Form\Type\ConstantContactType',
-                'arguments' => 'mautic.factory',
+                'arguments' => ['mautic.factory', 'session', 'mautic.helper.core_parameters'],
                 'alias'     => 'emailmarketing_constantcontact',
             ],
             'mautic.form.type.emailmarketing.icontact' => [
                 'class'     => 'MauticPlugin\MauticEmailMarketingBundle\Form\Type\IcontactType',
-                'arguments' => 'mautic.factory',
+                'arguments' => ['mautic.factory', 'session', 'mautic.helper.core_parameters'],
                 'alias'     => 'emailmarketing_icontact',
             ],
         ],

--- a/plugins/MauticEmailMarketingBundle/Config/config.php
+++ b/plugins/MauticEmailMarketingBundle/Config/config.php
@@ -19,7 +19,7 @@ return [
         'forms' => [
             'mautic.form.type.emailmarketing.mailchimp' => [
                 'class'     => 'MauticPlugin\MauticEmailMarketingBundle\Form\Type\MailchimpType',
-                'arguments' => 'mautic.factory',
+                'arguments' => ['mautic.factory', 'session', 'mautic.helper.core_parameters'],
                 'alias'     => 'emailmarketing_mailchimp',
             ],
             'mautic.form.type.emailmarketing.constantcontact' => [

--- a/plugins/MauticEmailMarketingBundle/Form/Type/ConstantContactType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/ConstantContactType.php
@@ -12,11 +12,13 @@
 namespace MauticPlugin\MauticEmailMarketingBundle\Form\Type;
 
 use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -28,10 +30,21 @@ class ConstantContactType extends AbstractType
      * @var MauticFactory
      */
     private $factory;
+    /**
+     * @var Session
+     */
+    protected $session;
 
-    public function __construct(MauticFactory $factory)
+    /**
+     * @var CoreParametersHelper
+     */
+    protected $coreParametersHelper;
+
+    public function __construct(MauticFactory $factory, Session $session, CoreParametersHelper $coreParametersHelper)
     {
-        $this->factory = $factory;
+        $this->factory              = $factory;
+        $this->session              = $session;
+        $this->coreParametersHelper = $coreParametersHelper;
     }
 
     /**
@@ -45,7 +58,14 @@ class ConstantContactType extends AbstractType
         $helper = $this->factory->getHelper('integration');
 
         /** @var \MauticPlugin\MauticEmailMarketingBundle\Integration\ConstantContactIntegration $object */
-        $object = $helper->getIntegrationObject('ConstantContact');
+        $object          = $helper->getIntegrationObject('ConstantContact');
+        $integrationName = $object->getName();
+        $session         = $this->session;
+        $limit           = $session->get(
+            'mautic.plugin.'.$integrationName.'.lead.limit',
+            $this->coreParametersHelper->getParameter('default_pagelimit')
+        );
+        $page = $session->get('mautic.plugin.'.$integrationName.'.lead.page', 1);
 
         $api = $object->getApiHelper();
         try {
@@ -62,6 +82,7 @@ class ConstantContactType extends AbstractType
         } catch (\Exception $e) {
             $choices = [];
             $error   = $e->getMessage();
+            $page    = 1;
         }
 
         $builder->add('list', 'choice', [
@@ -98,9 +119,14 @@ class ConstantContactType extends AbstractType
                 'label'                => 'mautic.integration.leadfield_matches',
                 'required'             => true,
                 'mautic_fields'        => $leadFields,
-                'data'                 => isset($options['data']['leadFields']) ? $options['data']['leadFields'] : [],
+                'integration'          => $object->getName(),
+                'integration_object'   => $object,
+                'limit'                => $limit,
+                'page'                 => $page,
+                'data'                 => isset($options['data']) ? $options['data'] : [],
                 'integration_fields'   => $fields,
                 'special_instructions' => $specialInstructions,
+                'mapped'               => true,
                 'alert_type'           => $alertType,
             ]);
         }

--- a/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
@@ -63,12 +63,11 @@ class MailchimpType extends AbstractType
 
         $api = $mailchimp->getApiHelper();
         try {
-            $lists = $api->getLists();
-
+            $lists   = $api->getLists();
             $choices = [];
             if (!empty($lists)) {
-                if ($lists['total']) {
-                    foreach ($lists['data'] as $list) {
+                if ($lists['total_items']) {
+                    foreach ($lists['lists'] as $list) {
                         $choices[$list['id']] = $list['name'];
                     }
                 }
@@ -139,7 +138,6 @@ class MailchimpType extends AbstractType
                     $fields = [];
                     $error  = $e->getMessage();
                     $page   = 1;
-                    $fields = $integrationCompanyFields = [];
                 }
 
                 list($specialInstructions) = $mailchimp->getFormNotes('leadfield_match');
@@ -154,7 +152,7 @@ class MailchimpType extends AbstractType
                     'data'                 => $data,
                     'integration_fields'   => $fields,
                     'special_instructions' => $specialInstructions,
-                    'mapped'               => false,
+                    'mapped'               => true,
                     'error_bubbling'       => false,
                 ]);
 

--- a/plugins/MauticEmailMarketingBundle/Integration/EmailAbstractIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/EmailAbstractIntegration.php
@@ -87,7 +87,8 @@ abstract class EmailAbstractIntegration extends AbstractIntegration
         $featureSettings = $this->settings->getFeatureSettings();
 
         if (isset($config['config']['list_settings']['leadFields'])) {
-            $config['config']['leadFields'] = $config['config']['list_settings']['leadFields'];
+            $config['config']['leadFields'] = $this->formatMatchedFields($config['config']['list_settings']['leadFields']);
+
             unset($config['config']['list_settings']['leadFields']);
         }
 

--- a/plugins/MauticEmailMarketingBundle/Integration/EmailAbstractIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/EmailAbstractIntegration.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\FormBuilder;
  */
 abstract class EmailAbstractIntegration extends AbstractIntegration
 {
+    protected $pushContactLink = false;
     /**
      * @return array
      */

--- a/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
@@ -151,9 +151,11 @@ class MailchimpIntegration extends EmailAbstractIntegration
     public function pushLead($lead, $config = [])
     {
         $config = $this->mergeConfigToFeatureSettings($config);
+        print_r($config);
 
-        $mappedData = $this->populateLeadData($lead, $config);
-
+        $mappedData = $this->populateLeadData($lead,
+            ['leadFields' => $config['leadFields'], 'object' => 'lead', 'feature_settings' => ['objects' => []]]);
+        print_r($mappedData);
         if (empty($mappedData)) {
             return false;
         } elseif (empty($mappedData['EMAIL'])) {

--- a/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
@@ -124,15 +124,21 @@ class MailchimpIntegration extends EmailAbstractIntegration
 
             $fields = $this->getApiHelper()->getCustomFields($listId);
 
-            if (!empty($fields['data'][0]['merge_vars']) && count($fields['data'][0]['merge_vars'])) {
-                foreach ($fields['data'][0]['merge_vars'] as $field) {
+            if (!empty($fields['merge_fields']) && count($fields['merge_fields'])) {
+                foreach ($fields['merge_fields'] as $field) {
                     $leadFields[$field['tag']] = [
                         'label'    => $field['name'],
                         'type'     => 'string',
-                        'required' => $field['req'],
+                        'required' => $field['required'],
                     ];
                 }
             }
+
+            $leadFields['EMAIL'] = [
+                'label'    => 'Email',
+                'type'     => 'string',
+                'required' => true,
+            ];
 
             $this->cache->set('leadFields'.$cacheSuffix, $leadFields);
 
@@ -150,12 +156,9 @@ class MailchimpIntegration extends EmailAbstractIntegration
      */
     public function pushLead($lead, $config = [])
     {
-        $config = $this->mergeConfigToFeatureSettings($config);
-        print_r($config);
+        $config     = $this->mergeConfigToFeatureSettings($config);
+        $mappedData = $this->populateLeadData($lead, $config);
 
-        $mappedData = $this->populateLeadData($lead,
-            ['leadFields' => $config['leadFields'], 'object' => 'lead', 'feature_settings' => ['objects' => []]]);
-        print_r($mappedData);
         if (empty($mappedData)) {
             return false;
         } elseif (empty($mappedData['EMAIL'])) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #4037 #3629
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Mailchimp, iContact and ConstantContact integrations had stopped working for a couple of issues, changes introduced in 2.8.0 did not allow the campaign action form to show correctly. Also Mailchimp has changed its API from 2.0 to 3.0 and this carried various changes in their endpoints.
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. enable Mailchimp, iContact and ConstantContact and create a list to push contacts in each of the integrations [this is not in mautic but in the mail services themselves]
2. create a campaign with a push to integration campaign, you will get a 500 error

#### Steps to test this PR:
1. follow steps 1-2 500 error should not be there.
2. run campaign and contacts should be pushed to the list.
3. try running existing campaigns and make sure that it pushes contacts to your list.