### PR TITLE
Fixed bug where custom tokens were not made available to dynamic email content

### DIFF
--- a/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
@@ -135,6 +135,9 @@ class DynamicContentSubscriber extends CommonSubscriber
         $this->auditLogModel->writeToLog($log);
     }
 
+    /**
+     * @param MauticEvents\TokenReplacementEvent $event
+     */
     public function onTokenReplacement(MauticEvents\TokenReplacementEvent $event)
     {
         /** @var Lead $lead */

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -14,7 +14,6 @@ namespace Mautic\EmailBundle\Controller\Api;
 use FOS\RestBundle\Util\Codes;
 use Mautic\ApiBundle\Controller\CommonApiController;
 use Mautic\CoreBundle\Helper\InputHelper;
-use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\LeadBundle\Controller\LeadAccessTrait;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,9 +21,6 @@ use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
 /**
  * Class EmailApiController.
- *
- * @property EmailModel $model
- *
  */
 class EmailApiController extends CommonApiController
 {
@@ -134,7 +130,7 @@ class EmailApiController extends CommonApiController
             $cleanTokens = [];
 
             foreach ($tokens as $token => $value) {
-                $value =  InputHelper::clean($value);
+                $value = InputHelper::clean($value);
                 if (!preg_match('/^{.*?}$/', $token)) {
                     $token = '{'.$token.'}';
                 }

--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -292,9 +292,15 @@ class EmailSendEvent extends CommonEvent
      *
      * @return array
      */
-    public function getTokens()
+    public function getTokens($includeGlobal = true)
     {
-        return $this->tokens;
+        $tokens = $this->tokens;
+
+        if ($includeGlobal && null !== $this->helper) {
+            $tokens = array_merge($this->helper->getGlobalTokens(), $tokens);
+        }
+
+        return $tokens;
     }
 
     /**

--- a/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
@@ -50,13 +50,17 @@ class TokenSubscriber extends CommonSubscriber
             $event->setPlainText($plainText);
         }
 
-        $lead                  = $event->getLead();
-        $email                 = $event->getEmail();
-        $tokens                = $event->getTokens();
-        $dynamicContentAsArray = $email instanceof Email ? $email->getDynamicContent() : null;
-
-        if (!empty($dynamicContentAsArray)) {
-            $tokenEvent = new TokenReplacementEvent(null, $lead, ['tokens' => $tokens, 'lead' => null, 'dynamicContent' => $dynamicContentAsArray]);
+        $email = $event->getEmail();
+        if ($dynamicContentAsArray = $email instanceof Email ? $email->getDynamicContent() : null) {
+            $lead       = $event->getLead();
+            $tokens     = $event->getTokens();
+            $tokenEvent = new TokenReplacementEvent(
+                null, $lead, [
+                    'tokens'         => $tokens,
+                    'lead'           => null,
+                    'dynamicContent' => $dynamicContentAsArray
+                ]
+            );
             $this->dispatcher->dispatch(EmailEvents::TOKEN_REPLACEMENT, $tokenEvent);
             $event->addTokens($tokenEvent->getTokens());
         }

--- a/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
@@ -58,7 +58,7 @@ class TokenSubscriber extends CommonSubscriber
                 null, $lead, [
                     'tokens'         => $tokens,
                     'lead'           => null,
-                    'dynamicContent' => $dynamicContentAsArray
+                    'dynamicContent' => $dynamicContentAsArray,
                 ]
             );
             $this->dispatcher->dispatch(EmailEvents::TOKEN_REPLACEMENT, $tokenEvent);

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -935,8 +935,6 @@ class MailHelper
 
     /**
      * Set plain text for $this->message, replacing if necessary.
-     *
-     * @return null|string
      */
     protected function setMessagePlainText()
     {
@@ -1270,7 +1268,7 @@ class MailHelper
     }
 
     /**
-     * @return null
+     * @return string|null
      */
     public function getIdHash()
     {

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -21,6 +21,7 @@ use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\EmailBundle\Swiftmailer\Exception\BatchQueueMaxException;
 use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
 use Mautic\EmailBundle\Swiftmailer\Transport\InterfaceTokenTransport;
+use Mautic\LeadBundle\Entity\Lead;
 
 /**
  * Class MailHelper.
@@ -1268,6 +1269,9 @@ class MailHelper
         }
     }
 
+    /**
+     * @return null
+     */
     public function getIdHash()
     {
         return $this->idHash;
@@ -1293,6 +1297,9 @@ class MailHelper
         $this->message->leadIdHash = $idHash;
     }
 
+    /**
+     * @return Lead
+     */
     public function getLead()
     {
         return $this->lead;
@@ -1532,6 +1539,14 @@ class MailHelper
     }
 
     /**
+     * @return array
+     */
+    public function getGlobalTokens()
+    {
+        return $this->globalTokens;
+    }
+
+    /**
      * Parses html into basic plaintext.
      *
      * @param string $content
@@ -1595,7 +1610,7 @@ class MailHelper
 
         $this->dispatcher->dispatch(EmailEvents::EMAIL_ON_SEND, $event);
 
-        $this->eventTokens = array_merge($this->eventTokens, $event->getTokens());
+        $this->eventTokens = array_merge($this->eventTokens, $event->getTokens(false));
 
         unset($event);
     }

--- a/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
@@ -11,7 +11,6 @@
 
 namespace Mautic\EmailBundle\Test\EventListener;
 
-
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Event\EmailSendEvent;
@@ -33,7 +32,7 @@ class TokenSubscriberTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $tokens = [
-            '{test}' => 'value'
+            '{test}' => 'value',
         ];
 
         $mailHelper = new MailHelper($mockFactory, $swiftMailer);
@@ -41,7 +40,7 @@ class TokenSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $email = new Email();
         $email->setCustomHtml(
-            <<<CONTENT
+            <<<'CONTENT'
 <html xmlns="http://www.w3.org/1999/xhtml">
     <body style="margin: 0px; cursor: auto;" class="ui-sortable">
         <div data-section-wrapper="1">
@@ -76,17 +75,17 @@ CONTENT
                                 'content' => null,
                                 'filters' => [
 
-                                ]
-                            ]
-                        ]
+                                ],
+                            ],
+                        ],
                     ],
                     [
                         'tokenName' => 'Dynamic Content 2',
                         'content'   => 'DEC {test}',
                         'filters'   => [
 
-                        ]
-                    ]
+                        ],
+                    ],
                 ]
             );
         $mailHelper->setEmail($email);

--- a/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Test\EventListener;
+
+
+use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Event\EmailSendEvent;
+use Mautic\EmailBundle\EventListener\TokenSubscriber;
+use Mautic\EmailBundle\Helper\MailHelper;
+use Mautic\LeadBundle\Entity\Lead;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class TokenSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDynamicContentCustomTokens()
+    {
+        $mockFactory = $this->getMockBuilder(MauticFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $swiftMailer = $this->getMockBuilder(\Swift_Mailer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $tokens = [
+            '{test}' => 'value'
+        ];
+
+        $mailHelper = new MailHelper($mockFactory, $swiftMailer);
+        $mailHelper->setTokens($tokens);
+
+        $email = new Email();
+        $email->setCustomHtml(
+            <<<CONTENT
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <body style="margin: 0px; cursor: auto;" class="ui-sortable">
+        <div data-section-wrapper="1">
+            <center>
+                <table data-section="1" style="width: 600;" width="600" cellpadding="0" cellspacing="0">
+                    <tbody>
+                        <tr>
+                            <td>
+                                <div data-slot-container="1" style="min-height: 30px">
+                                    <div data-slot="text"><br /><h2>Hello there!</h2><br />{test} test We haven't heard from you for a while...<a href="https://google.com">check this link</a><br /><br />{unsubscribe_text} | {webview_text}</div>{dynamiccontent="Dynamic Content 2"}<div data-slot="codemode">
+                                    <div id="codemodeHtmlContainer">
+    <p>Place your content here {test}</p></div>
+
+                                </div>
+                                </div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </center>
+        </div>
+</body></html>
+CONTENT
+        )
+            ->setDynamicContent(
+                [
+                    [
+                        'tokenName' => 'Dynamic Content 1',
+                        'content'   => 'Default Dynamic Content',
+                        'filters'   => [
+                            [
+                                'content' => null,
+                                'filters' => [
+
+                                ]
+                            ]
+                        ]
+                    ],
+                    [
+                        'tokenName' => 'Dynamic Content 2',
+                        'content'   => 'DEC {test}',
+                        'filters'   => [
+
+                        ]
+                    ]
+                ]
+            );
+        $mailHelper->setEmail($email);
+
+        $lead = new Lead();
+        $lead->setEmail('hello@someone.com');
+        $mailHelper->setLead($lead);
+
+        /** @var TokenSubscriber $subscriber */
+        $subscriber = $this->getMockBuilder(TokenSubscriber::class)
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber($subscriber);
+        $subscriber->setDispatcher($dispatcher);
+
+        $event = new EmailSendEvent($mailHelper);
+
+        $subscriber->decodeTokens($event);
+
+        $eventTokens = $event->getTokens(false);
+        $this->assertEquals(
+            $eventTokens,
+            [
+                '{dynamiccontent="Dynamic Content 1"}' => 'Default Dynamic Content',
+                '{dynamiccontent="Dynamic Content 2"}' => 'DEC value',
+            ]
+        );
+        $mailHelper->addTokens($eventTokens);
+        $mailerTokens = $mailHelper->getTokens();
+        $mailHelper->message->setBody($email->getCustomHtml());
+
+        MailHelper::searchReplaceTokens(array_keys($mailerTokens), $mailerTokens, $mailHelper->message);
+        $parsedBody = $mailHelper->message->getBody();
+
+        $this->assertNotFalse(strpos($parsedBody, 'DEC value'));
+        $this->assertNotFalse(strpos($parsedBody, 'value test We'));
+        $this->assertNotFalse(strpos($parsedBody, 'Place your content here value'));
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When using the /emails/ID/contact/ID/send endpoint with custom tokens, those tokens were required to have brackets and dynamic email content did not recognize custom tokens. This PR fixes this.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create an email and insert somewhere in a text slot `{test}` then create a dynamic email slot and insert the same token into it.
2. Send an email to a contact using the API endpoint above. Post an equivalent body of: 
```
{"tokens":{"test":"value"}}
```
3. Note that neither token is replaced or replaced incorrectly.  

#### Steps to test this PR:
1. Repeat the above and this time both tokens in the text slot and the dec slot should be replaced with `value`
2. Run the new tests

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 