### PR TITLE
Company is_primary column default value fix

### DIFF
--- a/app/bundles/LeadBundle/Entity/CompanyLead.php
+++ b/app/bundles/LeadBundle/Entity/CompanyLead.php
@@ -74,6 +74,7 @@ class CompanyLead
 
         $builder->createField('primary', 'boolean')
             ->columnName('is_primary')
+            ->nullable()
             ->build();
 
         // @deprecated 2.9 to be removed in 3.0

--- a/app/migrations/Version20170728110351.php
+++ b/app/migrations/Version20170728110351.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * @package     Mautic
+ * @copyright   2017 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170728110351 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        $table = $schema->getTable($this->prefix.'companies_leads');
+
+        if ($table->hasColumn('score') && $table->getColumn('score')->getNotnull() === false) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // Please modify to your needs
+        $this->addSql('ALTER TABLE '.$this->prefix.'companies_leads CHANGE is_primary is_primary TINYINT(1) NULL');
+    }
+}

--- a/app/migrations/Version20170728110351.php
+++ b/app/migrations/Version20170728110351.php
@@ -29,7 +29,7 @@ class Version20170728110351 extends AbstractMauticMigration
     {
         $table = $schema->getTable($this->prefix.'companies_leads');
 
-        if ($table->hasColumn('score') && $table->getColumn('score')->getNotnull() === false) {
+        if ($table->hasColumn('is_primary') && $table->getColumn('is_primary')->getNotnull() === false) {
             throw new SkipMigrationException('Schema includes this migration');
         }
     }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
when upgrading from version 2.8.2 to latest version of Mautic, migrating companies, will error because is_primary is not a nullable field, this fixes it.
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. try to run the upgrade script from versions 2.8.2 to latest Mautic, you will hit this error when running migrations

#### Steps to test this PR:
1. Above error should not happen