### PR TITLE
Fix custom field saving bug introduced in #4019

### DIFF
--- a/app/bundles/LeadBundle/Event/LeadFieldEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadFieldEvent.php
@@ -32,7 +32,7 @@ class LeadFieldEvent extends CommonEvent
     /**
      * Returns the Field entity.
      *
-     * @return Field
+     * @return LeadField
      */
     public function getField()
     {
@@ -40,9 +40,9 @@ class LeadFieldEvent extends CommonEvent
     }
 
     /**
-     * Sets the Field entity.
+     * Sets the LeadField entity.
      *
-     * @param Field $field
+     * @param LeadField $field
      */
     public function setField(LeadField $field)
     {

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -412,10 +412,12 @@ class FieldModel extends FormModel
 
             try {
                 $leadsSchema->executeChanges();
+                $isCreated = true;
             } catch (DriverException $e) {
                 $this->logger->addWarning($e->getMessage());
 
                 if ($e->getErrorCode() === 1118 /* ER_TOO_BIG_ROWSIZE */) {
+                    $isCreated = false;
                     throw new DBALException($this->translator->trans('mautic.core.error.max.field'));
                 } else {
                     throw $e;
@@ -423,7 +425,7 @@ class FieldModel extends FormModel
             }
 
             // If this is a new contact field, and it was successfully added to the contacts table, save it
-            if ($isNew === false) {
+            if ($isNew === true) {
                 $event = $this->dispatchEvent('pre_save', $entity, $isNew);
                 $this->getRepository()->saveEntity($entity);
                 $this->dispatchEvent('post_save', $entity, $isNew, $event);

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -13,10 +13,12 @@ namespace Mautic\LeadBundle\Model;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Exception\DriverException;
+use Mautic\CoreBundle\Doctrine\Helper\ColumnSchemaHelper;
 use Mautic\CoreBundle\Doctrine\Helper\SchemaHelperFactory;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\LeadBundle\Entity\LeadField;
+use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\LeadBundle\Event\LeadFieldEvent;
 use Mautic\LeadBundle\Helper\FormFieldHelper;
 use Mautic\LeadBundle\LeadEvents;
@@ -282,7 +284,7 @@ class FieldModel extends FormModel
     }
 
     /**
-     * @return \Doctrine\ORM\EntityRepository
+     * @return LeadFieldRepository
      */
     public function getRepository()
     {
@@ -333,6 +335,8 @@ class FieldModel extends FormModel
      * @param   $entity
      * @param   $unlock
      *
+     * @throws DBALException
+     *
      * @return mixed
      */
     public function saveEntity($entity, $unlock = true)
@@ -341,7 +345,7 @@ class FieldModel extends FormModel
             throw new MethodNotAllowedHttpException(['LeadEntity']);
         }
 
-        $isNew = ($entity->getId()) ? false : true;
+        $isNew = $entity->getId() ? false : true;
 
         //set some defaults
         $this->setTimestamps($entity, $isNew, $unlock);
@@ -377,39 +381,49 @@ class FieldModel extends FormModel
             if ($testAlias != $alias) {
                 $alias = $testAlias;
             }
+
             $entity->setAlias($alias);
         }
 
         $type = $entity->getType();
+
         if ($type == 'time') {
             //time does not work well with list filters
             $entity->setIsListable(false);
         }
 
-        $isUnique = $entity->getIsUniqueIdentifier();
+        // Save the entity now if it's an existing entity
+        if (!$isNew) {
+            $event = $this->dispatchEvent('pre_save', $entity, $isNew);
+            $this->getRepository()->saveEntity($entity);
+            $this->dispatchEvent('post_save', $entity, $isNew, $event);
+        }
 
-        //create the field as its own column in the leads table
+        // Create the field as its own column in the leads table.
+        /** @var ColumnSchemaHelper $leadsSchema */
         $leadsSchema = $this->schemaHelperFactory->getSchemaHelper('column', $object);
-        if ($isNew || (!$isNew && !$leadsSchema->checkColumnExists($alias))) {
+        $isUnique    = $entity->getIsUniqueIdentifier();
+
+        // If the column does not exist in the contacts table, add it
+        if (!$leadsSchema->checkColumnExists($alias)) {
             $schemaDefinition = self::getSchemaDefinition($alias, $type, $isUnique);
-            $leadsSchema->addColumn(
-                $schemaDefinition
-            );
+
+            $leadsSchema->addColumn($schemaDefinition);
 
             try {
                 $leadsSchema->executeChanges();
-                $isCreated = true;
             } catch (DriverException $e) {
                 $this->logger->addWarning($e->getMessage());
+
                 if ($e->getErrorCode() === 1118 /* ER_TOO_BIG_ROWSIZE */) {
-                    $isCreated = false;
                     throw new DBALException($this->translator->trans('mautic.core.error.max.field'));
                 } else {
                     throw $e;
                 }
             }
 
-            if ($isCreated === true) {
+            // If this is a new contact field, and it was successfully added to the contacts table, save it
+            if ($isNew === false) {
                 $event = $this->dispatchEvent('pre_save', $entity, $isNew);
                 $this->getRepository()->saveEntity($entity);
                 $this->dispatchEvent('post_save', $entity, $isNew, $event);
@@ -418,10 +432,12 @@ class FieldModel extends FormModel
             // Update the unique_identifier_search index and add an index for this field
             /** @var \Mautic\CoreBundle\Doctrine\Helper\IndexSchemaHelper $modifySchema */
             $modifySchema = $this->schemaHelperFactory->getSchemaHelper('index', $object);
+
             if ('string' == $schemaDefinition['type']) {
                 try {
                     $modifySchema->addIndex([$alias], $alias.'_search');
                     $modifySchema->allowColumn($alias);
+
                     if ($isUnique) {
                         // Get list of current uniques
                         $uniqueIdentifierFields = $this->getUniqueIdentifierFields();
@@ -435,6 +451,7 @@ class FieldModel extends FormModel
                         $indexColumns = array_slice($indexColumns, 0, 3);
                         $modifySchema->addIndex($indexColumns, 'unique_identifier_search');
                     }
+
                     $modifySchema->executeChanges();
                 } catch (DriverException $e) {
                     if ($e->getErrorCode() === 1069 /* ER_TOO_MANY_KEYS */) {
@@ -446,7 +463,7 @@ class FieldModel extends FormModel
             }
         }
 
-        //update order of other fields
+        // Update order of the other fields.
         $this->reorderFieldsByEntity($entity);
     }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
PR #4019 introduced a bug that modification to custom fields were never saved unless that field was not already added as a column to the leads table. This PR fixes that by always saving the entity if it was an existing entity prior to checking if it exists as a column on the leads table. New fields are only saved if they are successfully created as a column.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. On current staging, make modifications to the label of a custom field
2. Save the custom field.
3. The changes will show on the list view page.
4. Refresh the page, you'll see in the list view those changes aren't there.
5. Go back into the custom field edit screen, and see that the changes you made weren't persisted.

#### Steps to test this PR:
1. Apply PR, retest
2. Changes are properly persisted
