### PR TITLE
Fixed various areas problematic for users tracked as leads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: precise
+
 language: php
 
 services:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This is a simple 3 step installation process. You'll want to make sure you alrea
 **Get stuck?** *No problem. Check out [general troubleshooting](https://mautic.org/docs/en/tips/troubleshooting.html) and if it won't solve your issue join us at the <a href="https://www.mautic.org/community">Mautic community</a> for help and answers.*
 
 # Disclaimer
-Installing from source is only recommended if you are comfortable using the command line. You'll be required to use various CLI commands to get Mautic working and to keep it working. If the source and/or database schema gets out of sync with Mautic's releases, the release updater may not work and will require manual updates. For production is recommened the pre-packaged Mautic available at [mautic.com/download](https://www.mautic.org/download).
+Installing from source is only recommended if you are comfortable using the command line. You'll be required to use various CLI commands to get Mautic working and to keep it working. If the source and/or database schema gets out of sync with Mautic's releases, the release updater may not work and will require manual updates. For production the pre-packaged Mautic available at [mautic.com/download](https://www.mautic.org/download) is recommended.
 
 *Also note that the source outside <a href="https://github.com/mautic/mautic/releases">a tagged release</a> should be considered "alpha" and may contain bugs, cause unexpected results, data corruption or loss, and is not recommended for use in a production environment. Use at your own risk.*
 
@@ -156,19 +156,19 @@ There are many more ways in which automation can be used throughout Mautic to im
 
 ## Customizing - Plugins, Themes
 
-There are many benefits to using Mautic as your marketing automation tool. As the first and only community-driven, open source marketing automation platform there are many distinct advantages. You can choose whether you want to submit your feature as to the community as a pull request or wheter to build it as a plugin or theme.
+There are many benefits to using Mautic as your marketing automation tool. As the first and only community-driven, open source marketing automation platform there are many distinct advantages. You can choose whether you want to submit your feature to the community as a pull request or whether to build it as a plugin or theme.
 
 Read more about plugins and themes in the [Mautic Developer Docummentation](https://developer.mautic.org).
 
 ## Connecting - API, Webhooks
 
-Mautic have a REST API which you can use to connect it with another app. Of you can use the webhooks to send the updates which happens in Mautic to another app.
+Mautic have a REST API which you can use to connect it with another app. You can use the webhooks to send the updates which happen in Mautic to another app.
 
 Read more about API and webhooks in the [Mautic Developer Docummentation](https://developer.mautic.org).
 
 ## Translations
 
-One benefit of using Mautic is the ability to modify and customize the solution to fit your needs. Mautic allows you to quickly change to your preferred language, or modify any string through the language files. These language files are available for the translation by the community at [Transifex](https://www.transifex.com/mautic/mautic/dashboard) and if you are interested you can add more languages, or help to translate the current ones.
+One benefit of using Mautic is the ability to modify and customize the solution to fit your needs. Mautic allows you to quickly change to your preferred language, or modify any string through the language files. These language files are available for translation by the community at [Transifex](https://www.transifex.com/mautic/mautic/dashboard) and if you are interested you can add more languages, or help to translate the current ones.
 
 ## How to test a pull request
 
@@ -183,27 +183,27 @@ Everyone can test submitted features and bug fixes. No programming skills are re
 5. Install dependencies (`composer install`).
 6. Visit Mautic in a browser (probably at http://localhost/mautic) and follow installation steps.
 
-### Development environement
+### Development environment
 
-Mautic downloaded from GitHub have the development environment. You can access it by adding `index_dev.php` after the Mautic URL. Eg. `http://localhost/mautic/index_dev.php/s/`. Or in case of CLI commands, add `--env=dev` attribute to it.
+Mautic downloaded from GitHub has the development environment. You can access it by adding `index_dev.php` after the Mautic URL. Eg. `http://localhost/mautic/index_dev.php/s/`. Or in case of CLI commands, add `--env=dev` attribute to it.
 
-This development environment will display the PHP errors, warnigns and notices directly as the output so you don't have to open the log to see them. It will also load for example translations without cache, so every change you make will be visible without clearing it. The only changes which requires clearing the cache are in the `config.php` files.
+This development environment will display the PHP errors, warnings and notices directly as the output so you don't have to open the log to see them. It will also load for example translations without cache, so every change you make will be visible without clearing it. The only changes which require clearing the cache are in the `config.php` files.
 
-In case of assets like JS, CSS, the source files are loaded instead of concatinated, minified file. This way the changes in those files will be directly visible on refresh. If you'd want to see the change in production environment, you'd have to run the `app/console mautic:assets:generate` command.
+In case of assets like JS, CSS, the source files are loaded instead of concatenated, minified files. This way the changes in those files will be directly visible on refresh. If you'd wanted to see the change in the production environment, you'd have to have run the `app/console mautic:assets:generate` command.
 
 In many cases, the CSS files are built from LESS files. To compile the changes in the LESS files, run `grunt compile-less` command.
 
 ### Test a pull request (PR)
 
-Every change to Mautic core happens via PRs. Every PR must have 2 successful tests to be merged to the core and released in the next version. Testing a PR is a great way how to move Mautic forward and personally improve its quality and stability.
+Every change to Mautic core happens via PRs. Every PR must have 2 successful tests to be merged to the core and released in the next version. Testing a PR is a great way to move Mautic forward and personally improve its quality and stability.
 
 1. [Select a PR](https://github.com/mautic/mautic/pulls) to test.
-2. Read the description and steps to test. If it's a bug fix, follow the steps if you'll be able to recreate the issue.
+2. Read the description and steps to test. If it's a bug fix, follow the steps to ensure you can recreate the issue.
 3. Use the development environment (above) for testing.
 3. [Apply the PR](https://help.github.com/articles/checking-out-pull-requests-locally/#modifying-an-inactive-pull-request-locally)
 4. Clear cache for development environment (`rm -rf app/cache/*` or `app/console cache:clear -e dev`).
 5. Follow the steps from the PR description again to see if the result is as described.
-6. Write a comment how the test went. If there is a problem, provide as many information as possible including error log messages.
+6. Write a comment about how the test went. If there is a problem, provide as much information as possible including error log messages.
 
 ## Unit Tests
 

--- a/app/bundles/AssetBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/BuilderSubscriber.php
@@ -95,11 +95,12 @@ class BuilderSubscriber extends CommonSubscriber
      */
     public function onPageDisplay(PageDisplayEvent $event)
     {
-        $page   = $event->getPage();
-        $leadId = ($this->security->isAnonymous()) ? $this->leadModel->getCurrentLead()->getId() : null;
-        $tokens = $this->generateTokensFromContent($event, $leadId, ['page', $page->getId()]);
-
+        $page    = $event->getPage();
+        $lead    = ($this->security->isAnonymous()) ? $this->leadModel->getCurrentLead() : null;
+        $leadId  = ($lead) ? $lead->getId() : null;
+        $tokens  = $this->generateTokensFromContent($event, $leadId, ['page', $page->getId()]);
         $content = $event->getContent();
+
         if (!empty($tokens)) {
             $content = str_ireplace(array_keys($tokens), $tokens, $content);
         }

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -250,8 +250,15 @@ class EventModel extends CommonFormModel
             return false;
         }*/
 
-        //get the current lead
-        $lead   = $this->leadModel->getCurrentLead();
+        // get the current lead
+        $lead = $this->leadModel->getCurrentLead();
+
+        if (!$lead instanceof Lead) {
+            $this->logger->debug('CAMPAIGN: unidentifiable contact; abort');
+
+            return false;
+        }
+
         $leadId = $lead->getId();
         $this->logger->debug('CAMPAIGN: Current Lead ID# '.$leadId);
 

--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -234,12 +234,7 @@ Mautic.onPageLoad = function (container, response, inModal) {
     Mautic.initDateRangePicker(container + ' #daterange_date_from', container + ' #daterange_date_to');
 
     //initiate links
-    mQuery(container + " a[data-toggle='ajax']").off('click.ajax');
-    mQuery(container + " a[data-toggle='ajax']").on('click.ajax', function (event) {
-        event.preventDefault();
-
-        return Mautic.ajaxifyLink(this, event);
-    });
+    Mautic.makeLinksAlive(mQuery(container + " a[data-toggle='ajax']"));
 
     //initialize forms
     mQuery(container + " form[data-toggle='ajax']").each(function (index) {
@@ -247,12 +242,7 @@ Mautic.onPageLoad = function (container, response, inModal) {
     });
 
     //initialize ajax'd modals
-    mQuery(container + " *[data-toggle='ajaxmodal']").off('click.ajaxmodal');
-    mQuery(container + " *[data-toggle='ajaxmodal']").on('click.ajaxmodal', function (event) {
-        event.preventDefault();
-
-        Mautic.ajaxifyModal(this, event);
-    });
+    Mautic.makeModalsAlive(mQuery(container + " *[data-toggle='ajaxmodal']"))
 
     //initialize embedded modal forms
     Mautic.activateModalEmbeddedForms(container);
@@ -306,12 +296,7 @@ Mautic.onPageLoad = function (container, response, inModal) {
         Mautic.initiateFileDownload(mQuery(this).attr('href'));
     });
 
-    mQuery(container + " a[data-toggle='confirmation']").off('click.confirmation');
-    mQuery(container + " a[data-toggle='confirmation']").on('click.confirmation', function (event) {
-        event.preventDefault();
-        MauticVars.ignoreIconSpin = true;
-        return Mautic.showConfirmation(this);
-    });
+    Mautic.makeConfirmationsAlive(mQuery(container + " a[data-toggle='confirmation']"));
 
     //initialize date/time
     mQuery(container + " *[data-toggle='datetime']").each(function() {
@@ -718,6 +703,33 @@ Mautic.onPageLoad = function (container, response, inModal) {
     if ((response && typeof response.stopPageLoading != 'undefined' && response.stopPageLoading) || container == '#app-content' || container == '.page-list') {
         Mautic.stopPageLoadingBar();
     }
+};
+
+Mautic.makeConfirmationsAlive = function(jQueryObject) {
+    jQueryObject.off('click.confirmation');
+    jQueryObject.on('click.confirmation', function (event) {
+        event.preventDefault();
+        MauticVars.ignoreIconSpin = true;
+        return Mautic.showConfirmation(this);
+    });
+};
+
+Mautic.makeModalsAlive = function(jQueryObject) {
+    jQueryObject.off('click.ajaxmodal');
+    jQueryObject.on('click.ajaxmodal', function (event) {
+        event.preventDefault();
+
+        Mautic.ajaxifyModal(this, event);
+    });
+};
+
+Mautic.makeLinksAlive = function(jQueryObject) {
+    jQueryObject.off('click.ajax');
+    jQueryObject.on('click.ajax', function (event) {
+        event.preventDefault();
+
+        return Mautic.ajaxifyLink(this, event);
+    });
 };
 
 /**

--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -653,7 +653,7 @@ Mautic.onPageLoad = function (container, response, inModal) {
     }
 
     if (contentSpecific && typeof Mautic[contentSpecific + "OnLoad"] == 'function') {
-        if (typeof Mautic.loadedContent[contentSpecific] == 'undefined') {
+        if (inModal || typeof Mautic.loadedContent[contentSpecific] == 'undefined') {
             Mautic.loadedContent[contentSpecific] = true;
             Mautic[contentSpecific + "OnLoad"](container, response);
         }

--- a/app/bundles/CoreBundle/Assets/js/9.modals.js
+++ b/app/bundles/CoreBundle/Assets/js/9.modals.js
@@ -240,12 +240,6 @@ Mautic.processModalContent = function (response, target) {
             mQuery('body').removeClass('noscroll');
             mQuery(target).modal('hide');
 
-            if (response.mauticContent) {
-                if (typeof Mautic[response.mauticContent + "OnLoad"] == 'function') {
-                    Mautic[response.mauticContent + "OnLoad"](target, response);
-                }
-            }
-
             if (!response.updateModalContent) {
                 Mautic.onPageUnload(target, response);
             }

--- a/app/bundles/CoreBundle/Form/EventListener/CleanFormSubscriber.php
+++ b/app/bundles/CoreBundle/Form/EventListener/CleanFormSubscriber.php
@@ -53,7 +53,7 @@ class CleanFormSubscriber implements EventSubscriberInterface
     {
         $data = $event->getData();
 
-        //clean the data
+        // clean the data
         $data = InputHelper::_($data, $this->masks);
 
         $event->setData($data);

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -399,6 +399,14 @@ class InputHelper
                 },
                 $value, -1, $needsDecoding);
 
+            // Slecial handling for script tags
+            $value = preg_replace_callback(
+                "/<script>(.*?)<\/script>/is",
+                function ($matches) {
+                    return '<mscript>'.base64_encode($matches[0]).'</mscript>';
+                },
+                $value, -1, $needsScriptDecoding);
+
             // Special handling for HTML comments
             $value = str_replace(['<!--', '-->'], ['<mcomment>', '</mcomment>'], $value, $commentCount);
 
@@ -422,12 +430,23 @@ class InputHelper
                 $value = str_replace(['<mcomment>', '</mcomment>'], ['<!--', '-->'], $value);
             }
 
-            $value = preg_replace_callback(
-                "/<mencoded>(.*?)<\/mencoded>/is",
-                function ($matches) {
-                    return htmlspecialchars_decode($matches[1]);
-                },
-                $value);
+            if ($needsDecoding) {
+                $value = preg_replace_callback(
+                    "/<mencoded>(.*?)<\/mencoded>/is",
+                    function ($matches) {
+                        return htmlspecialchars_decode($matches[1]);
+                    },
+                    $value);
+            }
+
+            if ($needsScriptDecoding) {
+                $value = preg_replace_callback(
+                    "/<mscript>(.*?)<\/mscript>/is",
+                    function ($matches) {
+                        return base64_decode($matches[1]);
+                    },
+                    $value);
+            }
         }
 
         return $value;

--- a/app/bundles/CoreBundle/Model/AbstractCommonModel.php
+++ b/app/bundles/CoreBundle/Model/AbstractCommonModel.php
@@ -18,6 +18,7 @@ use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
+use Monolog\Logger;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -79,7 +80,7 @@ abstract class AbstractCommonModel
     protected $userHelper;
 
     /**
-     * @var LoggerInterface
+     * @var Logger
      */
     protected $logger;
 

--- a/app/bundles/CoreBundle/Templating/Helper/AssetsHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/AssetsHelper.php
@@ -125,7 +125,12 @@ class AssetsHelper
         $url = $this->packages->getUrl($path, $packageName, $version);
 
         if ($absolute) {
-            $url = $this->getBaseUrl().$url;
+            $url = $this->getBaseUrl().'/'.$path;
+        }
+
+        // Remove the dev index so the assets work in the dev mode
+        if (strpos($url, '/index_dev.php/')) {
+            $url = str_replace('index_dev.php/', '', $url);
         }
 
         return $url;

--- a/app/bundles/CoreBundle/Tests/Helper/InputHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Helper/InputHelperTest.php
@@ -19,9 +19,9 @@ use Mautic\CoreBundle\Helper\InputHelper;
 class InputHelperTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @testdox The guessTimezoneFromOffset returns correct values
+     * @testdox The html returns correct values
      *
-     * @covers \Mautic\CoreBundle\Helper\InputHelperTest::guessTimezoneFromOffset
+     * @covers \Mautic\CoreBundle\Helper\InputHelper::html
      */
     public function testHtmlFilter()
     {
@@ -38,7 +38,8 @@ class InputHelperTest extends \PHPUnit_Framework_TestCase
         $xhtml1Doctype = '<!DOCTYPE html PUBLIC
   "-//W3C//DTD XHTML 1.0 Transitional//EN"
   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">';
-        $cdata = '<![CDATA[content]]>';
+        $cdata  = '<![CDATA[content]]>';
+        $script = '<script>for (let i = 0; i < 10; i += 1) {console.log(i);}</script>';
 
         $samples = [
             $outlookXML                => $outlookXML,
@@ -46,6 +47,7 @@ class InputHelperTest extends \PHPUnit_Framework_TestCase
             $html5DoctypeWithContent   => $html5DoctypeWithContent,
             $xhtml1Doctype             => $xhtml1Doctype,
             $cdata                     => $cdata,
+            $script                    => $script,
             '<applet>content</applet>' => 'content',
         ];
 

--- a/app/bundles/CoreBundle/Tests/Templating/Helper/AssetsHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Templating/Helper/AssetsHelperTest.php
@@ -12,6 +12,7 @@
 namespace Mautic\CoreBundle\Tests\Helper;
 
 use Mautic\CoreBundle\Helper\PathsHelper;
+use Mautic\CoreBundle\Templating\Helper\AssetsHelper;
 use Symfony\Component\Asset\Packages;
 
 class AssetsHelperTest extends \PHPUnit_Framework_TestCase
@@ -34,7 +35,7 @@ class AssetsHelperTest extends \PHPUnit_Framework_TestCase
         $pathsHelper->method('getSystemPath')
             ->willReturn('');
 
-        $assetHelper = new \Mautic\CoreBundle\Templating\Helper\AssetsHelper($packagesMock);
+        $assetHelper = new AssetsHelper($packagesMock);
         $assetHelper->setPathsHelper($pathsHelper);
 
         $assetHelper->addStylesheet('/app.css');
@@ -42,16 +43,106 @@ class AssetsHelperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains('app.css', $head);
 
-        $assetHelper->setContext(\Mautic\CoreBundle\Templating\Helper\AssetsHelper::CONTEXT_BUILDER)
+        $assetHelper->setContext(AssetsHelper::CONTEXT_BUILDER)
             ->addStylesheet('/builder.css')
             ->setContext();
 
         $head = $assetHelper->getHeadDeclarations();
         $this->assertNotContains('builder.css', $head);
 
-        $head = $assetHelper->setContext(\Mautic\CoreBundle\Templating\Helper\AssetsHelper::CONTEXT_BUILDER)
+        $head = $assetHelper->setContext(AssetsHelper::CONTEXT_BUILDER)
             ->getHeadDeclarations();
         $this->assertContains('builder.css', $head);
         $this->assertNotContains('app.css', $head);
+    }
+
+    public function testGetUrlWithAbsolutePath()
+    {
+        $packagesMock = $this->getMockBuilder(Packages::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $assetHelper = new AssetsHelper($packagesMock);
+
+        $this->assertEquals('http://some.absolute/path', $assetHelper->getUrl('http://some.absolute/path'));
+        $this->assertEquals('https://some.absolute/path', $assetHelper->getUrl('https://some.absolute/path'));
+    }
+
+    public function testGetUrlWithRelativePath()
+    {
+        $packagesMock = $this->getMockBuilder(Packages::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $packagesMock->method('getUrl')
+            ->will($this->returnCallback(function () {
+                $args = func_get_args();
+
+                return $args[0];
+            }));
+
+        $pathsHelper = $this->getMockBuilder(PathsHelper::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+
+        $pathsHelper->method('getSystemPath')
+            ->willReturn('http://some.mautic');
+
+        $assetHelper = new AssetsHelper($packagesMock);
+        $assetHelper->setPathsHelper($pathsHelper);
+
+        $this->assertEquals('http://some.mautic/some/path', $assetHelper->getUrl('some/path'));
+    }
+
+    public function testGetUrlWithRelativePathWhenMauticInSubfolder()
+    {
+        $packagesMock = $this->getMockBuilder(Packages::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $packagesMock->method('getUrl')
+            ->will($this->returnCallback(function () {
+                $args = func_get_args();
+
+                return $args[0];
+            }));
+
+        $pathsHelper = $this->getMockBuilder(PathsHelper::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+
+        $pathsHelper->method('getSystemPath')
+            ->willReturn('http://some.mautic/m');
+
+        $assetHelper = new AssetsHelper($packagesMock);
+        $assetHelper->setPathsHelper($pathsHelper);
+
+        $this->assertEquals('http://some.mautic/m/some/path', $assetHelper->getUrl('some/path'));
+    }
+
+    public function testGetUrlWithRelativePathWithDevIndex()
+    {
+        $packagesMock = $this->getMockBuilder(Packages::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $packagesMock->method('getUrl')
+            ->will($this->returnCallback(function () {
+                $args = func_get_args();
+
+                return $args[0];
+            }));
+
+        $pathsHelper = $this->getMockBuilder(PathsHelper::class)
+             ->disableOriginalConstructor()
+             ->getMock();
+
+        $pathsHelper->method('getSystemPath')
+            ->willReturn('http://some.mautic/index_dev.php/');
+
+        $assetHelper = new AssetsHelper($packagesMock);
+        $assetHelper->setPathsHelper($pathsHelper);
+
+        $this->assertEquals('http://some.mautic/some/path', $assetHelper->getUrl('some/path'));
     }
 }

--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -147,6 +147,10 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface
      */
     public function getSlotContentForLead($slot, $lead)
     {
+        if (!$lead) {
+            return [];
+        }
+
         $qb = $this->em->getConnection()->createQueryBuilder();
 
         $id = $lead instanceof Lead ? $lead->getId() : $lead['id'];

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -307,7 +307,7 @@ return [
                 'serviceAlias' => 'swiftmailer.mailer.transport.%s',
                 'methodCalls'  => [
                     'setUsername'      => ['%mautic.mailer_user%'],
-                    'setPassword'      => ['%mautic.mailer_password%'],
+                    'setPassword'      => ['%mautic.mailer_api_key%'],
                     'setMauticFactory' => ['mautic.factory'],
                 ],
             ],

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1243,7 +1243,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
                             $errorMessages[$stat->getLead()->getId()] = $error;
                             // Down sent counts
                             $emailId = $stat->getEmail()->getId();
-                            ++$emailSentCounts[$emailId];
+                            --$emailSentCounts[$emailId];
 
                             if ($stat->getId()) {
                                 $deleteEntities[] = $stat;

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/MandrillTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/MandrillTransport.php
@@ -212,7 +212,9 @@ class MandrillTransport extends AbstractTokenHttpTransport implements InterfaceC
         unset($message['recipients']);
 
         // Set the merge vars
-        $message['merge_vars'] = $rcptMergeVars;
+        if (!empty($rcptMergeVars)) {
+            $message['merge_vars'] = $rcptMergeVars;
+        }
 
         // Set the rest of $metadata as recipient_metadata
         $message['recipient_metadata'] = $rcptMetadata;
@@ -223,10 +225,17 @@ class MandrillTransport extends AbstractTokenHttpTransport implements InterfaceC
         }
         unset($message['replyTo']);
 
+        $key = $this->getApiKey();
+
+        if (empty($key)) {
+            // BC support @deprecated - remove in 3.0
+            $key = $this->getPassword();
+        }
+
         // Package it up
         $payload = json_encode(
             [
-                'key'     => $this->getPassword(),
+                'key'     => $key,
                 'message' => $message,
             ]
         );

--- a/app/bundles/FormBundle/Controller/AjaxController.php
+++ b/app/bundles/FormBundle/Controller/AjaxController.php
@@ -78,7 +78,22 @@ class AjaxController extends CommonAjaxController
                 $options    = [];
 
                 if (!empty($properties['list']['list'])) {
-                    $options = $properties['list']['list'];
+                    //If the field is a SELECT field then the data gets stored in [list][list]
+                    $optionList = $properties['list']['list'];
+                } elseif (!empty($properties['optionlist']['list'])) {
+                    //If the field is a radio or a checkbox then it will be stored in [optionlist][list]
+                    $optionList = $properties['optionlist']['list'];
+                }
+                if (!empty($optionList)) {
+                    foreach ($optionList as $listItem) {
+                        if (is_array($listItem) && isset($listItem['value']) && isset($listItem['label'])) {
+                            //The select box needs values to be [value] => label format so make sure we have that style then put it in
+                            $options[$listItem['value']] = $listItem['label'];
+                        } elseif (!is_array($listItem)) {
+                            //Keeping for BC
+                            $options[] = $listItem;
+                        }
+                    }
                 }
 
                 $fields[] = [

--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -12,6 +12,7 @@
 namespace Mautic\FormBundle\Controller\Api;
 
 use Mautic\ApiBundle\Controller\CommonApiController;
+use Mautic\CoreBundle\Helper\InputHelper;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
 /**
@@ -156,7 +157,13 @@ class FormApiController extends CommonApiController
 
                 $fieldEntityArray           = $fieldEntity->convertToArray();
                 $fieldEntityArray['formId'] = $formId;
-                $fieldEntityArray['alias']  = $fieldParams['alias']  = $fieldModel->generateAlias($fieldEntityArray['label'], $aliases);
+                $escapedAlias               = InputHelper::filename($fieldParams['alias']);
+
+                if (!in_array($escapedAlias, $aliases)) {
+                    $fieldEntityArray['alias'] = $escapedAlias;
+                } else {
+                    $fieldEntityArray['alias'] = $fieldModel->generateAlias($fieldEntityArray['label'], $aliases);
+                }
 
                 $fieldForm = $this->createFieldEntityForm($fieldEntityArray);
                 $fieldForm->submit($fieldParams, 'PATCH' !== $method);

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -715,7 +715,7 @@ class FormController extends CommonFormController
             foreach ($existingFields as $formField) {
                 // Check to see if the field still exists
 
-                if ($formField->getAlias() == 'submit' && $formField->getType() == 'button') {
+                if ($formField->getType() == 'button') {
                     //submit button found
                     $submitButton = true;
                 }

--- a/app/bundles/FormBundle/Controller/PublicController.php
+++ b/app/bundles/FormBundle/Controller/PublicController.php
@@ -26,6 +26,11 @@ use Symfony\Component\HttpFoundation\Response;
 class PublicController extends CommonFormController
 {
     /**
+     * @var array
+     */
+    private $tokens = [];
+
+    /**
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
     public function submitAction()
@@ -446,14 +451,18 @@ class PublicController extends CommonFormController
      */
     private function replacePostSubmitTokens($string, SubmissionEvent $submissionEvent)
     {
-        static $tokens = [];
-        if (empty($tokens)) {
-            $tokens = array_merge(
-                $submissionEvent->getTokens(),
-                TokenHelper::findLeadTokens($string, $submissionEvent->getLead()->getProfileFields())
-            );
+        if (empty($this->tokens)) {
+            if ($lead = $submissionEvent->getLead()) {
+                $this->tokens = array_merge(
+                    $submissionEvent->getTokens(),
+                    TokenHelper::findLeadTokens(
+                        $string,
+                        $lead->getProfileFields()
+                    )
+                );
+            }
         }
 
-        return str_replace(array_keys($tokens), array_values($tokens), $string);
+        return str_replace(array_keys($this->tokens), array_values($this->tokens), $string);
     }
 }

--- a/app/bundles/FormBundle/Entity/Submission.php
+++ b/app/bundles/FormBundle/Entity/Submission.php
@@ -14,7 +14,9 @@ namespace Mautic\FormBundle\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\PageBundle\Entity\Page;
 
 /**
  * Class Submission.
@@ -219,7 +221,7 @@ class Submission
      *
      * @return Submission
      */
-    public function setIpAddress(\Mautic\CoreBundle\Entity\IpAddress $ipAddress = null)
+    public function setIpAddress(IpAddress $ipAddress = null)
     {
         $this->ipAddress = $ipAddress;
 
@@ -256,6 +258,8 @@ class Submission
     public function setResults($results)
     {
         $this->results = $results;
+
+        return $this;
     }
 
     /**
@@ -265,7 +269,7 @@ class Submission
      *
      * @return Submission
      */
-    public function setPage(\Mautic\PageBundle\Entity\Page $page = null)
+    public function setPage(Page $page = null)
     {
         $this->page = $page;
 
@@ -291,11 +295,15 @@ class Submission
     }
 
     /**
-     * @param mixed $lead
+     * @param Lead|null $lead
+     *
+     * @return $this
      */
-    public function setLead(Lead $lead)
+    public function setLead(Lead $lead = null)
     {
         $this->lead = $lead;
+
+        return $this;
     }
 
     /**
@@ -307,11 +315,15 @@ class Submission
     }
 
     /**
-     * @param mixed $trackingId
+     * @param $trackingId
+     *
+     * @return $this
      */
     public function setTrackingId($trackingId)
     {
         $this->trackingId = $trackingId;
+
+        return  $this;
     }
 
     /**

--- a/app/bundles/FormBundle/Form/Type/CampaignEventFormFieldValueType.php
+++ b/app/bundles/FormBundle/Form/Type/CampaignEventFormFieldValueType.php
@@ -101,7 +101,13 @@ class CampaignEventFormFieldValueType extends AbstractType
                         if (!empty($properties['list']['list'])) {
                             $options[$field->getAlias()] = [];
                             foreach ($properties['list']['list'] as $option) {
-                                $options[$field->getAlias()][$option] = $option;
+                                if (is_array($option) && isset($option['value']) && isset($option['label'])) {
+                                    //The select box needs values to be [value] => label format so make sure we have that style then put it in
+                                    $options[$field->getAlias()][$option['value']] = $option['label'];
+                                } elseif (!is_array($option)) {
+                                    //Kept here for BC
+                                    $options[$field->getAlias()][$option] = $option;
+                                }
                             }
                         }
                     }

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -457,7 +457,7 @@ class FormModel extends CommonFormModel
             $theme .= '|';
         }
 
-        if ($entity->usesProgressiveProfiling()) {
+        if ($lead && $entity->usesProgressiveProfiling()) {
             $submissions = $this->getLeadSubmissions($entity, $lead->getId());
         }
 

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -855,7 +855,7 @@ class SubmissionModel extends CommonFormModel
             $foundLeadFields = $this->leadModel->flattenFields($foundLead->getFields());
 
             // Get unique identifier fields for the found lead then compare with the lead currently tracked
-            $uniqueFieldsFound = $getData($foundLeadFields, true);
+            $uniqueFieldsFound             = $getData($foundLeadFields, true);
             list($hasConflict, $conflicts) = $checkForIdentifierConflict($uniqueFieldsFound, $uniqueFieldsCurrent);
 
             if ($inKioskMode || $hasConflict || !$lead->getId()) {

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -320,28 +320,20 @@ class SubmissionModel extends CommonFormModel
         $this->validateActionCallbacks($submissionEvent, $validationErrors, $alias);
 
         // Create/update lead
+        $lead = null;
         if (!empty($leadFieldMatches)) {
-            $lead = $this->createLeadFromSubmit($form, $leadFieldMatches, $leadFields);
-            $submission->setLead($lead);
+            $this->createLeadFromSubmit($form, $leadFieldMatches, $leadFields);
         }
 
         // Get updated lead if applicable with tracking ID
-        if ($form->isInKioskMode()) {
-            $lead = $this->leadModel->getCurrentLead();
-        } else {
-            list($lead, $trackingId, $generated) = $this->leadModel->getCurrentLead(true);
+        list($lead, $trackingId, $generated) = $this->leadModel->getCurrentLead(true);
 
-            //set tracking ID for stats purposes to determine unique hits
-            $submission->setTrackingId($trackingId);
-        }
-
-        // If a user is testing a form, $lead will not have an ID
-        if ($lead && $lead->getId()) {
-            $submission->setLead($lead);
-        }
+        //set tracking ID for stats purposes to determine unique hits
+        $submission->setTrackingId($trackingId)
+            ->setLead($lead);
 
         // Remove validation errors if the field is not visible
-        if ($form->usesProgressiveProfiling()) {
+        if ($lead && $form->usesProgressiveProfiling()) {
             $leadSubmissions = $this->formModel->getLeadSubmissions($form, $lead->getId());
 
             foreach ($fields as $field) {
@@ -775,27 +767,28 @@ class SubmissionModel extends CommonFormModel
     protected function createLeadFromSubmit($form, array $leadFieldMatches, $leadFields)
     {
         //set the mapped data
-        $inKioskMode = $form->isInKioskMode();
+        $inKioskMode   = $form->isInKioskMode();
+        $leadId        = null;
+        $lead          = new Lead();
+        $currentFields = $leadFieldMatches;
 
         if (!$inKioskMode) {
             // Default to currently tracked lead
-            $lead          = $this->leadModel->getCurrentLead();
-            $leadId        = $lead->getId();
-            $currentFields = $lead->getProfileFields();
+            if ($currentLead = $this->leadModel->getCurrentLead()) {
+                $lead          = $currentLead;
+                $leadId        = $lead->getId();
+                $currentFields = $lead->getProfileFields();
+            }
 
-            $this->logger->debug('FORM: Not in kiosk mode so using current contact ID #'.$lead->getId());
+            $this->logger->debug('FORM: Not in kiosk mode so using current contact ID #'.$leadId);
         } else {
             // Default to a new lead in kiosk mode
-            $lead = new Lead();
             $lead->setNewlyCreated(true);
-            $currentFields = $leadFieldMatches;
-
-            $leadId = null;
 
             $this->logger->debug('FORM: In kiosk mode so assuming a new contact');
         }
 
-        $uniqueLeadFields = $this->leadFieldModel->getUniqueIdentiferFields();
+        $uniqueLeadFields = $this->leadFieldModel->getUniqueIdentifierFields();
 
         // Closure to get data and unique fields
         $getData = function ($currentFields, $uniqueOnly = false) use ($leadFields, $uniqueLeadFields) {
@@ -862,10 +855,10 @@ class SubmissionModel extends CommonFormModel
             $foundLeadFields = $this->leadModel->flattenFields($foundLead->getFields());
 
             // Get unique identifier fields for the found lead then compare with the lead currently tracked
-            $uniqueFieldsFound             = $getData($foundLeadFields, true);
+            $uniqueFieldsFound = $getData($foundLeadFields, true);
             list($hasConflict, $conflicts) = $checkForIdentifierConflict($uniqueFieldsFound, $uniqueFieldsCurrent);
 
-            if ($inKioskMode || $hasConflict) {
+            if ($inKioskMode || $hasConflict || !$lead->getId()) {
                 // Use the found lead without merging because there is some sort of conflict with unique identifiers or in kiosk mode and thus should not merge
                 $lead = $foundLead;
 
@@ -882,7 +875,7 @@ class SubmissionModel extends CommonFormModel
             }
 
             // Update unique fields data for comparison with submitted data
-            $currentFields       = $this->leadModel->flattenFields($lead->getFields());
+            $currentFields       = $lead->getProfileFields();
             $uniqueFieldsCurrent = $getData($currentFields, true);
         }
 

--- a/app/bundles/FormBundle/Tests/FormTestAbstract.php
+++ b/app/bundles/FormBundle/Tests/FormTestAbstract.php
@@ -91,6 +91,7 @@ class FormTestAbstract extends WebTestCase
             ->getMockBuilder(LeadModel::class)
             ->disableOriginalConstructor()
             ->getMock();
+
         $fieldHelper = $this
             ->getMockBuilder(FormFieldHelper::class)
             ->disableOriginalConstructor()
@@ -201,6 +202,10 @@ class FormTestAbstract extends WebTestCase
             ->getMockBuilder(LeadFieldModel::class)
             ->disableOriginalConstructor()
             ->getMock();
+
+        $leadFieldModel->expects($this
+            ->any())->method('getUniqueIdentifierFields')
+            ->willReturn(['eyJpc1B1Ymxpc2hlZCI6dHJ1ZSwiaXNVbmlxdWVJZGVudGlmZXIiOnRydWUsIm9iamVjdCI6ImxlYWQifQ==' => ['email' => 'Email']]);
 
         $companyModel = $this
             ->getMockBuilder(CompanyModel::class)

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -862,34 +862,26 @@ Mautic.leadNoteOnLoad = function (container, response) {
             mQuery('#LeadNotes').prepend(response.noteHtml);
         }
 
-        //initialize ajax'd modals
-        mQuery(el + " *[data-toggle='ajaxmodal']").off('click.ajaxmodal');
-        mQuery(el + " *[data-toggle='ajaxmodal']").on('click.ajaxmodal', function (event) {
-            event.preventDefault();
-
-            Mautic.ajaxifyModal(this, event);
-        });
-
-        //initiate links
-        mQuery(el + " a[data-toggle='ajax']").off('click.ajax');
-        mQuery(el + " a[data-toggle='ajax']").on('click.ajax', function (event) {
-            event.preventDefault();
-
-            return Mautic.ajaxifyLink(this, event);
-        });
+        Mautic.makeModalsAlive(mQuery(el + " *[data-toggle='ajaxmodal']"));
+        Mautic.makeConfirmationsAlive(mQuery(el+' a[data-toggle="confirmation"]'));
+        Mautic.makeLinksAlive(mQuery(el + " a[data-toggle='ajax']"));
     } else if (response.deleteId && mQuery('#LeadNote' + response.deleteId).length) {
         mQuery('#LeadNote' + response.deleteId).remove();
     }
 
     if (response.upNoteCount || response.noteCount || response.downNoteCount) {
-        if (response.upNoteCount || response.downNoteCount) {
-            var count = parseInt(mQuery('#NoteCount').html());
-            count = (response.upNoteCount) ? count + 1 : count - 1;
+        var noteCountWrapper = mQuery('#NoteCount');
+        var count = parseInt(noteCountWrapper.text().trim());
+
+        if (response.upNoteCount) {
+            count++;
+        } else if (response.downNoteCount) {
+            count--;
         } else {
-            var count = parseInt(response.noteCount);
+            count = parseInt(response.noteCount);
         }
 
-        mQuery('#NoteCount').html(count);
+        noteCountWrapper.text(count);
     }
 };
 

--- a/app/bundles/LeadBundle/Entity/Company.php
+++ b/app/bundles/LeadBundle/Entity/Company.php
@@ -160,6 +160,7 @@ class Company extends FormEntity implements CustomFieldEntityInterface
             ->build();
 
         $builder->createField('score', 'integer')
+            ->nullable()
             ->build();
 
         self::loadFixedFieldMetadata(

--- a/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
@@ -65,8 +65,9 @@ trait CustomFieldEntityTrait
         if (($isSetter && array_key_exists(0, $arguments)) || $isGetter) {
             $fieldRequested = mb_strtolower(mb_substr($name, 3));
             $fields         = $this->getProfileFields();
+
             if (array_key_exists($fieldRequested, $fields)) {
-                return ($isSetter) ? $this->addUpdatedField($fieldRequested, $arguments[0]) : $this->getFieldValue($name);
+                return ($isSetter) ? $this->addUpdatedField($fieldRequested, $arguments[0]) : $this->getFieldValue($fieldRequested);
             }
         }
 
@@ -113,10 +114,9 @@ trait CustomFieldEntityTrait
     {
         $property = (defined('self::FIELD_ALIAS')) ? str_replace(self::FIELD_ALIAS, '', $alias) : $alias;
 
-        if (property_exists($this, $property)) {
-            // Fixed custom field so use the setter
-            $setter = 'set'.ucfirst($property);
-
+        $setter = 'set'.ucfirst($property);
+        if (property_exists($this, $property) && method_exists($this, $setter)) {
+            // Fixed custom field so use the setter but don't get caught in a loop such as a custom field called "notes"
             $this->$setter($value);
         }
 

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -279,8 +279,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
             ->build();
 
         $builder->createManyToOne('owner', 'Mautic\UserBundle\Entity\User')
-            ->cascadeDetach()
-            ->cascadeMerge()
+            ->fetchLazy()
             ->addJoinColumn('owner_id', 'id', true, false, 'SET NULL')
             ->build();
 

--- a/app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
@@ -109,8 +109,8 @@ class LeadEventLogRepository extends CommonRepository
             ->andWhere($alias.'.object = :object')
             ->setParameter('object', $object);
 
-        if (isset($options['search']) && $options['search']) {
-            $qb->andWhere($qb->expr()->like($alias.'.original_file', $qb->expr()->literal('%'.$options['search'].'%')));
+        if (!empty($options['search'])) {
+            $qb->andWhere($qb->expr()->like($alias.'.properties', $qb->expr()->literal('%'.$options['search'].'%')));
         }
 
         return $this->getTimelineResults($qb, $options, $alias.'.original_file', $alias.'.date_added', ['query'], ['date_added']);

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\LeadBundle\Entity;
 
+use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Types\DateType;
 use Doctrine\DBAL\Types\FloatType;
@@ -377,7 +378,7 @@ class LeadListRepository extends CommonRepository
                 }
 
                 if ($newOnly) {
-                    $expr = $this->generateSegmentExpression($filters, $parameters, $q, null, $l['id']);
+                    $expr = $this->generateSegmentExpression($filters, $parameters, $q, null, $id);
 
                     if (!$this->hasCompanyFilter && !$expr->count()) {
                         // Treat this as if it has no filters since all the filters are now invalid (fields were deleted)
@@ -678,8 +679,9 @@ class LeadListRepository extends CommonRepository
         $groups    = [];
         $groupExpr = $q->expr()->andX();
 
+        $defaultObject = $object;
         foreach ($filters as $k => $details) {
-            $object = 'lead';
+            $object = $defaultObject;
             if (!empty($details['object'])) {
                 $object = $details['object'];
             }
@@ -1353,15 +1355,40 @@ class LeadListRepository extends CommonRepository
                     $isLeadList = false;
                     switch ($details['field']) {
                         case 'leadlist':
-                            $newListId = $details['filter'];
-                            if ($listId !== $newListId) { // prevent infinite loop
-                                $isLeadList = true;
-                                $ll         = $this->getEntity($newListId);
-                                $nq         = $this->_em->getConnection()->createQueryBuilder();
-                                $nf         = $ll->getFilters();
-                                $isNot      = 'NOT EXISTS' === $func;
-                                $se         = $this->generateSegmentExpression($nf, $parameters, $nq, null, $newListId, $isNot);
+                            $newListIds = $details['filter'];
+                            $nq         = $this->_em->getConnection()->createQueryBuilder();
+                            $isNot      = 'NOT EXISTS' === $func;
+                            if (!is_array($newListIds)) {
+                                if ($listId !== $newListIds) {
+                                    $ll = $this->getEntity($newListIds);
+                                    if (null !== $ll) {
+                                        $nf = $ll->getFilters();
+                                        if (count($nf) > 0) {
+                                            $se         = $this->generateSegmentExpression($nf, $parameters, $nq, null, $newListIds, $isNot);
+                                            $isLeadList = true;
+                                        }
+                                    }
+                                }
                             } else {
+                                $se    = $isNot ? $nq->expr()->andX() : $nq->expr()->orX(); // for including segments
+                                $count = 0;
+                                foreach ($newListIds as $newListId) {
+                                    $ll = $this->getEntity($newListId);
+                                    if (null === $ll) {
+                                        continue;
+                                    }
+                                    $nf = $ll->getFilters();
+                                    if (count($nf) > 0) {
+                                        /** @var CompositeExpression $si */
+                                        $si = $this->generateSegmentExpression($nf, $parameters, $nq, null, $newListId, $isNot);
+                                        $se->add($si);
+                                        ++$count;
+                                    }
+                                }
+                                $isLeadList = $count > 0;
+                            }
+
+                            if (!$isLeadList) {
                                 $table  = 'lead_lists_leads';
                                 $column = 'leadlist_id';
                             }

--- a/app/bundles/LeadBundle/Form/Type/ContactFrequencyType.php
+++ b/app/bundles/LeadBundle/Form/Type/ContactFrequencyType.php
@@ -176,7 +176,19 @@ class ContactFrequencyType extends AbstractType
             }
         }
 
-        if (!$options['public_view'] || $showContactSegments) {
+        if (!$options['public_view']) {
+            $builder->add(
+                'lead_lists',
+                'leadlist_choices',
+                [
+                    'label'      => 'mautic.lead.form.list',
+                    'label_attr' => ['class' => 'control-label'],
+                    'multiple'   => true,
+                    'expanded'   => $options['public_view'],
+                    'required'   => false,
+                ]
+            );
+        } elseif ($showContactSegments) {
             $builder->add(
                 'lead_lists',
                 'leadlist_choices',

--- a/app/bundles/LeadBundle/Helper/EventHelper.php
+++ b/app/bundles/LeadBundle/Helper/EventHelper.php
@@ -45,7 +45,9 @@ class EventHelper
     {
         /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
         $leadModel = $factory->getModel('lead');
-        $lead      = $leadModel->getCurrentLead();
+        if (!$lead = $leadModel->getCurrentLead()) {
+            return;
+        }
 
         $queryReferer = [];
 

--- a/app/bundles/LeadBundle/Helper/FormEventHelper.php
+++ b/app/bundles/LeadBundle/Helper/FormEventHelper.php
@@ -76,17 +76,22 @@ class FormEventHelper
         }
     }
 
+    /**
+     * @param $action
+     * @param $factory
+     */
     public static function scoreContactsCompanies($action, $factory)
     {
         $properties = $action->getProperties();
 
         /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
         $leadModel = $factory->getModel('lead');
-        $lead      = $leadModel->getCurrentLead();
-        $score     = $properties['score'];
+        if ($lead = $leadModel->getCurrentLead()) {
+            $score = $properties['score'];
 
-        if (!empty($score)) {
-            $leadModel->scoreContactsCompany($lead, $score);
+            if (!empty($score)) {
+                $leadModel->scoreContactsCompany($lead, $score);
+            }
         }
     }
 }

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -867,7 +867,7 @@ class FieldModel extends FormModel
             $this->uniqueIdentifierFields[$key] = $this->getFieldList(false, true, $filters);
         }
 
-        return ($this->uniqueIdentifierFields[$key]) ? $this->uniqueIdentifierFields[$key] : [];
+        return $this->uniqueIdentifierFields[$key];
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -867,7 +867,7 @@ class FieldModel extends FormModel
             $this->uniqueIdentifierFields[$key] = $this->getFieldList(false, true, $filters);
         }
 
-        return $this->uniqueIdentifierFields[$key];
+        return ($this->uniqueIdentifierFields[$key]) ? $this->uniqueIdentifierFields[$key] : [];
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
@@ -104,6 +104,37 @@ class LeadTest extends \PHPUnit_Framework_TestCase
         $this->adjustPointsTest(10, $this->getLeadChangedArray(150, 15), $lead, 'divide');
     }
 
+    public function testCustomFieldGetterSetters()
+    {
+        $lead = new Lead();
+
+        $fields = [
+            'core' => [
+                'notes' => [
+                    'alias' => 'notes',
+                    'label' => 'Notes',
+                    'type'  => 'textarea',
+                    'value' => 'Blah blah blah',
+                ],
+                'test' => [
+                    'alias' => 'test',
+                    'label' => 'Test',
+                    'type'  => 'textarea',
+                    'value' => 'Test blah',
+                ],
+            ],
+        ];
+
+        $lead->setFields($fields);
+
+        // This should not killover with a segmentation fault due to a loop
+        $lead->setNotes('hello');
+
+        // Not using getNotes because it conflicts with an existing method and not sure what to do about that yet
+        $lead->setTest('hello');
+        $this->assertEquals('hello', $lead->getTest());
+    }
+
     /**
      * @param $points
      * @param $expected

--- a/app/bundles/LeadBundle/Translations/en_US/flashes.ini
+++ b/app/bundles/LeadBundle/Translations/en_US/flashes.ini
@@ -12,4 +12,4 @@ mautic.lead.lead.notice.removedfromlists="<a href='%url%' data-toggle='ajax' dat
 mautic.lead.list.error.notfound="No list with an id of %id% was found!"
 mautic.lead.list.notice.batch_deleted="%count% lists have been deleted!"
 mautic.lead.list.frequency.rules.msg="No "
-mautic.lead.batch.import.created="Import configuration was successfully created. The background job will import it and notify you when finished."
+mautic.lead.batch.import.created="Import process was successfully created. You will be notified when finished."

--- a/app/bundles/NotificationBundle/Controller/Api/NotificationApiController.php
+++ b/app/bundles/NotificationBundle/Controller/Api/NotificationApiController.php
@@ -45,11 +45,10 @@ class NotificationApiController extends CommonApiController
             /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
             $leadModel = $this->getModel('lead');
 
-            $currentLead = $leadModel->getCurrentLead();
-
-            $currentLead->addPushIDEntry($osid);
-
-            $leadModel->saveEntity($currentLead);
+            if ($currentLead = $leadModel->getCurrentLead()) {
+                $currentLead->addPushIDEntry($osid);
+                $leadModel->saveEntity($currentLead);
+            }
 
             return new JsonResponse(['success' => true, 'osid' => $osid], 200, ['Access-Control-Allow-Origin' => '*']);
         }

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -380,7 +380,7 @@ class PublicController extends CommonFormController
         return new JsonResponse(
             [
                 'success' => 1,
-                'id'      => $lead->getId(),
+                'id'      => ($lead) ? $lead->getId() : null,
                 'sid'     => $trackingId,
             ]
         );
@@ -426,7 +426,7 @@ class PublicController extends CommonFormController
         /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
         $leadModel = $this->getModel('lead');
         $lead      = $leadModel->getCurrentLead();
-        $leadArray = $lead->getProfileFields();
+        $leadArray = ($lead) ? $lead->getProfileFields() : [];
         $url       = TokenHelper::findLeadTokens($url, $leadArray, true);
 
         return $this->redirect($url);
@@ -553,7 +553,7 @@ class PublicController extends CommonFormController
 
             list($lead, $trackingId, $generated) = $leadModel->getCurrentLead(true);
             $data                                = [
-                'id'  => $lead->getId(),
+                'id'  => ($lead) ? $lead->getId() : null,
                 'sid' => $trackingId,
             ];
         }

--- a/app/bundles/PageBundle/Model/VideoModel.php
+++ b/app/bundles/PageBundle/Model/VideoModel.php
@@ -99,7 +99,7 @@ class VideoModel extends FormModel
         $lead = $this->leadModel->getCurrentLead();
         $guid = $request->get('guid');
 
-        $hit = $this->getHitForLeadByGuid($lead, $guid);
+        $hit = ($lead) ? $this->getHitForLeadByGuid($lead, $guid) : new VideoHit();
 
         $hit->setGuid($guid);
         $hit->setDateHit(new \Datetime());
@@ -117,7 +117,9 @@ class VideoModel extends FormModel
         unset($query['d']);
         $hit->setQuery($query);
 
-        $hit->setLead($lead);
+        if ($lead) {
+            $hit->setLead($lead);
+        }
 
         //glean info from the IP address
         if ($details = $ipAddress->getIpDetails()) {

--- a/app/bundles/PageBundle/Tests/EventListener/PageSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/PageSubscriberTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\PageBundle\Tests\EventListener;
+
+use Mautic\CoreBundle\Translation\Translator;
+use Mautic\PageBundle\Event\PageBuilderEvent;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class PageSubscriberTest extends WebTestCase
+{
+    public function testGetTokens_WhenCalled_ReturnsValidTokens()
+    {
+        $translator = $this->getMockBuilder(Translator::class)->disableOriginalConstructor()
+            ->getMock();
+
+        $pageBuilderEvent = new PageBuilderEvent($translator);
+        $pageBuilderEvent->addToken('{token_test}', 'TOKEN VALUE');
+        $tokens = $pageBuilderEvent->getTokens();
+        $this->assertArrayHasKey('{token_test}', $tokens);
+        $this->assertEquals($tokens['{token_test}'], 'TOKEN VALUE');
+    }
+}

--- a/app/bundles/PageBundle/Tests/Model/PageModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/PageModelTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\PageBundle\Tests\Model;
+
+use Mautic\PageBundle\Entity\Page;
+use Mautic\PageBundle\Tests\PageTestAbstract;
+
+class PageModelTest extends PageTestAbstract
+{
+    public function testGenerateUrl_WhenCalled_ReturnsValidUrl()
+    {
+        $page = new Page();
+        $page->setAlias('this-is-a-test');
+        $pageModel = $this->getPageModel();
+        $url       = $pageModel->generateUrl($page);
+        $this->assertContains('/this-is-a-test', $url);
+    }
+}

--- a/app/bundles/PageBundle/Tests/Model/RedirectModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/RedirectModelTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\PageBundle\Tests\Model;
+
+use Mautic\PageBundle\Entity\Redirect;
+use Mautic\PageBundle\Tests\PageTestAbstract;
+
+class RedirectModelTest extends PageTestAbstract
+{
+    public function testCreateRedirectEntity_WhenCalled_ReturnsRedirect()
+    {
+        $redirectModel = $this->getRedirectModel();
+        $entity        = $redirectModel->createRedirectEntity('http://some-url.com');
+
+        $this->assertInstanceOf(Redirect::class, $entity);
+    }
+
+    public function testGenerateRedirectUrl_WhenCalled_ReturnsValidUrl()
+    {
+        $redirect = new Redirect();
+        $redirect->setUrl('http://some-url.com');
+        $redirect->setRedirectId('redirect-id');
+
+        $redirectModel = $this->getRedirectModel();
+        $url           = $redirectModel->generateRedirectUrl($redirect);
+
+        $this->assertContains($url, 'http://some-url.com');
+    }
+}

--- a/app/bundles/PageBundle/Tests/PageTestAbstract.php
+++ b/app/bundles/PageBundle/Tests/PageTestAbstract.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\PageBundle\Tests;
+
+use Doctrine\ORM\EntityManager;
+use Mautic\CoreBundle\Helper\CookieHelper;
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\CoreBundle\Helper\UrlHelper;
+use Mautic\CoreBundle\Translation\Translator;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\FieldModel;
+use Mautic\LeadBundle\Model\LeadModel;
+use Mautic\PageBundle\Entity\PageRepository;
+use Mautic\PageBundle\Model\PageModel;
+use Mautic\PageBundle\Model\RedirectModel;
+use Mautic\PageBundle\Model\TrackableModel;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class PageTestAbstract extends WebTestCase
+{
+    protected static $mockId   = 123;
+    protected static $mockName = 'Mock test name';
+    protected $mockTrackingId;
+    protected $container;
+
+    protected function setUp()
+    {
+        self::bootKernel();
+        $this->mockTrackingId = hash('sha1', uniqid(mt_rand(), true));
+        $this->container      = self::$kernel->getContainer();
+    }
+
+    /**
+     * @return PageModel
+     */
+    protected function getPageModel()
+    {
+        $cookieHelper = $this
+            ->getMockBuilder(CookieHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $router = $this->container->get('router');
+
+        $ipLookupHelper = $this
+            ->getMockBuilder(IpLookupHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $leadModel = $this
+            ->getMockBuilder(LeadModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $leadFieldModel = $this
+            ->getMockBuilder(FieldModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $redirectModel = $this->getRedirectModel();
+
+        $trackableModel = $this
+            ->getMockBuilder(TrackableModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dispatcher = $this
+            ->getMockBuilder(EventDispatcher::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $translator = $this
+            ->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $leadModel->expects($this
+            ->any())
+            ->method('getCurrentLead')
+            ->willReturn($this
+                ->returnValue(['id' => self::$mockId, 'name' => self::$mockName]));
+
+        $entityManager = $this
+            ->getMockBuilder(EntityManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $pageRepository = $this
+            ->getMockBuilder(PageRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entityManager->expects($this
+            ->any())
+            ->method('getRepository')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['MauticPageBundle:Page', $pageRepository],
+                    ]
+                )
+            );
+
+        $pageModel = new PageModel(
+            $cookieHelper,
+            $ipLookupHelper,
+            $leadModel,
+            $leadFieldModel,
+            $redirectModel,
+            $trackableModel
+        );
+
+        $pageModel->setDispatcher($dispatcher);
+        $pageModel->setTranslator($translator);
+        $pageModel->setEntityManager($entityManager);
+        $pageModel->setRouter($router);
+
+        return $pageModel;
+    }
+
+    public function getCurrentLead($tracking)
+    {
+        return $tracking ? [new Lead(), $this->mockTrackingId, true] : new Lead();
+    }
+
+    /**
+     * @return RedirectModel
+     */
+    protected function getRedirectModel()
+    {
+        $urlHelper = $this
+            ->getMockBuilder(UrlHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockRedirectModel = $this->getMockBuilder('Mautic\PageBundle\Model\RedirectModel')
+            ->setConstructorArgs([$urlHelper])
+            ->setMethods(['createRedirectEntity', 'generateRedirectUrl'])
+            ->getMock();
+
+        $mockRedirect = $this->getMockBuilder('Mautic\PageBundle\Entity\Redirect')
+            ->getMock();
+
+        $mockRedirectModel->expects($this->any())
+            ->method('createRedirectEntity')
+            ->willReturn($mockRedirect);
+
+        $mockRedirectModel->expects($this->any())
+            ->method('generateRedirectUrl')
+            ->willReturn('http://some-url.com');
+
+        return $mockRedirectModel;
+    }
+}

--- a/app/bundles/PluginBundle/Assets/js/plugin.js
+++ b/app/bundles/PluginBundle/Assets/js/plugin.js
@@ -171,7 +171,7 @@ Mautic.getIntegrationFields = function(settings, page, el) {
     var object    = settings.object ? settings.object : 'lead';
     var fieldsTab = ('lead' === object) ? '#fields-tab' : '#'+object+'-fields-container';
 
-    if (el) {
+    if (el && mQuery(el).is('input')) {
         Mautic.activateLabelLoadingIndicator(mQuery(el).attr('id'));
 
         var namePrefix = mQuery(el).attr('name').split('[')[0];

--- a/app/bundles/PluginBundle/Assets/js/plugin.js
+++ b/app/bundles/PluginBundle/Assets/js/plugin.js
@@ -173,8 +173,14 @@ Mautic.getIntegrationFields = function(settings, page, el) {
 
     if (el) {
         Mautic.activateLabelLoadingIndicator(mQuery(el).attr('id'));
-    }
 
+        var namePrefix = mQuery(el).attr('name').split('[')[0];
+        if ('integration_details' !== namePrefix) {
+            var nameParts = mQuery(el).attr('name').match(/\[.*?\]+/g);
+            nameParts = nameParts.slice(0, -1);
+            settings.prefix = namePrefix + nameParts.join('') + "[" + object + "Fields]";
+        }
+    }
     var fieldsContainer = '#'+object+'FieldsContainer';
 
     var inModal = mQuery(fieldsContainer).closest('.modal');

--- a/app/bundles/PluginBundle/Controller/AjaxController.php
+++ b/app/bundles/PluginBundle/Controller/AjaxController.php
@@ -78,7 +78,6 @@ class AjaxController extends CommonAjaxController
                     // Get a list of custom form fields
                     $mauticFields       = ($isLead) ? $pluginModel->getLeadFields() : $pluginModel->getCompanyFields();
                     $featureSettings    = $integrationObject->getIntegrationSettings()->getFeatureSettings();
-                    $formSettings       = $integrationObject->getFormDisplaySettings();
                     $enableDataPriority = $integrationObject->getDataPriority();
                     $formType           = $isLead ? 'integration_fields' : 'integration_company_fields';
                     $form               = $this->createForm(

--- a/app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
@@ -53,6 +53,8 @@ class CampaignSubscriber extends CommonSubscriber
 
     /**
      * @param CampaignExecutionEvent $event
+     *
+     * @return $this
      */
     public function onCampaignTriggerAction(CampaignExecutionEvent $event)
     {

--- a/app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php
@@ -42,6 +42,7 @@ class IntegrationSubscriber extends CommonSubscriber
      */
     public function onRequest(PluginIntegrationRequestEvent $event)
     {
+        $name    = strtoupper($event->getIntegrationName());
         $headers = (count($event->getHeaders())) ? implode(PHP_EOL, array_map(function ($k, $v) {
             return "$k: $v";
         }, array_keys($event->getHeaders()), array_values($event->getHeaders()))) : '';
@@ -74,16 +75,16 @@ class IntegrationSubscriber extends CommonSubscriber
             $output->writeln('<fg=cyan>'.$params.'</>');
             $output->writeln('');
             $output->writeln('<fg=cyan>'.$settings.'</>');
-        } elseif ('dev' === MAUTIC_ENV) {
-            $this->logger->debug('INTEGRATION REQUEST: '.$event->getMethod().' '.$event->getUrl());
+        } else {
+            $this->logger->debug("$name REQUEST URL: ".$event->getMethod().' '.$event->getUrl());
             if ('' !== $headers) {
-                $this->logger->debug("REQUEST HEADERS: \n".$headers.PHP_EOL);
+                $this->logger->debug("$name REQUEST HEADERS: \n".$headers.PHP_EOL);
             }
             if ('' !== $params) {
-                $this->logger->debug("REQUEST PARAMS: \n".$params.PHP_EOL);
+                $this->logger->debug("$name REQUEST PARAMS: \n".$params.PHP_EOL);
             }
             if ('' !== $settings) {
-                $this->logger->debug("REQUEST SETTINGS: \n".$settings.PHP_EOL);
+                $this->logger->debug("$name REQUEST SETTINGS: \n".$settings.PHP_EOL);
             }
         }
     }

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -2651,7 +2651,7 @@ abstract class AbstractIntegration
                 if (isset($fields['i_'.$i]) && isset($fields['m_'.$i])) {
                     $formattedFields[$fields['i_'.$i]] = $fields['m_'.$i];
                 } else {
-                    break;
+                    continue;
                 }
             }
         }

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -2594,7 +2594,8 @@ abstract class AbstractIntegration
      */
     protected function getLastSyncDate($entity = null, $params = [], $ignoreEntityChanges = true)
     {
-        if (!$ignoreEntityChanges && isset($params['start']) && $entity && method_exists($entity, 'getChanges')) {
+        $isNew = method_exists($entity, 'isNew') && $entity->isNew();
+        if (!$isNew && !$ignoreEntityChanges && isset($params['start']) && $entity && method_exists($entity, 'getChanges')) {
             // Check to see if this contact was modified prior to the fetch so that the push catches it
             /** @var FormEntity $entity */
             $changes = $entity->getChanges(true);

--- a/app/migrations/Version20170725155053.php
+++ b/app/migrations/Version20170725155053.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * @package     Mautic
+ * @copyright   2017 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170725155053 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        $table = $schema->getTable($this->prefix.'companies');
+
+        if ($table->hasColumn('score') && $table->getColumn('score')->getNotnull() === false) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // Please modify to your needs
+        $this->addSql('ALTER TABLE '.$this->prefix.'companies CHANGE score score INT(11) NULL');
+    }
+}

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -636,17 +636,22 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 foreach (['Contact', 'Lead'] as $object) {
                     if (!empty($existingPersons[$object])) {
                         $personFound = true;
-                        if (!empty($mappedData[$object]['update'])) {
-                            foreach ($existingPersons[$object] as $person) {
-                                $personData                     = $this->getApiHelper()->updateObject($mappedData[$object]['update'], $object, $person['Id']);
-                                $people[$object][$person['Id']] = $person['Id'];
+                        foreach ($existingPersons[$object] as $person) {
+                            if (!empty($mappedData[$object]['update'])) {
+                                $personData = $this->getApiHelper()->updateObject(
+                                    $mappedData[$object]['update'],
+                                    $object,
+                                    $person['Id']
+                                );
                             }
+                            $people[$object][$person['Id']] = $person['Id'];
                         }
                     }
 
                     if ('Lead' === $object && !$personFound) {
                         $personData                         = $this->getApiHelper()->createLead($mappedData[$object]['create']);
                         $people[$object][$personData['Id']] = $personData['Id'];
+                        $personFound                        = true;
                     }
 
                     if (isset($personData['Id'])) {
@@ -665,7 +670,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 }
 
                 // Return success if any Contact or Lead was updated or created
-                return ($people) ? $people : false;
+                return ($personFound) ? $people : false;
             }
         } catch (\Exception $e) {
             if ($e instanceof ApiErrorException) {
@@ -1540,7 +1545,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     $campaignMembers = $this->getApiHelper()->checkCampaignMembership($campaignId, $pushObject, $personIds[$pushObject]);
                     $pushPeople      = $personIds[$pushObject];
                 }
-            }
+            } // pushLead should have handled this
 
             foreach ($pushPeople as $memberId) {
                 $campaignMappingId = '-'.$campaignId;

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -247,17 +247,18 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                         // Match Sugar object to Mautic's
                         $sObject = 'company';
                     }
+                    $sObject = trim($sObject);
                     if ($this->isAuthorized()) {
                         // Check the cache first
-                        $settings['cache_suffix'] = $cacheSuffix = '.'.trim($sObject);
+                        $settings['cache_suffix'] = $cacheSuffix = '.'.$sObject;
                         if ($fields = parent::getAvailableLeadFields($settings)) {
-                            if (('company' === trim($sObject) && isset($fields['id'])) || isset($fields['id__'.trim($sObject)])) {
-                                $sugarFields[trim($sObject)] = $fields;
+                            if (('company' === $sObject && isset($fields['id'])) || isset($fields['id__'.$sObject])) {
+                                $sugarFields[$sObject] = $fields;
                                 continue;
                             }
                         }
-                        if (!isset($sugarFields[trim($sObject)])) {
-                            $fields = $this->getApiHelper()->getLeadFields(trim($sObject));
+                        if (!isset($sugarFields[$sObject])) {
+                            $fields = $this->getApiHelper()->getLeadFields($sObject);
 
                             if ($fields != null && !empty($fields)) {
                                 if (isset($fields['module_fields']) && !empty($fields['module_fields'])) {
@@ -272,24 +273,23 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                                             $fieldName = (strpos($fieldInfo['name'], 'webtolead_email') === false) ? $fieldInfo['name'] : str_replace('webtolead_', '', $fieldInfo['name']);
                                             // make these congruent as some come in with colons and some do not
                                             $label = str_replace(':', '', $fieldInfo['label']);
-                                            if (trim($sObject) !== 'company') {
-                                                $sugarFields[trim($sObject)][$fieldName.'__'.trim($sObject)] = [
+                                            if ($sObject !== 'company') {
+                                                $sugarFields[$sObject][$fieldName.'__'.$sObject] = [
                                                     'type'        => $type,
-                                                    'label'       => trim($sObject).'-'.$label,
-                                                    'required'    => $isRequired($fieldInfo, trim($sObject)),
-                                                    'group'       => trim($sObject),
+                                                    'label'       => $sObject.'-'.$label,
+                                                    'required'    => $isRequired($fieldInfo, $sObject),
+                                                    'group'       => $sObject,
                                                     'optionLabel' => $fieldInfo['label'],
                                                 ];
                                             } else {
-                                                $sugarFields[trim($sObject)][$fieldName] = [
+                                                $sugarFields[$sObject][$fieldName] = [
                                                     'type'     => $type,
                                                     'label'    => $label,
-                                                    'required' => $isRequired($fieldInfo, trim($sObject)),
+                                                    'required' => $isRequired($fieldInfo, $sObject),
                                                 ];
                                             }
                                         }
                                     }
-                                    $this->cache->set('leadFields'.$cacheSuffix, $sugarFields[trim($sObject)]);
                                 } elseif (isset($fields['fields']) && !empty($fields['fields'])) {
                                     //7.x
                                     foreach ($fields['fields'] as $fieldInfo) {
@@ -321,27 +321,26 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                                                 );
 
                                             $type = 'string';
-                                            if (trim($sObject) !== 'company') {
-                                                $sugarFields[trim($sObject)][$fieldName.'__'.trim($sObject)] = [
+                                            if ($sObject !== 'company') {
+                                                $sugarFields[$sObject][$fieldName.'__'.$sObject] = [
                                                     'type'        => $type,
-                                                    'label'       => trim($sObject).'-'.$label,
-                                                    'required'    => $isRequired($fieldInfo, trim($sObject)),
-                                                    'group'       => trim($sObject),
+                                                    'label'       => $sObject.'-'.$label,
+                                                    'required'    => $isRequired($fieldInfo, $sObject),
+                                                    'group'       => $sObject,
                                                     'optionLabel' => $label,
                                                 ];
                                             } else {
-                                                $sugarFields[trim($sObject)][$fieldName] = [
+                                                $sugarFields[$sObject][$fieldName] = [
                                                     'type'     => $type,
                                                     'label'    => $label,
-                                                    'required' => $isRequired($fieldInfo, trim($sObject)),
+                                                    'required' => $isRequired($fieldInfo, $sObject),
                                                 ];
                                             }
                                         }
                                     }
                                 }
-
-                                $this->cache->set('leadFields', $sugarFields);
                             }
+                            $this->cache->set('leadFields'.$cacheSuffix, $sugarFields[$sObject]);
                         }
                     } else {
                         throw new ApiErrorException($this->authorzationError);

--- a/plugins/MauticCrmBundle/Tests/SalesforceIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/SalesforceIntegrationTest.php
@@ -279,7 +279,12 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($lastSync instanceof \DateTime);
         $this->assertEquals(MAUTIC_DATE_MODIFIED_OVERRIDE, $lastSync->format('U'));
 
-        $lead     = new Lead();
+        $lead          = new Lead();
+        $reflectedLead = new \ReflectionObject($lead);
+        $reflectedId   = $reflectedLead->getProperty('id');
+        $reflectedId->setAccessible(true);
+        $reflectedId->setValue($lead, 1);
+
         $modified = new \DateTime('-15 minutes');
         $lead->setDateModified($modified);
         // Set it twice to get an original and updated datetime

--- a/plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
+++ b/plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
@@ -51,9 +51,8 @@ class MailchimpApi extends EmailMarketingApi
         } elseif (is_array($response) && !empty($response['errors'])) {
             $errors = [];
             foreach ($response['errors'] as $error) {
-                $errors[] = $error['error'];
+                $errors[] = $error['message'];
             }
-
             throw new ApiErrorException(implode(' ', $errors));
         } else {
             return $response;
@@ -93,9 +92,11 @@ class MailchimpApi extends EmailMarketingApi
         $emailStruct->email = $email;
 
         $parameters = array_merge($config, [
-            'id'           => $listId,
-            'merge_fields' => $fields,
+            'id' => $listId,
         ]);
+        if (!empty($fields)) {
+            $parameters = array_merge($parameters, ['merge_fields' => $fields]);
+        }
         $parameters['email_address'] = $email;
         $parameters['status']        = 'subscribed';
 

--- a/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
@@ -164,6 +164,9 @@ class MailchimpType extends AbstractType
             $builder->addEventListener(FormEvents::PRE_SET_DATA,
                 function (FormEvent $event) use ($formModifier) {
                     $data = $event->getData();
+                    if (isset($data['leadFields']['leadFields'])) {
+                        $data['leadFields'] = $data['leadFields']['leadFields'];
+                    }
                     $formModifier($event->getForm(), $data);
                 }
             );
@@ -171,6 +174,9 @@ class MailchimpType extends AbstractType
             $builder->addEventListener(FormEvents::PRE_SUBMIT,
                 function (FormEvent $event) use ($formModifier) {
                     $data = $event->getData();
+                    if (isset($data['leadFields']['leadFields'])) {
+                        $data['leadFields'] = $data['leadFields']['leadFields'];
+                    }
                     $formModifier($event->getForm(), $data);
                 }
             );

--- a/plugins/MauticSocialBundle/Entity/PostCountRepository.php
+++ b/plugins/MauticSocialBundle/Entity/PostCountRepository.php
@@ -45,8 +45,8 @@ class PostCountRepository extends CommonRepository
     {
         $chartQuery = new ChartQuery($this->getEntityManager()->getConnection(), $dateFrom, $dateTo);
 
-        // Load points for selected period
-        $q = $chartQuery->prepareTimeDataQuery(MAUTIC_TABLE_PREFIX.'monitor_post_count', 'post_date', $options);
+        // Load points for selected periods
+        $q = $chartQuery->prepareTimeDataQuery(MAUTIC_TABLE_PREFIX.'monitor_post_count', 'post_date', $options, 'post_count', false);
         if (isset($options['monitor_id'])) {
             $q->andwhere($q->expr()->eq('t.monitor_id', (int) $options['monitor_id']));
         }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

2.9 stopped tracking a user as a contact. But it caused issues in various places that expected a Lead entity leading to Doctrine exceptions. This PR fixes those areas. 

#### Steps to test this PR:
1. Download an asset as a user
2. View dynamic web content as a user
3. Submit a form as a user in both kiosk and not kiosk mode
4. View a landing page as a user
5. Video hit tracking (#4480)