### PR TITLE
Prevent number from converting to 0 when the value is null

### DIFF
--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -99,12 +99,15 @@ trait RequestTrait
      */
     public function cleanFields(&$fieldData, $leadField)
     {
+        // This will catch null values or non-existent values to prevent null from converting to false/0
+        if (!isset($fieldData[$leadField['alias']])) {
+            return;
+        }
+
         switch ($leadField['type']) {
             // Adjust the boolean values from text to boolean. Do not convert null to false.
             case 'boolean':
-                if (!is_null($fieldData[$leadField['alias']])) {
-                    $fieldData[$leadField['alias']] = (int) filter_var($fieldData[$leadField['alias']], FILTER_VALIDATE_BOOLEAN);
-                }
+                $fieldData[$leadField['alias']] = (int) filter_var($fieldData[$leadField['alias']], FILTER_VALIDATE_BOOLEAN);
                 break;
             // Ensure date/time entries match what symfony expects
             case 'datetime':

--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -299,13 +299,15 @@ trait CustomFieldRepositoryTrait
 
         //loop over results to put fields in something that can be assigned to the entities
         foreach ($values as $k => $r) {
-            switch ($fields[$k]['type']) {
-                case 'number':
-                    $r = (float) $r;
-                    break;
-                case 'boolean':
-                    $r = is_null($r) ? $r : (bool) $r;
-                    break;
+            if (!is_null($r)) {
+                switch ($fields[$k]['type']) {
+                    case 'number':
+                        $r = (float) $r;
+                        break;
+                    case 'boolean':
+                        $r = (bool) $r;
+                        break;
+                }
             }
 
             if (isset($fields[$k])) {

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -594,7 +594,7 @@ class LeadModel extends FormModel
 
                 // Only update fields that are part of the passed $data array
                 if (array_key_exists($alias, $data)) {
-                    if (!$bindWithForm && null !== $field['value']) {
+                    if (!$bindWithForm) {
                         $this->cleanFields($data, $field);
                     }
                     $curValue = $field['value'];

--- a/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
@@ -119,7 +119,7 @@ class LeadTest extends \PHPUnit_Framework_TestCase
                     'type'  => 'textarea',
                     'value' => 'Blah blah blah',
                 ],
-                'test' => [
+                'test'  => [
                     'alias' => 'test',
                     'label' => 'Test',
                     'type'  => 'textarea',
@@ -142,13 +142,13 @@ class LeadTest extends \PHPUnit_Framework_TestCase
     {
         $fields = [
             'core' => [
-                'boolean' => [
+                'boolean'     => [
                     'alias' => 'boolean',
                     'label' => 'Boolean',
                     'type'  => 'boolean',
                     'value' => false,
                 ],
-                'dateField' => [
+                'dateField'   => [
                     'alias' => 'dateField',
                     'label' => 'Date Time',
                     'type'  => 'datetime',
@@ -162,7 +162,7 @@ class LeadTest extends \PHPUnit_Framework_TestCase
                 ],
             ],
         ];
-        $data = [
+        $data   = [
             'boolean'   => 'yes',
             'dateField' => '12-12-2017 22:03:59',
             'multi'     => 'a|b',
@@ -191,7 +191,7 @@ class LeadTest extends \PHPUnit_Framework_TestCase
                     'type'  => 'boolean',
                     'value' => false,
                 ],
-                'number' => [
+                'number'  => [
                     'alias' => 'number',
                     'label' => 'Number',
                     'type'  => 'number',
@@ -199,11 +199,10 @@ class LeadTest extends \PHPUnit_Framework_TestCase
                 ],
             ],
         ];
-        $data = [
-            'boolean'   => null,
-            'number' => null,
+        $data   = [
+            'boolean' => null,
+            'number'  => null,
         ];
-
 
         $this->cleanFields($data, $fields['core']['boolean']);
         $this->cleanFields($data, $fields['core']['number']);
@@ -213,8 +212,8 @@ class LeadTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param $points
-     * @param $expected
+     * @param      $points
+     * @param      $expected
      * @param Lead $lead
      * @param bool $operator
      */

--- a/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
@@ -19,6 +19,7 @@ use Mautic\LeadBundle\Entity\Lead;
 class LeadTest extends \PHPUnit_Framework_TestCase
 {
     use RequestTrait;
+
     public function testPreferredChannels()
     {
         $frequencyRules = [
@@ -124,6 +125,23 @@ class LeadTest extends \PHPUnit_Framework_TestCase
                     'type'  => 'textarea',
                     'value' => 'Test blah',
                 ],
+            ],
+        ];
+
+        $lead->setFields($fields);
+
+        // This should not killover with a segmentation fault due to a loop
+        $lead->setNotes('hello');
+
+        // Not using getNotes because it conflicts with an existing method and not sure what to do about that yet
+        $lead->setTest('hello');
+        $this->assertEquals('hello', $lead->getTest());
+    }
+
+    public function testDataIsCleanedCorrectly()
+    {
+        $fields = [
+            'core' => [
                 'boolean' => [
                     'alias' => 'boolean',
                     'label' => 'Boolean',
@@ -145,8 +163,6 @@ class LeadTest extends \PHPUnit_Framework_TestCase
             ],
         ];
         $data = [
-            'notes'     => 'hello',
-            'test'      => 'test',
             'boolean'   => 'yes',
             'dateField' => '12-12-2017 22:03:59',
             'multi'     => 'a|b',
@@ -163,15 +179,37 @@ class LeadTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($testDateObject->format('Y-m-d H:i'), $data['dateField']);
         $this->assertEquals((int) true, $data['boolean']);
         $this->assertEquals(['a', 'b'], $data['multi']);
+    }
 
-        $lead->setFields($fields);
+    public function testCleanBooleanAndNumberAsNullAreNotConverted()
+    {
+        $fields = [
+            'core' => [
+                'boolean' => [
+                    'alias' => 'boolean',
+                    'label' => 'Boolean',
+                    'type'  => 'boolean',
+                    'value' => false,
+                ],
+                'number' => [
+                    'alias' => 'number',
+                    'label' => 'Number',
+                    'type'  => 'number',
+                    'value' => '1234',
+                ],
+            ],
+        ];
+        $data = [
+            'boolean'   => null,
+            'number' => null,
+        ];
 
-        // This should not killover with a segmentation fault due to a loop
-        $lead->setNotes('hello');
 
-        // Not using getNotes because it conflicts with an existing method and not sure what to do about that yet
-        $lead->setTest('hello');
-        $this->assertEquals('hello', $lead->getTest());
+        $this->cleanFields($data, $fields['core']['boolean']);
+        $this->cleanFields($data, $fields['core']['number']);
+
+        $this->assertEquals(null, $data['boolean']);
+        $this->assertEquals(null, $data['number']);
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
@@ -119,7 +119,7 @@ class LeadTest extends \PHPUnit_Framework_TestCase
                     'type'  => 'textarea',
                     'value' => 'Blah blah blah',
                 ],
-                'test'  => [
+                'test' => [
                     'alias' => 'test',
                     'label' => 'Test',
                     'type'  => 'textarea',
@@ -142,13 +142,13 @@ class LeadTest extends \PHPUnit_Framework_TestCase
     {
         $fields = [
             'core' => [
-                'boolean'     => [
+                'boolean' => [
                     'alias' => 'boolean',
                     'label' => 'Boolean',
                     'type'  => 'boolean',
                     'value' => false,
                 ],
-                'dateField'   => [
+                'dateField' => [
                     'alias' => 'dateField',
                     'label' => 'Date Time',
                     'type'  => 'datetime',
@@ -162,7 +162,7 @@ class LeadTest extends \PHPUnit_Framework_TestCase
                 ],
             ],
         ];
-        $data   = [
+        $data = [
             'boolean'   => 'yes',
             'dateField' => '12-12-2017 22:03:59',
             'multi'     => 'a|b',
@@ -191,7 +191,7 @@ class LeadTest extends \PHPUnit_Framework_TestCase
                     'type'  => 'boolean',
                     'value' => false,
                 ],
-                'number'  => [
+                'number' => [
                     'alias' => 'number',
                     'label' => 'Number',
                     'type'  => 'number',
@@ -199,7 +199,7 @@ class LeadTest extends \PHPUnit_Framework_TestCase
                 ],
             ],
         ];
-        $data   = [
+        $data = [
             'boolean' => null,
             'number'  => null,
         ];


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This piggy backs off #4609 which was the same issue for booleans. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a boolean custom field
2. Create a campaign with an update contact action (don't change anything)
3. Edit a contact in the campaign and set Points to non-zero
3. Execute the campaign
4. Note that points will be reset to 0 (bad) but boolean field is not changed to false/0 (good)


#### Steps to test this PR:
1. Same as above but boolean will remain null (validate still fixed) and points will not be overwritten
