### PR TITLE
Fixes encoding characters that come in contact fields

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
@@ -222,8 +222,8 @@ trait EntityFieldsBuildFormTrait
                             break;
                         case 'email':
                             // Enforce a valid email
-                            unset($attr['data-encoding']);
-                            $constraints[] = new Email(
+                            $attr['data-encoding'] = 'email';
+                            $constraints[]         = new Email(
                                 [
                                     'message' => 'mautic.core.email.required',
                                 ]

--- a/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
@@ -228,14 +228,15 @@ trait EntityFieldsBuildFormTrait
                             );
                             break;
                     }
-
+                    $attr['data-encoding'] = 'RAW';
                     $builder->add(
                         $alias,
                         $type,
                         [
-                            'required'    => $field['isRequired'],
-                            'label'       => $field['label'],
-                            'label_attr'  => ['class' => 'control-label'],
+                            'required'   => $field['isRequired'],
+                            'label'      => $field['label'],
+                            'label_attr' => ['class' => 'control-label'],
+
                             'attr'        => $attr,
                             'data'        => $value,
                             'mapped'      => $mapped,

--- a/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
@@ -222,8 +222,8 @@ trait EntityFieldsBuildFormTrait
                             break;
                         case 'email':
                             // Enforce a valid email
-                            $attr['data-encoding'] = 'email';
-                            $constraints[]         = new Email(
+                            unset($attr['data-encoding']);
+                            $constraints[] = new Email(
                                 [
                                     'message' => 'mautic.core.email.required',
                                 ]

--- a/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
@@ -221,14 +221,15 @@ trait EntityFieldsBuildFormTrait
                             break;
                         case 'email':
                             // Enforce a valid email
-                            $constraints[] = new Email(
+                            $attr['data-encoding'] = 'email';
+                            $constraints[]         = new Email(
                                 [
                                     'message' => 'mautic.core.email.required',
                                 ]
                             );
                             break;
                     }
-                    $attr['data-encoding'] = 'RAW';
+                    $attr['data-encoding'] = 'raw';
                     $builder->add(
                         $alias,
                         $type,

--- a/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
@@ -208,6 +208,7 @@ trait EntityFieldsBuildFormTrait
                     );
                     break;
                 default:
+                    $attr['data-encoding'] = 'raw';
                     switch ($type) {
                         case 'lookup':
                             $type                = 'text';
@@ -229,7 +230,7 @@ trait EntityFieldsBuildFormTrait
                             );
                             break;
                     }
-                    $attr['data-encoding'] = 'raw';
+
                     $builder->add(
                         $alias,
                         $type,

--- a/app/bundles/LeadBundle/Form/Type/LeadType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadType.php
@@ -199,7 +199,7 @@ class LeadType extends AbstractType
             );
         }
 
-        $builder->addEventSubscriber(new CleanFormSubscriber(['clean', 'RAW'])); //move this to the end array masks to get form fields make reference hydrate in
+        $builder->addEventSubscriber(new CleanFormSubscriber(['clean', 'raw']));
 
         if (!empty($options['action'])) {
             $builder->setAction($options['action']);

--- a/app/bundles/LeadBundle/Form/Type/LeadType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadType.php
@@ -199,7 +199,7 @@ class LeadType extends AbstractType
             );
         }
 
-        $builder->addEventSubscriber(new CleanFormSubscriber(['clean', 'raw']));
+        $builder->addEventSubscriber(new CleanFormSubscriber(['clean', 'raw', 'email' => 'email']));
 
         if (!empty($options['action'])) {
             $builder->setAction($options['action']);

--- a/app/bundles/LeadBundle/Form/Type/LeadType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadType.php
@@ -49,7 +49,6 @@ class LeadType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->addEventSubscriber(new CleanFormSubscriber());
         $builder->addEventSubscriber(new FormExitSubscriber('lead.lead', $options));
 
         if (!$options['isShortForm']) {
@@ -199,6 +198,8 @@ class LeadType extends AbstractType
                 ]
             );
         }
+
+        $builder->addEventSubscriber(new CleanFormSubscriber(['clean', 'RAW'])); //move this to the end array masks to get form fields make reference hydrate in
 
         if (!empty($options['action'])) {
             $builder->setAction($options['action']);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When creating Contacts through the UI, the API and through integrations and imports. Values that may have certain characters like & get encoded, resulting in various errors.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. create a user through the API or the UI, containing an & sign
2. check in your database and see encoded value

#### Steps to test this PR:
1. Apply this PR and create a new contact with ampersand or edit existing one
2. Look in your database and values should not be encoded