### PR TITLE
Fixed bug when importing with mapped IP address on the background. Th…

### DIFF
--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -126,7 +126,7 @@ class LeadSubscriber extends CommonSubscriber
                         'objectId'  => $lead->getId(),
                         'action'    => 'ipadded',
                         'details'   => $details['ipAddresses'],
-                        'ipAddress' => $this->request->server->get('REMOTE_ADDR'),
+                        'ipAddress' => $this->ipLookupHelper->getIpAddressFromRequest(),
                     ];
                     $this->auditLogModel->writeToLog($log);
                 }


### PR DESCRIPTION
…e request property is not set there.

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The LeadSubscriber was using request object to save IP address of the user changing the contact IP address. This PR changes that to use the IpLookupHelper instead like all other audit log changes in that file with does not fail.

## Testing CSV:
```
id,first_name,last_name,email,company,ip_address
1,Gilly,Tilburn,gt@guma.cz,Abatz,67.128.57.3
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to import the CSV above on background
2. IT should fail on command execution `app/console mautic:import`

#### Steps to test this PR:
1. Apply this PR and test again
2. It should not fail, the contact should have the right IP address assigned and the audit log should contain an IP address as well.
