### PR TITLE
Memory consumption improvements on contact save (import)

### DIFF
--- a/app/bundles/LeadBundle/Entity/CustomFieldEntityInterface.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldEntityInterface.php
@@ -63,6 +63,16 @@ interface CustomFieldEntityInterface
     public function getFieldValue($field, $group = null);
 
     /**
+     * Get field details.
+     *
+     * @param string $key
+     * @param string $group
+     *
+     * @return array|false
+     */
+    public function getField($key, $group = null);
+
+    /**
      * Get flat array of profile fields without groups.
      *
      * @return mixed

--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -12,6 +12,7 @@
 namespace Mautic\LeadBundle\Entity;
 
 use Doctrine\DBAL\Query\QueryBuilder;
+use Mautic\LeadBundle\Helper\CustomFieldHelper;
 
 /**
  * Class CustomFieldRepositoryTrait.
@@ -307,6 +308,8 @@ trait CustomFieldRepositoryTrait
 
         //loop over results to put fields in something that can be assigned to the entities
         foreach ($values as $k => $r) {
+            $r = CustomFieldHelper::fixValueType($fields[$k]['type'], $r);
+
             if (isset($fields[$k])) {
                 if (!is_null($r)) {
                     switch ($fields[$k]['type']) {

--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -87,7 +87,7 @@ class LeadSubscriber extends CommonSubscriber
                 return;
             }
 
-            $check = base64_encode($lead->getId().serialize($details));
+            $check = base64_encode($lead->getId().md5(json_encode($details)));
             if (!in_array($check, $preventLoop)) {
                 $preventLoop[] = $check;
 

--- a/app/bundles/LeadBundle/Helper/CustomFieldHelper.php
+++ b/app/bundles/LeadBundle/Helper/CustomFieldHelper.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Helper;
+
+/**
+ * Helper class custom field operations.
+ */
+class CustomFieldHelper
+{
+    const TYPE_BOOLEAN = 'boolean';
+    const TYPE_NUMBER  = 'number';
+    const TYPE_SELECT  = 'select';
+
+    /**
+     * Fixes value type for specific field types.
+     *
+     * @param string $type
+     * @param mixed  $value
+     *
+     * @return mixed
+     */
+    public static function fixValueType($type, $value)
+    {
+        if (!is_null($value)) {
+            switch ($type) {
+                case self::TYPE_NUMBER:
+                    $value = (float) $value;
+                    break;
+                case self::TYPE_BOOLEAN:
+                    $value = (bool) $value;
+                    break;
+                case self::TYPE_SELECT:
+                    $value = (string) $value;
+                    break;
+            }
+        }
+
+        return $value;
+    }
+}

