### PR TITLE
Fix Imports create Duplicates when Email is publicly updatable

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1026,13 +1026,16 @@ class LeadModel extends FormModel
     {
         // Search for lead by request and/or update lead fields if some data were sent in the URL query
         if (null == $this->availableLeadFields) {
+            $filter = ['isPublished' => true];
+
+            if ($onlyPubliclyUpdateable) {
+                $filter['isPubliclyUpdatable'] = true;
+            }
+
             $this->availableLeadFields = $this->leadFieldModel->getFieldList(
                 false,
                 false,
-                [
-                    'isPublished'         => true,
-                    'isPubliclyUpdatable' => $onlyPubliclyUpdateable,
-                ]
+                $filter
             );
         }
 

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Mautic\LeadBundle\Tests\Model;
+
+use Mautic\LeadBundle\Model\FieldModel;
+use Mautic\LeadBundle\Model\LeadModel;
+
+class LeadModelTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCheckForDuplicateContact()
+    {
+        $mockFieldModel = $this->getMockBuilder(FieldModel::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getFieldList', 'getUniqueIdentifierFields'])
+            ->getMock();
+
+        $mockFieldModel->expects($this->exactly(2))
+            ->method('getFieldList')
+            ->withConsecutive(
+                [false, false, ['isPublished' => true]],
+                [false, false, ['isPublished' => true, 'isPubliclyUpdatable' => true]]
+            )
+            ->will($this->onConsecutiveCalls(
+                ['a' => 1],
+                ['a' => 3]
+            ));
+
+        $mockFieldModel->expects($this->exactly(2))
+            ->method('getUniqueIdentifierFields')
+            ->will($this->onConsecutiveCalls(
+                ['b' => 2],
+                ['b' => 4]
+            ));
+
+        $mockLeadModel = $this->getMockBuilder(LeadModel::class)
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
+        $reflectedProp = new \ReflectionProperty(LeadModel::class, 'leadFieldModel');
+
+        $reflectedProp->setAccessible(true);
+        $reflectedProp->setValue($mockLeadModel, $mockFieldModel);
+
+        $this->assertAttributeEquals(
+            [],
+            'availableLeadFields',
+            $mockLeadModel,
+            'The availableLeadFields property should start empty'
+        );
+
+        $mockLeadModel->checkForDuplicateContact([]);
+        $this->assertAttributeEquals(['a' => 1], 'availableLeadFields', $mockLeadModel);
+
+        $reflectedProp = new \ReflectionProperty(LeadModel::class, 'availableLeadFields');
+        $reflectedProp->setAccessible(true);
+        $reflectedProp->setValue($mockLeadModel, []);
+
+        $mockLeadModel->checkForDuplicateContact([], null, false, true);
+        $this->assertAttributeEquals(['a' => 3], 'availableLeadFields', $mockLeadModel);
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? |N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #5281 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Avoid duplicate lead on import when email is publicUpdatable
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make the email field publicly updatable
2. Import a CSV file as simple as the following:
```
email
test@example.com
```
 3. Import that same file again
 4. You should have two identical leads
2. 

#### Steps to test this PR:
1. apply this PR
2. Import the same file to see contact are merged
