### PR TITLE
Bug import continue on background

### DIFF
--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -93,7 +93,7 @@ class ImportController extends FormController
             $importModel->saveEntity($import);
         }
 
-        $this->resetImport($fullPath);
+        $this->resetImport($fullPath, false);
 
         return $this->indexAction();
     }

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -150,18 +150,20 @@ class ImportModel extends FormModel
                 ->setStatusInfo($this->translator->trans('mautic.lead.import.ghost.limit.hit', ['%limit%' => $ghostDelay]))
                 ->removeFile();
 
-            $this->notificationModel->addNotification(
-                $this->translator->trans(
-                    'mautic.lead.import.result.info',
-                    ['%import%' => $this->generateLink($import)]
-                ),
-                'info',
-                false,
-                $this->translator->trans('mautic.lead.import.failed'),
-                'fa-download',
-                null,
-                $this->em->getReference('MauticUserBundle:User', $import->getCreatedBy())
-            );
+            if ($import->getCreatedBy()) {
+                $this->notificationModel->addNotification(
+                    $this->translator->trans(
+                        'mautic.lead.import.result.info',
+                        ['%import%' => $this->generateLink($import)]
+                    ),
+                    'info',
+                    false,
+                    $this->translator->trans('mautic.lead.import.failed'),
+                    'fa-download',
+                    null,
+                    $this->em->getReference('MauticUserBundle:User', $import->getCreatedBy())
+                );
+            }
         }
 
         $this->saveEntities($imports);
@@ -219,18 +221,20 @@ class ImportModel extends FormModel
         // Save the end changes so the user could see it
         $this->saveEntity($import);
 
-        $this->notificationModel->addNotification(
-            $this->translator->trans(
-                'mautic.lead.import.result.info',
-                ['%import%' => $this->generateLink($import)]
-            ),
-            'info',
-            false,
-            $this->translator->trans('mautic.lead.import.completed'),
-            'fa-download',
-            null,
-            $this->em->getReference('MauticUserBundle:User', $import->getCreatedBy())
-        );
+        if ($import->getCreatedBy()) {
+            $this->notificationModel->addNotification(
+                $this->translator->trans(
+                    'mautic.lead.import.result.info',
+                    ['%import%' => $this->generateLink($import)]
+                ),
+                'info',
+                false,
+                $this->translator->trans('mautic.lead.import.completed'),
+                'fa-download',
+                null,
+                $this->em->getReference('MauticUserBundle:User', $import->getCreatedBy())
+            );
+        }
 
         return true;
     }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When the import has been started in browser and switched to background job, it removed the source file.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Start a longer import (so you'd be able to click the button in the middle) in the browser.
2. Switch to the background.
- The import then fails because it removes the source file while you hit the "continue in background" button.

#### Steps to test this PR:
1. Repeat the test steps
2. It will finish the background in the background (you'll have to trigger `app/console mautic:import` command to trigger the background job)
