### PR TITLE
Hide Tweet campaign action if the Twitter plugin is not published

### DIFF
--- a/plugins/MauticSocialBundle/Config/config.php
+++ b/plugins/MauticSocialBundle/Config/config.php
@@ -54,10 +54,10 @@ return [
                 'class' => 'MauticPlugin\MauticSocialBundle\EventListener\FormSubscriber',
             ],
             'mautic.social.campaignbundle.subscriber' => [
-                'class'     => 'MauticPlugin\MauticSocialBundle\EventListener\CampaignSubscriber',
+                'class'     => \MauticPlugin\MauticSocialBundle\EventListener\CampaignSubscriber::class,
                 'arguments' => [
-                    'mautic.factory',
                     'mautic.social.helper.campaign',
+                    'mautic.helper.integration',
                 ],
             ],
             'mautic.social.configbundle.subscriber' => [


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4610
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The tweet campaign action is visible even if the Twitter plugin is disabled. This PR fixes that and the action will appear only if the plugin is enabled.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Disable Twitter plugin
2. Check if the campaign action exists. It does.

#### Steps to test this PR:
1. Apply this PR
2. Clear the cache
3. Check if the campaign action exists. It does not.
4. Enable Twitter plugin.
5. Check if the campaign action exists. It does.