### PR TITLE
Feature/unit test warnings

### DIFF
--- a/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
@@ -34,7 +34,7 @@ class ImportModelTest extends StandardImportTestHelper
             ->setOriginalFile($fileName);
         $log = $model->initEventLog($entity, $line);
 
-        $this->assertTrue($log instanceof LeadEventLog);
+        $this->assertInstanceOf(LeadEventLog::class, $log);
         $this->assertSame($userId, $log->getUserId());
         $this->assertSame($userName, $log->getUserName());
         $this->assertSame('lead', $log->getBundle());
@@ -81,7 +81,7 @@ class ImportModelTest extends StandardImportTestHelper
             ->method('getRepository')
             ->will($this->returnValue($repository));
 
-        $result = $model->checkParallelImportLimit($entity);
+        $result = $model->checkParallelImportLimit();
 
         $this->assertFalse($result);
     }
@@ -111,7 +111,7 @@ class ImportModelTest extends StandardImportTestHelper
             ->method('getRepository')
             ->will($this->returnValue($repository));
 
-        $result = $model->checkParallelImportLimit($entity);
+        $result = $model->checkParallelImportLimit();
 
         $this->assertFalse($result);
     }
@@ -141,7 +141,7 @@ class ImportModelTest extends StandardImportTestHelper
             ->method('getRepository')
             ->will($this->returnValue($repository));
 
-        $result = $model->checkParallelImportLimit($entity);
+        $result = $model->checkParallelImportLimit();
 
         $this->assertTrue($result);
     }

--- a/app/bundles/LeadBundle/Tests/StandardImportTestHelper.php
+++ b/app/bundles/LeadBundle/Tests/StandardImportTestHelper.php
@@ -126,10 +126,6 @@ abstract class StandardImportTestHelper extends CommonMocks
 
         $companyModel->setEntityManager($entityManager);
 
-        $companyModel->expects($this->any())
-            ->method('getEventLogRepository')
-            ->willReturn($logRepository);
-
         $notificationModel = $this->getMockBuilder(NotificationModel::class)
             ->disableOriginalConstructor()
             ->getMock();


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Fixed PHPUnit warning from `ImportModelTest` class. It tried to configure `getEventLogRepository` method that does not exists in `CompanyModel`.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run tests and you will see warnings related to `ImportModelTest` (`bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml --filter ImportModelTest`)
<img width="1372" alt="screen shot 2017-09-25 at 11 11 51" src="https://user-images.githubusercontent.com/1649279/30801084-687441b0-a1e2-11e7-8f66-ecbfd6350000.png">


#### Steps to test this PR:
1. Apply this PR
2. Run tests again. Now there is no warning and all tests pass.
3. You can check them i Travis too.