### PR TITLE
Fix zoho push lead

### DIFF
--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -188,6 +188,18 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
     }
 
     /**
+     * Sets the API helper.
+     *
+     * @param object $helper
+     */
+    public function setApiHelper($helper)
+    {
+        if ($helper instanceof CrmApi) {
+            $this->helper = $helper;
+        }
+    }
+
+    /**
      * @param array $params
      */
     public function pushLeadActivity($params = [])

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -188,18 +188,6 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
     }
 
     /**
-     * Sets the API helper.
-     *
-     * @param object $helper
-     */
-    public function setApiHelper($helper)
-    {
-        if ($helper instanceof CrmApi) {
-            $this->helper = $helper;
-        }
-    }
-
-    /**
      * @param array $params
      */
     public function pushLeadActivity($params = [])

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -815,8 +815,9 @@ class ZohoIntegration extends CrmAbstractIntegration
                                 ];
                             }
                         }
-
-                        $this->cache->set('leadFields'.$cacheSuffix, $zohoFields[$zohoObject]);
+                        if (empty($settings['ignore_field_cache'])) {
+                            $this->cache->set('leadFields'.$cacheSuffix, $zohoFields[$zohoObject]);
+                        }
                     }
                 }
             }
@@ -852,8 +853,8 @@ class ZohoIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param $lead
-     * @param $config
+     * @param Lead  $lead
+     * @param array $config
      *
      * @return string
      */
@@ -861,9 +862,12 @@ class ZohoIntegration extends CrmAbstractIntegration
     {
         $config['object'] = 'Leads';
         $mappedData       = parent::populateLeadData($lead, $config);
-        $writer           = (new Writer($config['object']));
-        $row              = $writer->row($lead['id']);
-
+        $writer           = new Writer($config['object']);
+        if ($lead instanceof Lead) {
+            $row = $writer->row($lead->getId());
+        } else {
+            $row = $writer->row($lead['id']);
+        }
         foreach ($mappedData as $name => $value) {
             $row->add($name, $value);
         }

--- a/plugins/MauticCrmBundle/Tests/ZohoIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/ZohoIntegrationTest.php
@@ -47,7 +47,10 @@ class ZohoIntegrationTest extends \PHPUnit_Framework_TestCase
         $translator->expects($this->any())
                    ->method('trans')
                    ->willReturnArgument(0);
-        $this->integration = new ZohoIntegration();
+        $this->integration = $this->getMockBuilder(ZohoIntegration::class)
+            ->setMethods(['getApiHelper'])
+            ->getMock();
+
         $this->integration->setTranslator($translator);
         $this->integration->setEncryptionHelper($encryptionHelper);
         $eventMock = $this->getMockBuilder(Event::class)
@@ -123,7 +126,8 @@ class ZohoIntegrationTest extends \PHPUnit_Framework_TestCase
         $apiHelper->expects($this->any())
                        ->method('getLeadFields')
                        ->willReturn($leadFields);
-        $this->integration->setApiHelper($apiHelper);
+        $this->integration->method('getApiHelper')
+            ->willReturn($apiHelper);
         $this->integration->setIntegrationSettings($settings);
     }
 

