### PR TITLE
Fix name of select options parsed by AbstractFormFieldHelper:: parseList

### DIFF
--- a/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
+++ b/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
@@ -152,7 +152,7 @@ abstract class AbstractFormFieldHelper
                     $label = $val;
                 }
 
-                $choices[trim(html_entity_decode($label, ENT_QUOTES))] = trim(html_entity_decode($val, ENT_QUOTES));
+                $choices[trim(html_entity_decode($val, ENT_QUOTES))] = trim(html_entity_decode($label, ENT_QUOTES));
             }
         }
 

--- a/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
+++ b/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
@@ -152,7 +152,7 @@ abstract class AbstractFormFieldHelper
                     $label = $val;
                 }
 
-                $choices[trim(html_entity_decode($val, ENT_QUOTES))] = trim(html_entity_decode($val, ENT_QUOTES));
+                $choices[trim(html_entity_decode($label, ENT_QUOTES))] = trim(html_entity_decode($val, ENT_QUOTES));
             }
         }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
PR fixs app/bundles/CoreBundle/Form/Type/SortableListType.php
This form type use Mobile Notifcations and new https://github.com/mautic/mautic/pull/4357
Labels was replaced by values everytime.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Enable Mobile notifciation
2. Add mobile notifciaon
3. Add data with different labels and values  in Additional Data tab
4.  Save and  labels was replaced by values

#### Steps to test this PR:
1.  Repeat reproduce steps and check if works


#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 