### PR TITLE
Prevented a notice from the SF integration unit tests

### DIFF
--- a/plugins/MauticCrmBundle/Tests/SalesforceIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/SalesforceIntegrationTest.php
@@ -987,7 +987,6 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
                 $this->returnCallback(
                     function () use ($maxSfContacts, $maxSfLeads) {
                         $args = func_get_args();
-
                         // Determine what to return by analyzing the URL and query parameters
                         switch (true) {
                             case strpos($args[0], '/query') !== false:
@@ -997,6 +996,12 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
                                     return 'fetched campaigns';
                                 } elseif (isset($args[1]['q']) && strpos($args[1]['q'], 'from Account') !== false) {
                                     return 'fetched accounts';
+                                } elseif (isset($args[1]['q']) && $args[1]['q'] === 'SELECT CreatedDate from Organization') {
+                                    return [
+                                        'records' => [
+                                                ['CreatedDate' => '2012-10-30T17:56:50.000+0000'],
+                                            ],
+                                        ];
                                 } else {
                                     // Extract emails
                                     $found = preg_match('/Email in \(\'(.*?)\'\)/', $args[1]['q'], $match);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This simply prevents the `PHP Notice:  Undefined offset: 0 in /home/travis/build/mautic/mautic/plugins/MauticCrmBundle/Api/SalesforceApi.php on line 371` notices when running unit tests.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run the SalesforceIntegrationTest unit tests and note the notice

#### Steps to test this PR:
1. Run the SalesforceIntegrationTest unit tests and note there are no notices
