### PR TITLE
Return http code 500 on errors

### DIFF
--- a/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
+++ b/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
@@ -210,6 +210,8 @@ namespace Mautic\CoreBundle\ErrorHandler {
                 return $content;
             }
 
+            http_response_code(500);
+
             if (!empty($GLOBALS['MAUTIC_AJAX_DIRECT_RENDER'])) {
                 header('Content-Type: application/json');
                 $content = json_encode(['newContent' => $content]);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

Mautic should return http error 500 on all errors. Before this pr certain class of errors returned error message but http code 200.


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. mess with constructor of app/bundles/PageBundle/Model/PageModel.php
 - you can add a new required parameter so you get error like 
```mautic.ERROR: Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Argument 7 passed to Mautic\PageBundle\Model\PageModel::__construct() must be an instance of Mautic\PageBundle\Model\TrackableModel, none given```

2. visit a landing page
3. you get error page but with 200 OK http code

#### Steps to test this PR:
1. apply the pr and repeat the steps
2. you get an error but with correct 500 error code
