### PR TITLE
Prevent an exception when a Mautic user is test submitting a form

### DIFF
--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -334,7 +334,11 @@ class SubmissionModel extends CommonFormModel
             //set tracking ID for stats purposes to determine unique hits
             $submission->setTrackingId($trackingId);
         }
-        $submission->setLead($lead);
+
+        // If a user is testing a form, $lead will not have an ID
+        if ($lead && $lead->getId()) {
+            $submission->setLead($lead);
+        }
 
         // Remove validation errors if the field is not visible
         if ($form->usesProgressiveProfiling()) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

2.9.0 introduced a bug when a user is logged into Mautic and tries to submits the form in the same browser session, an exception is thrown. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Login to Mautic and view the submit page for a form in the same browser (/form/ID).
2. Submit the form which will result in an exception because Lead doesn't have an ID

#### Steps to test this PR:
1. Repeat and this time the form will submit
