### PR TITLE
Setting from name and email when sending email from contact detail page via Sparkpost fixed

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -594,7 +594,10 @@ class MailHelper
                 foreach ($this->metadata as $fromKey => $metadatum) {
                     $this->errors = [];
 
-                    if ($useOwnerAsMailer && 'default' !== $fromKey) {
+                    if ($from = $this->message->getFrom()) {
+                        // The from email and name were set directly for the message
+                        $this->setFrom($from);
+                    } elseif ($useOwnerAsMailer && 'default' !== $fromKey) {
                         $this->setFrom($metadatum['from']['email'], $metadatum['from']['first_name'].' '.$metadatum['from']['last_name']);
                     } else {
                         $this->setFrom($this->from);

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -339,13 +339,13 @@ class MailHelper
         if (!$isQueueFlush) {
             if ($useOwnerAsMailer) {
                 if ($owner = $this->getContactOwner($this->lead)) {
-                    $this->setFrom($owner['email'], $owner['first_name'].' '.$owner['last_name']);
+                    $this->setFrom($owner['email'], $owner['first_name'].' '.$owner['last_name'], false);
                     $ownerSignature = $this->getContactOwnerSignature($owner);
                 } else {
-                    $this->setFrom($this->from);
+                    $this->setFrom($this->from, null, false);
                 }
             } elseif (!$from = $this->message->getFrom()) {
-                $this->setFrom($this->from);
+                $this->setFrom($this->from, null, false);
             }
         } // from is set in flushQueue
 
@@ -602,9 +602,9 @@ class MailHelper
                     $this->errors = [];
 
                     if (!$this->useGlobalFrom && $useOwnerAsMailer && 'default' !== $fromKey) {
-                        $this->setFrom($metadatum['from']['email'], $metadatum['from']['first_name'].' '.$metadatum['from']['last_name']);
+                        $this->setFrom($metadatum['from']['email'], $metadatum['from']['first_name'].' '.$metadatum['from']['last_name'], false);
                     } else {
-                        $this->setFrom($this->from);
+                        $this->setFrom($this->from, null, false);
                     }
 
                     foreach ($metadatum['contacts'] as $email => $contact) {
@@ -1237,16 +1237,19 @@ class MailHelper
     /**
      * Set from email address and name (defaults to system unles isGlobal is true).
      *
-     * @param string $fromEmail
-     * @param string $fromName
-     * @param bool   $isGlobal
+     * @param string|array $fromEmail
+     * @param string       $fromName
+     * @param bool         $isGlobal
      */
-    public function setFrom($fromEmail, $fromName = null, $isGlobal = false)
+    public function setFrom($fromEmail, $fromName = null, $isGlobal = true)
     {
-        if ($isGlobal) {
-            $this->from          = [$fromEmail => $fromName];
-            $this->useGlobalFrom = true;
+        if (is_array($fromEmail)) {
+            $this->from = $fromEmail;
+        } else {
+            $this->from = [$fromEmail => $fromName];
         }
+
+        $this->useGlobalFrom = $isGlobal;
 
         try {
             $fromName = $this->cleanName($fromName);
@@ -1391,7 +1394,7 @@ class MailHelper
                 $fromEmail = key($this->from);
             }
 
-            $this->setFrom($fromEmail, $fromName);
+            $this->setFrom($fromEmail, $fromName, false);
             $this->from = [$fromEmail => $fromName];
         } else {
             $this->from = $this->systemFrom;

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1243,15 +1243,18 @@ class MailHelper
      */
     public function setFrom($fromEmail, $fromName = null, $isGlobal = true)
     {
-        if ($isGlobal) {
-            if (is_array($fromEmail)) {
-                $this->from = $fromEmail;
-            } else {
-                $this->from = [$fromEmail => $fromName];
-            }
-        }
-
         if (null !== $isGlobal) {
+            if ($isGlobal) {
+                if (is_array($fromEmail)) {
+                    $this->from = $fromEmail;
+                } else {
+                    $this->from = [$fromEmail => $fromName];
+                }
+            } else {
+                // Reset the default to the system from
+                $this->from = $this->systemFrom;
+            }
+
             $this->useGlobalFrom = $isGlobal;
         }
 

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1235,7 +1235,7 @@ class MailHelper
     }
 
     /**
-     * Set from email address and name (defaults to system unles isGlobal is true).
+     * Set from email address and name (defaults to determining automatically unless isGlobal is true).
      *
      * @param string|array $fromEmail
      * @param string       $fromName
@@ -1243,13 +1243,15 @@ class MailHelper
      */
     public function setFrom($fromEmail, $fromName = null, $isGlobal = true)
     {
-        if (is_array($fromEmail)) {
-            $this->from = $fromEmail;
-        } else {
-            $this->from = [$fromEmail => $fromName];
-        }
+        if ($isGlobal) {
+            if (is_array($fromEmail)) {
+                $this->from = $fromEmail;
+            } else {
+                $this->from = [$fromEmail => $fromName];
+            }
 
-        $this->useGlobalFrom = $isGlobal;
+            $this->useGlobalFrom = $isGlobal;
+        }
 
         try {
             $fromName = $this->cleanName($fromName);

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -339,13 +339,13 @@ class MailHelper
         if (!$isQueueFlush) {
             if ($useOwnerAsMailer) {
                 if ($owner = $this->getContactOwner($this->lead)) {
-                    $this->setFrom($owner['email'], $owner['first_name'].' '.$owner['last_name'], false);
+                    $this->setFrom($owner['email'], $owner['first_name'].' '.$owner['last_name'], null);
                     $ownerSignature = $this->getContactOwnerSignature($owner);
                 } else {
-                    $this->setFrom($this->from, null, false);
+                    $this->setFrom($this->from, null, null);
                 }
             } elseif (!$from = $this->message->getFrom()) {
-                $this->setFrom($this->from, null, false);
+                $this->setFrom($this->from, null, null);
             }
         } // from is set in flushQueue
 
@@ -602,9 +602,9 @@ class MailHelper
                     $this->errors = [];
 
                     if (!$this->useGlobalFrom && $useOwnerAsMailer && 'default' !== $fromKey) {
-                        $this->setFrom($metadatum['from']['email'], $metadatum['from']['first_name'].' '.$metadatum['from']['last_name'], false);
+                        $this->setFrom($metadatum['from']['email'], $metadatum['from']['first_name'].' '.$metadatum['from']['last_name'], null);
                     } else {
-                        $this->setFrom($this->from, null, false);
+                        $this->setFrom($this->from, null, null);
                     }
 
                     foreach ($metadatum['contacts'] as $email => $contact) {
@@ -1239,7 +1239,7 @@ class MailHelper
      *
      * @param string|array $fromEmail
      * @param string       $fromName
-     * @param bool         $isGlobal
+     * @param bool|null    $isGlobal
      */
     public function setFrom($fromEmail, $fromName = null, $isGlobal = true)
     {
@@ -1249,7 +1249,9 @@ class MailHelper
             } else {
                 $this->from = [$fromEmail => $fromName];
             }
+        }
 
+        if (null !== $isGlobal) {
             $this->useGlobalFrom = $isGlobal;
         }
 
@@ -1396,7 +1398,7 @@ class MailHelper
                 $fromEmail = key($this->from);
             }
 
-            $this->setFrom($fromEmail, $fromName, false);
+            $this->setFrom($fromEmail, $fromName, null);
             $this->from = [$fromEmail => $fromName];
         } else {
             $this->from = $this->systemFrom;

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -249,6 +249,34 @@ class MailHelperTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testGlobalFromThatAllFromAddressesAreTheSame()
+    {
+        $mockFactory = $this->getMockFactory();
+
+        $transport   = new BatchTransport();
+        $swiftMailer = new \Swift_Mailer($transport);
+
+        $mailer = new MailHelper($mockFactory, $swiftMailer, ['nobody@nowhere.com' => 'No Body']);
+        $mailer->enableQueue();
+
+        $mailer->setSubject('Hello');
+        $mailer->setFrom('override@owner.com');
+
+        foreach ($this->contacts as $contact) {
+            $mailer->addTo($contact['email']);
+            $mailer->setLead($contact);
+            $mailer->queue();
+        }
+
+        $mailer->flushQueue();
+
+        $this->assertEmpty($mailer->getErrors()['failures']);
+
+        $fromAddresses = $transport->getFromAddresses();;
+
+        $this->assertEquals(['override@owner.com'], array_unique($fromAddresses));
+    }
+
     public function testStandardOwnerAsMailer()
     {
         $mockFactory = $this->getMockFactory();

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -212,7 +212,7 @@ class MailHelperTest extends \PHPUnit_Framework_TestCase
             $mailer->queue();
         }
 
-        $mailer->flushQueue();
+        $mailer->flushQueue([]);
 
         $this->assertEmpty($mailer->getErrors()['failures']);
 
@@ -247,6 +247,9 @@ class MailHelperTest extends \PHPUnit_Framework_TestCase
                 }
             }
         }
+
+        // Validate that the message object only has the contacts for the last "from" group to ensure we aren't sending duplicates
+        $this->assertEquals(['contact3@somewhere.com' => null], $mailer->message->getTo());
     }
 
     public function testGlobalFromThatAllFromAddressesAreTheSame()

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -272,7 +272,7 @@ class MailHelperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEmpty($mailer->getErrors()['failures']);
 
-        $fromAddresses = $transport->getFromAddresses();;
+        $fromAddresses = $transport->getFromAddresses();
 
         $this->assertEquals(['override@owner.com'], array_unique($fromAddresses));
     }

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1320,7 +1320,8 @@ class LeadController extends FormController
 
                         $mailer->setFrom(
                             $email['from'],
-                            empty($email['fromname']) ? '' : $email['fromname']
+                            empty($email['fromname']) ? null : $email['fromname'],
+                            true
                         );
 
                         // Set Content

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1320,8 +1320,7 @@ class LeadController extends FormController
 
                         $mailer->setFrom(
                             $email['from'],
-                            empty($email['fromname']) ? null : $email['fromname'],
-                            true
+                            empty($email['fromname']) ? null : $email['fromname']
                         );
 
                         // Set Content


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Tokenized transports like Sparkpost were sending emails only from the global From Email and Name even if defined different in the direct email from the contact detail page.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Use Sparkpost transport
2. Go to a contact detail with your email address
3. Open the Send Email modal
4. Edit the From Name and From Email to something different than what's filled in them.
5. Send the email - you should see that From Name and From Email of the received email are still the default ones.

Test 2:
1. Enabled mail as owner in configuration
2. Have at least two contacts in a segment with only one of them set with an owner
3. Assign the email to a segment and send it
4. You will get two copies of the email per contact

#### Steps to test this PR:
1. Checkout this PR
2. Test again - the From Name and From Email should be as you configured it.
3. Make sure other email sending like from campaign or segment have the correct From Email and Name.

Test 2:
1. Repeat test 2 above and only one copy email per contact should be received
