### PR TITLE
[Bugfix] Preference page loading

### DIFF
--- a/app/bundles/CoreBundle/Views/Slots/preferredchannel.html.php
+++ b/app/bundles/CoreBundle/Views/Slots/preferredchannel.html.php
@@ -12,7 +12,7 @@
 ?>
 <?php if (isset($form)) : ?>
     <?php if ($showContactPreferredChannels):?>
-        <div class="preferred_channel text-left"><?php echo $view['form']->row($form['preferred_channel']); ?></div>
+        <div class="preferred_channel text-left"><?php echo $view['form']->rowIfExists($form, 'preferred_channel'); ?></div>
         <?php
     else:
         unset($form['preferred_channel']);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When loading a preference center page, if the preferred_channel key did not exist, the page would crash due to trying to pass `null` instead of a `FormView` instance. It would cause this error:

```
[2017-10-31 19:13:57] mautic.ERROR: Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Argument 1 passed to Symfony\Bundle\FrameworkBundle\Templating\Helper\FormHelper::row() must be an instance of Symfony\Component\Form\FormView, null given, called in /Users/dgilbert/Sites/mautic/app/bundles/CoreBundle/Views/Slots/preferredchannel.html.php on line 15 - in file /Users/dgilbert/Sites/mautic/vendor/symfony/framework-bundle/Templating/Helper/FormHelper.php - at line 175 [] []
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to Mautic's Configuration -> Email Settings -> set Show contact's preferred channel option to No
2. Create a preference center page, adding all available preference options 
3. Create a test segment with a sample contact with whom you have access to their email.
4. Create a test email with the created preference center page as the preference center for that email.
5. Send the email, and click the unsubscribe link in the email
6. Page will fail to load and error will be logged.

#### Steps to test this PR:
1. Apply & restest
2. Page will load and error is not logged.