### PR TITLE
Fixing error on batch edit users via API

### DIFF
--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -197,7 +197,6 @@ class User extends FormEntity implements AdvancedUserInterface, \Serializable, E
         $builder->createManyToOne('role', 'Role')
             ->inversedBy('users')
             ->cascadeMerge()
-            ->cascadeDetach()
             ->addJoinColumn('role_id', 'id', false)
             ->build();
 


### PR DESCRIPTION
…rsist them in the entity manager?" on user batch edit via API

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The [memory usage optimizations](https://github.com/mautic/mautic/commit/0f38ee85e2cebff38a905364270f98c3a882a891) cause a problem on batch edit users via API

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run `phpunit --filter UsersTest::testBatchEndpoints` on Mautic API Library
2. You'll get the error `Entities passed to the choice field must be managed. Maybe persist them in the entity manager?`

#### Steps to test this PR:
1. Apply this PR
2. Run the phpunit command again - it will be successful.
