### PR TITLE
Bugfix - Custom field values not populating in form builder for "select" fields

### DIFF
--- a/app/bundles/FormBundle/Form/Type/FieldType.php
+++ b/app/bundles/FormBundle/Form/Type/FieldType.php
@@ -373,9 +373,6 @@ class FieldType extends AbstractType
                             if (!empty($options['leadFieldProperties'][$object][$val]) && (in_array($options['leadFieldProperties'][$object][$val]['type'], FormFieldHelper::getListTypes()) || !empty($options['leadFieldProperties'][$object][$val]['properties']['list']) || !empty($options['leadFieldProperties'][$object][$val]['properties']['optionlist']))) {
                                 return ['data-list-type' => 1];
                             }
-                            if (!empty($options['leadFieldProperties'][$object][$val]) && (in_array($options['leadFieldProperties'][$object][$val]['type'], FormFieldHelper::getListTypes()) || !empty($options['leadFieldProperties'][$object][$val]['properties']['list']) || !empty($options['leadFieldProperties'][$object][$val]['properties']['optionlist']))) {
-                                return ['data-list-type' => 1];
-                            }
                         }
 
                         return [];

--- a/app/bundles/FormBundle/Views/Builder/field.html.php
+++ b/app/bundles/FormBundle/Views/Builder/field.html.php
@@ -143,13 +143,17 @@ $propertiesTabError = (isset($form['properties']) && ($view['form']->containsErr
                                 <?php
                                 foreach ($group->choices as $subGroup => $fields):
                                     foreach ($fields->choices as $field) :
-                                        $attr  = (!empty($field->attr)) ? $field->attr : [];
+                                        $attr       = (!empty($field->attr)) ? $field->attr : [];
+                                        $attrString = '';
+                                        foreach ($attr as $k => $v) {
+                                            $attrString .= $k.'="'.preg_replace('/"/', '&quot;', $v).'" ';
+                                        }
                                         $label = $field->label;
                                         $value = $field->value;
                                         ?>
                                         <option value="<?php echo $value?>" class="segment-filter <?php echo $icon; ?>" <?php if ($data === $value) {
                                             echo 'Selected';
-                                        } ?> ><?php echo $label; ?></option>
+                                        } ?> <?php echo $attrString; ?> ><?php echo $label; ?></option>
                                     <?php endforeach; ?>
                                 <?php endforeach; ?>
                             </optgroup>


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4890, https://github.com/mautic/mautic/issues/4968
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
Since version 2.10.0 the option **Use assigned contact field's list choices.** is not present anymore when building a form and using custom "select" fields.

#### Steps to reproduce the bug:
1. Create a custom "Select" field.
2. Add some values.
3. Create or edit a form.
4. Add any of Select, Checkbox Group or Radio Group field
5. In Contact Field, select the custom field you created.
6. Go to properties tab.
7. You will not be able to use assigned contact field's list choices.

#### Steps to test this PR:
1. Apply this PR
2. Try to replicate the bug.
3. The assigned choices in the custom field will be populated in the form.

