### PR TITLE
Missing Translations for Top Lists Dashboard Widget

### DIFF
--- a/app/bundles/AssetBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/DashboardSubscriber.php
@@ -145,8 +145,8 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 $event->setTemplateData([
                     'headItems' => [
-                        $event->getTranslator()->trans('mautic.dashboard.label.title'),
-                        $event->getTranslator()->trans('mautic.dashboard.label.downloads'),
+                        'mautic.dashboard.label.title',
+                        'mautic.dashboard.label.downloads',
                     ],
                     'bodyItems' => $items,
                     'raw'       => $assets,
@@ -188,7 +188,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 $event->setTemplateData([
                     'headItems' => [
-                        $event->getTranslator()->trans('mautic.dashboard.label.title'),
+                        'mautic.dashboard.label.title',
                     ],
                     'bodyItems' => $items,
                     'raw'       => $assets,

--- a/app/bundles/EmailBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/DashboardSubscriber.php
@@ -175,8 +175,8 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 $event->setTemplateData([
                     'headItems' => [
-                        $event->getTranslator()->trans('mautic.dashboard.label.title'),
-                        $event->getTranslator()->trans('mautic.email.label.sends'),
+                        'mautic.dashboard.label.title',
+                        'mautic.email.label.sends',
                     ],
                     'bodyItems' => $items,
                     'raw'       => $emails,
@@ -227,8 +227,8 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 $event->setTemplateData([
                     'headItems' => [
-                        $event->getTranslator()->trans('mautic.dashboard.label.title'),
-                        $event->getTranslator()->trans('mautic.email.label.reads'),
+                        'mautic.dashboard.label.title',
+                        'mautic.email.label.reads',
                     ],
                     'bodyItems' => $items,
                     'raw'       => $emails,
@@ -282,7 +282,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 $event->setTemplateData([
                     'headItems' => [
-                        $event->getTranslator()->trans('mautic.dashboard.label.title'),
+                        'mautic.dashboard.label.title',
                     ],
                     'bodyItems' => $items,
                     'raw'       => $emails,

--- a/app/bundles/FormBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/DashboardSubscriber.php
@@ -138,8 +138,8 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 $event->setTemplateData([
                     'headItems' => [
-                        $event->getTranslator()->trans('mautic.form.result.thead.referrer'),
-                        $event->getTranslator()->trans('mautic.form.graph.line.submissions'),
+                        'mautic.form.result.thead.referrer',
+                        'mautic.form.graph.line.submissions',
                     ],
                     'bodyItems' => $items,
                     'raw'       => $referrers,
@@ -191,8 +191,8 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 $event->setTemplateData([
                     'headItems' => [
-                        $event->getTranslator()->trans('mautic.form.lead'),
-                        $event->getTranslator()->trans('mautic.form.graph.line.submissions'),
+                        'mautic.form.lead',
+                        'mautic.form.graph.line.submissions',
                     ],
                     'bodyItems' => $items,
                     'raw'       => $submitters,
@@ -234,7 +234,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 $event->setTemplateData([
                     'headItems' => [
-                        $event->getTranslator()->trans('mautic.dashboard.label.title'),
+                        'mautic.dashboard.label.title',
                     ],
                     'bodyItems' => $items,
                     'raw'       => $forms,

--- a/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
@@ -187,8 +187,8 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 $event->setTemplateData([
                     'headItems' => [
-                        $event->getTranslator()->trans('mautic.dashboard.label.title'),
-                        $event->getTranslator()->trans('mautic.lead.leads'),
+                        'mautic.dashboard.label.title',
+                        'mautic.lead.leads',
                     ],
                     'bodyItems' => $items,
                     'raw'       => $lists,

--- a/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
@@ -340,8 +340,8 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 $event->setTemplateData([
                     'headItems' => [
-                        $event->getTranslator()->trans('mautic.user.account.permissions.editname'),
-                        $event->getTranslator()->trans('mautic.lead.leads'),
+                        'mautic.user.account.permissions.editname',
+                        'mautic.lead.leads',
                     ],
                     'bodyItems' => $items,
                     'raw'       => $owners,
@@ -395,8 +395,8 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 $event->setTemplateData([
                     'headItems' => [
-                        $event->getTranslator()->trans('mautic.user.account.permissions.editname'),
-                        $event->getTranslator()->trans('mautic.lead.leads'),
+                        'mautic.user.account.permissions.editname',
+                        'mautic.lead.leads',
                     ],
                     'bodyItems' => $items,
                     'raw'       => $creators,
@@ -447,7 +447,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 $event->setTemplateData([
                     'headItems' => [
-                        $event->getTranslator()->trans('mautic.dashboard.label.title'),
+                        'mautic.dashboard.label.title',
                     ],
                     'bodyItems' => $items,
                     'raw'       => $leads,

--- a/app/bundles/PageBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/DashboardSubscriber.php
@@ -167,8 +167,8 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 $event->setTemplateData([
                     'headItems' => [
-                        $event->getTranslator()->trans('mautic.dashboard.label.title'),
-                        $event->getTranslator()->trans('mautic.dashboard.label.hits'),
+                        'mautic.dashboard.label.title',
+                        'mautic.dashboard.label.hits',
                     ],
                     'bodyItems' => $items,
                     'raw'       => $pages,
@@ -210,7 +210,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 $event->setTemplateData([
                     'headItems' => [
-                        $event->getTranslator()->trans('mautic.dashboard.label.title'),
+                        'mautic.dashboard.label.title',
                     ],
                     'bodyItems' => $items,
                     'raw'       => $pages,


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL |  N/A
| Related developer documentation PR URL |  N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? |  N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Currently the default dashboard widget of "top.lists" or Contact Widgets > Top Segment is throwing off a warning that it's missing translations for "Contact" and "Title".

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Load up the homepage of a new install in development
2.  Notice debug bar shows a warning for missing translation

#### Steps to test this PR:
1.  Load up the homepage of a new install in development
2.  Notice debug bar DOES NOT show a warning for missing translation