### PR TITLE
Bug webhook payload too big

### DIFF
--- a/app/bundles/WebhookBundle/Command/ProcessWebhookQueuesCommand.php
+++ b/app/bundles/WebhookBundle/Command/ProcessWebhookQueuesCommand.php
@@ -43,10 +43,11 @@ class ProcessWebhookQueuesCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         /** @var \Mautic\WebhookBundle\Model\WebhookModel $model */
-        $model = $this->getContainer()->get('mautic.webhook.model.webhook');
+        $model  = $this->getContainer()->get('mautic.webhook.model.webhook');
+        $params = $this->getContainer()->get('mautic.helper.core_parameters');
 
         // check to make sure we are in queue mode
-        if ($this->getContainer()->get('mautic.helper.core_parameters')->getParameter('queue_mode') != 'command_process') {
+        if ($params->getParameter('queue_mode') != $model::COMMAND_PROCESS) {
             $output->writeLn('Webhook Bundle is in immediate process mode. To use the command function change to command mode.');
 
             return 0;

--- a/app/bundles/WebhookBundle/Entity/Log.php
+++ b/app/bundles/WebhookBundle/Entity/Log.php
@@ -152,13 +152,15 @@ class Log
     }
 
     /**
+     * Strips tags and keeps first 254 characters so it would fit in the varchar 255 limit.
+     *
      * @param string $note
      *
      * @return Log
      */
     public function setNote($note)
     {
-        $this->note = $note;
+        $this->note = substr(strip_tags($note), 0, 254);
 
         return $this;
     }

--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -80,6 +80,8 @@ class WebhookModel extends FormModel
     protected $webhookTimeout;
 
     /**
+     * The key is queue ID, the value is the WebhookQueue object.
+     *
      * @var array
      */
     protected $webhookQueueIdList = [];
@@ -322,7 +324,13 @@ class WebhookModel extends FormModel
 
         try {
             $response = $http->post($webhook->getWebhookUrl(), $payload, $headers, $this->webhookTimeout);
-            $this->addLog($webhook, $response->code, (microtime(true) - $start));
+
+            // remove successfully processed queues from the Webhook object so they won't get stored again
+            foreach ($this->webhookQueueIdList as $id => $queue) {
+                $webhook->removeQueue($queue);
+            }
+
+            $this->addLog($webhook, $response->code, (microtime(true) - $start), $response->body);
 
             // throw an error exception if we don't get a 200 back
             if ($response->code >= 300 && $response->code < 200) {
@@ -351,13 +359,15 @@ class WebhookModel extends FormModel
             return false;
         }
 
-        if ($this->queueMode === self::COMMAND_PROCESS && !empty($this->webhookQueueIdList)) {
+        // Run this on command as well as immediate send because if switched from queue to immediate
+        // it can have some rows in the queue which will be send in every webhook forever
+        if (!empty($this->webhookQueueIdList)) {
 
             /** @var \Mautic\WebhookBundle\Entity\WebhookQueueRepository $webhookQueueRepo */
             $webhookQueueRepo = $this->getQueueRepository();
 
             // delete all the queued items we just processed
-            $webhookQueueRepo->deleteQueuesById($this->webhookQueueIdList);
+            $webhookQueueRepo->deleteQueuesById(array_keys($this->webhookQueueIdList));
             $queueCount = $webhookQueueRepo->getQueueCountByWebhookId($webhook->getId());
 
             // reset the array to blank so none of the IDs are repeated
@@ -498,7 +508,7 @@ class WebhookModel extends FormModel
 
         $payload = [];
 
-        if ($this->queueMode == self::COMMAND_PROCESS) {
+        if ($this->queueMode === self::COMMAND_PROCESS) {
             $queuesArray = $this->getWebhookQueues($webhook);
         } else {
             $queuesArray = [$webhook->getQueues()];
@@ -523,8 +533,16 @@ class WebhookModel extends FormModel
                 // its important to decode the payload form the DB as we re-encode it with the
                 $payload[$type][] = $queuePayload;
 
-                $this->webhookQueueIdList[] = $queue->getId();
-                $this->em->clear(WebhookQueue::class);
+                // Add to the webhookQueueIdList only if ID exists. That means if it was stored to DB.
+                // That means if not sent via immediate send.
+                if ($queue->getId()) {
+                    $this->webhookQueueIdList[$queue->getId()] = $queue;
+                    $this->em->clear(WebhookQueue::class);
+                } else {
+                    // remove the queue from the webhook right away so it won't get persisted to DB
+                    // This happens on immediate send only
+                    $webhook->removeQueue($queue);
+                }
             }
         }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | Part of https://github.com/mautic/mautic/issues/4151
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The webhook payloads were increasing on every send. The queue records were not deleted properly. It caused that the payloads were too big to fit in the POST HTTP request and in some cases it caused server memory issues. This PR fixes that.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Set your webhooks to be sent immediately.
2. Create a webhook with contact update event with link to [this script](https://gist.github.com/escopecz/0d9adba753300b88326d) which will create a log file where it will log the request body. Do not use RequestBin since it is limited to 10 kB.
3. Go to a contact edit form and hit apply several times.

You should see that the request is adding new lead and contact every time. And the records in the webhook_queue table are growing.

You can use https://jsonformatter.curiousconcept.com/ to see the JSON in more human friendly way.

#### Steps to test this PR:
1. Apply this PR
2. Update the contact once more. It will clear the queue. Apply again.
3. Check the request. It's containing only one lead and one contact object.
4. Check the webhook_queue table. It doesn't contain any row for your current webhook.
5. Switch to the command sending and test also that option. Run `app/console mautic:webhooks:trigger` to hit the webhook.