### PR TITLE
System default theme for resubscribe action for code mode  email

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -321,8 +321,9 @@ class PublicController extends CommonFormController
             $message = $this->translator->trans('mautic.email.stat_record.not_found');
         }
 
-        $template = ($email !== null) ? $email->getTemplate() : $this->coreParametersHelper->getParameter('theme');
-        $theme    = $this->factory->getTheme($template);
+        $template = ($email !== null && 'mautic_code_mode' !== $email->getTemplate()) ? $email->getTemplate() : $this->coreParametersHelper->getParameter('theme');
+
+        $theme = $this->factory->getTheme($template);
 
         if ($theme->getTheme() != $template) {
             $template = $theme->getTheme();


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Add default template to Configurations
2. Create email with unsubscribe in code mode and send to you
3. Click on unsubscribe in email -  see unsubscribe page with style from default heme
4. Click on re-subscribe
5. See subscribe confirmation page without style from default theme

#### Steps to test this PR:
1. Repeat all steps and check if works now