### PR TITLE
Bug field api where

### DIFF
--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -401,7 +401,7 @@ class CommonApiController extends FOSRestController implements MauticController
             $this->customSelectRequested = true;
         }
 
-        if ($where = $this->getWhereFromResponse()) {
+        if ($where = $this->getWhereFromRequest()) {
             $args['filter']['where'] = $where;
         }
 
@@ -426,7 +426,7 @@ class CommonApiController extends FOSRestController implements MauticController
      *
      * @return array
      */
-    protected function getWhereFromResponse()
+    protected function getWhereFromRequest()
     {
         $where = InputHelper::cleanArray($this->request->get('where', []));
 

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -401,13 +401,7 @@ class CommonApiController extends FOSRestController implements MauticController
             $this->customSelectRequested = true;
         }
 
-        if ($where = InputHelper::cleanArray($this->request->get('where', []))) {
-            // Ensure internal flag is not spoofed
-            foreach ($where as $key => $statement) {
-                if (isset($statement['internal'])) {
-                    unset($where[$key]);
-                }
-            }
+        if ($where = $this->getWhereFromResponse()) {
             $args['filter']['where'] = $where;
         }
 
@@ -425,6 +419,20 @@ class CommonApiController extends FOSRestController implements MauticController
         $this->setSerializationContext($view);
 
         return $this->handleView($view);
+    }
+
+    /**
+     * Sanitizes and returns an array of where statements from the request.
+     *
+     * @return array
+     */
+    protected function getWhereFromResponse()
+    {
+        $where = InputHelper::cleanArray($this->request->get('where', []));
+
+        $this->sanitizeWhereClauseArrayFromRequest($where);
+
+        return $where;
     }
 
     /**

--- a/app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
@@ -9,10 +9,11 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-namespace Mautic\CampaignBundle\Tests\Model;
+namespace Mautic\ApiBundle\Tests\Controller;
 
 use Mautic\ApiBundle\Controller\CommonApiController;
 use Mautic\CampaignBundle\Tests\CampaignTestAbstract;
+use Symfony\Component\HttpFoundation\Request;
 
 class CommonApiControllerTest extends CampaignTestAbstract
 {
@@ -44,9 +45,48 @@ class CommonApiControllerTest extends CampaignTestAbstract
         $this->assertEquals('f.dateAdded,f.dateModified', $result);
     }
 
-    protected function getResultFromProtectedMethod($method, array $args)
+    public function testGetWhereFromResponseWithNoWhere()
     {
-        $controller           = new CommonApiController();
+        $request = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $result = $this->getResultFromProtectedMethod('getWhereFromResponse', [], $request);
+
+        $this->assertEquals([], $result);
+    }
+
+    public function testGetWhereFromResponseWithSomeWhere()
+    {
+        $where = [
+            [
+                'col'  => 'id',
+                'expr' => 'eq',
+                'val'  => 5,
+            ],
+        ];
+
+        $request = $this->getMockBuilder(Request::class)
+            ->setMethods(['get'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $request->method('get')
+            ->willReturn($where);
+
+        $result = $this->getResultFromProtectedMethod('getWhereFromResponse', [], $request);
+
+        $this->assertEquals($where, $result);
+    }
+
+    protected function getResultFromProtectedMethod($method, array $args, Request $request = null)
+    {
+        $controller = new CommonApiController();
+
+        if ($request) {
+            $controller->setRequest($request);
+        }
+
         $controllerReflection = new \ReflectionClass(CommonApiController::class);
         $method               = $controllerReflection->getMethod($method);
         $method->setAccessible(true);

--- a/app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
@@ -45,18 +45,18 @@ class CommonApiControllerTest extends CampaignTestAbstract
         $this->assertEquals('f.dateAdded,f.dateModified', $result);
     }
 
-    public function testGetWhereFromResponseWithNoWhere()
+    public function testgetWhereFromRequestWithNoWhere()
     {
         $request = $this->getMockBuilder(Request::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $result = $this->getResultFromProtectedMethod('getWhereFromResponse', [], $request);
+        $result = $this->getResultFromProtectedMethod('getWhereFromRequest', [], $request);
 
         $this->assertEquals([], $result);
     }
 
-    public function testGetWhereFromResponseWithSomeWhere()
+    public function testgetWhereFromRequestWithSomeWhere()
     {
         $where = [
             [
@@ -74,7 +74,7 @@ class CommonApiControllerTest extends CampaignTestAbstract
         $request->method('get')
             ->willReturn($where);
 
-        $result = $this->getResultFromProtectedMethod('getWhereFromResponse', [], $request);
+        $result = $this->getResultFromProtectedMethod('getWhereFromRequest', [], $request);
 
         $this->assertEquals($where, $result);
     }

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -361,6 +361,12 @@ class InputHelper
     {
         $value = self::clean($value, $urldecode);
 
+        // Return empty array for empty values
+        if (empty($value)) {
+            return [];
+        }
+
+        // Put a value into array if not an array
         if (!is_array($value)) {
             $value = [$value];
         }

--- a/app/bundles/CoreBundle/Tests/unit/Helper/InputHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Helper/InputHelperTest.php
@@ -56,4 +56,22 @@ class InputHelperTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($expected, $actual);
         }
     }
+
+    public function testCleanArrayWithEmptyValue()
+    {
+        $this->assertEquals([], InputHelper::cleanArray(null));
+    }
+
+    public function testCleanArrayWithStringValue()
+    {
+        $this->assertEquals(['kuk'], InputHelper::cleanArray('kuk'));
+    }
+
+    public function testCleanArrayWithJS()
+    {
+        $this->assertEquals(
+            ['&#60;script&#62;console.log(&#34;log me&#34;);&#60;/script&#62;'],
+            InputHelper::cleanArray(['<script>console.log("log me");</script>'])
+        );
+    }
 }

--- a/app/bundles/LeadBundle/Controller/Api/FieldApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/FieldApiController.php
@@ -21,6 +21,11 @@ use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
  */
 class FieldApiController extends CommonApiController
 {
+    /**
+     * Can have value of 'contact' or 'company'.
+     *
+     * @var string
+     */
     protected $fieldObject;
 
     public function initialize(FilterControllerEvent $event)
@@ -45,6 +50,24 @@ class FieldApiController extends CommonApiController
         ];
 
         parent::initialize($event);
+    }
+
+    /**
+     * Sanitizes and returns an array of where statements from the request.
+     *
+     * @return array
+     */
+    protected function getWhereFromRequest()
+    {
+        $where = parent::getWhereFromRequest();
+
+        $where[] = [
+            'col'  => 'object',
+            'expr' => 'eq',
+            'val'  => $this->fieldObject,
+        ];
+
+        return $where;
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerTest.php
@@ -9,7 +9,7 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-namespace Mautic\LeadBundle\Tests\Controller;
+namespace Mautic\LeadBundle\Tests\Controller\Api;
 
 use Mautic\CampaignBundle\Tests\CampaignTestAbstract;
 use Mautic\LeadBundle\Controller\Api\FieldApiController;

--- a/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Controller;
+
+use Mautic\CampaignBundle\Tests\CampaignTestAbstract;
+use Mautic\LeadBundle\Controller\Api\FieldApiController;
+use Symfony\Component\HttpFoundation\Request;
+
+class FieldApiControllerTest extends CampaignTestAbstract
+{
+    private $defaultWhere = [
+        [
+            'col'  => 'object',
+            'expr' => 'eq',
+            'val'  => null,
+        ],
+    ];
+
+    public function testgetWhereFromRequestWithNoWhere()
+    {
+        $request = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $result = $this->getResultFromProtectedMethod('getWhereFromRequest', [], $request);
+
+        $this->assertEquals($this->defaultWhere, $result);
+    }
+
+    public function testgetWhereFromRequestWithSomeWhere()
+    {
+        $where = [
+            [
+                'col'  => 'id',
+                'expr' => 'eq',
+                'val'  => 5,
+            ],
+        ];
+
+        $request = $this->getMockBuilder(Request::class)
+            ->setMethods(['get'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $request->method('get')
+            ->willReturn($where);
+
+        $result = $this->getResultFromProtectedMethod('getWhereFromRequest', [], $request);
+
+        $this->assertEquals(array_merge($where, $this->defaultWhere), $result);
+    }
+
+    protected function getResultFromProtectedMethod($method, array $args, Request $request = null)
+    {
+        $controller = new FieldApiController();
+
+        if ($request) {
+            $controller->setRequest($request);
+        }
+
+        $controllerReflection = new \ReflectionClass(FieldApiController::class);
+        $method               = $controllerReflection->getMethod($method);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($controller, $args);
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The custom field API is divided into 2 endpoints.

1. `/api/fields/contact`
2. `/api/fields/company`

Those will get the right fields for each, but if the query builder is used, the company endponint will also return contact fields and the other way around. You can test it with request similar to this one:
<img width="624" alt="screen shot 2017-09-25 at 15 21 11" src="https://user-images.githubusercontent.com/1235442/30810367-366f691a-a205-11e7-9212-497ab6b25c67.png">

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Request company fields with some where conditions like in the image above.
2. Notice the response contains fields with `object = 'lead'` and not just `company`.
3. Run API Library tests ('phpunit --filter Field`) with https://github.com/mautic/api-library/pull/134 applied.

#### Steps to test this PR:
1. Checkout this PR
2. The company fields endpoint will return only company fields.
3. Run the API Library tests again.
