### PR TITLE
Bugfix for empty integrations tab error

### DIFF
--- a/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
+++ b/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
@@ -434,7 +434,9 @@ class IntegrationEntityRepository extends CommonRepository
             $plugins = array_map(function ($i) {
                 return "'${i['name']}'";
             }, $rows);
-            $q->andWhere($q->expr()->in('i.integration', $plugins));
+            if (count($plugins) > 0) {
+                $q->andWhere($q->expr()->in('i.integration', $plugins));
+            }
         } else {
             $q->andWhere($q->expr()->eq('i.integration', ':integration'));
             $q->setParameter('integration', $integration);

--- a/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
+++ b/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
@@ -436,6 +436,8 @@ class IntegrationEntityRepository extends CommonRepository
             }, $rows);
             if (count($plugins) > 0) {
                 $q->andWhere($q->expr()->in('i.integration', $plugins));
+            } else {
+                return [];
             }
         } else {
             $q->andWhere($q->expr()->eq('i.integration', ':integration'));


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes an issue with the new integrations tab (#4426). It shows a 500 internal server error when there are no integrations enabled.

#### Steps to reproduce the bug:
1. Disable all integrations
2. Try to view any contact details
3. An error will be thrown

#### Steps to test this PR:
1. Apply this PR
2. Try to reproduce the bug
3. There will be no error and the integrations tab will be empty.

