### PR TITLE
Bugfix - Fix membership filter for multiple segments

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -1370,7 +1370,7 @@ class LeadListRepository extends CommonRepository
                                     }
                                 }
                             } else {
-                                $se    = $nq->expr()->andX();
+                                $se    = $isNot ? $nq->expr()->andX() : $nq->expr()->orX(); // for including segments
                                 $count = 0;
                                 foreach ($newListIds as $newListId) {
                                     $ll = $this->getEntity($newListId);


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes an issue introduced in https://github.com/mautic/mautic/pull/4482 where segment membership filters were being treated as a scalar value. When the value is an array it throws an error.

#### Steps to reproduce the bug:
1. Follow steps on https://github.com/mautic/mautic/pull/4482 but instead of excluding a single segment, exclude two or more.
2. An error will be thrown.

#### Steps to test this PR:
1. Apply this PR
2. Try to replicate the error
3. The segments will be updated correctly.

