### PR TITLE
API: Change POST to PATCH request while contact is moving from createAction to editAction 

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -55,7 +55,6 @@ class LeadApiController extends CommonApiController
     public function newEntityAction()
     {
         $existingLeads = $this->getExistingLeads();
-
         if (!empty($existingLeads)) {
             $this->request->setMethod('PATCH');
 

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -56,6 +56,7 @@ class LeadApiController extends CommonApiController
     {
         $existingLeads = $this->getExistingLeads();
         if (!empty($existingLeads)) {
+            $this->request->setMethod('PATCH');
             return parent::editEntityAction($existingLeads[0]->getId());
         }
 

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -55,8 +55,10 @@ class LeadApiController extends CommonApiController
     public function newEntityAction()
     {
         $existingLeads = $this->getExistingLeads();
+
         if (!empty($existingLeads)) {
             $this->request->setMethod('PATCH');
+
             return parent::editEntityAction($existingLeads[0]->getId());
         }
 


### PR DESCRIPTION
… editAction

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Create contact in Mautic with youremail and firstname
2.  Call API just with yourmail  $`contactAPI->create(['email'=>'youremail']);`
3. firstname was removed

#### Steps to test this PR:
1. Repeat reproduce process
2. Firstname  should not removed