### PR TITLE
Form delete fix

### DIFF
--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -87,24 +87,18 @@ class FormModel extends CommonFormModel
     private $formUploader;
 
     /**
-     * @var SubmissionResultLoader
-     */
-    private $submissionResultLoader;
-
-    /**
      * FormModel constructor.
      *
-     * @param RequestStack           $requestStack
-     * @param TemplatingHelper       $templatingHelper
-     * @param ThemeHelper            $themeHelper
-     * @param SchemaHelperFactory    $schemaHelperFactory
-     * @param ActionModel            $formActionModel
-     * @param FieldModel             $formFieldModel
-     * @param LeadModel              $leadModel
-     * @param FormFieldHelper        $fieldHelper
-     * @param LeadFieldModel         $leadFieldModel
-     * @param FormUploader           $formUploader
-     * @param SubmissionResultLoader $submissionResultLoader
+     * @param RequestStack        $requestStack
+     * @param TemplatingHelper    $templatingHelper
+     * @param ThemeHelper         $themeHelper
+     * @param SchemaHelperFactory $schemaHelperFactory
+     * @param ActionModel         $formActionModel
+     * @param FieldModel          $formFieldModel
+     * @param LeadModel           $leadModel
+     * @param FormFieldHelper     $fieldHelper
+     * @param LeadFieldModel      $leadFieldModel
+     * @param FormUploader        $formUploader
      */
     public function __construct(
         RequestStack $requestStack,
@@ -116,20 +110,18 @@ class FormModel extends CommonFormModel
         LeadModel $leadModel,
         FormFieldHelper $fieldHelper,
         LeadFieldModel $leadFieldModel,
-        FormUploader $formUploader,
-        SubmissionResultLoader $submissionResultLoader
+        FormUploader $formUploader
     ) {
-        $this->request                = $requestStack->getCurrentRequest();
-        $this->templatingHelper       = $templatingHelper;
-        $this->themeHelper            = $themeHelper;
-        $this->schemaHelperFactory    = $schemaHelperFactory;
-        $this->formActionModel        = $formActionModel;
-        $this->formFieldModel         = $formFieldModel;
-        $this->leadModel              = $leadModel;
-        $this->fieldHelper            = $fieldHelper;
-        $this->leadFieldModel         = $leadFieldModel;
-        $this->formUploader           = $formUploader;
-        $this->submissionResultLoader = $submissionResultLoader;
+        $this->request             = $requestStack->getCurrentRequest();
+        $this->templatingHelper    = $templatingHelper;
+        $this->themeHelper         = $themeHelper;
+        $this->schemaHelperFactory = $schemaHelperFactory;
+        $this->formActionModel     = $formActionModel;
+        $this->formFieldModel      = $formFieldModel;
+        $this->leadModel           = $leadModel;
+        $this->fieldHelper         = $fieldHelper;
+        $this->leadFieldModel      = $leadFieldModel;
+        $this->formUploader        = $formUploader;
     }
 
     /**

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -621,7 +621,7 @@ class FormModel extends CommonFormModel
     public function deleteEntity($entity)
     {
         /* @var Form $entity */
-        //parent::deleteEntity($entity);
+        parent::deleteEntity($entity);
 
         $this->deleteFormFiles($entity);
 

--- a/app/bundles/FormBundle/Tests/FormTestAbstract.php
+++ b/app/bundles/FormBundle/Tests/FormTestAbstract.php
@@ -27,7 +27,6 @@ use Mautic\FormBundle\Model\ActionModel;
 use Mautic\FormBundle\Model\FieldModel;
 use Mautic\FormBundle\Model\FormModel;
 use Mautic\FormBundle\Model\SubmissionModel;
-use Mautic\FormBundle\Model\SubmissionResultLoader;
 use Mautic\FormBundle\Validator\UploadFieldValidator;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
