### PR TITLE
Forms autofill improvements

### DIFF
--- a/app/bundles/FormBundle/Entity/Field.php
+++ b/app/bundles/FormBundle/Entity/Field.php
@@ -843,11 +843,6 @@ class Field
 
         if ($this->showWhenValueExists === false) {
 
-            // Hide the field if the value is already known from the lead profile
-            if ($lead !== null && $this->leadField && !empty($lead->getFieldValue($this->leadField))) {
-                return false;
-            }
-
             // Hide the field if there is the value condition and if we already know the value for this field
             if ($submissions) {
                 foreach ($submissions as $submission) {
@@ -855,6 +850,11 @@ class Field
                         return false;
                     }
                 }
+            }
+
+            // Hide the field if the value is already known from the lead profile
+            if ($lead !== null && $this->leadField && !empty($lead->getFieldValue($this->leadField))) {
+                return false;
             }
         }
 

--- a/app/bundles/FormBundle/Entity/Field.php
+++ b/app/bundles/FormBundle/Entity/Field.php
@@ -843,6 +843,11 @@ class Field
 
         if ($this->showWhenValueExists === false) {
 
+            // Hide the field if the value is already known from the lead profile
+            if ($lead !== null && $this->leadField && !empty($lead->getFieldValue($this->leadField))) {
+                return true;
+            }
+
             // Hide the field if there is the value condition and if we already know the value for this field
             if ($submissions) {
                 foreach ($submissions as $submission) {
@@ -850,11 +855,6 @@ class Field
                         return false;
                     }
                 }
-            }
-
-            // Hide the field if the value is already known from the lead profile
-            if ($lead !== null && $this->leadField && !empty($lead->getFieldValue($this->leadField))) {
-                return false;
             }
         }
 

--- a/app/bundles/FormBundle/Entity/Field.php
+++ b/app/bundles/FormBundle/Entity/Field.php
@@ -846,14 +846,14 @@ class Field
             // Hide the field if there is the value condition and if we already know the value for this field
             if ($submissions) {
                 foreach ($submissions as $submission) {
-                    if (!empty($submission[$this->alias])) {
+                    if (!empty($submission[$this->alias]) && !$this->isAutoFill) {
                         return false;
                     }
                 }
             }
 
             // Hide the field if the value is already known from the lead profile
-            if ($lead !== null && $this->leadField && !empty($lead->getFieldValue($this->leadField))) {
+            if ($lead !== null && $this->leadField && !empty($lead->getFieldValue($this->leadField)) && !$this->isAutoFill) {
                 return false;
             }
         }

--- a/app/bundles/FormBundle/Entity/Field.php
+++ b/app/bundles/FormBundle/Entity/Field.php
@@ -845,7 +845,7 @@ class Field
 
             // Hide the field if the value is already known from the lead profile
             if ($lead !== null && $this->leadField && !empty($lead->getFieldValue($this->leadField))) {
-                return true;
+                return false;
             }
 
             // Hide the field if there is the value condition and if we already know the value for this field

--- a/app/bundles/FormBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/PageSubscriber.php
@@ -106,10 +106,6 @@ class PageSubscriber extends CommonSubscriber
                     $formHtml  = preg_replace('#</form>#', $pageInput.'</form>', $formHtml);
 
                     //pouplate get parameters
-                    //priority populate value order by: query string (parameters) -> with lead
-                    if (!$form->getInKioskMode()) {
-                        $this->formModel->populateValuesWithLead($form, $formHtml);
-                    }
                     $this->formModel->populateValuesWithGetParameters($form, $formHtml);
 
                     $content = preg_replace('#{form='.$id.'}#', $formHtml, $content);

--- a/app/bundles/FormBundle/Helper/TokenHelper.php
+++ b/app/bundles/FormBundle/Helper/TokenHelper.php
@@ -65,10 +65,6 @@ class TokenHelper
                         '';
 
                     //pouplate get parameters
-                    //priority populate value order by: query string (parameters) -> with lead
-                    if (!$form->getInKioskMode()) {
-                        $this->formModel->populateValuesWithLead($form, $formHtml);
-                    }
                     $this->formModel->populateValuesWithGetParameters($form, $formHtml);
 
                     $tokens[$token] = $formHtml;

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -411,6 +411,10 @@ class FormModel extends CommonFormModel
             $cachedHtml = $this->generateHtml($form, $useCache);
         }
 
