### PR TITLE
Set Primary company when reassigning an existing contact company

### DIFF
--- a/app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
@@ -21,23 +21,25 @@ class CompanyLeadRepository extends CommonRepository
     /**
      * @param CompanyLead[] $entities
      */
-    public function saveEntities($entities)
+    public function saveEntities($entities, $new = true)
     {
         // Get a list of contacts and set primary to 0
-        $contacts = [];
-        foreach ($entities as $entity) {
-            $contactId            = $entity->getLead()->getId();
-            $contacts[$contactId] = $contactId;
-            $entity->setPrimary(true);
-        }
-        if ($contactId) {
-            $qb = $this->getEntityManager()->getConnection()->createQueryBuilder()
-                ->update(MAUTIC_TABLE_PREFIX.'companies_leads')
-                ->set('is_primary', 0);
+        if ($new) {
+            $contacts = [];
+            foreach ($entities as $entity) {
+                $contactId            = $entity->getLead()->getId();
+                $contacts[$contactId] = $contactId;
+                $entity->setPrimary(true);
+            }
+            if ($contactId) {
+                $qb = $this->getEntityManager()->getConnection()->createQueryBuilder()
+                    ->update(MAUTIC_TABLE_PREFIX.'companies_leads')
+                    ->set('is_primary', 0);
 
-            $qb->where(
-                $qb->expr()->in('lead_id', $contactId)
-            )->execute();
+                $qb->where(
+                    $qb->expr()->in('lead_id', $contacts)
+                )->execute();
+            }
         }
 
         return parent::saveEntities($entities);

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -369,7 +369,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
             }
         }
 
-        unset($lead, $persistCompany, $companies);
+        //unset($lead, $persistCompany, $companies);
 
         return $contactAdded;
     }

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -456,7 +456,7 @@ class LeadModel extends FormModel
         if (!empty($company)) {
             // Save after the lead in for new leads created through the API and maybe other places
             $this->companyModel->addLeadToCompany($companyEntity, $entity);
-            $this->em->detach($companyEntity);
+            $this->setPrimaryCompany($companyEntity->getId(), $entity->getId());
         }
         $this->em->clear(CompanyChangeLog::class);
     }
@@ -2674,19 +2674,13 @@ class LeadModel extends FormModel
         $companyLeads = $this->companyModel->getCompanyLeadRepository()->getEntitiesByLead($lead);
 
         foreach ($companyLeads as $companyLead) {
-            $company     = $companyLead->getCompany();
-            $companyLead = $this->companyModel->getCompanyLeadRepository()->findOneBy(
-                [
-                    'lead'    => $lead,
-                    'company' => $company,
-                ]
-            );
+            $company = $companyLead->getCompany();
+
             if ($companyLead) {
-                if ($companyLead->getPrimary()) {
+                if ($companyLead->getPrimary() && !$oldPrimaryCompany) {
                     $oldPrimaryCompany = $companyLead->getCompany()->getId();
                 }
-
-                if ($company->getId() == $companyId and !$companyLead->getPrimary()) {
+                if ($company->getId() === (int) $companyId) {
                     $companyLead->setPrimary(true);
                     $newPrimaryCompany = $companyId;
                     $lead->addUpdatedField('company', $company->getName());
@@ -2707,7 +2701,7 @@ class LeadModel extends FormModel
 
         if (!empty($companyArray)) {
             $this->em->getRepository('MauticLeadBundle:Lead')->saveEntity($lead);
-            $this->companyModel->getCompanyLeadRepository()->saveEntities($companyArray);
+            $this->companyModel->getCompanyLeadRepository()->saveEntities($companyArray, false);
         }
 
         return ['oldPrimary' => $oldPrimaryCompany, 'newPrimary' => $companyId];


### PR DESCRIPTION
…s different from the UI

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
if a contact gets reassigned a company that it already has assigned, but it's not set as primary. This company should be assigned as primary. Since our rule is that a contact's primary company is the one set last.
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. you need a  contact that has multiple companies assigned Company A (primary), Company B
2. update this contact through an integration with Company B. You will see the company in the contact text field set as Company B, but in the company_leads table Company A will still be set as primary.

#### Steps to test this PR:
1. Apply this pr and follow steps 1 and 2
2. Now Company B should also be set as primary company
