### PR TITLE
Contact fields mapping on form submission fix

### DIFF
--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -762,19 +762,19 @@ class SubmissionModel extends CommonFormModel
     /**
      * Create/update lead from form submit.
      *
-     * @param       $form
+     * @param Form  $form
      * @param array $leadFieldMatches
      *
      * @return Lead
      */
-    protected function createLeadFromSubmit($form, array $leadFieldMatches, $leadFields)
+    protected function createLeadFromSubmit(Form $form, array $leadFieldMatches, $leadFields)
     {
         //set the mapped data
         $inKioskMode   = $form->isInKioskMode();
         $leadId        = null;
         $lead          = new Lead();
         $currentFields = $leadFieldMatches;
-        $companyFields = $leadFields = $this->leadFieldModel->getFieldListWithProperties('company');
+        $companyFields = $this->leadFieldModel->getFieldListWithProperties('company');
 
         if (!$inKioskMode) {
             // Default to currently tracked lead


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
There was a bug introduced in https://github.com/mautic/mautic/pull/4660 where the contact field variable was overwritten by contact field variable.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form with email field
2. Submit it
3. View the created contact. It has no email value.

#### Steps to test this PR:
1. Checkout this PR
2. Submit the form again
3. The contact has the email value
