### PR TITLE
Don't execute JS in the form builder

### DIFF
--- a/app/bundles/CoreBundle/Templating/Helper/ContentHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/ContentHelper.php
@@ -79,6 +79,18 @@ class ContentHelper extends Helper
     }
 
     /**
+     * Replaces HTML script tags with non HTML tags so the JS inside them won't execute and will be readable.
+     *
+     * @param string $html
+     *
+     * @return string
+     */
+    public function showScriptTags($html)
+    {
+        return str_replace(['<script>', '</script>'], ['[script]', '[/script]'], $html);
+    }
+
+    /**
      * @return string
      */
     public function getName()

--- a/app/bundles/CoreBundle/Tests/Templating/Helper/ContentHelperTest.html.php
+++ b/app/bundles/CoreBundle/Tests/Templating/Helper/ContentHelperTest.html.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Tests\Templating\Helper;
+
+use Mautic\CoreBundle\Templating\Helper\ContentHelper;
+use Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class ContentHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAssetContext()
+    {
+        $dispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $delegationMock = $this->getMockBuilder(DelegatingEngine::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+
+        $contentHelper = new ContentHelper($dispatcherMock, $delegationMock);
+        $sample        = '<h1>Hello World</h1>
+
+        <script>
+            console.log("do not mind me");
+        </script>';
+
+        $expected = '<h1>Hello World</h1>
+
+        [script]
+            console.log("do not mind me");
+        [/script]';
+
+        $result = $contentHelper->showScriptTags($sample);
+
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/app/bundles/FormBundle/Controller/FieldController.php
+++ b/app/bundles/FormBundle/Controller/FieldController.php
@@ -154,6 +154,7 @@ class FieldController extends CommonFormController
                     'id'            => $keyId,
                     'formId'        => $formId,
                     'contactFields' => $this->getModel('lead.field')->getFieldListWithProperties(),
+                    'inBuilder'     => true,
                 ]
             );
         }
@@ -295,6 +296,7 @@ class FieldController extends CommonFormController
                     'id'            => $objectId,
                     'formId'        => $formId,
                     'contactFields' => $this->getModel('lead.field')->getFieldListWithProperties(),
+                    'inBuilder'     => true,
                 ]
             );
 

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -451,6 +451,7 @@ class FormController extends CommonFormController
                     'activeForm'     => $entity,
                     'form'           => $form->createView(),
                     'contactFields'  => $this->getModel('lead.field')->getFieldListWithProperties(),
+                    'inBuilder'      => true,
                 ],
                 'contentTemplate' => 'MauticFormBundle:Builder:index.html.php',
                 'passthroughVars' => [
@@ -804,6 +805,7 @@ class FormController extends CommonFormController
                     'form'               => $form->createView(),
                     'forceTypeSelection' => $forceTypeSelection,
                     'contactFields'      => $this->getModel('lead.field')->getFieldListWithProperties(),
+                    'inBuilder'          => true,
                 ],
                 'contentTemplate' => 'MauticFormBundle:Builder:index.html.php',
                 'passthroughVars' => [

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -531,6 +531,7 @@ class FormModel extends CommonFormModel
                 'formPages'     => $pages,
                 'lastFormPage'  => $lastPage,
                 'style'         => $style,
+                'inBuilder'     => false,
             ]
         );
 

--- a/app/bundles/FormBundle/Views/Builder/fieldwrapper.html.php
+++ b/app/bundles/FormBundle/Views/Builder/fieldwrapper.html.php
@@ -8,6 +8,11 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
+
+if (!isset($inBuilder)) {
+    $inBuilder = false;
+}
+
 ?>
 <div class="panel form-field-wrapper" data-sortable-id="mauticform_<?php echo $field['id']; ?>">
     <?php
@@ -28,6 +33,7 @@
             'id'            => $field['id'],
             'formId'        => $formId,
             'contactFields' => (isset($contactFields)) ? $contactFields : [],
+            'inBuilder'     => $inBuilder,
         ]
     ); ?>
     </div>

