### PR TITLE
Decrease the sent email count instead of increasing it when the sending fails

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1243,7 +1243,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
                             $errorMessages[$stat->getLead()->getId()] = $error;
                             // Down sent counts
                             $emailId = $stat->getEmail()->getId();
-                            ++$emailSentCounts[$emailId];
+                            --$emailSentCounts[$emailId];
 
                             if ($stat->getId()) {
                                 $deleteEntities[] = $stat;


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If the email send fails for whatever reason, it will add 2 times more 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
There will be other possibilities to fake email sending error. Here is how I did it:
1. Configure Sparkpost credentials at the Mautic configuration.
2. Use an email address which is not verified in the Sparkpost account as the send from address.
3. Send a segment email to some testing segment containing 3 testing contacts.
- Notice the send count is 6, but no email was actually sent.

#### Steps to test this PR:
1. Apply this PR.
2. Clone the email you created during reproducing the bug.
3. Send the cloned email.
- The sent count is 0 as it should be.