### PR TITLE
BugFix - HubSpot integration: undefined method named "pushLeads"

### DIFF
--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -86,6 +86,14 @@ class HubspotIntegration extends CrmAbstractIntegration
     /**
      * @return array
      */
+    public function getSupportedFeatures()
+    {
+        return ['push_lead', 'get_leads'];
+    }
+
+    /**
+     * @return array
+     */
     public function getFormSettings()
     {
         $enableDataPriority = $this->getDataPriority();


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4085
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
When executing `app/console mautic:integration:fetchleads -i Hubspot` an error is thrown because the `pushLeads` method does not exist.

#### Steps to reproduce the bug:
1. See https://github.com/mautic/mautic/issues/4085

#### Steps to test this PR:
1. Apply this PR
2. The error will not show anymore.

