### PR TITLE
Fixed timeline for citrix events from changes made for activity api endpoint

### DIFF
--- a/plugins/MauticCitrixBundle/Entity/CitrixEventRepository.php
+++ b/plugins/MauticCitrixBundle/Entity/CitrixEventRepository.php
@@ -62,6 +62,11 @@ class CitrixEventRepository extends CommonRepository
      */
     public function getEventsForTimeline($product, $leadId = null, array $options = [])
     {
+        $eventType = null;
+        if (is_array($product)) {
+            list($product, $eventType) = $product;
+        }
+
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->from(MAUTIC_TABLE_PREFIX.'plugin_citrix_events', 'c')
             ->select('c.*');
@@ -70,6 +75,13 @@ class CitrixEventRepository extends CommonRepository
             $query->expr()->eq('c.product', ':product')
         )
             ->setParameter('product', $product);
+
+        if ($eventType) {
+            $query->andWhere(
+                $query->expr()->eq('c.event_type', ':type')
+            )
+                ->setParameter('type', $eventType);
+        }
 
         if ($leadId) {
             $query->andWhere('c.lead_id = '.(int) $leadId);

--- a/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
+++ b/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
@@ -101,7 +101,6 @@ class LeadSubscriber extends CommonSubscriber
                     $event->getQueryOptions()
                 );
 
-
                 // Add total number to counter
                 $event->addToCounter($eventType, $citrixEvents);
 
