### PR TITLE
Avoid data too long errors in db when fetching from integration

### DIFF
--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -320,6 +320,14 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
             $company = $existingCompany[2];
         }
 
+        $companyFieldTypes = $this->fieldModel->getFieldListWithProperties('company');
+
+        foreach ($matchedFields as $companyField => $value) {
+            if (isset($companyFieldTypes[$companyField]['type']) && $companyFieldTypes[$companyField]['type'] == 'text') {
+                $matchedFields[$companyField] = substr($value, 0, 255);
+            }
+        }
+
         if (!$company->isNew()) {
             $fieldsToUpdate = $this->getPriorityFieldsForMautic($config, $object, 'mautic_company');
             $fieldsToUpdate = array_intersect_key($config['companyFields'], $fieldsToUpdate);
@@ -370,10 +378,14 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
         $leadModel           = $this->leadModel;
         $uniqueLeadFields    = $this->fieldModel->getUniqueIdentifierFields();
         $uniqueLeadFieldData = [];
+        $leadFieldTypes      = $this->fieldModel->getFieldListWithProperties();
 
         foreach ($matchedFields as $leadField => $value) {
             if (array_key_exists($leadField, $uniqueLeadFields) && !empty($value)) {
                 $uniqueLeadFieldData[$leadField] = $value;
+            }
+            if (isset($leadFieldTypes[$leadField]['type']) && $leadFieldTypes[$leadField]['type'] == 'text') {
+                $matchedFields[$leadField] = substr($value, 0, 255);
             }
         }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4976
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When fetching contact or company data from an integration if an integration longtext is mapped to a text field in Mautic, we get a data too long error when updating the DB. 
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to map a long text field from your favourite CRM integration to a text field in Mautic
2. Make sure your contact or company data has more than 255 characters
3. run the sync command for your integration 
(in my case I used salesforce, <php app/console mautic:integration:fetchleads  --integration=Salesforce --time-interval='2 days' --env dev>) and you will get the data too long error.

#### Steps to test this PR:
1. Apply this PR, follow steps above and the data should be truncated to 255 characters. making it possible to update the DB, Although long text fields should really be mapped to long text fields in mautic.