### PR TITLE
Bugfix - Apply button in email builder hangs when on a new window

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -91,10 +91,11 @@ Mautic.launchBuilder = function (formName, actionName) {
         Mautic.activateButtonLoadingIndicator(applyBtn);
         Mautic.sendBuilderContentToTextarea(function() {
             Mautic.inBuilderSubmissionOn(form);
-            if ("1" === Mautic.getUrlParameter('contentOnly') || Mautic.isInBuilder) {
+            var bgApplyBtn = mQuery('.btn-apply');
+            if (0 === bgApplyBtn.length && ("1" === Mautic.getUrlParameter('contentOnly') || Mautic.isInBuilder)) {
                 mQuery('.btn-save').trigger('click');
             } else {
-                mQuery('.btn-apply').trigger('click');
+                bgApplyBtn.trigger('click');
             }
             Mautic.inBuilderSubmissionOff();
         }, true);

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -87,15 +87,15 @@ Mautic.launchBuilder = function (formName, actionName) {
     var spinnerTop = (mQuery(window).height() - panelHeight - 60) / 2;
     var form = mQuery('form[name='+formName+']');
 
-    if ("1" === Mautic.getUrlParameter('contentOnly')) {
-        applyBtn.hide();
-    }
-
     applyBtn.off('click').on('click', function(e) {
         Mautic.activateButtonLoadingIndicator(applyBtn);
         Mautic.sendBuilderContentToTextarea(function() {
             Mautic.inBuilderSubmissionOn(form);
-            mQuery('.btn-apply').trigger('click');
+            if ("1" === Mautic.getUrlParameter('contentOnly') || Mautic.isInBuilder) {
+                mQuery('.btn-save').trigger('click');
+            } else {
+                mQuery('.btn-apply').trigger('click');
+            }
             Mautic.inBuilderSubmissionOff();
         }, true);
     });
@@ -141,6 +141,7 @@ Mautic.inBuilderSubmissionOn = function(form) {
  * @param jQuery object of form
  */
 Mautic.inBuilderSubmissionOff = function(form) {
+    Mautic.isInBuilder = false;
     mQuery('input[name="inBuilder"]').remove();
 }
 

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -93,7 +93,10 @@ Mautic.launchBuilder = function (formName, actionName) {
             Mautic.inBuilderSubmissionOn(form);
             var bgApplyBtn = mQuery('.btn-apply');
             if (0 === bgApplyBtn.length && ("1" === Mautic.getUrlParameter('contentOnly') || Mautic.isInBuilder)) {
-                mQuery('.btn-save').trigger('click');
+                var frm = mQuery('.btn-save').closest('form');
+                Mautic.inBuilderSubmissionOn(frm);
+                frm.submit();
+                Mautic.inBuilderSubmissionOff();
             } else {
                 bgApplyBtn.trigger('click');
             }

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -1,4 +1,16 @@
 /**
+ * Parses the query string and returns a parameter value
+ * @param name
+ * @returns {string}
+ */
+Mautic.getUrlParameter = function (name) {
+    name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
+    var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+    var results = regex.exec(location.search);
+    return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+};
+
+/**
  * Launch builder
  *
  * @param formName
@@ -74,6 +86,10 @@ Mautic.launchBuilder = function (formName, actionName) {
     var spinnerLeft = (mQuery(window).width() - panelWidth - 60) / 2;
     var spinnerTop = (mQuery(window).height() - panelHeight - 60) / 2;
     var form = mQuery('form[name='+formName+']');
+
+    if ("1" === Mautic.getUrlParameter('contentOnly')) {
+        applyBtn.hide();
+    }
 
     applyBtn.off('click').on('click', function(e) {
         Mautic.activateButtonLoadingIndicator(applyBtn);

--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -19,6 +19,7 @@ Mautic.emailOnLoad = function (container, response) {
 
         // Open the builder directly when saved from the builder
         if (response && response.inBuilder) {
+            Mautic.isInBuilder = true;
             Mautic.launchBuilder('emailform');
             Mautic.processBuilderErrors(response);
         }

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -602,6 +602,13 @@ class EmailController extends FormController
         $slotTypes   = $model->getBuilderComponents($entity, 'slotTypes');
         $sections    = $model->getBuilderComponents($entity, 'sections');
         $sectionForm = $this->get('form.factory')->create('builder_section');
+        $routeParams = [
+            'objectAction' => 'new',
+        ];
+        if ($updateSelect) {
+            $routeParams['updateSelect'] = $updateSelect;
+            $routeParams['contentOnly']  = 1;
+        }
 
         return $this->delegateView(
             [
@@ -618,15 +625,10 @@ class EmailController extends FormController
                 ],
                 'contentTemplate' => 'MauticEmailBundle:Email:form.html.php',
                 'passthroughVars' => [
-                    'activeLink'    => '#mautic_email_index',
-                    'mauticContent' => 'email',
-                    'updateSelect'  => $updateSelect,
-                    'route'         => $this->generateUrl(
-                        'mautic_email_action',
-                        [
-                            'objectAction' => 'new',
-                        ]
-                    ),
+                    'activeLink'      => '#mautic_email_index',
+                    'mauticContent'   => 'email',
+                    'updateSelect'    => $updateSelect,
+                    'route'           => $this->generateUrl('mautic_email_action', $routeParams),
                     'validationError' => $this->getFormErrorForBuilder($form),
                 ],
             ]
@@ -805,6 +807,14 @@ class EmailController extends FormController
         $slotTypes   = $model->getBuilderComponents($entity, 'slotTypes');
         $sections    = $model->getBuilderComponents($entity, 'sections');
         $sectionForm = $this->get('form.factory')->create('builder_section');
+        $routeParams = [
+            'objectAction' => 'edit',
+            'objectId'     => $entity->getId(),
+        ];
+        if ($updateSelect) {
+            $routeParams['updateSelect'] = $updateSelect;
+            $routeParams['contentOnly']  = 1;
+        }
 
         return $this->delegateView(
             [
@@ -822,16 +832,10 @@ class EmailController extends FormController
                 ],
                 'contentTemplate' => 'MauticEmailBundle:Email:form.html.php',
                 'passthroughVars' => [
-                    'activeLink'    => '#mautic_email_index',
-                    'mauticContent' => 'email',
-                    'updateSelect'  => InputHelper::clean($this->request->query->get('updateSelect')),
-                    'route'         => $this->generateUrl(
-                        'mautic_email_action',
-                        [
-                            'objectAction' => 'edit',
-                            'objectId'     => $entity->getId(),
-                        ]
-                    ),
+                    'activeLink'      => '#mautic_email_index',
+                    'mauticContent'   => 'email',
+                    'updateSelect'    => InputHelper::clean($this->request->query->get('updateSelect')),
+                    'route'           => $this->generateUrl('mautic_email_action', $routeParams),
                     'validationError' => $this->getFormErrorForBuilder($form),
                 ],
             ]

--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -140,13 +140,14 @@ class CampaignSubscriber extends CommonSubscriber
         $event->addAction(
             'email.send.to.user',
             [
-                'label'          => 'mautic.email.campaign.event.send.to.user',
-                'description'    => 'mautic.email.campaign.event.send.to.user_descr',
-                'eventName'      => EmailEvents::ON_CAMPAIGN_TRIGGER_ACTION,
-                'formType'       => 'email_to_user',
-                'formTheme'      => 'MauticEmailBundle:FormTheme\EmailSendList',
-                'channel'        => 'email',
-                'channelIdField' => 'email',
+                'label'           => 'mautic.email.campaign.event.send.to.user',
+                'description'     => 'mautic.email.campaign.event.send.to.user_descr',
+                'eventName'       => EmailEvents::ON_CAMPAIGN_TRIGGER_ACTION,
+                'formType'        => 'email_to_user',
+                'formTypeOptions' => ['update_select' => 'campaignevent_properties_useremail_email'],
+                'formTheme'       => 'MauticEmailBundle:FormTheme\EmailSendList',
+                'channel'         => 'email',
+                'channelIdField'  => 'email',
             ]
         );
     }

--- a/app/bundles/EmailBundle/Form/Type/EmailToUserType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailToUserType.php
@@ -14,7 +14,7 @@ namespace Mautic\EmailBundle\Form\Type;
 use Mautic\CoreBundle\Form\ToBcBccFieldsTrait;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class EmailToUserType.
@@ -35,7 +35,7 @@ class EmailToUserType extends AbstractType
                 'class'   => 'form-control',
                 'tooltip' => 'mautic.email.choose.emails_descr',
             ],
-            'update_select' => 'formaction_properties_useremail_email',
+            'update_select' => empty($options['update_select']) ? 'formaction_properties_useremail_email' : $options['update_select'],
         ]);
 
         $builder->add('user_id', 'user_list', [
@@ -60,11 +60,16 @@ class EmailToUserType extends AbstractType
         $this->addToBcBccFields($builder);
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    /**
+     * @param OptionsResolver $resolver
+     */
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'label' => false,
         ]);
+
+        $resolver->setDefined(['update_select']);
     }
 
     /**

--- a/app/bundles/EmailBundle/Form/Type/EmailType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailType.php
@@ -465,29 +465,21 @@ class EmailType extends AbstractType
             ],
         ];
 
+        $builder->add(
+            'buttons',
+            'form_buttons',
+            [
+                'pre_extra_buttons' => $customButtons,
+            ]
+        );
+
         if (!empty($options['update_select'])) {
-            $builder->add(
-                'buttons',
-                'form_buttons',
-                [
-                    'apply_text'        => false,
-                    'pre_extra_buttons' => $customButtons,
-                ]
-            );
             $builder->add(
                 'updateSelect',
                 'hidden',
                 [
                     'data'   => $options['update_select'],
                     'mapped' => false,
-                ]
-            );
-        } else {
-            $builder->add(
-                'buttons',
-                'form_buttons',
-                [
-                    'pre_extra_buttons' => $customButtons,
                 ]
             );
         }


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
When trying to create a new email on the campaign action of `Send email` or `Send email to user` the new `Apply` button hangs spinning. This PR fixes that issue.

![image](https://user-images.githubusercontent.com/2924026/29977637-4dfe4be0-8efb-11e7-951e-48e4aeee539e.png)

#### Steps to reproduce the bug:
1. Edit or create a new campaign
2. Add a campaign source
3. Add a `Send email` action
4. Click on the `New email` button
5. On the new windows, open the builder
6. Click on apply
7. The button will just hang spinning

#### Steps to test this PR:
1. Apply this PR
2. Repeat the steps to reproduce the bug
3. The Apply button will work
