### PR TITLE
Fixed error in FocusModel where clicks and submissions were for all f…

### DIFF
--- a/plugins/MauticFocusBundle/Model/FocusModel.php
+++ b/plugins/MauticFocusBundle/Model/FocusModel.php
@@ -411,14 +411,14 @@ class FocusModel extends FormModel
 
         if ($focus->getType() != 'notification') {
             if ($focus->getType() == 'link') {
-                $q = $query->prepareTimeDataQuery('focus_stats', 'date_added', ['type' => Stat::TYPE_CLICK,'focus_id' => $focus->getId()]);
+                $q = $query->prepareTimeDataQuery('focus_stats', 'date_added', ['type' => Stat::TYPE_CLICK, 'focus_id' => $focus->getId()]);
                 if (!$canViewOthers) {
                     $this->limitQueryToCreator($q);
                 }
                 $data = $query->loadAndBuildTimeData($q);
                 $chart->setDataset($this->translator->trans('mautic.focus.graph.clicks'), $data);
             } else {
-                $q = $query->prepareTimeDataQuery('focus_stats', 'date_added', ['type' => Stat::TYPE_FORM,'focus_id' => $focus->getId()]);
+                $q = $query->prepareTimeDataQuery('focus_stats', 'date_added', ['type' => Stat::TYPE_FORM, 'focus_id' => $focus->getId()]);
                 if (!$canViewOthers) {
                     $this->limitQueryToCreator($q);
                 }

--- a/plugins/MauticFocusBundle/Model/FocusModel.php
+++ b/plugins/MauticFocusBundle/Model/FocusModel.php
@@ -411,14 +411,14 @@ class FocusModel extends FormModel
 
         if ($focus->getType() != 'notification') {
             if ($focus->getType() == 'link') {
-                $q = $query->prepareTimeDataQuery('focus_stats', 'date_added', ['type' => Stat::TYPE_CLICK]);
+                $q = $query->prepareTimeDataQuery('focus_stats', 'date_added', ['type' => Stat::TYPE_CLICK,'focus_id' => $focus->getId()]);
                 if (!$canViewOthers) {
                     $this->limitQueryToCreator($q);
                 }
                 $data = $query->loadAndBuildTimeData($q);
                 $chart->setDataset($this->translator->trans('mautic.focus.graph.clicks'), $data);
             } else {
-                $q = $query->prepareTimeDataQuery('focus_stats', 'date_added', ['type' => Stat::TYPE_FORM]);
+                $q = $query->prepareTimeDataQuery('focus_stats', 'date_added', ['type' => Stat::TYPE_FORM,'focus_id' => $focus->getId()]);
                 if (!$canViewOthers) {
                     $this->limitQueryToCreator($q);
                 }


### PR DESCRIPTION
…ocus, not just the one selected

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #5175
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: Focus stats were showing global clicks/submissions, not stats for just the viewed focus item.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create multiple focus items. Create submissions/ clicks for each.
2.  Note that the clicks/ submissions will be the same for both

#### Steps to test this PR:
1. Repeat steps above for producing bug and note that the problem has been solved.
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 