### PR TITLE
Pass table name on which to drop index

### DIFF
--- a/app/bundles/CoreBundle/Doctrine/Helper/IndexSchemaHelper.php
+++ b/app/bundles/CoreBundle/Doctrine/Helper/IndexSchemaHelper.php
@@ -153,7 +153,7 @@ class IndexSchemaHelper
 
         if (count($this->dropIndexes)) {
             foreach ($this->dropIndexes as $index) {
-                $sql[] = $platform->getDropIndexSQL($index);
+                $sql[] = $platform->getDropIndexSQL($index, $this->table);
             }
         }
 

--- a/app/bundles/CoreBundle/Doctrine/Helper/IndexSchemaHelper.php
+++ b/app/bundles/CoreBundle/Doctrine/Helper/IndexSchemaHelper.php
@@ -146,7 +146,7 @@ class IndexSchemaHelper
         $sql = [];
         if (count($this->changedIndexes)) {
             foreach ($this->changedIndexes as $index) {
-                $sql[] = $platform->getDropIndexSQL($index);
+                $sql[] = $platform->getDropIndexSQL($index, $this->table);
                 $sql[] = $platform->getCreateIndexSQL($index, $this->table);
             }
         }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | n/a
| Related developer documentation PR URL | n/a
| Issues addressed (#s or URLs) | #5030 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Pass the table name to ``getDropIndexSQL()`` so that it knows on which table it should drop the old index.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Have the test DB already set up with fixtures...
2. Try to reload the fixtures (e.g. after messing around with the data while testing)
```
php app/console doctrine:fixtures:load --no-interaction --env=test
[2017-09-27 04:16:11]   > purging database
[2017-09-27 04:16:11]   > loading [1] Mautic\UserBundle\DataFixtures\ORM\LoadRoleData
[2017-09-27 04:16:11]   > loading [2] Mautic\UserBundle\DataFixtures\ORM\LoadUserData
[2017-09-27 04:16:13]   > loading [4] Mautic\LeadBundle\DataFixtures\ORM\LoadLeadFieldData

                                                                                                          
  [InvalidArgumentException]                                                                              
  MysqlPlatform::getDropIndexSQL() expects $table parameter to be string or \Doctrine\DBAL\Schema\Table.  
```

#### Steps to test this PR:
1. Have the test DB already set up with fixtures...
2. Try to reload the fixtures (e.g. after messing around with the data while testing)
```
php app/console doctrine:fixtures:load --no-interaction --env=test
[2017-09-27 04:16:36]   > purging database
[2017-09-27 04:16:36]   > loading [1] Mautic\UserBundle\DataFixtures\ORM\LoadRoleData
[2017-09-27 04:16:36]   > loading [2] Mautic\UserBundle\DataFixtures\ORM\LoadUserData
[2017-09-27 04:16:38]   > loading [4] Mautic\LeadBundle\DataFixtures\ORM\LoadLeadFieldData
[2017-09-27 04:16:40]   > loading [5] Mautic\ReportBundle\DataFixtures\ORM\LoadReportData
[2017-09-27 04:16:40]   > loading [5] Mautic\LeadBundle\DataFixtures\ORM\LoadLeadListData
[2017-09-27 04:16:41]   > loading [5] Mautic\LeadBundle\DataFixtures\ORM\LoadLeadData
[2017-09-27 04:16:42]   > loading [6] Mautic\PageBundle\DataFixtures\ORM\LoadPageCategoryData
[2017-09-27 04:16:42]   > loading [7] Mautic\PageBundle\DataFixtures\ORM\LoadPageData
[2017-09-27 04:16:42]   > loading [8] Mautic\PageBundle\DataFixtures\ORM\LoadPageHitData
[2017-09-27 04:16:43]   > loading [8] Mautic\FormBundle\DataFixtures\ORM\LoadFormData
[2017-09-27 04:16:43]   > loading [9] Mautic\EmailBundle\DataFixtures\ORM\LoadEmailData
[2017-09-27 04:16:43]   > loading [9] Mautic\FormBundle\DataFixtures\ORM\LoadFormResultData
[2017-09-27 04:16:47]   > loading [10] Mautic\AssetBundle\DataFixtures\ORM\LoadAssetData
```
