### PR TITLE
Always trigger the *OnLoad methods if onPageLoad is called from a modal

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -653,7 +653,7 @@ Mautic.onPageLoad = function (container, response, inModal) {
     }
 
     if (contentSpecific && typeof Mautic[contentSpecific + "OnLoad"] == 'function') {
-        if (typeof Mautic.loadedContent[contentSpecific] == 'undefined') {
+        if (inModal || typeof Mautic.loadedContent[contentSpecific] == 'undefined') {
             Mautic.loadedContent[contentSpecific] = true;
             Mautic[contentSpecific + "OnLoad"](container, response);
         }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
My previous PR, particularly [this code](https://github.com/mautic/mautic/pull/4475/files#diff-db502121e59063b2a00441af581ceeb6L243) removal caused troubles when adding form fields or creating new campaign flow. It was removed because in case of contact notes it called the same *OnLoad method twice and therefore counting 1 note as 2. Removing that code fixed it. But in case of forms and campaigns the *OnLoad method was not called because of the content was already marked as loaded (`if (typeof Mautic.loadedContent[contentSpecific] == 'undefined') {`) So my suggested solution is do not check for this condition in case it's called from modals.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to add new form fields
2. Try to create a new campaign flow
- You will see what's wrong.

#### Steps to test this PR:
1. Apply this PR
2. Run `app/console mautic:assets:generate` or use the dev env.
3. Retest
- The form fields are being created and campaigns can be defined with various events.