--- a/plugins/MauticCrmBundle/Tests/ZohoIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/ZohoIntegrationTest.php
@@ -1,0 +1,165 @@
+<?php
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Integration;
+
+use Mautic\CoreBundle\Helper\EncryptionHelper;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\PluginBundle\Entity\Integration;
+use MauticPlugin\MauticCrmBundle\Api\CrmApi;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Translation\Translator;
+
+/**
+ * Class ZohoIntegrationTest.
+ */
+class ZohoIntegrationTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var ZohoIntegration */
+    private $integration;
+
+    /**
+     * Set up tests.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $encryptionHelper = $this->getMockBuilder(EncryptionHelper::class)
+                           ->disableOriginalConstructor()
+                           ->setMethods(['decrypt'])
+                           ->getMock();
+        $encryptionHelper->expects($this->any())
+                   ->method('decrypt')
+                   ->willReturnArgument(0);
+        $translator = $this->getMockBuilder(Translator::class)
+                           ->disableOriginalConstructor()
+                           ->setMethods(['trans'])
+                           ->getMock();
+        $translator->expects($this->any())
+                   ->method('trans')
+                   ->willReturnArgument(0);
+        $this->integration = new ZohoIntegration();
+        $this->integration->setTranslator($translator);
+        $this->integration->setEncryptionHelper($encryptionHelper);
+        $eventMock = $this->getMockBuilder(Event::class)
+                          ->disableOriginalConstructor()
+                          ->setMethods(['getKeys'])
+                          ->getMock();
+        $apiKeys = [
+            'EMAIL_ID'     => 'test',
+            'PASSWORD'     => 'test',
+            'updateBlanks' => '',
+            'datacenter'   => 'zoho.com',
+            'AUTHTOKEN'    => 'test',
+            'RESULT'       => 'test',
+        ];
+        $eventMock->expects($this->any())
+                  ->method('getKeys')
+                  ->willReturn($apiKeys);
+        $dispatcherMock = $this->getMockBuilder(EventDispatcher::class)
+                               ->disableOriginalConstructor()
+                               ->setMethods(['dispatch'])
+                               ->getMock();
+        $dispatcherMock->expects($this->any())
+                       ->method('dispatch')
+                       ->willReturn($eventMock);
+        $this->integration->setDispatcher($dispatcherMock);
+        $settings        = new Integration();
+        $featureSettings = [
+            'update_mautic' => [
+                'Company'  => '1',
+                'LastName' => '1',
+            ],
+            'leadFields' => [
+                'Company'  => 'company',
+                'LastName' => 'lastname',
+            ],
+            'updateBlanks'          => [],
+            'objects'               => ['Leads'],
+            'companyFields'         => [],
+            'update_mautic_company' => [],
+            'ignore_field_cache'    => true,
+        ];
+        $settings->setFeatureSettings($featureSettings);
+        $settings->setSupportedFeatures(['push_lead', 'get_leads', 'push_leads']);
+        $settings->setApiKeys($apiKeys);
+        $leadFields = [
+            'Leads' => [
+                'section' => [
+                    [
+                        'FL' => [
+                            [
+                                'dv'         => 'Company',
+                                'label'      => 'Company',
+                                'type'       => 'Text',
+                                'req'        => 'true',
+                                'isreadonly' => 'false',
+                            ],
+                            [
+                                'dv'         => 'Last Name',
+                                'label'      => 'Last Name',
+                                'type'       => 'Text',
+                                'req'        => 'true',
+                                'isreadonly' => 'false',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $apiHelper = $this->getMockBuilder(CrmApi::class)
+                          ->disableOriginalConstructor()
+                          ->setMethods(['getLeadFields'])
+                          ->getMock();
+        $apiHelper->expects($this->any())
+                       ->method('getLeadFields')
+                       ->willReturn($leadFields);
+        $this->integration->setApiHelper($apiHelper);
+        $this->integration->setIntegrationSettings($settings);
+    }
+
+    /**
+     * Test integration.
+     */
+    public function testIntegration()
+    {
+        $this->assertSame('Zoho', $this->integration->getName());
+    }
+
+    /**
+     * Test method.
+     */
+    public function testPopulateLeadData()
+    {
+        $fields = [
+            'id'       => '0',
+            'lastname' => [
+                'value' => 'user',
+            ],
+            'company' => [
+                'value' => 'company',
+            ],
+        ];
+        $lead = new Lead();
+        $lead->setFields($fields);
+        $data         = $this->integration->populateLeadData($lead, $this->integration->getIntegrationSettings()->getFeatureSettings());
+        $expectedData = <<<'EOF'
+<Leads>
+<row no="">
+<FL val="Company"><![CDATA[company]]></FL>
+<FL val="Last Name"><![CDATA[user]]></FL>
+</row>
+</Leads>
+EOF;
+        $this->assertEquals($data, $expectedData);
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3651 #5485
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The zoho plugin can not push contacts to zoho due to an incorrect function name

#### Steps to test this PR:
1. see issue https://github.com/mautic/mautic/issues/3651
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 