### PR TITLE
Revert changes to generate.js.php that caused errors for modal positioning

### DIFF
--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -269,7 +269,7 @@ class TrackableModel extends AbstractCommonModel
         }
 
         foreach ($content as &$text) {
-            if (preg_match('/<(.*?) href/i', $text)) {
+            if (preg_match('/<[^<]+>/', $text) != 0) {
                 // Parse as HTML
                 $trackableUrls = array_merge(
                     $trackableUrls,

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
@@ -439,6 +439,23 @@ class TrackableModelTest extends WebTestCase
     }
 
     /**
+     * @testdox Test that css images are not converted if there are no links
+     */
+    public function testCssUrlsAreNotConvertedIfThereAreNoLinks()
+    {
+        $url   = 'https://foo-bar.com?foo=bar';
+        $model = $this->getModel($url);
+
+        list($content, $trackables) = $model->parseContentForTrackables(
+            '<style> .mf-modal { background-image: url(\'https://www.mautic.org/wp-content/uploads/2014/08/iTunesArtwork.png\'); } </style>',
+            [],
+            'email',
+            1
+        );
+
+        $this->assertEmpty($trackables);
+    }
+    /**
      * @param       $urls
      * @param null  $tokenUrls
      * @param array $doNotTrack

--- a/media/js/mautic-form-src.js
+++ b/media/js/mautic-form-src.js
@@ -120,6 +120,7 @@
                 if (typeof data == 'undefined') {
                     data = null;
                 }
+
                 return MauticFormCallback[formId][event](data);
             }
 
@@ -272,7 +273,10 @@
             });
 
             // Show the wanted page
-            theForm.querySelector('[data-mautic-form-page="' + showPageNumber + '"]').style.display = 'block';
+            var thePage = theForm.querySelector('[data-mautic-form-page="' + showPageNumber + '"]');
+            if (thePage) {
+                thePage.style.display = 'block'
+            }
             var showPageBreak = theForm.querySelector('[data-mautic-form-pagebreak="' + showPageNumber + '"]');
             if (showPageBreak) {
                 showPageBreak.style.display = 'block';
@@ -583,6 +587,7 @@
                 resetForm: function () {
 
                     this.clearErrors();
+
                     Form.switchPage(document.getElementById('mauticform_' + formId), 1);
 
                     document.getElementById('mauticform_' + formId).reset();
@@ -624,6 +629,7 @@
 
                 try {
                     var response = JSON.parse(event.data);
+
                     if (response && response.formName) {
                         Core.getValidator(response.formName).parseFormResponse(response);
                     }

--- a/plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
@@ -208,7 +208,7 @@ class FocusSubscriber extends CommonSubscriber
             list($content, $trackables) = $this->trackableModel->parseContentForTrackables(
                 $content,
                 $tokens,
-                'focusItems',
+                'focus',
                 $clickthrough['focus_id']
             );
 

--- a/plugins/MauticFocusBundle/Views/Builder/Notification/index.html.php
+++ b/plugins/MauticFocusBundle/Views/Builder/Notification/index.html.php
@@ -14,8 +14,8 @@ echo $view->render(
     'MauticFocusBundle:Builder\Modal:index.html.php',
     [
         'focus'    => $focus,
-        'form'     => $form,
         'preview'  => $preview,
         'clickUrl' => $clickUrl,
+        'htmlMode' => $htmlMode,
     ]
 );

--- a/plugins/MauticFocusBundle/Views/Builder/Page/index.html.php
+++ b/plugins/MauticFocusBundle/Views/Builder/Page/index.html.php
@@ -14,8 +14,8 @@ echo $view->render(
     'MauticFocusBundle:Builder\Modal:index.html.php',
     [
         'focus'    => $focus,
-        'form'     => $form,
         'preview'  => $preview,
         'clickUrl' => $clickUrl,
+        'htmlMode' => $htmlMode,
     ]
 );

--- a/plugins/MauticFocusBundle/Views/Builder/form.html.php
+++ b/plugins/MauticFocusBundle/Views/Builder/form.html.php
@@ -44,8 +44,8 @@ if (empty($preview)):
             var headline = document.getElementsByClassName('mf-headline');
             if (headline.length) {
                 headline[0].style.display = "none";
-
             }
+
             var tagline = document.getElementsByClassName('mf-tagline');
             if (tagline.length) {
                 tagline[0].style.display = "none";

--- a/plugins/MauticFocusBundle/Views/Builder/generate.js.php
+++ b/plugins/MauticFocusBundle/Views/Builder/generate.js.php
@@ -211,37 +211,37 @@ switch ($style) {
                 if (Focus.debug)
                     console.log('scroll event registered');
 
-                    <?php if ($useTimeout): ?>
-                    if (Focus.debug)
-                        console.log('timeout event registered');
+                <?php if ($useTimeout): ?>
+                if (Focus.debug)
+                    console.log('timeout event registered');
 
-                    setTimeout(function () {
-                        window.addEventListener('scroll', Focus.engageVisitorAtScrollPosition);
-                    }, <?php echo $timeout; ?>);
+                setTimeout(function () {
+                    window.addEventListener('scroll', Focus.engageVisitorAtScrollPosition);
+                }, <?php echo $timeout; ?>);
 
-                    <?php else: ?>
+                <?php else: ?>
 
-                     window.addEventListener('scroll', Focus.engageVisitorAtScrollPosition);
+                window.addEventListener('scroll', Focus.engageVisitorAtScrollPosition);
 
-                   <?php endif; ?>
+                <?php endif; ?>
 
                 <?php elseif ($useUnloadEvent): ?>
                 if (Focus.debug)
                     console.log('show when visitor leaves');
 
-                    <?php if ($useTimeout): ?>
-                    if (Focus.debug)
-                        console.log('timeout event registered');
+                <?php if ($useTimeout): ?>
+                if (Focus.debug)
+                    console.log('timeout event registered');
 
-                    setTimeout(function () {
-                        document.documentElement.addEventListener('mouseleave', Focus.engageVisitor);
-                    }, <?php echo $timeout; ?>);
-
-                    <?php else: ?>
-
+                setTimeout(function () {
                     document.documentElement.addEventListener('mouseleave', Focus.engageVisitor);
+                }, <?php echo $timeout; ?>);
 
-                    <?php endif; ?>
+                <?php else: ?>
+
+                document.documentElement.addEventListener('mouseleave', Focus.engageVisitor);
+
+                <?php endif; ?>
 
                 // Add a listener to every link
                 <?php if ($linkActivation): ?>
@@ -266,21 +266,21 @@ switch ($style) {
                 if (Focus.debug)
                     console.log('show immediately');
 
-                    <?php if ($useTimeout): ?>
-                    if (Focus.debug)
-                        console.log('timeout event registered');
+                <?php if ($useTimeout): ?>
+                if (Focus.debug)
+                    console.log('timeout event registered');
 
-                    setTimeout(function () {
-                        // Give a slight delay to allow browser to process style injection into header
-                        Focus.engageVisitor();
-                    }, <?php echo $timeout; ?>);
-
-                    <?php else: ?>
-
+                setTimeout(function () {
                     // Give a slight delay to allow browser to process style injection into header
                     Focus.engageVisitor();
+                }, <?php echo $timeout; ?>);
 
-                    <?php endif; ?>
+                <?php else: ?>
+
+                // Give a slight delay to allow browser to process style injection into header
+                Focus.engageVisitor();
+
+                <?php endif; ?>
 
                 <?php endif; ?>
             },
@@ -531,15 +531,15 @@ switch ($style) {
                             Math.max(Focus.iframeDoc.body.clientHeight, Focus.iframeDoc.documentElement.clientHeight)
                         );
 
-                        var useHeight = ((window.innerHeight < trueHeight || trueHeight === 0) ?
-                            window.innerHeight : trueHeight);
+                        var useHeight = ((window.innerHeight < Focus.iframeFocus.offsetHeight) ?
+                            window.innerHeight : Focus.iframeFocus.offsetHeight);
 
                         useHeight += 10;
                         useHeight = useHeight + 'px';
 
                         if (Focus.debug) {
                             console.log('window inner height = ' + window.innerHeight);
-                            console.log('iframe offset height = ' + trueHeight);
+                            console.log('iframe offset height = ' + Focus.iframeFocus.offsetHeight);
                             console.log('iframe height set to ' + useHeight)
                         }
 
@@ -557,10 +557,10 @@ switch ($style) {
 
                         if (Focus.debug) {
                             console.log('window inner width = ' + window.innerWidth);
-                            console.log('iframe offset width = ' + trueWidth);
+                            console.log('iframe offset width = ' +  Focus.iframeFocus.offsetWidth);
                         }
 
-                        if (window.innerWidth < trueWidth || trueWidth === 0) {
+                        if (window.innerWidth <  Focus.iframeFocus.offsetWidth) {
                             // Responsive iframe
                             Focus.addClass(Focus.iframeFocus, 'mf-responsive');
                             Focus.addClass(Focus.iframe, 'mf-responsive');
@@ -570,8 +570,8 @@ switch ($style) {
                                 console.log('iframe set to responsive width: ');
 
                         } else {
-                            Focus.iframe.style.width = trueWidth + 'px';
-                            Focus.iframe.width = trueWidth + 'px';
+                            Focus.iframe.style.width =  Focus.iframeFocus.offsetWidth + 'px';
+                            Focus.iframe.width =  Focus.iframeFocus.offsetWidth + 'px';
                             Focus.removeClass(Focus.iframeFocus, 'mf-responsive');
                             Focus.removeClass(Focus.iframe, 'mf-responsive');
 

--- a/plugins/MauticFocusBundle/Views/Builder/generate.js.php
+++ b/plugins/MauticFocusBundle/Views/Builder/generate.js.php
@@ -120,7 +120,9 @@ switch ($style) {
                     Focus.modalsDismissed["<?php echo $focus['id']; ?>"] = true;
 
                     // Remove iframe
-                    Focus.iframe.parentNode.removeChild(Focus.iframe);
+                    if (Focus.iframe.parentNode) {
+                        Focus.iframe.parentNode.removeChild(Focus.iframe);
+                    }
 
                     var overlays = document.getElementsByClassName('mf-modal-overlay-<?php echo $focus['id']; ?>');
                     if (overlays.length) {
@@ -525,12 +527,6 @@ switch ($style) {
                 Focus.iframeWidth = 0;
                 Focus.iframeResizeInterval = setInterval(function () {
                     if (Focus.iframeHeight !== Focus.iframe.style.height) {
-                        var trueHeight = Math.max(
-                            Math.max(Focus.iframeDoc.body.scrollHeight, Focus.iframeDoc.documentElement.scrollHeight),
-                            Math.max(Focus.iframeDoc.body.offsetHeight, Focus.iframeDoc.documentElement.offsetHeight),
-                            Math.max(Focus.iframeDoc.body.clientHeight, Focus.iframeDoc.documentElement.clientHeight)
-                        );
-
                         var useHeight = ((window.innerHeight < Focus.iframeFocus.offsetHeight) ?
                             window.innerHeight : Focus.iframeFocus.offsetHeight);
 
@@ -549,12 +545,6 @@ switch ($style) {
 
                     <?php if (in_array($style, ['modal', 'notification'])): ?>
                     if (Focus.iframeWidth !== Focus.iframe.style.width) {
-                        var trueWidth = Math.max(
-                            Math.max(Focus.iframeDoc.body.scrollWidth, Focus.iframeDoc.documentElement.scrollWidth),
-                            Math.max(Focus.iframeDoc.body.offsetWidth, Focus.iframeDoc.documentElement.offsetWidth),
-                            Math.max(Focus.iframeDoc.body.clientWidth, Focus.iframeDoc.documentElement.clientWidth)
-                        );
-
                         if (Focus.debug) {
                             console.log('window inner width = ' + window.innerWidth);
                             console.log('iframe offset width = ' +  Focus.iframeFocus.offsetWidth);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #4947
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Create a modal focus item and embed it on your website.
2. See that the positioning is always top left regardless of settings.
3. Submit a form with a post submit message and notice that after a few seconds, the form will be restored with the submit button stuck as Please Wait
4. Create a page focus item and a notification item and embed it on the website; the positions will be off
5. Use custom HTML or editor to add content to a page or notification item and it'll create a notice that htmlMode is undefined instead of showing the content
6. Add this custom code to HTML mode:
```
<style> .mf-modal { background-image: url('https://www.mautic.org/wp-content/uploads/2014/08/iTunesArtwork.png'); } </style>
```
Notice it'll be converted to a trackable when viewing the focus item on a website.

#### Steps to test this PR:
1. Apply PR, and refresh page where it is embedded. 
2. See that the positioning is back to where it should be. 
3. Submitting a form will restore the form correctly 
4. Page and Notification items will be positioned correctly with correct content for editor and HTML modes
5. CSS urls will not be converted to trackables
6. Run the TrackableModel test cases.