### PR TITLE
Preventing a PHP error when Focus tried to create stat with no lead 

### DIFF
--- a/plugins/MauticFocusBundle/Controller/PublicController.php
+++ b/plugins/MauticFocusBundle/Controller/PublicController.php
@@ -56,9 +56,10 @@ class PublicController extends CommonController
             /** @var \MauticPlugin\MauticFocusBundle\Model\FocusModel $model */
             $model = $this->getModel('focus');
             $focus = $model->getEntity($id);
+            $lead  = $this->getModel('lead')->getCurrentLead();
 
-            if ($focus && $focus->isPublished()) {
-                $model->addStat($focus, Stat::TYPE_NOTIFICATION, $this->request, $this->getModel('lead')->getCurrentLead());
+            if ($focus && $focus->isPublished() && $lead) {
+                $model->addStat($focus, Stat::TYPE_NOTIFICATION, $this->request, $lead);
             }
         }
 


### PR DESCRIPTION
(when logged in as Mautic user)

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3909
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The Focus tracking pixel throws an error when viewing the page with a Focus item while logged in to Mautic.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a Focus item.
2. Place the tracking script to a web page.
3. Visit the page in the same browser you are logged in to Mautic.
4. The error will be recorded the Mautic logs.

#### Steps to test this PR:
1. Checkout this PR.
2. Refresh the page. No error anywhere. The stat won't get created for logged in user.
3. Make sure the stat gets created for a contact. Use incognito browser to test that.