### PR TITLE
Fixes several timeline bugs

### DIFF
--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -56,6 +56,7 @@ Mautic.leadOnLoad = function (container, response) {
         };
 
         Mautic.leadTimelineOnLoad(container, response);
+        Mautic.leadAuditlogOnLoad(container, response);
     }
 
     // Auditlog filters
@@ -179,7 +180,12 @@ Mautic.leadTimelineOnLoad = function (container, response) {
         }
     });
 
-    // auditlog
+    if (response && typeof response.timelineCount != 'undefined') {
+        mQuery('#TimelineCount').html(response.timelineCount);
+    }
+};
+
+Mautic.leadAuditlogOnLoad = function (container, response) {
     mQuery("#contact-auditlog a[data-activate-details='all']").on('click', function() {
         if (mQuery(this).find('span').first().hasClass('fa-level-down')) {
             mQuery("#contact-auditlog a[data-activate-details!='all']").each(function () {
@@ -215,10 +221,6 @@ Mautic.leadTimelineOnLoad = function (container, response) {
             }
         }
     });
-
-    if (response && typeof response.timelineCount != 'undefined') {
-        mQuery('#TimelineCount').html(response.timelineCount);
-    }
 };
 
 Mautic.leadOnUnload = function(id) {

--- a/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
@@ -175,7 +175,7 @@ trait CustomFieldEntityTrait
      */
     public function getFieldValue($field, $group = null)
     {
-        if (isset($this->updatedFields[$field])) {
+        if (array_key_exists($field, $this->updatedFields)) {
             return $this->updatedFields[$field];
         }
 

--- a/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
@@ -171,7 +171,7 @@ trait CustomFieldEntityTrait
      * @param string $field
      * @param string $group
      *
-     * @return array|false
+     * @return mixed
      */
     public function getFieldValue($field, $group = null)
     {
@@ -183,7 +183,7 @@ trait CustomFieldEntityTrait
             return CustomFieldHelper::fixValueType($field['type'], $field['value']);
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -1542,7 +1542,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
 
         if (!empty($attribution) && empty($attributionDate)) {
             $this->addUpdatedField('attribution_date', (new \DateTime())->format('Y-m-d'));
-        } elseif (empty($attribution)) {
+        } elseif (empty($attribution) && !empty($attributionDate)) {
             $this->addUpdatedField('attribution_date', null);
         }
     }

--- a/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
@@ -217,15 +217,31 @@ class LeadTest extends \PHPUnit_Framework_TestCase
         $lead->addUpdatedField('attribution', 100);
         $lead->checkAttributionDate();
         $this->assertEquals((new \Datetime())->format('Y-m-d'), $lead->getFieldValue('attribution_date'));
+        $this->assertNotEmpty($lead->getChanges());
     }
 
     public function testAttributionDateIsRemoved()
     {
         $lead = new Lead();
+        $lead->setFields(
+            [
+                'core' => [
+                    'attribution_date' => [
+                        'type'  => 'date',
+                        'value' => '2017-09-09',
+                    ],
+                    'attribution' => [
+                        'type'  => 'int',
+                        'value' => 100,
+                    ],
+                ],
+            ]
+        );
+
         $lead->addUpdatedField('attribution', 0);
-        $lead->addUpdatedField('attribution_date', '2017-09-09');
         $lead->checkAttributionDate();
         $this->assertNull($lead->getFieldValue('attribution_date'));
+        $this->assertNotEmpty($lead->getChanges());
     }
 
     public function testAttributionDateIsNotChangedWhen0ChangedToNull()
@@ -233,19 +249,20 @@ class LeadTest extends \PHPUnit_Framework_TestCase
         $lead = new Lead();
         $lead->setFields(
             [
-                'attribution_date' => [
-                    'type'  => 'date',
-                    'value' => 0,
-                ],
-                'attribution' => [
-                    'type'  => 'int',
-                    'value' => 0,
-                ],
+                'core' => [
+                        'attribution_date' => [
+                            'type'  => 'date',
+                            'value' => 0,
+                        ],
+                        'attribution' => [
+                            'type'  => 'int',
+                            'value' => 0,
+                        ],
+                    ],
             ]
         );
 
         $lead->checkAttributionDate();
-
         $this->assertEmpty($lead->getChanges());
     }
 

--- a/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
@@ -211,6 +211,44 @@ class LeadTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(null, $data['number']);
     }
 
+    public function testAttributionDateIsAdded()
+    {
+        $lead = new Lead();
+        $lead->addUpdatedField('attribution', 100);
+        $lead->checkAttributionDate();
+        $this->assertEquals((new \Datetime())->format('Y-m-d'), $lead->getFieldValue('attribution_date'));
+    }
+
+    public function testAttributionDateIsRemoved()
+    {
+        $lead = new Lead();
+        $lead->addUpdatedField('attribution', 0);
+        $lead->addUpdatedField('attribution_date', '2017-09-09');
+        $lead->checkAttributionDate();
+        $this->assertNull($lead->getFieldValue('attribution_date'));
+    }
+
+    public function testAttributionDateIsNotChangedWhen0ChangedToNull()
+    {
+        $lead = new Lead();
+        $lead->setFields(
+            [
+                'attribution_date' => [
+                    'type'  => 'date',
+                    'value' => 0,
+                ],
+                'attribution' => [
+                    'type'  => 'int',
+                    'value' => 0,
+                ],
+            ]
+        );
+
+        $lead->checkAttributionDate();
+
+        $this->assertEmpty($lead->getChanges());
+    }
+
     /**
      * @param      $points
      * @param      $expected

--- a/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -92,6 +92,7 @@ $query = $event['extra']['hit']['query'];
 
     <?php
     if (!empty($query)) {
+        $counter = 0;
         foreach ($query as $k => $v) {
             if (in_array($v, ['', null, []])) {
                 continue;

--- a/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -89,6 +89,55 @@ $query = $event['extra']['hit']['query'];
         <?php endif; ?>
 
     <?php endif; ?>
+
+    <?php
+    if (!empty($query)) {
+        foreach ($query as $k => $v) {
+            if (in_array($v, ['', null, []])) {
+                continue;
+            }
+            if (in_array($k, ['ct', 'page_title', 'page_referrer', 'page_url'])) {
+                continue;
+            }
+            if (is_array($v)) {
+                foreach ($v as $k2 => $v2) {
+                    ++$counter;
+                    $k2 = ucwords(str_replace('_', ' ', $k));
+
+                    echo '<dt>'.$k2.':</dt>';
+                    echo '<dd class="ellipsis">'.$v2.'</dd>';
+
+                    if (empty($showMore) && $counter > 5) {
+                        $showMore = true;
+
+                        echo '<div style="display:none">';
+                    }
+                }
+
+                continue;
+            }
+
+            ++$counter;
+            $k = ucwords(str_replace('_', ' ', $k));
+
+            echo '<dt>'.$k.':</dt>';
+            echo '<dd class="ellipsis">'.$v.'</dd>';
+
+            if (empty($showMore) && $counter > 5) {
+                $showMore = true;
+
+                echo '<div style="display:none">';
+            }
+        }
+
+        if (!empty($showMore)) {
+            echo '</div>';
+            echo '<a href="javascript:void(0);" class="text-center small center-block mt-xs" onclick="Mautic.toggleTimelineMoreVisiblity(mQuery(this).prev());">';
+            echo $view['translator']->trans('mautic.core.more.show');
+            echo '</a>';
+        }
+    }
+    ?>
 </dl>
 <div class="small">
     <?php echo InputHelper::clean($event['extra']['hit']['userAgent']); ?>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR fixes three timeline bugs:
1. It adds back showing the query parameters for page hits. This is important when debugging page hits and updatable fields. 
2. If filtering or changing pages for the audit log entries, the details expansion buttons no longer work
3. Many contact update records were added to the audit log that noted a changed attribution date even though it wasn't changed. This prevents this entries that cluttered up the timeline. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Add the tracking code to a 3rd party page and update the mt() call to be `mt('send', 'pageview', {'foo': 'bar', 'bar': 'foo', 'foobar': 'barfoo', 'barfoo': 'foobar', 'yadda': 'nadda', 'nadda': 'yadda'});`. HIt up the page as a visitor. Find the visitor in Mautic and view the details of the page hit. Only device information will be visible. Nothing will be there about what parameters were passed. 
2. Go to the audit log tab and filter by something. Try to click the details button on the left and they will not work. 
3. View the audit log for the contact created with the page hit. View the created or updated entries and not the empty attribution date fields

#### Steps to test this PR:
Clear browser cache or use a new guest session and repeat the three above 
1. The query params will be visible in the page hit details.
2. The audit log filtering will not break the view details buttons.
3. There will be no empty entries for attribution dates.
