### PR TITLE
Use $contactObjectName when pulling contacts.  Fixes #4497

### DIFF
--- a/app/bundles/PluginBundle/Command/FetchLeadsCommand.php
+++ b/app/bundles/PluginBundle/Command/FetchLeadsCommand.php
@@ -152,7 +152,7 @@ class FetchLeadsCommand extends ContainerAwareCommand
                         $output->writeln('');
                         $output->writeln('<comment>'.$translator->trans('mautic.plugin.command.fetch.contacts.starting').'</comment>');
                         $contactList = [];
-                        $results     = $integrationObject->getLeads($params, null, $contactsExecuted, $contactList, 'Contact');
+                        $results     = $integrationObject->getLeads($params, null, $contactsExecuted, $contactList, $contactObjectName);
                         if (is_array($results)) {
                             list($justUpdated, $justCreated) = $results;
                             $updated += (int) $justUpdated;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4497
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
See https://github.com/mautic/mautic/issues/4497 for details, Contacts are not being pulled from SugarCRM due to an incorrect module name.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 