### PR TITLE
Set display values for select box on condition forms to show correct value/label instead of [Object object]

### DIFF
--- a/app/bundles/FormBundle/Controller/AjaxController.php
+++ b/app/bundles/FormBundle/Controller/AjaxController.php
@@ -78,7 +78,22 @@ class AjaxController extends CommonAjaxController
                 $options    = [];
 
                 if (!empty($properties['list']['list'])) {
-                    $options = $properties['list']['list'];
+                    //If the field is a SELECT field then the data gets stored in [list][list]
+                    $optionList = $properties['list']['list'];
+                } elseif (!empty($properties['optionlist']['list'])) {
+                    //If the field is a radio or a checkbox then it will be stored in [optionlist][list]
+                    $optionList = $properties['optionlist']['list'];
+                }
+                if (!empty($optionList)) {
+                    foreach ($optionList as $listItem) {
+                        if (is_array($listItem) && isset($listItem['value']) && isset($listItem['label'])) {
+                            //The select box needs values to be [value] => label format so make sure we have that style then put it in
+                            $options[$listItem['value']] = $listItem['label'];
+                        } elseif (!is_array($listItem)) {
+                            //Keeping for BC
+                            $options[] = $listItem;
+                        }
+                    }
                 }
 
                 $fields[] = [

--- a/app/bundles/FormBundle/Form/Type/CampaignEventFormFieldValueType.php
+++ b/app/bundles/FormBundle/Form/Type/CampaignEventFormFieldValueType.php
@@ -101,7 +101,13 @@ class CampaignEventFormFieldValueType extends AbstractType
                         if (!empty($properties['list']['list'])) {
                             $options[$field->getAlias()] = [];
                             foreach ($properties['list']['list'] as $option) {
-                                $options[$field->getAlias()][$option] = $option;
+                                if (is_array($option) && isset($option['value']) && isset($option['label'])) {
+                                    //The select box needs values to be [value] => label format so make sure we have that style then put it in
+                                    $options[$field->getAlias()][$option['value']] = $option['label'];
+                                } elseif (!is_array($option)) {
+                                    //Kept here for BC
+                                    $options[$field->getAlias()][$option] = $option;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION


[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? |  Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |  #4323 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fixed the listing of select items as associative array instead of [label => '' , value => ''] items
Added missing radio options to show select drop down box

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Campiagns New
2. launch campiagn Builder
3. Conditions > Form Field Value
4. Add a 'select' field into the form with at least 1 valid option
5. Limit to Forms: Choose form
6. Field: Select the Drop List Field
7. Operator: equals
8. Values: When I try to select a value I am greeted with [object Object] for both of the choices so do bot know which is which.

#### Steps to test this PR:

##### Test 1:
1. Campiagns New
2. launch campiagn Builder
3. Conditions > Form Field Value
4. Add a 'select' field into the form with at least 1 valid option
5. Limit to Forms: Choose form
6. Field: Select the Drop List Field
7. Operator: equals
8. Values: When I try to select a value I am greeted with **The values entered in step 4** for both of the choices so do bot know which is which.

##### Test 2:
1. Campiagns New
2. launch campiagn Builder
3. Conditions > Form Field Value
4. Add a 'radio' field into the form with at least 1 valid option
5. Limit to Forms: Choose form
6. Field: Select the Drop List Field
7. Operator: equals
8. Values: When I try to select a value I am greeted with **The values entered in step 4** for both of the choices so do bot know which is which.

#### List backwards compatibility breaks:
1. Possibly some BC breaking with values if any rely on the display values from select/radios using the label/value arrays