+        if (!$form->getInKioskMode()) {
+            $this->populateValuesWithLead($form, $cachedHtml);
+        }
+
         if ($withScript) {
             $cachedHtml = $this->getFormScript($form)."\n\n".$cachedHtml;
         }
@@ -535,7 +539,6 @@ class FormModel extends CommonFormModel
                 'inBuilder'     => false,
             ]
         );
-
         if (!$entity->usesProgressiveProfiling()) {
             $entity->setCachedHtml($html);
 
@@ -785,45 +788,45 @@ class FormModel extends CommonFormModel
     {
         $operatorOptions = [
             '=' => [
-                    'label'       => 'mautic.lead.list.form.operator.equals',
-                    'expr'        => 'eq',
-                    'negate_expr' => 'neq',
-                ],
+                'label'       => 'mautic.lead.list.form.operator.equals',
+                'expr'        => 'eq',
+                'negate_expr' => 'neq',
+            ],
             '!=' => [
-                    'label'       => 'mautic.lead.list.form.operator.notequals',
-                    'expr'        => 'neq',
-                    'negate_expr' => 'eq',
-                ],
+                'label'       => 'mautic.lead.list.form.operator.notequals',
+                'expr'        => 'neq',
+                'negate_expr' => 'eq',
+            ],
             'gt' => [
-                    'label'       => 'mautic.lead.list.form.operator.greaterthan',
-                    'expr'        => 'gt',
-                    'negate_expr' => 'lt',
-                ],
+                'label'       => 'mautic.lead.list.form.operator.greaterthan',
+                'expr'        => 'gt',
+                'negate_expr' => 'lt',
+            ],
             'gte' => [
-                    'label'       => 'mautic.lead.list.form.operator.greaterthanequals',
-                    'expr'        => 'gte',
-                    'negate_expr' => 'lt',
-                ],
+                'label'       => 'mautic.lead.list.form.operator.greaterthanequals',
+                'expr'        => 'gte',
+                'negate_expr' => 'lt',
+            ],
             'lt' => [
-                    'label'       => 'mautic.lead.list.form.operator.lessthan',
-                    'expr'        => 'lt',
-                    'negate_expr' => 'gt',
-                ],
+                'label'       => 'mautic.lead.list.form.operator.lessthan',
+                'expr'        => 'lt',
+                'negate_expr' => 'gt',
+            ],
             'lte' => [
-                    'label'       => 'mautic.lead.list.form.operator.lessthanequals',
-                    'expr'        => 'lte',
-                    'negate_expr' => 'gt',
-                ],
+                'label'       => 'mautic.lead.list.form.operator.lessthanequals',
+                'expr'        => 'lte',
+                'negate_expr' => 'gt',
+            ],
             'like' => [
-                    'label'       => 'mautic.lead.list.form.operator.islike',
-                    'expr'        => 'like',
-                    'negate_expr' => 'notLike',
-                ],
+                'label'       => 'mautic.lead.list.form.operator.islike',
+                'expr'        => 'like',
+                'negate_expr' => 'notLike',
+            ],
             '!like' => [
-                    'label'       => 'mautic.lead.list.form.operator.isnotlike',
-                    'expr'        => 'notLike',
-                    'negate_expr' => 'like',
-                ],
+                'label'       => 'mautic.lead.list.form.operator.isnotlike',
+                'expr'        => 'notLike',
+                'negate_expr' => 'like',
+            ],
         ];
 
         return ($operator === null) ? $operatorOptions : $operatorOptions[$operator];

