### PR TITLE
The SQL error when a API call used orderBy with column name without the table alias fixed

### DIFF
--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -387,7 +387,7 @@ class CommonApiController extends FOSRestController implements MauticController
                     'string' => $this->request->query->get('search', ''),
                     'force'  => $this->listFilters,
                 ],
-                'orderBy'        => $this->request->query->get('orderBy', ''),
+                'orderBy'        => $this->addAliasIfNotPresent($this->request->query->get('orderBy', ''), $tableAlias),
                 'orderByDir'     => $this->request->query->get('orderByDir', 'ASC'),
                 'withTotalCount' => true, //for repositories that break free of Paginator
             ],
@@ -423,6 +423,36 @@ class CommonApiController extends FOSRestController implements MauticController
         $this->setSerializationContext($view);
 
         return $this->handleView($view);
+    }
+
+    /**
+     * Adds the repository alias to the column name if it doesn't exist.
+     *
+     * @param string $column name
+     *
+     * @return string $column name with alias prefix
+     */
+    protected function addAliasIfNotPresent($columns, $alias)
+    {
+        if (!$columns) {
+            return $columns;
+        }
+
+        $columns = explode(',', trim($columns));
+        $prefix  = $alias.'.';
+
+        array_walk(
+            $columns,
+            function (&$column, $key, $prefix) {
+                $column = trim($column);
+                if (strpos($column, $prefix) === false) {
+                    $column = $prefix.$column;
+                }
+            },
+            $prefix
+        );
+
+        return implode(',', $columns);
     }
 
     /**

--- a/app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CampaignBundle\Tests\Model;
+
+use Mautic\ApiBundle\Controller\CommonApiController;
+use Mautic\CampaignBundle\Tests\CampaignTestAbstract;
+
+class CommonApiControllerTest extends CampaignTestAbstract
+{
+    public function testAddAliasIfNotPresentWithOneColumnWithoutAlias()
+    {
+        $result = $this->getResultFromProtectedMethod('addAliasIfNotPresent', ['dateAdded', 'f']);
+
+        $this->assertEquals('f.dateAdded', $result);
+    }
+
+    public function testAddAliasIfNotPresentWithOneColumnWithAlias()
+    {
+        $result = $this->getResultFromProtectedMethod('addAliasIfNotPresent', ['f.dateAdded', 'f']);
+
+        $this->assertEquals('f.dateAdded', $result);
+    }
+
+    public function testAddAliasIfNotPresentWithTwoColumnsWithAlias()
+    {
+        $result = $this->getResultFromProtectedMethod('addAliasIfNotPresent', ['f.dateAdded, f.dateModified', 'f']);
+
+        $this->assertEquals('f.dateAdded,f.dateModified', $result);
+    }
+
+    public function testAddAliasIfNotPresentWithTwoColumnsWithoutAlias()
+    {
+        $result = $this->getResultFromProtectedMethod('addAliasIfNotPresent', ['dateAdded, dateModified', 'f']);
+
+        $this->assertEquals('f.dateAdded,f.dateModified', $result);
+    }
+
+    protected function getResultFromProtectedMethod($method, array $args)
+    {
+        $controller           = new CommonApiController();
+        $controllerReflection = new \ReflectionClass(CommonApiController::class);
+        $method               = $controllerReflection->getMethod($method);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($controller, $args);
+    }
+}


### PR DESCRIPTION
…. The new method unit-tested

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4532
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If you try to get a list of entities with orderBy column, it will fail because it doesn't have the table alias attached to it. This change fixes that. It is also BC, so if someone uses order column with the table alias, it will work too. (the alias won't be duplicated)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to get a list of forms ordered by dateAdded for example. Like `/api/forms?orderBy=dateAdded`

#### Steps to test this PR:
1. Repeat the test.