### PR TITLE
Fixed SF activity sync that prevented all records from syncing

### DIFF
--- a/app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php
@@ -92,7 +92,6 @@ class IntegrationSubscriber extends CommonSubscriber
             $xml = $doc->saveXML();
         }
 
-
         if (defined('IN_MAUTIC_CONSOLE') && defined('MAUTIC_CONSOLE_VERBOSITY')
             && MAUTIC_CONSOLE_VERBOSITY >= ConsoleOutput::VERBOSITY_VERY_VERBOSE) {
             $output = new ConsoleOutput();

--- a/app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php
@@ -42,31 +42,13 @@ class IntegrationSubscriber extends CommonSubscriber
      */
     public function onRequest(PluginIntegrationRequestEvent $event)
     {
-        $name    = strtoupper($event->getIntegrationName());
-        $headers = (count($event->getHeaders())) ? implode(PHP_EOL, array_map(function ($k, $v) {
-            return "$k: $v";
-        }, array_keys($event->getHeaders()), array_values($event->getHeaders()))) : '';
+        $name     = strtoupper($event->getIntegrationName());
+        $headers  = var_export($event->getHeaders(), true);
+        $params   = var_export($event->getParameters(), true);
+        $settings = var_export($event->getSettings(), true);
 
-        $params = (count($event->getParameters())) ? implode(PHP_EOL, array_map(function ($k, $v) {
-            if (is_object($v)) {
-                return "$k=(object)";
-            }
-            if (is_array($v)) {
-                return "$k=(array)";
-            }
-
-            return "$k=$v";
-        }, array_keys($event->getParameters()), array_values($event->getParameters()))) : '';
-
-        $settings = (count($event->getSettings())) ? implode(PHP_EOL, array_map(function ($k, $v) {
-            if ($k === 'post_data') {
-                return $v;
-            }
-
-            return "$k=".json_encode($v, JSON_PRETTY_PRINT);
-        }, array_keys($event->getSettings()), array_values($event->getSettings()))) : '';
-
-        if (defined('IN_MAUTIC_CONSOLE') && defined('MAUTIC_CONSOLE_VERBOSITY') && MAUTIC_CONSOLE_VERBOSITY >= ConsoleOutput::VERBOSITY_VERY_VERBOSE) {
+        if (defined('IN_MAUTIC_CONSOLE') && defined('MAUTIC_CONSOLE_VERBOSITY')
+            && MAUTIC_CONSOLE_VERBOSITY >= ConsoleOutput::VERBOSITY_VERY_VERBOSE) {
             $output = new ConsoleOutput();
             $output->writeln('<fg=magenta>REQUEST:</>');
             $output->writeln('<fg=white>'.$event->getMethod().' '.$event->getUrl().'</>');
@@ -96,6 +78,8 @@ class IntegrationSubscriber extends CommonSubscriber
     {
         /** @var Response $response */
         $response = $event->getResponse();
+        $headers  = var_export($response->headers, true);
+        $name     = strtoupper($event->getIntegrationName());
         $isJson   = isset($response->headers['Content-Type']) && preg_match('/application\/json/', $response->headers['Content-Type']);
         $json     = $isJson ? str_replace('    ', '  ', json_encode(json_decode($response->body), JSON_PRETTY_PRINT)) : '';
         $xml      = '';
@@ -108,11 +92,9 @@ class IntegrationSubscriber extends CommonSubscriber
             $xml = $doc->saveXML();
         }
 
-        $headers = implode(PHP_EOL, array_map(function ($k, $v) {
-            return "$k: $v";
-        }, array_keys($response->headers), array_values($response->headers)));
 
-        if (defined('IN_MAUTIC_CONSOLE') && defined('MAUTIC_CONSOLE_VERBOSITY') && MAUTIC_CONSOLE_VERBOSITY >= ConsoleOutput::VERBOSITY_VERY_VERBOSE) {
+        if (defined('IN_MAUTIC_CONSOLE') && defined('MAUTIC_CONSOLE_VERBOSITY')
+            && MAUTIC_CONSOLE_VERBOSITY >= ConsoleOutput::VERBOSITY_VERY_VERBOSE) {
             $output = new ConsoleOutput();
             $output->writeln(sprintf('<fg=magenta>RESPONSE: %d</>', $response->code));
             $output->writeln('<fg=cyan>'.$headers.'</>');
@@ -125,20 +107,22 @@ class IntegrationSubscriber extends CommonSubscriber
             } else {
                 $output->writeln('<fg=cyan>'.$response->body.'</>');
             }
-        } elseif ('dev' === MAUTIC_ENV) {
-            $this->logger->debug('RESPONSE CODE: '.$response->code);
+        } else {
+            $this->logger->debug("$name RESPONSE CODE: {$response->code}");
             if ('' !== $headers) {
-                $this->logger->debug("RESPONSE HEADERS: \n".$headers.PHP_EOL);
+                $this->logger->debug("$name RESPONSE HEADERS: \n".$headers.PHP_EOL);
             }
             if ('' !== $json || '' !== $xml || '' !== $response->body) {
-                $this->logger->debug('RESPONSE BODY:');
+                $body = "$name RESPONSE BODY: ";
                 if ($isJson) {
-                    $this->logger->debug($json."\n");
+                    $body .= $json;
                 } elseif ($isXml) {
-                    $this->logger->debug($xml."\n");
+                    $body .= $xml;
                 } else {
-                    $this->logger->debug($response->body."\n");
+                    $body = $response->body;
                 }
+
+                $this->logger->debug($body);
             }
         }
     }

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -212,20 +212,15 @@ class SalesforceApi extends CrmApi
      */
     public function createLeadActivity(array $activity, $object)
     {
-        $config   = $this->integration->getIntegrationSettings()->getFeatureSettings();
-        $contacts = $leads = [];
-
+        $config              = $this->integration->getIntegrationSettings()->getFeatureSettings();
         $namespace           = (!empty($config['namespace'])) ? $config['namespace'].'__' : '';
         $mActivityObjectName = $namespace.'mautic_timeline__c';
+        $activityData        = [];
 
         if (!empty($activity)) {
             foreach ($activity as $sfId => $records) {
-                foreach ($records['records'] as $key => $record) {
-                    $activityData['records'][$key] = [
-                        'attributes' => [
-                            'type'        => $mActivityObjectName,
-                            'referenceId' => $record['id'].'-'.$sfId,
-                        ],
+                foreach ($records['records'] as $record) {
+                    $body = [
                         $namespace.'ActivityDate__c' => $record['dateAdded']->format('c'),
                         $namespace.'Description__c'  => $record['description'],
                         'Name'                       => $record['name'],
@@ -234,24 +229,34 @@ class SalesforceApi extends CrmApi
                     ];
 
                     if ($object === 'Lead') {
-                        $activityData['records'][$key][$namespace.'WhoId__c'] = $sfId;
+                        $body[$namespace.'WhoId__c'] = $sfId;
                     } elseif ($object === 'Contact') {
-                        $activityData['records'][$key][$namespace.'contact_id__c'] = $sfId;
+                        $body[$namespace.'contact_id__c'] = $sfId;
                     }
+
+                    $activityData[] = [
+                        'method'      => 'POST',
+                        'url'         => '/services/data/v38.0/sobjects/'.$mActivityObjectName,
+                        'referenceId' => $record['id'].'-'.$sfId,
+                        'body'        => $body,
+                    ];
                 }
             }
 
             if (!empty($activityData)) {
-                //todo: log posted activities so that they don't get sent over again
-                $queryUrl = $this->integration->getQueryUrl();
-                $results  = $this->request(
-                    'composite/tree/'.$mActivityObjectName,
-                    $activityData,
-                    'POST',
-                    false,
-                    null,
-                    $queryUrl
-                );
+                $request              = [];
+                $request['allOrNone'] = 'false';
+                $chunked              = array_chunk($activityData, 25);
+                $results              = [];
+                foreach ($chunked as $chunk) {
+                    // We can only submit 25 at a time
+                    if ($chunk) {
+                        $request['compositeRequest'] = $chunk;
+                        $result                      = $this->syncMauticToSalesforce($request);
+                        $results[]                   = $result;
+                        $this->integration->getLogger()->debug('SALESFORCE: Activity response '.var_export($result, true));
+                    }
+                }
 
                 return $results;
             }

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -835,8 +835,10 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
                         // Extract a list of lead Ids
                         $leadIds = [];
+                        $sfIds   = [];
                         foreach ($salesForceIds as $ids) {
                             $leadIds[] = $ids['internal_entity_id'];
+                            $sfIds[]   = $ids['integration_entity_id'];
                         }
 
                         // Collect lead activity for this batch
@@ -845,6 +847,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
                             $endDate,
                             $leadIds
                         );
+
+                        $this->logger->debug('SALESFORCE: Syncing activity for '.count($leadActivity).' contacts ('.implode(', ', array_keys($leadActivity)).')');
+                        $this->logger->debug('SALESFORCE: Syncing activity for '.var_export($sfIds, true));
 
                         $salesForceLeadData = [];
                         foreach ($salesForceIds as $ids) {
@@ -859,11 +864,15 @@ class SalesforceIntegration extends CrmAbstractIntegration
                                     ['integration' => 'Salesforce', 'leadId' => $leadId],
                                     UrlGeneratorInterface::ABSOLUTE_URL
                                 );
+                            } else {
+                                $this->logger->debug('SALESFORCE: No activity found for contact ID '.$leadId);
                             }
                         }
 
                         if (!empty($salesForceLeadData)) {
                             $apiHelper->createLeadActivity($salesForceLeadData, $object);
+                        } else {
+                            $this->logger->debug('SALESFORCE: No contact activity to sync');
                         }
 
                         // Get the next batch
@@ -1266,15 +1275,11 @@ class SalesforceIntegration extends CrmAbstractIntegration
      */
     public function getCampaigns()
     {
-        $silenceExceptions = (isset($settings['silence_exceptions'])) ? $settings['silence_exceptions'] : true;
         $campaigns         = [];
         try {
             $campaigns = $this->getApiHelper()->getCampaigns();
         } catch (\Exception $e) {
             $this->logIntegrationError($e);
-            if (!$silenceExceptions) {
-                throw $e;
-            }
         }
 
         return $campaigns;
@@ -1470,15 +1475,11 @@ class SalesforceIntegration extends CrmAbstractIntegration
      */
     public function getCampaignMemberStatus($campaignId)
     {
-        $silenceExceptions    = (isset($settings['silence_exceptions'])) ? $settings['silence_exceptions'] : true;
         $campaignMemberStatus = [];
         try {
             $campaignMemberStatus = $this->getApiHelper()->getCampaignMemberStatus($campaignId);
         } catch (\Exception $e) {
             $this->logIntegrationError($e);
-            if (!$silenceExceptions) {
-                throw $e;
-            }
         }
 
         return $campaignMemberStatus;

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -970,10 +970,10 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     if ((int) $row['delta'] > 0) {
                         $subject = 'added';
                     } else {
-                        $subject      = 'subtracted';
+                        $subject = 'subtracted';
                         $row['delta'] *= -1;
                     }
-                    $pointsString                = $translator->transChoice(
+                    $pointsString = $translator->transChoice(
                         "mautic.salesforce.activity.points_{$subject}",
                         $row['delta'],
                         ['%points%' => $row['delta']]
@@ -1277,7 +1277,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
      */
     public function getCampaigns()
     {
-        $campaigns         = [];
+        $campaigns = [];
         try {
             $campaigns = $this->getApiHelper()->getCampaigns();
         } catch (\Exception $e) {

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -931,10 +931,12 @@ class SalesforceIntegration extends CrmAbstractIntegration
         unset($results);
 
         /** @var EmailModel $emailModel */
-        $emailModel = $this->factory->getModel('email');
-        $emailRepo  = $emailModel->getStatRepository();
-        $results    = $emailRepo->getLeadStats(null, $options);
-        $emailStats = [];
+        $emailModel            = $this->factory->getModel('email');
+        $emailRepo             = $emailModel->getStatRepository();
+        $emailOptions          = $options;
+        $emailOptions['state'] = 'read';
+        $results               = $emailRepo->getLeadStats(null, $emailOptions);
+        $emailStats            = [];
         foreach ($results as $result) {
             if (!isset($emailStats[$result['lead_id']])) {
                 $emailStats[$result['lead_id']] = [];
@@ -968,10 +970,10 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     if ((int) $row['delta'] > 0) {
                         $subject = 'added';
                     } else {
-                        $subject = 'subtracted';
+                        $subject      = 'subtracted';
                         $row['delta'] *= -1;
                     }
-                    $pointsString = $translator->transChoice(
+                    $pointsString                = $translator->transChoice(
                         "mautic.salesforce.activity.points_{$subject}",
                         $row['delta'],
                         ['%points%' => $row['delta']]


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The SF activity sync had two issues:

1. The same keys were reused when building the activity to sync to SF which meant that keys were overwritten which meant that not all activity was synced over
2. We were using SF's tree batching which fails the entire request if a single record has an error. This is now converted to use composite so that each individual record is created regardless if another errors. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup SF activity sync
2. Ensure that multiple contacts that have entries in the integration_entity table have submitted a form, was sent an email, or had points changed
3. Run the `mautic:integration:pushactivity` command
4. Search the two Leads in SF. Note that only one has activity and the other does not. 
5. Submit a form as a third contact that has an entry in the integration_entity table.
6. Sync again - if you look at the logs, there will be errors with DUPLICATE_VALUE and the contact will not have activity in SF 

#### Steps to test this PR:
1. Repeat the above - all three contacts should now have activity logged in SF
2. If adding a fourth contact, DUPLICATE_VALUE errors will not prevent the fourth's activity from syncing