### PR TITLE
Prevent null boolean value from automatically setting the value to false/0 for campaign's update contact

### DIFF
--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -100,9 +100,11 @@ trait RequestTrait
     public function cleanFields(&$fieldData, $leadField)
     {
         switch ($leadField['type']) {
-            // Adjust the boolean values from text to boolean
+            // Adjust the boolean values from text to boolean. Do not convert null to false.
             case 'boolean':
-                $fieldData[$leadField['alias']] = (int) filter_var($fieldData[$leadField['alias']], FILTER_VALIDATE_BOOLEAN);
+                if (!is_null($fieldData[$leadField['alias']])) {
+                    $fieldData[$leadField['alias']] = (int) filter_var($fieldData[$leadField['alias']], FILTER_VALIDATE_BOOLEAN);
+                }
                 break;
             // Ensure date/time entries match what symfony expects
             case 'datetime':

--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -304,7 +304,7 @@ trait CustomFieldRepositoryTrait
                     $r = (float) $r;
                     break;
                 case 'boolean':
-                    $r = (int) $r;
+                    $r = is_null($r) ? $r : (bool) $r;
                     break;
             }
 

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -594,7 +594,7 @@ class LeadModel extends FormModel
 
                 // Only update fields that are part of the passed $data array
                 if (array_key_exists($alias, $data)) {
-                    if (!$bindWithForm) {
+                    if (!$bindWithForm && null !== $field['value']) {
                         $this->cleanFields($data, $field);
                     }
                     $curValue = $field['value'];


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Any boolean field not set either false or true in the campaign action, update contact, will result in being set to false instead of being left alone. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a boolean custom field
2. Create a campaign with an update contact action (don't change anything)
3. Execute the campaign
4. Note that the boolean custom field will be set to 0/false even though it was not supposed to be updated by the campaign

#### Steps to test this PR:
1. Repeat with new custom fields and the values will remain null or true if it was true to start with
