### PR TITLE
Displaying company email in the table fixed

### DIFF
--- a/app/bundles/LeadBundle/Views/Company/list.html.php
+++ b/app/bundles/LeadBundle/Views/Company/list.html.php
@@ -120,7 +120,7 @@ if ($tmpl == 'index') {
                         </div>
                     </td>
                     <td>
-                        <?php if (isset($fields['core']['companyeail'])): ?>
+                        <?php if (isset($fields['core']['companyemail'])): ?>
                         <div class="text-muted mt-4">
                             <small>
                                 <?php echo $fields['core']['companyemail']['value']; ?>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4672
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The company email was not showing in the table of companies even though the company had one because of a typo.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make sure you have a company with an email address.
2. Find it in the table view and see that the email column is empty.

#### Steps to test this PR:
1. Checkout this PR
2. Refresh the table - the email address is in the column.