### PR TITLE
Fix imports that contain both company and lead fields

### DIFF
--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -685,7 +685,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
      *
      * @return array
      */
-    public function extractCompanyDataFromImport(array $mappedFields, array &$data)
+    public function extractCompanyDataFromImport(array &$mappedFields, array &$data)
     {
         $companyData    = [];
         $companyFields  = [];

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1773,12 +1773,6 @@ class LeadModel extends FormModel
     {
         $fields    = array_flip($fields);
         $fieldData = [];
-        foreach ($fields as $leadField => $importField) {
-            // Prevent overwriting existing data with empty data
-            if (array_key_exists($importField, $data) && !is_null($data[$importField]) && $data[$importField] != '') {
-                $fieldData[$leadField] = InputHelper::clean($data[$importField]);
-            }
-        }
 
         $lead   = $this->checkForDuplicateContact($fieldData);
         $merged = ($lead->getId());
@@ -1799,6 +1793,13 @@ class LeadModel extends FormModel
             $companyState   = isset($companyFields['companystate']) ? $companyData[$companyFields['companystate']] : null;
 
             $company = $this->companyModel->getRepository()->identifyCompany($companyName, $companyCity, $companyCountry, $companyState);
+        }
+
+        foreach ($fields as $leadField => $importField) {
+            // Prevent overwriting existing data with empty data
+            if (array_key_exists($importField, $data) && !is_null($data[$importField]) && $data[$importField] != '') {
+                $fieldData[$leadField] = InputHelper::clean($data[$importField]);
+            }
         }
 
         if (!empty($fields['dateAdded']) && !empty($data[$fields['dateAdded']])) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
With the introduction of company import, I missed a bug that would attempt to set imported company fields on the associated contact, causing an SQL error (trying to update fields that do not exist).

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Attempt to import the attached file via contact import, in browser (unzip it first)
2. See errors in post-import screen

#### Steps to test this PR:
1. Apply PR & retest
2. Errors are gone and contacts/companies are imported.

[importcompany.csv.zip](https://github.com/mautic/mautic/files/1304520/importcompany.csv.zip)
