### PR TITLE
force compound fields to push to integration

### DIFF
--- a/app/bundles/PluginBundle/Assets/js/plugin.js
+++ b/app/bundles/PluginBundle/Assets/js/plugin.js
@@ -7,7 +7,7 @@ Mautic.matchedFields = function (index, object, integration) {
 
     if (mQuery.inArray(mauticField, compoundMauticFields) >= 0) {
         mQuery('.btn-arrow' + index).removeClass('active');
-        mQuery('#integration_details_featureSettings_leadFields_update_mautic'+ index +'_0').attr('checked', 'checked');
+        mQuery('#integration_details_featureSettings_'+object+'Fields_update_mautic'+ index +'_0').attr('checked', 'checked');
         mQuery('input[name="integration_details[featureSettings]['+object+'Fields][update_mautic' + index + ']"]').prop('disabled', true).trigger("chosen:updated");
         mQuery('.btn-arrow' + index).addClass('disabled');
     } else {

--- a/app/bundles/PluginBundle/Assets/js/plugin.js
+++ b/app/bundles/PluginBundle/Assets/js/plugin.js
@@ -7,6 +7,7 @@ Mautic.matchedFields = function (index, object, integration) {
 
     if (mQuery.inArray(mauticField, compoundMauticFields) >= 0) {
         mQuery('.btn-arrow' + index).removeClass('active');
+        mQuery('#integration_details_featureSettings_leadFields_update_mautic'+ index +'_0').attr('checked', 'checked');
         mQuery('input[name="integration_details[featureSettings]['+object+'Fields][update_mautic' + index + ']"]').prop('disabled', true).trigger("chosen:updated");
         mQuery('.btn-arrow' + index).addClass('disabled');
     } else {

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -2689,12 +2689,12 @@ abstract class AbstractIntegration
      */
     public function getLeadDonotContact($leadId, $channel = 'email')
     {
-        $isContactable = 0;
+        $isContactable = 1;
         $lead          = $this->leadModel->getEntity($leadId);
         if ($lead) {
             $isContactableReason = $this->leadModel->isContactable($lead, $channel);
             if ($isContactableReason === 0) {
-                $isContactable = 1;
+                $isContactable = 0;
             }
         }
 

--- a/plugins/MauticCrmBundle/Tests/SalesforceIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/SalesforceIntegrationTest.php
@@ -605,7 +605,7 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
                         'company'                           => 'Contact1',
                         'email'                             => 'Contact1@sftest.com',
                         'mauticContactTimelineLink'         => 'mautic_plugin_timeline_view',
-                        'mauticContactIsContactableByEmail' => 0,
+                        'mauticContactIsContactableByEmail' => 1,
 
                     ],
                     'contact2@sftest.com' => [
@@ -618,7 +618,7 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
                         'company'                           => 'Contact2',
                         'email'                             => 'Contact2@sftest.com',
                         'mauticContactTimelineLink'         => 'mautic_plugin_timeline_view',
-                        'mauticContactIsContactableByEmail' => 0,
+                        'mauticContactIsContactableByEmail' => 1,
                     ],
                 ],
                 'FirstName,LastName,Email'


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
when mapping contact link or do not contact these should be forced to point to the integration
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. map either fields
2. they wont get updated in the integration

#### Steps to test this PR:
1. with this PR they should be pushed to the integration
