### PR TITLE
Contact activity events api

### DIFF
--- a/app/bundles/AssetBundle/Entity/DownloadRepository.php
+++ b/app/bundles/AssetBundle/Entity/DownloadRepository.php
@@ -65,7 +65,7 @@ class DownloadRepository extends CommonRepository
     public function getLeadDownloads($leadId = null, array $options = [])
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder()
-            ->select('a.id as asset_id, d.date_download as dateDownload, a.title')
+            ->select('a.id as asset_id, d.date_download as dateDownload, a.title, d.lead_id')
             ->from(MAUTIC_TABLE_PREFIX.'asset_downloads', 'd')
             ->leftJoin('d', MAUTIC_TABLE_PREFIX.'assets', 'a', 'd.asset_id = a.id');
 

--- a/app/bundles/AssetBundle/Entity/DownloadRepository.php
+++ b/app/bundles/AssetBundle/Entity/DownloadRepository.php
@@ -65,7 +65,7 @@ class DownloadRepository extends CommonRepository
     public function getLeadDownloads($leadId = null, array $options = [])
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder()
-            ->select('a.id as asset_id, d.date_download as dateDownload, a.title, d.lead_id')
+            ->select('a.id as asset_id, d.date_download as dateDownload, a.title, d.id as download_id, d.lead_id')
             ->from(MAUTIC_TABLE_PREFIX.'asset_downloads', 'd')
             ->leftJoin('d', MAUTIC_TABLE_PREFIX.'assets', 'a', 'd.asset_id = a.id');
 

--- a/app/bundles/AssetBundle/Entity/DownloadRepository.php
+++ b/app/bundles/AssetBundle/Entity/DownloadRepository.php
@@ -57,18 +57,21 @@ class DownloadRepository extends CommonRepository
     /**
      * Get a lead's page downloads.
      *
-     * @param       $leadId
-     * @param array $options
+     * @param int|null $leadId
+     * @param array    $options
      *
      * @return array
      */
-    public function getLeadDownloads($leadId, array $options = [])
+    public function getLeadDownloads($leadId = null, array $options = [])
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->select('a.id as asset_id, d.date_download as dateDownload, a.title')
             ->from(MAUTIC_TABLE_PREFIX.'asset_downloads', 'd')
-            ->leftJoin('d', MAUTIC_TABLE_PREFIX.'assets', 'a', 'd.asset_id = a.id')
-            ->where('d.lead_id = '.(int) $leadId);
+            ->leftJoin('d', MAUTIC_TABLE_PREFIX.'assets', 'a', 'd.asset_id = a.id');
+
+        if ($leadId) {
+            $query->where('d.lead_id = '.(int) $leadId);
+        }
 
         if (isset($options['search']) && $options['search']) {
             $query->andWhere($query->expr()->like('a.title', $query->expr()->literal('%'.$options['search'].'%')));

--- a/app/bundles/AssetBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/LeadSubscriber.php
@@ -67,11 +67,9 @@ class LeadSubscriber extends CommonSubscriber
             return;
         }
 
-        $lead = $event->getLead();
-
         /** @var \Mautic\AssetBundle\Entity\DownloadRepository $downloadRepository */
         $downloadRepository = $this->em->getRepository('MauticAssetBundle:Download');
-        $downloads          = $downloadRepository->getLeadDownloads($lead->getId(), $event->getQueryOptions());
+        $downloads          = $downloadRepository->getLeadDownloads($event->getLeadId(), $event->getQueryOptions());
 
         // Add total number to counter
         $event->addToCounter($eventTypeKey, $downloads);

--- a/app/bundles/AssetBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/LeadSubscriber.php
@@ -61,6 +61,7 @@ class LeadSubscriber extends CommonSubscriber
         $eventTypeKey  = 'asset.download';
         $eventTypeName = $this->translator->trans('mautic.asset.event.download');
         $event->addEventType($eventTypeKey, $eventTypeName);
