### PR TITLE
Fix for saving values from multi-select custom fields

### DIFF
--- a/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
+++ b/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
@@ -109,8 +109,9 @@ abstract class AbstractFormFieldHelper
         // for BC purposes
         $checkNumericalKeys = true;
         if (!is_array($list)) {
+
             // Try to json decode first
-            if ($json = json_decode($list, true)) {
+            if (strpos($list, '{') === 0 && $json = json_decode($list, true)) {
                 $list = $json;
             } else {
                 if (strpos($list, '|') !== false) {
@@ -125,8 +126,7 @@ abstract class AbstractFormFieldHelper
                         $values = $labels;
                         $list   = array_combine($values, $labels);
                     }
-                }
-                if (!empty($list) && !is_array($list)) {
+                } elseif (!empty($list) && !is_array($list)) {
                     $list = [$list => $list];
                 }
             }

--- a/app/bundles/CoreBundle/Tests/Helper/AbstractFormFieldHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Helper/AbstractFormFieldHelperTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Tests\Helper;
+
+use Mautic\CoreBundle\Helper\AbstractFormFieldHelper;
+
+class AbstractFormFieldHelperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @testdox The string is parsed correctly into a choise array
+     *
+     * @covers \Mautic\CoreBundle\\Helper\AbstractFormFieldHelper::parseList
+     */
+    public function testBarFormatConvertedToArray()
+    {
+        $string   = 'value1|value2|value3';
+        $expected = [
+            'value1' => 'value1',
+            'value2' => 'value2',
+            'value3' => 'value3',
+        ];
+        $actual = AbstractFormFieldHelper::parseList($string);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @testdox The string is parsed correctly into a choise array
+     *
+     * @covers \Mautic\CoreBundle\\Helper\AbstractFormFieldHelper::parseList
+     */
+    public function testBarLabelValueFormatConvertedToArray()
+    {
+        $string   = 'label1|label2|label3||value1|value2|value3';
+        $expected = [
+            'value1' => 'label1',
+            'value2' => 'label2',
+            'value3' => 'label3',
+        ];
+        $actual = AbstractFormFieldHelper::parseList($string);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @testdox The string is parsed correctly into a choise array
+     *
+     * @covers \Mautic\CoreBundle\\Helper\AbstractFormFieldHelper::parseList
+     */
+    public function testJsonEncodedFormatConvertedToArray()
+    {
+        $string   = '{"value1":"label1","value2":"label2","value3":"label3"}';
+        $expected = [
+            'value1' => 'label1',
+            'value2' => 'label2',
+            'value3' => 'label3',
+        ];
+        $actual = AbstractFormFieldHelper::parseList($string);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @testdox The string is parsed correctly into a choise array
+     *
+     * @covers \Mautic\CoreBundle\\Helper\AbstractFormFieldHelper::parseList
+     */
+    public function testSingleSelectedValueDoesNotGoIntoJson()
+    {
+        $string   = '1';
+        $expected = [
+            '1' => '1',
+        ];
+        $actual = AbstractFormFieldHelper::parseList($string);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @testdox The string is parsed correctly into a choise array
+     *
+     * @covers \Mautic\CoreBundle\\Helper\AbstractFormFieldHelper::parseList
+     */
+    public function testLabelValuePairsAreFlattened()
+    {
+        $array = [
+            [
+                'label' => 'label1',
+                'value' => 'value1',
+            ],
+            [
+                'label' => 'label2',
+                'value' => 'value2',
+            ],
+            [
+                'label' => 'label3',
+                'value' => 'value3',
+            ],
+        ];
+        $expected = [
+            'value1' => 'label1',
+            'value2' => 'label2',
+            'value3' => 'label3',
+        ];
+        $actual = AbstractFormFieldHelper::parseList($array);
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -209,10 +209,8 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
      * @param Company    $company
      * @param array      $data
      * @param bool|false $overwriteWithBlank
-     *
-     * @return array
      */
-    public function setFieldValues(Company &$company, array $data, $overwriteWithBlank = false)
+    public function setFieldValues(Company $company, array $data, $overwriteWithBlank = false)
     {
         //save the field values
         $fieldValues = $company->getFields();
@@ -231,7 +229,6 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
             }
             $fieldValues = $fields;
         }
-
         //update existing values
         foreach ($fieldValues as $group => &$groupFields) {
             foreach ($groupFields as $alias => &$field) {
@@ -242,6 +239,10 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
                 if (array_key_exists($alias, $data)) {
                     $curValue = $field['value'];
                     $newValue = $data[$alias];
+
+                    if (is_array($newValue)) {
+                        $newValue = implode('|', $newValue);
+                    }
 
                     if ($curValue !== $newValue && (strlen($newValue) > 0 || (strlen($newValue) === 0 && $overwriteWithBlank))) {
                         $field['value'] = $newValue;

--- a/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Model;
+
+use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Model\CompanyModel;
+
+class CompanyModelTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @testdox Ensure that an array value is flattened before saving
+     *
+     * @covers \Mautic\CoreBundle\\Helper\AbstractFormFieldHelper::parseList
+     */
+    public function testArrayValueIsFlattenedBeforeSave()
+    {
+        /** @var CompanyModel $companyModel */
+        $companyModel = $this->getMockBuilder(CompanyModel::class)
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
+        $company = new Company();
+        $company->setFields(
+            [
+                'core' => [
+                    'multiselect' => [
+                        'type'  => 'multiselect',
+                        'alias' => 'multiselect',
+                        'value' => 'abc|123',
+                    ],
+                ],
+            ]
+        );
+
+        $companyModel->setFieldValues($company, ['multiselect' => ['abc', 'def']]);
+
+        $updatedFields = $company->getUpdatedFields();
+
+        $this->assertEquals(
+            [
+                'multiselect' => 'abc|def',
+            ],
+            $updatedFields
+        );
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Saving values from multiselect custom fields for companies fail. But also, it'll not repopulate into the form if the value saved is just an integer. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a multiselect custom field for company with a label value pair of "label1 => value1, label2 => value2"
2. Edit/create a company and select label1 and click apply
3. Note that the value is not saved
4. Create a multiselect custom field for contacts with a label/value pair of "label1 => 1, label2 => 2" 
5. Edit/create a contact and select label1 and click apply
6. Note that the value is not repopulated to the form although if you check the database, it's stored the value

#### Steps to test this PR:
1. Repeat the above and the values should be save and restored
2. Run/review the new tests