### PR TITLE
Minor Code Mode slot container fix

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -1094,8 +1094,8 @@ Mautic.initSlotListeners = function() {
                         extraKeys: {"Ctrl-Space": "autocomplete"},
                         lineWrapping: true,
                     });
-                    Mautic.builderCodeMirror.getDoc().setValue(slot.find('#codemodeHtmlContainer').html());
-                    Mautic.keepPreviewAlive(null, slot.find('#codemodeHtmlContainer'));
+                    Mautic.builderCodeMirror.getDoc().setValue(slot.find('#codemodeHtmlContainer,.codemodeHtmlContainer').html());
+                    Mautic.keepPreviewAlive(null, slot.find('#codemodeHtmlContainer,.codemodeHtmlContainer'));
                 }
             }
 

--- a/app/bundles/CoreBundle/Views/Slots/codemode.html.php
+++ b/app/bundles/CoreBundle/Views/Slots/codemode.html.php
@@ -9,7 +9,7 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 ?>
-<div id="codemodeHtmlContainer">
+<div class="codemodeHtmlContainer">
     <p>Place your content here</p>
 </div>
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
ID html attribute should be unique on page.  Multiple Code Mode slots do not meet the rule.
This PR replace id attribute with class attribute with backward compatibility.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create email with 2 Code Mode slots.
2.  See source code and  two <div id="codemodeHtmlContainer"></div> elements.

#### Steps to test this PR:
1. Apply PR and repeat first step. Run php app/console mautic:assets:generate
2. See source code  and two `<div class="codemodeHtmlContainer"></div>`
3. Also test if builder works like before