@@ -152,11 +151,6 @@ class FormTestAbstract extends WebTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $submissionResultLoader = $this
-            ->getMockBuilder(SubmissionResultLoader::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $formModel = new FormModel(
             $requestStack,
             $templatingHelperMock,
@@ -167,8 +161,7 @@ class FormTestAbstract extends WebTestCase
             $leadModel,
             $fieldHelper,
             $leadFieldModel,
-            $formUploaderMock,
-            $submissionResultLoader
+            $formUploaderMock
         );
 
         $formModel->setDispatcher($dispatcher);

--- a/app/bundles/FormBundle/Tests/Model/DeleteFormTest.php
+++ b/app/bundles/FormBundle/Tests/Model/DeleteFormTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\FormBundle\Test;
+
+use Doctrine\ORM\EntityManager;
+use Mautic\CoreBundle\Doctrine\Helper\SchemaHelperFactory;
+use Mautic\CoreBundle\Helper\TemplatingHelper;
+use Mautic\CoreBundle\Helper\ThemeHelper;
+use Mautic\FormBundle\Entity\Form;
+use Mautic\FormBundle\Entity\FormRepository;
+use Mautic\FormBundle\Helper\FormFieldHelper;
+use Mautic\FormBundle\Helper\FormUploader;
+use Mautic\FormBundle\Model\ActionModel;
+use Mautic\FormBundle\Model\FieldModel;
+use Mautic\FormBundle\Model\FormModel;
+use Mautic\FormBundle\Tests\FormTestAbstract;
+use Mautic\LeadBundle\Model\FieldModel as LeadFieldModel;
+use Mautic\LeadBundle\Model\LeadModel;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class DeleteFormTest extends FormTestAbstract
+{
+    public function testDelete()
+    {
+        $requestStack = $this
+            ->getMockBuilder(RequestStack::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $templatingHelperMock = $this
+            ->getMockBuilder(TemplatingHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $themeHelper = $this
+            ->getMockBuilder(ThemeHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $schemaHelperFactory = $this
+            ->getMockBuilder(SchemaHelperFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $formActionModel = $this
+            ->getMockBuilder(ActionModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $formFieldModel = $this
+            ->getMockBuilder(FieldModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $leadModel = $this
+            ->getMockBuilder(LeadModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $fieldHelper = $this
+            ->getMockBuilder(FormFieldHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $leadFieldModel = $this
+            ->getMockBuilder(LeadFieldModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $formUploaderMock = $this
+            ->getMockBuilder(FormUploader::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $formModel = new FormModel(
+            $requestStack,
+            $templatingHelperMock,
+            $themeHelper,
+            $schemaHelperFactory,
+            $formActionModel,
+            $formFieldModel,
+            $leadModel,
+            $fieldHelper,
+            $leadFieldModel,
+            $formUploaderMock
+        );
+
+        $dispatcher = $this
+            ->getMockBuilder(EventDispatcher::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dispatcher->expects($this->at(0))
+            ->method('hasListeners')
+            ->with('mautic.form_pre_delete')
+            ->willReturn(false);
+
+        $dispatcher->expects($this->at(1))
+            ->method('hasListeners')
+            ->with('mautic.form_post_delete')
+            ->willReturn(false);
+
+        $entityManager = $this
+            ->getMockBuilder(EntityManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $formRepository = $this
+            ->getMockBuilder(FormRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entityManager->expects($this->once())
+            ->method('getRepository')
+            ->willReturn($formRepository);
+
+        $formModel->setDispatcher($dispatcher);
+        $formModel->setEntityManager($entityManager);
+
+        $form = $this
+            ->getMockBuilder(Form::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $form->expects($this->exactly(2))
+            ->method('getId')
+            ->with()
+            ->willReturn(1);
+
+        $formUploaderMock->expects($this->once())
+            ->method('deleteFilesOfForm')
+            ->with($form);
+
+        $formRepository->expects($this->once())
+            ->method('deleteEntity')
+            ->with($form);
+
+        $formModel->deleteEntity($form);
+
+        $this->assertSame(1, $form->deletedId);
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR fixes bug in form delete.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to delete any form
2. You will get a notification, but form remains in the list

#### Steps to test this PR:
1. Apply PR and delete form
2. Form will be deleted
#. Run test on `DeleteFormTest` (`phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml --filter DeleteFormTest`)