### PR TITLE
LeadFieldData set type correctly for comparison with textarea

### DIFF
--- a/app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
+++ b/app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
@@ -88,7 +88,7 @@ class LeadFieldData extends AbstractFixture implements OrderedFixtureInterface, 
                     // Schema already has this custom field; likely defined as a property in the entity class itself
                 }
 
-                $indexesToAdd[$object][] = $alias;
+                $indexesToAdd[$object][$alias] = $field;
 
                 $this->addReference('leadfield-'.$alias, $entity);
                 ++$order;
@@ -106,8 +106,8 @@ class LeadFieldData extends AbstractFixture implements OrderedFixtureInterface, 
                 $indexHelper = $this->container->get('mautic.schema.helper.factory')->getSchemaHelper('index', 'leads');
             }
 
-            foreach ($indexes as $name) {
-                $type = (isset($fields[$name]['type'])) ? $fields[$name]['type'] : 'text';
+            foreach ($indexes as $name => $field) {
+                $type = (isset($field['type'])) ? $field['type'] : 'text';
                 if ('textarea' != $type) {
                     $indexHelper->addIndex([$name], $name.'_search');
                 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | n/a
| Related developer documentation PR URL | n/a
| Issues addressed (#s or URLs) | #5032 
| BC breaks? | no
| Deprecations? | no

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Pass and calculate the value of the field type before comparing it to the string ``textarea``

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
This is a latent defect in the current code that sets up fixtures.

#### Steps to test this PR:
1. Check the value of ``$type`` (e.g. ``var_dump($type)`` ) when running the command to load fixtures:
```
php app/console doctrine:fixtures:load --no-interaction --env=test
```
That [will|should] show the various field types coming from the fixture definitions in ``FieldModel.php``
