### PR TITLE
Bugfix - Can't preview audio and video assets

### DIFF
--- a/app/bundles/AssetBundle/Views/Asset/preview.html.php
+++ b/app/bundles/AssetBundle/Views/Asset/preview.html.php
@@ -16,13 +16,13 @@
         <img src="<?php echo $assetDownloadUrl.'?stream=1'; ?>" alt="<?php echo $activeAsset->getTitle(); ?>" class="img-thumbnail" />
     <?php elseif (strtolower($activeAsset->getFileType()) == 'pdf') : ?>
         <iframe src="<?php echo $assetDownloadUrl.'?stream=1'; ?>#view=FitH" class="col-sm-12"></iframe>
-    <?php elseif (strpos($activeAsset->getMime(), 'video') === 0 || in_array($activeAsset->getExtension(), ['mp4', 'webm'])): ?>
-        <video src="<?php echo $assetDownloadUrl; ?>" controls>
+    <?php elseif (strpos($activeAsset->getMime(), 'video') === 0 || in_array($activeAsset->getExtension(), ['mpg', 'mpeg', 'mp4', 'webm'])): ?>
+        <video src="<?php echo $assetDownloadUrl.'?stream=1'; ?>" controls>
             <?php echo $view['translator']->trans('mautic.asset.no_video_support'); ?>
         </video>
-    <?php elseif (strpos($activeAsset->getMime(), 'audio') === 0 || in_array($activeAsset->getExtension(), ['mpg', 'mpeg', 'mp3', 'ogg', 'wav'])): ?>
+    <?php elseif (strpos($activeAsset->getMime(), 'audio') === 0 || in_array($activeAsset->getExtension(), ['mp3', 'ogg', 'wav'])): ?>
         <audio controls>
-            <source src="<?php echo $assetDownloadUrl; ?>" type="<?php echo $activeAsset->getMime(); ?>">
+            <source src="<?php echo $assetDownloadUrl.'?stream=1'; ?>" type="<?php echo $activeAsset->getMime(); ?>">
             <?php echo $view['translator']->trans('mautic.asset.no_audio_support'); ?>
         </audio>
     <?php else: ?>


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
When viewing a video or audio asset, the preview area in the bottom does not show it because the `stream=1` parameter is missing in the `src` attribute. This PR fixes that issue.

#### Steps to reproduce the bug:
1. Create/View any video or audio asset
2. View the details of the asset and in the bottom, in the preview area, the play control will do nothing.

![image](https://user-images.githubusercontent.com/2924026/28940197-18b56ae2-7851-11e7-992a-53fd42eed246.png)


#### Steps to test this PR:
1. Apply this PR
2. View the details of the asset and in the bottom, in the preview area, the asset will be rendered if it's a video and the controls will play it if it is an audio.

![image](https://user-images.githubusercontent.com/2924026/28940211-2b56edba-7851-11e7-9072-0e22179e5080.png)


