### PR TITLE
Bugfix - Pending email stats not showing contacts

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\EmailBundle\Entity;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Mautic\ChannelBundle\Entity\MessageQueue;
@@ -180,9 +181,9 @@ class EmailRepository extends CommonRepository
      * @param bool $countOnly
      * @param null $limit
      *
-     * @return array|int
+     * @return QueryBuilder|int|array
      */
-    public function getEmailPendingLeads($emailId, $variantIds = null, $listIds = null, $countOnly = false, $limit = null)
+    public function getEmailPendingQuery($emailId, $variantIds = null, $listIds = null, $countOnly = false, $limit = null)
     {
         // Do not include leads in the do not contact table
         $dncQb = $this->getEntityManager()->getConnection()->createQueryBuilder();
@@ -306,6 +307,26 @@ class EmailRepository extends CommonRepository
                 ->setMaxResults($limit);
         }
 
+        return $q;
+    }
+
+    /**
+     * @param      $emailId
+     * @param null $variantIds
+     * @param null $listIds
+     * @param bool $countOnly
+     * @param null $limit
+     *
+     * @return array|int
+     */
+    public function getEmailPendingLeads($emailId, $variantIds = null, $listIds = null, $countOnly = false, $limit = null)
+    {
+        $q = $this->getEmailPendingQuery($emailId, $variantIds, $listIds, $countOnly, $limit);
+
+        if (!($q instanceof QueryBuilder)) {
+            return $q;
+        }
+
         $results = $q->execute()->fetchAll();
 
         if ($countOnly) {
@@ -392,8 +413,8 @@ class EmailRepository extends CommonRepository
     }
 
     /**
-     * @param \Doctrine\ORM\QueryBuilder|\Doctrine\DBAL\Query\QueryBuilder $q
-     * @param                                                              $filter
+     * @param \Doctrine\ORM\QueryBuilder|QueryBuilder $q
+     * @param                                         $filter
      *
      * @return array
      */
@@ -406,8 +427,8 @@ class EmailRepository extends CommonRepository
     }
 
     /**
-     * @param \Doctrine\ORM\QueryBuilder|\Doctrine\DBAL\Query\QueryBuilder $q
-     * @param                                                              $filter
+     * @param \Doctrine\ORM\QueryBuilder|QueryBuilder $q
+     * @param                                         $filter
      *
      * @return array
      */

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -928,7 +928,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
                 $filter->strict  = 1;
                 $returnParameter = true;
                 break;
-            default :
+            default:
                 if (in_array($command, $this->availableSearchFields)) {
                     $expr = $q->expr()->$likeExpr("l.$command", ":$unique");
                 }


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes an issue when clicking on the pending email stats. Right now, the query to show pending emails uses the message_queue table to retrieve the contacts with pending status, the correct way to retrieve those contacts is to use the same query that gets the count in the stat.

![image](https://user-images.githubusercontent.com/2924026/30137421-7507ab86-9320-11e7-9a24-632bca8c8b13.png)

#### Steps to reproduce the bug:
1. Create a new segment email
2. Go to the emails list and click on the pending stat to show the list of contacts
3. The contacts list will be empty

#### Steps to test this PR:
1. Apply this PR
2. Try to replicate the bug
3. The contacts list will populate correctly
