### PR TITLE
Bug quick email cannot type

### DIFF
--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -187,7 +187,7 @@ Mautic.getLeadId = function() {
 
 Mautic.leadEmailOnLoad = function(container, response) {
     // Some hacky editations made on every form submit because of Froala (more at: https://github.com/froala/wysiwyg-editor/issues/1372)
-    mQuery('[name="lead_quickemail"]').on('click.ajaxform', function() {
+    mQuery('[name="lead_quickemail"]').on('submit.ajaxform', function() {
         var emailHtml = mQuery('.fr-iframe').contents();
         var textarea = mQuery(this).find('#lead_quickemail_body');
         mQuery.each(emailHtml.find('td, th, table'), function() {

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -484,8 +484,8 @@ return [
                 'alias'     => 'lead_field_import',
             ],
             'mautic.form.type.lead_quickemail' => [
-                'class'     => 'Mautic\LeadBundle\Form\Type\EmailType',
-                'arguments' => ['mautic.factory'],
+                'class'     => \Mautic\LeadBundle\Form\Type\EmailType::class,
+                'arguments' => ['mautic.helper.user'],
                 'alias'     => 'lead_quickemail',
             ],
             'mautic.form.type.lead_tags' => [

--- a/app/bundles/LeadBundle/Form/Type/EmailType.php
+++ b/app/bundles/LeadBundle/Form/Type/EmailType.php
@@ -11,8 +11,8 @@
 
 namespace Mautic\LeadBundle\Form\Type;
 
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
+use Mautic\CoreBundle\Helper\UserHelper;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\Email;
@@ -24,13 +24,16 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 class EmailType extends AbstractType
 {
     /**
-     * @var MauticFactory
+     * @var UserHelper
      */
-    private $factory;
+    private $userHelper;
 
-    public function __construct(MauticFactory $factory)
+    /**
+     * @param UserHelper $userHelper
+     */
+    public function __construct(UserHelper $userHelper)
     {
-        $this->factory = $factory;
+        $this->userHelper = $userHelper;
     }
 
     /**
@@ -52,7 +55,7 @@ class EmailType extends AbstractType
             ]
         );
 
-        $user = $this->factory->getUser();
+        $user = $this->userHelper->getUser();
 
         $default = (empty($options['data']['fromname'])) ? $user->getFirstName().' '.$user->getLastName() : $options['data']['fromname'];
         $builder->add(


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4639
| BC breaks? | See below
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The form sending email directly to a contact have some Froala sanitisation in it. It was triggered on each form click which made the editor un-editable after the first click. The edit issue was introduced in https://github.com/mautic/mautic/pull/4189.

This PR changes the behaviour to sanitise only on form submit event instead of form click event.

It also removes dependency of the form on MauticFactory which is deprecated.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to send email directly to a contact from the contact detail page.
2. Click on the subject field.
3. Try to write some text in the body. - you can't.

#### Steps to test this PR:
1. Checkout this PR
2. Clear the cache
3. Rebuild assets or run Mautic in dev mode.
4. Test again - you can edit the body.
5. Make sure that loading a template email still works.

#### List backwards compatibility breaks:
1. `Mautic\LeadBundle\Form\Type\EmailType`'s dependency on `MauticFactory` changed to dependency on `UserHelper`. Devs using the Mautic DI won't notice the change.