### PR TITLE
Forced email to be required for Salesforce

### DIFF
--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -254,9 +254,10 @@ class SalesforceIntegration extends CrmAbstractIntegration
         }
 
         $isRequired = function (array $field, $object) {
-            return ($field['type'] !== 'boolean' && empty($field['nillable']) && !in_array($field['name'], ['Status', 'Id']))
-                || ($object == 'Lead'
-                    && in_array($field['name'], ['Company']));
+            return
+                ($field['type'] !== 'boolean' && empty($field['nillable']) && !in_array($field['name'], ['Status', 'Id'])) ||
+                ($object == 'Lead' && in_array($field['name'], ['Company'])) ||
+                (in_array($object, ['Lead', 'Contact']) && 'Email' === $field['name']);
         };
 
         $salesFields = [];


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The email field is not required for SF but we use it as a key to an array that determines what gets created as new Lead's in Salesforce. This was a recipe for duplicates.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup a Salesforce Sync
2. Create a new Mautic contact
3. Sync to Salesforce "php app/console m:i:s -i Salesforce -a "2 minutes"
4. Ensure the Mautic contact was created as a SF lead
5. Manually delete the contact entry from the integration_entity table
6. Sync again
7. Search in SF and note the duplicate

#### Steps to test this PR:
1. Repeat with a new contact
2. No dups
