### PR TITLE
Fix batchsize & widget time math to address warnings in PHP 7.1.

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -719,10 +719,13 @@ class CommonRepository extends EntityRepository
     {
         //iterate over the results so the events are dispatched on each delete
         $batchSize = 20;
+        $i         = 0;
+
         foreach ($entities as $k => $entity) {
+            ++$i;
             $this->saveEntity($entity, false);
 
-            if ((($k + 1) % $batchSize) === 0) {
+            if ($i % $batchSize === 0) {
                 $this->getEntityManager()->flush();
             }
         }
@@ -740,6 +743,7 @@ class CommonRepository extends EntityRepository
     public function saveEntity($entity, $flush = true)
     {
         $this->getEntityManager()->persist($entity);
+
         if ($flush) {
             $this->getEntityManager()->flush($entity);
         }

--- a/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
@@ -43,7 +43,7 @@ class WidgetDetailEvent extends CommonEvent
     public function __construct(TranslatorInterface $translator)
     {
         $this->translator = $translator;
-        $this->startTime  = microtime();
+        $this->startTime  = microtime(true);
     }
 
     /**
@@ -161,7 +161,7 @@ class WidgetDetailEvent extends CommonEvent
     {
         $this->templateData = $templateData;
         $this->widget->setTemplateData($templateData);
-        $this->widget->setLoadTime(abs(microtime() - $this->startTime));
+        $this->widget->setLoadTime(abs(microtime(true) - $this->startTime));
 
         // Store the template data to the cache
         if (!$skipCache && $this->cacheDir && $this->widget->getCacheTimeout() > 0) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

PHP 7.1 throws a warning if you try to do math on non-numeric values. This manifests itself in Mautic during widget load time calculations because we were using `microtime()` which returns a string value, instead of `microtime(true)` which returns a float.

It also happens in the `CommonRepository::saveEntities()` method when the array of entities passed to the method does not use integer keys, as is the case when passing emails to save from the campaign (the test case)

This fix also likely fixes a memory leak when saving multiple entities using the `saveEntities` method, as the batch size limit was incorrectly calculated and the `flush()` method was not called when the passed entities array did not have integer keys.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Be running PHP 7.1
2. Create a campaign with a send email action and add contacts to the campaign
3. Trigger the campaign, you'll see the following error in your console:

<img width="442" alt="screen shot 2017-06-15 at 10 16 20 am" src="https://user-images.githubusercontent.com/718028/27185550-b8f82360-51b3-11e7-9806-9aa7fce32df9.png">

#### Steps to test this PR:
1. Apply PR
2. Retest and the error will be gone.
