### PR TITLE
Update PointActionHelper to use wildcard URL from Point Action instead of exact URL from hit event

### DIFF
--- a/app/bundles/PageBundle/Helper/PointActionHelper.php
+++ b/app/bundles/PageBundle/Helper/PointActionHelper.php
@@ -73,7 +73,7 @@ class PointActionHelper
 
         $hitRepository = $factory->getEntityManager()->getRepository('MauticPageBundle:Hit');
         $lead          = $eventDetails->getLead();
-        $urlWithSqlWC  = str_replace('*', '%', $url);
+        $urlWithSqlWC  = str_replace('*', '%', $limitToUrl);
 
         if (isset($action['properties']['first_time']) && $action['properties']['first_time'] === true) {
             $hitStats = $hitRepository->getDwellTimesForUrl($urlWithSqlWC, ['leadId' => $lead->getId()]);


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N (should be covered by existing tests but probably is not)
| Related user documentation PR URL | NA
| Related developer documentation PR URL | NA
| Issues addressed (#s or URLs) | #5295 
| BC breaks? | ?
| Deprecations? | None

[//]: # ( Required: )
#### Description:
This makes ```$hitRepository->getDwellTimesForUrl()``` work correctly (return aggregate for all hits within wildcard) instead of the current behaviour where it just returns the aggregate for the current hit exact URL.