### PR TITLE
Bug parallel import

### DIFF
--- a/app/bundles/LeadBundle/Entity/ImportRepository.php
+++ b/app/bundles/LeadBundle/Entity/ImportRepository.php
@@ -85,6 +85,14 @@ class ImportRepository extends CommonRepository
         return 0;
     }
 
+    /**
+     * @return int
+     */
+    public function countImportsInProgress()
+    {
+        return $this->countImportsWithStatuses([Import::IN_PROGRESS]);
+    }
+
     public function getQueryForStatuses($statuses)
     {
         $q = $this->createQueryBuilder($this->getTableAlias());

--- a/app/bundles/LeadBundle/LeadEvents.php
+++ b/app/bundles/LeadBundle/LeadEvents.php
@@ -329,6 +329,16 @@ final class LeadEvents
     const IMPORT_POST_DELETE = 'mautic.lead_import_post_delete';
 
     /**
+     * The mautic.lead_import_batch_processed event is dispatched after an import batch is processed.
+     *
+     * The event listener receives a
+     * Mautic\LeadBundle\Event\ImportEvent instance.
+     *
+     * @var string
+     */
+    const IMPORT_BATCH_PROCESSED = 'mautic.lead_import_batch_processed';
+
+    /**
      * The mautic.lead_device_pre_save event is dispatched right before a lead device is persisted.
      *
      * The event listener receives a

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -109,20 +109,14 @@ class ImportModel extends FormModel
     /**
      * Compares current number of imports in progress with the limit from the configuration.
      *
-     * @param Import $import
-     *
      * @return bool
      */
-    public function checkParallelImportLimit(Import $import)
+    public function checkParallelImportLimit()
     {
         $parallelImportLimit = $this->getParallelImportLimit();
-        $importsInProgress   = $this->getRepository()->countImportsWithStatuses([Import::IN_PROGRESS]);
+        $importsInProgress   = $this->getRepository()->countImportsInProgress();
 
-        if ($importsInProgress >= $parallelImportLimit) {
-            return false;
-        }
-
-        return true;
+        return !($importsInProgress >= $parallelImportLimit);
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -216,10 +216,9 @@ class ImportModel extends FormModel
         }
 
         if (!$this->checkParallelImportLimit($import)) {
-            $parallelImportLimit = $this->getParallelImportLimit();
-            $info                = $this->translator->trans(
+            $info = $this->translator->trans(
                 'mautic.lead.import.parallel.limit.hit',
-                ['%limit%' => $parallelImportLimit]
+                ['%limit%' => $this->getParallelImportLimit()]
             );
             $import->setStatus($import::DELAYED)->setStatusInfo($info);
             $this->saveEntity($import);
@@ -388,6 +387,8 @@ class ImportModel extends FormModel
                 // clear unit of work of already imported data to save memory
                 $this->em->clear('Mautic\LeadBundle\Entity\Lead');
                 $this->em->clear('Mautic\LeadBundle\Entity\Company');
+
+                $this->dispatchEvent('batch_processed', $import);
 
                 // Stop the import loop if the import got unpublished
                 if (!$isPublished) {
@@ -645,6 +646,9 @@ class ImportModel extends FormModel
                 break;
             case 'post_delete':
                 $name = LeadEvents::IMPORT_POST_DELETE;
+                break;
+            case 'batch_processed':
+                $name = LeadEvents::IMPORT_BATCH_PROCESSED;
                 break;
             default:
                 return null;

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -209,7 +209,7 @@ class ImportModel extends FormModel
             return false;
         }
 
-        if (!$this->checkParallelImportLimit($import)) {
+        if (!$this->checkParallelImportLimit()) {
             $info = $this->translator->trans(
                 'mautic.lead.import.parallel.limit.hit',
                 ['%limit%' => $this->getParallelImportLimit()]

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -235,12 +235,15 @@ class ImportModel extends FormModel
                 return false;
             }
         } catch (ORMException $e) {
-            // The EntityManager is probably closed. Let's delay for re-trial.
+            // The EntityManager is probably closed. The entity cannot be saved.
             $info = $this->translator->trans(
                 'mautic.lead.import.database.exception',
                 ['%message%' => $e->getMessage()]
             );
+
             $import->setStatus($import::DELAYED)->setStatusInfo($info);
+
+            $this->logDebug('Database had been overloaded', $import);
 
             return false;
         }

--- a/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
@@ -153,8 +153,7 @@ class ImportModelTest extends StandardImportTestHelper
             ->disableOriginalConstructor()
             ->getMock();
 
-        $model->expects($this->once())
-            ->method('checkParallelImportLimit')
+        $model->method('checkParallelImportLimit')
             ->will($this->returnValue(false));
 
         $model->expects($this->once())
@@ -166,7 +165,11 @@ class ImportModelTest extends StandardImportTestHelper
 
         $model->setTranslator($this->getTranslatorMock());
 
-        $entity = $this->initImportEntity();
+        $entity = $this->initImportEntity(['canProceed']);
+
+        $entity->method('canProceed')
+            ->will($this->returnValue(true));
+
         $result = $model->startImport($entity, new Progress());
 
         $this->assertFalse($result);
@@ -196,7 +199,11 @@ class ImportModelTest extends StandardImportTestHelper
 
         $model->setTranslator($this->getTranslatorMock());
 
-        $entity = $this->initImportEntity();
+        $entity = $this->initImportEntity(['canProceed']);
+
+        $entity->method('canProceed')
+            ->will($this->returnValue(true));
+
         $result = $model->startImport($entity, new Progress());
 
         $this->assertFalse($result);

--- a/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
@@ -190,7 +190,7 @@ class ImportModelTest extends StandardImportTestHelper
             ->method('checkParallelImportLimit')
             ->will($this->returnValue(true));
 
-        $model->expects($this->once())
+        $model->expects($this->exactly(2))
             ->method('logDebug');
 
         $model->expects($this->once())

--- a/app/bundles/LeadBundle/Tests/StandardImportTestHelper.php
+++ b/app/bundles/LeadBundle/Tests/StandardImportTestHelper.php
@@ -58,9 +58,12 @@ abstract class StandardImportTestHelper extends CommonMocks
         parent::tearDownAfterClass();
     }
 
-    protected function initImportEntity()
+    protected function initImportEntity(array $methods = null)
     {
-        $entity = new Import();
+        $entity = $this->getMockBuilder(Import::class)
+            ->setMethods($methods)
+            ->getMock();
+
         $entity->setFilePath(self::$csvPath)
             ->setLineCount(count(self::$initialList))
             ->setHeaders(self::$initialList[0])

--- a/app/bundles/LeadBundle/Translations/en_US/messages.ini
+++ b/app/bundles/LeadBundle/Translations/en_US/messages.ini
@@ -178,6 +178,7 @@ mautic.lead.background.import.if.more.rows.than="Automatically import in the bac
 mautic.lead.background.import.if.more.rows.than.tooltip="If this option is greater than 0, there will be only one Import button and the browser/background import will be decided based on the CSV row number"
 mautic.config.tab.leadconfig="Contact Settings"
 mautic.config.tab.importconfig="Import Settings"
+mautic.lead.import.database.exception="There was a database error: %message%. The import was set to delayed state and will be imported later."
 mautic.lead.lastactive="Last active"
 mautic.lead.lead.anonymous="Anonymous"
 mautic.lead.lead.anonymous_leads="Toggle anonymous contacts"


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4769
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixes 2 issues:
1. The `parallel_import_limit` was not working as one would expect. If the limit was 1, it allowed to run up to 2 parallel import processes. With this PR it will be exactly 1.
2. There is a high risk that multiple parallel import processes cause `[Doctrine\ORM\ORMException] The EntityManager is closed.` to be thrown. In that case the import staid in the `In Progress` state but didn't do anything. This PR will set it as Delayed and it will be picked up by the next command.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Prepare 1 CSV with 1000 contacts or so.
2. Create parallel 3 imports on the background with this CSV. Do not run the command just yet!
3. Open 3 terminal windows and run `app/console mautic:import` in all of them at one time. 1000 contact CSV will give you some time to do so.

Results:
- Notice that 2 of them run and only the last one was set as Delayed.
- When I run it I got the `The EntityManager is closed` error so the second didn't finish either. I'm not sure if you'll be able to replicate on your device.

#### Steps to test this PR:
1. Run the test again.

Results:
- 1 import should run, 2 should be set as delayed.
-  If you increase the `parallel_import_limit` in your local.php to more than 1 and you'll manage to get the entity manager closed error, it should only set the import to Delayed and it will be triggered later when you run the import command again.

There are unit tests for both fixes.