### PR TITLE
Change hit comparison from exact to equals-or-more

### DIFF
--- a/app/bundles/PageBundle/Helper/PointActionHelper.php
+++ b/app/bundles/PageBundle/Helper/PointActionHelper.php
@@ -105,7 +105,7 @@ class PointActionHelper
             if (!isset($hitStats)) {
                 $hitStats = $hitRepository->getDwellTimesForUrl($urlWithSqlWC, ['leadId' => $lead->getId()]);
             }
-            if (isset($hitStats['count']) && $hitStats['count'] === $action['properties']['page_hits']) {
+            if (isset($hitStats['count']) && $hitStats['count'] >= $action['properties']['page_hits']) {
                 $changePoints['page_hits'] = true;
             } else {
                 $changePoints['page_hits'] = false;


### PR DESCRIPTION
The hit comparison is now TRUE only if exactly the required amount of hits is reached. It should be TRUE if the exact amount of hits or more is reached because the exact amount of hits may have already been reached before the total time spent. FIX #5298

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | #5298
| BC breaks? | ?
| Deprecations? | N