### PR TITLE
Fix code that determines "click uniqueness"

### DIFF
--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -503,17 +503,16 @@ class PageModel extends FormModel
         $hit->setTrackingId($trackingId);
         $hit->setLead($lead);
 
-        $isUnique = $trackingNewlyGenerated;
         if (!$trackingNewlyGenerated) {
             $lastHit = $request->cookies->get('mautic_referer_id');
             if (!empty($lastHit)) {
                 //this is not a new session so update the last hit if applicable with the date/time the user left
                 $this->getHitRepository()->updateHitDateLeft($lastHit);
             }
-
-            // Check if this is a unique page hit
-            $isUnique = $this->getHitRepository()->isUniquePageHit($page, $trackingId);
         }
+
+        // Check if this is a unique page hit
+        $isUnique = $this->getHitRepository()->isUniquePageHit($page, $trackingId, $lead);
 
         if (!empty($page)) {
             if ($page instanceof Page) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The way the uniqueness of a click/visit to a trackable URL is determined was creating inconsistencies in the expected unique click counts. Previously, if a contact had 2 email clients, and clicked the link in each client within a different browser / on a different device (one where the tracking cookie was not already present), then each of those clicks were counted as unique. This is because the code depended on the fact that a tracking cookie was newly generated as a "pre-check" to determining if it was a unique hit. This is incorrect. To properly determine uniqueness, we must determine first if the contact in question clicked the link. Then, if there is no contact associated with the click, fall back to the generated tracking cookie.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Send an email with a trackable link to an address which you have access to on multiple devices / in multiple browsers. 
2. Ensure that a tracking cookie does not exist for you in Mautic on those devices / browsers. (Easiest way is to clear you cookies on your Mautic domain in that browser).
3. Open the email in each browser / on each device, and click the trackable link in each.
4. Go to the email in question, and see that there are 2 unique clicks on your trackable URL, even though you only sent the email to a single contact who clicked it twice. 

#### Steps to test this PR:
1. Apply PR
2. Redo reproduction steps. Instead of 2 unique clicks, you should see only 1 unique, and 2 total. 