### PR TITLE
Fix date format on dynamic date filters in reports

### DIFF
--- a/app/bundles/ReportBundle/Controller/ReportController.php
+++ b/app/bundles/ReportBundle/Controller/ReportController.php
@@ -639,7 +639,7 @@ class ReportController extends FormController
                 foreach ($dynamicFilters as $dfcol => $dfval) {
                     if (1 === $filter['dynamic'] && $filter['column'] === $dfcol) {
                         $dynamicFilters[$dfcol]['expr'] = $filter['condition'];
-                        break 2;
+                        break;
                     }
                 }
             }

--- a/app/bundles/ReportBundle/Form/Type/DynamicFiltersType.php
+++ b/app/bundles/ReportBundle/Form/Type/DynamicFiltersType.php
@@ -61,14 +61,14 @@ class DynamicFiltersType extends AbstractType
                         $type           = 'date';
                         $args['input']  = 'string';
                         $args['widget'] = 'single_text';
-                        $args['format'] = 'y-M-d';
+                        $args['format'] = 'y-MM-dd';
                         $args['attr']['class'] .= ' datepicker';
                         break;
                     case 'datetime':
                         $type           = 'datetime';
                         $args['input']  = 'string';
                         $args['widget'] = 'single_text';
-                        $args['format'] = 'y-MM-dd H:m:s';
+                        $args['format'] = 'y-MM-dd HH:mm:ss';
                         $args['attr']['class'] .= ' datetimepicker';
                         break;
                     case 'multiselect':


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/pull/4756
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
There is an issue with Date filters in reports: 
Set the dynamic date to some date. For example 2017-01-01. Then refresh the page and the dynamic filter date is 2017-1-1 which is invalid format.

#### Steps to reproduce the bug:
1. Create a custom field Birthday of type Date
2. Create a contact report with a dynamic filter of "birthday < 1/1/2017".  
3. Close and save report
4. Enter a new date for the filter: 2017-01-01
5. Refresh the page
6. Expand the filters and the date will be 2017-1-1

#### Steps to test this PR:
1. Apply this PR
2. Repeat the steps to reproduce the bug
3. This time the date will be in correct format
