### PR TITLE
fix lost submit button on edit view

### DIFF
--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -710,9 +710,15 @@ class FormController extends CommonFormController
             $modifiedFields = [];
             $usedLeadFields = [];
             $existingFields = $entity->getFields()->toArray();
+            $submitButton   = false;
 
             foreach ($existingFields as $formField) {
                 // Check to see if the field still exists
+
+                if ($formField->getAlias() == 'submit' && $formField->getType() == 'button') {
+                    //submit button found
+                    $submitButton = true;
+                }
                 if ($formField->getType() !== 'button' && !isset($availableFields[$formField->getType()])) {
                     continue;
                 }
@@ -739,7 +745,21 @@ class FormController extends CommonFormController
                     $usedLeadFields[$id] = $field['leadField'];
                 }
             }
+            if (!$submitButton) { //means something deleted the submit button from the form
+                //add a submit button
+                $keyId = 'new'.hash('sha1', uniqid(mt_rand()));
+                $field = new Field();
 
+                $modifiedFields[$keyId]                    = $field->convertToArray();
+                $modifiedFields[$keyId]['label']           = $this->translator->trans('mautic.core.form.submit');
+                $modifiedFields[$keyId]['alias']           = 'submit';
+                $modifiedFields[$keyId]['showLabel']       = 1;
+                $modifiedFields[$keyId]['type']            = 'button';
+                $modifiedFields[$keyId]['id']              = $keyId;
+                $modifiedFields[$keyId]['inputAttributes'] = 'class="btn btn-default"';
+                $modifiedFields[$keyId]['formId']          = $objectId;
+                unset($modifiedFields[$keyId]['form']);
+            }
             $session->set('mautic.form.'.$objectId.'.fields.leadfields', $usedLeadFields);
 
             if (!empty($reorder)) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Sometimes it happens that a submit button is lost on a form. This PR fixes this on editing and saving the form.
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. The only way I found to reproduce this bug is to manually delete the submit button field in the form_fields table.

#### Steps to test this PR:
1. Apply this PR, delete the submit button field in the form_fields table
2. go to your form and edit and save the form, the submit button should be there again.