### PR TITLE
The select lists label will now be displayed in contact's details instead of value

### DIFF
--- a/app/bundles/LeadBundle/Views/Lead/lead.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/lead.html.php
@@ -205,7 +205,11 @@ $view['slots']->set(
                                                         <?php if (is_array($field['value']) && 'multiselect' === $field['type']): ?>
                                                             <?php echo implode(', ', $field['value']); ?>
                                                         <?php else: ?>
-                                                            <?php echo $field['value']; ?>
+                                                            <?php if ('select' === $field['type']): ?>
+                                                                <?php echo $field['label']; ?>
+                                                            <?php else: ?>
+                                                                <?php echo $field['value']; ?>
+                                                            <?php endif; ?>
                                                         <?php endif; ?>
                                                     <?php endif; ?>
                                                 </td>

--- a/app/bundles/LeadBundle/Views/Lead/lead.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/lead.html.php
@@ -202,10 +202,10 @@ $view['slots']->set(
                                                     <img class="mr-sm" src="<?php echo $flag; ?>" alt="" style="max-height: 24px;"/>
                                                     <span class="mt-1"><?php echo $field['value']; ?>
                                                     <?php else: ?>
-                                                        <?php if (is_array($field['value']) && 'multiselect' === $field['type']): ?>
+                                                        <?php if (is_array($field['value']) && $field['type'] === 'multiselect'): ?>
                                                             <?php echo implode(', ', $field['value']); ?>
                                                         <?php else: ?>
-                                                            <?php if ('select' === $field['type']): ?>
+                                                            <?php if ($field['type'] === 'select'): ?>
                                                                 <?php echo $field['label']; ?>
                                                             <?php else: ?>
                                                                 <?php echo $field['value']; ?>


### PR DESCRIPTION
Before the fields value was displayed because no check for the field type was made.

Should fix to #3664 and be usefull for fixing #4330

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | Fixes #3664 and is useful #4330 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
In the contact's details section (expandable area) custom select field displayed their value, not their label. This is not desired for select fields because they are key-value focused. This commit checks if the field type is ```select``` and if so displays the fields label.

This might also be useful for fixing #4330, but I haven't looked into that issue yet.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
*Refer to #3664*

#### Steps to test this PR:
1. Create a custom select field for a contact
2. Add at least one value-label option. Choose a different label that value
3. Create a contact, set the created custom field to any option you like.
4. Save and close the contact
5. Open the details tab of the contact and you'll see the field label.

This is my first mautic / php related contribution, be kind :wink: 