### PR TITLE
Fixed issues with scheduling messages for frequency rules

### DIFF
--- a/app/bundles/ChannelBundle/Model/MessageQueueModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageQueueModel.php
@@ -96,8 +96,8 @@ class MessageQueueModel extends FormModel
 
         /** @var \Mautic\LeadBundle\Entity\FrequencyRuleRepository $frequencyRulesRepo */
         $frequencyRulesRepo     = $this->em->getRepository('MauticLeadBundle:FrequencyRule');
-        $defaultFrequencyNumber = $this->coreParametersHelper->getParameter('email_frequency_number');
-        $defaultFrequencyTime   = $this->coreParametersHelper->getParameter('email_frequency_time');
+        $defaultFrequencyNumber = $this->coreParametersHelper->getParameter($channel.'_frequency_number');
+        $defaultFrequencyTime   = $this->coreParametersHelper->getParameter($channel.'_frequency_time');
 
         $dontSendTo = $frequencyRulesRepo->getAppliedFrequencyRules(
             $channel,

--- a/app/bundles/ChannelBundle/Model/MessageQueueModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageQueueModel.php
@@ -112,7 +112,7 @@ class MessageQueueModel extends FormModel
         $queuedContacts = [];
         if (!empty($dontSendTo)) {
             foreach ($dontSendTo as $frequencyRuleMet) {
-                $scheduleInterval = $frequencyRuleMet['frequency_number'].substr($frequencyRuleMet['frequency_time'], 0, 1);
+                $scheduleInterval = '1'.substr($frequencyRuleMet['frequency_time'], 0, 1);
                 if ($messageQueue && isset($messageQueue[$frequencyRuleMet['lead_id']])) {
                     $this->rescheduleMessage($messageQueue[$frequencyRuleMet['lead_id']], $scheduleInterval);
                 } else {

--- a/app/bundles/EmailBundle/EventListener/MessageQueueSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/MessageQueueSubscriber.php
@@ -68,21 +68,21 @@ class MessageQueueSubscriber extends CommonSubscriber
                 'email_type' => 'marketing',
             ];
 
-            /** @var MessageQueue $message */
-            foreach ($messages as $id => $message) {
-                if ($email && $message->getLead()) {
-                    $contact = $message->getLead()->getProfileFields();
-                    if (empty($contact['email'])) {
-                        // No email so just let this slide
-                        $message->setProcessed();
-                        $message->setSuccess();
-                    }
-                    $sendTo[$contact['id']]            = $contact;
-                    $messagesByContact[$contact['id']] = $message;
-                } else {
-                    $message->setFailed();
+        /** @var MessageQueue $message */
+        foreach ($messages as $id => $message) {
+            if ($email && $message->getLead() && $email->isPublished()) {
+                $contact = $message->getLead()->getProfileFields();
+                if (empty($contact['email'])) {
+                    // No email so just let this slide
+                    $message->setProcessed();
+                    $message->setSuccess();
                 }
+                $sendTo[$contact['id']]            = $contact;
+                $messagesByContact[$contact['id']] = $message;
+            } else {
+                $message->setFailed();
             }
+        }
 
         if (count($sendTo)) {
             $options['resend_message_queue'] = $messagesByContact;

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1192,7 +1192,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         //no one to send to so bail or if marketing email from a campaign has been put in a queue
         if (empty($count)) {
             if ($returnErrorMessages) {
-                return $singleEmail ? $errors[$singleEmail] : $errors;
+                return $singleEmail && isset($errors[$singleEmail]) ? $errors[$singleEmail] : $errors;
             }
 
             return $singleEmail ? true : $errors;

--- a/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
+++ b/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
@@ -71,11 +71,12 @@ class FrequencyRuleRepository extends CommonRepository
 
         $q->groupBy("ch.$statContactColumn, fr.frequency_time, fr.frequency_number");
 
+        $havingWhere = 'WHERE '.$q->expr()->in("ch.$statContactColumn", $leadIds);
         if ($defaultFrequencyNumber != null) {
-            $q->having("(count(ch.$statContactColumn) >= IFNULL(fr.frequency_number,:defaultNumber))")
+            $q->having("(count(ch.$statContactColumn) >= IFNULL(fr.frequency_number,:defaultNumber) $havingWhere)")
                 ->setParameter('defaultNumber', $defaultFrequencyNumber);
         } else {
-            $q->having("(count(ch.$statContactColumn) >= fr.frequency_number)");
+            $q->having("(count(ch.$statContactColumn) >= fr.frequency_number $havingWhere)");
         }
 
         $results = $q->execute()->fetchAll();

--- a/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
+++ b/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
@@ -71,12 +71,12 @@ class FrequencyRuleRepository extends CommonRepository
 
         $q->groupBy("ch.$statContactColumn, fr.frequency_time, fr.frequency_number");
 
-        $havingWhere = 'WHERE '.$q->expr()->in("ch.$statContactColumn", $leadIds);
+        $havingAnd = 'AND '.$q->expr()->in("ch.$statContactColumn", $leadIds);
         if ($defaultFrequencyNumber != null) {
-            $q->having("(count(ch.$statContactColumn) >= IFNULL(fr.frequency_number,:defaultNumber) $havingWhere)")
+            $q->having("(count(ch.$statContactColumn) >= IFNULL(fr.frequency_number,:defaultNumber) $havingAnd)")
                 ->setParameter('defaultNumber', $defaultFrequencyNumber);
         } else {
-            $q->having("(count(ch.$statContactColumn) >= fr.frequency_number $havingWhere)");
+            $q->having("(count(ch.$statContactColumn) >= fr.frequency_number $havingAnd)");
         }
 
         $results = $q->execute()->fetchAll();

--- a/app/bundles/SmsBundle/EventListener/MessageQueueSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/MessageQueueSubscriber.php
@@ -66,7 +66,7 @@ class MessageQueueSubscriber extends CommonSubscriber
 
         /** @var MessageQueue $message */
         foreach ($messages as $id => $message) {
-            if ($sms && $message->getLead()) {
+            if ($sms && $message->getLead() && $sms->isPublished()) {
                 $contact = $message->getLead();
                 $mobile  = $contact->getMobile();
                 $phone   = $contact->getPhone();


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR addresses three issues:

1. It scheduled the message based on the set frequency number. So if the contact is not to receive more than 3 emails per week, the first message over 3 would be scheduled for 3 weeks later instead of the following week. 
2. The SMS message processing used the email frequency default settings
3. Unpublished emails/sms items were still sent when the queued message was processed

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
Bug 1
1. Configure email frequency rules in Configuration to 3  per week
2. Send 3 segment emails (or 3 marketing campaign emails) to a contact
3. Send a fourth email
4. Check the message_queue table for the scheduled_date, it'll be 3 weeks in the future

Bug 2
1. Code review app/bundles/ChannelBundle/Model/MessageQueueModel.php line 99 and 100 as it was hard coded to the email frequency settings. 

Bug 3
1. hack the message_queue table to update the scheduled_date to be in the past
2. Unpublish the email associated with channel_id
3. Delete one of the stats from email_stats table for this contact
3. Note the ID of the queue item and run `php app/console m:m:s -m ID`
4. Note that the email will be sent even though it's unpublished

#### Steps to test this PR:
1. Repeat the above and bug 1 should schedule the email for next week and bug 3 should not process the message (it'll be reinjected as failed until it hits max tries then gives up just in case the unpublished state is temporary)
