### PR TITLE
fixed readding a submit button if name has changed

### DIFF
--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -715,7 +715,7 @@ class FormController extends CommonFormController
             foreach ($existingFields as $formField) {
                 // Check to see if the field still exists
 
-                if ($formField->getAlias() == 'submit' && $formField->getType() == 'button') {
+                if ($formField->getType() == 'button') {
                     //submit button found
                     $submitButton = true;
                 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If submit button name has changed it adds a new submit button
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. change submit button name save
2. edit, a new submit button will be added

#### Steps to test this PR:
1. follow steps above
2. no new submit button will be added

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 