### PR TITLE
Remove cascade merge for owner because it causes issues with batch processing Lead entities

### DIFF
--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -279,8 +279,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
             ->build();
 
         $builder->createManyToOne('owner', 'Mautic\UserBundle\Entity\User')
-            ->cascadeDetach()
-            ->cascadeMerge()
+            ->fetchLazy()
             ->addJoinColumn('owner_id', 'id', true, false, 'SET NULL')
             ->build();
 


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

2.9 introduced cascading detaching User entity for Lead owner to save RAM. But, this causes issues when multiple Lead's have the same User leading to a Doctrine exception. So this PR does not auto detach User entity rather it only loads if used. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup Salesforce sync and enable automatic Owner mapping
2. Create two new contacts in SF and assign to a SF user that exists as a Mautic user
3. Sync with Mautic - should experience the "a new entity was found" exception on the second contact

#### Steps to test this PR:
1. Repeat and this time both contacts will be created and assigned to the user