+        $event->addSerializerGroup('assetList');
 
         // Decide if those events are filtered
         if (!$event->isApplicable($eventTypeKey)) {

--- a/app/bundles/AssetBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/LeadSubscriber.php
@@ -83,6 +83,7 @@ class LeadSubscriber extends CommonSubscriber
                 $event->addEvent(
                     [
                         'event'      => $eventTypeKey,
+                        'eventId'    => $eventTypeKey.$download['download_id'],
                         'eventLabel' => [
                             'label' => $download['title'],
                             'href'  => $this->router->generate('mautic_asset_action', ['objectAction' => 'view', 'objectId' => $download['asset_id']]),

--- a/app/bundles/AssetBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/LeadSubscriber.php
@@ -94,6 +94,7 @@ class LeadSubscriber extends CommonSubscriber
                         'timestamp'       => $download['dateDownload'],
                         'icon'            => 'fa-download',
                         'contentTemplate' => 'MauticAssetBundle:SubscribedEvents\Timeline:index.html.php',
+                        'contactId'       => $download['lead_id'],
                     ]
                 );
             }

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -73,7 +73,8 @@ class LeadEventLogRepository extends CommonRepository
         $query = $this->getEntityManager()
                       ->getConnection()
                       ->createQueryBuilder()
-                      ->select('ll.event_id,
+                      ->select('ll.id as log_id,
+                    ll.event_id,
                     ll.campaign_id,
                     ll.date_triggered as dateTriggered,
                     e.name AS event_name,

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -60,15 +60,15 @@ class LeadEventLogRepository extends CommonRepository
     /**
      * Get a lead's page event log.
      *
-     * @param int   $leadId
-     * @param array $options
+     * @param int|null $leadId
+     * @param array    $options
      *
      * @return array
      *
      * @throws \Doctrine\ORM\NoResultException
      * @throws \Doctrine\ORM\NonUniqueResultException
      */
-    public function getLeadLogs($leadId, array $options = [])
+    public function getLeadLogs($leadId = null, array $options = [])
     {
         $query = $this->getEntityManager()
                       ->getConnection()
@@ -92,8 +92,11 @@ class LeadEventLogRepository extends CommonRepository
                       ->leftJoin('ll', MAUTIC_TABLE_PREFIX.'campaign_events', 'e', 'll.event_id = e.id')
                       ->leftJoin('ll', MAUTIC_TABLE_PREFIX.'campaigns', 'c', 'll.campaign_id = c.id')
                       ->where('ll.lead_id = '.(int) $leadId)
-                      ->andWhere('e.event_type != :eventType')
-                      ->setParameter('eventType', 'decision');
+                      ->andWhere('e.event_type != :eventType');
+
+        if ($leadId) {
+            $query->setParameter('eventType', 'decision');
+        }
 
         if (isset($options['scheduledState'])) {
             if ($options['scheduledState']) {

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -85,17 +85,18 @@ class LeadEventLogRepository extends CommonRepository
                     ll.is_scheduled as isScheduled,
                     ll.trigger_date as triggerDate,
                     ll.channel,
-                    ll.channel_id as channel_id
+                    ll.channel_id as channel_id,
+                    ll.lead_id
                     '
                       )
                       ->from(MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'll')
                       ->leftJoin('ll', MAUTIC_TABLE_PREFIX.'campaign_events', 'e', 'll.event_id = e.id')
                       ->leftJoin('ll', MAUTIC_TABLE_PREFIX.'campaigns', 'c', 'll.campaign_id = c.id')
-                      ->where('ll.lead_id = '.(int) $leadId)
-                      ->andWhere('e.event_type != :eventType');
+                      ->andWhere('e.event_type != :eventType')
+                      ->setParameter('eventType', 'decision');
 
         if ($leadId) {
-            $query->setParameter('eventType', 'decision');
+            $query->where('ll.lead_id = '.(int) $leadId);
         }
 
         if (isset($options['scheduledState'])) {

--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -194,6 +194,7 @@ class LeadSubscriber extends CommonSubscriber
     protected function addTimelineEvents(LeadTimelineEvent $event, $eventTypeKey, $eventTypeName)
     {
         $event->addEventType($eventTypeKey, $eventTypeName);
+        $event->addSerializerGroup('campaignList');
 
         // Decide if those events are filtered
         if (!$event->isApplicable($eventTypeKey)) {

--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -239,8 +239,8 @@ class LeadSubscriber extends CommonSubscriber
 
                 $event->addEvent(
                     [
-                        'event'           => $eventTypeKey,
-                        'eventLabel'      => [
+                        'event'      => $eventTypeKey,
+                        'eventLabel' => [
                             'label' => $label,
                             'href'  => $this->router->generate(
                                 'mautic_campaign_action',

--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -228,22 +228,27 @@ class LeadSubscriber extends CommonSubscriber
                         .'" class="fa fa-warning text-danger"></i>';
                 }
 
+                $extra = [
+                    'log' => $log,
+                ];
+
+                if ($event->isForTimeline()) {
+                    $extra['campaignEventSettings'] = $eventSettings;
+                }
+
                 $event->addEvent(
                     [
-                        'event'      => $eventTypeKey,
-                        'eventLabel' => [
+                        'event'           => $eventTypeKey,
+                        'eventLabel'      => [
                             'label' => $label,
                             'href'  => $this->router->generate(
                                 'mautic_campaign_action',
                                 ['objectAction' => 'view', 'objectId' => $log['campaign_id']]
                             ),
                         ],
-                        'eventType' => $eventTypeName,
-                        'timestamp' => $log['dateTriggered'],
-                        'extra'     => [
-                            'log'                   => $log,
-                            'campaignEventSettings' => $eventSettings,
-                        ],
+                        'eventType'       => $eventTypeName,
+                        'timestamp'       => $log['dateTriggered'],
+                        'extra'           => $extra,
                         'contentTemplate' => $template,
                         'icon'            => 'fa-clock-o',
                         'contactId'       => $log['lead_id'],

--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -13,6 +13,7 @@ namespace Mautic\CampaignBundle\EventListener;
 
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CoreBundle\EventListener\CommonSubscriber;
+use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Event\LeadMergeEvent;
 use Mautic\LeadBundle\Event\LeadTimelineEvent;
 use Mautic\LeadBundle\Event\ListChangeEvent;
@@ -199,13 +200,11 @@ class LeadSubscriber extends CommonSubscriber
             return;
         }
 
-        $lead = $event->getLead();
-
         /** @var \Mautic\CampaignBundle\Entity\LeadEventLogRepository $logRepository */
         $logRepository             = $this->em->getRepository('MauticCampaignBundle:LeadEventLog');
         $options                   = $event->getQueryOptions();
         $options['scheduledState'] = ('campaign.event' === $eventTypeKey) ? false : true;
-        $logs                      = $logRepository->getLeadLogs($lead->getId(), $options);
+        $logs                      = $logRepository->getLeadLogs($event->getLeadId(), $options);
         $eventSettings             = $this->campaignModel->getEvents();
 
         // Add total number to counter

--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -239,9 +239,9 @@ class LeadSubscriber extends CommonSubscriber
 
                 $event->addEvent(
                     [
-                        'event'           => $eventTypeKey,
-                        'eventId'         => $eventTypeKey.$log['log_id'],
-                        'eventLabel'      => [
+                        'event'      => $eventTypeKey,
+                        'eventId'    => $eventTypeKey.$log['log_id'],
+                        'eventLabel' => [
                             'label' => $label,
                             'href'  => $this->router->generate(
                                 'mautic_campaign_action',

--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -246,6 +246,7 @@ class LeadSubscriber extends CommonSubscriber
                         ],
                         'contentTemplate' => $template,
                         'icon'            => 'fa-clock-o',
+                        'contactId'       => $log['lead_id'],
                     ]
                 );
             }

--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -240,6 +240,7 @@ class LeadSubscriber extends CommonSubscriber
                 $event->addEvent(
                     [
                         'event'           => $eventTypeKey,
+                        'eventId'         => $eventTypeKey.$log['log_id'],
                         'eventLabel'      => [
                             'label' => $label,
                             'href'  => $this->router->generate(

--- a/app/bundles/CoreBundle/Entity/AuditLogRepository.php
+++ b/app/bundles/CoreBundle/Entity/AuditLogRepository.php
@@ -79,7 +79,7 @@ class AuditLogRepository extends CommonRepository
         $sqb = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
         $sqb
-            ->select('MAX(l.date_added) as date_added, l.ip_address, l.object_id as lead_id')
+            ->select('MAX(l.date_added) as date_added, MIN(l.id) as id, l.ip_address, l.object_id as lead_id')
             ->from(MAUTIC_TABLE_PREFIX.'audit_log', 'l')
             ->where(
                 $sqb->expr()->andX(

--- a/app/bundles/CoreBundle/Entity/AuditLogRepository.php
+++ b/app/bundles/CoreBundle/Entity/AuditLogRepository.php
@@ -103,7 +103,7 @@ class AuditLogRepository extends CommonRepository
         }
 
         $qb
-            ->select('ip.date_added, ip.ip_address, ip.lead_id')
+            ->select('ip.date_added, ip.ip_address, ip.lead_id, ip.id')
             ->from(sprintf('(%s)', $sqb->getSQL()), 'ip');
 
         return $this->getTimelineResults($qb, $options, 'ip.ip_address', 'ip.date_added', [], ['date_added']);

--- a/app/bundles/CoreBundle/Entity/AuditLogRepository.php
+++ b/app/bundles/CoreBundle/Entity/AuditLogRepository.php
@@ -79,7 +79,7 @@ class AuditLogRepository extends CommonRepository
         $sqb = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
         $sqb
-            ->select('MAX(l.date_added) as date_added, l.ip_address')
+            ->select('MAX(l.date_added) as date_added, l.ip_address, l.object_id as lead_id')
             ->from(MAUTIC_TABLE_PREFIX.'audit_log', 'l')
             ->where(
                 $sqb->expr()->andX(
@@ -103,7 +103,7 @@ class AuditLogRepository extends CommonRepository
         }
 
         $qb
-            ->select('ip.date_added, ip.ip_address')
+            ->select('ip.date_added, ip.ip_address, ip.lead_id')
             ->from(sprintf('(%s)', $sqb->getSQL()), 'ip');
 
         return $this->getTimelineResults($qb, $options, 'ip.ip_address', 'ip.date_added', [], ['date_added']);

--- a/app/bundles/DynamicContentBundle/Entity/StatRepository.php
+++ b/app/bundles/DynamicContentBundle/Entity/StatRepository.php
@@ -116,22 +116,25 @@ class StatRepository extends CommonRepository
     /**
      * Get a lead's dynamic content stat.
      *
-     * @param int   $leadId
-     * @param array $options
+     * @param int|null $leadId
+     * @param array    $options
      *
      * @return array
      *
      * @throws \Doctrine\ORM\NoResultException
      * @throws \Doctrine\ORM\NonUniqueResultException
      */
-    public function getLeadStats($leadId, array $options = [])
+    public function getLeadStats($leadId = null, array $options = [])
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
         $query->select('dc.id AS dynamic_content_id, s.id, s.date_sent as dateSent, dc.name, s.sent_details as sentDetails')
             ->from(MAUTIC_TABLE_PREFIX.'dynamic_content_stats', 's')
-            ->leftJoin('s', MAUTIC_TABLE_PREFIX.'dynamic_content', 'dc', 'dc.id = s.dynamic_content_id')
-            ->where($query->expr()->eq('s.lead_id', (int) $leadId));
+            ->leftJoin('s', MAUTIC_TABLE_PREFIX.'dynamic_content', 'dc', 'dc.id = s.dynamic_content_id');
+
+        if ($leadId) {
+            $query->where($query->expr()->eq('s.lead_id', (int) $leadId));
+        }
 
         if (isset($options['search']) && $options['search']) {
             $query->andWhere(

--- a/app/bundles/DynamicContentBundle/Entity/StatRepository.php
+++ b/app/bundles/DynamicContentBundle/Entity/StatRepository.php
@@ -128,7 +128,7 @@ class StatRepository extends CommonRepository
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
-        $query->select('dc.id AS dynamic_content_id, s.id, s.date_sent as dateSent, dc.name, s.sent_details as sentDetails')
+        $query->select('dc.id AS dynamic_content_id, s.id, s.date_sent as dateSent, dc.name, s.sent_details as sentDetails, s.lead_id')
             ->from(MAUTIC_TABLE_PREFIX.'dynamic_content_stats', 's')
             ->leftJoin('s', MAUTIC_TABLE_PREFIX.'dynamic_content', 'dc', 'dc.id = s.dynamic_content_id');
 

--- a/app/bundles/DynamicContentBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/LeadSubscriber.php
@@ -59,6 +59,8 @@ class LeadSubscriber extends CommonSubscriber
 
             // Add the events to the event array
             foreach ($stats['results'] as $stat) {
+                $contactId = $stat['lead_id'];
+                unset($stat['lead_id']);
                 if ($stat['dateSent']) {
                     $event->addEvent(
                         [
@@ -78,6 +80,7 @@ class LeadSubscriber extends CommonSubscriber
                             ],
                             'contentTemplate' => 'MauticDynamicContentBundle:SubscribedEvents\Timeline:index.html.php',
                             'icon'            => 'fa-envelope',
+                            'contactId'       => $contactId,
                         ]
                     );
                 }

--- a/app/bundles/DynamicContentBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/LeadSubscriber.php
@@ -66,6 +66,7 @@ class LeadSubscriber extends CommonSubscriber
                     $event->addEvent(
                         [
                             'event'      => $eventTypeKey,
+                            'eventId'    => $eventTypeKey.$stat['id'],
                             'eventLabel' => [
                                 'label' => $stat['name'],
                                 'href'  => $this->router->generate(

--- a/app/bundles/DynamicContentBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/LeadSubscriber.php
@@ -43,6 +43,7 @@ class LeadSubscriber extends CommonSubscriber
         $eventTypeKey      = 'dynamic.content.sent';
         $eventTypeNameSent = $this->translator->trans('mautic.dynamic.content.sent');
         $event->addEventType($eventTypeKey, $eventTypeNameSent);
+        $event->addSerializerGroup('dwcList');
 
         if (!$event->isApplicable($eventTypeKey)) {
             return;

--- a/app/bundles/DynamicContentBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/LeadSubscriber.php
@@ -48,11 +48,9 @@ class LeadSubscriber extends CommonSubscriber
             return;
         }
 
-        $lead = $event->getLead();
-
         /** @var \Mautic\DynamicContentBundle\Entity\StatRepository $statRepository */
         $statRepository = $this->em->getRepository('MauticDynamicContentBundle:Stat');
-        $stats          = $statRepository->getLeadStats($lead->getId(), $event->getQueryOptions());
+        $stats          = $statRepository->getLeadStats($event->getLeadId(), $event->getQueryOptions());
 
         // Add total number to counter
         $event->addToCounter($eventTypeKey, $stats);

--- a/app/bundles/EmailBundle/Entity/StatRepository.php
+++ b/app/bundles/EmailBundle/Entity/StatRepository.php
@@ -363,7 +363,7 @@ class StatRepository extends CommonRepository
             );
         } else {
             $query->select(
-                's.email_id, s.id, s.date_read as dateRead, s.date_sent as dateSent,e.subject, e.name as email_name, s.is_read as isRead, s.is_failed as isFailed, s.viewed_in_browser as viewedInBrowser, s.retry_count as retryCount, s.list_id, l.name as list_name, s.tracking_hash as idHash, s.open_details as openDetails, ec.subject as storedSubject'
+                's.email_id, s.id, s.date_read as dateRead, s.date_sent as dateSent,e.subject, e.name as email_name, s.is_read as isRead, s.is_failed as isFailed, s.viewed_in_browser as viewedInBrowser, s.retry_count as retryCount, s.list_id, l.name as list_name, s.tracking_hash as idHash, s.open_details as openDetails, ec.subject as storedSubject, s.lead_id'
             )
                 ->leftJoin('s', MAUTIC_TABLE_PREFIX.'lead_lists', 'l', 's.list_id = l.id');
         }

--- a/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
@@ -71,13 +71,11 @@ class LeadSubscriber extends CommonSubscriber
             return;
         }
 
-        $lead = $event->getLead();
-
         /** @var \Mautic\EmailBundle\Entity\StatRepository $statRepository */
         $statRepository        = $this->em->getRepository('MauticEmailBundle:Stat');
         $queryOptions          = $event->getQueryOptions();
         $queryOptions['state'] = $state;
-        $stats                 = $statRepository->getLeadStats($lead->getId(), $queryOptions);
+        $stats                 = $statRepository->getLeadStats($event->getLeadId(), $queryOptions);
 
         // Add total to counter
         $event->addToCounter($eventTypeKey, $stats);

--- a/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
@@ -65,6 +65,7 @@ class LeadSubscriber extends CommonSubscriber
         $eventTypeKey  = 'email.'.$state;
         $eventTypeName = $this->translator->trans('mautic.email.'.$state);
         $event->addEventType($eventTypeKey, $eventTypeName);
+        $event->addSerializerGroup('emailList');
 
         // Decide if those events are filtered
         if (!$event->isApplicable($eventTypeKey)) {

--- a/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
@@ -113,6 +113,7 @@ class LeadSubscriber extends CommonSubscriber
                 $event->addEvent(
                     [
                         'event'      => $eventTypeKey,
+                        'eventId'    => $eventTypeKey.$stat['id'],
                         'eventLabel' => $eventName,
                         'eventType'  => $eventTypeName,
                         'timestamp'  => $stat['date'.ucfirst($dateSent)],

--- a/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
@@ -115,7 +115,6 @@ class LeadSubscriber extends CommonSubscriber
                         'eventLabel' => $eventName,
                         'eventType'  => $eventTypeName,
                         'timestamp'  => $stat['date'.ucfirst($dateSent)],
-                        'dateSent'   => $stat['dateSent'],
                         'extra'      => [
                             'stat' => $stat,
                             'type' => $state,

--- a/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
@@ -105,6 +105,10 @@ class LeadSubscriber extends CommonSubscriber
                 } else {
                     $dateSent = 'read';
                 }
+
+                $contactId = $stat['lead_id'];
+                unset($stat['lead_id']);
+
                 $event->addEvent(
                     [
                         'event'      => $eventTypeKey,
@@ -118,6 +122,7 @@ class LeadSubscriber extends CommonSubscriber
                         ],
                         'contentTemplate' => 'MauticEmailBundle:SubscribedEvents\Timeline:index.html.php',
                         'icon'            => ($state == 'read') ? 'fa-envelope-o' : 'fa-envelope',
+                        'contactId'       => $contactId,
                     ]
                 );
             }

--- a/app/bundles/EmailBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/EmailBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -27,7 +27,7 @@ if ($item = ((isset($event['extra'])) ? $event['extra']['stat'] : false)): ?>
                 [
                     '%date%'     => $view['date']->toFull($event['timestamp']),
                     '%interval%' => $view['date']->formatRange($event['timestamp']),
-                    '%sent%'     => $view['date']->toFull($event['dateSent']),
+                    '%sent%'     => $view['date']->toFull($item['dateSent']),
                 ]
             ); ?>
         <?php endif; ?>

--- a/app/bundles/FormBundle/Entity/Form.php
+++ b/app/bundles/FormBundle/Entity/Form.php
@@ -289,7 +289,6 @@ class Form extends FormEntity
                     'fields',
                     'actions',
                     'template',
-                    'submissionCount',
                     'inKioskMode',
                     'renderStyle',
                     'formType',

--- a/app/bundles/FormBundle/Entity/Submission.php
+++ b/app/bundles/FormBundle/Entity/Submission.php
@@ -129,6 +129,19 @@ class Submission
                     'results',
                 ]
             )
+            ->setGroupPrefix('submissionEvent')
+            ->addProperties(
+                [
+                    'id',
+                    'ipAddress',
+                    'form',
+                    'trackingId',
+                    'dateSubmitted',
+                    'referer',
+                    'page',
+                    'results',
+                ]
+            )
             ->build();
     }
 

--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -227,7 +227,7 @@ class SubmissionRepository extends CommonRepository
     public function getSubmissions(array $options = [])
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $query->select('fs.id, f.name, fs.form_id, fs.page_id, fs.date_submitted AS "dateSubmitted"')
+        $query->select('fs.id, f.name, fs.form_id, fs.page_id, fs.date_submitted AS "dateSubmitted", fs.lead_id')
             ->from(MAUTIC_TABLE_PREFIX.'form_submissions', 'fs')
             ->leftJoin('fs', MAUTIC_TABLE_PREFIX.'forms', 'f', 'f.id = fs.form_id');
 

--- a/app/bundles/FormBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/LeadSubscriber.php
@@ -67,6 +67,7 @@ class LeadSubscriber extends CommonSubscriber
         $eventTypeKey  = 'form.submitted';
         $eventTypeName = $this->translator->trans('mautic.form.event.submitted');
         $event->addEventType($eventTypeKey, $eventTypeName);
+        $event->addSerializerGroup(['formList', 'submissionDetails']);
 
         if (!$event->isApplicable($eventTypeKey)) {
             return;

--- a/app/bundles/FormBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/LeadSubscriber.php
@@ -67,7 +67,7 @@ class LeadSubscriber extends CommonSubscriber
         $eventTypeKey  = 'form.submitted';
         $eventTypeName = $this->translator->trans('mautic.form.event.submitted');
         $event->addEventType($eventTypeKey, $eventTypeName);
-        $event->addSerializerGroup(['formList', 'submissionDetails']);
+        $event->addSerializerGroup(['formList', 'submissionEventDetails']);
 
         if (!$event->isApplicable($eventTypeKey)) {
             return;

--- a/app/bundles/FormBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/LeadSubscriber.php
@@ -102,6 +102,7 @@ class LeadSubscriber extends CommonSubscriber
                         ],
                         'contentTemplate' => 'MauticFormBundle:SubscribedEvents\Timeline:index.html.php',
                         'icon'            => 'fa-pencil-square-o',
+                        'contactId'       => $row['lead_id'],
                     ]
                 );
             }

--- a/app/bundles/FormBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/LeadSubscriber.php
@@ -90,6 +90,7 @@ class LeadSubscriber extends CommonSubscriber
                 $event->addEvent(
                     [
                         'event'      => $eventTypeKey,
+                        'eventId'    => $eventTypeKey.$row['id'],
                         'eventLabel' => [
                             'label' => $form->getName(),
                             'href'  => $this->router->generate('mautic_form_action', ['objectAction' => 'view', 'objectId' => $form->getId()]),

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -123,6 +123,10 @@ return [
                 'path'       => '/contacts/{id}/events',
                 'controller' => 'MauticLeadBundle:Api\LeadApi:getEvents',
             ],
+            'mautic_api_getcontactsevents' => [
+                'path'       => '/contacts/events',
+                'controller' => 'MauticLeadBundle:Api\LeadApi:getAllEvents',
+            ],
             'mautic_api_getcontactnotes' => [
                 'path'       => '/contacts/{id}/notes',
                 'controller' => 'MauticLeadBundle:Api\LeadApi:getNotes',

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -120,12 +120,12 @@ return [
                 'method'     => 'POST',
             ],
             'mautic_api_getcontactevents' => [
-                'path'       => '/contacts/{id}/events',
-                'controller' => 'MauticLeadBundle:Api\LeadApi:getEvents',
+                'path'       => '/contacts/{id}/activity',
+                'controller' => 'MauticLeadBundle:Api\LeadApi:getActivity',
             ],
             'mautic_api_getcontactsevents' => [
-                'path'       => '/contacts/events',
-                'controller' => 'MauticLeadBundle:Api\LeadApi:getAllEvents',
+                'path'       => '/contacts/activity',
+                'controller' => 'MauticLeadBundle:Api\LeadApi:getAllActivity',
             ],
             'mautic_api_getcontactnotes' => [
                 'path'       => '/contacts/{id}/notes',
@@ -256,6 +256,11 @@ return [
                 'path'       => '/contacts/{id}/dnc/remove/{channel}',
                 'controller' => 'MauticLeadBundle:Api\LeadApi:removeDnc',
                 'method'     => 'POST',
+            ],
+            // @deprecated 2.10.0 to be removed in 3.0
+            'bc_mautic_api_getcontactevents' => [
+                'path'       => '/contacts/{id}/events',
+                'controller' => 'MauticLeadBundle:Api\LeadApi:getEvents',
             ],
         ],
     ],

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -419,8 +419,8 @@ class LeadApiController extends CommonApiController
      */
     public function getAllActivityAction($lead = null)
     {
-        $canViewOwn     = $this->security->isGranted('lead:leads:viewown');
-        $canViewOthers  = $this->security->isGranted('lead:leads:others');
+        $canViewOwn    = $this->security->isGranted('lead:leads:viewown');
+        $canViewOthers = $this->security->isGranted('lead:leads:others');
 
         if (!$canViewOthers && !$canViewOwn) {
             return $this->accessDenied();
@@ -431,9 +431,9 @@ class LeadApiController extends CommonApiController
         $page    = (int) $this->request->get('page', 1);
         $order   = InputHelper::clean($this->request->get('order', ['timestamp', 'DESC']));
 
-        list($events, $serializerGroups)  = $this->model->getEngagements($lead, $filters, $order, $page, $limit, false);
+        list($events, $serializerGroups) = $this->model->getEngagements($lead, $filters, $order, $page, $limit, false);
 
-        $view = $this->view($events);
+        $view    = $this->view($events);
         $context = SerializationContext::create()->setGroups($serializerGroups);
         $view->setSerializationContext($context);
 

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -397,7 +397,7 @@ class LeadApiController extends CommonApiController
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function getEventsAction($id)
+    public function getActivityAction($id)
     {
         $entity = $this->model->getEntity($id);
 
@@ -409,12 +409,7 @@ class LeadApiController extends CommonApiController
             return $this->accessDenied();
         }
 
-        $filters = $this->sanitizeEventFilter(InputHelper::clean($this->request->get('filters', [])));
-        $order   = InputHelper::clean($this->request->get('order', ['timestamp', 'DESC']));
-        $page    = (int) $this->request->get('page', 1);
-        $events  = $this->model->getEngagements($entity, $filters, $order, $page);
-
-        return $this->handleView($this->view($events));
+        return $this->getAllActivityAction($entity);
     }
 
     /**
@@ -422,7 +417,7 @@ class LeadApiController extends CommonApiController
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function getAllEventsAction()
+    public function getAllActivityAction($lead = null)
     {
         $canViewOwn     = $this->security->isGranted('lead:leads:viewown');
         $canViewOthers  = $this->security->isGranted('lead:leads:others');
@@ -436,7 +431,7 @@ class LeadApiController extends CommonApiController
         $page    = (int) $this->request->get('page', 1);
         $order   = InputHelper::clean($this->request->get('order', ['timestamp', 'DESC']));
 
-        list($events, $serializerGroups)  = $this->model->getEngagements(null, $filters, $order, $page, $limit, false);
+        list($events, $serializerGroups)  = $this->model->getEngagements($lead, $filters, $order, $page, $limit, false);
 
         $view = $this->view($events);
         $context = SerializationContext::create()->setGroups($serializerGroups);
@@ -574,6 +569,35 @@ class LeadApiController extends CommonApiController
     public function removeUtmTagsAction($id, $utmid)
     {
         return $this->applyUtmTagsAction($id, 'removeUtmTags', (int) $utmid);
+    }
+
+    /**
+     * Obtains a list of contact events.
+     *
+     * @deprecated 2.10.0 to be removed in 3.0
+     *
+     * @param $id
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function getEventsAction($id)
+    {
+        $entity = $this->model->getEntity($id);
+
+        if ($entity === null) {
+            return $this->notFound();
+        }
+
+        if (!$this->checkEntityAccess($entity, 'view')) {
+            return $this->accessDenied();
+        }
+
+        $filters = $this->sanitizeEventFilter(InputHelper::clean($this->request->get('filters', [])));
+        $order   = InputHelper::clean($this->request->get('order', ['timestamp', 'DESC']));
+        $page    = (int) $this->request->get('page', 1);
+        $events  = $this->model->getEngagements($entity, $filters, $order, $page);
+
+        return $this->handleView($this->view($events));
     }
 
     /**

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -414,11 +414,7 @@ class LeadApiController extends CommonApiController
         $page    = (int) $this->request->get('page', 1);
         $events  = $this->model->getEngagements($entity, $filters, $order, $page);
 
-        $view = $this->view($events);
-        $context = SerializationContext::create()->setGroups($this->serializerGroups);
-        $view->setSerializationContext($context);
-
-        return $this->handleView($view);
+        return $this->handleView($this->view($events));
     }
 
     /**
@@ -440,11 +436,13 @@ class LeadApiController extends CommonApiController
         $page    = (int) $this->request->get('page', 1);
         $order   = InputHelper::clean($this->request->get('order', ['timestamp', 'DESC']));
 
-        $events  = $this->model->getEngagements(null, $filters, $order, $page, $limit, false);
+        list($events, $serializerGroups)  = $this->model->getEngagements(null, $filters, $order, $page, $limit, false);
 
+        $view = $this->view($events);
+        $context = SerializationContext::create()->setGroups($serializerGroups);
+        $view->setSerializationContext($context);
 
-
-        return $this->handleView($this->view($events));
+        return $this->handleView($view);
     }
 
     /**

--- a/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
+++ b/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
@@ -32,7 +32,7 @@ trait LeadDetailsTrait
 
         if (null == $filters) {
             $filters = $session->get(
-                'mautic.gmail.timeline.filters',
+                'mautic.plugin.timeline.filters',
                 [
                     'search'        => '',
                     'includeEvents' => [],
@@ -42,14 +42,14 @@ trait LeadDetailsTrait
         }
 
         if (null == $orderBy) {
-            if (!$session->has('mautic.gmail.timeline.orderby')) {
-                $session->set('mautic.gmail.timeline.orderby', 'timestamp');
-                $session->set('mautic.gmail.timeline.orderbydir', 'DESC');
+            if (!$session->has('mautic.plugin.timeline.orderby')) {
+                $session->set('mautic.plugin.timeline.orderby', 'timestamp');
+                $session->set('mautic.plugin.timeline.orderbydir', 'DESC');
             }
 
             $orderBy = [
-                $session->get('mautic.gmail.timeline.orderby'),
-                $session->get('mautic.gmail.timeline.orderbydir'),
+                $session->get('mautic.plugin.timeline.orderby'),
+                $session->get('mautic.plugin.timeline.orderbydir'),
             ];
         }
 

--- a/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
+++ b/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
@@ -100,33 +100,33 @@ trait LeadDetailsTrait
     }
 
     /**
-     * @param array      $leads
-     * @param array|null $filters
-     * @param array|null $orderBy
-     * @param int        $page
+     * Makes sure that the event filter array is in the right format.
+     *
+     * @param mixed $filters
      *
      * @return array
+     *
+     * @throws InvalidArgumentException if not an array
      */
-    protected function getAllEngagementsForAllUsers(array $filters = null, array $orderBy = null, $page = 1, $limit = 25, $canViewOnlyOwn = false)
+    public function sanitizeEventFilter($filters)
     {
-        $result = [
-            'events'   => [],
-            'filters'  => $filters,
-            'order'    => $orderBy,
-            'types'    => [],
-            'total'    => 0,
-            'page'     => $page,
-            'limit'    => $limit,
-            'maxPages' => 0,
-        ];
+        if (!is_array($filters)) {
+            throw new \InvalidArgumentException('filters parameter must be an array');
+        }
 
-        /** @var LeadModel $model */
-        $model       = $this->getModel('lead');
-        $engagements = $model->getEngagements($lead, $filters, $orderBy, $page, $limit);
+        if (!isset($filters['search'])) {
+            $filters['search'] = '';
+        }
 
-        echo '<pre>';
-        var_dump($engagements);
-        die('</pre>');
+        if (!isset($filters['includeEvents'])) {
+            $filters['includeEvents'] = [];
+        }
+
+        if (!isset($filters['excludeEvents'])) {
+            $filters['excludeEvents'] = [];
+        }
+
+        return $filters;
     }
 
     /**

--- a/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
+++ b/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
@@ -100,6 +100,36 @@ trait LeadDetailsTrait
     }
 
     /**
+     * @param array      $leads
+     * @param array|null $filters
+     * @param array|null $orderBy
+     * @param int        $page
+     *
+     * @return array
+     */
+    protected function getAllEngagementsForAllUsers(array $filters = null, array $orderBy = null, $page = 1, $limit = 25, $canViewOnlyOwn = false)
+    {
+        $result = [
+            'events'   => [],
+            'filters'  => $filters,
+            'order'    => $orderBy,
+            'types'    => [],
+            'total'    => 0,
+            'page'     => $page,
+            'limit'    => $limit,
+            'maxPages' => 0,
+        ];
+
+        /** @var LeadModel $model */
+        $model       = $this->getModel('lead');
+        $engagements = $model->getEngagements($lead, $filters, $orderBy, $page, $limit);
+
+        echo '<pre>';
+        var_dump($engagements);
+        die('</pre>');
+    }
+
+    /**
      * @param $a
      * @param $b
      *

--- a/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
+++ b/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
@@ -107,16 +107,19 @@ class DoNotContactRepository extends CommonRepository
     }
 
     /**
-     * @param       $leadId
-     * @param array $options
+     * @param int|null $leadId
+     * @param array    $options
      */
-    public function getTimelineStats($leadId, array $options = [])
+    public function getTimelineStats($leadId = null, array $options = [])
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
         $query->select('dnc.channel, dnc.channel_id, dnc.date_added, dnc.reason, dnc.comments')
-            ->from(MAUTIC_TABLE_PREFIX.'lead_donotcontact', 'dnc')
-            ->where($query->expr()->eq('dnc.lead_id', (int) $leadId));
+            ->from(MAUTIC_TABLE_PREFIX.'lead_donotcontact', 'dnc');
+
+        if ($leadId) {
+            $query->where($query->expr()->eq('dnc.lead_id', (int) $leadId));
+        }
 
         if (isset($options['search']) && $options['search']) {
             $query->andWhere(

--- a/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
+++ b/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
@@ -114,7 +114,7 @@ class DoNotContactRepository extends CommonRepository
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
-        $query->select('dnc.channel, dnc.channel_id, dnc.date_added, dnc.reason, dnc.comments, dnc.lead_id')
+        $query->select('dnc.id, dnc.channel, dnc.channel_id, dnc.date_added, dnc.reason, dnc.comments, dnc.lead_id')
             ->from(MAUTIC_TABLE_PREFIX.'lead_donotcontact', 'dnc');
 
         if ($leadId) {

--- a/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
+++ b/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
@@ -114,7 +114,7 @@ class DoNotContactRepository extends CommonRepository
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
-        $query->select('dnc.channel, dnc.channel_id, dnc.date_added, dnc.reason, dnc.comments')
+        $query->select('dnc.channel, dnc.channel_id, dnc.date_added, dnc.reason, dnc.comments, dnc.lead_id')
             ->from(MAUTIC_TABLE_PREFIX.'lead_donotcontact', 'dnc');
 
         if ($leadId) {

--- a/app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
@@ -84,30 +84,28 @@ class LeadEventLogRepository extends CommonRepository
     /**
      * Loads data for specified lead events.
      *
-     * @param string $bundle
-     * @param string $object
-     * @param Lead   $lead
-     * @param array  $options
+     * @param string    $bundle
+     * @param string    $object
+     * @param Lead|null $lead
+     * @param array     $options
      *
      * @return array
      */
-    public function getEventsByLead($bundle, $object, Lead $lead, array $options)
+    public function getEventsByLead($bundle, $object, Lead $lead = null, array $options)
     {
-        if (empty($lead)) {
-            return [];
-        }
-
         $alias = $this->getTableAlias();
-
-        $qb = $this->getEntityManager()->getConnection()->createQueryBuilder()
+        $qb    = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->select('*')
             ->from(MAUTIC_TABLE_PREFIX.'lead_event_log', $alias)
-            ->where($alias.'.lead_id = :lead')
-            ->setParameter('lead', $lead->getId())
-            ->andWhere($alias.'.bundle = :bundle')
+            ->where($alias.'.bundle = :bundle')
             ->setParameter('bundle', $bundle)
             ->andWhere($alias.'.object = :object')
             ->setParameter('object', $object);
+
+        if ($lead) {
+            $qb->andWhere($alias.'.lead_id = :lead')
+                ->setParameter('lead', $lead->getId());
+        }
 
         if (!empty($options['search'])) {
             $qb->andWhere($qb->expr()->like($alias.'.properties', $qb->expr()->literal('%'.$options['search'].'%')));

--- a/app/bundles/LeadBundle/Entity/PointsChangeLogRepository.php
+++ b/app/bundles/LeadBundle/Entity/PointsChangeLogRepository.php
@@ -23,18 +23,18 @@ class PointsChangeLogRepository extends CommonRepository
     /**
      * Get a lead's point log.
      *
-     * @param int   $leadId
-     * @param array $options
+     * @param int|null $leadId
+     * @param array    $options
      *
      * @return array
      */
-    public function getLeadTimelineEvents($leadId, array $options = [])
+    public function getLeadTimelineEvents($leadId = null, array $options = [])
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->from(MAUTIC_TABLE_PREFIX.'lead_points_change_log', 'lp')
             ->select('lp.event_name as eventName, lp.action_name as actionName, lp.date_added as dateAdded, lp.type, lp.delta, lp.id');
 
-        if (null !== $leadId) {
+        if ($leadId) {
             $query->where('lp.lead_id = '.(int) $leadId);
         }
 

--- a/app/bundles/LeadBundle/Entity/PointsChangeLogRepository.php
+++ b/app/bundles/LeadBundle/Entity/PointsChangeLogRepository.php
@@ -32,7 +32,7 @@ class PointsChangeLogRepository extends CommonRepository
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->from(MAUTIC_TABLE_PREFIX.'lead_points_change_log', 'lp')
-            ->select('lp.event_name as eventName, lp.action_name as actionName, lp.date_added as dateAdded, lp.type, lp.delta, lp.id');
+            ->select('lp.event_name as eventName, lp.action_name as actionName, lp.date_added as dateAdded, lp.type, lp.delta, lp.id, .lp.lead_id');
 
         if ($leadId) {
             $query->where('lp.lead_id = '.(int) $leadId);

--- a/app/bundles/LeadBundle/Entity/StagesChangeLogRepository.php
+++ b/app/bundles/LeadBundle/Entity/StagesChangeLogRepository.php
@@ -32,7 +32,7 @@ class StagesChangeLogRepository extends CommonRepository
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->from(MAUTIC_TABLE_PREFIX.'lead_stages_change_log', 'ls')
-            ->select('ls.stage_id as reference, ls.event_name as eventName, ls.action_name as actionName, ls.date_added as dateAdded');
+            ->select('ls.stage_id as reference, ls.event_name as eventName, ls.action_name as actionName, ls.date_added as dateAdded, ls.lead_id');
 
         if ($leadId) {
             $query->where('ls.lead_id = '.(int) $leadId);

--- a/app/bundles/LeadBundle/Entity/StagesChangeLogRepository.php
+++ b/app/bundles/LeadBundle/Entity/StagesChangeLogRepository.php
@@ -23,17 +23,20 @@ class StagesChangeLogRepository extends CommonRepository
     /**
      * Get a lead's stage log.
      *
-     * @param int   $leadId
-     * @param array $options
+     * @param int|null $leadId
+     * @param array    $options
      *
      * @return array
      */
-    public function getLeadTimelineEvents($leadId, array $options = [])
+    public function getLeadTimelineEvents($leadId = null, array $options = [])
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->from(MAUTIC_TABLE_PREFIX.'lead_stages_change_log', 'ls')
-            ->select('ls.stage_id as reference, ls.event_name as eventName, ls.action_name as actionName, ls.date_added as dateAdded')
-            ->where('ls.lead_id = '.(int) $leadId);
+            ->select('ls.stage_id as reference, ls.event_name as eventName, ls.action_name as actionName, ls.date_added as dateAdded');
+
+        if ($leadId) {
+            $query->where('ls.lead_id = '.(int) $leadId);
+        }
 
         if (isset($options['search']) && $options['search']) {
             $query->andWhere($query->expr()->orX(

--- a/app/bundles/LeadBundle/Entity/UtmTagRepository.php
+++ b/app/bundles/LeadBundle/Entity/UtmTagRepository.php
@@ -28,18 +28,15 @@ class UtmTagRepository extends CommonRepository
      *
      * @return array
      */
-    public function getUtmTagsByLead(Lead $lead, $options = [])
+    public function getUtmTagsByLead(Lead $lead = null, $options = [])
     {
-        if (empty($lead)) {
-            return [];
-        }
-
         $qb = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->select('*')
-            ->from(MAUTIC_TABLE_PREFIX.'lead_utmtags', 'ut')
-            ->where(
-                'ut.lead_id = '.$lead->getId()
-            );
+            ->from(MAUTIC_TABLE_PREFIX.'lead_utmtags', 'ut');
+
+        if ($lead instanceof Lead) {
+            $qb->where('ut.lead_id = '.(int) $lead->getId());
+        }
 
         if (isset($options['search']) && $options['search']) {
             $qb->andWhere($qb->expr()->orX(

--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -118,7 +118,9 @@ class LeadTimelineEvent extends Event
     /**
      * @var array
      */
-    protected $serializerGroups = [];
+    protected $serializerGroups = [
+        'ipAddressList',
+    ];
 
     /**
      * LeadTimelineEvent constructor.
@@ -185,8 +187,17 @@ class LeadTimelineEvent extends Event
             }
 
             if (!$this->isForTimeline()) {
-                // Unset the common stuff used only for the timeline
-                unset($data['contentTemplate'], $data['icon']);
+                // standardize the payload
+                $keepThese = [
+                    'event'      => true,
+                    'eventLabel' => true,
+                    'eventType'  => true,
+                    'timestamp'  => true,
+                    'contactId'  => true,
+                    'extra'      => true
+                ];
+
+                $data = array_intersect_key($data, $keepThese);
 
                 // Rename extra to details
                 if (isset($data['extra'])) {

--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -190,6 +190,7 @@ class LeadTimelineEvent extends Event
                 // standardize the payload
                 $keepThese = [
                     'event'      => true,
+                    'eventId'    => true,
                     'eventLabel' => true,
                     'eventType'  => true,
                     'timestamp'  => true,

--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -105,6 +105,11 @@ class LeadTimelineEvent extends Event
     protected $chartQuery;
 
     /**
+     * @var bool
+     */
+    protected $forTimeline = true;
+
+    /**
      * LeadTimelineEvent constructor.
      *
      * @param Lead       $lead
@@ -113,18 +118,21 @@ class LeadTimelineEvent extends Event
      * @param int        $page
      * @param int        $limit   Limit per type
      */
-    public function __construct(Lead $lead = null, array $filters = [], array $orderBy = null, $page = 1, $limit = 25)
+    public function __construct(Lead $lead = null, array $filters = [], array $orderBy = null, $page = 1, $limit = 25, $forTimeline = true)
     {
-        $this->lead    = $lead;
-        $this->filters = !empty($filters) ? $filters :
+        $this->lead        = $lead;
+        $this->filters     = !empty($filters)
+            ? $filters
+            :
             [
                 'search'        => '',
                 'includeEvents' => [],
                 'excludeEvents' => [],
             ];
-        $this->orderBy = $orderBy;
-        $this->page    = $page;
-        $this->limit   = $limit;
+        $this->orderBy     = $orderBy;
+        $this->page        = $page;
+        $this->limit       = $limit;
+        $this->forTimeline = $forTimeline;
     }
 
     /**
@@ -161,6 +169,18 @@ class LeadTimelineEvent extends Event
             if (!isset($this->events[$data['event']])) {
                 $this->events[$data['event']] = [];
             }
+
+            if (!$this->isForTimeline()) {
+                // Unset the common stuff used only for the timeline
+                unset($data['contentTemplate'], $data['icon']);
+
+                // Rename extra to details
+                if (isset($data['extra'])) {
+                    $data['details'] = $data['extra'];
+                    unset($data['extra']);
+                }
+            }
+
             $this->events[$data['event']][] = $data;
         }
     }
@@ -485,5 +505,15 @@ class LeadTimelineEvent extends Event
     public function getChartQuery()
     {
         return $this->chartQuery;
+    }
+
+    /**
+     * Check if the data is to be display for the contact's timeline or used for the API
+     *
+     * @return bool
+     */
+    public function isForTimeline()
+    {
+        return $this->forTimeline;
     }
 }

--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -13,7 +13,6 @@ namespace Mautic\LeadBundle\Event;
 
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
-use Mautic\CoreBundle\Templating\Helper\AssetsHelper;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Component\EventDispatcher\Event;
 
@@ -125,18 +124,18 @@ class LeadTimelineEvent extends Event
     /**
      * LeadTimelineEvent constructor.
      *
-     * @param Lead|null         $lead
-     * @param array             $filters
-     * @param array|null        $orderBy
-     * @param int               $page
-     * @param int               $limit          Limit per type
-     * @param bool              $forTimeline
-     * @param string|null       $siteDomain
+     * @param Lead|null   $lead
+     * @param array       $filters
+     * @param array|null  $orderBy
+     * @param int         $page
+     * @param int         $limit       Limit per type
+     * @param bool        $forTimeline
+     * @param string|null $siteDomain
      */
     public function __construct(Lead $lead = null, array $filters = [], array $orderBy = null, $page = 1, $limit = 25, $forTimeline = true, $siteDomain = null)
     {
-        $this->lead        = $lead;
-        $this->filters     = !empty($filters)
+        $this->lead    = $lead;
+        $this->filters = !empty($filters)
             ? $filters
             :
             [
@@ -194,7 +193,7 @@ class LeadTimelineEvent extends Event
                     'eventType'  => true,
                     'timestamp'  => true,
                     'contactId'  => true,
-                    'extra'      => true
+                    'extra'      => true,
                 ];
 
                 $data = array_intersect_key($data, $keepThese);
@@ -544,7 +543,7 @@ class LeadTimelineEvent extends Event
     }
 
     /**
-     * Check if the data is to be display for the contact's timeline or used for the API
+     * Check if the data is to be display for the contact's timeline or used for the API.
      *
      * @return bool
      */
@@ -554,7 +553,7 @@ class LeadTimelineEvent extends Event
     }
 
     /**
-     * Add a serializer group for API formatting
+     * Add a serializer group for API formatting.
      *
      * @param $group
      */
@@ -579,7 +578,7 @@ class LeadTimelineEvent extends Event
     }
 
     /**
-     * Convert all snake case keys o camel case for API congruency
+     * Convert all snake case keys o camel case for API congruency.
      *
      * @param array $details
      */
@@ -597,7 +596,7 @@ class LeadTimelineEvent extends Event
             }
 
             if (strstr($key, '_')) {
-                $newKey = lcfirst(str_replace('_', '', ucwords($key, '_')));
+                $newKey           = lcfirst(str_replace('_', '', ucwords($key, '_')));
                 $details[$newKey] = $details[$key];
                 unset($details[$key]);
             }

--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -113,7 +113,7 @@ class LeadTimelineEvent extends Event
      * @param int        $page
      * @param int        $limit   Limit per type
      */
-    public function __construct(Lead $lead, array $filters = [], array $orderBy = null, $page = 1, $limit = 25)
+    public function __construct(Lead $lead = null, array $filters = [], array $orderBy = null, $page = 1, $limit = 25)
     {
         $this->lead    = $lead;
         $this->filters = !empty($filters) ? $filters :
@@ -294,7 +294,7 @@ class LeadTimelineEvent extends Event
     public function getEventLimit()
     {
         return [
-            'leadId' => $this->lead->getId(),
+            'leadId' => ($this->lead instanceof Lead) ? $this->lead->getId() : null,
             'limit'  => $this->limit,
             'start'  => (1 >= $this->page) ? 0 : ($this->page - 1) * $this->limit,
         ];
@@ -328,6 +328,16 @@ class LeadTimelineEvent extends Event
     public function getLead()
     {
         return $this->lead;
+    }
+
+    /**
+     * Returns the lead ID if any.
+     *
+     * @return int|null
+     */
+    public function getLeadId()
+    {
+        return ($this->lead instanceof Lead) ? $this->lead->getId() : null;
     }
 
     /**

--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -132,8 +132,15 @@ class LeadTimelineEvent extends Event
      * @param bool        $forTimeline
      * @param string|null $siteDomain
      */
-    public function __construct(Lead $lead = null, array $filters = [], array $orderBy = null, $page = 1, $limit = 25, $forTimeline = true, $siteDomain = null)
-    {
+    public function __construct(
+        Lead $lead = null,
+        array $filters = [],
+        array $orderBy = null,
+        $page = 1,
+        $limit = 25,
+        $forTimeline = true,
+        $siteDomain = null
+    ) {
         $this->lead    = $lead;
         $this->filters = !empty($filters)
             ? $filters
@@ -148,6 +155,14 @@ class LeadTimelineEvent extends Event
         $this->limit       = $limit;
         $this->forTimeline = $forTimeline;
         $this->siteDomain  = $siteDomain;
+
+        if (!empty($filters['dateFrom'])) {
+            $this->dateFrom = new \DateTime($filters['dateFrom']);
+        }
+
+        if (!empty($filters['dateTo'])) {
+            $this->dateTo = new \DateTime($filters['dateTo']);
+        }
     }
 
     /**

--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -494,6 +494,7 @@ class LeadSubscriber extends CommonSubscriber
                                 'utmtags' => $utmTag,
                             ],
                             'contentTemplate' => 'MauticLeadBundle:SubscribedEvents\Timeline:utmadded.html.php',
+                            'contactId'       => $utmTag['lead_id'],
                         ]
                     );
             }
@@ -572,7 +573,8 @@ class LeadSubscriber extends CommonSubscriber
                         }
                     }
                 }
-
+                $contactId = $row['lead_id'];
+                unset($row['lead_id']);
                 $event->addEvent(
                     [
                         'event'      => $eventTypeKey,
@@ -588,6 +590,7 @@ class LeadSubscriber extends CommonSubscriber
                         ],
                         'contentTemplate' => $template,
                         'icon'            => $icon,
+                        'contactId'       => $contactId,
                     ]
                 );
             }
@@ -635,6 +638,7 @@ class LeadSubscriber extends CommonSubscriber
                             'icon'            => 'fa-download',
                             'extra'           => $import,
                             'contentTemplate' => 'MauticLeadBundle:SubscribedEvents\Timeline:import.html.php',
+                            'contactId'       => $import['lead_id'],
                         ]
                     );
             }

--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -347,10 +347,10 @@ class LeadSubscriber extends CommonSubscriber
             $event->addToCounter($eventTypeKey, $rows);
 
             // Add the entries to the event array
-            $ipAddresses = ($lead instanceof Lead) ? $lead->getIpAddresses()->toArray() : [];
+            $ipAddresses = ($lead instanceof Lead) ? $lead->getIpAddresses()->toArray() : null;
 
             foreach ($rows['results'] as $row) {
-                if (!isset($ipAddresses[$row['ip_address']])) {
+                if ($ipAddresses !== null && !isset($ipAddresses[$row['ip_address']])) {
                     continue;
                 }
 
@@ -365,6 +365,7 @@ class LeadSubscriber extends CommonSubscriber
                             'ipDetails' => $ipAddresses[$row['ip_address']],
                         ],
                         'contentTemplate' => 'MauticLeadBundle:SubscribedEvents\Timeline:ipadded.html.php',
+                        'contactId'       => $row['lead_id'],
                     ]
                 );
             }
@@ -381,7 +382,7 @@ class LeadSubscriber extends CommonSubscriber
     protected function addTimelineDateCreatedEntry(Events\LeadTimelineEvent $event, $eventTypeKey, $eventTypeName)
     {
         // Do nothing if the lead is not set
-        if ($event->getLead() instanceof Lead) {
+        if (!$event->getLead() instanceof Lead) {
             return;
         }
 
@@ -414,7 +415,7 @@ class LeadSubscriber extends CommonSubscriber
     protected function addTimelineDateIdentifiedEntry(Events\LeadTimelineEvent $event, $eventTypeKey, $eventTypeName)
     {
         // Do nothing if the lead is not set
-        if ($event->getLead() instanceof Lead) {
+        if (!$event->getLead() instanceof Lead) {
             return;
         }
 

--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -286,13 +286,18 @@ class LeadSubscriber extends CommonSubscriber
     public function onTimelineGenerate(Events\LeadTimelineEvent $event)
     {
         $eventTypes = [
-            'lead.create'       => 'mautic.lead.event.create',
-            'lead.identified'   => 'mautic.lead.event.identified',
-            'lead.ipadded'      => 'mautic.lead.event.ipadded',
             'lead.utmtagsadded' => 'mautic.lead.event.utmtagsadded',
             'lead.donotcontact' => 'mautic.lead.event.donotcontact',
             'lead.imported'     => 'mautic.lead.event.imported',
         ];
+
+        // Following events takes the event from the lead itself, so not applicable for API
+        // where we are getting events for all leads.
+        if ($event->isForTimeline()) {
+            $eventTypes['lead.create']     = 'mautic.lead.event.create';
+            $eventTypes['lead.identified'] = 'mautic.lead.event.identified';
+            $eventTypes['lead.ipadded']    = 'mautic.lead.event.ipadded';
+        }
 
         $filters = $event->getEventFilters();
 

--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -357,6 +357,7 @@ class LeadSubscriber extends CommonSubscriber
                 $event->addEvent(
                     [
                         'event'         => $eventTypeKey,
+                        'eventId'       => $eventTypeKey.$row['id'],
                         'eventLabel'    => $row['ip_address'],
                         'eventType'     => $eventTypeName,
                         'eventPriority' => -1, // Usually an IP is added after another event
@@ -395,6 +396,7 @@ class LeadSubscriber extends CommonSubscriber
                 $event->addEvent(
                     [
                         'event'         => $eventTypeKey,
+                        'eventId'       => $eventTypeKey.$event->getLead()->getId(),
                         'icon'          => 'fa-user-secret',
                         'eventType'     => $eventTypeName,
                         'eventPriority' => -5, // Usually something happened to create the lead so this should display afterward
@@ -428,6 +430,7 @@ class LeadSubscriber extends CommonSubscriber
                     $event->addEvent(
                         [
                             'event'         => $eventTypeKey,
+                            'eventId'       => $eventTypeKey.$event->getLead()->getId(),
                             'icon'          => 'fa-user',
                             'eventType'     => $eventTypeName,
                             'eventPriority' => -4, // A lead is created prior to being identified
@@ -487,6 +490,7 @@ class LeadSubscriber extends CommonSubscriber
                         [
                             'event'      => $eventTypeKey,
                             'eventType'  => $eventTypeName,
+                            'eventId'    => $eventTypeKey.$utmTag['id'],
                             'eventLabel' => !empty($utmTag) ? $utmTag['utm_campaign'] : 'UTM Tags',
                             'timestamp'  => $utmTag['date_added'],
                             'icon'       => $icon,
@@ -578,6 +582,7 @@ class LeadSubscriber extends CommonSubscriber
                 $event->addEvent(
                     [
                         'event'      => $eventTypeKey,
+                        'eventId'    => $eventTypeKey.$row['id'],
                         'eventLabel' => (isset($row['itemName'])) ?
                             [
                                 'label' => ucfirst($row['channel']).' / '.$row['itemName'],
@@ -626,6 +631,7 @@ class LeadSubscriber extends CommonSubscriber
                 $event->addEvent(
                         [
                             'event'      => $eventTypeKey,
+                            'eventId'    => $eventTypeKey.$import['id'],
                             'eventType'  => $eventTypeName,
                             'eventLabel' => !empty($import['object_id']) ? [
                                 'label' => $eventLabel,

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -2521,14 +2521,15 @@ class LeadModel extends FormModel
      * @param array|null $orderBy
      * @param int        $page
      * @param int        $limit
+     * @param bool       $forTimeline
      *
      * @return array
      */
-    public function getEngagements(Lead $lead = null, $filters = null, array $orderBy = null, $page = 1, $limit = 25)
+    public function getEngagements(Lead $lead = null, $filters = null, array $orderBy = null, $page = 1, $limit = 25, $forTimeline = true)
     {
         $event = $this->dispatcher->dispatch(
             LeadEvents::TIMELINE_ON_GENERATE,
-            new LeadTimelineEvent($lead, $filters, $orderBy, $page, $limit)
+            new LeadTimelineEvent($lead, $filters, $orderBy, $page, $limit, $forTimeline)
         );
 
         return [

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -2529,10 +2529,10 @@ class LeadModel extends FormModel
     {
         $event = $this->dispatcher->dispatch(
             LeadEvents::TIMELINE_ON_GENERATE,
-            new LeadTimelineEvent($lead, $filters, $orderBy, $page, $limit, $forTimeline)
+            new LeadTimelineEvent($lead, $filters, $orderBy, $page, $limit, $forTimeline, $this->coreParametersHelper->getParameter('site_url'))
         );
 
-        return [
+        $payload = [
             'events'   => $event->getEvents(),
             'filters'  => $filters,
             'order'    => $orderBy,
@@ -2542,6 +2542,8 @@ class LeadModel extends FormModel
             'limit'    => $limit,
             'maxPages' => $event->getMaxPage(),
         ];
+
+        return ($forTimeline) ? $payload : [$payload, $event->getSerializerGroups()];
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -2516,7 +2516,7 @@ class LeadModel extends FormModel
     /**
      * Get timeline/engagement data.
      *
-     * @param Lead       $lead
+     * @param Lead|null  $lead
      * @param null       $filters
      * @param array|null $orderBy
      * @param int        $page
@@ -2524,7 +2524,7 @@ class LeadModel extends FormModel
      *
      * @return array
      */
-    public function getEngagements(Lead $lead, $filters = null, array $orderBy = null, $page = 1, $limit = 25)
+    public function getEngagements(Lead $lead = null, $filters = null, array $orderBy = null, $page = 1, $limit = 25)
     {
         $event = $this->dispatcher->dispatch(
             LeadEvents::TIMELINE_ON_GENERATE,

--- a/app/bundles/PageBundle/Entity/HitRepository.php
+++ b/app/bundles/PageBundle/Entity/HitRepository.php
@@ -76,19 +76,22 @@ class HitRepository extends CommonRepository
     /**
      * Get a lead's page hits.
      *
-     * @param int   $leadId
-     * @param array $options
+     * @param int|null $leadId
+     * @param array    $options
      *
      * @return array
      */
-    public function getLeadHits($leadId, array $options = [])
+    public function getLeadHits($leadId = null, array $options = [])
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
         $query->select('h.page_id, h.user_agent as userAgent, h.date_hit as dateHit, h.date_left as dateLeft, h.referer, h.source, h.source_id as sourceId, h.url, h.url_title as urlTitle, h.query, ds.client_info as clientInfo, ds.device, ds.device_os_name as deviceOsName, ds.device_brand as deviceBrand, ds.device_model as deviceModel')
             ->from(MAUTIC_TABLE_PREFIX.'page_hits', 'h')
-            ->leftJoin('h', MAUTIC_TABLE_PREFIX.'pages', 'p', 'h.page_id = p.id')
-            ->where('h.lead_id = '.(int) $leadId);
+            ->leftJoin('h', MAUTIC_TABLE_PREFIX.'pages', 'p', 'h.page_id = p.id');
+
+        if ($leadId) {
+            $query->where('h.lead_id = '.(int) $leadId);
+        }
 
         if (isset($options['search']) && $options['search']) {
             $query->andWhere($query->expr()->like('p.title', $query->expr()->literal('%'.$options['search'].'%')));

--- a/app/bundles/PageBundle/Entity/HitRepository.php
+++ b/app/bundles/PageBundle/Entity/HitRepository.php
@@ -85,7 +85,7 @@ class HitRepository extends CommonRepository
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
-        $query->select('h.page_id, h.user_agent as userAgent, h.date_hit as dateHit, h.date_left as dateLeft, h.referer, h.source, h.source_id as sourceId, h.url, h.url_title as urlTitle, h.query, ds.client_info as clientInfo, ds.device, ds.device_os_name as deviceOsName, ds.device_brand as deviceBrand, ds.device_model as deviceModel')
+        $query->select('h.page_id, h.user_agent as userAgent, h.date_hit as dateHit, h.date_left as dateLeft, h.referer, h.source, h.source_id as sourceId, h.url, h.url_title as urlTitle, h.query, ds.client_info as clientInfo, ds.device, ds.device_os_name as deviceOsName, ds.device_brand as deviceBrand, ds.device_model as deviceModel, h.lead_id')
             ->from(MAUTIC_TABLE_PREFIX.'page_hits', 'h')
             ->leftJoin('h', MAUTIC_TABLE_PREFIX.'pages', 'p', 'h.page_id = p.id');
 

--- a/app/bundles/PageBundle/Entity/VideoHitRepository.php
+++ b/app/bundles/PageBundle/Entity/VideoHitRepository.php
@@ -26,18 +26,21 @@ class VideoHitRepository extends CommonRepository
     /**
      * Get video hit info for lead timeline.
      *
-     * @param       $leadId
-     * @param array $options
+     * @param int|null $leadId
+     * @param array    $options
      *
      * @return array
      */
-    public function getTimelineStats($leadId, array $options = [])
+    public function getTimelineStats($leadId = null, array $options = [])
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
         $query->select('h.id, h.url, h.date_hit, h.time_watched, h.duration, h.referer, h.user_agent')
-            ->from(MAUTIC_TABLE_PREFIX.'video_hits', 'h')
-            ->where($query->expr()->eq('h.lead_id', (int) $leadId));
+            ->from(MAUTIC_TABLE_PREFIX.'video_hits', 'h');
+
+        if ($leadId) {
+            $query->where($query->expr()->eq('h.lead_id', (int) $leadId));
+        }
 
         if (isset($options['search']) && $options['search']) {
             $query->andWhere(

--- a/app/bundles/PageBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/LeadSubscriber.php
@@ -146,6 +146,9 @@ class LeadSubscriber extends CommonSubscriber
                     ];
                 }
 
+                $contactId = $hit['lead_id'];
+                unset($hit['lead_id']);
+
                 $event->addEvent(
                     [
                         'event'      => $eventTypeKey,
@@ -157,6 +160,7 @@ class LeadSubscriber extends CommonSubscriber
                         ],
                         'contentTemplate' => $template,
                         'icon'            => $icon,
+                        'contactId'       => $contactId,
                     ]
                 );
             }

--- a/app/bundles/PageBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/LeadSubscriber.php
@@ -76,6 +76,7 @@ class LeadSubscriber extends CommonSubscriber
         $eventTypeKey  = 'page.hit';
         $eventTypeName = $this->translator->trans('mautic.page.event.hit');
         $event->addEventType($eventTypeKey, $eventTypeName);
+        $event->addSerializerGroup('pageList', 'hitDetails');
 
         if (!$event->isApplicable($eventTypeKey)) {
             return;
@@ -178,6 +179,7 @@ class LeadSubscriber extends CommonSubscriber
         $eventTypeKey  = 'page.videohit';
         $eventTypeName = $this->translator->trans('mautic.page.event.videohit');
         $event->addEventType($eventTypeKey, $eventTypeName);
+        $event->addSerializerGroup('pageList', 'hitDetails');
 
         if (!$event->isApplicable($eventTypeKey)) {
             return;

--- a/app/bundles/PageBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/LeadSubscriber.php
@@ -81,11 +81,9 @@ class LeadSubscriber extends CommonSubscriber
             return;
         }
 
-        $lead = $event->getLead();
-
         /** @var \Mautic\PageBundle\Entity\HitRepository $hitRepository */
         $hitRepository = $this->em->getRepository('MauticPageBundle:Hit');
-        $hits          = $hitRepository->getLeadHits($lead->getId(), $event->getQueryOptions());
+        $hits          = $hitRepository->getLeadHits($event->getLeadId(), $event->getQueryOptions());
 
         // Add to counter
         $event->addToCounter($eventTypeKey, $hits);
@@ -184,7 +182,7 @@ class LeadSubscriber extends CommonSubscriber
         /** @var \Mautic\PageBundle\Entity\VideoHitRepository $hitRepository */
         $hitRepository = $this->em->getRepository('MauticPageBundle:VideoHit');
 
-        $hits = $hitRepository->getTimelineStats($event->getLead()->getId(), $event->getQueryOptions());
+        $hits = $hitRepository->getTimelineStats($event->getLeadId(), $event->getQueryOptions());
 
         $event->addToCounter($eventTypeKey, $hits);
 

--- a/app/bundles/PointBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/LeadSubscriber.php
@@ -110,7 +110,8 @@ class LeadSubscriber extends CommonSubscriber
                         'extra'      => [
                             'log' => $log,
                         ],
-                        'icon' => 'fa-calculator',
+                        'icon'      => 'fa-calculator',
+                        'contactId' => $log['lead_id'],
                     ]
                 );
             }

--- a/app/bundles/PointBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/LeadSubscriber.php
@@ -86,6 +86,7 @@ class LeadSubscriber extends CommonSubscriber
         $eventTypeKey  = 'point.gained';
         $eventTypeName = $this->translator->trans('mautic.point.event.gained');
         $event->addEventType($eventTypeKey, $eventTypeName);
+        $event->addSerializerGroup('pointList');
 
         if (!$event->isApplicable($eventTypeKey)) {
             return;

--- a/app/bundles/PointBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/LeadSubscriber.php
@@ -91,11 +91,9 @@ class LeadSubscriber extends CommonSubscriber
             return;
         }
 
-        $lead = $event->getLead();
-
         /** @var \Mautic\PageBundle\Entity\HitRepository $hitRepository */
         $logRepository = $this->em->getRepository('MauticLeadBundle:PointsChangeLog');
-        $logs          = $logRepository->getLeadTimelineEvents($lead->getId(), $event->getQueryOptions());
+        $logs          = $logRepository->getLeadTimelineEvents($event->getLeadId(), $event->getQueryOptions());
 
         // Add to counter
         $event->addToCounter($eventTypeKey, $logs);

--- a/app/bundles/StageBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/LeadSubscriber.php
@@ -79,7 +79,8 @@ class LeadSubscriber extends CommonSubscriber
                         'extra'      => [
                             'log' => $log,
                         ],
-                        'icon' => 'fa-tachometer',
+                        'icon'      => 'fa-tachometer',
+                        'contactId' => $log['lead_id'],
                     ]
                 );
             }

--- a/app/bundles/StageBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/LeadSubscriber.php
@@ -50,11 +50,9 @@ class LeadSubscriber extends CommonSubscriber
             return;
         }
 
-        $lead = $event->getLead();
-
         /** @var StagesChangeLogRepository $logRepository */
         $logRepository = $this->em->getRepository('MauticLeadBundle:StagesChangeLog');
-        $logs          = $logRepository->getLeadTimelineEvents($lead->getId(), $event->getQueryOptions());
+        $logs          = $logRepository->getLeadTimelineEvents($event->getLeadId(), $event->getQueryOptions());
 
         // Add to counter
         $event->addToCounter($eventTypeKey, $logs);

--- a/app/bundles/StageBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/LeadSubscriber.php
@@ -45,6 +45,7 @@ class LeadSubscriber extends CommonSubscriber
         $eventTypeKey  = 'stage.changed';
         $eventTypeName = $this->translator->trans('mautic.stage.event.changed');
         $event->addEventType($eventTypeKey, $eventTypeName);
+        $event->addSerializerGroup('stageList');
 
         if (!$event->isApplicable($eventTypeKey)) {
             return;

--- a/plugins/MauticCitrixBundle/Entity/CitrixEvent.php
+++ b/plugins/MauticCitrixBundle/Entity/CitrixEvent.php
@@ -127,11 +127,15 @@ class CitrixEvent
     }
 
     /**
-     * @param string $product
+     * @param $product
+     *
+     * @return $this
      */
     public function setProduct($product)
     {
         $this->product = $product;
+
+        return $this;
     }
 
     /**
@@ -205,11 +209,15 @@ class CitrixEvent
     }
 
     /**
-     * @param string $eventName
+     * @param $eventName
+     *
+     * @return $this
      */
     public function setEventName($eventName)
     {
         $this->eventName = $eventName;
+
+        return $this;
     }
 
     /**
@@ -222,10 +230,14 @@ class CitrixEvent
 
     /**
      * @param \DateTime $eventDate
+     *
+     * @return $this
      */
     public function setEventDate(\DateTime $eventDate)
     {
         $this->eventDate = $eventDate;
+
+        return $this;
     }
 
     /**
@@ -237,19 +249,27 @@ class CitrixEvent
     }
 
     /**
-     * @param string $eventType
+     * @param $eventType
+     *
+     * @return $this
      */
     public function setEventType($eventType)
     {
         $this->eventType = $eventType;
+
+        return $this;
     }
 
     /**
-     * @param mixed $eventDesc
+     * @param $eventDesc
+     *
+     * @return $this
      */
     public function setEventDesc($eventDesc)
     {
         $this->eventDesc = $eventDesc;
+
+        return $this;
     }
 
     /**

--- a/plugins/MauticCitrixBundle/Entity/CitrixEventRepository.php
+++ b/plugins/MauticCitrixBundle/Entity/CitrixEventRepository.php
@@ -81,7 +81,7 @@ class CitrixEventRepository extends CommonRepository
                 $query->expr()->like('c.product', $query->expr()->literal('%'.$options['search'].'%'))
             ));
         }
-define('CITRIX',1);
+
         return $this->getTimelineResults($query, $options, 'c.event_name', 'c.event_date', [], ['event_date']);
     }
 

--- a/plugins/MauticCitrixBundle/Entity/CitrixEventRepository.php
+++ b/plugins/MauticCitrixBundle/Entity/CitrixEventRepository.php
@@ -13,9 +13,12 @@ namespace MauticPlugin\MauticCitrixBundle\Entity;
 
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Mautic\CoreBundle\Entity\CommonRepository;
+use Mautic\LeadBundle\Entity\TimelineTrait;
 
 class CitrixEventRepository extends CommonRepository
 {
+    use TimelineTrait;
+
     /**
      * Fetch the base event data from the database.
      *
@@ -48,6 +51,38 @@ class CitrixEventRepository extends CommonRepository
             ->setParameter('product', $product);
 
         return $q->getQuery()->getArrayResult();
+    }
+
+    /**
+     * @param       $product
+     * @param null  $leadId
+     * @param array $options
+     *
+     * @return array
+     */
+    public function getEventsForTimeline($product, $leadId = null, array $options = [])
+    {
+        $query = $this->getEntityManager()->getConnection()->createQueryBuilder()
+            ->from(MAUTIC_TABLE_PREFIX.'plugin_citrix_events', 'c')
+            ->select('c.*');
+
+        $query->where(
+            $query->expr()->eq('c.product', ':product')
+        )
+            ->setParameter('product', $product);
+
+        if ($leadId) {
+            $query->andWhere('c.lead_id = '.(int) $leadId);
+        }
+
+        if (isset($options['search']) && $options['search']) {
+            $query->andWhere($query->expr()->orX(
+                $query->expr()->like('c.event_name', $query->expr()->literal('%'.$options['search'].'%')),
+                $query->expr()->like('c.product', $query->expr()->literal('%'.$options['search'].'%'))
+            ));
+        }
+define('CITRIX',1);
+        return $this->getTimelineResults($query, $options, 'c.event_name', 'c.event_date', [], ['event_date']);
     }
 
     /**

--- a/plugins/MauticCitrixBundle/Entity/CitrixEventRepository.php
+++ b/plugins/MauticCitrixBundle/Entity/CitrixEventRepository.php
@@ -81,7 +81,8 @@ class CitrixEventRepository extends CommonRepository
                 $query->expr()->like('c.product', $query->expr()->literal('%'.$options['search'].'%'))
             ));
         }
-define('CITRIX',1);
+        define('CITRIX', 1);
+
         return $this->getTimelineResults($query, $options, 'c.event_name', 'c.event_date', [], ['event_date']);
     }
 

--- a/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
+++ b/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
@@ -135,6 +135,7 @@ class LeadSubscriber extends CommonSubscriber
                     $event->addEvent(
                         [
                             'event'      => $timelineEventType,
+                            'eventId'    => $timelineEventType.$citrixEvent['id'],
                             'eventLabel' => $timelineEventLabel,
                             'eventType'  => $timelineEventTypeLabel,
                             'timestamp'  => $entity->getEventDate(),


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/67
| Issues addressed (#s or URLs) | /
| BC breaks? | It makes timeline method argument `$lead` voluntary
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
There is already an API endpoint to get events for 1 or limited number of contacts, but there was none for getting contact events unrelated to contacts.

Note: Some events like `lead.identified` or `lead.create` will not return any events since those events require a lead object. The functionality can be added though.

#### Steps to test this PR:
1. Apply this PR
2. Clear the cache
3. Apply https://github.com/mautic/api-library/pull/126 to your API Library
4. Run `phpunit --filter testGetAllEvents`
5. Try to access the API endpoint with some filters with your favorite API testing app and make sure the results are as you'd expect based on your filters. Use the attached docs to know all possibilities.
6. Make sure the timeline on a contact detail page still works as before.
