### PR TITLE
Changed public isGuest to construct/getter

### DIFF
--- a/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
@@ -116,7 +116,7 @@ class CoreSubscriber extends CommonSubscriber
      */
     public function onKernelRequestAddGlobalJS(FilterControllerEvent $event)
     {
-        if (defined('MAUTIC_INSTALLER') || $this->userHelper->getUser()->isGuest || !$event->isMasterRequest()) {
+        if (defined('MAUTIC_INSTALLER') || $this->userHelper->getUser()->isGuest() || !$event->isMasterRequest()) {
             return;
         }
 

--- a/app/bundles/CoreBundle/Helper/UserHelper.php
+++ b/app/bundles/CoreBundle/Helper/UserHelper.php
@@ -53,8 +53,7 @@ class UserHelper
                 return null;
             }
 
-            $user          = new User();
-            $user->isGuest = true;
+            $user = new User(true);
         }
 
         return $user;

--- a/app/bundles/CoreBundle/Model/NotificationModel.php
+++ b/app/bundles/CoreBundle/Model/NotificationModel.php
@@ -177,7 +177,7 @@ class NotificationModel extends FormModel
      */
     public function getNotificationContent($afterId = null, $includeRead = false, $limit = null)
     {
-        if ($this->userHelper->getUser()->isGuest) {
+        if ($this->userHelper->getUser()->isGuest()) {
             return [[], false, ''];
         }
 

--- a/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
@@ -444,7 +444,7 @@ class CorePermissions
     {
         $userEntity = $this->userHelper->getUser();
 
-        return ($userEntity instanceof User && $userEntity->getId()) ? false : true;
+        return ($userEntity instanceof User && !$userEntity->isGuest()) ? false : true;
     }
 
     /**

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -108,13 +108,6 @@ class User extends FormEntity implements AdvancedUserInterface, \Serializable, E
     private $onlineStatus = 'offline';
 
     /**
-     * Notes if user is guest or not.
-     *
-     * @var bool
-     */
-    public $isGuest = false;
-
-    /**
      * Stores active role permissions.
      *
      * @var
@@ -130,6 +123,34 @@ class User extends FormEntity implements AdvancedUserInterface, \Serializable, E
      * @var string
      */
     private $signature;
+
+    /**
+     * @var bool
+     */
+    private $guest = false;
+
+    /**
+     * User constructor.
+     *
+     * @param bool $isGuest
+     */
+    public function __construct($isGuest = false)
+    {
+        $this->guest = $isGuest;
+    }
+
+    /**
+     * @deprecated 2.9.0 to be removed in 3.0; support for $isGuest public property
+     * @param $name
+     */
+    public function __get($name)
+    {
+        if ('isGuest' === $name) {
+            @trigger_error('$isGuest is deprecated as of 2.9.0; use construct and isGuest() instead', E_USER_DEPRECATED);
+
+            return $this->guest;
+        }
+    }
 
     /**
      * @param ORM\ClassMetadata $metadata
@@ -877,5 +898,13 @@ class User extends FormEntity implements AdvancedUserInterface, \Serializable, E
         $thatUser = $user->getId().$user->getUsername().$user->getPassword();
 
         return $thisUser === $thatUser;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isGuest()
+    {
+        return $this->guest;
     }
 }

--- a/app/bundles/UserBundle/Tests/Entity/UserTest.php
+++ b/app/bundles/UserBundle/Tests/Entity/UserTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\UserBundle\Tests\Entity;
+
+
+use Mautic\UserBundle\Entity\User;
+
+class UserTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testUserIsGuest()
+    {
+        $user = new User(true);
+        $this->assertTrue($user->isGuest());
+    }
+
+    public function testUserIsNotGuest()
+    {
+        $user = new User();
+        $this->assertFalse($user->isGuest());
+    }
+
+    public function testUserIsGuestDeprecatedVariable()
+    {
+        $user = new User(true);
+        $this->assertTrue($user->isGuest);
+    }
+
+    public function testUserIsNotGuestDeprecatedVariable()
+    {
+        $user = new User();
+        $this->assertFAlse($user->isGuest);
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | n
| New feature? | n
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | $user->isGuest

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR changes the public property isGuest on a User entity to leverage a construct argument and isGuest() method instead. BC for ->isGuest property has been kept using a __get method till 3.0.

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Review and run the new tests in UserBundle

#### List deprecations along with the new alternative:
1. `$user = new User(); if ($user->isGuest) ...` is deprecated in favor of `$user = new User(true); if ($user->isGuest()) ...`
