### PR TITLE
Track merged contacts so that tracked contacts will continue to be associated for 3rd party form submits

### DIFF
--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -287,6 +287,7 @@ class FormModel extends AbstractCommonModel
         $id    = $entity->getId();
         $event = $this->dispatchEvent('pre_delete', $entity);
         $this->getRepository()->deleteEntity($entity);
+
         //set the id for use in events
         $entity->deletedId = $id;
         $this->dispatchEvent('post_delete', $entity, false, $event);

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -295,7 +295,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
             ->addIndex(['date_added'], 'lead_date_added');
 
         $builder->createField('id', 'integer')
-            ->isPrimaryKey()
+            ->makePrimaryKey()
             ->generatedValue()
             ->build();
 

--- a/app/bundles/LeadBundle/Entity/MergeRecord.php
+++ b/app/bundles/LeadBundle/Entity/MergeRecord.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class MergeRecord
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var Lead
+     */
+    private $contact;
+
+    /**
+     * @var \DateTime
+     */
+    private $dateAdded;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var int
+     */
+    private $mergedId;
+
+    /**
+     * @param ORM\ClassMetadata $metadata
+     */
+    public static function loadMetadata(ORM\ClassMetadata $metadata)
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('contact_merge_records')
+            ->setCustomRepositoryClass('Mautic\LeadBundle\Entity\MergeRecordRepository')
+            ->addIndex(['date_added'], 'contact_merge_date_added')
+            ->addIndex(['merged_id'], 'contact_merge_ids');
+
+        $builder->createField('id', 'integer')
+            ->makePrimaryKey()
+            ->generatedValue()
+            ->build();
+
+        $builder->addContact()
+            ->addDateAdded()
+            ->addNamedField('mergedId', 'integer', 'merged_id')
+            ->addField('name', 'string');
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return Lead
+     */
+    public function getContact()
+    {
+        return $this->contact;
+    }
+
+    /**
+     * @param Lead $contact
+     *
+     * @return MergeRecord
+     */
+    public function setContact(Lead $contact)
+    {
+        $this->contact = $contact;
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDateAdded()
+    {
+        return $this->dateAdded;
+    }
+
+    /**
+     * @param \DateTime $dateAdded
+     *
+     * @return MergeRecord
+     */
+    public function setDateAdded(\DateTime $dateAdded = null)
+    {
+        if (null === $dateAdded) {
+            $dateAdded = new \DateTime();
+        }
+
+        $this->dateAdded = $dateAdded;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return MergeRecord
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMergedId()
+    {
+        return $this->mergedId;
+    }
+
+    /**
+     * @param int $mergedId
+     *
+     * @return MergeRecord
+     */
+    public function setMergedId($mergedId)
+    {
+        $this->mergedId = (int) $mergedId;
+
+        return $this;
+    }
+}

--- a/app/bundles/LeadBundle/Entity/MergeRecordRepository.php
+++ b/app/bundles/LeadBundle/Entity/MergeRecordRepository.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Entity;
+
+use Mautic\CoreBundle\Entity\CommonRepository;
+
+/**
+ * Class MergeRecordRepository.
+ */
+class MergeRecordRepository extends CommonRepository
+{
+    /**
+     * @param $id
+     *
+     * @return null|Lead
+     */
+    public function findMergedContact($id)
+    {
+        /** @var MergeRecord[] $entities */
+        $entities = $this->findBy(['mergedId' => $id]);
+
+        if (count($entities)) {
+            return $entities[0]->getContact();
+        }
+
+        return null;
+    }
+}

--- a/app/bundles/LeadBundle/Entity/MergeRecordRepository.php
+++ b/app/bundles/LeadBundle/Entity/MergeRecordRepository.php
@@ -25,13 +25,31 @@ class MergeRecordRepository extends CommonRepository
      */
     public function findMergedContact($id)
     {
-        /** @var MergeRecord[] $entities */
-        $entities = $this->findBy(['mergedId' => $id]);
+        /** @var MergeRecord $record */
+        if ($record = $this->findOneBy(['mergedId' => (int) $id], ['dateAdded' => 'desc'])) {
+            $contact = $record->getContact();
 
-        if (count($entities)) {
-            return $entities[0]->getContact();
+            // Clear these records from the EM so that subsequent fetches don't return deleted entities
+            $this->getEntityManager()->clear(MergeRecord::class);
+
+            return $contact;
         }
 
         return null;
+    }
+
+    /**
+     * Keep track of subseqent merges by cascading records to the latest lead that was merged into.
+     *
+     * @param $fromId
+     * @param $toId
+     */
+    public function moveMergeRecord($fromId, $toId)
+    {
+        $this->getEntityManager()->getConnection()->createQueryBuilder()
+            ->update(MAUTIC_TABLE_PREFIX.'contact_merge_records')
+            ->set('contact_id', (int) $toId)
+            ->where('contact_id = '.(int) $fromId)
+            ->execute();
     }
 }

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1353,11 +1353,14 @@ class LeadModel extends FormModel
         //save the updated lead
         $this->saveEntity($mergeWith, false);
 
+        // Update merge records for the lead about to be deleted
+        $this->getMergeRecordRepository()->moveMergeRecord($mergeFrom->getId(), $mergeWith->getId());
+
         // Create an entry this contact was merged
         $mergeRecord = new MergeRecord();
         $mergeRecord->setContact($mergeWith)
             ->setDateAdded()
-            ->setName($mergeWith->getPrimaryIdentifier())
+            ->setName($mergeFrom->getPrimaryIdentifier())
             ->setMergedId($mergeFrom->getId());
         $this->getMergeRecordRepository()->saveEntity($mergeRecord);
 

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Model;
+
+use Mautic\CoreBundle\Test\MauticWebTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+
+class LeadModelFunctionalTest extends MauticWebTestCase
+{
+    public function testMergedContactFound()
+    {
+        $model = $this->container->get('mautic.lead.model.lead');
+
+        $lead1 = new Lead();
+        $lead1->setFirstname('Bob')
+            ->setLastname('Smith')
+            ->setEmail('bob.smith@test.com');
+        $model->saveEntity($lead1);
+        $lead1Id = $lead1->getId();
+
+        $lead2 = new Lead();
+        $lead2->setFirstname('Jane')
+            ->setLastname('Smith')
+            ->setEmail('jane.smith@test.com');
+        $model->saveEntity($lead2);
+        $lead2Id = $lead2->getId();
+
+        $model->mergeLeads($lead1, $lead2, false);
+
+        // Bob should have been merged into Jane
+        $jane = $model->getEntity($lead2Id);
+        $this->assertEquals($lead2Id, $jane->getId());
+
+        // If Bob is queried, Jane should be returned
+        $jane = $model->getEntity($lead1Id);
+        $this->assertEquals($lead2Id, $jane->getId());
+
+        // If Jane is deleted, querying for Bob should result in null
+        $model->deleteEntity($jane);
+        $bob = $model->getEntity($lead1Id);
+        $this->assertNull($bob);
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
@@ -20,33 +20,49 @@ class LeadModelFunctionalTest extends MauticWebTestCase
     {
         $model = $this->container->get('mautic.lead.model.lead');
 
-        $lead1 = new Lead();
-        $lead1->setFirstname('Bob')
+        $bob = new Lead();
+        $bob->setFirstname('Bob')
             ->setLastname('Smith')
             ->setEmail('bob.smith@test.com');
-        $model->saveEntity($lead1);
-        $lead1Id = $lead1->getId();
+        $model->saveEntity($bob);
+        $bobId = $bob->getId();
 
-        $lead2 = new Lead();
-        $lead2->setFirstname('Jane')
+        $jane = new Lead();
+        $jane->setFirstname('Jane')
             ->setLastname('Smith')
             ->setEmail('jane.smith@test.com');
-        $model->saveEntity($lead2);
-        $lead2Id = $lead2->getId();
+        $model->saveEntity($jane);
+        $janeId = $jane->getId();
 
-        $model->mergeLeads($lead1, $lead2, false);
+        $model->mergeLeads($bob, $jane, false);
 
         // Bob should have been merged into Jane
-        $jane = $model->getEntity($lead2Id);
-        $this->assertEquals($lead2Id, $jane->getId());
+        $jane = $model->getEntity($janeId);
+        $this->assertEquals($janeId, $jane->getId());
 
         // If Bob is queried, Jane should be returned
-        $jane = $model->getEntity($lead1Id);
-        $this->assertEquals($lead2Id, $jane->getId());
+        $jane = $model->getEntity($bobId);
+        $this->assertEquals($janeId, $jane->getId());
 
-        // If Jane is deleted, querying for Bob should result in null
-        $model->deleteEntity($jane);
-        $bob = $model->getEntity($lead1Id);
+        // Merge Jane into a third contact
+        $joey = new Lead();
+        $joey->setFirstname('Joey')
+            ->setLastname('Smith')
+            ->setEmail('joey.smith@test.com');
+        $model->saveEntity($joey);
+        $joeyId = $joey->getId();
+
+        $model->mergeLeads($jane, $joey, false);
+
+        // Query for Bob which should now return Joey
+        $joey = $model->getEntity($bobId);
+        $this->assertEquals($joeyId, $joey->getId());
+
+        // If Joey is deleted, querying for Bob or Jane should result in null
+        $model->deleteEntity($joey);
+        $bob = $model->getEntity($bobId);
         $this->assertNull($bob);
+        $jane = $model->getEntity($janeId);
+        $this->assertNull($jane);
     }
 }

--- a/app/migrations/Version20170906161951.php
+++ b/app/migrations/Version20170906161951.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * @package     Mautic
+ * @copyright   2017 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170906161951 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        if ($schema->hasTable(MAUTIC_TABLE_PREFIX.'contact_merge_records')) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $idx = $this->generatePropertyName('contact_merge_records', 'idx', ['contact_id']);
+        $fk  = $this->generatePropertyName('contact_merge_records', 'fk', ['contact_id']);
+
+        $sql = <<<SQL
+CREATE TABLE {$this->prefix}contact_merge_records (
+    id INT AUTO_INCREMENT NOT NULL, 
+    contact_id INT NOT NULL, 
+    date_added DATETIME NOT NULL COMMENT '(DC2Type:datetime)', 
+    merged_id INT NOT NULL, 
+    name VARCHAR(255) NOT NULL, 
+    INDEX $idx (contact_id), 
+    INDEX {$this->prefix}contact_merge_date_added (date_added), INDEX {$this->prefix}contact_merge_ids (merged_id), 
+    PRIMARY KEY(id)
+) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB
+SQL;
+        $this->addSql($sql);
+
+        $this->addSql("ALTER TABLE {$this->prefix}contact_merge_records ADD CONSTRAINT $fk FOREIGN KEY (contact_id) REFERENCES {$this->prefix}leads (id) ON DELETE CASCADE");
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y/enhancement
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If a 3rd party submits a form to Mautic, Mautic will create/merge the contact which may result in a new ID. But then browser will continue to track the contact as a visitor rather than the contact identified through the form submit. This PR keeps track of IDs merged into a contact so that if a contact ID is given that has been merged into another, the resulting contact is still found and the browser updated with the new contact ID. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Reproducing is tricky due to requiring an advanced form setup that requires using a script to post to a Mautic form with mtc_id=ID of a visitor in the payload so that Mautic merges the visitor with that identified by the form
2. Redirect to a thank you page tracked by Mautic and the hit will be under a new visitor

#### Steps to test this PR:
1. Run migrations to update schema
2. Repeat the above and this time the hit will be under the merged contact
3. Run the functional tests