### PR TITLE
Bugfix - Add Base64 encoded images to Sparkpost emails

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
@@ -249,6 +249,17 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
             $content['text'] = $message['text'];
         }
 
+        $encoder = new \Swift_Mime_ContentEncoder_Base64ContentEncoder();
+        foreach ($this->message->getChildren() as $child) {
+            if ($child instanceof \Swift_Image) {
+                $content['inline_images'][] = [
+                    'type' => $child->getContentType(),
+                    'name' => $child->getId(),
+                    'data' => $encoder->encodeString($child->getBody()),
+                ];
+            }
+        }
+
         $sparkPostMessage = [
             'content'    => $content,
             'recipients' => $recipients,


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes an issue with Sparkpost and Base64 encoded images in emails. It is currently not working as it's supposed to.

#### Steps to reproduce the bug:
1. Make sure Sparkpost is enabled as Email transport in the configuration
2. Enable "Convert embed images to Base64" in Configuration/Email Settings

![image](https://user-images.githubusercontent.com/2924026/29783687-98fccaf6-8bde-11e7-8cf6-6e576cdf72d9.png)

2. Send an email with images in it.
3. Check the recipient, the images will be missing in the email.

#### Steps to test this PR:
1. Apply this PR
2. Test sending the email with images again
3. Check the recipient, the images will be included in the email

