### PR TITLE
[BUGFIX] API will recognize and process incoming form field alias

### DIFF
--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -156,10 +156,10 @@ class FormApiController extends CommonApiController
 
                 $fieldEntityArray           = $fieldEntity->convertToArray();
                 $fieldEntityArray['formId'] = $formId;
-                $fieldEntityArray['alias']  = str_replace('"', '', $fieldEntityArray['alias']);
+                $escapedAlias               = str_replace('"', '', $fieldParams['alias']);
 
-                if (!in_array($fieldEntityArray['alias'], $aliases)) {
-                    $fieldEntityArray['alias'] = $fieldParams['alias'];
+                if (!in_array($escapedAlias, $aliases)) {
+                    $fieldEntityArray['alias'] = $escapedAlias;
                 } else {
                     $fieldEntityArray['alias'] = $fieldModel->generateAlias($fieldEntityArray['label'], $aliases);
                 }

--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -13,6 +13,7 @@ namespace Mautic\FormBundle\Controller\Api;
 
 use Mautic\ApiBundle\Controller\CommonApiController;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Mautic\CoreBundle\Helper\InputHelper;
 
 /**
  * Class FormApiController.
@@ -156,7 +157,7 @@ class FormApiController extends CommonApiController
 
                 $fieldEntityArray           = $fieldEntity->convertToArray();
                 $fieldEntityArray['formId'] = $formId;
-                $escapedAlias               = str_replace('"', '', $fieldParams['alias']);
+                $escapedAlias               = InputHelper::filename($fieldParams['alias']);
 
                 if (!in_array($escapedAlias, $aliases)) {
                     $fieldEntityArray['alias'] = $escapedAlias;

--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -12,8 +12,8 @@
 namespace Mautic\FormBundle\Controller\Api;
 
 use Mautic\ApiBundle\Controller\CommonApiController;
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Mautic\CoreBundle\Helper\InputHelper;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
 /**
  * Class FormApiController.

--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -156,6 +156,7 @@ class FormApiController extends CommonApiController
 
                 $fieldEntityArray           = $fieldEntity->convertToArray();
                 $fieldEntityArray['formId'] = $formId;
+                $fieldEntityArray['alias']  = str_replace('"', '', $fieldEntityArray['alias']);
 
                 if (!in_array($fieldEntityArray['alias'], $aliases)) {
                     $fieldEntityArray['alias'] = $fieldParams['alias'];

--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -156,7 +156,12 @@ class FormApiController extends CommonApiController
 
                 $fieldEntityArray           = $fieldEntity->convertToArray();
                 $fieldEntityArray['formId'] = $formId;
-                $fieldEntityArray['alias']  = $fieldParams['alias']  = $fieldModel->generateAlias($fieldEntityArray['label'], $aliases);
+
+                if (!in_array($fieldEntityArray['alias'], $aliases)) {
+                    $fieldEntityArray['alias'] = $fieldParams['alias'];
+                } else {
+                    $fieldEntityArray['alias'] = $fieldModel->generateAlias($fieldEntityArray['label'], $aliases);
+                }
 
                 $fieldForm = $this->createFieldEntityForm($fieldEntityArray);
                 $fieldForm->submit($fieldParams, 'PATCH' !== $method);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3820
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
In previous versions of Mautic for some odd reason the API would 100% reject form field aliasses that were passed to the API endpoint. I have now changed this. It will now check if the given form already has a field with the alias you pass. If it does, a random one will be generated instead, if it does not, your alias will be used.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
N/A

#### Steps to test this PR:
1. Create a form using the API
2. Set the alias of fields in your API request
3. See the alias appear in the backend of Mautic

#### List deprecations along with the new alternative:
N/A

#### List backwards compatibility breaks:
N/A