### PR TITLE
BUG: Fix issue with email click counts being inconsistent

### DIFF
--- a/app/bundles/EmailBundle/Entity/StatRepository.php
+++ b/app/bundles/EmailBundle/Entity/StatRepository.php
@@ -87,66 +87,55 @@ class StatRepository extends CommonRepository
      * @param null            $emailIds
      * @param null            $listId
      * @param ChartQuery|null $chartQuery
+     * @param bool            $combined
      *
      * @return array|int
      */
-    public function getSentCount($emailIds = null, $listId = null, ChartQuery $chartQuery = null)
+    public function getSentCount($emailIds = null, $listId = null, ChartQuery $chartQuery = null, $combined = false)
     {
-        $q = $this->_em->getConnection()->createQueryBuilder();
-
-        $q->select('count(s.id) as sent_count')
-            ->from(MAUTIC_TABLE_PREFIX.'email_stats', 's');
-
-        if ($emailIds) {
-            if (!is_array($emailIds)) {
-                $emailIds = [(int) $emailIds];
-            }
-            $q->where(
-                $q->expr()->in('s.email_id', $emailIds)
-            );
-        }
-
-        if (true === $listId) {
-            $q->addSelect('s.list_id')
-                ->groupBy('s.list_id');
-        } elseif ($listId) {
-            $q->andWhere('s.list_id = '.(int) $listId);
-        }
-
-        $q->andWhere('s.is_failed = :false')
-            ->setParameter('false', false, 'boolean');
-
-        if ($chartQuery) {
-            $chartQuery->applyDateFilters($q, 'date_sent', 's');
-        }
-
-        $results = $q->execute()->fetchAll();
-
-        if (true === $listId) {
-            // Return list group of counts
-            $byList = [];
-            foreach ($results as $result) {
-                $byList[$result['list_id']] = $result['sent_count'];
-            }
-
-            return $byList;
-        }
-
-        return (isset($results[0])) ? $results[0]['sent_count'] : 0;
+        return $this->getStatusCount('is_sent', $emailIds, $listId, $chartQuery, $combined);
     }
 
     /**
      * @param null            $emailIds
      * @param null            $listId
      * @param ChartQuery|null $chartQuery
+     * @param bool            $combined
      *
      * @return array|int
      */
-    public function getReadCount($emailIds = null, $listId = null, ChartQuery $chartQuery = null)
+    public function getReadCount($emailIds = null, $listId = null, ChartQuery $chartQuery = null, $combined = false)
+    {
+        return $this->getStatusCount('is_read', $emailIds, $listId, $chartQuery, $combined);
+    }
+
+    /**
+     * @param null            $emailIds
+     * @param null            $listId
+     * @param ChartQuery|null $chartQuery
+     * @param bool            $combined
+     *
+     * @return array|int
+     */
+    public function getFailedCount($emailIds = null, $listId = null, ChartQuery $chartQuery = null, $combined = false)
+    {
+        return $this->getStatusCount('is_failed', $emailIds, $listId, $chartQuery, $combined);
+    }
+
+    /**
+     * @param                 $column
+     * @param null            $emailIds
+     * @param null            $listId
+     * @param ChartQuery|null $chartQuery
+     * @param bool            $combined
+     *
+     * @return array|int
+     */
+    public function getStatusCount($column, $emailIds = null, $listId = null, ChartQuery $chartQuery = null, $combined = false)
     {
         $q = $this->_em->getConnection()->createQueryBuilder();
 
-        $q->select('count(s.id) as read_count')
+        $q->select('count(s.id) as count')
             ->from(MAUTIC_TABLE_PREFIX.'email_stats', 's');
 
         if ($emailIds) {
@@ -158,15 +147,44 @@ class StatRepository extends CommonRepository
             );
         }
 
-        if (true === $listId) {
-            $q->addSelect('s.list_id')
-                ->groupBy('s.list_id');
-        } elseif ($listId) {
-            $q->andWhere('s.list_id = '.(int) $listId);
+        if ($listId) {
+            if (!$combined) {
+                if (true === $listId) {
+                    $q->addSelect('s.list_id')
+                        ->groupBy('s.list_id');
+                } elseif (is_array($listId)) {
+                    $q->andWhere(
+                        $q->expr()->in('s.list_id', array_map('intval', $listId))
+                    );
+
+                    $q->addSelect('s.list_id')
+                        ->groupBy('s.list_id');
+                } else {
+                    $q->andWhere('s.list_id = :list_id')
+                        ->setParameter('list_id', $listId);
+                }
+            } else {
+                $subQ = $this->getEntityManager()->getConnection()->createQueryBuilder();
+                $subQ->select('null')
+                    ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'list')
+                    ->andWhere(
+                        $q->expr()->andX(
+                            $q->expr()->in('list.leadlist_id', array_map('intval', $listId)),
+                            $q->expr()->eq('list.lead_id', 's.lead_id')
+                        )
+                    );
+
+                $q->andWhere(sprintf('EXISTS (%s)', $subQ->getSQL()));
+            }
         }
 
