### PR TITLE
Make unit tests fail on warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 script:
 
   # Run PHPUnit
-  - bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist
+  - bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --fail-on-warning
 
   # Run PHPSTAN analysis for PHP 7+
   - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.6" ]]; then ~/.composer/vendor/phpstan/phpstan-shim/phpstan.phar analyse app/bundles/CampaignBundle app/bundles/WebhookBundle app/bundles/LeadBundle; fi

--- a/app/bundles/FormBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -171,7 +171,7 @@ class ReportSubscriberTest extends WebTestCase
     {
         $mockEvent = $this->getMockBuilder(ReportGraphEvent::class)
             ->disableOriginalConstructor()
-            ->setMethods(['checkContext'])
+            ->setMethods(['checkContext', 'getRequestedGraphs'])
             ->getMock();
 
         $mockEvent->expects($this->once())

--- a/app/bundles/PageBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -167,7 +167,7 @@ class ReportSubscriberTest extends WebTestCase
     {
         $mockEvent = $this->getMockBuilder(ReportGraphEvent::class)
             ->disableOriginalConstructor()
-            ->setMethods(['checkContext'])
+            ->setMethods(['checkContext', 'getRequestedGraphs'])
             ->getMock();
 
         $mockEvent->expects($this->once())


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Make the unit tests fail on warnings, so that the Travis-CI status will clearly show that there are warnings, and they cannot be just ignored.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run Travis-CI
2. See that with current ``staging`` branch there are 2 warnings in the logs, but that Travis report the job has passed.

#### Steps to test this PR:
1. Run Travis-CI
2. See that it fails, due to the warnings in the unit tests.
