### PR TITLE
others permission fixed to viewother

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -420,7 +420,7 @@ class LeadApiController extends CommonApiController
     public function getAllActivityAction($lead = null)
     {
         $canViewOwn    = $this->security->isGranted('lead:leads:viewown');
-        $canViewOthers = $this->security->isGranted('lead:leads:others');
+        $canViewOthers = $this->security->isGranted('lead:leads:viewother');
 
         if (!$canViewOthers && !$canViewOwn) {
             return $this->accessDenied();


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Preventing error
`Mautic\CoreBundle\Security\Exception\PermissionNotFoundException: Permission not found. 'lead:leads:others'`

when accessing the new `api/contacts/activity` with user having restricted permissions.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create role with all *own permissions on contact
2. Create new user with that permission
3. Try to fetch activity events from `api/contacts/activity` - you should get the error.

#### Steps to test this PR:
1. Checkout this PR
2. Try to fetch again - you'll get the correct response.