### PR TITLE
No data priority for compound mautic fields in integration

### DIFF
--- a/app/bundles/PluginBundle/Assets/js/plugin.js
+++ b/app/bundles/PluginBundle/Assets/js/plugin.js
@@ -1,7 +1,17 @@
 /* PluginBundle */
 Mautic.matchedFields = function (index, object, integration) {
+    var compoundMauticFields = ['mauticContactTimelineLink', 'mauticContactIsContactableByEmail'];
+
     var integrationField = mQuery('#integration_details_featureSettings_'+object+'Fields_i_' + index).attr('data-value');
     var mauticField = mQuery('#integration_details_featureSettings_'+object+'Fields_m_' + index + ' option:selected').val();
+
+    if (mQuery.inArray(mauticField, compoundMauticFields) >= 0) {
+        mQuery('input[name="integration_details[featureSettings]['+object+'Fields][update_mautic' + index + ']"]').prop('disabled', true).trigger("chosen:updated");
+        mQuery('.btn-arrow' + index).addClass('disabled');
+    } else {
+        mQuery('input[name="integration_details[featureSettings]['+object+'Fields][update_mautic' + index + ']"]').prop('disabled', false).trigger("chosen:updated");
+        mQuery('.btn-arrow' + index).removeClass('disabled');
+    }
     if (object == 'lead') {
         var updateMauticField = mQuery('input[name="integration_details[featureSettings]['+object+'Fields][update_mautic' + index + ']"]:checked').val();
     } else {

--- a/app/bundles/PluginBundle/Assets/js/plugin.js
+++ b/app/bundles/PluginBundle/Assets/js/plugin.js
@@ -6,6 +6,7 @@ Mautic.matchedFields = function (index, object, integration) {
     var mauticField = mQuery('#integration_details_featureSettings_'+object+'Fields_m_' + index + ' option:selected').val();
 
     if (mQuery.inArray(mauticField, compoundMauticFields) >= 0) {
+        mQuery('.btn-arrow' + index).removeClass('active');
         mQuery('input[name="integration_details[featureSettings]['+object+'Fields][update_mautic' + index + ']"]').prop('disabled', true).trigger("chosen:updated");
         mQuery('.btn-arrow' + index).addClass('disabled');
     } else {

--- a/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
+++ b/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
@@ -166,6 +166,7 @@ trait FieldsTypeTrait
                                 'attr'        => [
                                     'data-toggle' => 'tooltip',
                                     'title'       => 'mautic.plugin.direction.data.update',
+                                    'disabled'    => (isset($fieldData[$fieldsName][$field]) && $options['integration_object']->isCompoundMauticField($fieldData[$fieldsName][$field])) ? true : false,
                                 ],
                             ]
                         );

--- a/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
+++ b/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
@@ -166,7 +166,7 @@ trait FieldsTypeTrait
                                 'attr'        => [
                                     'data-toggle' => 'tooltip',
                                     'title'       => 'mautic.plugin.direction.data.update',
-                                    'disabled'    => (isset($fieldData[$fieldsName][$field]) && $options['integration_object']->isCompoundMauticField($fieldData[$fieldsName][$field])) ? true : false,
+                                    'disabled'    => (isset($fieldData[$fieldsName][$field])) ? $options['integration_object']->isCompoundMauticField($fieldData[$fieldsName][$field]) : false,
                                 ],
                             ]
                         );

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -2681,6 +2681,12 @@ abstract class AbstractIntegration
         return $fields;
     }
 
+    /**
+     * @param $leadId
+     * @param string $channel
+     *
+     * @return int
+     */
     public function getLeadDonotContact($leadId, $channel = 'email')
     {
         $isContactable = 0;
@@ -2695,6 +2701,11 @@ abstract class AbstractIntegration
         return $isContactable;
     }
 
