### PR TITLE
Bugfix for reports paginator and emails date range filter

### DIFF
--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -294,7 +294,8 @@ class ReportSubscriber extends CommonSubscriber
                 $qb->from(MAUTIC_TABLE_PREFIX.'emails', 'e')
                     ->leftJoin('e', MAUTIC_TABLE_PREFIX.'emails', 'vp', 'vp.id = e.variant_parent_id');
 
-                $event->addCategoryLeftJoin($qb, 'e');
+                $event->addCategoryLeftJoin($qb, 'e')
+                    ->applyDateFilters($qb, 'date_added', 'e');
 
                 if (!$hasGroupBy) {
                     $qb->groupBy('e.id');

--- a/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
@@ -334,11 +334,11 @@ class ReportGeneratorEvent extends AbstractReportEvent
         }
 
         if ($dateOnly) {
-            $queryBuilder->andWhere('DATE('.$tablePrefix.$dateColumn.') BETWEEN :dateFrom AND :dateTo');
+            $queryBuilder->andWhere(sprintf('%1$s IS NULL OR (DATE(%1$s) BETWEEN :dateFrom AND :dateTo)', $tablePrefix.$dateColumn));
             $queryBuilder->setParameter('dateFrom', $this->options['dateFrom']->format('Y-m-d'));
             $queryBuilder->setParameter('dateTo', $this->options['dateTo']->format('Y-m-d'));
         } else {
-            $queryBuilder->andWhere($tablePrefix.$dateColumn.' BETWEEN :dateFrom AND :dateTo');
+            $queryBuilder->andWhere(sprintf('%1$s IS NULL OR (%1$s BETWEEN :dateFrom AND :dateTo)', $tablePrefix.$dateColumn));
             $queryBuilder->setParameter('dateFrom', $this->options['dateFrom']->format('Y-m-d H:i:s'));
             $queryBuilder->setParameter('dateTo', $this->options['dateTo']->format('Y-m-d H:i:s'));
         }

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -627,9 +627,12 @@ class ReportModel extends FormModel
 
                 // Get the count
                 $query->select('COUNT(*) as count');
+                $countQuery = clone $query;
+                $countQuery->resetQueryPart('groupBy');
 
-                $result       = $query->execute()->fetchAll();
+                $result       = $countQuery->execute()->fetchAll();
                 $totalResults = (!empty($result[0]['count'])) ? $result[0]['count'] : 0;
+                unset($countQuery);
 
                 // Set the limit and get the results
                 if ($limit > 0) {


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2877, https://github.com/mautic/mautic/issues/5211
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This PR fixes the issues listed above. It also enables the date filters for reports that use `emails` as source.

In the current reports, if a record has the date field used in the date range filter set to NULL, the query will not include it (because of the BETWEEN operator for the date field), and thus the record data will be excluded from all reports. This PR fixes this issue.

#### Steps to reproduce the bug:
1. See https://github.com/mautic/mautic/issues/2877 and https://github.com/mautic/mautic/issues/5211
2. Create a new report with source `emails` (use the instructions in https://github.com/mautic/mautic/issues/5211)
3. Try to change the date range in the filters
4. The report data will be the same

#### Steps to test this PR:
1. Apply this PR
2. The paginator will show the correct number of pages.
3. The date range filter will work on email reports


