### PR TITLE
Fixed lead view endpoints when using a non-admin user

### DIFF
--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -24,6 +24,7 @@ use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Form\RequestTrait;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
+use Mautic\CoreBundle\Security\Exception\PermissionException;
 use Mautic\UserBundle\Entity\User;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Form;
@@ -345,8 +346,12 @@ class CommonApiController extends FOSRestController implements MauticController
         $publishedOnly = $this->request->get('published', 0);
         $minimal       = $this->request->get('minimal', 0);
 
-        if (!$this->security->isGranted($this->permissionBase.':view')) {
-            return $this->accessDenied();
+        try {
+            if (!$this->security->isGranted($this->permissionBase.':view')) {
+                return $this->accessDenied();
+            }
+        } catch (PermissionException $e) {
+            return $this->accessDenied($e->getMessage());
         }
 
         if ($this->security->checkPermissionExists($this->permissionBase.':viewother')
@@ -667,7 +672,7 @@ class CommonApiController extends FOSRestController implements MauticController
      * @param mixed  $entity
      * @param string $action view|create|edit|publish|delete
      *
-     * @return bool
+     * @return bool|Response
      */
     protected function checkEntityAccess($entity, $action = 'view')
     {
@@ -680,7 +685,11 @@ class CommonApiController extends FOSRestController implements MauticController
             return $this->security->hasEntityAccess($ownPerm, $otherPerm, $owner);
         }
 
-        return $this->security->isGranted("{$this->permissionBase}:{$action}");
+        try {
+            return $this->security->isGranted("{$this->permissionBase}:{$action}");
+        } catch (PermissionException $e) {
+            return $this->accessDenied($e->getMessage());
+        }
     }
 
     /**

--- a/app/bundles/CoreBundle/Security/Exception/PermissionBadFormatException.php
+++ b/app/bundles/CoreBundle/Security/Exception/PermissionBadFormatException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Security\Exception;
+
+class PermissionBadFormatException extends PermissionException
+{
+}

--- a/app/bundles/CoreBundle/Security/Exception/PermissionException.php
+++ b/app/bundles/CoreBundle/Security/Exception/PermissionException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Security\Exception;
+
+class PermissionException extends \InvalidArgumentException
+{
+    protected $code = 403;
+}

--- a/app/bundles/CoreBundle/Security/Exception/PermissionNotFoundException.php
+++ b/app/bundles/CoreBundle/Security/Exception/PermissionNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Security\Exception;
+
+class PermissionNotFoundException extends PermissionException
+{
+}

--- a/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
@@ -12,6 +12,8 @@
 namespace Mautic\CoreBundle\Security\Permissions;
 
 use Mautic\CoreBundle\Helper\UserHelper;
+use Mautic\CoreBundle\Security\Exception\PermissionBadFormatException;
+use Mautic\CoreBundle\Security\Exception\PermissionNotFoundException;
 use Mautic\UserBundle\Entity\Permission;
 use Mautic\UserBundle\Entity\User;
 use Symfony\Component\Translation\Translator;
@@ -252,7 +254,7 @@ class CorePermissions
             }
 
             if (count($parts) != 3) {
-                throw new \InvalidArgumentException(
+                throw new PermissionBadFormatException(
                     $this->getTranslator()->trans(
                         'mautic.core.permissions.badformat',
                         ['%permission%' => $permission]
@@ -274,7 +276,7 @@ class CorePermissions
                     if ($allowUnknown) {
                         $permissions[$permission] = false;
                     } else {
-                        throw new \InvalidArgumentException(
+                        throw new PermissionNotFoundException(
                             $this->getTranslator()->trans(
                                 'mautic.core.permissions.notfound',
                                 ['%permission%' => $permission]
@@ -304,7 +306,7 @@ class CorePermissions
         } elseif ($mode == 'RETURN_ARRAY') {
             return $permissions;
         } else {
-            throw new \InvalidArgumentException(
+            throw new PermissionNotFoundException(
                 $this->getTranslator()->trans(
                     'mautic.core.permissions.mode.notfound',
                     ['%mode%' => $mode]

--- a/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
+++ b/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
@@ -114,12 +114,21 @@ class LeadPermissions extends AbstractPermissions
      */
     protected function getSynonym($name, $level)
     {
-        if ($name == 'fields') {
+        if ($name === 'fields') {
             //set some synonyms
             switch ($level) {
                 case 'publishown':
                 case 'publishother':
                     $level = 'full';
+                    break;
+            }
+        }
+
+        if ($name === 'lists') {
+            switch ($level) {
+                case 'view':
+                case 'viewown':
+                    $name = 'leads';
                     break;
             }
         }

--- a/app/bundles/UserBundle/Config/config.php
+++ b/app/bundles/UserBundle/Config/config.php
@@ -257,6 +257,7 @@ return [
                     'monolog.logger',
                     'event_dispatcher',
                     '', // providerKey
+                    'mautic.permission.repository',
                 ],
                 'public' => false,
             ],

--- a/app/bundles/UserBundle/Security/Firewall/AuthenticationListener.php
+++ b/app/bundles/UserBundle/Security/Firewall/AuthenticationListener.php
@@ -205,6 +205,6 @@ class AuthenticationListener implements ListenerInterface
 
         $token->setUser($user);
 
-        $this->tokenStorage->setToken($user);
+        $this->tokenStorage->setToken($token);
     }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When using a non-admin role through the API, get api/contacts will throw an exception that permission lead:leads:view does not exist. This PR fixes this.

This PR further fixes the API system for non-admin users authenticated with OAuth. Such users were never granted the appropriate permissions, and thus denied all API access.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup a role that has view own and other access to contacts.
2. Assign role to a _NON-ADMIN_ user and setup OAuth (1 or 2) API credentials
2A. Seriously - you must test this with a non-admin user.
3. Authenticate with your OAuth credentials to Mautic
4. Hit up the API endpoint api/contacts
5. Will get a 500 error

#### Steps to test this PR:
1. Repeat and will get list of contacts
2. Verify that segments endpoints also works.