+    /**
+     * @param $lead
+     *
+     * @return mixed
+     */
     public function getCompoundMauticFields($lead)
     {
         if ($lead['internal_entity_id']) {
@@ -2705,6 +2716,11 @@ abstract class AbstractIntegration
         return $lead;
     }
 
+    /**
+     * @param $fieldName
+     *
+     * @return bool
+     */
     public function isCompoundMauticField($fieldName)
     {
         $compoundFields = [
@@ -2712,10 +2728,6 @@ abstract class AbstractIntegration
             'mauticContactIsContactableByEmail' => 'mauticContactIsContactableByEmail',
         ];
 
-        if (isset($compoundFields[$fieldName])) {
-            return true;
-        }
-
-        return false;
+        return isset($compoundFields[$fieldName]);
     }
 }

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -2702,6 +2702,8 @@ abstract class AbstractIntegration
     }
 
     /**
+     * Get pseudo fields from mautic, these are lead properties we want to map to integration fields.
+     *
      * @param $lead
      *
      * @return mixed

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -2704,4 +2704,18 @@ abstract class AbstractIntegration
 
         return $lead;
     }
+
+    public function isCompoundMauticField($fieldName)
+    {
+        $compoundFields = [
+            'mauticContactTimelineLink'         => 'mauticContactTimelineLink',
+            'mauticContactIsContactableByEmail' => 'mauticContactIsContactableByEmail',
+        ];
+
+        if (isset($compoundFields[$fieldName])) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/app/bundles/PluginBundle/Views/FormTheme/Integration/fields_row.html.php
+++ b/app/bundles/PluginBundle/Views/FormTheme/Integration/fields_row.html.php
@@ -83,9 +83,7 @@ $indexCount = 1;
                         <div class="choice-wrapper">
                             <div class="btn-group btn-block" data-toggle="buttons">
                                 <?php $checked = $child->vars['value'] === '0'; ?>
-                                <label class="btn-arrow<?php echo $indexCount; ?> btn btn-default<?php if ($checked): echo ' active'; endif; ?> <?php if ($child->vars['attr']['disabled']) {
-                    echo 'disabled';
-                } ?>">
+                                <label class="btn-arrow<?php echo $indexCount; ?> btn btn-default<?php if ($checked): echo ' active'; endif; ?> <?php if ($child->vars['attr']['disabled']) : echo 'disabled'; endif; ?>">
                                     <input type="radio"
                                            id="<?php echo $child->vars['id']; ?>_0"
                                            name="<?php echo $child->vars['full_name']; ?>"
@@ -94,15 +92,11 @@ $indexCount = 1;
                                            value="0"
                                            onchange="Mautic.matchedFields(<?php echo $indexCount; ?>, '<?php echo $object; ?>', '<?php echo $integration; ?>')"
                                            <?php if ($checked): ?>checked="checked"<?php endif; ?>
-                                           <?php if ($child->vars['attr']['disabled']) {
-                    echo 'disabled';
-                } ?>>
+                                           <?php if ($child->vars['attr']['disabled']) : echo 'disabled'; endif; ?>>
                                     <btn class="btn-nospin fa fa-arrow-circle-left"></btn>
                                 </label>
                                 <?php $checked = $child->vars['value'] === '1'; ?>
-                                <label class="btn-arrow<?php echo $indexCount; ?> btn btn-default<?php if ($checked): echo ' active'; endif; ?> <?php if ($child->vars['attr']['disabled']) {
-                    echo 'disabled';
-                } ?>">
+                                <label class="btn-arrow<?php echo $indexCount; ?> btn btn-default<?php if ($checked): echo ' active'; endif; ?> <?php if ($child->vars['attr']['disabled']) :echo 'disabled'; endif; ?>">
                                     <input type="radio" id="<?php echo $child->vars['id']; ?>_1"
                                            name="<?php echo $child->vars['full_name']; ?>"
                                            title=""
@@ -110,9 +104,7 @@ $indexCount = 1;
                                            value="1"
                                            onchange="Mautic.matchedFields(<?php echo $indexCount; ?>, '<?php echo $object; ?>', '<?php echo $integration; ?>')"
                                            <?php if ($child->vars['value'] === '1'): ?>checked="checked"<?php endif; ?>
-                                           <?php if ($child->vars['attr']['disabled']) {
-                    echo 'disabled';
-                } ?>>
+                                           <?php if ($child->vars['attr']['disabled']) : echo 'disabled'; endif; ?>>
                                     <btn class="btn-nospin fa fa-arrow-circle-right"></btn>
                                 </label>
                             </div>

--- a/app/bundles/PluginBundle/Views/FormTheme/Integration/fields_row.html.php
+++ b/app/bundles/PluginBundle/Views/FormTheme/Integration/fields_row.html.php
@@ -83,7 +83,7 @@ $indexCount = 1;
                         <div class="choice-wrapper">
                             <div class="btn-group btn-block" data-toggle="buttons">
                                 <?php $checked = $child->vars['value'] === '0'; ?>
-                                <label class="btn btn-default<?php if ($checked): echo ' active'; endif; ?>">
+                                <label class="btn-arrow<?php echo $indexCount; ?> btn btn-default<?php if ($checked): echo ' active'; endif; ?>">
                                     <input type="radio"
                                            id="<?php echo $child->vars['id']; ?>_0"
                                            name="<?php echo $child->vars['full_name']; ?>"
@@ -95,7 +95,7 @@ $indexCount = 1;
                                     <btn class="btn-nospin fa fa-arrow-circle-left"></btn>
                                 </label>
                                 <?php $checked = $child->vars['value'] === '1'; ?>
-                                <label class="btn btn-default<?php if ($checked): echo ' active'; endif; ?>">
+                                <label class="btn-arrow<?php echo $indexCount; ?> btn btn-default<?php if ($checked): echo ' active'; endif; ?>">
                                     <input type="radio" id="<?php echo $child->vars['id']; ?>_1"
                                            name="<?php echo $child->vars['full_name']; ?>"
                                            title=""

--- a/app/bundles/PluginBundle/Views/FormTheme/Integration/fields_row.html.php
+++ b/app/bundles/PluginBundle/Views/FormTheme/Integration/fields_row.html.php
@@ -83,7 +83,9 @@ $indexCount = 1;
                         <div class="choice-wrapper">
                             <div class="btn-group btn-block" data-toggle="buttons">
                                 <?php $checked = $child->vars['value'] === '0'; ?>
-                                <label class="btn-arrow<?php echo $indexCount; ?> btn btn-default<?php if ($checked): echo ' active'; endif; ?>">
+                                <label class="btn-arrow<?php echo $indexCount; ?> btn btn-default<?php if ($checked): echo ' active'; endif; ?> <?php if ($child->vars['attr']['disabled']) {
+                    echo 'disabled';
+                } ?>">
                                     <input type="radio"
                                            id="<?php echo $child->vars['id']; ?>_0"
                                            name="<?php echo $child->vars['full_name']; ?>"
@@ -91,18 +93,26 @@ $indexCount = 1;
                                            autocomplete="false"
                                            value="0"
                                            onchange="Mautic.matchedFields(<?php echo $indexCount; ?>, '<?php echo $object; ?>', '<?php echo $integration; ?>')"
-                                           <?php if ($checked): ?>checked="checked"<?php endif; ?>>
+                                           <?php if ($checked): ?>checked="checked"<?php endif; ?>
+                                           <?php if ($child->vars['attr']['disabled']) {
+                    echo 'disabled';
+                } ?>>
                                     <btn class="btn-nospin fa fa-arrow-circle-left"></btn>
                                 </label>
                                 <?php $checked = $child->vars['value'] === '1'; ?>
-                                <label class="btn-arrow<?php echo $indexCount; ?> btn btn-default<?php if ($checked): echo ' active'; endif; ?>">
+                                <label class="btn-arrow<?php echo $indexCount; ?> btn btn-default<?php if ($checked): echo ' active'; endif; ?> <?php if ($child->vars['attr']['disabled']) {
+                    echo 'disabled';
+                } ?>">
                                     <input type="radio" id="<?php echo $child->vars['id']; ?>_1"
                                            name="<?php echo $child->vars['full_name']; ?>"
                                            title=""
                                            autocomplete="false"
                                            value="1"
                                            onchange="Mautic.matchedFields(<?php echo $indexCount; ?>, '<?php echo $object; ?>', '<?php echo $integration; ?>')"
-                                           <?php if ($child->vars['value'] === '1'): ?>checked="checked"<?php endif; ?>>
+                                           <?php if ($child->vars['value'] === '1'): ?>checked="checked"<?php endif; ?>
+                                           <?php if ($child->vars['attr']['disabled']) {
+                    echo 'disabled';
+                } ?>>
                                     <btn class="btn-nospin fa fa-arrow-circle-right"></btn>
                                 </label>
                             </div>


### PR DESCRIPTION
…ot be a direction set

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When selecting a compound mautic field in this case (timeline contact link and the do not contact me by email) at this point these are hardcoded since there is only a couple. the direction priority does not apply. With this PR the arrows to set the data direction are disabled to avoid confusion
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. When configuring a CRM plugin or one that has datapriority = true, select either Mautic contact link or do not contact me by email in the mautic fields, you are able to select the direction of the data flow.

#### Steps to test this PR:
1. Do the same above and the arrows to select the direction of the data flow are disabled.