@@ -119,12 +118,12 @@ class LeadSubscriber extends CommonSubscriber
 
                             $event->addEvent(
                                 [
-                                    'event'           => $eventType,
-                                    'eventId'         => $eventType.$citrixEvent['id'],
-                                    'eventLabel'      => $eventTypeName.' - '.$entity->getEventDesc(),
-                                    'eventType'       => $eventTypeLabel,
-                                    'timestamp'       => $entity->getEventDate(),
-                                    'extra'           => [
+                                    'event'      => $eventType,
+                                    'eventId'    => $eventType.$citrixEvent['id'],
+                                    'eventLabel' => $eventTypeName.' - '.$entity->getEventDesc(),
+                                    'eventType'  => $eventTypeLabel,
+                                    'timestamp'  => $entity->getEventDate(),
+                                    'extra'      => [
                                         'eventName' => $entity->getEventNameOnly(),
                                         'eventId'   => $entity->getEventId(),
                                         'eventDesc' => $entity->getEventDesc(),

--- a/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
+++ b/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
@@ -85,71 +85,58 @@ class LeadSubscriber extends CommonSubscriber
         }
 
         foreach ($activeProducts as $product) {
-            $eventTypeRegistered      = $product.'.registered';
-            $eventTypeRegisteredLabel = $this->translator->trans('plugin.citrix.timeline.event.'.$product.'.registered');
-            $eventTypeRegisteredName  = $this->translator->trans('plugin.citrix.timeline.'.$product.'.registered');
-            $event->addEventType($eventTypeRegistered, $eventTypeRegisteredName);
+            foreach ([CitrixEventTypes::REGISTERED, CitrixEventTypes::ATTENDED] as $type) {
+                $eventType = $product.'.'.$type;
+                if (!$event->isApplicable($eventType)) {
+                    continue;
+                }
 
-            $eventTypeAttended      = $product.'.attended';
-            $eventTypeAttendedLabel = $this->translator->trans('plugin.citrix.timeline.event.'.$product.'.attended');
-            $eventTypeAttendedName  = $this->translator->trans('plugin.citrix.timeline.'.$product.'.attended');
-            $event->addEventType($eventTypeAttended, $eventTypeAttendedName);
+                $eventTypeLabel = $this->translator->trans('plugin.citrix.timeline.event.'.$product.'.'.$type);
+                $eventTypeName  = $this->translator->trans('plugin.citrix.timeline.'.$product.'.'.$type);
+                $event->addEventType($eventType, $eventTypeName);
 
-            $isApplicable = [
-                CitrixEventTypes::REGISTERED => $event->isApplicable($eventTypeRegistered),
-                CitrixEventTypes::ATTENDED   => $event->isApplicable($eventTypeAttended),
-            ];
+                $citrixEvents = $this->model->getRepository()->getEventsForTimeline(
+                    [$product, $type],
+                    $event->getLeadId(),
+                    $event->getQueryOptions()
+                );
 
-            $citrixEvents = $this->model->getRepository()->getEventsForTimeline($product, $event->getLeadId(), $event->getQueryOptions());
 
-            if ($citrixEvents['total']) {
-                // Use a single entity class to help parse the name, description, etc without hydrating entities for every single event
-                $entity = new CitrixEvent();
+                // Add total number to counter
+                $event->addToCounter($eventType, $citrixEvents);
 
-                foreach ($citrixEvents['results'] as $citrixEvent) {
-                    $entity->setProduct($citrixEvent['product'])
-                        ->setEventName($citrixEvent['event_name'])
-                        ->setEventDesc($citrixEvent['event_desc'])
-                        ->setEventType($citrixEvent['event_type'])
-                        ->setEventDate($citrixEvent['event_date']);
+                if (!$event->isEngagementCount()) {
+                    if ($citrixEvents['total']) {
+                        // Use a single entity class to help parse the name, description, etc without hydrating entities for every single event
+                        $entity = new CitrixEvent();
 
-                    $eventType = $entity->getEventType();
-                    if ($eventType === CitrixEventTypes::REGISTERED) {
-                        $timelineEventType      = $eventTypeRegistered;
-                        $timelineEventTypeLabel = $eventTypeRegisteredLabel;
-                        $timelineEventLabel     = $eventTypeRegisteredName.' - '.$entity->getEventDesc();
-                    } else {
-                        if ($eventType === CitrixEventTypes::ATTENDED) {
-                            $timelineEventType      = $eventTypeAttended;
-                            $timelineEventTypeLabel = $eventTypeAttendedLabel;
-                            $timelineEventLabel     = $eventTypeAttendedName.' - '.$entity->getEventDesc();
-                        } else {
-                            continue;
+                        foreach ($citrixEvents['results'] as $citrixEvent) {
+                            $entity->setProduct($citrixEvent['product'])
+                                ->setEventName($citrixEvent['event_name'])
+                                ->setEventDesc($citrixEvent['event_desc'])
+                                ->setEventType($citrixEvent['event_type'])
+                                ->setEventDate($citrixEvent['event_date']);
+
+                            $event->addEvent(
+                                [
+                                    'event'           => $eventType,
+                                    'eventId'         => $eventType.$citrixEvent['id'],
+                                    'eventLabel'      => $eventTypeName.' - '.$entity->getEventDesc(),
+                                    'eventType'       => $eventTypeLabel,
+                                    'timestamp'       => $entity->getEventDate(),
+                                    'extra'           => [
+                                        'eventName' => $entity->getEventNameOnly(),
+                                        'eventId'   => $entity->getEventId(),
+                                        'eventDesc' => $entity->getEventDesc(),
+                                        'joinUrl'   => $entity->getJoinUrl(),
+                                    ],
+                                    'contentTemplate' => 'MauticCitrixBundle:SubscribedEvents\Timeline:citrix_event.html.php',
+                                    'contactId'       => $citrixEvent['lead_id'],
+
+                                ]
+                            );
                         }
                     }
-
-                    if (!$isApplicable[$eventType]) {
-                        continue;
-                    }
-
-                    $event->addEvent(
-                        [
-                            'event'      => $timelineEventType,
-                            'eventId'    => $timelineEventType.$citrixEvent['id'],
-                            'eventLabel' => $timelineEventLabel,
-                            'eventType'  => $timelineEventTypeLabel,
-                            'timestamp'  => $entity->getEventDate(),
-                            'extra'      => [
-                                'eventName' => $entity->getEventNameOnly(),
-                                'eventId'   => $entity->getEventId(),
-                                'eventDesc' => $entity->getEventDesc(),
-                                'joinUrl'   => $entity->getJoinUrl(),
-                            ],
-                            'contentTemplate' => 'MauticCitrixBundle:SubscribedEvents\Timeline:citrix_event.html.php',
-                            'contactId'       => $citrixEvent['lead_id'],
-
-                        ]
-                    );
                 }
             }
         } // foreach $product


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When viewing a contact's timeline that has citrix events, a PHP notice will be displayed due to changes for the activity timeline

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Hack or view a contact's in the plugin_citrix_events table
2. View the contact's timeline
3. Note the notice

#### Steps to test this PR:
1. Repeat and entries will be viewable
