### PR TITLE
Changes email frequency field to number type

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/ContactFrequencyType.php
+++ b/app/bundles/LeadBundle/Form/Type/ContactFrequencyType.php
@@ -90,7 +90,7 @@ class ContactFrequencyType extends AbstractType
 
                     $builder->add(
                         'frequency_number_'.$channel,
-                        'number',
+                        'integer',
                         [
                             'precision'  => 0,
                             'label'      => 'mautic.lead.list.frequency.number',


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #4882
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The current frequency preference field is a text field and should be a number

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Enable user preferences and frequency options in email configuration
2. Check the preferences page and the field type will be text

#### Steps to test this PR:
1. After the update, check the frequency field type, it should be a number field
