### PR TITLE
Update MailChimp integration to request double opt-in as MailChimp API 3 wants it

### DIFF
--- a/plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
+++ b/plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
@@ -98,7 +98,6 @@ class MailchimpApi extends EmailMarketingApi
             $parameters = array_merge($parameters, ['merge_fields' => $fields]);
         }
         $parameters['email_address'] = $email;
-        $parameters['status']        = 'subscribed';
 
         return $this->request('lists/'.$listId.'/members', $parameters, 'POST');
     }

--- a/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
@@ -173,7 +173,7 @@ class MailchimpIntegration extends EmailAbstractIntegration
                 unset($mappedData['EMAIL']);
 
                 $options                 = [];
-                $options['double_optin'] = $config['list_settings']['doubleOptin'];
+                $options['status']       = $config['list_settings']['doubleOptin'] ? 'pending' : 'subscribed';
                 $options['send_welcome'] = $config['list_settings']['sendWelcome'];
                 $listId                  = $config['list_settings']['list'];
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | http://developer.mailchimp.com/documentation/mailchimp/guides/manage-subscribers-with-the-mailchimp-api/
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? | N

#### Description:
I noticed that MailChimp sign-ups weren't getting the double opt-in mail. Checking the code, and reading MC's docs, I get the impression that the code is working the way MC's API 2 did, and that doesn't appear to work any more.

This patch brings the integration inline with what I read here: http://developer.mailchimp.com/documentation/mailchimp/guides/manage-subscribers-with-the-mailchimp-api/
and my users now get the e-mail.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup a push to mail chimp with double opt in on.
2. Sign up.
3. Notice that you get no confirmation e-mail.

#### Steps to test this PR:
1. Setup a push to mail chimp with double opt in on.
2. Sign up.
3. Notice that you now do get a confirmation e-mail.