### PR TITLE
Fix: Campaign preview horizontal overflow

### DIFF
--- a/app/bundles/CampaignBundle/Assets/css/campaign.css
+++ b/app/bundles/CampaignBundle/Assets/css/campaign.css
@@ -218,6 +218,9 @@
 
 .preview .builder-content {
     position: relative;
+    width: 100%;
+    height: 100%;
+    overflow: visible;
 }
 
 .preview .builder-active {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Just added horizontal overflow to campaign preview:

Before:

![image](https://user-images.githubusercontent.com/462477/32492897-19b8b938-c3bc-11e7-814c-6aae7a16965a.png)


After
![image](https://user-images.githubusercontent.com/462477/32492881-0deb77b2-c3bc-11e7-89bc-efbcc2cd10dd.png)


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Create campaign width  decision on the right side 
2.  Save and see preview tab.
3. Can't scrool to right

#### Steps to test this PR:
1.  Repeat all steps
2. Should see both scroll options - horizontal and vertical
