### PR TITLE
Bugfix - Dynamic email content variants not working

### DIFF
--- a/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
@@ -238,10 +238,13 @@ class TokenSubscriber extends CommonSubscriber
                     $groups[$groupNum] = !empty($leadVal);
                     break;
                 case 'like':
-                    $groups[$groupNum] = strpos($leadVal, $filterVal) !== false;
+                    $filterVal         = str_replace(['.', '*', '%'], ['\.', '\*', '.*'], $filterVal);
+                    $groups[$groupNum] = preg_match('/'.$filterVal.'/', $leadVal) === 1;
                     break;
                 case '!like':
-                    $groups[$groupNum] = strpos($leadVal, $filterVal) === false;
+                    $filterVal         = str_replace(['.', '*'], ['\.', '\*'], $filterVal);
+                    $filterVal         = str_replace('%', '.*', $filterVal);
+                    $groups[$groupNum] = preg_match('/'.$filterVal.'/', $leadVal) !== 1;
                     break;
                 case 'in':
                     foreach ($leadVal as $k => $v) {


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
When sending an email with a Dynamic Email Content (DEC) slot and with variants in it, they are not working. This PR fixes this issue. It also fixes an issue with the like operator in variants to let users enter the wildcard operator (%).

#### Steps to reproduce the bug:
1. Create a segment or template email
2. Add a DEC slot and add some variants
3. Send the email to the segment (use a campaign if it's a template email)
4. Check the email in one of the recipients that should display the variant.
5. Only the default content will be displayed.

#### Steps to test this PR:
1. Apply this PR
2. Repeat the steps to reproduce the bug
4. Only this time, the variants will work as they suppose to.
