### PR TITLE
Public Segment bugfix

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/ContactFrequencyType.php
+++ b/app/bundles/LeadBundle/Form/Type/ContactFrequencyType.php
@@ -176,7 +176,19 @@ class ContactFrequencyType extends AbstractType
             }
         }
 
-        if (!$options['public_view'] || $showContactSegments) {
+        if (!$options['public_view']) {
+            $builder->add(
+                'lead_lists',
+                'leadlist_choices',
+                [
+                    'label'      => 'mautic.lead.form.list',
+                    'label_attr' => ['class' => 'control-label'],
+                    'multiple'   => true,
+                    'expanded'   => $options['public_view'],
+                    'required'   => false,
+                ]
+            );
+        } elseif ($showContactSegments) {
             $builder->add(
                 'lead_lists',
                 'leadlist_choices',


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
No public segments can't add to contact from profile in Mautic

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create Public and No Public segment
2.  Enable Show contact preference settings and Show contact segment preferences  from Configurations
3.  Go to contact profile in Mautic and try add to contact No Public segment - does not appear - doesn't work
4.  Send email to contact with unsubscribe link - open unsubscribe link - should see Public segment - works


#### Steps to test this PR:
1.  Applty PR
2.  Check  step 3 from above If works 