### PR TITLE
Fix: Contacts API doesn't return stage metadata for contact

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -44,7 +44,7 @@ class LeadApiController extends CommonApiController
         $this->entityClass      = 'Mautic\LeadBundle\Entity\Lead';
         $this->entityNameOne    = 'contact';
         $this->entityNameMulti  = 'contacts';
-        $this->serializerGroups = ['leadDetails', 'frequencyRulesList', 'doNotContactList', 'userList', 'publishDetails', 'ipAddress', 'tagList', 'utmtagsList'];
+        $this->serializerGroups = ['leadDetails', 'frequencyRulesList', 'doNotContactList', 'userList', 'stageList', 'publishDetails', 'ipAddress', 'tagList', 'utmtagsList'];
 
         parent::initialize($event);
     }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5214
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Add stage to Contact
2. Create API call $contactsApi->get($contactID)
3. dump result and see stage metadata wasn't loaded (ID, NAME..)

#### Steps to test this PR:
1. Apply PR and repeat steps to reprouce
2. Stage metadata should load

Before:

![image](https://user-images.githubusercontent.com/462477/32050795-6d01a244-ba52-11e7-818a-f775f0b67993.png)

After PR:

![image](https://user-images.githubusercontent.com/462477/32050819-7cb9772a-ba52-11e7-9c41-0cb8f00104c9.png)

