### PR TITLE
fixed updating campaign members

### DIFF
--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -383,7 +383,7 @@ class SalesforceApi extends CrmApi
             $foundCampaignMembers = $this->request('query', ['q' => $query], 'GET', false, null, $this->integration->getQueryUrl());
             if (!empty($foundCampaignMembers['records'])) {
                 foreach ($foundCampaignMembers['records'] as $member) {
-                    $campaignMembers[$member[$idField]] = $member[$idField];
+                    $campaignMembers[$member[$idField]] = $member['Id'];
                 }
             }
         }

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -171,7 +171,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
      */
     public function getCompositeUrl()
     {
-        return sprintf('%s/services/data/v39.0', $this->keys['instance_url']);
+        return sprintf('%s/services/data/v38.0', $this->keys['instance_url']);
     }
 
     /**

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -171,7 +171,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
      */
     public function getCompositeUrl()
     {
-        return sprintf('%s/services/data/v38.0', $this->keys['instance_url']);
+        return sprintf('%s/services/data/v39.0', $this->keys['instance_url']);
     }
 
     /**
@@ -1501,33 +1501,12 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
         /** @var IntegrationEntityRepository $integrationEntityRepo */
         $integrationEntityRepo = $this->em->getRepository('MauticPluginBundle:IntegrationEntity');
-        //find campaignMember
-        $existingCampaignMember = $integrationEntityRepo->getIntegrationsEntityId(
-            'Salesforce',
-            'CampaignMember',
-            'lead',
-            $lead->getId(),
-            null,
-            null,
-            null,
-            false,
-            0,
-            0,
-            "'$campaignId'"
-        );
 
         $body = [
             'Status' => $status,
         ];
         $object = 'CampaignMember';
         $url    = '/services/data/v38.0/sobjects/'.$object;
-        if ($existingCampaignMember) {
-            foreach ($existingCampaignMember as $member) {
-                $integrationEntity = $integrationEntityRepo->getEntity($member['id']);
-                $referenceId       = $integrationEntity->getId();
-                $internalLeadId    = $integrationEntity->getInternalEntityId();
-            }
-        }
 
         if (!empty($lead->getEmail())) {
             $pushPeople = [];
@@ -1551,11 +1530,30 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 $campaignMappingId = '-'.$campaignId;
 
                 if (isset($campaignMembers[$memberId])) {
+                    $existingCampaignMember = $integrationEntityRepo->getIntegrationsEntityId(
+                        'Salesforce',
+                        'CampaignMember',
+                        'lead',
+                        null,
+                        null,
+                        null,
+                        false,
+                        0,
+                        0,
+                        "'".$campaignMembers[$memberId]."'"
+                    );
+                    if ($existingCampaignMember) {
+                        foreach ($existingCampaignMember as $member) {
+                            $integrationEntity = $integrationEntityRepo->getEntity($member['id']);
+                            $referenceId       = $integrationEntity->getId();
+                            $internalLeadId    = $integrationEntity->getInternalEntityId();
+                        }
+                    }
                     $id = !empty($lead->getId()) ? $lead->getId() : '';
-                    $id .= '-CampaignMember'.$memberId;
-                    $id .= !empty($referenceId && $internalLeadId == $lead->getId()) ? '-'.$referenceId : '';
+                    $id .= '-CampaignMember'.$campaignMembers[$memberId];
+                    $id .= !empty($referenceId) ? '-'.$referenceId : '';
                     $id .= $campaignMappingId;
-                    $patchurl        = $url.'/'.$memberId;
+                    $patchurl        = $url.'/'.$campaignMembers[$memberId];
                     $mauticData[$id] = [
                         'method'      => 'PATCH',
                         'url'         => $patchurl,


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
when trying to update an existing campaign members, it would throw and resource does not exist error. meaning it could not find the existing campaign member.
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. setup a campaign to push contacts to a SF campaign with a sent status, run it.
2. setup a campaign to update the same contacts to a responded status in same SF campaign, status will not change.

#### Steps to test this PR:
1. Apply this PR and follow steps above, status should change