### PR TITLE
False values for booleans custom fields would not persist

### DIFF
--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -261,6 +261,7 @@ trait CustomFieldRepositoryTrait
         }
 
         if (!empty($fields)) {
+            $this->prepareDbalFieldsForSave($fields);
             $this->getEntityManager()->getConnection()->update($table, $fields, ['id' => $entity->getId()]);
         }
     }
@@ -366,5 +367,18 @@ trait CustomFieldRepositoryTrait
         }
 
         return $this->customFieldList;
+    }
+
+    /**
+     * @param $fields
+     */
+    private function prepareDbalFieldsForSave(&$fields)
+    {
+        // Ensure booleans are integers
+        foreach ($fields as $field => &$value) {
+            if (is_bool($value)) {
+                $fields[$field] = (int) $value;
+            }
+        }
     }
 }

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -621,7 +621,6 @@ class LeadModel extends FormModel
             }
         }
 
-
         $lead->setFields($fieldValues);
     }
 

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -591,7 +591,8 @@ class LeadModel extends FormModel
                         $newValue = implode('|', $newValue);
                     }
 
-                    if ($curValue !== $newValue && (strlen($newValue) > 0 || (strlen($newValue) === 0 && $overwriteWithBlank))) {
+                    $isEmpty = (null === $newValue || '' === $newValue);
+                    if ($curValue !== $newValue && (!$isEmpty || ($isEmpty && $overwriteWithBlank))) {
                         $field['value'] = $newValue;
                         $lead->addUpdatedField($alias, $newValue, $curValue);
                     }
@@ -619,6 +620,7 @@ class LeadModel extends FormModel
                 }
             }
         }
+
 
         $lead->setFields($fieldValues);
     }

--- a/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryTest.php
@@ -11,7 +11,6 @@
 
 namespace Mautic\LeadBundle\Tests;
 
-
 use Mautic\LeadBundle\Entity\CustomFieldRepositoryTrait;
 
 class LeadRepositoryTest extends \PHPUnit_Framework_TestCase
@@ -23,7 +22,7 @@ class LeadRepositoryTest extends \PHPUnit_Framework_TestCase
         $fields = [
             'true'   => true,
             'false'  => false,
-            'string' => 'blah'
+            'string' => 'blah',
         ];
 
         $this->prepareDbalFieldsForSave($fields);

--- a/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests;
+
+
+use Mautic\LeadBundle\Entity\CustomFieldRepositoryTrait;
+
+class LeadRepositoryTest extends \PHPUnit_Framework_TestCase
+{
+    use CustomFieldRepositoryTrait;
+
+    public function testBooleanWithPrepareDbalFieldsForSave()
+    {
+        $fields = [
+            'true'   => true,
+            'false'  => false,
+            'string' => 'blah'
+        ];
+
+        $this->prepareDbalFieldsForSave($fields);
+
+        $this->assertEquals(1, $fields['true']);
+        $this->assertEquals(0, $fields['false']);
+        $this->assertEquals('blah', $fields['string']);
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Boolean custom fields that tried to set a value to false (such as a contact synced from an integration or other plugin) would not persist due to the comparison use of strlen which is 0 for false. So, changed that to checking for `null `or `''`. If a boolean value was made it through, the SQL threw an exception since mysql expects an int for a boolean. So added a method to check and convert booleans to ints when the field values are updated. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup sync from SF.
2. Create a boolean field in SF and in Mautic
3. Map the two in the SF plugin configuration giving priority to SF (right arrow)
4. Update a Lead or contact in SF setting the boolean field to true (checked)
5. Run `php app/console m:i:s -i Salesforce -a "5 minutes"`
6. Check the Mautic contact synced and that the boolean field is set to Yes. 
7. Update the Lead/contact in SF again this time unchecking the boolean field.
8. Run the sync and check Mautic's contact - the boolean field will still be Yes

#### Steps to test this PR:
1. repeat the above and the boolean field will update to false/no
2. Run the new test