### PR TITLE
BugFix - Tokens are only visible in the builder if user has lead:fields:full permissions

### DIFF
--- a/app/bundles/LeadBundle/EventListener/EmailSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/EmailSubscriber.php
@@ -53,7 +53,8 @@ class EmailSubscriber extends CommonSubscriber
     public function onEmailBuild(EmailBuilderEvent $event)
     {
         $tokenHelper = new BuilderTokenHelper($this->factory, 'lead.field', 'lead:fields', 'MauticLeadBundle');
-        $tokenHelper->setPermissionSet(['lead:fields:full']);
+        // the permissions are for viewing contact data, not for managing contact fields
+        $tokenHelper->setPermissionSet(['lead:leads:viewown', 'lead:leads:viewother']);
 
         if ($event->tokensRequested(self::$leadFieldRegex)) {
             $event->addTokensFromHelper($tokenHelper, self::$leadFieldRegex, 'label', 'alias', true);


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
When a user clicks on the add tokens button in the editor, the list is not complete unless the user is an admin or has the  lead:fields:full permission set.

#### Steps to reproduce the bug:
1. Create a new user.
2. Set permissions to create email and view contacts
3. Create a new email
4. Try to insert a token using the token button or by starting to type {leadfield=firstname}
5. The lead fields tokens will not be displayed.

#### Steps to test this PR:
1. Apply this PR
2. Repeat the steps to reproduce the bug
3. The tokens will display

