### PR TITLE
BugFix - Previewing assets increments the download count

### DIFF
--- a/app/bundles/AssetBundle/Views/Asset/details.html.php
+++ b/app/bundles/AssetBundle/Views/Asset/details.html.php
@@ -155,7 +155,10 @@ $view['slots']->set(
         <div class="tab-content pa-md preview-detail">
             <?php echo $view->render(
                 'MauticAssetBundle:Asset:preview.html.php',
-                ['activeAsset' => $activeAsset, 'assetDownloadUrl' => $assetDownloadUrl]
+                ['activeAsset' => $activeAsset, 'assetDownloadUrl' => $view['router']->generate(
+                    'mautic_asset_action',
+                    ['objectAction' => 'preview', 'objectId' => $activeAsset->getId()]
+                )]
             ); ?>
         </div>
         <!--/ end: tab-content -->

--- a/app/bundles/AssetBundle/Views/Asset/form.html.php
+++ b/app/bundles/AssetBundle/Views/Asset/form.html.php
@@ -69,7 +69,10 @@ $view['slots']->set('mauticContent', 'asset');
 		    	<div class="col-md-6">
 		    		<div class="row">
 				    	<div class="form-group col-xs-12 preview">
-				    		<?php echo $view->render('MauticAssetBundle:Asset:preview.html.php', ['activeAsset' => $activeAsset, 'assetDownloadUrl' => $assetDownloadUrl]); ?>
+				    		<?php echo $view->render('MauticAssetBundle:Asset:preview.html.php', ['activeAsset' => $activeAsset, 'assetDownloadUrl' => $view['router']->generate(
+                                'mautic_asset_action',
+                                ['objectAction' => 'preview', 'objectId' => $activeAsset->getId()]
+                            )]); ?>
 			    		</div>
 		    		</div>
 		    	</div>

--- a/app/bundles/AssetBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/AssetBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -11,5 +11,8 @@
 ?>
 
 <div>
-<?php echo $view->render('MauticAssetBundle:Asset:preview.html.php', ['activeAsset' => $event['extra']['asset'], 'assetDownloadUrl' => $event['extra']['assetDownloadUrl']]); ?>
+<?php echo $view->render('MauticAssetBundle:Asset:preview.html.php', ['activeAsset' => $event['extra']['asset'], 'assetDownloadUrl' => $view['router']->generate(
+    'mautic_asset_action',
+    ['objectAction' => 'preview', 'objectId' => $event['extra']['asset']->getId()]
+)]); ?>
 </div>


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes an issue where the asset download count increments every time the asset is previewed.
It also fixes a mismatch with the download counts in the Downloads of All Assets report

#### Steps to reproduce the bug:
1. (This issue could be hard to reproduce)
2. Create an asset or view an existing one
3. Every time the asset is viewed, the download count is incremented.

#### Steps to test this PR:
1. Apply this PR
2. Try to reproduce the bug
3. The download count does not increase


