### PR TITLE
Use MAUTIC_TABLE_PREFIX in leadlist repo tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 /bin/*
 /bundles
 /node_modules
+/build/coverage
 /build/packaging
 /build/packages/*
 !/build/packages/.placeholder

--- a/app/bundles/LeadBundle/Tests/Entity/LeadListRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadListRepositoryTest.php
@@ -47,11 +47,11 @@ class LeadListRepositoryTest extends \PHPUnit_Framework_TestCase
         $expr   = $reflectedMethod->invokeArgs($mockRepository, [$filters, &$parameters, $qb]);
         $string = (string) $expr;
 
-        $found = preg_match_all('/EXISTS \(SELECT null FROM leads .*? LEFT JOIN lead_lists_leads/', $string, $matches);
+        $found = preg_match_all('/EXISTS \(SELECT null FROM '.MAUTIC_TABLE_PREFIX.'leads .*? LEFT JOIN '.MAUTIC_TABLE_PREFIX.'lead_lists_leads/', $string, $matches);
         $this->assertEquals(2, $found, $string);
 
         // Segment filters combined by OR to keep consistent behavior with the use of leadlist_id IN (1,2,3)
-        $found = preg_match_all('/OR \(EXISTS \(SELECT null FROM leads .*? LEFT JOIN lead_lists_leads/', $string, $matches);
+        $found = preg_match_all('/OR \(EXISTS \(SELECT null FROM '.MAUTIC_TABLE_PREFIX.'leads .*? LEFT JOIN '.MAUTIC_TABLE_PREFIX.'lead_lists_leads/', $string, $matches);
         $this->assertEquals(1, $found, $string);
 
         $found = preg_match_all('/\(l.email = :(.*?)\)/', $string, $matches);
@@ -86,11 +86,11 @@ class LeadListRepositoryTest extends \PHPUnit_Framework_TestCase
         $string = (string) $expr;
 
         // Two segments included
-        $found = preg_match_all('/EXISTS \(SELECT null FROM lead_lists_leads/', $string, $matches);
+        $found = preg_match_all('/EXISTS \(SELECT null FROM '.MAUTIC_TABLE_PREFIX.'lead_lists_leads/', $string, $matches);
         $this->assertEquals(2, $found, $string);
 
         // Segment filters combined by OR to keep consistent behavior with the use of leadlist_id IN (1,2,3)
-        $found = preg_match_all('/OR \(EXISTS \(SELECT null FROM lead_lists_leads/', $string, $matches);
+        $found = preg_match_all('/OR \(EXISTS \(SELECT null FROM '.MAUTIC_TABLE_PREFIX.'lead_lists_leads/', $string, $matches);
         $this->assertEquals(1, $found, $string);
     }
 
@@ -117,11 +117,11 @@ class LeadListRepositoryTest extends \PHPUnit_Framework_TestCase
         $expr   = $reflectedMethod->invokeArgs($mockRepository, [$filters, &$parameters, $qb]);
         $string = (string) $expr;
 
-        $found = preg_match_all('/NOT EXISTS \(SELECT null FROM leads .*? LEFT JOIN lead_lists_leads/', $string, $matches);
+        $found = preg_match_all('/NOT EXISTS \(SELECT null FROM '.MAUTIC_TABLE_PREFIX.'leads .*? LEFT JOIN '.MAUTIC_TABLE_PREFIX.'lead_lists_leads/', $string, $matches);
         $this->assertEquals(2, $found, $string);
 
         // Segment filters combined by AND to keep consistent behavior with the use of leadlist_id IN (1,2,3)
-        $found = preg_match_all('/AND \(NOT EXISTS \(SELECT null FROM leads .*? LEFT JOIN lead_lists_leads/', $string, $matches);
+        $found = preg_match_all('/AND \(NOT EXISTS \(SELECT null FROM '.MAUTIC_TABLE_PREFIX.'leads .*? LEFT JOIN '.MAUTIC_TABLE_PREFIX.'lead_lists_leads/', $string, $matches);
         $this->assertEquals(1, $found, $string);
 
         $found = preg_match_all('/\(l.email = :(.*?)\)/', $string, $matches);
@@ -156,11 +156,11 @@ class LeadListRepositoryTest extends \PHPUnit_Framework_TestCase
         $string = (string) $expr;
 
         // Two segments included
-        $found = preg_match_all('/NOT EXISTS \(SELECT null FROM lead_lists_leads/', $string, $matches);
+        $found = preg_match_all('/NOT EXISTS \(SELECT null FROM '.MAUTIC_TABLE_PREFIX.'lead_lists_leads/', $string, $matches);
         $this->assertEquals(2, $found, $string);
 
         // Segment filters combined by AND to keep consistent behavior with the use of leadlist_id NOT IN (1,2,3)
-        $found = preg_match_all('/AND \(NOT EXISTS \(SELECT null FROM lead_lists_leads/', $string, $matches);
+        $found = preg_match_all('/AND \(NOT EXISTS \(SELECT null FROM '.MAUTIC_TABLE_PREFIX.'lead_lists_leads/', $string, $matches);
         $this->assertEquals(1, $found, $string);
     }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If you have a table prefix set, the tests in `LeadListRepositoryTest` fail because the regex's expect no prefix. This fixes that.

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Apply PR
2. Have a `MAUTIC_TABLE_PREFIX` set in you `.env`
3. Run the unit tests - they should pass