### PR TITLE
Code correction and insert form in correct place for focus items

### DIFF
--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -269,7 +269,7 @@ class TrackableModel extends AbstractCommonModel
         }
 
         foreach ($content as &$text) {
-            if (preg_match('/<[^<]+>/', $text) != 0) {
+            if (preg_match('/<[^<]+>/', $text) !== 0) {
                 // Parse as HTML
                 $trackableUrls = array_merge(
                     $trackableUrls,

--- a/plugins/MauticFocusBundle/Views/Builder/Modal/index.html.php
+++ b/plugins/MauticFocusBundle/Views/Builder/Modal/index.html.php
@@ -34,7 +34,7 @@ $animate   = (!empty($preview) && !empty($props['animate'])) ? ' mf-animate' : '
                     <div class="mf-tagline"><?php echo $props['content']['tagline']; ?></div>
                 <?php endif; ?>
                 <div class="mf-inner-container">
-                    <?php if ($focus['type'] == 'form' && !empty($form)): ?>
+                    <?php if ($focus['type'] == 'form'): ?>
                         {focus_form}
                     <?php elseif ($focus['type'] == 'link'): ?>
                         <a href="<?php echo (empty($preview)) ? $clickUrl


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR addresses a couple issues caught in #4950. It corrects the operator comparison and then removes the unused catch of $form since it's now token based. Although #4950 appended the form regardless, this ensures it's inserted in the expected place. 

#### Steps to test this PR:
1. Create a modal, page, notification, and bar focus items each using a form
2. Embed each on a page
3. Ensure the selected form shows up in both the preview and on the embedded page
