### PR TITLE
Modified AbstractIntegration to handle $settings['curl_options'] as expected

### DIFF
--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -977,8 +977,8 @@ abstract class AbstractIntegration
             CURLOPT_USERAGENT      => $this->getUserAgent(),
         ];
 
-        if (isset($settings['curl_options'])) {
-            $options = array_merge($options, $settings['curl_options']);
+        if (isset($settings['curl_options']) && is_array($settings['curl_options'])) {
+            $options = $settings['curl_options'] + $options;
         }
 
         if (isset($settings['ssl_verifypeer'])) {


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL |  /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | ?
| Deprecations? |  N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
Currently calling makeRequest with $settings['curl_options'] will call array_merge to merge the curl options together https://github.com/mautic/mautic/blob/4e5beb83218c1611929aa6fdf4b0a7f6df2444d0/app/bundles/PluginBundle/Integration/AbstractIntegration.php#L981
Doing this may produce unexpected results as array_merge reindexes an array, which when using options with CURLOPT_* they will be internally converted to number not kept as const.

Example:
```
php > 
php >         $options = [
php >             CURLOPT_HTTP_VERSION   => CURL_HTTP_VERSION_1_1,
php >             CURLOPT_HEADER         => 1,
php >             CURLOPT_RETURNTRANSFER => 1,
php >             CURLOPT_FOLLOWLOCATION => 0,
php >             CURLOPT_REFERER        => 'http://localhost',
php >             CURLOPT_USERAGENT      => 'Fruit Device',
php >         ];
php > 
php > 
php >         $options_override = [
php >             CURLOPT_RETURNTRANSFER => 1,
php >             CURLOPT_CONNECT_ONLY => 1,
php >             CURLOPT_REFERER        => 'http://localhost',
php >             CURLOPT_USERAGENT      => 'Green Robot Device',
php >         ];
php > print_r(array_merge($options_override, $options));
Array
(
    [0] => 1
    [1] => 1
    [2] => http://localhost
    [3] => Green Robot Device
    [4] => 2
    [5] => 1
    [6] => 1
    [7] => 0
    [8] => http://localhost
    [9] => Fruit Device
)
php > print_r($options_override + $options);
Array
(
    [19913] => 1
    [141] => 1
    [10016] => http://localhost
    [10018] => Green Robot Device
    [84] => 2
    [42] => 1
    [52] => 0
)
php > 
```
[//]: # ( As applicable: )
#### Steps to test this PR:
As it stands i found there are only 2 cases in the main codebase which this is used https://github.com/mautic/mautic/blob/4e5beb83218c1611929aa6fdf4b0a7f6df2444d0/plugins/MauticCrmBundle/Api/SalesforceApi.php#L24-L26 https://github.com/mautic/mautic/blob/4e5beb83218c1611929aa6fdf4b0a7f6df2444d0/plugins/MauticCrmBundle/Api/DynamicsApi.php#L205
Which may need someone with those integrations to test making requests.

#### List backwards compatibility breaks:
1. Possible SalesforceApi integrations
2. Possible DynamicsApi integrations
3. Possible Custom AbstractIntegration extends relying on the variable being wrong