### PR TITLE
Bugfix - Missing use statement in videohit.html.php

### DIFF
--- a/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/videohit.html.php
+++ b/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/videohit.html.php
@@ -8,6 +8,9 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
+
+use Mautic\CoreBundle\Helper\InputHelper;
+
 $viewTime = $duration = $percentage = $unknown = $view['translator']->trans('mautic.core.unknown');
 
 if ($event['extra']['hit']['time_watched']) {


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
When viewing a contact's timeline with a video hit in it, an exception is thrown:
`Symfony\Component\Debug\Exception\FatalThrowableError: Class 'InputHelper' not found` because a use statement for that class is missing. This PR fixes this issue.

#### Steps to reproduce the bug:
1. Generate a video hit on a contact's timeline:
  1. Upload a video asset
  2. Create or edit a landing page
  3. Add a gated video slot using the URL of the video asset and an existing form
  4. Save and close the LP
  5. Go to the landing page from another browser or guest window
  6. Play the video and submit the form
2. View the contact's timeline.
3. The error will be displayed.

#### Steps to test this PR:
1. Try to replicate the bug
2. The timeline will show and no error will be displayed.
