### PR TITLE
Don't use composer test on travis to prevent timeouts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 script:
 
   # Run PHPUnit
-  - composer test
+  - phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist
 
   # Run PHPSTAN analysis for PHP 7+
   - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.6" ]]; then ~/.composer/vendor/phpstan/phpstan-shim/phpstan.phar analyse app/bundles/CampaignBundle app/bundles/WebhookBundle; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 script:
 
   # Run PHPUnit
-  - phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist
+  - bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist
 
   # Run PHPSTAN analysis for PHP 7+
   - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.6" ]]; then ~/.composer/vendor/phpstan/phpstan-shim/phpstan.phar analyse app/bundles/CampaignBundle app/bundles/WebhookBundle; fi


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Travis would timeout if PHPUnit tests took longer than 300 seconds due to composer script configuration. This PR changes the travis script to not use `composer test` but rather call `phpunit` directly.

This will be considered passed if travis says so.