### PR TITLE
DWC ordering by name and category fixed

### DIFF
--- a/app/bundles/DynamicContentBundle/Views/DynamicContent/list.html.php
+++ b/app/bundles/DynamicContentBundle/Views/DynamicContent/list.html.php
@@ -37,9 +37,9 @@ if ($tmpl == 'index') {
                     'MauticCoreBundle:Helper:tableheader.html.php',
                     [
                         'sessionVar' => 'dynamicContent',
-                        'orderBy'    => 'e.title',
-                        'text'       => 'mautic.core.title',
-                        'class'      => 'col-dwc-title',
+                        'orderBy'    => 'e.name',
+                        'text'       => 'mautic.core.name',
+                        'class'      => 'col-dwc-name',
                         'default'    => true,
                     ]
                 );
@@ -48,7 +48,7 @@ if ($tmpl == 'index') {
                     'MauticCoreBundle:Helper:tableheader.html.php',
                     [
                         'sessionVar' => 'dynamicContent',
-                        'orderBy'    => 'e.name',
+                        'orderBy'    => 'c.title',
                         'text'       => 'mautic.core.category',
                         'class'      => 'visible-md visible-lg col-dwc-category',
                     ]


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4236
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Ordering DWC items by title threw the error described in the linked issue. While fixing that, I noticed that the category ordering was wrong too, so that's fixed too.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to DWC
2. Make sure you have at least 2 items there with different names and categories
3. Try to order by different columns
4. you'll probably get the error. If you do, you have to log out and back in to clear the session to make it go away.

#### Steps to test this PR:
1. Apply this PR
2. Test again. Ordering of all columns will work correctly.