### PR TITLE
Fix: MauticDomain != event.origin

### DIFF
--- a/media/js/mautic-form-src.js
+++ b/media/js/mautic-form-src.js
@@ -627,7 +627,7 @@
             window.addEventListener('message', function(event) {
                 if (Core.debug()) console.log(event);
 
-                if (event.origin !== MauticDomain) return;
+                if (MauticDomain.indexOf(event.origin) == -1) return;
 
                 try {
                     var response = JSON.parse(event.data);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  Y
| New feature? | N
| Related user documentation PR URL |  N
| Related developer documentation PR URL |  N
| Issues addressed (#s or URLs) |  #5071 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
Any attempt to send a form that previously creates the form remains waiting for the message "please wait" and I had received a response

![error](https://user-images.githubusercontent.com/4906962/31058544-234f6500-a6bb-11e7-8de9-372d909ed722.png)

The problem is that when the validation in mautic-form.js is validated the variable MauticDomain with source parameter json of postmessage event IS NOT EQUAL

![originq](https://user-images.githubusercontent.com/4906962/31058552-31de5946-a6bb-11e7-8f0f-b4bca2cf4690.png)

![error2](https://user-images.githubusercontent.com/4906962/31058548-2b35342a-a6bb-11e7-99b5-2ebaef0124f4.png)

#### Steps to test this PR:
1. Install Mautic With Tilde Character example: http://184.171.246.29/~inboundsumatec/
2. create form and validate response
 