### PR TITLE
Renaming campaign action name from "Send email" to "Send or schedule email" to avoid confusion

### DIFF
--- a/app/bundles/EmailBundle/Translations/en_US/messages.ini
+++ b/app/bundles/EmailBundle/Translations/en_US/messages.ini
@@ -1,5 +1,5 @@
 mautic.campaign.email.open="Email is opened"
-mautic.campaign.email.send="Send email"
+mautic.campaign.email.send="Send or schedule email"
 mautic.config.tab.emailconfig="Email Settings"
 mautic.email.abtest.criteria.clickthrough="Clickthrough rate"
 mautic.email.abtest.criteria.open="Read rate"


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | A little
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4527
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
There is a confusion if campaign action "Send email" is 100% complete, but the email stats show different results. The difference is that the campaign action was triggered for all contacts, but some or all emails could be scheduled for future date. This PR simply renames the action so users would understand what it really does.

![send-email-action](https://user-images.githubusercontent.com/1235442/29122599-3170c5f6-7d13-11e7-8cbf-6c3ff7792808.png)

#### Steps to test this PR:
1. Just review the code change and dis/agree with it :)
