### PR TITLE
fixed bug when updating records - added field priority

### DIFF
--- a/plugins/MauticCrmBundle/Api/SugarcrmApi.php
+++ b/plugins/MauticCrmBundle/Api/SugarcrmApi.php
@@ -54,9 +54,12 @@ class SugarcrmApi extends CrmApi
                 return $response;
             }
         } else {
-            $request_url                 = sprintf('%s/rest/v10/%s', $tokenData['sugarcrm_url'], $sMethod);
-            $settings['request_timeout'] = 50;
-            $response                    = $this->integration->makeRequest($request_url, $data, $method, $settings);
+            $request_url = sprintf('%s/rest/v10/%s', $tokenData['sugarcrm_url'], $sMethod);
+            $settings    = [
+                'request_timeout'   => 50,
+                'encode_parameters' => 'json',
+            ];
+            $response = $this->integration->makeRequest($request_url, $data, $method, $settings);
 
             if (isset($response['error'])) {
                 throw new ApiErrorException(isset($response['error_message']) ? $response['error_message'] : $response['error']['message'], ($response['error'] == 'invalid_grant') ? 1 : 500);
@@ -171,11 +174,18 @@ class SugarcrmApi extends CrmApi
                     $sugarLeadId = (isset($sLeadRecord['integration_entity_id']) ? $sLeadRecord['integration_entity_id'] : $sLeadRecord['id']);
                     $sugarObject = (isset($sLeadRecord['integration_entity']) ? $sLeadRecord['integration_entity'] : 'Leads');
                     //update the converted contact if found and not the Lead
+                    $config                = $this->integration->mergeConfigToFeatureSettings();
+                    $fieldsToUpdateInSugar = isset($config['update_mautic']) ? array_keys($config['update_mautic'], 1) : [];
+
                     if (isset($sLeadRecord['contact_id']) && $sLeadRecord['contact_id'] != null && $sLeadRecord['contact_id'] != '') {
                         unset($fields['Company']); //because this record is not in the Contact object
-                        $createdLeadData[] = $this->request("Contacts/$sugarLeadId", $fields, 'PUT', 'Contacts');
+                        $fieldsToUpdateInContactsSugar = $this->integration->cleanSugarData($config, $fieldsToUpdateInSugar, 'Contacts');
+                        $contactSugarFields            = array_diff_key($fields, $fieldsToUpdateInContactsSugar);
+                        $createdLeadData[]             = $this->request("Contacts/$sugarLeadId", $contactSugarFields, 'PUT', 'Contacts');
                     } else {
-                        $createdLeadData[] = $this->request("$sugarObject/$sugarLeadId", $fields, 'PUT', $sugarObject);
+                        $fieldsToUpdateInLeadsSugar = $this->integration->cleanSugarData($config, $fieldsToUpdateInSugar, 'Leads');
+                        $leadSugarFields            = array_diff_key($fields, $fieldsToUpdateInLeadsSugar);
+                        $createdLeadData[]          = $this->request("$sugarObject/$sugarLeadId", $leadSugarFields, 'PUT', $sugarObject);
                     }
                 }
             } else {

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -987,6 +987,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
 
                                 $companyModel->addLeadToCompany($company, $entity);
                                 $this->em->clear(Company::class);
+                                $this->em->detach($entity);
                             }
                         }
                     } elseif ($object == 'Accounts') {
@@ -1557,12 +1558,12 @@ class SugarcrmIntegration extends CrmAbstractIntegration
      */
     protected function processCompositeResponse($response, array $sugarcrmIdMapping = [])
     {
-        $created = 0;
-        $errored = 0;
-        $updated = 0;
-        $object  = 'Lead';
+        $created         = 0;
+        $errored         = 0;
+        $updated         = 0;
+        $object          = 'Lead';
+        $persistEntities = [];
         if (is_array($response)) {
-            $persistEntities = [];
             foreach ($response as $item) {
                 $contactId = $integrationEntityId = null;
                 if (!empty($item['reference_id'])) {

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -969,8 +969,8 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                         }
                         $mauticObjectReference = 'lead';
                         $entity                = $this->getMauticLead($dataObject, true, null, null, $object);
-
-                        $company = null;
+                        $detachClass           = Lead::class;
+                        $company               = null;
                         if ($entity && isset($dataObject['account_id'.$newName]) && trim($dataObject['account_id'.$newName]) != '') {
                             $integrationCompanyEntity = $integrationEntityRepo->findOneBy(
                                 [
@@ -986,10 +986,12 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                                 $company      = $companyRepo->find($companyId);
 
                                 $companyModel->addLeadToCompany($company, $entity);
+                                $this->em->clear(Company::class);
                             }
                         }
                     } elseif ($object == 'Accounts') {
                         $entity                = $this->getMauticCompany($dataObject, true, null);
+                        $detachClass           = Company::class;
                         $mauticObjectReference = 'company';
                     } else {
                         $this->logIntegrationError(
@@ -1025,6 +1027,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                             $integrationEntities[] = $integrationEntity;
                         }
                         $this->em->detach($entity);
+                        $this->em->clear($detachClass);
                         unset($entity);
                     } else {
                         continue;

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -229,7 +229,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
 
         $isRequired = function (array $field, $object) {
             switch (true) {
-                case 'Leads' === $object && 'webtolead_email1' === $field['name']:
+                case 'Leads' === $object && ('webtolead_email1' === $field['name'] || 'email1' === $field['name']):
                     return true;
                 case 'Contacts' === $object && 'email1' === $field['name']:
                     return true;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When updating existing records,SugarCRM API would return an error
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to push a contact through a campaign which already exists in SugarCRM, this errors.
2. Also updating records when pushing through a campaign was not taking field priority into account.

#### Steps to test this PR:
1. Apply this PR try to push a record to SugarCRM and the record should be updated correctly, taking Field priority into account.