### PR TITLE
BugFix - Displaying array values on Request EventListener shows warning

### DIFF
--- a/app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php
@@ -47,8 +47,8 @@ class IntegrationSubscriber extends CommonSubscriber
         }, array_keys($event->getHeaders()), array_values($event->getHeaders()))) : '';
 
         $params = (count($event->getParameters())) ? implode(PHP_EOL, array_map(function ($k, $v) {
-            if (is_object($v)) {
-                return "$k=(object)";
+            if (is_object($v) || is_array($v)) {
+                return "$k=".json_encode($v, JSON_PRETTY_PRINT);
             }
 
             return "$k=$v";


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
When running `app/console mautic:integration:fetchleads ` and a request parameter is an array, a warning will be displayed:
```
PHP Notice:  Array to string conversion in app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php on line 54
```
This PR fixes this problem by returning the value as a JSON string.

