### PR TITLE
Add template and customHtml to the page API get endpoints

### DIFF
--- a/app/bundles/PageBundle/Controller/Api/PageApiController.php
+++ b/app/bundles/PageBundle/Controller/Api/PageApiController.php
@@ -12,6 +12,7 @@
 namespace Mautic\PageBundle\Controller\Api;
 
 use Mautic\ApiBundle\Controller\CommonApiController;
+use Mautic\PageBundle\Entity\Page;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
 /**
@@ -25,10 +26,11 @@ class PageApiController extends CommonApiController
     public function initialize(FilterControllerEvent $event)
     {
         $this->model            = $this->getModel('page');
-        $this->entityClass      = 'Mautic\PageBundle\Entity\Page';
+        $this->entityClass      = Page::class;
         $this->entityNameOne    = 'page';
         $this->entityNameMulti  = 'pages';
         $this->serializerGroups = ['pageDetails', 'categoryList', 'publishDetails'];
+        $this->dataInputMasks   = ['customHtml' => 'html'];
 
         parent::initialize($event);
     }

--- a/app/bundles/PageBundle/Entity/Page.php
+++ b/app/bundles/PageBundle/Entity/Page.php
@@ -290,6 +290,7 @@ class Page extends FormEntity implements TranslationEntityInterface, VariantEnti
                     'translationParent',
                     'translationChildren',
                     'template',
+                    'customHtml',
                 ]
             )
             ->setMaxDepth(1, 'variantParent')

--- a/app/bundles/PageBundle/Entity/Page.php
+++ b/app/bundles/PageBundle/Entity/Page.php
@@ -289,6 +289,7 @@ class Page extends FormEntity implements TranslationEntityInterface, VariantEnti
                     'variantChildren',
                     'translationParent',
                     'translationChildren',
+                    'template',
                 ]
             )
             ->setMaxDepth(1, 'variantParent')


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Enhancement
| Related user documentation PR URL | /
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/84
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The template property was not sent in the GET API requests for Landing Pages. This PR adds that.

Another issue was that when customHtml contained some HTML tags, they were stripped on create/edit. So this PR also adds a mask which fixes that.

#### Steps to test this PR:
1. Checkout this PR
2. Access the `/api/pages` API endpoint and notice the `template` and `customHtml` property is there.
3. API Library tests with https://github.com/mautic/api-library/pull/133 are passing
