### PR TITLE
Bugfix: Javascript loop causing browser to lock up in Page Builder

### DIFF
--- a/app/bundles/PageBundle/Assets/js/prefcenter.js
+++ b/app/bundles/PageBundle/Assets/js/prefcenter.js
@@ -3,28 +3,31 @@ if (typeof MauticPrefCenterLoaded === 'undefined') {
     var MauticPrefCenterLoaded = true;
 
     function replaceSlotParams(slot){
-        var i, l = slot.dataset['paramLabelText'];
+        var i;
+        var text = slot.dataset['paramLabelText'];
 
-        function setLabelText(query) {
-            var labels = slot.querySelectorAll(query);
-            for (i = 0; i < labels.length; i++) {
-                labels[i].innerHTML = l;
-            }
-        }
-
-        if (l) {
-            setLabelText('label.control-label', l);
+        if (text) {
+            setLabelText(slot, 'label.control-label', text);
             var channels = slot.querySelectorAll('label[data-channel]');
             for (i = 0; i < channels.length; i++) {
-                channels[i].innerHTML = l.replace('%channel%', channels[i].dataset['channel']);
+                channels[i].innerHTML = text.replace('%channel%', channels[i].dataset['channel']);
             }
         }
+
         var numOfLabelsInSlot = 4;
         for (i = 1; i <= numOfLabelsInSlot; i++) {
-            l = slot.dataset['paramLabelText' + i];
-            if (l) {
-                setLabelText('label.label' + i, l);
+            text = slot.dataset['paramLabelText' + i];
+            if (typeof text !== "undefined") {
+                setLabelText(slot, 'label.label' + i, text);
             }
+        }
+    }
+
+    function setLabelText(slot, querySelector, text) {
+        var labels = slot.querySelectorAll(querySelector);
+
+        for (var i = 0; i < labels.length; i++) {
+            labels[i].innerHTML = text;
         }
     }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When building a preference center page, if you added the Channel Frequency slot and then edited the "Frequency label 2" input in the form area, then closed and tried to reopen the builder it would lock up the browser.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new preference center page.
2. In the builder, add the Channel Frequency slot. 
3. Edit the "Frequency label 2", "Pause label 1", and "Pause label 2" texts to be something different.
4. Close the builder & then click the builder button to reopen it
5. It will lock up your browser tab.

#### Steps to test this PR:
1. Apply PR and run `app/console m:a:g` to regenerate production assets.
2. Follow the steps to reproduce, except instead of locking your browser tab with a js loop, the builder will open normally.