### PR TITLE
Fix memory leak in background import

### DIFF
--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -338,6 +338,10 @@ class ImportModel extends FormModel
 
                 $this->saveEntity($import);
 
+                // clear unit of work of already imported data to save memory
+                $this->em->clear('Mautic\LeadBundle\Entity\Lead');
+                $this->em->clear('Mautic\LeadBundle\Entity\Company');
+
                 // Stop the import loop if the import got unpublished
                 if (!$isPublished) {
                     $this->logDebug('The import has been unpublished. Stopping the import now.', $import);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N


[//]: # ( Required: )
#### Description:
Fix memory leak on background import
Before PR : 1000 contact from 59Mo for First contact to 104Mo for last lead and growing for more lead
After PR : 59Mo to 61Mo and stay around 61Mo for more lead

#### Steps to test this PR:
1. (optional) add `echo round(memory_get_usage ()/1024/1024,3). ' Mo'."\r\n";` at line 340 of ImportModel.php to see memory consumption 
2. Run in console a background import file with 1000emails -> see memory
3. apply PR and do the same to see memory improvement

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 