### PR TITLE
Company identify method had several issues

### DIFF
--- a/app/bundles/LeadBundle/Helper/IdentifyCompanyHelper.php
+++ b/app/bundles/LeadBundle/Helper/IdentifyCompanyHelper.php
@@ -74,6 +74,8 @@ class IdentifyCompanyHelper
 
         if (isset($parameters['company'])) {
             $companyName = filter_var($parameters['company']);
+        } elseif (isset($parameters['email']) || isset($parameters['companyemail'])) {
+            $companyName = isset($parameters['email']) ? self::domainExists($parameters['email']) : self::domainExists($parameters['companyemail']);
         } elseif (isset($parameters['companyname'])) {
             $companyName = filter_var($parameters['companyname']);
         }

--- a/app/bundles/LeadBundle/Helper/IdentifyCompanyHelper.php
+++ b/app/bundles/LeadBundle/Helper/IdentifyCompanyHelper.php
@@ -61,22 +61,25 @@ class IdentifyCompanyHelper
     }
 
     /**
-     * @param              $parameters
+     * @param array        $parameters
      * @param CompanyModel $companyModel
      *
      * @return array
      */
-    public static function findCompany($parameters, CompanyModel $companyModel)
+    public static function findCompany(array $parameters, CompanyModel $companyModel)
     {
-        $companyName   = $companyDomain   = null;
+        $companyName   = null;
+        $companyDomain = null;
         $companyEntity = null;
 
         if (isset($parameters['company'])) {
             $companyName = filter_var($parameters['company']);
-        } elseif (isset($parameters['email'])) {
-            $companyName = $companyDomain = self::domainExists($parameters['email']);
         } elseif (isset($parameters['companyname'])) {
             $companyName = filter_var($parameters['companyname']);
+        }
+
+        if (empty($parameters['companywebsite']) && !empty($parameters['companyemail'])) {
+            $companyDomain = self::domainExists($parameters['companyemail']);
         }
 
         if ($companyName) {
@@ -98,13 +101,10 @@ class IdentifyCompanyHelper
                 ]
             );
 
-            $company = [
+            $company = array_merge([
                 'companyname'    => $companyName,
                 'companywebsite' => $companyDomain,
-                'companycity'    => $parameters['companycity'],
-                'companystate'   => $parameters['companystate'],
-                'companycountry' => $parameters['companycountry'],
-            ];
+            ], $parameters);
 
             if (1 === count($companyEntities)) {
                 end($companyEntities);
@@ -119,25 +119,30 @@ class IdentifyCompanyHelper
     }
 
     /**
-     * @param $email
+     * Checks if email address' domain has a DNS MX record. Returns the domain if found.
      *
-     * @return mixed
+     * @param string $email
+     *
+     * @return string|false
      */
