### PR TITLE
Fix for array_count_values error when there are null values

### DIFF
--- a/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
+++ b/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
@@ -219,9 +219,9 @@ class EntityLookupChoiceLoader implements ChoiceLoaderInterface
 
         if (!$isGrouped) {
             // fix for array_count_values error when there are null values
-            $ar = array_replace($prepped, array_fill_keys(array_keys($prepped, null), ''));
+            $prepped = array_replace($prepped, array_fill_keys(array_keys($prepped, null), ''));
             // Same labels will cause options to be merged with Symfony 2.8+ so ensure labels are unique
-            $counts     = array_count_values($ar);
+            $counts     = array_count_values($prepped);
             $duplicates = array_filter(
                 $prepped,
                 function ($value) use ($counts) {

--- a/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
+++ b/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
@@ -218,8 +218,10 @@ class EntityLookupChoiceLoader implements ChoiceLoaderInterface
         }
 
         if (!$isGrouped) {
+            // fix for array_count_values error when there are null values
+            $ar = array_replace($prepped, array_fill_keys(array_keys($prepped, null), ''));
             // Same labels will cause options to be merged with Symfony 2.8+ so ensure labels are unique
-            $counts     = array_count_values($prepped);
+            $counts     = array_count_values($ar);
             $duplicates = array_filter(
                 $prepped,
                 function ($value) use ($counts) {


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
When trying to add a new contact and there are companies with null in their names, the form will throw the following error:

mautic.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\ContextErrorException: "PHP Warning - array_count_values(): Can only count STRING and INTEGER values!" at /var/www/mautic-fork/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php line 222

#### Steps to reproduce the bug:
1. Create a new company
2. Set the company name to null using mysql or another tool
3. Try to create a new contact
4. The error message will pop up and the form won't load.

#### Steps to test this PR:
1. Apply this PR
2. Try to reproduce the bug
3. The error will be gone and the form will load
