### PR TITLE
New API route - get recent contacts with web activity

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -252,7 +252,11 @@ return [
                 'path'            => '/devices',
                 'controller'      => 'MauticLeadBundle:Api\DeviceApi',
             ],
-
+            'mautic_api_contactsrecentwebactivity' => [
+                'path'       => '/contacts/recentwebactivity/{minutes}',
+                'controller' => 'MauticLeadBundle:Api\LeadApi:getContactsRecentWebActivity',
+                'method'     => 'GET',
+            ],
             // @deprecated 2.6.0 to be removed in 3.0
             'bc_mautic_api_segmentaddcontact' => [
                 'path'       => '/segments/{id}/contact/add/{leadId}',

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -602,6 +602,28 @@ class LeadApiController extends CommonApiController
     }
 
     /**
+     * Get the list of contact active last $minutes.
+     *
+     * @param int $minutes
+     *
+     * @return Response
+     */
+    public function getContactsRecentWebActivityAction($minutes)
+    {
+        $entity = $this->model->getContactsRecentWebActivity($minutes);
+
+        $this->preSerializeEntity($entity);
+        $view = $this->view(
+            [
+                $this->entityNameOne => $entity,
+            ],
+            Codes::HTTP_OK
+        );
+        $this->setSerializationContext($view);
+
+        return $this->handleView($view);
+    }
+    /**
      * {@inheritdoc}
      *
      * @param \Mautic\LeadBundle\Entity\Lead &$entity

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -606,7 +606,7 @@ class LeadApiController extends CommonApiController
      *
      * @param int $minutes
      *
-     * @return Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function getContactsRecentWebActivityAction($minutes)
     {

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -347,6 +347,39 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
     }
 
     /**
+     * Get the list of contact with webactivity last $minutes.
+     *
+     * @param int $minutes
+     *
+     * @return mixed|null
+     */
+    public function getContactsRecentWebActivity($minutes = 0)
+    {
+        $dateHelper = new DateTimeHelper('', null, 'local');
+
+        $dateHelper->sub('PT'.$minutes.'M', false);
+
+        $date = $dateHelper->toUtcString('Y-m-d H:i:s');
+
+        $q = $this->_em->getConnection()->createQueryBuilder();
+        $q->select('l.email, h.*')
+            ->from(MAUTIC_TABLE_PREFIX.'leads', 'l')
+            ->leftJoin('l', MAUTIC_TABLE_PREFIX.'page_hits', 'h', 'l.id = h.lead_id')
+            ->where('h.date_hit > :date')
+            ->andWhere($q->expr()->isNotNull('l.email'))
+            ->groupBy('l.email')
+            ->setParameter(':date', $date);
+
+        $result = $q->execute()->fetchAll();
+
+        if (count($result) > 0) {
+            return $result;
+        } else {
+            return null;
+        }
+    }
+
+    /**
      * Get a contact entity with the primary company data populated.
      *
      * The primary company data will be a flat array on the entity

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -2841,4 +2841,20 @@ class LeadModel extends FormModel
 
         return $lead;
     }
+
+    /**
+     * Get the list of contact with webactivity last $minutes.
+     *
+     * @param int $minutes
+     *
+     * @return null|object
+     */
+    public function getContactsRecentWebActivity($minutes = 0)
+    {
+        if (!is_null($minutes)) {
+            return $this->getRepository()->getContactsRecentWebActivity($minutes);
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/82
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Required: )
#### Description:
New route added to get the list of all contact with web activity last N minutes
route : `/api/contacts/recentwebactivity/60`

Api-library PR : https://github.com/mautic/api-library/pull/132

