### PR TITLE
added standard columns to queue report

### DIFF
--- a/app/bundles/ChannelBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/ChannelBundle/EventListener/ReportSubscriber.php
@@ -101,6 +101,7 @@ class ReportSubscriber extends CommonSubscriber
                     'display_name' => 'mautic.message.queue',
                     'columns'      => array_merge(
                         $columns,
+                        $event->getStandardColumns('l.', [], 'mautic_contact_action'),
                         $event->getLeadColumns()
                     ),
                 ]


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR adds standard contact columns to the message queue report with a link to the contact's detail page.

#### Steps to test this PR:
1. create a message queue report add ID for contact's ID and it should add a link to the contact's detail view