### PR TITLE
PHP error when DEC has no filters fixed

### DIFF
--- a/app/bundles/EmailBundle/Views/Email/form.html.php
+++ b/app/bundles/EmailBundle/Views/Email/form.html.php
@@ -8,12 +8,25 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
+
+use Symfony\Component\Form\FormView;
+
 $view->extend('MauticCoreBundle:Default:content.html.php');
 $view['slots']->set('mauticContent', 'email');
 
 $dynamicContentPrototype = $form['dynamicContent']->vars['prototype'];
-$filterBlockPrototype    = $form['dynamicContent']->children[0]['filters']->vars['prototype'];
-$filterSelectPrototype   = $form['dynamicContent']->children[0]['filters']->children[0]['filters']->vars['prototype'];
+
+if (empty($form['dynamicContent']->children[0]['filters']->vars['prototype'])) {
+    $filterBlockPrototype = null;
+} else {
+    $filterBlockPrototype = $form['dynamicContent']->children[0]['filters']->vars['prototype'];
+}
+
+if (empty($form['dynamicContent']->children[0]['filters']->children[0]['filters']->vars['prototype'])) {
+    $filterSelectPrototype = null;
+} else {
+    $filterSelectPrototype = $form['dynamicContent']->children[0]['filters']->children[0]['filters']->vars['prototype'];
+}
 
 $variantParent = $email->getVariantParent();
 $isExisting    = $email->getId();
@@ -211,8 +224,12 @@ $isCodeMode = ($email->getTemplate() === 'mautic_code_mode');
 <?php echo $view['form']->end($form); ?>
 
 <div id="dynamicContentPrototype" data-prototype="<?php echo $view->escape($view['form']->widget($dynamicContentPrototype)); ?>"></div>
+<?php if ($filterBlockPrototype instanceof FormView) : ?>
 <div id="filterBlockPrototype" data-prototype="<?php echo $view->escape($view['form']->widget($filterBlockPrototype)); ?>"></div>
+<?php endif; ?>
+<?php if ($filterSelectPrototype instanceof FormView) : ?>
 <div id="filterSelectPrototype" data-prototype="<?php echo $view->escape($view['form']->widget($filterSelectPrototype)); ?>"></div>
+<?php endif; ?>
 
 <div class="hide" id="templates">
     <?php foreach ($templates as $dataKey => $template): ?>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
A Mautic user cannot edit emails. I looked into the database, email table and confirmed it happens because of DEC configuration. Here it is (censored):
```
a:2:{i:0;a:3:{s:9:"tokenName";s:17:"Dynamic Content 1";s:7:"content";s:176:"iii iiii iiiiiii tomorrow for iii iiiii. Please <a href="https://iiiiiiiii.iiiiiiii.org/login" rel="noopener noreferrer" target="_blank">login to your account</a> to view them.";s:7:"filters";a:0:{}}i:1;a:3:{s:9:"tokenName";s:17:"Dynamic Content 2";s:7:"content";s:16:"Censored content";s:7:"filters";a:2:{i:0;a:2:{s:7:"content";s:16:"Censored content";s:7:"filters";a:0:{}}i:1;a:2:{s:7:"content";s:16:"Censored content";s:7:"filters";a:0:{}}}}}
```

The thing is I don't know how the could clear the filters array via UI. I tried everything I could, but I couldn't edit the first item of the array.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new email
2. Copy the code above to the emails table, dynamic_content column.
3. Try to edit the email - you get the error.

#### Steps to test this PR:
1. Apply this PR
2. The email form previous test should be editable again.
3. Make sure the DEC is still working as before.