### PR TITLE
Bugfix - Check if pushLeads method exists on FetchLeadsCommand

### DIFF
--- a/app/bundles/PluginBundle/Command/FetchLeadsCommand.php
+++ b/app/bundles/PluginBundle/Command/FetchLeadsCommand.php
@@ -226,7 +226,7 @@ class FetchLeadsCommand extends ContainerAwareCommand
                 }
             }
 
-            if (isset($supportedFeatures) && in_array('push_leads', $supportedFeatures)) {
+            if (isset($supportedFeatures) && in_array('push_leads', $supportedFeatures) && method_exists($integrationObject, 'pushLeads')) {
                 $output->writeln('<info>'.$translator->trans('mautic.plugin.command.pushing.leads', ['%integration%' => $integration]).'</info>');
                 $result  = $integrationObject->pushLeads($params);
                 $ignored = 0;


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3651
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes an issue in `FetchLeadsCommand.php` that occurs when for some reason push_leads is enabled in the integration features. An error will be thrown if the pushLeads method does not exist in the integration:
```
PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\UndefinedMethodException: 
Attempted to call an undefined method named "pushLeads" of class 
"MauticPlugin\MauticCrmBundle\Integration\VtigerIntegration".
```

#### Steps to reproduce the bug:
1. Manually hack the `plugin_integration_settings` table and set `supported_features` to `a:3:{i:0;s:9:"push_lead";i:1;s:9:"get_leads";i:2;s:10:"push_leads";}` on Pipedrive, Hubspot, vTiger or another integration that does not include `push_leads` in the `getSupportedFeatures()` method.
2. Execute `app/console mautic:integration:fetchleads`
3. The fatal error will be thrown

#### Steps to test this PR:
1. Apply this PR
2. Try to replicate the bug
3. The error will not be thrown