-        $q->andWhere('is_read = :true')
-            ->setParameter('true', true, 'boolean');
+        if ($column === 'is_sent') {
+            $q->andWhere('s.is_failed = :false')
+                ->setParameter('false', false, 'boolean');
+        } else {
+            $q->andWhere($column.' = :true')
+                ->setParameter('true', true, 'boolean');
+        }
 
         if ($chartQuery) {
             $chartQuery->applyDateFilters($q, 'date_sent', 's');
@@ -174,17 +192,17 @@ class StatRepository extends CommonRepository
 
         $results = $q->execute()->fetchAll();
 
-        if (true === $listId) {
+        if ((true === $listId || is_array($listId)) && !$combined) {
             // Return list group of counts
             $byList = [];
             foreach ($results as $result) {
-                $byList[$result['list_id']] = $result['read_count'];
+                $byList[$result['list_id']] = $result['count'];
             }
 
             return $byList;
         }
 
-        return (isset($results[0])) ? $results[0]['read_count'] : 0;
+        return (isset($results[0])) ? $results[0]['count'] : 0;
     }
 
     /**
@@ -247,58 +265,6 @@ class StatRepository extends CommonRepository
         }
 
         return (!is_array($emailIds)) ? $return[$emailIds] : $return;
-    }
-
-    /**
-     * @param null            $emailIds
-     * @param null            $listId
-     * @param ChartQuery|null $chartQuery
-     *
-     * @return array|int
-     */
-    public function getFailedCount($emailIds = null, $listId = null, ChartQuery $chartQuery = null)
-    {
-        $q = $this->_em->getConnection()->createQueryBuilder();
-
-        $q->select('count(s.id) as failed_count')
-            ->from(MAUTIC_TABLE_PREFIX.'email_stats', 's');
-
-        if ($emailIds) {
-            if (!is_array($emailIds)) {
-                $emailIds = [(int) $emailIds];
-            }
-            $q->where(
-                $q->expr()->in('s.email_id', $emailIds)
-            );
-        }
-
-        if (true === $listId) {
-            $q->addSelect('s.list_id')
-                ->groupBy('s.list_id');
-        } elseif ($listId) {
-            $q->andWhere('s.list_id = '.(int) $listId);
-        }
-
-        $q->andWhere('is_failed = :true')
-            ->setParameter('true', true, 'boolean');
-
-        if ($chartQuery) {
-            $chartQuery->applyDateFilters($q, 'date_sent', 's');
-        }
-
-        $results = $q->execute()->fetchAll();
-
-        if (true === $listId) {
-            // Return list group of counts
-            $byList = [];
-            foreach ($results as $result) {
-                $byList[$result['list_id']] = $result['failed_count'];
-            }
-
-            return $byList;
-        }
-
-        return (isset($results[0])) ? $results[0]['failed_count'] : 0;
     }
 
     /**

--- a/app/bundles/PageBundle/Entity/TrackableRepository.php
+++ b/app/bundles/PageBundle/Entity/TrackableRepository.php
@@ -202,7 +202,7 @@ class TrackableRepository extends CommonRepository
 
         $results = $q->execute()->fetchAll();
 
-        if ((true === $listId || is_array($listId)) && !$combined ) {
+        if ((true === $listId || is_array($listId)) && !$combined) {
             // Return array of results
             $byList = [];
             foreach ($results as $result) {

--- a/app/bundles/PageBundle/Entity/TrackableRepository.php
+++ b/app/bundles/PageBundle/Entity/TrackableRepository.php
@@ -29,11 +29,12 @@ class TrackableRepository extends CommonRepository
      */
     public function findByChannel($channel, $channelId)
     {
-        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        $q          = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        $tableAlias = $this->getTableAlias();
 
-        return $q->select('r.redirect_id, r.url, r.hits, r.unique_hits')
+        return $q->select('r.redirect_id, r.url, '.$tableAlias.'.hits, '.$tableAlias.'.unique_hits')
             ->from(MAUTIC_TABLE_PREFIX.'page_redirects', 'r')
-            ->innerJoin('r', MAUTIC_TABLE_PREFIX.'channel_url_trackables', $this->getTableAlias(),
+            ->innerJoin('r', MAUTIC_TABLE_PREFIX.'channel_url_trackables', $tableAlias,
                 $q->expr()->andX(
                     $q->expr()->eq('r.id', 't.redirect_id'),
                     $q->expr()->eq('t.channel', ':channel'),
@@ -145,12 +146,12 @@ class TrackableRepository extends CommonRepository
      *
      * @return array|int
      */
-    public function getCount($channel, $channelIds, $listId, ChartQuery $chartQuery = null)
+    public function getCount($channel, $channelIds, $listId, ChartQuery $chartQuery = null, $combined = false)
     {
         $q = $this->_em->getConnection()->createQueryBuilder()
             ->select('count(ph.id) as click_count')
             ->from(MAUTIC_TABLE_PREFIX.'channel_url_trackables', 'cut')
-            ->leftJoin('cut', MAUTIC_TABLE_PREFIX.'page_hits', 'ph', 'ph.redirect_id = cut.redirect_id');
+            ->innerJoin('cut', MAUTIC_TABLE_PREFIX.'page_hits', 'ph', 'ph.redirect_id = cut.redirect_id AND ph.source = cut.channel AND ph.source_id = cut.channel_id');
 
         $q->where(
             'cut.channel = :channel'
@@ -166,20 +167,32 @@ class TrackableRepository extends CommonRepository
         }
 
         if ($listId) {
-            $q->leftJoin('ph', MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'cs', 'cs.lead_id = ph.lead_id');
+            if (!$combined) {
+                $q->innerJoin('ph', MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'cs', 'cs.lead_id = ph.lead_id');
 
-            if (true === $listId) {
-                $q->addSelect('cs.leadlist_id')
-                    ->groupBy('cs.leadlist_id');
-            } elseif (is_array($listId)) {
-                $q->andWhere(
-                    $q->expr()->in('cs.leadlist_id', array_map('intval', $listId))
-                )
-                    ->addSelect('cs.leadlist_id')
-                    ->groupBy('cs.leadlist_id');
+                if (true === $listId) {
+                    $q->addSelect('cs.leadlist_id')
+                        ->groupBy('cs.leadlist_id');
+                } elseif (is_array($listId)) {
+                    $q->andWhere(
+                        $q->expr()->in('cs.leadlist_id', array_map('intval', $listId))
+                    );
+
+                    $q->addSelect('cs.leadlist_id')
+                        ->groupBy('cs.leadlist_id');
+                } else {
+                    $q->andWhere('cs.leadlist_id = :list_id')
+                        ->setParameter('list_id', $listId);
+                }
             } else {
-                $q->andWhere('cs.leadlist_id = :list_id')
-                    ->setParameter('list_id', $listId);
+                $subQ = $this->getEntityManager()->getConnection()->createQueryBuilder();
+                $subQ->select('distinct(list.lead_id)')
+                    ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'list')
+                    ->andWhere(
+                        $q->expr()->in('list.leadlist_id', array_map('intval', $listId))
+                    );
+
+                $q->innerJoin('ph', sprintf('(%s)', $subQ->getSQL()), 'cs', 'cs.lead_id = ph.lead_id');
             }
         }
 
@@ -189,7 +202,7 @@ class TrackableRepository extends CommonRepository
 
         $results = $q->execute()->fetchAll();
 
-        if (true === $listId || is_array($listId)) {
+        if ((true === $listId || is_array($listId)) && !$combined ) {
             // Return array of results
             $byList = [];
             foreach ($results as $result) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N.A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Email click counts were incorrectly showing all clicks to a given trackable including clicks generated from a test email that had no clickthrough data associated. Additionally, the "All Lists Combined" stat in the segments graph area incorrectly counted contacts that were in multiple segments.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create 2 new segments, and add the same 2 contacts to each segment. 
2. Create a segment email with those 2 segments. The content should include a trackable link.
3. Send the email to the segments, but only open and click on the trackable in one of those emails.
4. You should see 2 total clicks in the "All Lists Combined" stat, even though you only clicked the email from a tracked user once.
5. You should see 1 total click in the Click Counts tab. 
6. Send a test email to yourself. Click the trackable. It will add a click to the Click Counts tab even though the recipient is not in any of the associated segments.

#### Steps to test this PR:
1. Apply PR and retest with a new email.
2. At step 4 above, you should only see 1 click in the Click Counts tab.
3. At step 6 above, it will not add a click to the Click Counts tab.
