### PR TITLE
Fix getRequestedGraphs unit test warnings

### DIFF
--- a/app/bundles/FormBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -171,7 +171,7 @@ class ReportSubscriberTest extends WebTestCase
     {
         $mockEvent = $this->getMockBuilder(ReportGraphEvent::class)
             ->disableOriginalConstructor()
-            ->setMethods(['checkContext'])
+            ->setMethods(['checkContext', 'getRequestedGraphs'])
             ->getMock();
 
         $mockEvent->expects($this->once())

--- a/app/bundles/PageBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -167,7 +167,7 @@ class ReportSubscriberTest extends WebTestCase
     {
         $mockEvent = $this->getMockBuilder(ReportGraphEvent::class)
             ->disableOriginalConstructor()
-            ->setMethods(['checkContext'])
+            ->setMethods(['checkContext', 'getRequestedGraphs'])
             ->getMock();
 
         $mockEvent->expects($this->once())


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fix the 2 unit test warnings that have started happening in the Travis-CI logs.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Look in Travis-CI logs
2. See:
```
There were 2 warnings:

1) Mautic\FormBundle\Tests\EventListener\ReportSubscriberTest::testOnReportGraphGenerateBadContextWillReturn

Trying to configure method "getRequestedGraphs" which cannot be configured because it does not exist, has not been specified, is final, or is static

2) Mautic\PageBundle\Tests\EventListener\ReportSubscriberTest::testOnReportGraphGenerateBadContextWillReturn

Trying to configure method "getRequestedGraphs" which cannot be configured because it does not exist, has not been specified, is final, or is static
```

#### Steps to test this PR:
1. Look in Travis-CI logs
2. See that there are no unit test warnings
