### PR TITLE
Fix: Notification title and loop bugfix

### DIFF
--- a/app/bundles/NotificationBundle/Api/OneSignalApi.php
+++ b/app/bundles/NotificationBundle/Api/OneSignalApi.php
@@ -73,6 +73,7 @@ class OneSignalApi extends AbstractNotificationApi
         $data = [];
 
         $buttonId = $notification->getHeading();
+        $title    = $notification->getHeading();
         $url      = $notification->getUrl();
         $button   = $notification->getButton();
         $message  = $notification->getMessage();
@@ -93,9 +94,9 @@ class OneSignalApi extends AbstractNotificationApi
             if (!is_array($title)) {
                 $title = ['en' => $title];
             }
-
-            $data['headings'] = $title;
         }
+
+        $data['headings'] = $title;
 
         if ($url) {
             $data['url'] = $url;

--- a/app/bundles/NotificationBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/CampaignSubscriber.php
@@ -142,6 +142,15 @@ class CampaignSubscriber extends CommonSubscriber
             return $event->setFailed('mautic.notification.campaign.failed.not_contactable');
         }
 
+        $notificationId = (int) $event->getConfig()['notification'];
+
+        /** @var \Mautic\NotificationBundle\Entity\Notification $notification */
+        $notification = $this->notificationModel->getEntity($notificationId);
+
+        if ($notification->getId() !== $notificationId) {
+            return $event->setFailed('mautic.notification.campaign.failed.missing_entity');
+        }
+
         // If lead has subscribed on multiple devices, get all of them.
         /** @var \Mautic\NotificationBundle\Entity\PushID[] $pushIDs */
         $pushIDs = $lead->getPushIDs();
@@ -164,15 +173,6 @@ class CampaignSubscriber extends CommonSubscriber
 
         if (empty($playerID)) {
             return $event->setFailed('mautic.notification.campaign.failed.not_subscribed');
-        }
-
-        $notificationId = (int) $event->getConfig()['notification'];
-
-        /** @var \Mautic\NotificationBundle\Entity\Notification $notification */
-        $notification = $this->notificationModel->getEntity($notificationId);
-
-        if ($notification->getId() !== $notificationId) {
-            return $event->setFailed('mautic.notification.campaign.failed.missing_entity');
         }
 
         if ($url = $notification->getUrl()) {

--- a/app/bundles/NotificationBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/CampaignSubscriber.php
@@ -202,13 +202,15 @@ class CampaignSubscriber extends CommonSubscriber
             new NotificationSendEvent($tokenEvent->getContent(), $notification->getHeading(), $lead)
         );
 
-        $notification->setUrl($url);
-        $notification->setMessage($sendEvent->getMessage());
-        $notification->setHeading($sendEvent->getHeading());
+        // prevent rewrite notification entity
+        $sendNotification = clone $notification;
+        $sendNotification->setUrl($url);
+        $sendNotification->setMessage($sendEvent->getMessage());
+        $sendNotification->setHeading($sendEvent->getHeading());
 
         $response = $this->notificationApi->sendNotification(
             $playerID,
-            $notification
+            $sendNotification
         );
 
         $event->setChannel('notification', $notification->getId());


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Send notification with URL to 2 contacts at least
2.  Title (header) wasn't send with notification
3. Check also Click Counts stat in detail view of notification
4.  Should see in table redirect urls. Somehing like http://yourmauticurl.tld/r/randomhash because notification entity was looped with setUrl()...

#### Steps to test this PR:
1.  Apply PR  and repeat all steps
2.  See it title was send with notification
3.  Check also Click Counts stat in detail view of notification
4.  Should see table just with one URL in correct way