### PR TITLE
check that account id is mapped in Salesforce

### DIFF
--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -414,7 +414,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     switch ($object) {
                         case 'Contact':
                             //get company from account id and assign company name
-                            if ($dataObject['AccountId__'.$object]) {
+                            if (isset($dataObject['AccountId__'.$object])) {
                                 $companyName = $this->getCompanyName($dataObject['AccountId__'.$object], 'Name');
 
                                 if ($companyName) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. try to sync contacts with no Account Id mapped in your salesforce plugin you should see an undefined index

#### Steps to test this PR:
1. with this PR you should not see the undefined index and contacts should be mapped accordingly