### PR TITLE
Bugfix - Update segment excluding/including membership

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -377,7 +377,7 @@ class LeadListRepository extends CommonRepository
                 }
 
                 if ($newOnly) {
-                    $expr = $this->generateSegmentExpression($filters, $parameters, $q);
+                    $expr = $this->generateSegmentExpression($filters, $parameters, $q, null, $l['id']);
 
                     if (!$this->hasCompanyFilter && !$expr->count()) {
                         // Treat this as if it has no filters since all the filters are now invalid (fields were deleted)
@@ -561,7 +561,7 @@ class LeadListRepository extends CommonRepository
      *
      * @return QueryBuilder
      */
-    protected function generateSegmentExpression(array $filters, array &$parameters, QueryBuilder $q, QueryBuilder $parameterQ = null)
+    protected function generateSegmentExpression(array $filters, array &$parameters, QueryBuilder $q, QueryBuilder $parameterQ = null, $listId = null, $not = false)
     {
         if (null === $parameterQ) {
             $parameterQ = $q;
@@ -571,7 +571,7 @@ class LeadListRepository extends CommonRepository
         $this->hasCompanyFilter = isset($objectFilters['company']) && count($objectFilters['company']) > 0;
 
         $this->listFiltersInnerJoinCompany = false;
-        $expr                              = $this->getListFilterExpr($filters, $parameters, $q, false, null);
+        $expr                              = $this->getListFilterExpr($filters, $parameters, $q, $not, null, 'lead', $listId);
 
         if ($this->hasCompanyFilter) {
             $this->applyCompanyFieldFilters($q);
@@ -648,7 +648,7 @@ class LeadListRepository extends CommonRepository
      *
      * @return \Doctrine\DBAL\Query\Expression\CompositeExpression|mixed
      */
-    public function getListFilterExpr($filters, &$parameters, QueryBuilder $q, $not = false, $leadId = null, $object = 'lead')
+    public function getListFilterExpr($filters, &$parameters, QueryBuilder $q, $not = false, $leadId = null, $object = 'lead', $listId = null)
     {
         static $leadTable;
         static $companyTable;
@@ -1350,10 +1350,18 @@ class LeadListRepository extends CommonRepository
                         );
                     }
 
+                    $isLeadList = false;
                     switch ($details['field']) {
                         case 'leadlist':
-                            $table  = 'lead_lists_leads';
-                            $column = 'leadlist_id';
+                            $newListId = $details['filter'];
+                            if ($listId !== $newListId) { // prevent infinite loop
+                                $isLeadList = true;
+                                $ll         = $this->getEntity($newListId);
+                                $nq         = $this->_em->getConnection()->createQueryBuilder();
+                                $nf         = $ll->getFilters();
+                                $isNot      = 'NOT EXISTS' === $func;
+                                $se         = $this->generateSegmentExpression($nf, $parameters, $nq, null, $newListId, $isNot);
+                            }
 
                             $falseParameter = $this->generateRandomParameterName();
                             $subExpr->add(
@@ -1395,6 +1403,12 @@ class LeadListRepository extends CommonRepository
                             $table  = 'lead_devices';
                             $column = 'device_os_name';
                             break;
+                    }
+
+                    if ($isLeadList) {
+                        // add segment filters to current filters
+                        $groupExpr->add($se);
+                        break;
                     }
 
                     $deviceFilterParamater = $this->generateRandomParameterName();

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -1361,6 +1361,9 @@ class LeadListRepository extends CommonRepository
                                 $nf         = $ll->getFilters();
                                 $isNot      = 'NOT EXISTS' === $func;
                                 $se         = $this->generateSegmentExpression($nf, $parameters, $nq, null, $newListId, $isNot);
+                            } else {
+                                $table  = 'lead_lists_leads';
+                                $column = 'leadlist_id';
                             }
 
                             $falseParameter = $this->generateRandomParameterName();

--- a/app/bundles/LeadBundle/Entity/OperatorListTrait.php
+++ b/app/bundles/LeadBundle/Entity/OperatorListTrait.php
@@ -162,17 +162,17 @@ trait OperatorListTrait
         'startsWith' => [
             'label'       => 'mautic.core.operator.starts.with',
             'expr'        => 'startsWith',
-            'negate_expr' => false,
+            'negate_expr' => 'startsWith',
         ],
         'endsWith' => [
             'label'       => 'mautic.core.operator.ends.with',
             'expr'        => 'endsWith',
-            'negate_expr' => false,
+            'negate_expr' => 'endsWith',
         ],
         'contains' => [
             'label'       => 'mautic.core.operator.contains',
             'expr'        => 'contains',
-            'negate_expr' => false,
+            'negate_expr' => 'contains',
         ],
     ];
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
When there are two or more segments with filters that match a contact but one of those segments includes a filter to exclude the other segments that also match, it will be after the next `mautic:segment:update` command execution that the segments will be updated correctly.

This is because right now the including/excluding filters work by joining with the `lead_lists_leads` table and using `EXISTS` or `NOR EXISTS` SQL operators. But because the segments have not been populated yet, the subqueries return no results until the next mautic:segment:update command is executed.

This only happens if the segment with the including/excluding filter is updated before the other segments (the order in which the segments are updated is alphabetical)

This PR fixes that behaviour by taking the filters in the including/excluding segments and then appending those filters to the segment SQL query at once. (If it is an excluding segment it negates the filters before appending them). That way it doesn't matter if the contact already exists or not in the segments.

#### Steps to reproduce the bug:
1. Create a contact with First Name = Mario
2. Create a segment **s2** with filter: First Name = Mario
3. Create a segment **s1** with filters:
  First Name like m%
  Segment membership excluding **s2**
4. Run the command `php app/console m:s:u`
5. Check the contacts segments, it will belong to **s1** and **s2** because the contact still doesn't belong to **s2** and the first name begins with m.
6. Run the command `php app/console m:s:u` again
7. Check the contact segments, it will belong only to **s2**

#### Steps to test this PR:
1. Apply this PR
2. Delete the segments **s1** and **s2** that were created previously
2. Follow the steps to reproduce the bug from step 2 to step 4
3. Check the contact segments, it will belong only to **s2**

