### PR TITLE
Bugfix: @covers in AbstractFormFieldHelperTest

### DIFF
--- a/app/bundles/CoreBundle/Tests/Helper/AbstractFormFieldHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Helper/AbstractFormFieldHelperTest.php
@@ -16,9 +16,9 @@ use Mautic\CoreBundle\Helper\AbstractFormFieldHelper;
 class AbstractFormFieldHelperTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @testdox The string is parsed correctly into a choise array
+     * @testdox The string is parsed correctly into a choice array
      *
-     * @covers \Mautic\CoreBundle\\Helper\AbstractFormFieldHelper::parseList
+     * @covers \Mautic\CoreBundle\Helper\AbstractFormFieldHelper::parseList
      */
     public function testBarFormatConvertedToArray()
     {
@@ -34,9 +34,9 @@ class AbstractFormFieldHelperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @testdox The string is parsed correctly into a choise array
+     * @testdox The string is parsed correctly into a choice array
      *
-     * @covers \Mautic\CoreBundle\\Helper\AbstractFormFieldHelper::parseList
+     * @covers \Mautic\CoreBundle\Helper\AbstractFormFieldHelper::parseList
      */
     public function testBarLabelValueFormatConvertedToArray()
     {
@@ -52,9 +52,9 @@ class AbstractFormFieldHelperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @testdox The string is parsed correctly into a choise array
+     * @testdox The string is parsed correctly into a choice array
      *
-     * @covers \Mautic\CoreBundle\\Helper\AbstractFormFieldHelper::parseList
+     * @covers \Mautic\CoreBundle\Helper\AbstractFormFieldHelper::parseList
      */
     public function testJsonEncodedFormatConvertedToArray()
     {
@@ -70,9 +70,9 @@ class AbstractFormFieldHelperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @testdox The string is parsed correctly into a choise array
+     * @testdox The string is parsed correctly into a choice array
      *
-     * @covers \Mautic\CoreBundle\\Helper\AbstractFormFieldHelper::parseList
+     * @covers \Mautic\CoreBundle\Helper\AbstractFormFieldHelper::parseList
      */
     public function testSingleSelectedValueDoesNotGoIntoJson()
     {
@@ -86,9 +86,9 @@ class AbstractFormFieldHelperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @testdox The string is parsed correctly into a choise array
+     * @testdox The string is parsed correctly into a choice array
      *
-     * @covers \Mautic\CoreBundle\\Helper\AbstractFormFieldHelper::parseList
+     * @covers \Mautic\CoreBundle\Helper\AbstractFormFieldHelper::parseList
      */
     public function testLabelValuePairsAreFlattened()
     {
@@ -116,9 +116,9 @@ class AbstractFormFieldHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $actual);
     }
     /**
-     * @testdox The string is parsed correctly into a choise array
+     * @testdox The string is parsed correctly into a choice array
      *
-     * @covers \Mautic\CoreBundle\\Helper\AbstractFormFieldHelper::parseList
+     * @covers \Mautic\CoreBundle\Helper\AbstractFormFieldHelper::parseList
      */
     public function testLabelValuePairsAreFlattenedWithOptGroup()
     {

--- a/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
@@ -19,7 +19,7 @@ class CompanyModelTest extends \PHPUnit_Framework_TestCase
     /**
      * @testdox Ensure that an array value is flattened before saving
      *
-     * @covers \Mautic\CoreBundle\\Helper\AbstractFormFieldHelper::parseList
+     * @covers \Mautic\CoreBundle\Helper\AbstractFormFieldHelper::parseList
      */
     public function testArrayValueIsFlattenedBeforeSave()
     {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The `@covers` in the docblocks within `AbstractFormFieldHelper` test would cause a fatal error when running phpunit with a coverage report enabled. This PR fixes that (and a minor spelling error).

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run unit tests via `bin/phpunit -c app/phpunit.xml.dist --coverage-html build/coverage`
2. Get a fatal error before long (Cannot redeclare class)

#### Steps to test this PR:
1. Apply PR and run tests again
2. No fatal error
