### PR TITLE
undefined index when campaign doesn't exist

### DIFF
--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -872,10 +872,12 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
 
         if (!empty($campaigns)) {
             foreach ($campaigns as $campaign) {
-                $choices[] = [
-                    'value' => $campaign['id'],
-                    'label' => $campaign['name'],
-                ];
+                if (isset($campaign['id'])) {
+                    $choices[] = [
+                        'value' => $campaign['id'],
+                        'label' => $campaign['name'],
+                    ];
+                }
             }
         }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. when connectwise plugin is enabled, an error may occur is the campaign id doesn't exist in the segment edit page
#### Steps to test this PR:
1. with this PR this issue is resolved