### PR TITLE
Fixed import when --limit is used where the second run will skip the batch

### DIFF
--- a/app/bundles/LeadBundle/Entity/Import.php
+++ b/app/bundles/LeadBundle/Entity/Import.php
@@ -764,6 +764,24 @@ class Import extends FormEntity
     }
 
     /**
+     * @param $line
+     *
+     * @return Import
+     */
+    public function setLastLineImported($line)
+    {
+        $this->properties['line'] = (int) $line;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLastLineImported()
+    {
+        return isset($this->properties['line']) ? $this->properties['line'] : 0;
+    }
+
+    /**
      * @return array
      */
     public function getMatchedFields()
@@ -772,7 +790,7 @@ class Import extends FormEntity
     }
 
     /**
-     * @param string $properties
+     * @param array $properties
      *
      * @return Import
      */
@@ -880,7 +898,7 @@ class Import extends FormEntity
     }
 
     /**
-     * @return string
+     * @return array
      */
     public function getProperties()
     {

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -304,17 +304,19 @@ class ImportModel extends FormModel
             return false;
         }
 
-        $lineNumber  = $progress->getDone();
-        $headers     = $import->getHeaders();
-        $headerCount = count($headers);
-        $config      = $import->getParserConfig();
-        $counter     = 0;
+        $lastImportedLine = $import->getLastLineImported();
+        $headers          = $import->getHeaders();
+        $headerCount      = count($headers);
+        $config           = $import->getParserConfig();
+        $counter          = 0;
 
-        $this->logDebug('The import is starting on line '.$lineNumber, $import);
-
-        if ($lineNumber > 0) {
-            $file->seek($lineNumber);
+        if ($lastImportedLine > 0) {
+            // Seek is zero-based line numbering and
+            $file->seek($lastImportedLine - 1);
         }
+
+        $lineNumber = $lastImportedLine + 1;
+        $this->logDebug('The import is starting on line '.$lineNumber, $import);
 
         $batchSize = $config['batchlimit'];
 
@@ -325,9 +327,10 @@ class ImportModel extends FormModel
 
         while ($batchSize && !$file->eof()) {
             $data = $file->fgetcsv($config['delimiter'], $config['enclosure'], $config['escape']);
+            $import->setLastLineImported($lineNumber);
 
             // Ignore the header row
-            if ($lineNumber === 0) {
+            if ($lineNumber === 1) {
                 ++$lineNumber;
                 continue;
             }
@@ -419,7 +422,6 @@ class ImportModel extends FormModel
             if ($limit && $counter >= $limit) {
                 $import->setStatus($import::DELAYED);
                 $this->saveEntity($import);
-
                 break;
             }
         }

--- a/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
@@ -316,4 +316,45 @@ class ImportModelTest extends StandardImportTestHelper
             $this->assertSame($test['mod'], $test['row']);
         }
     }
+
+    public function testLimit()
+    {
+        $model = $this->initImportModel();
+
+        $import = new Import();
+        $import->setFilePath(self::$largeCsvPath)
+            ->setLineCount(511)
+            ->setHeaders(self::$initialList[0])
+            ->setParserConfig(
+                [
+                    'batchlimit' => 10,
+                    'delimiter'  => ',',
+                    'enclosure'  => '"',
+                    'escape'     => '/',
+                ]
+            );
+
+        $import->start();
+        $progress = new Progress();
+        // Each batch should have the last line imported recorded as limit + 1
+        $model->process($import, $progress, 100);
+        $this->assertEquals(101, $import->getLastLineImported());
+        $model->process($import, $progress, 100);
+        $this->assertEquals(201, $import->getLastLineImported());
+        $model->process($import, $progress, 100);
+        $this->assertEquals(301, $import->getLastLineImported());
+        $model->process($import, $progress, 100);
+        $this->assertEquals(401, $import->getLastLineImported());
+        $model->process($import, $progress, 100);
+        $this->assertEquals(501, $import->getLastLineImported());
+        $model->process($import, $progress, 100);
+
+        // 512 is an empty line in the CSV
+        $this->assertEquals(512, $import->getLastLineImported());
+
+        // Excluding the header but including the empty row in 512, there are 511 rows
+        $this->assertEquals(511, $import->getProcessedRows());
+
+        $import->end();
+    }
 }

--- a/app/bundles/LeadBundle/Tests/StandardImportTestHelper.php
+++ b/app/bundles/LeadBundle/Tests/StandardImportTestHelper.php
@@ -11,19 +11,23 @@
 
 namespace Mautic\LeadBundle\Tests;
 
+use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\NotificationModel;
 use Mautic\CoreBundle\Tests\CommonMocks;
 use Mautic\LeadBundle\Entity\Import;
 use Mautic\LeadBundle\Entity\ImportRepository;
-use Mautic\LeadBundle\Entity\LeadEventLog;
 use Mautic\LeadBundle\Entity\LeadEventLogRepository;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\ImportModel;
 use Mautic\LeadBundle\Model\LeadModel;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 abstract class StandardImportTestHelper extends CommonMocks
 {
+    protected $eventEntities = [];
     protected static $csvPath;
+    protected static $largeCsvPath;
+
     protected static $initialList = [
         ['email', 'firstname', 'lastname'],
         ['john@doe.email', 'John', 'Doe'],
@@ -45,8 +49,20 @@ abstract class StandardImportTestHelper extends CommonMocks
         }
 
         fclose($file);
-
         self::$csvPath = $tmpFile;
+
+        $tmpFile = tempnam(sys_get_temp_dir(), 'mautic_import_large_test_');
+        $file    = fopen($tmpFile, 'w');
+        fputcsv($file, ['email', 'firstname', 'lastname']);
+        $counter = 510;
+        while ($counter) {
+            fputcsv($file, [uniqid().'@gmail.com', uniqid(), uniqid()]);
+
+            --$counter;
+        }
+
+        fclose($file);
+        self::$largeCsvPath = $tmpFile;
     }
 
     public static function tearDownAfterClass()
@@ -56,6 +72,13 @@ abstract class StandardImportTestHelper extends CommonMocks
         }
 
         parent::tearDownAfterClass();
+    }
+
+    public function setup()
+    {
+        defined('MAUTIC_ENV') or define('MAUTIC_ENV', 'test');
+
+        $this->eventEntities = [];
     }
 
     protected function initImportEntity(array $methods = null)
@@ -98,6 +121,8 @@ abstract class StandardImportTestHelper extends CommonMocks
         $importRepository = $this->getMockBuilder(ImportRepository::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $importRepository->method('getValue')
+            ->willReturn(true);
 
         $entityManager->expects($this->any())
             ->method('getRepository')
@@ -135,6 +160,13 @@ abstract class StandardImportTestHelper extends CommonMocks
         $importModel = new ImportModel($pathsHelper, $leadModel, $notificationModel, $coreParametersHelper, $companyModel);
         $importModel->setEntityManager($entityManager);
         $importModel->setTranslator($translator);
+
+        $userHelper = $this->getMockBuilder(UserHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $importModel->setUserHelper($userHelper);
+
+        $importModel->setDispatcher(new EventDispatcher());
 
         return $importModel;
     }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When using --limit with the import command, the second run would  skip the second run/batch because it would import the same contacts from the first run. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Import the attached CSV using the Import in the background button (map to a segment to find them easily)
2. Run the `php app/console mautic:import --limit=3000`
3. Run it a second time after it finishes
4. View the segment and you will only have 3000 contacts instead of 6000

#### Steps to test this PR:
1. Apply the PR
2. Repeat the steps above
3. This time, all contacts should be imported
4. Run the unit tests