### PR TITLE
Mailchimp field matching on campaign push to integration

### DIFF
--- a/app/bundles/PluginBundle/Assets/js/plugin.js
+++ b/app/bundles/PluginBundle/Assets/js/plugin.js
@@ -173,8 +173,14 @@ Mautic.getIntegrationFields = function(settings, page, el) {
 
     if (el) {
         Mautic.activateLabelLoadingIndicator(mQuery(el).attr('id'));
-    }
 
+        var namePrefix = mQuery(el).attr('name').split('[')[0];
+        if ('integration_details' !== namePrefix) {
+            var nameParts = mQuery(el).attr('name').match(/\[.*?\]+/g);
+            nameParts = nameParts.slice(0, -1);
+            settings.prefix = namePrefix + nameParts.join('') + "[" + object + "Fields]";
+        }
+    }
     var fieldsContainer = '#'+object+'FieldsContainer';
 
     var inModal = mQuery(fieldsContainer).closest('.modal');

--- a/app/bundles/PluginBundle/Controller/AjaxController.php
+++ b/app/bundles/PluginBundle/Controller/AjaxController.php
@@ -78,7 +78,6 @@ class AjaxController extends CommonAjaxController
                     // Get a list of custom form fields
                     $mauticFields       = ($isLead) ? $pluginModel->getLeadFields() : $pluginModel->getCompanyFields();
                     $featureSettings    = $integrationObject->getIntegrationSettings()->getFeatureSettings();
-                    $formSettings       = $integrationObject->getFormDisplaySettings();
                     $enableDataPriority = $integrationObject->getDataPriority();
                     $formType           = $isLead ? 'integration_fields' : 'integration_company_fields';
                     $form               = $this->createForm(

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -2651,7 +2651,7 @@ abstract class AbstractIntegration
                 if (isset($fields['i_'.$i]) && isset($fields['m_'.$i])) {
                     $formattedFields[$fields['i_'.$i]] = $fields['m_'.$i];
                 } else {
-                    break;
+                    continue;
                 }
             }
         }

--- a/plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
+++ b/plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
@@ -51,9 +51,8 @@ class MailchimpApi extends EmailMarketingApi
         } elseif (is_array($response) && !empty($response['errors'])) {
             $errors = [];
             foreach ($response['errors'] as $error) {
-                $errors[] = $error['error'];
+                $errors[] = $error['message'];
             }
-
             throw new ApiErrorException(implode(' ', $errors));
         } else {
             return $response;
@@ -93,9 +92,11 @@ class MailchimpApi extends EmailMarketingApi
         $emailStruct->email = $email;
 
         $parameters = array_merge($config, [
-            'id'           => $listId,
-            'merge_fields' => $fields,
+            'id' => $listId,
         ]);
+        if (!empty($fields)) {
+            $parameters = array_merge($parameters, ['merge_fields' => $fields]);
+        }
         $parameters['email_address'] = $email;
         $parameters['status']        = 'subscribed';
 

--- a/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
@@ -149,7 +149,7 @@ class MailchimpType extends AbstractType
                     'integration_object'   => $mailchimp,
                     'limit'                => $limit,
                     'page'                 => $page,
-                    'data'                 => $data,
+                    'data'                 => $data['leadFields'],
                     'integration_fields'   => $fields,
                     'special_instructions' => $specialInstructions,
                     'mapped'               => true,

--- a/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
@@ -149,7 +149,7 @@ class MailchimpType extends AbstractType
                     'integration_object'   => $mailchimp,
                     'limit'                => $limit,
                     'page'                 => $page,
-                    'data'                 => $data['leadFields'],
+                    'data'                 => $data,
                     'integration_fields'   => $fields,
                     'special_instructions' => $specialInstructions,
                     'mapped'               => true,
@@ -164,6 +164,9 @@ class MailchimpType extends AbstractType
             $builder->addEventListener(FormEvents::PRE_SET_DATA,
                 function (FormEvent $event) use ($formModifier) {
                     $data = $event->getData();
+                    if (isset($data['leadFields']['leadFields'])) {
+                        $data['leadFields'] = $data['leadFields']['leadFields'];
+                    }
                     $formModifier($event->getForm(), $data);
                 }
             );
@@ -171,6 +174,9 @@ class MailchimpType extends AbstractType
             $builder->addEventListener(FormEvents::PRE_SUBMIT,
                 function (FormEvent $event) use ($formModifier) {
                     $data = $event->getData();
+                    if (isset($data['leadFields']['leadFields'])) {
+                        $data['leadFields'] = $data['leadFields']['leadFields'];
+                    }
                     $formModifier($event->getForm(), $data);
                 }
             );


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #4381 #4382 #4383
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fixed field matching in Mailchimp push to integration campaign config window.
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. enable your mailChimp plugin and authenticate
2. create a campaign with push to integration, try to match fields for the plugin configuration where fields are not sequentially picked. you will see that the field matching gets lost when closing and opening the modal window.

#### Steps to test this PR:
1. Apply this PR
2. fields should not be lost when updating