### PR TITLE
Add next/previous button form callback support

### DIFF
--- a/media/js/mautic-form-src.js
+++ b/media/js/mautic-form-src.js
@@ -219,13 +219,14 @@
                     var nextButton = pageBreak.querySelector('[data-mautic-form-pagebreak-button="next"]');
 
                     // Add button handlers
-                    prevButton.onclick = function(theForm, showPageNumber) {
+                    prevButton.onclick = function(formId, theForm, showPageNumber) {
                         return function() {
+                            Form.customCallbackHandler(formId, 'onShowPreviousPage', {'page': showPageNumber});
                             Form.switchPage(theForm, showPageNumber);
                         }
-                    } (theForm, prevPageNumber);
+                    } (formId, theForm, prevPageNumber);
 
-                    nextButton.onclick = function(theForm, hidePageNumber, showPageNumber) {
+                    nextButton.onclick = function(formId, theForm, hidePageNumber, showPageNumber) {
                         return function () {
                             // Validate fields first
                             var validations = theForm.querySelector('[data-mautic-form-page="' + hidePageNumber + '"]').querySelectorAll('[data-validate]');
@@ -240,9 +241,10 @@
                                 return;
                             }
 
+                            Form.customCallbackHandler(formId, 'onShowNextPage', {'page': showPageNumber});
                             Form.switchPage(theForm, showPageNumber);
                         }
-                    } (theForm, pageNumber, nextPageNumber);
+                    } (formId, theForm, pageNumber, nextPageNumber);
 
                     if (1 === pageNumber) {
                         prevButton.setAttribute('disabled', 'disabled');

--- a/media/js/mautic-form-src.js
+++ b/media/js/mautic-form-src.js
@@ -221,7 +221,7 @@
                     // Add button handlers
                     prevButton.onclick = function(formId, theForm, showPageNumber) {
                         return function() {
-                            Form.customCallbackHandler(formId, 'onShowPreviousPage', {'page': showPageNumber});
+                            Form.customCallbackHandler(formId, 'onShowPreviousPage', showPageNumber);
                             Form.switchPage(theForm, showPageNumber);
                         }
                     } (formId, theForm, prevPageNumber);
@@ -241,7 +241,7 @@
                                 return;
                             }
 
-                            Form.customCallbackHandler(formId, 'onShowNextPage', {'page': showPageNumber});
+                            Form.customCallbackHandler(formId, 'onShowNextPage', showPageNumber);
                             Form.switchPage(theForm, showPageNumber);
                         }
                     } (formId, theForm, pageNumber, nextPageNumber);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | y
| Related user documentation PR URL | 
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/85
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR adds two form callbacks when using pagination. This becomes useful to show/hide fields between pages. 

#### Steps to test this PR:
1. Apply the PR
2. Create a new form with at least two pages
3. On the page the form is embedded, add this JS

```
<script>
    if (typeof MauticFormCallback == 'undefined') {
        var MauticFormCallback = {};
    }
    MauticFormCallback['multipages'] = {
        onShowPreviousPage: function (pageNumber) {
            alert('prev page '+pageNumber);
        },
        onShowNextPage: function (pageNumber) {
            alert('next page '+pageNumber);
        }
    };

</script>
```

Browse the pages in the embedded form and you should get the appropriate alerts.
