### PR TITLE
Prevent a Mautic user from being tracked as a contact 

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -802,9 +802,17 @@ class LeadModel extends FormModel
             return $this->systemCurrentLead;
         }
 
+        if (!$this->security->isAnonymous()) {
+            // this is a Mautic user that's somehow tracked as a contact which we're going to ignore
+            $this->logger->addDebug('LEAD: In a Mautic user session');
+
+            return new Lead();
+        }
+
         if ($this->request) {
             $this->logger->addDebug('LEAD: Tracking session for '.$this->request->getMethod().' '.$this->request->getRequestUri());
         }
+
         list($trackingId, $generated) = $this->getTrackingCookie();
         $this->logger->addDebug("LEAD: Tracking ID for this contact is {$trackingId} (".(int) $generated.')');
 

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -469,7 +469,7 @@ class PageModel extends FormModel
             $lead = $this->leadModel->getContactFromRequest($query, $this->trackByFingerprint);
         }
 
-        if ($lead && !$lead->getId()) {
+        if (!$lead || !$lead->getId()) {
             // Lead came from a non-trackable IP so ignore
             return;
         }


### PR DESCRIPTION
… the contact last activity date to be updated but no history recorded

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form that has fields set to populate with known contact values
2. Create a landing page and embed the form
3. While not logged into Mautic, browse to the landing page
4. Determine your contact ID by viewing your cookies. Look for mautic_session_id then find the cookie that has the same name as the value of that cookie. The value of the second cookie is your contact ID. 
5. Login to Mautic in a separate tab
6. Got to contacts and find the contact your being tracked as
7. Wait at least one minute then refresh the landing page
8. Notice the last active date on the contact will update but no new activity exists in the timeline

#### Steps to test this PR:
1. Apply the PR and repeat steps 7 and 8 above. The last activity date should not update

