### PR TITLE
Fixed migration index names for DWC

### DIFF
--- a/app/migrations/Version20170926105027.php
+++ b/app/migrations/Version20170926105027.php
@@ -40,7 +40,7 @@ class Version20170926105027 extends AbstractMauticMigration
     public function up(Schema $schema)
     {
         $this->addSql('ALTER TABLE '.$this->prefix.'dynamic_content ADD COLUMN(filters LONGTEXT DEFAULT NULL  COMMENT \'(DC2Type:array)\', is_campaign_based TINYINT(1) DEFAULT 1 NOT NULL, slot_name VARCHAR(255) DEFAULT NULL)');
-        $this->addSql("CREATE INDEX {$this->prefix}is_campaign_based_index ON {$this->prefix}dynamic_content (slot_name)");
-        $this->addSql("CREATE INDEX {$this->prefix}slot_name_index ON {$this->prefix}dynamic_content (is_campaign_based)");
+        $this->addSql("CREATE INDEX {$this->prefix}is_campaign_based_index ON {$this->prefix}dynamic_content (is_campaign_based_index)");
+        $this->addSql("CREATE INDEX {$this->prefix}slot_name_index ON {$this->prefix}dynamic_content (slot_name_index)");
     }
 }

--- a/app/migrations/Version20170926105027.php
+++ b/app/migrations/Version20170926105027.php
@@ -39,11 +39,8 @@ class Version20170926105027 extends AbstractMauticMigration
      */
     public function up(Schema $schema)
     {
-        $idxSlotName   = $this->generatePropertyName('dynamic_content', 'idx', ['slot_name']);
-        $idxIsCampaign = $this->generatePropertyName('dynamic_content', 'idx', ['is_campaign_based']);
-
         $this->addSql('ALTER TABLE '.$this->prefix.'dynamic_content ADD COLUMN(filters LONGTEXT DEFAULT NULL  COMMENT \'(DC2Type:array)\', is_campaign_based TINYINT(1) DEFAULT 1 NOT NULL, slot_name VARCHAR(255) DEFAULT NULL)');
-        $this->addSql("CREATE INDEX $idxSlotName ON {$this->prefix}dynamic_content (slot_name)");
-        $this->addSql("CREATE INDEX $idxIsCampaign ON {$this->prefix}dynamic_content (is_campaign_based)");
+        $this->addSql("CREATE INDEX {$this->prefix}is_campaign_based_index ON {$this->prefix}dynamic_content (slot_name)");
+        $this->addSql("CREATE INDEX {$this->prefix}slot_name_index ON {$this->prefix}dynamic_content (is_campaign_based)");
     }
 }

--- a/app/migrations/Version20170926105027.php
+++ b/app/migrations/Version20170926105027.php
@@ -40,7 +40,7 @@ class Version20170926105027 extends AbstractMauticMigration
     public function up(Schema $schema)
     {
         $this->addSql('ALTER TABLE '.$this->prefix.'dynamic_content ADD COLUMN(filters LONGTEXT DEFAULT NULL  COMMENT \'(DC2Type:array)\', is_campaign_based TINYINT(1) DEFAULT 1 NOT NULL, slot_name VARCHAR(255) DEFAULT NULL)');
-        $this->addSql("CREATE INDEX {$this->prefix}is_campaign_based_index ON {$this->prefix}dynamic_content (is_campaign_based_index)");
-        $this->addSql("CREATE INDEX {$this->prefix}slot_name_index ON {$this->prefix}dynamic_content (slot_name_index)");
+        $this->addSql("CREATE INDEX {$this->prefix}is_campaign_based_index ON {$this->prefix}dynamic_content (is_campaign_based)");
+        $this->addSql("CREATE INDEX {$this->prefix}slot_name_index ON {$this->prefix}dynamic_content (slot_name)");
     }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y


[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Staging currently has a migration that is generating index and FK keys but Doctrine is expecting them to be prefixed. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. On an update to date staging with migrations ran, run `php app/console d:s:u --dump-sql` and note that Doctrine will rename the is_campaign_based and slot_name indexes from generated to named. 

#### Steps to test this PR:
1. Delete the columns is_campaign_based, filters, and slot_names from the dynamic_content table. 
2. Delete 20170926105027 from the migration table. 
3. Rerun migrations
4.  `php app/console d:s:u --dump-sql` and it shouldn't rename the migration

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 