### PR TITLE
Fixed custom content injection to include specific $item in the template vars

### DIFF
--- a/app/bundles/EmailBundle/Views/Email/list.html.php
+++ b/app/bundles/EmailBundle/Views/Email/list.html.php
@@ -70,9 +70,10 @@ if ($tmpl == 'index') {
             <tbody>
             <?php foreach ($items as $item): ?>
                 <?php
-                $hasVariants     = $item->isVariant();
-                $hasTranslations = $item->isTranslation();
-                $type            = $item->getEmailType();
+                $hasVariants                = $item->isVariant();
+                $hasTranslations            = $item->isTranslation();
+                $type                       = $item->getEmailType();
+                $mauticTemplateVars['item'] = $item;
                 ?>
                 <tr>
                     <td>
@@ -160,7 +161,7 @@ if ($tmpl == 'index') {
                         </span>
                     </td>
                     <td class="visible-sm visible-md visible-lg col-stats" data-stats="<?php echo $item->getId(); ?>">
-                        <?php  ?>
+                        <?php echo $view['content']->getCustomContent('email.stats.above', $mauticTemplateVars); ?>
                         <span class="mt-xs label label-default hide has-click-event clickable-stat"
                               id="pending-<?php echo $item->getId(); ?>"
                               data-toggle="tooltip"
@@ -216,6 +217,7 @@ if ($tmpl == 'index') {
                             </a>
                         </span>
                         <?php echo $view['content']->getCustomContent('email.stats', $mauticTemplateVars); ?>
+                        <?php echo $view['content']->getCustomContent('email.stats.below', $mauticTemplateVars); ?>
                     </td>
                     <td class="visible-md visible-lg"><?php echo $item->getId(); ?></td>
                 </tr>


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: 

The custom content event for email.stats did not include the individual $item so the listener could not inject content based on that. This PR fixes this.  It also adds above and below contexts. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Code review as it's a dev change
