### PR TITLE
Make video controls opt in with data-mautic-video data attribute

### DIFF
--- a/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
@@ -368,7 +368,7 @@ MauticJS.processGatedVideos = function (videoElements) {
         var playerFeatures = [];
         var source   = node.getElementsByTagName('source')[0];
         
-        if (source.type == 'video/mp4') {
+        if (source.type === 'video/mp4') {
             node.dataset.mp4 = true;
             playerFeatures = ['playpause','progress','current','duration','volume','fullscreen'];
         }
@@ -376,117 +376,121 @@ MauticJS.processGatedVideos = function (videoElements) {
         if (!node.id) {
             node.id = 'mautic-player-' + i;
         }
-       
 
-            mediaPlayers[i] = [];
-            
-            if(node.dataset.formId){
+        mediaPlayers[i] = [];
+        
+        if (node.dataset.formId) {
             var cookieName = 'mautic-player-'+i+'-'+node.dataset.formId;
             MauticJS.makeCORSRequest('GET', '{$mauticBaseUrl}form/embed/' + node.dataset.formId, {}, function (data) {
                 mediaPlayers[i].formHtml = data;
             });
-            }else{
-                mediaPlayers[i].formHtml = '';
-            }
+        } else {
+            mediaPlayers[i].formHtml = '';
+        }
+
+        // If we don't have a formId, and it's not explicitly set as a Mautic controlled video, return.
+        if (!node.dataset.formId && !node.dataset.mauticVideo) {
+            return;
+        }
+        
+        mediaPlayers[i].player = new MediaElementPlayer('#' + node.id, {features: playerFeatures, alwaysShowControls: true, enableKeyboard: false, success: function (mediaElement, domElement) {
+            mediaPlayers[i].inPoster = false;
+            mediaPlayers[i].success  = false;
+            mediaPlayers[i].views    = [];
+            mediaPlayers[i].mediaElement = mediaElement;
             
-            mediaPlayers[i].player = new MediaElementPlayer('#' + node.id, {features: playerFeatures, alwaysShowControls: true, enableKeyboard: false, success: function (mediaElement, domElement) {
-                mediaPlayers[i].inPoster = false;
-                mediaPlayers[i].success  = false;
-                mediaPlayers[i].views    = [];
-                mediaPlayers[i].mediaElement = mediaElement;
-                
-                if (!node.dataset.mp4) {
-                    node.parentElement.parentElement.parentElement.className += ' no-controls';
-                }
-                var iframes = node.parentElement.getElementsByTagName('iframe');
-                
-                if (iframes) {
-                    MauticJS.iterateCollection(iframes)(function(node, i) {
-                        node.setAttribute('tabindex', -1);
-                    });
-                }
-
-                mediaElement.addEventListener('ended', function(e) {
-                    MauticJS.endCurrentView(i);
+            if (!node.dataset.mp4) {
+                node.parentElement.parentElement.parentElement.className += ' no-controls';
+            }
+            var iframes = node.parentElement.getElementsByTagName('iframe');
+            
+            if (iframes) {
+                MauticJS.iterateCollection(iframes)(function(node, i) {
+                    node.setAttribute('tabindex', -1);
                 });
+            }
+
+            mediaElement.addEventListener('ended', function(e) {
+                MauticJS.endCurrentView(i);
+            });
+            
+            mediaElement.addEventListener('timeupdate', function (e) {
+                var currentTime = 0;
+                if ('Event' == e.constructor.name) {
+                    currentTime = e.srcElement.currentTime;
+                } else {
+                    currentTime = e.currentTime;
+                }
                 
-                mediaElement.addEventListener('timeupdate', function (e) {
-                    var currentTime = 0;
-                    if ('Event' == e.constructor.name) {
-                        currentTime = e.srcElement.currentTime;
-                    } else {
-                        currentTime = e.currentTime;
+                MauticJS.addVideoView(i, currentTime);
+
+                if (node.dataset.formId && document.cookie.indexOf(cookieName) == -1 && currentTime >= node.dataset.gateTime && mediaPlayers[i].inPoster === false && mediaPlayers[i].success === false) {
+                    if (document.activeElement.tagName == 'IFRAME') {
+                        window.mejs.previousActiveElement = document.activeElement;
+                        document.activeElement.blur();
                     }
+
+                    mediaPlayers[i].inPoster = true;
+                    mediaPlayers[i].player.pause();
+                    mediaPlayers[i].poster = document.getElementById(node.id).parentElement.parentElement.getElementsByClassName('mejs-poster')[0];
+                    mediaPlayers[i].poster.innerHTML = mediaPlayers[i].formHtml;
+                    mediaPlayers[i].poster.style.display = 'block';
+                    mediaPlayers[i].form = mediaPlayers[i].poster.getElementsByTagName('form')[0];
+                    mediaPlayers[i].form.className += ' mautic-gated-video-style';
                     
-                    MauticJS.addVideoView(i, currentTime);
-
-                    if (node.dataset.formId && document.cookie.indexOf(cookieName) == -1 && currentTime >= node.dataset.gateTime && mediaPlayers[i].inPoster === false && mediaPlayers[i].success === false) {
-                        if (document.activeElement.tagName == 'IFRAME') {
-                            window.mejs.previousActiveElement = document.activeElement;
-                            document.activeElement.blur();
-                        }
-
-                        mediaPlayers[i].inPoster = true;
-                        mediaPlayers[i].player.pause();
-                        mediaPlayers[i].poster = document.getElementById(node.id).parentElement.parentElement.getElementsByClassName('mejs-poster')[0];
-                        mediaPlayers[i].poster.innerHTML = mediaPlayers[i].formHtml;
-                        mediaPlayers[i].poster.style.display = 'block';
-                        mediaPlayers[i].form = mediaPlayers[i].poster.getElementsByTagName('form')[0];
-                        mediaPlayers[i].form.className += ' mautic-gated-video-style';
+                    mediaPlayers[i].form.addEventListener('submit', function (e) {
+                        e.preventDefault();
                         
-                        mediaPlayers[i].form.addEventListener('submit', function (e) {
-                            e.preventDefault();
-                            
-                            MauticJS.makeCORSRequest(
-                                'POST',
-                                '{$formSubmitUrl}?formId=' + node.dataset.formId,
-                                jQuery(mediaPlayers[i].form).serialize(),
-                                function (data) {
-                                    if (data.success) {
-                                        mediaPlayers[i].success = true;
-                                        if (!data.message) {
-                                            mediaPlayers[i].poster.style.display = 'none';
-                                            mediaPlayers[i].player.play();
+                        MauticJS.makeCORSRequest(
+                            'POST',
+                            '{$formSubmitUrl}?formId=' + node.dataset.formId,
+                            jQuery(mediaPlayers[i].form).serialize(),
+                            function (data) {
+                                if (data.success) {
+                                    mediaPlayers[i].success = true;
+                                    if (!data.message) {
+                                        mediaPlayers[i].poster.style.display = 'none';
+                                        mediaPlayers[i].player.play();
+                                        window.mejs.previousActiveElement.focus();
+                                    }
+                                    
+                                    // Set a cookie to prevent showing the same form again
+                                    document.cookie = cookieName+"=true; max-age=" + 60 * 60 * 24 * 7; 
+                                } 
+                                
+                                if (data.message) {
+                                    // Place the poster position just above center
+                                    var position = parseInt(mediaPlayers[i].poster.style.height) / 1.4;
+                                    mediaPlayers[i].poster.innerHTML = '<p style="padding:20px;padding-top:' + position + 'px;" class="mautic-response">' + data.message + '</p>';
+                                    setTimeout(function(){
+                                        mediaPlayers[i].poster.style.display = 'none';
+                                        mediaPlayers[i].player.play();
+                                        if (window.mejs.previousActiveElement && window.mejs.previousActiveElement.tagName == 'IFRAME') {
                                             window.mejs.previousActiveElement.focus();
                                         }
-                                        
-                                        // Set a cookie to prevent showing the same form again
-                                        document.cookie = cookieName+"=true; max-age=" + 60 * 60 * 24 * 7; 
-                                    } 
-                                    
-                                    if (data.message) {
-                                        // Place the poster position just above center
-                                        var position = parseInt(mediaPlayers[i].poster.style.height) / 1.4;
-                                        mediaPlayers[i].poster.innerHTML = '<p style="padding:20px;padding-top:' + position + 'px;" class="mautic-response">' + data.message + '</p>';
-                                        setTimeout(function(){
-                                            mediaPlayers[i].poster.style.display = 'none';
-                                            mediaPlayers[i].player.play();
-                                            if (window.mejs.previousActiveElement && window.mejs.previousActiveElement.tagName == 'IFRAME') {
-                                                window.mejs.previousActiveElement.focus();
-                                            }
-                                        }, 3000);
-                                    } else if (data.validationErrors) {
-                                        // Reset validation errors
-                                        jQuery('#mauticform_'+data.formName+' .mauticform-errormsg').css('display', 'none');
-                                        // Display validation errors
-                                        jQuery.each(data.validationErrors, function (field, message) {
-                                            if (jQuery('#mauticform_'+data.formName+'_'+field+' .mauticform-errormsg')) {
-                                                jQuery('#mauticform_'+data.formName+'_'+field+' .mauticform-errormsg').css('display', 'block');
-                                            }
-                                        });
-                                    }
+                                    }, 3000);
+                                } else if (data.validationErrors) {
+                                    // Reset validation errors
+                                    jQuery('#mauticform_'+data.formName+' .mauticform-errormsg').css('display', 'none');
+                                    // Display validation errors
+                                    jQuery.each(data.validationErrors, function (field, message) {
+                                        if (jQuery('#mauticform_'+data.formName+'_'+field+' .mauticform-errormsg')) {
+                                            jQuery('#mauticform_'+data.formName+'_'+field+' .mauticform-errormsg').css('display', 'block');
+                                        }
+                                    });
                                 }
-                            );
-                            
-                            return false;
-                        });
-                    }
-                });
-            }});
-            
-            if (node.autoplay) {
-                mediaPlayers[i].player.play();
-            }
+                            }
+                        );
+                        
+                        return false;
+                    });
+                }
+            });
+        }});
+        
+        if (node.autoplay) {
+            mediaPlayers[i].player.play();
+        }
     });
 }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Updates were made in 2.9 to allow Mautic to track video views for all videos on a tracked web page, not just gated videos. However, it tracks ALL videos on the page, even if the user doesn't want it to be. This PR fixes that by making non-gated video tracking opt-in using the `data-mautic-video` data attribute. To opt in, add `data-mautic-video="true"` to your `<video>` tags on your page.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Be on 2.9
2. Embed a `<video>` tag in your page, load the page, then load the video to see that it is tracked in Mautic even without opting in. 

#### Steps to test this PR:
1. Apply PR, clear cache, and rebuild assets via `app/console m:a:g`
2. Reload the page with the embedded video. Then load the video and see that the view is not tracked in Mautic.
3. Add the `data-mautic-video="true"` data attribute to your `<video>` tag, reload the page where it is embedded, then load the video and see the view tracked in Mautic.