### PR TITLE
fix timezone - dateTimeHelper 

### DIFF
--- a/app/bundles/CoreBundle/Helper/DateTimeHelper.php
+++ b/app/bundles/CoreBundle/Helper/DateTimeHelper.php
@@ -47,9 +47,9 @@ class DateTimeHelper
     private $datetime;
 
     /**
-     * @param string $string     Datetime string
-     * @param string $fromFormat Format the string is in
-     * @param string $timezone   Timezone the string is in
+     * @param \DateTime|string $string
+     * @param string           $fromFormat Format the string is in
+     * @param string           $timezone   Timezone the string is in
      */
     public function __construct($string = '', $fromFormat = 'Y-m-d H:i:s', $timezone = 'UTC')
     {
@@ -79,6 +79,7 @@ class DateTimeHelper
 
         if ($datetime instanceof \DateTime) {
             $this->datetime = $datetime;
+            $this->timezone = $datetime->getTimezone()->getName();
             $this->string   = $this->datetime->format($fromFormat);
         } elseif (empty($datetime)) {
             $this->datetime = new \DateTime('now', new \DateTimeZone($this->timezone));


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fix date time zone into dateTimeHelper.
Previously, date was never set to UTC when helper input was a dateTime object... si default value (utc) was used.
That fix toUtcString() function, mainly used for database query.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

#### Steps to test this PR:
1. set your server UTC date time
2. Set mautic configuration to Paris timezone
3. Make A/B testing email and shoot it (make this operation in less than 2h)
4. Look variant stat ==> no stat
5. Apply PR
6. Look variant stat ==> there is stat!
