### PR TITLE
Enable sorting on segment filters

### DIFF
--- a/app/bundles/LeadBundle/Assets/css/lead.css
+++ b/app/bundles/LeadBundle/Assets/css/lead.css
@@ -52,6 +52,11 @@
     margin-left:20px;
 }
 
+
+.selected-filters .glue-select {
+    margin-top:2px;
+}
+
 .selected-filters .panel {
     margin-bottom:0;
     margin-top:20px;

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -308,7 +308,66 @@ Mautic.leadlistOnLoad = function(container) {
                 }
             });
         });
+
+        var bodyOverflow = {};
+        mQuery('#leadlist_filters').sortable({
+            items: '.panel',
+            helper: function(e, ui) {
+                ui.children().each(function() {
+                    if (mQuery(this).is(":visible")) {
+                        mQuery(this).width(mQuery(this).width());
+                    }
+                });
+
+                // Fix body overflow that messes sortable up
+                bodyOverflow.overflowX = mQuery('body').css('overflow-x');
+                bodyOverflow.overflowY = mQuery('body').css('overflow-y');
+                mQuery('body').css({
+                    overflowX: 'visible',
+                    overflowY: 'visible'
+                });
+
+                return ui;
+            },
+            scroll: true,
+            axis: 'y',
+            stop: function(e, ui) {
+                // Restore original overflow
+                mQuery('body').css(bodyOverflow);
+
+                // First in the list should be an "and"
+                ui.item.find('select.glue-select').first().val('and');
+
+                Mautic.reorderSegmentFilters();
+            }
+        });
+
     }
+};
+
+Mautic.reorderSegmentFilters = function() {
+    // Update the filter numbers sot that they are ordered correctly when processed and grouped server side
+    var counter = 0;
+    mQuery('#leadlist_filters .panel').each(function() {
+        Mautic.updateFilterPositioning(mQuery(this).find('select.glue-select').first());
+        mQuery(this).find('[id^="leadlist_filters_"]').each(function() {
+            var id = mQuery(this).attr('id');
+            if ('leadlist_filters___name___filter' === id) {
+                return true;
+            }
+''
+            var suffix = id.split(/[_]+/).pop();
+
+            mQuery(this).attr('id', 'leadlist_filters_'+counter+'_'+suffix);
+            mQuery(this).attr('name', 'leadlist[filters]['+counter+']['+suffix+']');
+        });
+
+        ++counter;
+    });
+
+    mQuery('#leadlist_filters .panel-heading').removeClass('hide');
+    mQuery('#leadlist_filters .panel-heading').first().addClass('hide');
+    mQuery('#leadlist_filters .panel').first().removeClass('in-group');
 };
 
 Mautic.convertLeadFilterInput = function(el) {
@@ -547,6 +606,9 @@ Mautic.addLeadListFilter = function (elId) {
 
     // Convert based on first option in list
     Mautic.convertLeadFilterInput('#' + filterIdBase + 'operator');
+
+    // Reposition if applicable
+    Mautic.updateFilterPositioning(mQuery('#' + filterIdBase + 'glue'));
 };
 
 Mautic.leadfieldOnLoad = function (container) {

--- a/app/bundles/LeadBundle/Views/List/form.html.php
+++ b/app/bundles/LeadBundle/Views/List/form.html.php
@@ -85,7 +85,7 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
                     </div>
                     <div class="tab-pane fade bdr-w-0" id="filters">
                         <div class="form-group">
-                            <div class="available-filters mb-md pl-0 col-md-4" data-prototype="<?php echo $view->escape($view['form']->row($form['filters']->vars['prototype'])); ?>" data-index="<?php echo $index + 1; ?>">
+                            <div class="available-filters mb-md pl-0 col-md-4" data-prototype="<?php echo $view->escape($view['form']->widget($form['filters']->vars['prototype'])); ?>" data-index="<?php echo $index + 1; ?>">
                                 <select class="chosen form-control" id="available_filters">
                                     <option value=""></option>
                                     <?php


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Once a group of segment filters is created, they are stuck as is. For example, if I have a segment that has several groups of OR filters and then want to add an AND filter to the root of the query, the added AND will be appended to the last OR group. 

This PR thus adds sorting to the segments so that filters can be moved around in the groups. It also improves the UI a bit to be have more consistent group indentions when applicable. 


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new segment with three filters. Change the second one to an OR and save
2. Add a new filter and leave as AND. Save and edit. Note that the AND is now part of the previous OR group.

#### Steps to test this PR:
1. Repeat the above. This time when adding the fourth filter, drag it up into the top AND group. It'll become part of the root AND/query. Can also move the filter into any of the OR groups. 
2. Save and the filters will be restored with the desired ordering.
