### PR TITLE
SQL query error fixed when searching for a specific contact event by name at the timeline

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
@@ -109,8 +109,8 @@ class LeadEventLogRepository extends CommonRepository
             ->andWhere($alias.'.object = :object')
             ->setParameter('object', $object);
 
-        if (isset($options['search']) && $options['search']) {
-            $qb->andWhere($qb->expr()->like($alias.'.original_file', $qb->expr()->literal('%'.$options['search'].'%')));
+        if (!empty($options['search'])) {
+            $qb->andWhere($qb->expr()->like($alias.'.properties', $qb->expr()->literal('%'.$options['search'].'%')));
         }
 
         return $this->getTimelineResults($qb, $options, $alias.'.original_file', $alias.'.date_added', ['query'], ['date_added']);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Searching for a contact's timeline events by some string will throw a SQL query error:
```
Uncaught PHP Exception Doctrine\DBAL\Exception\NotNullConstraintViolationException: "An exception occurred while executing 'INSERT INTO mautic_imports (is_published, date_added, created_by, created_by_user, date_modified, modified_by, modified_by_user, checked_out, checked_out_by, checked_out_by_user, dir, file, original_file, line_count, inserted_count, updated_count, ignored_count, priority, status, date_started, date_ended, object, properties) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params [1, "2017-07-20 13:17:53", null, "Mautic Support", null, null, null, null, null, null, null, "import.csv", null, 0, 0, 0, 0, 512, 1, null, null, "lead", "[]"]: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'dir' cannot be null"
```

This PR fixes that. It uses the lead_event_log.params to search for a full text search instead of the problematic field from the imports table.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make sure you have some contacts imported after you upgraded to 2.9.0.
2. Go to the detail of an imported contact.
3. Search for the name of the imported CSV file.
- It will throw the error above.

#### Steps to test this PR:
1. Apply this PR
2. Search again.
- The event will be listed. No error.