### PR TITLE
Fixes "PHP Notice - Undefined index: alias" on form API endpoints

### DIFF
--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -157,12 +157,17 @@ class FormApiController extends CommonApiController
 
                 $fieldEntityArray           = $fieldEntity->convertToArray();
                 $fieldEntityArray['formId'] = $formId;
-                $escapedAlias               = InputHelper::filename($fieldParams['alias']);
 
-                if (!in_array($escapedAlias, $aliases)) {
-                    $fieldEntityArray['alias'] = $escapedAlias;
-                } else {
-                    $fieldEntityArray['alias'] = $fieldModel->generateAlias($fieldEntityArray['label'], $aliases);
+                if (!empty($fieldParams['alias'])) {
+                    $fieldParams['alias'] = InputHelper::filename($fieldParams['alias']);
+
+                    if (!in_array($fieldParams['alias'], $aliases)) {
+                        $fieldEntityArray['alias'] = $fieldParams['alias'];
+                    }
+                }
+
+                if (empty($fieldEntityArray['alias'])) {
+                    $fieldEntityArray['alias'] = $fieldParams['alias'] = $fieldModel->generateAlias($fieldEntityArray['label'], $aliases);
                 }
 
                 $fieldForm = $this->createFieldEntityForm($fieldEntityArray);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR fixes `PHP Notice - Undefined index: alias` when running `phpunit --filter FormsTest` on API Library. It happens if the field aliases aren't defined in the request. Introduced in https://github.com/mautic/mautic/pull/4317

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run `phpunit --filter FormsTest` on API Library

#### Steps to test this PR:
1. Repeat the test