### PR TITLE
Prevent overwriting filters when a subquery is set via an event listener

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -1763,7 +1763,7 @@ class LeadListRepository extends CommonRepository
                 $event = new LeadListFilteringEvent($details, $leadId, $alias, $func, $q, $this->getEntityManager());
                 $this->dispatcher->dispatch(LeadEvents::LIST_FILTERS_ON_FILTERING, $event);
                 if ($event->isFilteringDone()) {
-                    $groupExpr = $q->expr()->andX($event->getSubQuery());
+                    $groupExpr->add($event->getSubQuery());
                 }
             }
         }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If a plugin (such as citrix) inserted a filter for segments, it lost the rest of the filters part of that group.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new segment with a filter based on email and a GoTo based filter. 
2. Save and run the `php app/console m:s:u`
3. Email filter will be ignored

#### Steps to test this PR:
1. Repeat and the email field will not be ignored