-    private static function domainExists($email)
+    protected static function domainExists($email)
     {
         list($user, $domain) = explode('@', $email);
         $arr                 = dns_get_record($domain, DNS_MX);
-        if ($arr[0]['host'] == $domain && !empty($arr[0]['target'])) {
-            return $arr[0]['target'];
+
+        if ($arr && $arr[0]['host'] === $domain) {
+            return $domain;
         }
+
+        return false;
     }
 
     /**
-     * @param $field
-     * @param $parameters
-     * @param $filter
+     * @param string $field
+     * @param array  $parameters
+     * @param array  $filter
      */
-    private static function setCompanyFilter($field, &$parameters, &$filter)
+    private static function setCompanyFilter($field, array &$parameters, array &$filter)
     {
         if (isset($parameters[$field]) || isset($parameters['company'.$field])) {
             if (!isset($parameters['company'.$field])) {

--- a/app/bundles/LeadBundle/Tests/Helper/IdentifyCompanyHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/IdentifyCompanyHelperTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Helper;
+
+use Mautic\LeadBundle\Helper\IdentifyCompanyHelper;
+use Mautic\LeadBundle\Model\CompanyModel;
+
+class IdentifyCompanyHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDomainExistsRealDomain()
+    {
+        $helper     = new IdentifyCompanyHelper();
+        $reflection = new \ReflectionClass(IdentifyCompanyHelper::class);
+        $method     = $reflection->getMethod('domainExists');
+        $method->setAccessible(true);
+        $result = $method->invokeArgs($helper, ['hello@mautic.org']);
+
+        $this->assertTrue(is_string($result));
+        $this->assertGreaterThan(0, strlen($result));
+    }
+
+    public function testDomainExistsWithFakeDomain()
+    {
+        $helper     = new IdentifyCompanyHelper();
+        $reflection = new \ReflectionClass(IdentifyCompanyHelper::class);
+        $method     = $reflection->getMethod('domainExists');
+        $method->setAccessible(true);
+        $result = $method->invokeArgs($helper, ['hello@domain.fake']);
+
+        $this->assertFalse($result);
+    }
+
+    public function testFindCompanyByName()
+    {
+        $company = [
+            'company' => 'Mautic',
+        ];
+
+        $expected = [
+            'company'        => 'Mautic',
+            'companycity'    => '',
+            'companystate'   => '',
+            'companycountry' => '',
+            'companyname'    => 'Mautic',
+            'companywebsite' => null,
+        ];
+
+        $model = $this->getMockBuilder(CompanyModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $helper     = new IdentifyCompanyHelper();
+        $reflection = new \ReflectionClass(IdentifyCompanyHelper::class);
+        $method     = $reflection->getMethod('findCompany');
+        $method->setAccessible(true);
+        list($resultCompany, $entities) = $method->invokeArgs($helper, [$company, $model]);
+
+        $this->assertEquals($expected, $resultCompany);
+    }
+
+    public function testFindCompanyByNameWithValidEmail()
+    {
+        $company = [
+            'company'      => 'Mautic',
+            'companyemail' => 'hello@mautic.org',
+        ];
+
+        $expected = [
+            'company'        => 'Mautic',
+            'companycity'    => '',
+            'companystate'   => '',
+            'companycountry' => '',
+            'companyname'    => 'Mautic',
+            'companywebsite' => 'mautic.org',
+            'companyemail'   => 'hello@mautic.org',
+        ];
+
+        $model = $this->getMockBuilder(CompanyModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $helper     = new IdentifyCompanyHelper();
+        $reflection = new \ReflectionClass(IdentifyCompanyHelper::class);
+        $method     = $reflection->getMethod('findCompany');
+        $method->setAccessible(true);
+        list($resultCompany, $entities) = $method->invokeArgs($helper, [$company, $model]);
+
+        $this->assertEquals($expected, $resultCompany);
+    }
+
+    public function testFindCompanyByNameWithValidEmailAndCustomWebsite()
+    {
+        $company = [
+            'company'        => 'Mautic',
+            'companyemail'   => 'hello@mautic.org',
+            'companywebsite' => 'https://mautic.org',
+        ];
+
+        $expected = [
+            'company'        => 'Mautic',
+            'companycity'    => '',
+            'companystate'   => '',
+            'companycountry' => '',
+            'companyname'    => 'Mautic',
+            'companywebsite' => 'https://mautic.org',
+            'companyemail'   => 'hello@mautic.org',
+        ];
+
+        $model = $this->getMockBuilder(CompanyModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $helper     = new IdentifyCompanyHelper();
+        $reflection = new \ReflectionClass(IdentifyCompanyHelper::class);
+        $method     = $reflection->getMethod('findCompany');
+        $method->setAccessible(true);
+        list($resultCompany, $entities) = $method->invokeArgs($helper, [$company, $model]);
+
+        $this->assertEquals($expected, $resultCompany);
+    }
+}


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
I was debugging why companyemail value goes missing on form submission and found several issues in `IdentifyCompanyHelper` along the way:

1. `companyemail` wasn't expected. `email` was expected instead. But even when that was changed, `companyemail` wasn't added to the result `$company` array of the `findCompany` method. As well as any other custom/field which wasn't documented in that method. I changed the method to return all params, not just selected ones.

2. MX check threw PHP error on fake email address. The `domainExist` method returned `target` which is for example `alt4.aspmx.l.google.com` for `mautic.org` and it was assigning it to companyname and companywebsite for some reason. Fixed it to assign the domain from email address if has a MX record and if the companywebsite is not defined to companywebsite.

I find the whole helper a bit cumbersome. For example if there is exactly 1 company found in the database, its ID is added to the resulted array. But I don't want to break BC if I try to change it.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. create new standalone form that takes company name and company email
2. link the fields to company name and company email
3. go to form preview and fill in the form
4. new contact and company are created but the company email is empty

#### Steps to test this PR:
1. Checkout this PR
2. Submit the form again - company with name and email should be created.