### PR TITLE
Prevent SQL error when an event is deleted from a cloned campaign prior to it being saved

### DIFF
--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -14,6 +14,7 @@ namespace Mautic\CampaignBundle\Controller;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CampaignBundle\Model\CampaignModel;
+use Mautic\CampaignBundle\Model\EventModel;
 use Mautic\CoreBundle\Controller\AbstractStandardFormController;
 use Mautic\LeadBundle\Controller\EntityContactsTrait;
 use Symfony\Component\Form\Form;
@@ -356,7 +357,9 @@ class CampaignController extends AbstractStandardFormController
 
         if ('edit' === $action && null !== $this->connections) {
             if (!empty($this->deletedEvents)) {
-                $this->getModel('campaign.event')->deleteEvents($entity->getEvents()->toArray(), $this->deletedEvents);
+                /** @var EventModel $eventModel */
+                $eventModel = $this->getModel('campaign.event');
+                $eventModel->deleteEvents($entity->getEvents()->toArray(), $this->deletedEvents);
             }
         }
 

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -210,14 +210,18 @@ class EventModel extends CommonFormModel
                 unset($deletedEvents[$k]);
             }
 
-            $deletedKeys[] = $deleteMe;
+            if (isset($deletedEvents[$k])) {
+                $deletedKeys[] = $deleteMe;
+            }
         }
 
-        // wipe out any references to these events to prevent restraint violations
-        $this->getRepository()->nullEventRelationships($deletedKeys);
+        if (count($deletedEvents)) {
+            // wipe out any references to these events to prevent restraint violations
+            $this->getRepository()->nullEventRelationships($deletedKeys);
 
-        // delete the events
-        $this->deleteEntities($deletedEvents);
+            // delete the events
+            $this->deleteEntities($deletedEvents);
+        }
     }
 
     /**

--- a/app/bundles/CampaignBundle/Tests/Model/EventModelTest.php
+++ b/app/bundles/CampaignBundle/Tests/Model/EventModelTest.php
@@ -11,7 +11,6 @@
 
 namespace Mautic\CampaignBundle\Tests\Model;
 
-
 use Mautic\CampaignBundle\Model\EventModel;
 
 class EventModelTest extends \PHPUnit_Framework_TestCase
@@ -29,11 +28,11 @@ class EventModelTest extends \PHPUnit_Framework_TestCase
         $currentEvents = [
             'new1',
             'new2',
-            'new3'
+            'new3',
         ];
 
         $deletedEvents = [
-            'new1'
+            'new1',
         ];
 
         $mockModel->deleteEvents($currentEvents, $deletedEvents);

--- a/app/bundles/CampaignBundle/Tests/Model/EventModelTest.php
+++ b/app/bundles/CampaignBundle/Tests/Model/EventModelTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CampaignBundle\Tests\Model;
+
+
+use Mautic\CampaignBundle\Model\EventModel;
+
+class EventModelTest extends \PHPUnit_Framework_TestCase
+{
+    public function testThatClonedEventsDoNotAttemptNullingParentInDeleteEvents()
+    {
+        $mockModel = $this->getMockBuilder(EventModel::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getRepository'])
+            ->getMock();
+
+        $mockModel->expects($this->exactly(0))
+            ->method('getRepository');
+
+        $currentEvents = [
+            'new1',
+            'new2',
+            'new3'
+        ];
+
+        $deletedEvents = [
+            'new1'
+        ];
+
+        $mockModel->deleteEvents($currentEvents, $deletedEvents);
+    }
+}


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When a campaign is cloned and events are deleted prior to saving the cloned campaign, saving will result in a SQL exception then editing the campaign will have all the events stacked in the corner. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Clone a campaign
2. Open the builder and delete an event
3. Close the builder and save
4. An exception will be thrown
5. Go back to campaigns and edit the campaign, open the builder. Notice the events are all stacked

#### Steps to test this PR:
1. Repeat and there should be no exception and 
2. Run new unit test
