### PR TITLE
Added support for pushing to SF campaigns for form submit action and point triggers

### DIFF
--- a/app/bundles/PluginBundle/Config/config.php
+++ b/app/bundles/PluginBundle/Config/config.php
@@ -72,7 +72,7 @@ return [
                 'class' => 'Mautic\PluginBundle\EventListener\PointSubscriber',
             ],
             'mautic.plugin.formbundle.subscriber' => [
-                'class' => 'Mautic\PluginBundle\EventListener\FormSubscriber',
+                'class'       => 'Mautic\PluginBundle\EventListener\FormSubscriber',
                 'methodCalls' => [
                     'setIntegrationHelper' => [
                         'mautic.helper.integration',

--- a/app/bundles/PluginBundle/Config/config.php
+++ b/app/bundles/PluginBundle/Config/config.php
@@ -73,11 +73,18 @@ return [
             ],
             'mautic.plugin.formbundle.subscriber' => [
                 'class' => 'Mautic\PluginBundle\EventListener\FormSubscriber',
+                'methodCalls' => [
+                    'setIntegrationHelper' => [
+                        'mautic.helper.integration',
+                    ],
+                ],
             ],
             'mautic.plugin.campaignbundle.subscriber' => [
-                'class'     => 'Mautic\PluginBundle\EventListener\CampaignSubscriber',
-                'arguments' => [
-                    'mautic.helper.integration',
+                'class'       => 'Mautic\PluginBundle\EventListener\CampaignSubscriber',
+                'methodCalls' => [
+                    'setIntegrationHelper' => [
+                        'mautic.helper.integration',
+                    ],
                 ],
             ],
             'mautic.plugin.leadbundle.subscriber' => [

--- a/app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
@@ -15,8 +15,6 @@ use Mautic\CampaignBundle\CampaignEvents;
 use Mautic\CampaignBundle\Event\CampaignBuilderEvent;
 use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
 use Mautic\CoreBundle\EventListener\CommonSubscriber;
-use Mautic\PluginBundle\Helper\IntegrationHelper;
-use Mautic\PluginBundle\Integration\AbstractIntegration;
 use Mautic\PluginBundle\PluginEvents;
 
 /**

--- a/app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
@@ -24,20 +24,7 @@ use Mautic\PluginBundle\PluginEvents;
  */
 class CampaignSubscriber extends CommonSubscriber
 {
-    /**
-     * @var IntegrationHelper
-     */
-    protected $integrationHelper;
-
-    /**
-     * CampaignSubscriber constructor.
-     *
-     * @param IntegrationHelper $integrationHelper
-     */
-    public function __construct(IntegrationHelper $integrationHelper)
-    {
-        $this->integrationHelper = $integrationHelper;
-    }
+    use PushToIntegrationTrait;
 
     /**
      * {@inheritdoc}
@@ -71,46 +58,10 @@ class CampaignSubscriber extends CommonSubscriber
      */
     public function onCampaignTriggerAction(CampaignExecutionEvent $event)
     {
-        $config = $event->getConfig();
-        $lead   = $event->getLead();
-
-        $integration             = (!empty($config['integration'])) ? $config['integration'] : null;
-        $integrationCampaign     = (!empty($config['config']['campaigns'])) ? $config['config']['campaigns'] : null;
-        $integrationMemberStatus = (!empty($config['campaign_member_status']['campaign_member_status']))
-            ? $config['campaign_member_status']['campaign_member_status'] : null;
-        $services = $this->integrationHelper->getIntegrationObjects($integration);
-        $success  = true;
-        $errors   = [];
-
-        /**
-         * @var
-         * @var AbstractIntegration $s
-         */
-        foreach ($services as $name => $s) {
-            $settings = $s->getIntegrationSettings();
-            if (!$settings->isPublished()) {
-                continue;
-            }
-
-            $personIds = null;
-            if (method_exists($s, 'pushLead')) {
-                if (!$personIds = $s->resetLastIntegrationError()->pushLead($lead, $config)) {
-                    $success = false;
-                    if ($error = $s->getLastIntegrationError()) {
-                        $errors[] = $error;
-                    }
-                }
-            }
-
-            if ($success && $integrationCampaign && method_exists($s, 'pushLeadToCampaign')) {
-                if (!$s->resetLastIntegrationError()->pushLeadToCampaign($lead, $integrationCampaign, $integrationMemberStatus, $personIds)) {
-                    $success = false;
-                    if ($error = $s->getLastIntegrationError()) {
-                        $errors[] = $error;
-                    }
-                }
-            }
-        }
+        $config  = $event->getConfig();
+        $lead    = $event->getLead();
+        $errors  = [];
+        $success = $this->pushToIntegration($config, $lead, $errors);
 
         if (count($errors)) {
             $event->setFailed(implode('<br />', $errors));

--- a/app/bundles/PluginBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/FormSubscriber.php
@@ -13,20 +13,26 @@ namespace Mautic\PluginBundle\EventListener;
 
 use Mautic\CoreBundle\EventListener\CommonSubscriber;
 use Mautic\FormBundle\Event\FormBuilderEvent;
+use Mautic\FormBundle\Event\FormEvent;
+use Mautic\FormBundle\Event\SubmissionEvent;
 use Mautic\FormBundle\FormEvents;
+use Mautic\PluginBundle\PluginEvents;
 
 /**
  * Class FormSubscriber.
  */
 class FormSubscriber extends CommonSubscriber
 {
+    use PushToIntegrationTrait;
+
     /**
      * {@inheritdoc}
      */
     public static function getSubscribedEvents()
     {
         return [
-            FormEvents::FORM_ON_BUILD => ['onFormBuild', 0],
+            FormEvents::FORM_ON_BUILD                     => ['onFormBuild', 0],
+            PluginEvents::ON_FORM_SUBMIT_ACTION_TRIGGERED => ['onFormSubmitActionTriggered', 0],
         ];
     }
 
@@ -41,8 +47,21 @@ class FormSubscriber extends CommonSubscriber
             'label'       => 'mautic.plugin.actions.push_lead',
             'formType'    => 'integration_list',
             'formTheme'   => 'MauticPluginBundle:FormTheme\Integration',
-            'callback'    => ['\\Mautic\\PluginBundle\\Helper\\EventHelper', 'pushLead'],
+            'eventName'   => PluginEvents::ON_FORM_SUBMIT_ACTION_TRIGGERED,
         ];
         $event->addSubmitAction('plugin.leadpush', $action);
+    }
+
+    /**
+     * @param SubmissionEvent $event
+     *
+     * @return mixed
+     */
+    public function onFormSubmitActionTriggered(SubmissionEvent $event)
+    {
+        $config  = $event->getActionConfig();
+        $lead    = $event->getLead();
+
+        $this->pushToIntegration($config, $lead);
     }
 }

--- a/app/bundles/PluginBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/FormSubscriber.php
@@ -13,7 +13,6 @@ namespace Mautic\PluginBundle\EventListener;
 
 use Mautic\CoreBundle\EventListener\CommonSubscriber;
 use Mautic\FormBundle\Event\FormBuilderEvent;
-use Mautic\FormBundle\Event\FormEvent;
 use Mautic\FormBundle\Event\SubmissionEvent;
 use Mautic\FormBundle\FormEvents;
 use Mautic\PluginBundle\PluginEvents;
@@ -59,8 +58,8 @@ class FormSubscriber extends CommonSubscriber
      */
     public function onFormSubmitActionTriggered(SubmissionEvent $event)
     {
-        $config  = $event->getActionConfig();
-        $lead    = $event->getLead();
+        $config = $event->getActionConfig();
+        $lead   = $event->getLead();
 
         $this->pushToIntegration($config, $lead);
     }

--- a/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
+++ b/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
@@ -76,7 +76,7 @@ trait PushToIntegrationTrait
         $services = static::$integrationHelper->getIntegrationObjects($integration);
         $success  = true;
 
-        /**
+        /*
          * @var AbstractIntegration
          */
         foreach ($services as $name => $s) {

--- a/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
+++ b/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
@@ -17,11 +17,9 @@ use Mautic\PluginBundle\Integration\AbstractIntegration;
 
 /**
  * Static methods must be used due to the Point triggers not being converted to Events yet
- * Once that happens, this can be converted to a standard method classes
+ * Once that happens, this can be converted to a standard method classes.
  *
  * Trait PushToIntegrationTrait
- *
- * @package Mautic\PluginBundle\EventListener
  */
 trait PushToIntegrationTrait
 {
@@ -31,7 +29,7 @@ trait PushToIntegrationTrait
     protected static $integrationHelper;
 
     /**
-     * Used by methodCalls to event subscribers
+     * Used by methodCalls to event subscribers.
      *
      * @param IntegrationHelper $integrationHelper
      */
@@ -41,7 +39,7 @@ trait PushToIntegrationTrait
     }
 
     /**
-     * Used by callback methods such as point triggers
+     * Used by callback methods such as point triggers.
      *
      * @param IntegrationHelper $integrationHelper
      */
@@ -54,13 +52,13 @@ trait PushToIntegrationTrait
      * @param array $config
      * @param       $lead
      */
-    protected function pushToIntegration(array $config, Lead $lead, array &$errors = array())
+    protected function pushToIntegration(array $config, Lead $lead, array &$errors = [])
     {
         return static::pushIt($config, $lead, $errors);
     }
 
     /**
-     * Used because the the Point trigger actions have not be converted to Events yet and thus must leverage a callback
+     * Used because the the Point trigger actions have not be converted to Events yet and thus must leverage a callback.
      *
      * @param IntegrationHelper $helper
      * @param                   $config
@@ -79,7 +77,7 @@ trait PushToIntegrationTrait
         $success  = true;
 
         /**
-         * @var AbstractIntegration $s
+         * @var AbstractIntegration
          */
         foreach ($services as $name => $s) {
             $settings = $s->getIntegrationSettings();

--- a/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
+++ b/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\PluginBundle\EventListener;
+
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\PluginBundle\Helper\IntegrationHelper;
+use Mautic\PluginBundle\Integration\AbstractIntegration;
+
+/**
+ * Static methods must be used due to the Point triggers not being converted to Events yet
+ * Once that happens, this can be converted to a standard method classes
+ *
+ * Trait PushToIntegrationTrait
+ *
+ * @package Mautic\PluginBundle\EventListener
+ */
+trait PushToIntegrationTrait
+{
+    /**
+     * @var IntegrationHelper
+     */
+    protected static $integrationHelper;
+
+    /**
+     * Used by methodCalls to event subscribers
+     *
+     * @param IntegrationHelper $integrationHelper
+     */
+    public function setIntegrationHelper(IntegrationHelper $integrationHelper)
+    {
+        static::setStaticIntegrationHelper($integrationHelper);
+    }
+
+    /**
+     * Used by callback methods such as point triggers
+     *
+     * @param IntegrationHelper $integrationHelper
+     */
+    public static function setStaticIntegrationHelper(IntegrationHelper $integrationHelper)
+    {
+        static::$integrationHelper = $integrationHelper;
+    }
+
+    /**
+     * @param array $config
+     * @param       $lead
+     */
+    protected function pushToIntegration(array $config, Lead $lead, array &$errors = array())
+    {
+        return static::pushIt($config, $lead, $errors);
+    }
+
+    /**
+     * Used because the the Point trigger actions have not be converted to Events yet and thus must leverage a callback
+     *
+     * @param IntegrationHelper $helper
+     * @param                   $config
+     * @param                   $lead
+     * @param                   $errors
+     *
+     * @return bool
+     */
+    protected static function pushIt($config, $lead, &$errors)
+    {
+        $integration             = (!empty($config['integration'])) ? $config['integration'] : null;
+        $integrationCampaign     = (!empty($config['config']['campaigns'])) ? $config['config']['campaigns'] : null;
+        $integrationMemberStatus = (!empty($config['campaign_member_status']['campaign_member_status']))
+            ? $config['campaign_member_status']['campaign_member_status'] : null;
+        $services = static::$integrationHelper->getIntegrationObjects($integration);
+        $success  = true;
+
+        /**
+         * @var AbstractIntegration $s
+         */
+        foreach ($services as $name => $s) {
+            $settings = $s->getIntegrationSettings();
+            if (!$settings->isPublished()) {
+                continue;
+            }
+
+            $personIds = null;
+            if (method_exists($s, 'pushLead')) {
+                if (!$personIds = $s->resetLastIntegrationError()->pushLead($lead, $config)) {
+                    $success = false;
+                    if ($error = $s->getLastIntegrationError()) {
+                        $errors[] = $error;
+                    }
+                }
+            }
+
+            if ($success && $integrationCampaign && method_exists($s, 'pushLeadToCampaign')) {
+                if (!$s->resetLastIntegrationError()->pushLeadToCampaign($lead, $integrationCampaign, $integrationMemberStatus, $personIds)) {
+                    $success = false;
+                    if ($error = $s->getLastIntegrationError()) {
+                        $errors[] = $error;
+                    }
+                }
+            }
+        }
+
+        return $success;
+    }
+}

--- a/app/bundles/PluginBundle/PluginEvents.php
+++ b/app/bundles/PluginBundle/PluginEvents.php
@@ -117,4 +117,13 @@ final class PluginEvents
      * @var string
      */
     const PLUGIN_ON_INTEGRATION_FORM_BUILD = 'mautic.plugin_on_integration_form_build';
+
+    /**
+     * The mautic.plugin.on_form_submit_action_triggered event is dispatched when a plugin related submit action is executed
+     *
+     * The event listener receives a Mautic\PluginBundle\Event\PluginIntegrationFormBuildEvent instance.
+     *
+     * @var string
+     */
+    const ON_FORM_SUBMIT_ACTION_TRIGGERED = 'mautic.plugin.on_form_submit_action_triggered';
 }

--- a/app/bundles/PluginBundle/PluginEvents.php
+++ b/app/bundles/PluginBundle/PluginEvents.php
@@ -119,7 +119,7 @@ final class PluginEvents
     const PLUGIN_ON_INTEGRATION_FORM_BUILD = 'mautic.plugin_on_integration_form_build';
 
     /**
-     * The mautic.plugin.on_form_submit_action_triggered event is dispatched when a plugin related submit action is executed
+     * The mautic.plugin.on_form_submit_action_triggered event is dispatched when a plugin related submit action is executed.
      *
      * The event listener receives a Mautic\PluginBundle\Event\PluginIntegrationFormBuildEvent instance.
      *

--- a/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
+++ b/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
@@ -69,6 +69,7 @@ class LeadListSubscriber extends CommonSubscriber
                 $choices[$campaign['Id']] = $campaign['Name'];
             }
         }
+
         if (!empty($campaigns)) {
             $config = [
                 'label'      => $this->translator->trans('mautic.plugin.integration.campaign_members'),


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Only campaigns supported pushing a Mautic contact into a SF campaign. This adds the same support to form and point trigger push to integration events. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Connect Mautic to Salesforce
2. Create a push to integration form submit action and a point trigger (set the points to something high like 3000)
3. Configure the config to push to a SF campaign
4. Submit the form in a private browser and check SF - the contact will not be in the campaign
5. Edit a contact's points to 3000 and save
6. Check SF - the contact will not be in the campaign
7. Add the same push to integration setup to a campaign and execute to ensure campaign push to integration still works

#### Steps to test this PR:
1. Repeat the above (use different contacts)
2. Each will be in the SF campaign
