### PR TITLE
add new segment filter "Unsubscribed - Manual" for filter do not contact manually added

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -1336,6 +1336,7 @@ class LeadListRepository extends CommonRepository
                     $groupExpr->add(sprintf('%s (%s)', $operand, $subqb->getSQL()));
                     break;
 
+                case 'dnc_manual':
                 case 'dnc_bounced':
                 case 'dnc_unsubscribed':
                 case 'dnc_bounced_sms':
@@ -1378,7 +1379,7 @@ class LeadListRepository extends CommonRepository
 
                     $ignoreAutoFilter = true;
 
-                    $parameters[$parameter]        = ($parts[1] === 'bounced') ? DoNotContact::BOUNCED : DoNotContact::UNSUBSCRIBED;
+                    $parameters[$parameter]        = ($parts[1] === 'bounced') ? DoNotContact::BOUNCED : (($parts[1] === 'manual') ? DoNotContact::MANUAL : DoNotContact::UNSUBSCRIBED);
                     $parameters[$channelParameter] = $channel;
 
                     break;

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -425,6 +425,18 @@ class ListModel extends FormModel
                 'operators' => $this->getOperatorsForFieldType('bool'),
                 'object'    => 'lead',
             ],
+            'dnc_manual' => [
+                'label'      => $this->translator->trans('mautic.lead.list.filter.dnc_manual'),
+                'properties' => [
+                    'type' => 'boolean',
+                    'list' => [
+                        0 => $this->translator->trans('mautic.core.form.no'),
+                        1 => $this->translator->trans('mautic.core.form.yes'),
+                    ],
+                ],
+                'operators' => $this->getOperatorsForFieldType('bool'),
+                'object'    => 'lead',
+            ],
             'dnc_bounced_sms' => [
                 'label'      => $this->translator->trans('mautic.lead.list.filter.dnc_bounced_sms'),
                 'properties' => [

--- a/app/bundles/LeadBundle/Translations/en_US/messages.ini
+++ b/app/bundles/LeadBundle/Translations/en_US/messages.ini
@@ -345,6 +345,7 @@ mautic.lead.list.rebuild.to_be_removed="%leads% total contact(s) to be removed i
 mautic.lead.list.filter.date_identified="Date Identified"
 mautic.lead.list.filter.dnc_bounced="Bounced - Email"
 mautic.lead.list.filter.dnc_unsubscribed="Unsubscribed - Email"
+mautic.lead.list.filter.dnc_manual="Unsubscribed - Manual"
 mautic.lead.list.filter.last_active="Date Last Active"
 mautic.lead.list.filter.date_modified="Modified date"
 mautic.lead.list.filter.lists="Segment Membership"


### PR DESCRIPTION
…act leads manually added

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Related user documentation PR URL | N
| Related developer documentation PR URL | N 
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Create/Modifiy segment with new filter "Unsubscribed-Manual"
2.  Update segments
3. Check if manually do not contact leads is added to the segment

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 