### PR TITLE
Prevent case differences from causing duplicates in Mautic when importing

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -149,33 +149,12 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
      *
      * @param     $uniqueFieldsWithData
      * @param int $leadId
-     * @param int $limit
      *
      * @return array
      */
-    public function getLeadsByUniqueFields($uniqueFieldsWithData, $leadId = null, $limit = null)
+    public function getLeadsByUniqueFields($uniqueFieldsWithData, $leadId = null)
     {
-        $q = $this->getEntityManager()->getConnection()->createQueryBuilder()
-            ->select('l.*')
-            ->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
-
-        // loop through the fields and
-        foreach ($uniqueFieldsWithData as $col => $val) {
-            $q->orWhere("l.$col = :".$col)
-                ->setParameter($col, $val);
-        }
-
-        // if we have a lead ID lets use it
-        if (!empty($leadId)) {
-            // make sure that its not the id we already have
-            $q->andWhere('l.id != '.$leadId);
-        }
-
-        if ($limit) {
-            $q->setMaxResults($limit);
-        }
-
-        $results = $q->execute()->fetchAll();
+        $results = $this->getLeadIdsByUniqueFields($uniqueFieldsWithData, $leadId);
 
         // Collect the IDs
         $leads = [];
@@ -213,12 +192,12 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
     /**
      * Get list of lead Ids by unique field data.
      *
-     * @param $uniqueFieldsWithData is an array of columns & values to filter by
-     * @param int $leadId is the current lead id. Added to query to skip and find other leads
+     * @param array $uniqueFieldsWithData An array of columns & values to filter by
+     * @param int   $leadId               is the current lead id. Added to query to skip and find other leads
      *
      * @return array
      */
-    public function getLeadIdsByUniqueFields($uniqueFieldsWithData, $leadId = null)
+    public function getLeadIdsByUniqueFields(array $uniqueFieldsWithData, $leadId = null)
     {
         $q = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->select('l.id')
@@ -226,8 +205,8 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
 
         // loop through the fields and
         foreach ($uniqueFieldsWithData as $col => $val) {
-            $q->orWhere("l.$col = :".$col)
-                ->setParameter($col, $val);
+            $q->orWhere("LOWER(l.$col) = :".$col)
+                ->setParameter($col, strtolower($val));
         }
 
         // if we have a lead ID lets use it

--- a/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
@@ -93,4 +93,24 @@ class LeadRepositoryFunctionalTest extends MauticWebTestCase
         $changes = $lead->getChanges(true);
         $this->assertEquals(60, $changes['points'][1]);
     }
+
+    /**
+     * @testdox Check that finding a contact based on a unique identifier is case insensitive
+     *
+     * @covers  \Mautic\LeadBundle\Entity\LeadRepository::getLeadsByUniqueFields()
+     * @covers  \Mautic\LeadBundle\Entity\LeadRepository::getLeadIdsByUniqueFields()
+     */
+    public function testUniqueIdentifierIsCaseInsensitive()
+    {
+        $repository = $this->container->get('doctrine')->getRepository('MauticLeadBundle:Lead');
+
+        $leads = $repository->getLeadsByUniqueFields(['email' => 'RoxieLShaw@fleckens.hu']);
+        $this->assertCount(1, $leads);
+        $leadId = $leads[0]->getId();
+
+        // Assert that the same lead is found by a capital email
+        $leads = $repository->getLeadsByUniqueFields(['email' => 'ROXIELSHAW@FLECKENS.HU']);
+        $this->assertCount(1, $leads);
+        $this->assertEquals($leadId, $leads[0]->getId());
+    }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #5149
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When checking for existing contacts by unique identifier, an all lower case email vs an all caps email would be recognized as two contacts causing duplicates. This PR fixes that by making comparisons case insensitive. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a contact with the email hello@email.com
2. Create a CSV file with the following and import it 
```
email
HELLO@EMAIL.COM
``` 

Notice that a new contact will be created instead of merged into the existing hello@email.com

#### Steps to test this PR:
1. Delete the all caps email
2. Reimport
3. It should be merged into the existing
4. Run the new functional test
