### PR TITLE
The array of failed email addresses is in the 'failures' array property

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1230,12 +1230,12 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
 
                     // Check to see if failed recipients were stored by the transport
                     if (!empty($sendFailures['failures'])) {
-                        $failures = $sendFailures;
+                        $failedEmailAddresses = $sendFailures['failures'];
                         unset($sendFailures['failures']);
                         $error = implode('; ', $sendFailures);
 
                         // Prevent the stat from saving
-                        foreach ($failures as $failedEmail) {
+                        foreach ($failedEmailAddresses as $failedEmail) {
                             /** @var Stat $stat */
                             $stat = $statEntities[$failedEmail];
                             // Add lead ID to list of failures


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The error handling for email transports sending emails with multiple recipients was wrong and it fails on error:

```
Warning:  Illegal offset type in /var/www/html/app/bundles/EmailBundle/Model/EmailModel.php on line 1240

                                                           
  [Symfony\Component\Debug\Exception\FatalThrowableError]  
  Call to a member function getLead() on null 
```

During my tests the array of emails that is expected in the foreach loop was in the `['failures']` property of the array. I hope it does not break some other transports.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Select Sparkpost as your email provider
2. Type in some random API key so it would fail to connect
3. Send a segment email to at least 2 contacts
- you should get the error. No emails will be sent.

#### Steps to test this PR:
1. Apply this PR
2. Try to send again.
- The emails should be sent.