### PR TITLE
Fix: Duplicate Points on Form Action where Company field present

### DIFF
--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -858,7 +858,10 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
      */
     public function getPointChanges()
     {
-        return $this->pointChanges;
+        $pointChanges       = $this->pointChanges;
+        $this->pointChanges = [];
+
+        return $pointChanges;
     }
 
     /**

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -1225,6 +1225,8 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
                 $changes['points'][1] = $newPoints;
                 $entity->setChanges($changes);
             }
+
+            $this->pointChanges = null;
         }
     }
 }

--- a/app/bundles/LeadBundle/Helper/FormEventHelper.php
+++ b/app/bundles/LeadBundle/Helper/FormEventHelper.php
@@ -50,6 +50,8 @@ class FormEventHelper
         $event->setDelta($newPoints - $oldPoints);
         $lead->addPointsChangeLog($event);
 
+        $lead->setPoints($newPoints);
+
         $model->saveEntity($lead, false);
     }
 

--- a/app/bundles/LeadBundle/Helper/FormEventHelper.php
+++ b/app/bundles/LeadBundle/Helper/FormEventHelper.php
@@ -50,8 +50,6 @@ class FormEventHelper
         $event->setDelta($newPoints - $oldPoints);
         $lead->addPointsChangeLog($event);
 
-        $lead->setPoints($newPoints);
-
         $model->saveEntity($lead, false);
     }
 

--- a/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
@@ -93,4 +93,29 @@ class LeadRepositoryFunctionalTest extends MauticWebTestCase
         $changes = $lead->getChanges(true);
         $this->assertEquals(60, $changes['points'][1]);
     }
+
+    public function testMixedModelAndRepositorySavesDoNotDoublePoints()
+    {
+        $model = $this->container->get('mautic.lead.model.lead');
+
+        $lead = $model->getEntity(1);
+        $lead->adjustPoints(120, Lead::POINTS_ADD);
+
+        $model->saveEntity($lead);
+
+        // Changes should be stored with points
+        $changes = $lead->getChanges(true);
+        $this->assertEquals(220, $changes['points'][1]);
+
+        // Points should now not be in changes
+        $model->saveEntity($lead);
+        $changes = $lead->getChanges(true);
+        $this->assertFalse(isset($changes['points']));
+
+        // Points should remain the same
+        $model->saveEntity($lead);
+        $this->em->getRepository('MauticLeadBundle:Lead')->saveEntity($lead);
+
+        $this->assertEquals(220, $lead->getPoints());
+    }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5188
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

This PR was donated with love by Webmecanik.

[//]: # ( Required: )
#### Description:
See https://github.com/mautic/mautic/issues/5188

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Create a form with an Email and Company field, both mapped to the respective contact fields
2. Add an Adjust Contact's Points form action, let's say +5 points
3. Submit the form
4. Check out the contact's sheet
5. Notice the contact has twice the expected amount of points (10 if you used 5 points)

#### Steps to test this PR:
Repeat steps to reproduce the bug: and check if score was update correctly
