### PR TITLE
Fixed API inconsistencies

### DIFF
--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -31,12 +31,22 @@ trait RequestTrait
                 switch ($type) {
                     case 'yesno_button_group':
                         if (is_object($entity)) {
+                            $setter = 'set'.ucfirst($name);
                             // Symfony fails to recognize true values on PATCH and add support for all boolean types (on, off, true, false, 1, 0)
                             $data = filter_var($params[$name], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
                             if ($data === null) {
-                                throw new \Exception('Boolean: value not accepted');
+                                throw new \Exception('boolean: value not accepted');
                             }
-                            $params[$name] = $data;
+                            $data = (bool) $data;
+                            try {
+                                $entity->$setter($data);
+
+                                // Manually handled so remove from form processing
+                                unset($form[$name], $params[$name]);
+                                break;
+                            } catch (\InvalidArgumentException $exception) {
+                            }
+                            $params[$name] = (bool) $data;
                         }
                         break;
                     case 'choice':

--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -46,7 +46,7 @@ trait RequestTrait
                                 break;
                             } catch (\InvalidArgumentException $exception) {
                             }
-                            $params[$name] = (bool) $data;
+                            $params[$name] = $data;
                         }
                         break;
                     case 'choice':

--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -32,17 +32,8 @@ trait RequestTrait
                     case 'yesno_button_group':
                         if (is_object($entity)) {
                             // Symfony fails to recognize true values on PATCH and add support for all boolean types (on, off, true, false, 1, 0)
-                            $setter = 'set'.ucfirst($name);
-                            $data   = filter_var($params[$name], FILTER_VALIDATE_BOOLEAN);
-
-                            try {
-                                $entity->$setter((int) $data);
-
-                                // Manually handled so remove from form processing
-                                unset($form[$name], $params[$name]);
-                            } catch (\InvalidArgumentException $exception) {
-                                // Setter not found
-                            }
+                            $data          = filter_var($params[$name], FILTER_VALIDATE_BOOLEAN);
+                            $params[$name] = (int) $data;
                         }
                         break;
                     case 'choice':

--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -32,8 +32,11 @@ trait RequestTrait
                     case 'yesno_button_group':
                         if (is_object($entity)) {
                             // Symfony fails to recognize true values on PATCH and add support for all boolean types (on, off, true, false, 1, 0)
-                            $data          = filter_var($params[$name], FILTER_VALIDATE_BOOLEAN);
-                            $params[$name] = (int) $data;
+                            $data = filter_var($params[$name], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+                            if ($data === null) {
+                                throw new \Exception('Boolean: value not accepted');
+                            }
+                            $params[$name] = $data;
                         }
                         break;
                     case 'choice':

--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -33,14 +33,10 @@ trait RequestTrait
                         if (is_object($entity)) {
                             $setter = 'set'.ucfirst($name);
                             // Symfony fails to recognize true values on PATCH and add support for all boolean types (on, off, true, false, 1, 0)
-                            $data = filter_var($params[$name], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
-                            if ($data === null) {
-                                throw new \Exception('boolean: value not accepted');
-                            }
+                            $data = filter_var($params[$name], FILTER_VALIDATE_BOOLEAN);
                             $data = (bool) $data;
                             try {
                                 $entity->$setter($data);
-
                                 // Manually handled so remove from form processing
                                 unset($form[$name], $params[$name]);
                                 break;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When creating a new contact through the api, a boolean value of 'True', 'Yes', 'On' or anything that would compute to true or false other than 1 or 0 would give an error. But when updating these values where taken as valid. This PR will now allow these values when creating new contacts through the API.
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. create a new contact through the API with a boolean value of True. this will error
2. update an existing contact through the API with a boolean value of True this is valid

#### Steps to test this PR:
1. Apply PR and follow steps 1 and 2 above
2. Both cases will be valid