--- a/app/bundles/FormBundle/Views/Builder/form.html.php
+++ b/app/bundles/FormBundle/Views/Builder/form.html.php
@@ -39,7 +39,14 @@ if (!isset($inBuilder)) {
                     echo "\n          <div class=\"mauticform-page-wrapper mauticform-page-$pageCount\" data-mautic-form-page=\"$pageCount\"$lastFieldAttribute>\n";
                 endif;
 
-                if ($f->showForContact($submissions, $lead, $form)):
+                // hidden field with autofill
+                $forceHidden = false;
+                if (!$f->getShowWhenValueExists() && $f->getLeadField() && $f->getIsAutoFill()) {
+                    $forceHidden = true;
+                    $f->setType('hidden');
+                }
+
+                if ($f->showForContact($submissions, $lead, $form) || $forceHidden):
                     if ($f->isCustom()):
                         if (!isset($fieldSettings[$f->getType()])):
                             continue;
@@ -49,9 +56,6 @@ if (!isset($inBuilder)) {
 
                         $template = $params['template'];
                     else:
-                        if (!$f->getShowWhenValueExists() && $f->getLeadField() && $f->getIsAutoFill()) {
-                            $f->setType('hidden');
-                        }
                         $template = 'MauticFormBundle:Field:'.$f->getType().'.html.php';
                     endif;
 

--- a/app/bundles/FormBundle/Views/Builder/form.html.php
+++ b/app/bundles/FormBundle/Views/Builder/form.html.php
@@ -38,15 +38,7 @@ if (!isset($inBuilder)) {
                     $lastFieldAttribute = ($lastFormPage === $fieldId) ? ' data-mautic-form-pagebreak-lastpage="true"' : '';
                     echo "\n          <div class=\"mauticform-page-wrapper mauticform-page-$pageCount\" data-mautic-form-page=\"$pageCount\"$lastFieldAttribute>\n";
                 endif;
-
-                // hidden field with autofill
-                $forceHidden = false;
-                if (!$f->getShowWhenValueExists() && $f->getLeadField() && $f->getIsAutoFill()) {
-                    $forceHidden = true;
-                    $f->setType('hidden');
-                }
-
-                if ($f->showForContact($submissions, $lead, $form) || $forceHidden):
+                if ($f->showForContact($submissions, $lead, $form)):
                     if ($f->isCustom()):
                         if (!isset($fieldSettings[$f->getType()])):
                             continue;
@@ -56,6 +48,9 @@ if (!isset($inBuilder)) {
 
                         $template = $params['template'];
                     else:
+                        if (!$f->getShowWhenValueExists() && $f->getLeadField() && $f->getIsAutoFill() && $lead && !empty($lead->getFieldValue($f->getLeadField()))) {
+                            $f->setType('hidden');
+                        }
                         $template = 'MauticFormBundle:Field:'.$f->getType().'.html.php';
                     endif;
 

--- a/app/bundles/FormBundle/Views/Builder/form.html.php
+++ b/app/bundles/FormBundle/Views/Builder/form.html.php
@@ -49,6 +49,9 @@ if (!isset($inBuilder)) {
 
                         $template = $params['template'];
                     else:
+                        if (!$f->getShowWhenValueExists() && $f->getLeadField() && $f->getIsAutoFill()) {
+                            $f->setType('hidden');
+                        }
                         $template = 'MauticFormBundle:Field:'.$f->getType().'.html.php';
                     endif;
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4047
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
I noticed some issues with forms and progressing profiling. 
This PR try improve it.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

**Autofill on external webpage**

1. Create form with autofill field and paste JS embed script to your website
2. Form field is not fill

**Hidden field with autofill should be really hidden**
1. Create form with autofill and disable show value if exists.
2. Add form action - Send email to contact with email and `{formfield}` tokens
3. Send form and see email and form results
4. Hidden fields are not replaced in emails and empty in results table even if we know contacts info. 
This confused of inexperienced users

#### Steps to test this PR:
1.  Apply PR and test both  `step to tests` 

**Autofill on external webpage**
Works if autofill works on external page.

**Hidden field with autofill should be really hidden**
Works if hidden field are really hidden in form and send values from contact profile.