### PR TITLE
Feature citrix events api

### DIFF
--- a/app/bundles/LeadBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/StatsSubscriber.php
@@ -40,6 +40,7 @@ class StatsSubscriber extends CommonStatsSubscriber
                 'MauticLeadBundle:CompanyLead',
                 'MauticLeadBundle:LeadCategory',
                 'MauticLeadBundle:LeadDevice',
+                'MauticLeadBundle:LeadEventLog',
                 'MauticLeadBundle:ListLead',
                 'MauticLeadBundle:DoNotContact',
                 'MauticLeadBundle:FrequencyRule',

--- a/plugins/MauticCitrixBundle/Config/config.php
+++ b/plugins/MauticCitrixBundle/Config/config.php
@@ -60,6 +60,12 @@ return [
                     'mautic.citrix.model.citrix',
                 ],
             ],
+            'mautic.citrix.stats.subscriber' => [
+                'class'     => \MauticPlugin\MauticCitrixBundle\EventListener\StatsSubscriber::class,
+                'arguments' => [
+                    'doctrine.orm.entity_manager',
+                ],
+            ],
         ],
         'forms' => [
             'mautic.form.type.fieldslist.citrixlist' => [

--- a/plugins/MauticCitrixBundle/EventListener/StatsSubscriber.php
+++ b/plugins/MauticCitrixBundle/EventListener/StatsSubscriber.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCitrixBundle\EventListener;
+
+use Doctrine\ORM\EntityManager;
+use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
+
+/**
+ * Class StatsSubscriber.
+ */
+class StatsSubscriber extends CommonStatsSubscriber
+{
+    /**
+     * @var EntityManager
+     */
+    protected $em;
+
+    /**
+     * StatsSubscriber constructor.
+     *
+     * @param EntityManager $em
+     */
+    public function __construct(EntityManager $em)
+    {
+        $this->addContactRestrictedRepositories(
+            $em,
+            [
+                'MauticCitrixBundle:CitrixEvent',
+            ]
+        );
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/65
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR makes data in `plugin_citrix_events` and new `lead_event_log` tables available via the `api/stats` API endpoint.

#### Steps to test this PR:
1. Try to get data from `api/stats/plugin_citrix_events`.
2. Try to get data from `api/stats/lead_event_log`
3. Run the API Library unit tests on this PR: https://github.com/mautic/api-library/pull/119