--- a/app/bundles/LeadBundle/Tests/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/LeadSubscriberTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\EventListener;
+
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\CoreBundle\Tests\CommonMocks;
+use Mautic\LeadBundle\Entity\lead;
+use Mautic\LeadBundle\Event\LeadEvent;
+use Mautic\LeadBundle\EventListener\LeadSubscriber;
+
+class LeadSubscriberTest extends CommonMocks
+{
+    public function testOnLeadPostSaveWillNotProcessTheSameLeadTwice()
+    {
+        $lead = new Lead();
+
+        $lead->setId(54);
+
+        $changes = [
+            'title' => [
+                '0' => 'sdf',
+                '1' => 'Mr.',
+            ],
+            'fields' => [
+                'firstname' => [
+                    '0' => 'Test',
+                    '1' => 'John',
+                ],
+                'lastname' => [
+                    '0' => 'test',
+                    '1' => 'Doe',
+                ],
+                'email' => [
+                    '0' => 'zrosa91@gmail.com',
+                    '1' => 'john@gmail.com',
+                ],
+                'mobile' => [
+                    '0' => '345345',
+                    '1' => '555555555',
+                ],
+            ],
+            'dateModified' => [
+                '0' => '2017-08-21T15:50:57+00:00',
+                '1' => '2017-08-22T08:04:31+00:00',
+            ],
+            'dateLastActive' => [
+                '0' => '2017-08-21T15:50:57+00:00',
+                '1' => '2017-08-22T08:04:31+00:00',
+            ],
+        ];
+
+        $ipLookupHelper = $this->getMockBuilder(IpLookupHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $auditLogModel = $this->getMockBuilder(AuditLogModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // This method will be called exactly once
+        // even though the onLeadPostSave was called twice for the same lead
+        $auditLogModel->expects($this->once())
+            ->method('writeToLog');
+
+        $subscriber = new LeadSubscriber($ipLookupHelper, $auditLogModel);
+
+        $leadEvent = $this->getMockBuilder(LeadEvent::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $leadEvent->expects($this->exactly(2))
+            ->method('getLead')
+            ->will($this->returnValue($lead));
+
+        $leadEvent->expects($this->exactly(2))
+            ->method('getChanges')
+            ->will($this->returnValue($changes));
+
+        $subscriber->onLeadPostSave($leadEvent);
+        $subscriber->onLeadPostSave($leadEvent);
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Helper/CustomFieldHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/CustomFieldHelperTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Helper;
+
+use Mautic\LeadBundle\Helper\CustomFieldHelper;
+
+class CustomFieldHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFixValueTypeForBooleans()
+    {
+        $this->assertNull(CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_BOOLEAN, null));
+        $this->assertTrue(CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_BOOLEAN, 1));
+        $this->assertTrue(CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_BOOLEAN, true));
+        $this->assertTrue(CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_BOOLEAN, '1'));
+        $this->assertFalse(CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_BOOLEAN, '0'));
+        $this->assertFalse(CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_BOOLEAN, ''));
+        $this->assertFalse(CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_BOOLEAN, false));
+        $this->assertFalse(CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_BOOLEAN, 0));
+    }
+
+    public function testFixValueTypeForNumbers()
+    {
+        $this->assertNull(CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_NUMBER, null));
+        $this->assertEquals(1, CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_NUMBER, 1));
+        $this->assertEquals(1, CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_NUMBER, true));
+        $this->assertEquals(0, CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_NUMBER, false));
+        $this->assertEquals(5, CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_NUMBER, '5'));
+        $this->assertEquals(0, CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_NUMBER, ''));
+        $this->assertEquals(0, CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_NUMBER, '0'));
+    }
+
+    public function testFixValueTypeForSelect()
+    {
+        $this->assertNull(CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_SELECT, null));
+        $this->assertEquals('1', CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_SELECT, true));
+        $this->assertEquals('', CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_SELECT, false));
+        $this->assertEquals('1', CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_SELECT, 1));
+        $this->assertEquals('1', CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_SELECT, '1'));
+        $this->assertEquals('one', CustomFieldHelper::fixValueType(CustomFieldHelper::TYPE_SELECT, 'one'));
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2605
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
While looking into this error reported in the linked issue:
```
php /var/www/app/console mautic:import
Import 13 with 40060 is rows starting.
 18194/40060 [============>---------------]  45%PHP Fatal error:  Allowed memory size of 536870912 bytes exhausted (tried to allocate 72 bytes) in /var/www/app/bundles/LeadBundle/EventListener/LeadSubscriber.php on line 90
```
I dumped what hash is being generated in the `$check` variable. One hash can have kilobytes. This way the `$preventLoop` array can grow into megabytes on contact import. I changed the hash generation to be much smaller but still unique.

Another issue I found when debugging was that if the contact contain some boolean, number or select fields, it will **always** have some changes in the changes array. Only because the value type doesn't match. For example `0` !== `false` for booleans. So I added value type fixing before comparing the values.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make sure you have some boolean, number and select custom fields. The custom fields should have numerical options to see the issue.
2. Go to LeadSubscriber in the LeadBundle and place this debug line on line 82: `echo "<pre>";var_dump($event->getChanges());die("</pre>");`
3. Go to a contact edit form, open the dev tools network tab and hit apply.
4. Open the last ajax response to see the array of changes. You should be able to see that the changes array contains changes even though you didn't change anything.

#### Steps to test this PR:
1. Checkout this PR
2. Test again. The changes array should contain only the modification date this time. That's correct.
3. The memory consumption required to save a contact should be smaller than before.