### PR TITLE
Prevent MauticJS.postEventDeliveryQueue[i] is not a function error

### DIFF
--- a/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
@@ -305,7 +305,9 @@ document.addEventListener('mauticPageEventDelivered', function(e) {
     if (!MauticJS.firstDeliveryMade) {
         MauticJS.firstDeliveryMade = true;
         for (var i in MauticJS.postEventDeliveryQueue) {
-            MauticJS.postEventDeliveryQueue[i](detail);
+            if (typeof MauticJS.postEventDeliveryQueue[i] == 'function') {
+                MauticJS.postEventDeliveryQueue[i](detail);
+            }
             delete MauticJS.postEventDeliveryQueue[i];
         }
     }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If something gets injected into the MauticJS.postEventDeliveryQueue object that is not a function, this error appears:

```
mtc.js:15 Uncaught TypeError: MauticJS.postEventDeliveryQueue[i] is not a function
    at HTMLDocument.<anonymous> (mtc.js:15)
    at Object.MauticJS.dispatchEvent (mtc.js:10)
    at mtc.js:73
    at XMLHttpRequest.xhr.onreadystatechange (mtc.js:7)
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Embed this tracking code on a site:

```
<script>
    (function(w,d,t,u,n,a,m){w['MauticTrackingObject']=n;
        w[n]=w[n]||function(){(w[n].q=w[n].q||[]).push(arguments)},a=d.createElement(t),
            m=d.getElementsByTagName(t)[0];a.async=1;a.src=u;m.parentNode.insertBefore(a,m);

        a.onload = a.onreadystatechange = function() {
            MauticJS.onFirstEventDelivery('hi');
            MauticJS.onFirstEventDelivery(function() {alert('hi')});
        }
    })(window,document,'script','https://YOURMAUTIC.COM/mtc.js','mt');

    mt('send', 'pageview');
</script>
```
2. Update https://YOURMAUTIC.COM to your Mautic installation. Then load the page.
3. Note the error above will show up in the browser's dev console

#### Steps to test this PR:
1. Repeat and the error will not occur
