### PR TITLE
hiturl SQL error fixed when creating visited url segments fixed

### DIFF
--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -103,7 +103,7 @@ class AjaxController extends CommonAjaxController
     {
         $dataArray = ['success' => 0];
         $filter    = InputHelper::clean($request->query->get('filter'));
-        $leadField = InputHelper::alphanum($request->query->get('field'));
+        $leadField = InputHelper::alphanum($request->query->get('field'), false, false, ['_']);
         if (!empty($leadField)) {
             if (strpos($leadField, 'company') === 0) {
                 $results = $this->getModel('lead.company')->getLookupResults('companyfield', [$leadField, $filter]);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4160
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The field sanitisation was clearing underscores and therefore `hit_url` was changed to `hiturl` and was not getting into the right condition later on.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to 'segments'
2. Edit a segment
3. Go to filters
4. Right click + inspect + console
5. Add value to Visited URL filter, add '/' to the url
6. Console will display the 500 error
7. Value can't be passed correctly, hence sql error.

#### Steps to test this PR:
1. Apply this PR
2. Refresh the segment edit form. The error is gone.