### PR TITLE
Fixes typo in mime error message

### DIFF
--- a/app/bundles/CoreBundle/Translations/en_US/validators.ini
+++ b/app/bundles/CoreBundle/Translations/en_US/validators.ini
@@ -11,5 +11,5 @@ mautic.core.theme.missing.config="The theme you tried to install doesn't have th
 mautic.core.theme.default.cannot.overwrite="%name% is the default theme and therefore cannot be overwritten."
 mautic.core.valid_url_required="A valid URL is required."
 mautic.core.theme.upload.empty="The file was not selected. Select a ZIP file to upload."
-mautic.core.invalid_file_type="Invalid file type {{ type }}. Use a file that matches of of the following mime types: {{ types }}."
+mautic.core.invalid_file_type="Invalid file type {{ type }}. Use a file that matches one of the following mime types: {{ types }}."
 mautic.core.not.allowed.file.extension="%extension% is not allowed file extension"


### PR DESCRIPTION
Typo in language string when uploading csv with invalid mime type:

![mautic-error-file-type-pascal-475x305](https://user-images.githubusercontent.com/411678/27700181-b4e51250-5cf4-11e7-930b-af897e4a8bb1.png)
