### PR TITLE
Contact note count and delete button fixed

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -234,12 +234,7 @@ Mautic.onPageLoad = function (container, response, inModal) {
     Mautic.initDateRangePicker(container + ' #daterange_date_from', container + ' #daterange_date_to');
 
     //initiate links
-    mQuery(container + " a[data-toggle='ajax']").off('click.ajax');
-    mQuery(container + " a[data-toggle='ajax']").on('click.ajax', function (event) {
-        event.preventDefault();
-
-        return Mautic.ajaxifyLink(this, event);
-    });
+    Mautic.makeLinksAlive(mQuery(container + " a[data-toggle='ajax']"));
 
     //initialize forms
     mQuery(container + " form[data-toggle='ajax']").each(function (index) {
@@ -247,12 +242,7 @@ Mautic.onPageLoad = function (container, response, inModal) {
     });
 
     //initialize ajax'd modals
-    mQuery(container + " *[data-toggle='ajaxmodal']").off('click.ajaxmodal');
-    mQuery(container + " *[data-toggle='ajaxmodal']").on('click.ajaxmodal', function (event) {
-        event.preventDefault();
-
-        Mautic.ajaxifyModal(this, event);
-    });
+    Mautic.makeModalsAlive(mQuery(container + " *[data-toggle='ajaxmodal']"))
 
     //initialize embedded modal forms
     Mautic.activateModalEmbeddedForms(container);
@@ -306,12 +296,7 @@ Mautic.onPageLoad = function (container, response, inModal) {
         Mautic.initiateFileDownload(mQuery(this).attr('href'));
     });
 
-    mQuery(container + " a[data-toggle='confirmation']").off('click.confirmation');
-    mQuery(container + " a[data-toggle='confirmation']").on('click.confirmation', function (event) {
-        event.preventDefault();
-        MauticVars.ignoreIconSpin = true;
-        return Mautic.showConfirmation(this);
-    });
+    Mautic.makeConfirmationsAlive(mQuery(container + " a[data-toggle='confirmation']"));
 
     //initialize date/time
     mQuery(container + " *[data-toggle='datetime']").each(function() {
@@ -718,6 +703,33 @@ Mautic.onPageLoad = function (container, response, inModal) {
     if ((response && typeof response.stopPageLoading != 'undefined' && response.stopPageLoading) || container == '#app-content' || container == '.page-list') {
         Mautic.stopPageLoadingBar();
     }
+};
+
+Mautic.makeConfirmationsAlive = function(jQueryObject) {
+    jQueryObject.off('click.confirmation');
+    jQueryObject.on('click.confirmation', function (event) {
+        event.preventDefault();
+        MauticVars.ignoreIconSpin = true;
+        return Mautic.showConfirmation(this);
+    });
+};
+
+Mautic.makeModalsAlive = function(jQueryObject) {
+    jQueryObject.off('click.ajaxmodal');
+    jQueryObject.on('click.ajaxmodal', function (event) {
+        event.preventDefault();
+
+        Mautic.ajaxifyModal(this, event);
+    });
+};
+
+Mautic.makeLinksAlive = function(jQueryObject) {
+    jQueryObject.off('click.ajax');
+    jQueryObject.on('click.ajax', function (event) {
+        event.preventDefault();
+
+        return Mautic.ajaxifyLink(this, event);
+    });
 };
 
 /**

--- a/app/bundles/CoreBundle/Assets/js/9.modals.js
+++ b/app/bundles/CoreBundle/Assets/js/9.modals.js
@@ -240,12 +240,6 @@ Mautic.processModalContent = function (response, target) {
             mQuery('body').removeClass('noscroll');
             mQuery(target).modal('hide');
 
-            if (response.mauticContent) {
-                if (typeof Mautic[response.mauticContent + "OnLoad"] == 'function') {
-                    Mautic[response.mauticContent + "OnLoad"](target, response);
-                }
-            }
-
             if (!response.updateModalContent) {
                 Mautic.onPageUnload(target, response);
             }

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -882,14 +882,19 @@ Mautic.leadNoteOnLoad = function (container, response) {
     }
 
     if (response.upNoteCount || response.noteCount || response.downNoteCount) {
-        if (response.upNoteCount || response.downNoteCount) {
-            var count = parseInt(mQuery('#NoteCount').html());
-            count = (response.upNoteCount) ? count + 1 : count - 1;
+        var noteCountWrapper = mQuery('#NoteCount');
+        var count = parseInt(noteCountWrapper.text().trim());
+        // console.log(response, count);
+
+        if (response.upNoteCount) {
+            count++;
+        } else if (response.downNoteCount) {
+            count--;
         } else {
-            var count = parseInt(response.noteCount);
+            count = parseInt(response.noteCount);
         }
 
-        mQuery('#NoteCount').html(count);
+        noteCountWrapper.text(count);
     }
 };
 

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -862,21 +862,9 @@ Mautic.leadNoteOnLoad = function (container, response) {
             mQuery('#LeadNotes').prepend(response.noteHtml);
         }
 
-        //initialize ajax'd modals
-        mQuery(el + " *[data-toggle='ajaxmodal']").off('click.ajaxmodal');
-        mQuery(el + " *[data-toggle='ajaxmodal']").on('click.ajaxmodal', function (event) {
-            event.preventDefault();
-
-            Mautic.ajaxifyModal(this, event);
-        });
-
-        //initiate links
-        mQuery(el + " a[data-toggle='ajax']").off('click.ajax');
-        mQuery(el + " a[data-toggle='ajax']").on('click.ajax', function (event) {
-            event.preventDefault();
-
-            return Mautic.ajaxifyLink(this, event);
-        });
+        Mautic.makeModalsAlive(mQuery(el + " *[data-toggle='ajaxmodal']"));
+        Mautic.makeConfirmationsAlive(mQuery(el+' a[data-toggle="confirmation"]'));
+        Mautic.makeLinksAlive(mQuery(el + " a[data-toggle='ajax']"));
     } else if (response.deleteId && mQuery('#LeadNote' + response.deleteId).length) {
         mQuery('#LeadNote' + response.deleteId).remove();
     }
@@ -884,7 +872,6 @@ Mautic.leadNoteOnLoad = function (container, response) {
     if (response.upNoteCount || response.noteCount || response.downNoteCount) {
         var noteCountWrapper = mQuery('#NoteCount');
         var count = parseInt(noteCountWrapper.text().trim());
-        // console.log(response, count);
 
         if (response.upNoteCount) {
             count++;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4469
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The issues are nicely shown in the video in the linked issue. The count was always increased by 2 instead of 1 because the *OnLoad method was called twice for modals. I removed the code which was calling it the same way with the same params for the second time.

The delete buttons did not have the right events after the new HTML was added asynchronously. The events were added and I also de-duplicated some code.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Follow the video and notice the issues

#### Steps to test this PR:
1. Apply this PR
2. Regenerate production assets with `app/console mautic:assets:generate` or use the dev env.
3. Retest - no issues.