--- a/app/bundles/FormBundle/Views/Builder/form.html.php
+++ b/app/bundles/FormBundle/Views/Builder/form.html.php
@@ -13,6 +13,10 @@ if (!isset($fields)) {
     $fields = $form->getFields();
 }
 $pageCount = 1;
+
+if (!isset($inBuilder)) {
+    $inBuilder = false;
+}
 ?>
 
 <?php echo $style; ?>
@@ -56,6 +60,7 @@ $pageCount = 1;
                             'formName'      => $formName,
                             'fieldPage'     => ($pageCount - 1), // current page,
                             'contactFields' => $contactFields,
+                            'inBuilder'     => $inBuilder,
                         ]
                     );
                 endif;

--- a/app/bundles/FormBundle/Views/Builder/index.html.php
+++ b/app/bundles/FormBundle/Views/Builder/index.html.php
@@ -22,6 +22,11 @@ $header = ($activeForm->getId())
 $view['slots']->set('headerTitle', $header);
 
 $formId = $form['sessionId']->vars['data'];
+
+if (!isset($inBuilder)) {
+    $inBuilder = false;
+}
+
 ?>
 <?php echo $view['form']->start($form); ?>
 <div class="box-layout">
@@ -77,6 +82,7 @@ $formId = $form['sessionId']->vars['data'];
                                                                     'type'         => $fieldType,
                                                                     'tmpl'         => 'field',
                                                                     'formId'       => $formId,
+                                                                    'inBuilder'    => $inBuilder,
                                                                 ]
                                                             ); ?>">     <?php echo $field; ?></option>
 
@@ -103,6 +109,7 @@ $formId = $form['sessionId']->vars['data'];
                                             'id'            => $field['id'],
                                             'formId'        => $formId,
                                             'contactFields' => $contactFields,
+                                            'inBuilder'     => $inBuilder,
                                         ]
                                     ); ?>
                                 <?php endif; ?>

--- a/app/bundles/FormBundle/Views/Field/freehtml.html.php
+++ b/app/bundles/FormBundle/Views/Field/freehtml.html.php
@@ -11,9 +11,16 @@
 $defaultInputClass = $containerType = 'freehtml';
 include __DIR__.'/field_helper.php';
 
+if ($inBuilder) {
+    $htmlContent = $view['content']->showScriptTags($properties['text']);
+} else {
+    $htmlContent = $properties['text'];
+}
+// $e = new \Exception;
+// var_dump($e->getTraceAsString());die;
 $label = (!$field['showLabel']) ? '' :
     <<<HTML
-    
+
                 <h3 $labelAttr>
                     {$field['label']}
                 </h3>
@@ -23,7 +30,7 @@ $html = <<<HTML
 
             <div $containerAttr>{$label}
                 <div $inputAttr>
-                    {$properties['text']}
+                    {$htmlContent}
                 </div>
             </div>
 

--- a/app/bundles/FormBundle/Views/Field/freehtml.html.php
+++ b/app/bundles/FormBundle/Views/Field/freehtml.html.php
@@ -16,8 +16,7 @@ if ($inBuilder) {
 } else {
     $htmlContent = $properties['text'];
 }
-// $e = new \Exception;
-// var_dump($e->getTraceAsString());die;
+
 $label = (!$field['showLabel']) ? '' :
     <<<HTML
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The **HTML Area** field type allows to add `<scrpit/>` tags to its content. The JS can break the builder if there is some bug in it. It can be also a security issue executing JS in the builder.

This PR displays the content of the JS in the builder instead and do not execute it. I chose to display the content instead of stripping it out completely because I find it helpful if I can see what's in the field without editing it.

#### Sample code for testing
```
<h1>This is a HTML field containing some JS</h1>

<script>
alert('This should appear only on production form, not in the builder');
</script>
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new form.
2. Add the HTML Area field.
3. Fill in the sample code from above to the textarea, give the field a name.
- you should get the alert directly and on every edit page load or refresh.

#### Steps to test this PR:
1. Apply this PR.
2. Repeat the test above with creating a new form. - You should not get any alert and the JS code is visible.
3. Edit the form and the field to ensure the edit endpoints are safe too.
4. Make sure the JS executes on the production form. It should execute on the preview page as well as if you embed the form anyhow.