### PR TITLE
IE11 - Tracking fatal error 

### DIFF
--- a/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
@@ -171,13 +171,14 @@ MauticJS.makeCORSRequest = function(method, url, data, callbackSuccess, callback
         }
     };
    
-    if (method.toUpperCase() === 'POST') {
-        xhr.setRequestHeader('Content-Type','application/x-www-form-urlencoded');
+    if (typeof xhr.setRequestHeader !== "undefined"){
+        if (method.toUpperCase() === 'POST') {
+            xhr.setRequestHeader('Content-Type','application/x-www-form-urlencoded');
+        }
+    
+        xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+        xhr.withCredentials = true;
     }
-
-    xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
-    xhr.withCredentials = true;
- 
     xhr.send(query);
 };
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4442
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
In certain case on IE11, mtc.js script run into fatal error. 
Wasn't reproductible in local but solved a problem on ASP.NET website

if a Javascipt object don't have `withCredentials` method in[ lign 121 of BuildJsSubscriber.php](https://github.com/mautic/mautic/blob/a3d720293c38fe9b46a03067b9b7fba9a8093947/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php#L116) xhr object returned is `XDomainRequest`

Later in code, at [lign 174](https://github.com/mautic/mautic/blob/a3d720293c38fe9b46a03067b9b7fba9a8093947/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php#L175) `setRequestHeader` is called... and `XDomainRequest` object don't have this method... that lead to a fatal error. According to documentation, you can't set a custom header to `XDomainRequest`

Seems th behavior of `withCredentials` changed in IE10 version, and it's exactly the same than other browsers.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

#### Steps to test this PR:
1. Install tracking script on ASP.NET website
2. In IE11 browser, Look in console, there is a fatal on mtc.js script
3. Apply PR and check console
