### PR TITLE
Correct end app-footer

### DIFF
--- a/app/bundles/CoreBundle/Views/Default/base.html.php
+++ b/app/bundles/CoreBundle/Views/Default/base.html.php
@@ -50,7 +50,7 @@
                     </div>
                 </div>
             </footer>
-            <!--/ end: app-content -->
+            <!--/ end: app-footer -->
 
             <!-- start: app-content -->
             <section id="app-content">


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y (sort of)
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
I noticed this when doing "inspect" on a page. It was a bit disconcerting to see "end: app-content" followed by "start: app-content" - but actually it turns out to be just a copy-paste text "bug".

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Inspect a page, look around the start of the app-content area.
2. See that there is some comment text about "end: app-content" just above "start: app-content"
3. Be worried that something worse is wrong

#### Steps to test this PR:
1. Inspect a page, look around the start of the app-content area.
2. See that there is some comment text about "end: app-footer" just above "start: app-content"
3. Be happy and keep working on what you were doing without being side-tracked by this.
