### PR TITLE
Fixed issue where push to campaign would if all mapped fields gave priority to Mautic

### DIFF
--- a/app/bundles/PluginBundle/Assets/js/plugin.js
+++ b/app/bundles/PluginBundle/Assets/js/plugin.js
@@ -171,7 +171,7 @@ Mautic.getIntegrationFields = function(settings, page, el) {
     var object    = settings.object ? settings.object : 'lead';
     var fieldsTab = ('lead' === object) ? '#fields-tab' : '#'+object+'-fields-container';
 
-    if (el) {
+    if (el && mQuery(el).is('input')) {
         Mautic.activateLabelLoadingIndicator(mQuery(el).attr('id'));
     }
 

--- a/app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
@@ -68,6 +68,8 @@ class CampaignSubscriber extends CommonSubscriber
 
     /**
      * @param CampaignExecutionEvent $event
+     *
+     * @return $this
      */
     public function onCampaignTriggerAction(CampaignExecutionEvent $event)
     {

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -635,17 +635,22 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 foreach (['Contact', 'Lead'] as $object) {
                     if (!empty($existingPersons[$object])) {
                         $personFound = true;
-                        if (!empty($mappedData[$object]['update'])) {
-                            foreach ($existingPersons[$object] as $person) {
-                                $personData                     = $this->getApiHelper()->updateObject($mappedData[$object]['update'], $object, $person['Id']);
-                                $people[$object][$person['Id']] = $person['Id'];
+                        foreach ($existingPersons[$object] as $person) {
+                            if (!empty($mappedData[$object]['update'])) {
+                                $personData = $this->getApiHelper()->updateObject(
+                                    $mappedData[$object]['update'],
+                                    $object,
+                                    $person['Id']
+                                );
                             }
+                            $people[$object][$person['Id']] = $person['Id'];
                         }
                     }
 
                     if ('Lead' === $object && !$personFound) {
                         $personData                         = $this->getApiHelper()->createLead($mappedData[$object]['create']);
                         $people[$object][$personData['Id']] = $personData['Id'];
+                        $personFound                        = true;
                     }
 
                     if (isset($personData['Id'])) {
@@ -664,7 +669,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 }
 
                 // Return success if any Contact or Lead was updated or created
-                return ($people) ? $people : false;
+                return ($personFound) ? $people : false;
             }
         } catch (\Exception $e) {
             if ($e instanceof ApiErrorException) {
@@ -1539,7 +1544,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     $campaignMembers = $this->getApiHelper()->checkCampaignMembership($campaignId, $pushObject, $personIds[$pushObject]);
                     $pushPeople      = $personIds[$pushObject];
                 }
-            }
+            } // pushLead should have handled this
 
             foreach ($pushPeople as $memberId) {
                 $campaignMappingId = '-'.$campaignId;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If all Salesforce fields were mapped giving priority to Mautic, and a Mautic contact already existed in Salesforce, pushing the SF person into a SF campaign would fail. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup Salesforce
2. Map the fields but set all of them with Mautic as priority (right arrow)
3. Setup a campaign to push to integration and select SF, a campaign, and a campaign status
4. Ensure the contact already exists in SF
5. Add the contact to the campaign and execute
6. Note that the contact will not be added to the SF campaign

#### Steps to test this PR:
1. Repeat and this time the contact should be added to the campaign
