### PR TITLE
View associated contacts in a new tab in Email details page

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -20,6 +20,10 @@ return [
                 'path'       => '/emails/{objectAction}/{objectId}',
                 'controller' => 'MauticEmailBundle:Email:execute',
             ],
+            'mautic_email_contacts' => [
+                'path'       => '/emails/contacts/{objectId}',
+                'controller' => 'MauticEmailBundle:Email:contacts',
+            ],
         ],
         'api' => [
             'mautic_api_emailstandard' => [

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -17,15 +17,18 @@ use Mautic\CoreBundle\Helper\EmojiHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Form\Type\ExampleSendType;
+use Mautic\LeadBundle\Controller\EntityContactsTrait;
 use Mautic\LeadBundle\Model\ListModel;
 use MauticPlugin\MauticCitrixBundle\Helper\CitrixHelper;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormError;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 class EmailController extends FormController
 {
     use BuilderControllerTrait;
+    use EntityContactsTrait;
 
     /**
      * @param int $page
@@ -455,6 +458,14 @@ class EmailController extends FormController
                         ['objectId' => $email->getId()],
                         true
                     ),
+                    'contacts' => $this->forward(
+                        'MauticEmailBundle:Email:contacts',
+                        [
+                            'objectId'   => $email->getId(),
+                            'page'       => $this->get('session')->get('mautic.email.contact.page', 1),
+                            'ignoreAjax' => true,
+                        ]
+                    )->getContent(),
                     'dateRangeForm' => $dateRangeForm->createView(),
                 ],
                 'contentTemplate' => 'MauticEmailBundle:Email:details.html.php',
@@ -1582,5 +1593,24 @@ class EmailController extends FormController
 
         // everything is ok
         return true;
+    }
+
+    /**
+     * @param     $objectId
+     * @param int $page
+     *
+     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
+     */
+    public function contactsAction($objectId, $page = 1)
+    {
+        return $this->generateContactsGrid(
+            $objectId,
+            $page,
+            ['email:emails:viewown', 'email:emails:viewother'],
+            'email',
+            'email_stats',
+            'email',
+            'email_id'
+        );
     }
 }

--- a/app/bundles/EmailBundle/Translations/en_US/messages.ini
+++ b/app/bundles/EmailBundle/Translations/en_US/messages.ini
@@ -392,3 +392,4 @@ mautic.email.config.show.contact.preferred.channels="Show contact's preferred ch
 mautic.email.config.show.contact.preferred.channels.tooltip="This will allow the contact to set their preferred channel; it will only show if there is more than one contact channels."
 mautic.lead.message.preferences="Message Preferences"
 mautic.lead.message.preferences.descr="Please use the form below to set your message preferences."
+mautic.email.associated.contacts="Associated contacts"

--- a/app/bundles/EmailBundle/Translations/en_US/messages.ini
+++ b/app/bundles/EmailBundle/Translations/en_US/messages.ini
@@ -392,4 +392,4 @@ mautic.email.config.show.contact.preferred.channels="Show contact's preferred ch
 mautic.email.config.show.contact.preferred.channels.tooltip="This will allow the contact to set their preferred channel; it will only show if there is more than one contact channels."
 mautic.lead.message.preferences="Message Preferences"
 mautic.lead.message.preferences.descr="Please use the form below to set your message preferences."
-mautic.email.associated.contacts="Associated contacts"
+mautic.email.associated.contacts="Contacts"

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -233,6 +233,11 @@ if (!$isEmbedded) {
                         <?php echo $view['translator']->trans('mautic.trackable.click_counts'); ?>
                     </a>
                 </li>
+                <li>
+                    <a href="#contacts-container" role="tab" data-toggle="tab">
+                        <?php echo $view['translator']->trans('mautic.email.associated.contacts'); ?>
+                    </a>
+                </li>
                 <?php if ($showVariants): ?>
                     <li>
                         <a href="#variants-container" role="tab" data-toggle="tab">
@@ -255,6 +260,10 @@ if (!$isEmbedded) {
         <div class="tab-content pa-md">
             <div class="tab-pane active bdr-w-0" id="clicks-container">
                 <?php echo $view->render('MauticPageBundle:Trackable:click_counts.html.php', ['trackables' => $trackables]); ?>
+            </div>
+
+            <div class="tab-pane bdr-w-0" id="contacts-container">
+                <?php echo $contacts; ?>
             </div>
 
             <?php if ($showVariants): ?>


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR adds a new tab in the email details page that shows all the contacts that the email has been sent to.

#### Steps to test this PR:
1. Apply this PR
2. Open an email
3. At the bottom there will be a new tab with the associated contacts for that email.

