### PR TITLE
Fix segment with visited url not contain all contact 

### DIFF
--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -487,7 +487,10 @@ class PageModel extends FormModel
         $query = InputHelper::cleanArray($query);
 
         $hit->setQuery($query);
-        $hit->setUrl((isset($query['page_url'])) ? $query['page_url'] : $request->getRequestUri());
+        $url = (isset($query['page_url'])) ? $query['page_url'] : $request->getRequestUri();
+        // Delete the port 443 to the url
+        $url = str_replace(':443', '', $url);
+        $hit->setUrl($url);
         if (isset($query['page_referrer'])) {
             $hit->setReferer($query['page_referrer']);
         }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When a landing page is visited the port 443 is used for HTTPS/SSL so when we would like create a condition in a segment on the landing page URL, not all contact is added in the segment because we check the exact URL but not with the port 443.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a landing page with a url in HTTPS
2. Go on this landing page with a contact (not a lead)
3. See the click in the statistic in this landing page
4. Create a segment with a condition : URL equals "URL of your landing page"
5. Launch mautic:segments:update
6. See not your contact in your segment

#### Steps to test this PR:
1. Apply this PR (becarefull the url in the database contains port 443)
2. Create a landing page with a url in HTTPS
3. Go on this landing page with a contact (not a lead)
4. See the click in the statistic in this landing page
5. Create a segment with a condition : URL equals "URL of your landing page"
6. Launch mautic:segments:update
7. See not your contact in your segment