### PR TITLE
Calculate fake import start from import end

### DIFF
--- a/app/bundles/LeadBundle/Entity/Import.php
+++ b/app/bundles/LeadBundle/Entity/Import.php
@@ -58,7 +58,7 @@ class Import extends FormEntity
     const MANUAL = 6;
 
     /**
-     * When the import happens is scheduled for later processing.
+     * When the import is scheduled for later processing.
      */
     const DELAYED = 7;
 
@@ -351,7 +351,7 @@ class Import extends FormEntity
     /**
      * Removes the file if exists.
      * It won't throw any exception if the file is not readable.
-     * Not removing the CSV file is not consodered a big trouble.
+     * Not removing the CSV file is not considered a big trouble.
      * It will be removed on the next cache:clear.
      */
     public function removeFile()
@@ -385,7 +385,7 @@ class Import extends FormEntity
     }
 
     /**
-     * getName method is used by standart templates so there it is for this entity.
+     * getName method is used by standard templates so there it is for this entity.
      *
      * @return string
      */
@@ -503,7 +503,7 @@ class Import extends FormEntity
     }
 
     /**
-     * Counts how many rows has been processed so far.
+     * Counts how many rows have been processed so far.
      *
      * @return int
      */
@@ -630,7 +630,7 @@ class Import extends FormEntity
     }
 
     /**
-     * Modify the entity for the start of import.
+     * Modify the entity for the end of import.
      *
      * @return Import
      */
@@ -671,7 +671,7 @@ class Import extends FormEntity
     }
 
     /**
-     * Counts how log the import run so far.
+     * Counts how long the import has run so far.
      *
      * @return \DateInterval|null
      */

--- a/app/bundles/LeadBundle/Tests/Entity/ImportTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/ImportTest.php
@@ -148,9 +148,9 @@ class ImportTest extends StandardImportTestHelper
 
         $this->assertNull($import->getRunTime());
 
-        $this->fakeImportStartDate($import, (10 * 60));
-
         $import->end(false);
+
+        $this->fakeImportStartDate($import, (10 * 60));
 
         $this->assertTrue($import->getRunTime() instanceof \DateInterval);
         $this->assertSame(10, $import->getRunTime()->i);
@@ -162,9 +162,9 @@ class ImportTest extends StandardImportTestHelper
 
         $this->assertSame(0, $import->getRunTimeSeconds());
 
-        $this->fakeImportStartDate($import, 600);
-
         $import->end(false);
+
+        $this->fakeImportStartDate($import, 600);
 
         $this->assertSame(600, $import->getRunTimeSeconds());
     }
@@ -175,10 +175,10 @@ class ImportTest extends StandardImportTestHelper
 
         $this->assertSame(0, $import->getSpeed());
 
-        $this->fakeImportStartDate($import, 600);
-
         $import->setInsertedCount(900);
         $import->end(false);
+
+        $this->fakeImportStartDate($import, 600);
 
         $this->assertSame(1.5, $import->getSpeed());
     }
@@ -203,7 +203,8 @@ class ImportTest extends StandardImportTestHelper
      */
     protected function fakeImportStartDate(Import $import, $runtime = 600)
     {
-        $dateStarted = new \DateTime();
+        $dateEnded   = $import->getDateEnded();
+        $dateStarted = new \DateTime($dateEnded->format('Y-m-d H:i:s.u'), $dateEnded->getTimezone());
         $dateStarted->modify('-'.$runtime.' seconds');
         $import->setDateStarted($dateStarted);
     }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | #5059
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
1) Calculate ``fakeImportStartDate()`` as an offset from the end date-time, rather than the current date-time. That should avoid rounding issues due to the real time delay between setting end date-time and then making the adjustment to fake the start date-time.

2) Fix a bunch of comment typos in ``Import.php`` while we are here.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. run the unit tests lots of times
2. see the failure:
```
There was 1 failure:
1) Mautic\LeadBundle\Tests\Entity\ImportTest::testGetRunTimeSeconds
Failed asserting that 601 is identical to 600.
```

#### Steps to test this PR:
1. run the unit tests lots more times
2. do not see any failure

