### PR TITLE
Bugfix - Salesforce EntityNotFoundException when a record is locked

### DIFF
--- a/app/bundles/PluginBundle/Model/IntegrationEntityModel.php
+++ b/app/bundles/PluginBundle/Model/IntegrationEntityModel.php
@@ -12,6 +12,7 @@
 namespace Mautic\PluginBundle\Model;
 
 use Mautic\CoreBundle\Model\FormModel;
+use Mautic\PluginBundle\Entity\IntegrationEntity;
 use Mautic\PluginBundle\Integration\IntegrationObject;
 
 /**
@@ -21,7 +22,7 @@ class IntegrationEntityModel extends FormModel
 {
     public function getIntegrationEntityRepository()
     {
-        return $this->em->getRepository('MauticPluginBundle:IntegrationEntity');
+        return $this->em->getRepository(IntegrationEntity::class);
     }
 
     public function logDataSync(IntegrationObject $integrationObject)
@@ -97,5 +98,21 @@ class IntegrationEntityModel extends FormModel
         );
 
         return $mauticContacts;
+    }
+
+    /**
+     * @param int       $id
+     * @param \DateTime $dateTime
+     *
+     * @return IntegrationEntity|null
+     */
+    public function getEntityByIdAndSetSyncDate($id, \DateTime $dateTime)
+    {
+        $entity = $this->getIntegrationEntityRepository()->find($id);
+        if ($entity) {
+            $entity->setLastSyncDate($dateTime);
+        }
+
+        return $entity;
     }
 }

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -2069,12 +2069,12 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     $this->logIntegrationError($exception);
                     $integrationEntity = null;
                     if ($integrationEntityId && $object !== 'CampaignMember') {
-                        $integrationEntity = $this->em->getReference('MauticPluginBundle:IntegrationEntity', $integrationEntityId);
+                        $integrationEntity = $this->em->find('MauticPluginBundle:IntegrationEntity', $integrationEntityId);
                         if ($integrationEntity) {
                             $integrationEntity->setLastSyncDate(new \DateTime());
                         }
                     } elseif (isset($campaignId) && $campaignId != null) {
-                        $integrationEntity = $this->em->getReference('MauticPluginBundle:IntegrationEntity', $campaignId);
+                        $integrationEntity = $this->em->find('MauticPluginBundle:IntegrationEntity', $campaignId);
                         if ($integrationEntity) {
                             $integrationEntity->setLastSyncDate($this->getLastSyncDate());
                         }
@@ -2118,7 +2118,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     // Record was updated
                     if ($integrationEntityId) {
                         /** @var IntegrationEntity $integrationEntity */
-                        $integrationEntity = $this->em->getReference('MauticPluginBundle:IntegrationEntity', $integrationEntityId);
+                        $integrationEntity = $this->em->find('MauticPluginBundle:IntegrationEntity', $integrationEntityId);
                         if ($integrationEntity) {
                             $integrationEntity->setLastSyncDate($this->getLastSyncDate());
                             if (isset($this->salesforceIdMapping[$contactId])) {
@@ -2160,7 +2160,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
                     if ($integrationEntityId) {
                         /** @var IntegrationEntity $integrationEntity */
-                        $integrationEntity = $this->em->getReference('MauticPluginBundle:IntegrationEntity', $integrationEntityId);
+                        $integrationEntity = $this->em->find('MauticPluginBundle:IntegrationEntity', $integrationEntityId);
                         if ($integrationEntity) {
                             $integrationEntity->setLastSyncDate($this->getLastSyncDate());
                             if (isset($this->salesforceIdMapping[$contactId])) {

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -2069,15 +2069,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     $this->logIntegrationError($exception);
                     $integrationEntity = null;
                     if ($integrationEntityId && $object !== 'CampaignMember') {
-                        $integrationEntity = $this->em->find('MauticPluginBundle:IntegrationEntity', $integrationEntityId);
-                        if ($integrationEntity) {
-                            $integrationEntity->setLastSyncDate(new \DateTime());
-                        }
-                    } elseif (isset($campaignId) && $campaignId != null) {
-                        $integrationEntity = $this->em->find('MauticPluginBundle:IntegrationEntity', $campaignId);
-                        if ($integrationEntity) {
-                            $integrationEntity->setLastSyncDate($this->getLastSyncDate());
-                        }
+                        $integrationEntity = $this->integrationEntityModel->getEntityByIdAndSetSyncDate($integrationEntityId, new \DateTime());
+                    } elseif (isset($campaignId)) {
+                        $integrationEntity = $this->integrationEntityModel->getEntityByIdAndSetSyncDate($campaignId, $this->getLastSyncDate());
                     } elseif ($contactId) {
                         $integrationEntity = $this->createIntegrationEntity(
                             $object,
@@ -2117,10 +2111,8 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 } elseif (204 === $item['httpStatusCode']) {
                     // Record was updated
                     if ($integrationEntityId) {
-                        /** @var IntegrationEntity $integrationEntity */
-                        $integrationEntity = $this->em->find('MauticPluginBundle:IntegrationEntity', $integrationEntityId);
+                        $integrationEntity = $this->integrationEntityModel->getEntityByIdAndSetSyncDate($integrationEntityId, $this->getLastSyncDate());
                         if ($integrationEntity) {
-                            $integrationEntity->setLastSyncDate($this->getLastSyncDate());
                             if (isset($this->salesforceIdMapping[$contactId])) {
                                 $integrationEntity->setIntegrationEntityId($this->salesforceIdMapping[$contactId]);
                             }
@@ -2159,10 +2151,8 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     ++$totalErrored;
 
                     if ($integrationEntityId) {
-                        /** @var IntegrationEntity $integrationEntity */
-                        $integrationEntity = $this->em->find('MauticPluginBundle:IntegrationEntity', $integrationEntityId);
+                        $integrationEntity = $this->integrationEntityModel->getEntityByIdAndSetSyncDate($integrationEntityId, $this->getLastSyncDate());
                         if ($integrationEntity) {
-                            $integrationEntity->setLastSyncDate($this->getLastSyncDate());
                             if (isset($this->salesforceIdMapping[$contactId])) {
                                 $integrationEntity->setIntegrationEntityId($this->salesforceIdMapping[$contactId]);
                             }

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -2070,10 +2070,14 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     $integrationEntity = null;
                     if ($integrationEntityId && $object !== 'CampaignMember') {
                         $integrationEntity = $this->em->getReference('MauticPluginBundle:IntegrationEntity', $integrationEntityId);
-                        $integrationEntity->setLastSyncDate(new \DateTime());
+                        if ($integrationEntity) {
+                            $integrationEntity->setLastSyncDate(new \DateTime());
+                        }
                     } elseif (isset($campaignId) && $campaignId != null) {
                         $integrationEntity = $this->em->getReference('MauticPluginBundle:IntegrationEntity', $campaignId);
-                        $integrationEntity->setLastSyncDate($this->getLastSyncDate());
+                        if ($integrationEntity) {
+                            $integrationEntity->setLastSyncDate($this->getLastSyncDate());
+                        }
                     } elseif ($contactId) {
                         $integrationEntity = $this->createIntegrationEntity(
                             $object,
@@ -2115,13 +2119,14 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     if ($integrationEntityId) {
                         /** @var IntegrationEntity $integrationEntity */
                         $integrationEntity = $this->em->getReference('MauticPluginBundle:IntegrationEntity', $integrationEntityId);
+                        if ($integrationEntity) {
+                            $integrationEntity->setLastSyncDate($this->getLastSyncDate());
+                            if (isset($this->salesforceIdMapping[$contactId])) {
+                                $integrationEntity->setIntegrationEntityId($this->salesforceIdMapping[$contactId]);
+                            }
 
-                        $integrationEntity->setLastSyncDate($this->getLastSyncDate());
-                        if (isset($this->salesforceIdMapping[$contactId])) {
-                            $integrationEntity->setIntegrationEntityId($this->salesforceIdMapping[$contactId]);
+                            $this->persistIntegrationEntities[] = $integrationEntity;
                         }
-
-                        $this->persistIntegrationEntities[] = $integrationEntity;
                     } elseif (!empty($this->salesforceIdMapping[$contactId])) {
                         // Found in Salesforce so create a new record for it
                         $this->persistIntegrationEntities[] = $this->createIntegrationEntity(
@@ -2156,13 +2161,14 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     if ($integrationEntityId) {
                         /** @var IntegrationEntity $integrationEntity */
                         $integrationEntity = $this->em->getReference('MauticPluginBundle:IntegrationEntity', $integrationEntityId);
+                        if ($integrationEntity) {
+                            $integrationEntity->setLastSyncDate($this->getLastSyncDate());
+                            if (isset($this->salesforceIdMapping[$contactId])) {
+                                $integrationEntity->setIntegrationEntityId($this->salesforceIdMapping[$contactId]);
+                            }
 
-                        $integrationEntity->setLastSyncDate($this->getLastSyncDate());
-                        if (isset($this->salesforceIdMapping[$contactId])) {
-                            $integrationEntity->setIntegrationEntityId($this->salesforceIdMapping[$contactId]);
+                            $this->persistIntegrationEntities[] = $integrationEntity;
                         }
-
-                        $this->persistIntegrationEntities[] = $integrationEntity;
                     } elseif (!empty($this->salesforceIdMapping[$contactId])) {
                         // Found in Salesforce so create a new record for it
                         $this->persistIntegrationEntities[] = $this->createIntegrationEntity(

--- a/plugins/MauticCrmBundle/Tests/SalesforceIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/SalesforceIntegrationTest.php
@@ -29,6 +29,7 @@ use Mautic\PluginBundle\Entity\IntegrationEntity;
 use Mautic\PluginBundle\Entity\IntegrationEntityRepository;
 use Mautic\PluginBundle\Event\PluginIntegrationKeyEvent;
 use Mautic\PluginBundle\Exception\ApiErrorException;
+use Mautic\PluginBundle\Model\IntegrationEntityModel;
 use MauticPlugin\MauticCrmBundle\Integration\SalesforceIntegration;
 use Monolog\Logger;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -147,7 +148,7 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
         $sf    = $this->getSalesforceIntegration();
         $stats = $sf->pushLeads();
 
-        $this->assertEquals(400, count($this->getPersistedIntegrationEntities()));
+        $this->assertCount(400, $this->getPersistedIntegrationEntities());
         $this->assertEquals(300, $stats[0], var_export($stats, true)); // update
         $this->assertEquals(100, $stats[1], var_export($stats, true)); // create
     }
@@ -160,11 +161,11 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
 
         // Validate there are only two integration entities (two contacts with same email)
         $integrationEntities = $this->getPersistedIntegrationEntities();
-        $this->assertEquals(2, count($integrationEntities));
+        $this->assertCount(2, $integrationEntities);
 
-        // Validate that there were 4 found entries (two duplciate leads)
+        // Validate that there were 4 found entries (two duplicate leads)
         $sfEntities = $this->getReturnedSfEntities();
-        $this->assertEquals(4, count($sfEntities));
+        $this->assertCount(4, $sfEntities);
     }
 
     public function testThatMultipleSfContactsReturnedAreUpdatedButOnlyOneIntegrationRecordIsCreated()
@@ -497,6 +498,7 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
 
         $sf->pushLeadToCampaign($lead, 1, 'Active', ['Lead' => [1]]);
     }
+
     public function testPushCompany()
     {
         $this->sfObjects     = ['Account'];
@@ -1100,6 +1102,12 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
             ->setConstructorArgs([$mockFactory])
             ->setMethods($this->sfMockMethods)
             ->getMock();
+
+        $integrationEntityModelMock = $this->getMockBuilder(IntegrationEntityModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $sf->setIntegrationEntityModel($integrationEntityModelMock);
 
         $sf->method('makeRequest')
             ->will(

--- a/plugins/MauticCrmBundle/Tests/SalesforceIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/SalesforceIntegrationTest.php
@@ -1107,6 +1107,9 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $integrationEntityModelMock->method('getEntityByIdAndSetSyncDate')
+            ->willReturn(new IntegrationEntity());
+
         $sf->setIntegrationEntityModel($integrationEntityModelMock);
 
         $sf->method('makeRequest')


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
Sometimes, when pushing a contact to a campaign, Salesforce will return an error with the following message: `unable to obtain exclusive access to the record`. [This can happen for several reasons.](https://developer.salesforce.com/forums/?id=906F00000008m69IAA).
When this happens, Mautic will not be able to find the `integration_entity` and an exception will be thrown when trying to access `$entity->setLastSyncDate`
This can also happen when the campaign is deleted in Salesforce.
This PR adds a few checks for null entities to prevent the exception to be thrown.

#### Steps to reproduce the bug:
1. In Salesforce,  create a test campaign (you will delete it later)
2. Back in Mautic, make sure that Salesforce integration is configured
2. Create a form with the required fields and a Push to Salesforce action
3. Select the SF campaign to push the contact to
4. Save the form
5. Preview the form
6. Fill out the form and submit it.
7. Check in SF that the campaign has the new member
8. Delete the SF campaign
9. Fill out the form again with new information and submit it.
10. The form will hang and in the logs you will see an EntityNotFoundException exception.

#### Steps to test the PR:
1. Apply this PR
2. Try to replicate the error.
3. The form will not hang
4. In the logs will be a more descriptive error: `INTEGRATION ERROR: Salesforce - Mautic\PluginBundle\Exception\ApiErrorException: entity is deleted`