### PR TITLE
Fixes a couple mailer issues unique to AbstractTokenArrayTransport with a batch recipient limit of 1

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -419,7 +419,7 @@ return [
                 ],
             ],
             'mautic.email.model.send_email_to_contacts' => [
-                'class'     => \Mautic\EmailBundle\Model\SendEmailToContacts::class,
+                'class'     => \Mautic\EmailBundle\Model\SendEmailToContact::class,
                 'arguments' => [
                     'mautic.helper.mailer',
                     'mautic.email.repository.stat',

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -309,6 +309,13 @@ return [
                     'mailer',
                 ],
             ],
+            'mautic.email.repository.stat' => [
+                'class'     => Doctrine\ORM\EntityRepository::class,
+                'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
+                'arguments' => [
+                    \Mautic\EmailBundle\Entity\Stat::class,
+                ],
+            ],
             // Mailers
             'mautic.transport.amazon' => [
                 'class'        => 'Mautic\EmailBundle\Swiftmailer\Transport\AmazonTransport',
@@ -402,12 +409,22 @@ return [
                     'mautic.page.model.trackable',
                     'mautic.user.model.user',
                     'mautic.channel.model.queue',
+                    'mautic.email.model.send_email_to_contacts',
                 ],
             ],
             'mautic.email.model.send_email_to_user' => [
                 'class'     => \Mautic\EmailBundle\Model\SendEmailToUser::class,
                 'arguments' => [
                     'mautic.email.model.email',
+                ],
+            ],
+            'mautic.email.model.send_email_to_contacts' => [
+                'class'     => \Mautic\EmailBundle\Model\SendEmailToContacts::class,
+                'arguments' => [
+                    'mautic.helper.mailer',
+                    'mautic.email.repository.stat',
+                    'mautic.lead.model.dnc',
+                    'translator',
                 ],
             ],
         ],

--- a/app/bundles/EmailBundle/Exception/FailedToSendToContactException.php
+++ b/app/bundles/EmailBundle/Exception/FailedToSendToContactException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Exception;
+
+class FailedToSendToContactException extends \Exception
+{
+}

--- a/app/bundles/EmailBundle/Model/SendEmailToContact.php
+++ b/app/bundles/EmailBundle/Model/SendEmailToContact.php
@@ -148,7 +148,7 @@ class SendEmailToContact
     }
 
     /**
-     * Flush any remaining queued contacts, process spending stats, create DNC entries and reset this class
+     * Flush any remaining queued contacts, process spending stats, create DNC entries and reset this class.
      */
     public function finalFlush()
     {
@@ -171,9 +171,9 @@ class SendEmailToContact
      * Use an Email entity to populate content, from, etc.
      *
      * @param Email $email
-     * @param array $channel ['channelName', 'channelId']
+     * @param array $channel          ['channelName', 'channelId']
      * @param array $assetAttachments
-     * @param array $slots   @deprecated to be removed in 3.0; support for old email template format
+     * @param array $slots            @deprecated to be removed in 3.0; support for old email template format
      *
      * @return $this
      */
@@ -314,7 +314,7 @@ class SendEmailToContact
     }
 
     /**
-     * @param bool $hasBadEmail
+     * @param bool   $hasBadEmail
      * @param string $errorMessages
      *
      * @throws FailedToSendToContactException

--- a/app/bundles/EmailBundle/Model/SendEmailToContact.php
+++ b/app/bundles/EmailBundle/Model/SendEmailToContact.php
@@ -26,92 +26,95 @@ class SendEmailToContact
     /**
      * @var MailHelper
      */
-    protected $mailer;
+    private $mailer;
 
     /**
      * @var StatRepository
      */
-    protected $statRepo;
+    private $statRepo;
 
     /**
      * @var DoNotContact
      */
-    protected $dncModel;
+    private $dncModel;
 
     /**
      * @var TranslatorInterface
      */
-    protected $translator;
+    private $translator;
 
     /**
      * @var null|string
      */
-    protected $singleEmailMode = null;
+    private $singleEmailMode = null;
 
     /**
      * @var Stat[]
      */
-    protected $statEntities = [];
+    private $statEntities = [];
 
     /**
      * @var Stat[]
      */
-    protected $saveEntities = [];
+    private $saveEntities = [];
 
     /**
      * @var Stat[]
      */
-    protected $deleteEntities = [];
+    private $deleteEntities = [];
 
     /**
      * @var array
      */
-    protected $failedContacts = [];
+    private $failedContacts = [];
 
     /**
      * @var array
      */
-    protected $errorMessages = [];
+    private $errorMessages = [];
 
     /**
      * @var array
      */
-    protected $badEmails = [];
+    private $badEmails = [];
 
     /**
      * @var array
      */
-    protected $emailSentCounts = [];
+    private $emailSentCounts = [];
 
     /**
      * @var
      */
-    protected $emailEntityErrors;
+    private $emailEntityErrors;
 
     /**
      * @var null|int
      */
-    protected $emailEntityId;
+    private $emailEntityId;
 
     /**
      * @var null|int
      */
-    protected $listId;
+    private $listId;
 
     /**
      * @var int
      */
-    protected $statBatchCounter = 0;
+    private $statBatchCounter = 0;
 
     /**
      * @var array
      */
-    protected $contact = [];
+    private $contact = [];
 
     /**
-     * Send constructor.
+     * SendEmailToContact constructor.
      *
-     * @param MailHelper $mailer
+     * @param MailHelper          $mailer
+     * @param StatRepository      $statRepository
+     * @param DoNotContact        $dncModel
+     * @param TranslatorInterface $translator
      */
     public function __construct(MailHelper $mailer, StatRepository $statRepository, DoNotContact $dncModel, TranslatorInterface $translator)
     {

--- a/app/bundles/EmailBundle/Model/SendEmailToContacts.php
+++ b/app/bundles/EmailBundle/Model/SendEmailToContacts.php
@@ -1,0 +1,398 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Model;
+
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\EmailBundle\Helper\MailHelper;
+use Mautic\EmailBundle\Swiftmailer\Exception\BatchQueueMaxException;
+use Mautic\LeadBundle\Entity\DoNotContact as DNC;
+use Mautic\LeadBundle\Model\DoNotContact;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class SendEmailToContacts
+{
+    /**
+     * @var MailHelper
+     */
+    protected $mailer;
+
+    /**
+     * @var StatRepository
+     */
+    protected $statRepo;
+
+    /**
+     * @var DoNotContact
+     */
+    protected $dncModel;
+
+    /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    /**
+     * @var null|string
+     */
+    protected $singleEmailMode = null;
+
+    /**
+     * @var Stat[]
+     */
+    protected $statEntities = [];
+
+    /**
+     * @var Stat[]
+     */
+    protected $saveEntities = [];
+
+    /**
+     * @var Stat[]
+     */
+    protected $deleteEntities = [];
+
+    /**
+     * @var array
+     */
+    protected $errors = [];
+
+    /**
+     * @var array
+     */
+    protected $errorMessages = [];
+
+    /**
+     * @var array
+     */
+    protected $badEmails = [];
+
+    /**
+     * @var array
+     */
+    protected $emailSentCounts = [];
+
+    /**
+     * @var
+     */
+    protected $emailEntityErrors;
+
+    /**
+     * @var null|int
+     */
+    protected $emailEntityId;
+
+    /**
+     * @var null|int
+     */
+    protected $listId;
+
+    /**
+     * @var int
+     */
+    protected $statBatchCounter = 0;
+
+    /**
+     * Send constructor.
+     *
+     * @param MailHelper $mailer
+     */
+    public function __construct(MailHelper $mailer, StatRepository $statRepository, DoNotContact $dncModel, TranslatorInterface $translator)
+    {
+        $this->mailer     = $mailer;
+        $this->statRepo   = $statRepository;
+        $this->dncModel   = $dncModel;
+        $this->translator = $translator;
+    }
+
+    /**
+     * @param bool $resetMailer
+     *
+     * @return $this
+     */
+    public function flush($resetMailer = true)
+    {
+        // Flushes the batch in case of using API mailers
+        if ($this->emailEntityId && !$flushResult = $this->mailer->flushQueue()) {
+            $sendFailures = $this->mailer->getErrors();
+
+            // Check to see if failed recipients were stored by the transport
+            if (!empty($sendFailures['failures'])) {
+                $this->processSendFailures($sendFailures);
+            } elseif ($this->singleEmailMode) {
+                $this->errorMessages[$this->singleEmailMode] = implode('; ', $sendFailures);
+            }
+        }
+
+        if ($resetMailer) {
+            $this->mailer->reset(true);
+        }
+
+        return $this;
+    }
+
+    public function finalFlush()
+    {
+        $this->flush();
+
+        // Persist left over stats
+        if (count($this->saveEntities)) {
+            $this->statRepo->saveEntities($this->saveEntities);
+        }
+        if (count($this->deleteEntities)) {
+            $this->statRepo->deleteEntities($this->deleteEntities);
+        }
+
+        $this->processBadEmails();
+
+        $this->reset();
+    }
+
+    /**
+     * Use an Email entity to populate content, from, etc.
+     *
+     * @param Email $email
+     * @param array $channel          ['channelName', 'channelId']
+     * @param array $assetAttachments
+     * @param array $slots            @deprecated to be removed in 3.0; support for old email template format
+     *
+     * @return $this
+     */
+    public function setEmail(Email $email, array $channel = [], array $customHeaders = [], array $assetAttachments = [], array $slots = [])
+    {
+        // Flush anything that's pending from a previous email
+        $this->flush();
+
+        if ($this->mailer->setEmail($email, true, $slots, $assetAttachments)) {
+            $this->mailer->setSource($channel);
+            $this->mailer->setCustomHeaders($customHeaders);
+
+            // Note that the entity is set so that addContact does not generate errors
+            $this->emailEntityId = $email->getId();
+        } else {
+            $this->emailEntityErrors = $this->mailer->getErrors();
+            $this->emailEntityId     = null;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param null|int $id
+     *
+     * @return $this
+     */
+    public function setListId($id)
+    {
+        $this->listId = (null !== $id) ? (int) $id : $id;
+
+        return $this;
+    }
+
+    /**
+     * @param array $contact
+     * @param array $tokens
+     */
+    public function sendToContact(array $contact, array $tokens = [])
+    {
+        if (!$this->emailEntityId) {
+            // There was an error configuring the email so auto fail
+            $this->failContact($contact, $this->emailEntityErrors);
+
+            return false;
+        }
+
+        $this->mailer->setTokens($tokens);
+        $this->mailer->setLead($contact);
+        $this->mailer->setIdHash(); //auto generates
+
+        try {
+            if (!$this->mailer->addTo($contact['email'], $contact['firstname'].' '.$contact['lastname'])) {
+                $this->failContact($contact);
+
+                return false;
+            }
+        } catch (BatchQueueMaxException $e) {
+            // Queue full so flush then try again
+            $this->flush(false);
+
+            if (!$this->mailer->addTo($contact['email'], $contact['firstname'].' '.$contact['lastname'])) {
+                $this->failContact($contact);
+
+                return false;
+            }
+        }
+
+        return $this->send($contact);
+    }
+
+    /**
+     * Reset everything.
+     */
+    public function reset()
+    {
+        $this->saveEntities      = [];
+        $this->deleteEntities    = [];
+        $this->statEntities      = [];
+        $this->badEmails         = [];
+        $this->errorMessages     = [];
+        $this->errors            = [];
+        $this->emailEntityErrors = null;
+        $this->emailEntityId     = null;
+        $this->emailSentCounts   = [];
+        $this->singleEmailMode   = null;
+        $this->listId            = null;
+        $this->statBatchCounter  = 0;
+
+        $this->mailer->reset();
+    }
+
+    /**
+     * @return array
+     */
+    public function getSentCounts()
+    {
+        return $this->emailSentCounts;
+    }
+
+    /**
+     * @return array [array $rawErrors, array $errorMessages]
+     */
+    public function getErrors()
+    {
+        return [$this->errors, $this->errorMessages];
+    }
+
+    /**
+     * @param array $contact
+     *
+     * @return bool
+     */
+    protected function send(array $contact)
+    {
+        //queue or send the message
+        list($queued, $queueErrors) = $this->mailer->queue(true, MailHelper::QUEUE_RETURN_ERRORS);
+        if (!$queued) {
+            unset($queueErrors['failures']);
+            $this->failContact($contact, implode('; ', $queueErrors));
+
+            return false;
+        }
+
+        $this->createContactStatEntry($contact['email']);
+
+        return true;
+    }
+
+    /**
+     * @param array $contact
+     * @param mixed $errorMessages
+     */
+    protected function failContact(array $contact, $errorMessages = null)
+    {
+        if (null === $errorMessages) {
+            // Clear the errors so it doesn't stop the next send
+            $errorMessages = $this->mailer->getErrors();
+        }
+
+        $this->errorMessages[$contact['id']] = $errorMessages;
+        $this->errors[$contact['id']]        = $contact['email'];
+        $this->badEmails[$contact['id']]     = $contact['email'];
+    }
+
+    /**
+     * @param $sendFailures
+     */
+    protected function processSendFailures($sendFailures)
+    {
+        $failedEmailAddresses = $sendFailures['failures'];
+        unset($sendFailures['failures']);
+        $error = implode('; ', $sendFailures);
+
+        // Prevent the stat from saving
+        foreach ($failedEmailAddresses as $failedEmail) {
+            /** @var Stat $stat */
+            $stat = $this->statEntities[$failedEmail];
+            // Add lead ID to list of failures
+            $this->errors[$stat->getLead()->getId()]        = $failedEmail;
+            $this->errorMessages[$stat->getLead()->getId()] = $error;
+
+            // Down sent counts
+            $emailId = $stat->getEmail()->getId();
+            $this->downEmailSentCount($emailId);
+
+            if ($stat->getId()) {
+                $this->deleteEntities[] = $stat;
+            }
+            unset($this->statEntities[$failedEmail], $this->saveEntities[$failedEmail]);
+        }
+    }
+
+    /**
+     * Add DNC entries for bad emails to get them out of the queue permanently.
+     */
+    protected function processBadEmails()
+    {
+        // Update bad emails as bounces
+        if (count($this->badEmails)) {
+            foreach ($this->badEmails as $contactId => $contactEmail) {
+                $this->dncModel->addDncForContact(
+                    $contactId,
+                    ['email' => $this->emailEntityId],
+                    $this->translator->trans('mautic.email.bounce.reason.bad_email'),
+                    DNC::BOUNCED,
+                    true,
+                    false
+                );
+            }
+        }
+    }
+
+    /**
+     * @param $email
+     */
+    protected function createContactStatEntry($email)
+    {
+        ++$this->statBatchCounter;
+
+        $stat = $this->saveEntities[$email] = $this->mailer->createEmailStat(false, null, $this->listId);
+        $this->upEmailSentCount($stat->getEmail()->getId());
+
+        if (20 === $this->statBatchCounter) {
+            // Save in batches of 20 to prevent email loops if the there are issuses with persisting a large number of stats at once
+            $this->statRepo->saveEntities($this->saveEntities);
+            $this->statBatchCounter = 0;
+            $this->saveEntities     = [];
+        }
+    }
+
+    /**
+     * Up sent counter for the given email ID.
+     */
+    protected function upEmailSentCount($emailId)
+    {
+        // Up sent counts
+        if (!isset($this->emailSentCounts[$emailId])) {
+            $this->emailSentCounts[$emailId] = 0;
+        }
+        ++$this->emailSentCounts[$emailId];
+    }
+
+    /**
+     * Down sent counter for the given email ID.
+     */
+    protected function downEmailSentCount($emailId)
+    {
+        --$this->emailSentCounts[$emailId];
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Helper/Transport/BatchTransport.php
+++ b/app/bundles/EmailBundle/Tests/Helper/Transport/BatchTransport.php
@@ -16,15 +16,19 @@ class BatchTransport extends AbstractTokenArrayTransport implements \Swift_Trans
     private $fromAddresses = [];
     private $metadatas     = [];
     private $validate      = false;
+    private $maxRecipients;
+    private $numberToFail;
 
     /**
      * BatchTransport constructor.
      *
      * @param bool $validate
      */
-    public function __construct($validate = false)
+    public function __construct($validate = false, $maxRecipients = 4, $numberToFail = 1)
     {
-        $this->validate = true;
+        $this->validate      = $validate;
+        $this->maxRecipients = $maxRecipients;
+        $this->numberToFail  = (int) $numberToFail;
     }
 
     /**
@@ -39,7 +43,9 @@ class BatchTransport extends AbstractTokenArrayTransport implements \Swift_Trans
 
         $messageArray = $this->messageToArray();
 
-        if ($this->validate) {
+        if ($this->validate && $this->numberToFail) {
+            --$this->numberToFail;
+
             if (empty($messageArray['subject'])) {
                 $this->throwException('Subject empty');
             }
@@ -57,7 +63,7 @@ class BatchTransport extends AbstractTokenArrayTransport implements \Swift_Trans
      */
     public function getMaxBatchLimit()
     {
-        return 4;
+        return $this->maxRecipients;
     }
 
     /**
@@ -69,7 +75,9 @@ class BatchTransport extends AbstractTokenArrayTransport implements \Swift_Trans
      */
     public function getBatchRecipientCount(\Swift_Message $message, $toBeAdded = 1, $type = 'to')
     {
-        return count($message->getTo()) + $toBeAdded;
+        $toCount = count($message->getTo());
+
+        return ('to' === $type) ? $toCount + $toBeAdded : $toCount;
     }
 
     /**

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -24,12 +24,14 @@ use Mautic\EmailBundle\Entity\EmailRepository;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\Helper\MailHelper;
+use Mautic\EmailBundle\Model\SendEmailToContacts;
 use Mautic\EmailBundle\MonitoredEmail\Mailbox;
 use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\FrequencyRuleRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Model\CompanyModel;
+use Mautic\LeadBundle\Model\DoNotContact;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PageBundle\Model\TrackableModel;
 use Mautic\UserBundle\Model\UserModel;
@@ -111,6 +113,15 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
         $emailEntity->method('isVariant')
             ->will($this->returnValue(true));
+
+        $mailHelper->method('createEmailStat')
+            ->will($this->returnCallback(function () use ($emailEntity) {
+                $stat = new Stat();
+                $stat->setEmail($emailEntity);
+
+                return $stat;
+            }
+        ));
 
         $variantA = $this->getMockBuilder(Email::class)
             ->disableOriginalConstructor()
@@ -207,6 +218,12 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
         $companyModel->method('getRepository')
             ->willReturn($companyRepository);
 
+        $dncModel = $this->getMockBuilder(DoNotContact::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $sendToContactModel = new SendEmailToContacts($mailHelper, $statRepository, $dncModel, $translator);
+
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,
             $themeHelper,
@@ -216,7 +233,8 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $companyModel,
             $trackableModel,
             $userModel,
-            $messageModel
+            $messageModel,
+            $sendToContactModel
         );
 
         $emailModel->setTranslator($translator);
@@ -331,6 +349,15 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
         $emailEntity->method('isVariant')
             ->will($this->returnValue(true));
 
+        $mailHelper->method('createEmailStat')
+            ->will($this->returnCallback(function () use ($emailEntity) {
+                $stat = new Stat();
+                $stat->setEmail($emailEntity);
+
+                return $stat;
+            }
+            ));
+
         $variantA = $this->getMockBuilder(Email::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -426,6 +453,12 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
         $companyModel->method('getRepository')
             ->willReturn($companyRepository);
 
+        $dncModel = $this->getMockBuilder(DoNotContact::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $sendToContactModel = new SendEmailToContacts($mailHelper, $statRepository, $dncModel, $translator);
+
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,
             $themeHelper,
@@ -435,7 +468,8 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $companyModel,
             $trackableModel,
             $userModel,
-            $messageModel
+            $messageModel,
+            $sendToContactModel
         );
 
         $emailModel->setTranslator($translator);
@@ -581,6 +615,10 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
         $companyModel->method('getRepository')
             ->willReturn($companyRepository);
 
+        $sendToContactModel = $this->getMockBuilder(SendEmailToContacts::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,
             $themeHelper,
@@ -590,7 +628,8 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $companyModel,
             $trackableModel,
             $userModel,
-            $messageModel
+            $messageModel,
+            $sendToContactModel
         );
 
         $emailModel->setTranslator($translator);
@@ -716,6 +755,10 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
         $companyModel->method('getRepository')
             ->willReturn($companyRepository);
 
+        $sendToContactModel = $this->getMockBuilder(SendEmailToContacts::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,
             $themeHelper,
@@ -725,7 +768,8 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $companyModel,
             $trackableModel,
             $userModel,
-            $messageModel
+            $messageModel,
+            $sendToContactModel
         );
 
         $emailModel->setTranslator($translator);
@@ -829,6 +873,10 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
         $companyModel->expects($this->exactly(0))
             ->method('getRepository');
 
+        $sendToContactModel = $this->getMockBuilder(SendEmailToContacts::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,
             $themeHelper,
@@ -838,7 +886,8 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $companyModel,
             $trackableModel,
             $userModel,
-            $messageModel
+            $messageModel,
+            $sendToContactModel
         );
 
         $emailModel->setTranslator($translator);
@@ -960,6 +1009,10 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
         $messageModel->setUserHelper($userHelper);
         $messageModel->setDispatcher($dispatcher);
 
+        $sendToContactModel = $this->getMockBuilder(SendEmailToContacts::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,
             $themeHelper,
@@ -969,7 +1022,8 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $companyModel,
             $trackableModel,
             $userModel,
-            $messageModel
+            $messageModel,
+            $sendToContactModel
         );
 
         $emailModel->setTranslator($translator);

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -24,7 +24,7 @@ use Mautic\EmailBundle\Entity\EmailRepository;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\Helper\MailHelper;
-use Mautic\EmailBundle\Model\SendEmailToContacts;
+use Mautic\EmailBundle\Model\SendEmailToContact;
 use Mautic\EmailBundle\MonitoredEmail\Mailbox;
 use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\FrequencyRuleRepository;
@@ -222,7 +222,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $sendToContactModel = new SendEmailToContacts($mailHelper, $statRepository, $dncModel, $translator);
+        $sendToContactModel = new SendEmailToContact($mailHelper, $statRepository, $dncModel, $translator);
 
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,
@@ -457,7 +457,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $sendToContactModel = new SendEmailToContacts($mailHelper, $statRepository, $dncModel, $translator);
+        $sendToContactModel = new SendEmailToContact($mailHelper, $statRepository, $dncModel, $translator);
 
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,
@@ -615,7 +615,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
         $companyModel->method('getRepository')
             ->willReturn($companyRepository);
 
-        $sendToContactModel = $this->getMockBuilder(SendEmailToContacts::class)
+        $sendToContactModel = $this->getMockBuilder(SendEmailToContact::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -755,7 +755,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
         $companyModel->method('getRepository')
             ->willReturn($companyRepository);
 
-        $sendToContactModel = $this->getMockBuilder(SendEmailToContacts::class)
+        $sendToContactModel = $this->getMockBuilder(SendEmailToContact::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -873,7 +873,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
         $companyModel->expects($this->exactly(0))
             ->method('getRepository');
 
-        $sendToContactModel = $this->getMockBuilder(SendEmailToContacts::class)
+        $sendToContactModel = $this->getMockBuilder(SendEmailToContact::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1009,7 +1009,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
         $messageModel->setUserHelper($userHelper);
         $messageModel->setDispatcher($dispatcher);
 
-        $sendToContactModel = $this->getMockBuilder(SendEmailToContacts::class)
+        $sendToContactModel = $this->getMockBuilder(SendEmailToContact::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
@@ -1,0 +1,576 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests;
+
+use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\CoreBundle\Translation\Translator;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\EmailBundle\Exception\FailedToSendToContactException;
+use Mautic\EmailBundle\Helper\MailHelper;
+use Mautic\EmailBundle\Model\SendEmailToContact;
+use Mautic\EmailBundle\Swiftmailer\Exception\BatchQueueMaxException;
+use Mautic\EmailBundle\Tests\Helper\Transport\BatchTransport;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\DoNotContact;
+use Psr\Log\NullLogger;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Routing\Router;
+
+class SendEmailToContactTest extends \PHPUnit_Framework_TestCase
+{
+    protected $contacts = [
+        [
+            'id'        => 1,
+            'email'     => 'contact1@somewhere.com',
+            'firstname' => 'Contact',
+            'lastname'  => '1',
+            'owner_id'  => 1,
+        ],
+        [
+            'id'        => 2,
+            'email'     => 'contact2@somewhere.com',
+            'firstname' => 'Contact',
+            'lastname'  => '2',
+            'owner_id'  => 0,
+        ],
+        [
+            'id'        => 3,
+            'email'     => 'contact3@somewhere.com',
+            'firstname' => 'Contact',
+            'lastname'  => '3',
+            'owner_id'  => 2,
+        ],
+        [
+            'id'        => 4,
+            'email'     => 'contact4@somewhere.com',
+            'firstname' => 'Contact',
+            'lastname'  => '4',
+            'owner_id'  => 1,
+        ],
+    ];
+
+    /**
+     * @testdox Tests that all contacts are temporarily failed if an Email entity happens to be incorrectly configured
+     *
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::setEmail()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::setContact()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::send()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::finalFlush()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::failContact()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::getFailedContacts()
+     */
+    public function testContactsAreFailedIfSettingEmailEntityFails()
+    {
+        $mailHelper = $this->getMockBuilder(MailHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mailHelper->method('setEmail')
+            ->willReturn(false);
+
+        $statRepository = $this->getMockBuilder(StatRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dncModel = $this->getMockBuilder(DoNotContact::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // This should not be called because contact emails are just fine; the problem is with the email entity
+        $dncModel->expects($this->never())
+            ->method('addDncForContact');
+
+        $translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $model = new SendEmailToContact($mailHelper, $statRepository, $dncModel, $translator);
+
+        $email = new Email();
+        $model->setEmail($email);
+
+        foreach ($this->contacts as $contact) {
+            try {
+                $model->setContact($contact)
+                    ->send();
+            } catch (FailedToSendToContactException $exception) {
+            }
+        }
+
+        $model->finalFlush();
+
+        $failedContacts = $model->getFailedContacts();
+
+        $this->assertCount(4, $failedContacts);
+    }
+
+    /**
+     * @testdox Tests that bad emails are failed
+     *
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::setContact()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::send()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::finalFlush()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::failContact()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::getFailedContacts()
+     */
+    public function testExceptionIsThrownIfEmailIsSentToBadContact()
+    {
+        $emailMock = $this->getMockBuilder(Email::class)
+            ->getMock();
+        $emailMock
+            ->expects($this->any())
+            ->method('getId')
+            ->will($this->returnValue(1));
+
+        $mailHelper = $this->getMockBuilder(MailHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mailHelper->method('setEmail')
+            ->willReturn(true);
+        $mailHelper->method('addTo')
+            ->willReturnCallback(
+                function ($email) {
+                    return '@bad.com' !== $email;
+                }
+            );
+        $mailHelper->method('queue')
+            ->willReturn([true, []]);
+
+        $stat = new Stat();
+        $stat->setEmail($emailMock);
+        $mailHelper->method('createEmailStat')
+            ->willReturn($stat);
+
+        $statRepository = $this->getMockBuilder(StatRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dncModel = $this->getMockBuilder(DoNotContact::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dncModel->expects($this->once())
+            ->method('addDncForContact');
+
+        $translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $model = new SendEmailToContact($mailHelper, $statRepository, $dncModel, $translator);
+        $model->setEmail($emailMock);
+
+        $contacts             = $this->contacts;
+        $contacts[0]['email'] = '@bad.com';
+
+        $exceptionThrown = false;
+        foreach ($contacts as $contact) {
+            try {
+                $model->setContact($contact)
+                    ->send();
+            } catch (FailedToSendToContactException $exception) {
+                $exceptionThrown = true;
+            }
+        }
+
+        if (!$exceptionThrown) {
+            $this->fail('FailedToSendToContactException not thrown');
+        }
+
+        $model->finalFlush();
+
+        $failedContacts = $model->getFailedContacts();
+
+        $this->assertCount(1, $failedContacts);
+    }
+
+    /**
+     * @testdox Test a tokenized transport that limits batches does not throw BatchQueueMaxException on subsequent contacts when one fails
+     *
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::setContact()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::send()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::failContact()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::getFailedContacts()
+     */
+    public function testBadEmailDoesNotCauseBatchQueueMaxExceptionOnSubsequentContacts()
+    {
+        defined('MAUTIC_ENV') or define('MAUTIC_ENV', 'test');
+
+        $emailMock = $this->getMockBuilder(Email::class)
+            ->getMock();
+        $emailMock
+            ->method('getId')
+            ->will($this->returnValue(1));
+        $emailMock->method('getFromAddress')
+            ->willReturn('test@mautic.com');
+
+        // Use our test token transport limiting to 1 recipient per queue
+        $transport = new BatchTransport(false, 1);
+        $mailer    = new \Swift_Mailer($transport);
+
+        // Mock factory to ensure that queue mode is handled until MailHelper is refactored completely away from MauticFactory
+        $factoryMock = $this->getMockBuilder(MauticFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $factoryMock->method('getParameter')
+            ->willReturnCallback(
+                function ($param) {
+                    switch ($param) {
+                        case 'mailer_spool_type':
+                            return 'memory';
+                        default:
+                            return '';
+                    }
+                }
+            );
+        $factoryMock->method('getLogger')
+            ->willReturn(
+                new NullLogger()
+            );
+        $factoryMock->method('getDispatcher')
+            ->willReturn(
+                new EventDispatcher()
+            );
+        $routerMock = $this->getMockBuilder(Router::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $factoryMock->method('getRouter')
+            ->willReturn($routerMock);
+
+        $mailHelper = $this->getMockBuilder(MailHelper::class)
+            ->setConstructorArgs([$factoryMock, $mailer])
+            ->setMethods(['createEmailStat'])
+            ->getMock();
+
+        $mailHelper->method('createEmailStat')
+            ->willReturnCallback(
+                function () use ($emailMock) {
+                    $stat = new Stat();
+                    $stat->setEmail($emailMock);
+
+                    $leadMock = $this->getMockBuilder(Lead::class)
+                        ->getMock();
+                    $leadMock->method('getId')
+                        ->willReturn(1);
+
+                    $stat->setLead($leadMock);
+
+                    return $stat;
+                }
+            );
+
+        // Enable queueing
+        $mailHelper->enableQueue();
+
+        $statRepository = $this->getMockBuilder(StatRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dncModel = $this->getMockBuilder(DoNotContact::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dncModel->expects($this->exactly(1))
+            ->method('addDncForContact');
+
+        $translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $model = new SendEmailToContact($mailHelper, $statRepository, $dncModel, $translator);
+        $model->setEmail($emailMock);
+
+        $contacts             = $this->contacts;
+        $contacts[0]['email'] = '@bad.com';
+
+        foreach ($contacts as $contact) {
+            try {
+                $model->setContact($contact)
+                    ->send();
+            } catch (FailedToSendToContactException $exception) {
+                // We're good here
+            } catch (BatchQueueMaxException $exception) {
+                $this->fail('BatchQueueMaxException thrown');
+            }
+        }
+
+        $model->finalFlush();
+
+        $failedContacts = $model->getFailedContacts();
+
+        $this->assertCount(1, $failedContacts);
+
+        // Our fake transport should have processed 3 metadatas
+        $this->assertCount(3, $transport->getMetadatas());
+
+        // We made it this far so all of the emails were processed despite a bad email in the batch
+    }
+
+    /**
+     * @testdox Test that stat entries are saved in batches of 20
+     *
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::setContact()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::send()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::failContact()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::createContactStatEntry()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::getFailedContacts()
+     */
+    public function testThatStatEntriesAreCreatedAndPersistedEveryBatch()
+    {
+        defined('MAUTIC_ENV') or define('MAUTIC_ENV', 'test');
+
+        $emailMock = $this->getMockBuilder(Email::class)
+            ->getMock();
+        $emailMock
+            ->method('getId')
+            ->will($this->returnValue(1));
+        $emailMock->method('getFromAddress')
+            ->willReturn('test@mautic.com');
+
+        // Use our test token transport limiting to 1 recipient per queue
+        $transport = new BatchTransport(false, 1);
+        $mailer    = new \Swift_Mailer($transport);
+
+        // Mock factory to ensure that queue mode is handled until MailHelper is refactored completely away from MauticFactory
+        $factoryMock = $this->getMockBuilder(MauticFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $factoryMock->method('getParameter')
+            ->willReturnCallback(
+                function ($param) {
+                    switch ($param) {
+                        case 'mailer_spool_type':
+                            return 'memory';
+                        default:
+                            return '';
+                    }
+                }
+            );
+        $factoryMock->method('getLogger')
+            ->willReturn(
+                new NullLogger()
+            );
+        $factoryMock->method('getDispatcher')
+            ->willReturn(
+                new EventDispatcher()
+            );
+        $routerMock = $this->getMockBuilder(Router::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $factoryMock->method('getRouter')
+            ->willReturn($routerMock);
+
+        $mailHelper = $this->getMockBuilder(MailHelper::class)
+            ->setConstructorArgs([$factoryMock, $mailer])
+            ->setMethods(['createEmailStat'])
+            ->getMock();
+
+        $mailHelper->expects($this->exactly(21))
+            ->method('createEmailStat')
+            ->willReturnCallback(
+                function () use ($emailMock) {
+                    $stat = new Stat();
+                    $stat->setEmail($emailMock);
+
+                    $leadMock = $this->getMockBuilder(Lead::class)
+                        ->getMock();
+                    $leadMock->method('getId')
+                        ->willReturn(1);
+
+                    $stat->setLead($leadMock);
+
+                    return $stat;
+                }
+            );
+
+        // Enable queueing
+        $mailHelper->enableQueue();
+
+        // Here's the test; this should be called after 20 contacts are processed
+        $statRepository = $this->getMockBuilder(StatRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $statRepository->expects($this->exactly(2))
+            ->method('saveEntities');
+
+        $dncModel = $this->getMockBuilder(DoNotContact::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dncModel->expects($this->never())
+            ->method('addDncForContact');
+
+        $translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $model = new SendEmailToContact($mailHelper, $statRepository, $dncModel, $translator);
+        $model->setEmail($emailMock);
+
+        // Let's generate 20 bogus contacts
+        $contacts = [];
+        $counter  = 0;
+        while ($counter <= 20) {
+            $contacts[] = [
+                'id'        => $counter,
+                'email'     => 'email'.uniqid().'@somewhere.com',
+                'firstname' => 'Contact',
+                'lastname'  => uniqid(),
+            ];
+
+            ++$counter;
+        }
+
+        foreach ($contacts as $contact) {
+            try {
+                $model->setContact($contact)
+                    ->send();
+            } catch (FailedToSendToContactException $exception) {
+                $this->fail('FailedToSendToContactException thrown: '.$exception->getMessage());
+            } catch (BatchQueueMaxException $exception) {
+                $this->fail('BatchQueueMaxException thrown: '.$exception->getMessage());
+            }
+        }
+
+        $model->finalFlush();
+
+        $failedContacts = $model->getFailedContacts();
+        $this->assertCount(0, $failedContacts);
+        $this->assertCount(21, $transport->getMetadatas());
+    }
+
+    /**
+     * @testdox Test that a failed email from the transport is handled
+     *
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::setContact()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::send()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::failContact()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::getFailedContacts()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::upEmailSentCount()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::downEmailSentCount()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::getSentCounts()
+     */
+    public function testThatAFailureFromTransportIsHandled()
+    {
+        defined('MAUTIC_ENV') or define('MAUTIC_ENV', 'test');
+
+        $emailMock = $this->getMockBuilder(Email::class)
+            ->getMock();
+        $emailMock
+            ->method('getId')
+            ->will($this->returnValue(1));
+        $emailMock->method('getFromAddress')
+            ->willReturn('test@mautic.com');
+
+        // Use our test token transport limiting to 1 recipient per queue
+        $transport = new BatchTransport(true, 1);
+        $mailer    = new \Swift_Mailer($transport);
+
+        // Mock factory to ensure that queue mode is handled until MailHelper is refactored completely away from MauticFactory
+        $factoryMock = $this->getMockBuilder(MauticFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $factoryMock->method('getParameter')
+            ->willReturnCallback(
+                function ($param) {
+                    switch ($param) {
+                        case 'mailer_spool_type':
+                            return 'memory';
+                        default:
+                            return '';
+                    }
+                }
+            );
+        $factoryMock->method('getLogger')
+            ->willReturn(
+                new NullLogger()
+            );
+        $factoryMock->method('getDispatcher')
+            ->willReturn(
+                new EventDispatcher()
+            );
+        $routerMock = $this->getMockBuilder(Router::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $factoryMock->method('getRouter')
+            ->willReturn($routerMock);
+
+        $mailHelper = $this->getMockBuilder(MailHelper::class)
+            ->setConstructorArgs([$factoryMock, $mailer])
+            ->setMethods(['createEmailStat'])
+            ->getMock();
+
+        $mailHelper->method('createEmailStat')
+            ->willReturnCallback(
+                function () use ($emailMock) {
+                    $stat = new Stat();
+                    $stat->setEmail($emailMock);
+
+                    $leadMock = $this->getMockBuilder(Lead::class)
+                        ->getMock();
+                    $leadMock->method('getId')
+                        ->willReturn(1);
+
+                    $stat->setLead($leadMock);
+
+                    return $stat;
+                }
+            );
+
+        // Enable queueing
+        $mailHelper->enableQueue();
+
+        $statRepository = $this->getMockBuilder(StatRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dncModel = $this->getMockBuilder(DoNotContact::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dncModel->expects($this->never())
+            ->method('addDncForContact');
+
+        $translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $model = new SendEmailToContact($mailHelper, $statRepository, $dncModel, $translator);
+        $model->setEmail($emailMock);
+
+        foreach ($this->contacts as $contact) {
+            try {
+                $model->setContact($contact)
+                    ->send();
+            } catch (FailedToSendToContactException $exception) {
+                // We're good here
+            } catch (BatchQueueMaxException $exception) {
+                $this->fail('BatchQueueMaxException thrown');
+            }
+        }
+
+        $model->finalFlush();
+
+        $failedContacts = $model->getFailedContacts();
+
+        $this->assertCount(1, $failedContacts);
+
+        $counts = $model->getSentCounts();
+
+        // Should have increased to 4, one failed via the transport so back down to 3
+        $this->assertEquals(3, $counts[1]);
+
+        // One error message from the transport
+        $errorMessages = $model->getErrors();
+        $this->assertCount(1, $errorMessages);
+    }
+}

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -675,6 +675,13 @@ return [
                 'tag'       => 'validator.constraint_validator',
                 'alias'     => 'uniqueleadlist',
             ],
+            'mautic.lead.repository.dnc' => [
+                'class'     => Doctrine\ORM\EntityRepository::class,
+                'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
+                'arguments' => [
+                    \Mautic\LeadBundle\Entity\DoNotContact::class,
+                ],
+            ],
         ],
         'helpers' => [
             'mautic.helper.template.avatar' => [
@@ -738,6 +745,13 @@ return [
                     'mautic.core.model.notification',
                     'mautic.helper.core_parameters',
                     'mautic.lead.model.company',
+                ],
+            ],
+            'mautic.lead.model.dnc' => [
+                'class'     => \Mautic\LeadBundle\Model\DoNotContact::class,
+                'arguments' => [
+                    'mautic.lead.model.lead',
+                    'mautic.lead.repository.dnc',
                 ],
             ],
         ],

--- a/app/bundles/LeadBundle/Model/DoNotContact.php
+++ b/app/bundles/LeadBundle/Model/DoNotContact.php
@@ -200,4 +200,12 @@ class DoNotContact
         // Re-add the entry to the lead
         $contact->addDoNotContactEntry($dnc);
     }
+
+    /**
+     * Clear DoNotContact entities from Doctrine UnitOfWork.
+     */
+    public function clearEntities()
+    {
+        $this->dncRepo->clear();
+    }
 }

--- a/app/bundles/LeadBundle/Model/DoNotContact.php
+++ b/app/bundles/LeadBundle/Model/DoNotContact.php
@@ -1,0 +1,203 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Model;
+
+use Mautic\LeadBundle\Entity\DoNotContact as DNC;
+use Mautic\LeadBundle\Entity\DoNotContactRepository;
+use Mautic\LeadBundle\Entity\Lead;
+
+class DoNotContact
+{
+    /**
+     * @var LeadModel
+     */
+    protected $leadModel;
+
+    /**
+     * @var DoNotContactRepository
+     */
+    protected $dncRepo;
+
+    /**
+     * DoNotContact constructor.
+     *
+     * @param LeadModel              $leadModel
+     * @param DoNotContactRepository $dncRepo
+     */
+    public function __construct(LeadModel $leadModel, DoNotContactRepository $dncRepo)
+    {
+        $this->leadModel = $leadModel;
+        $this->dncRepo   = $dncRepo;
+    }
+
+    /**
+     * Remove a Lead's DNC entry based on channel.
+     *
+     * @param int       $contactId
+     * @param string    $channel
+     * @param bool|true $persist
+     *
+     * @return bool
+     */
+    public function removeDncForContact($contactId, $channel, $persist = true)
+    {
+        $contact = $this->leadModel->getEntity($contactId);
+
+        /** @var DNC $dnc */
+        foreach ($contact->getDoNotContact() as $dnc) {
+            if ($dnc->getChannel() === $channel) {
+                $contact->removeDoNotContactEntry($dnc);
+
+                if ($persist) {
+                    $this->leadModel->saveEntity($contact);
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Create a DNC entry for a lead.
+     *
+     * @param int          $contactId
+     * @param string|array $channel            If an array with an ID, use the structure ['email' => 123]
+     * @param string       $comments
+     * @param int          $reason             Must be a class constant from the DoNotContact class
+     * @param bool         $persist
+     * @param bool         $checkCurrentStatus
+     *
+     * @return bool|DNC If a DNC entry is added or updated, returns the DoNotContact object. If a DNC is already present
+     *                  and has the specified reason, nothing is done and this returns false
+     */
+    public function addDncForContact($contactId, $channel, $reason = DNC::BOUNCED, $comments = '', $persist = true, $checkCurrentStatus = true)
+    {
+        $dnc     = false;
+        $contact = $this->leadModel->getEntity($contactId);
+
+        // if !$checkCurrentStatus, assume is contactable due to already being valided
+        $isContactable = ($checkCurrentStatus) ? $this->isContactable($contact, $channel) : DNC::IS_CONTACTABLE;
+
+        // If they don't have a DNC entry yet
+        if ($isContactable === DNC::IS_CONTACTABLE) {
+            $dnc = $this->createDncRecord($contact, $channel, $reason, $comments);
+        } elseif ($isContactable !== $reason) {
+            // Or if the given reason is different than the stated reason
+
+            /** @var DNC $dnc */
+            foreach ($contact->getDoNotContact() as $dnc) {
+                // Only update if the contact did not unsubscribe themselves
+                if ($dnc->getChannel() === $channel && $dnc->getReason() !== DNC::UNSUBSCRIBED) {
+                    // Note the outdated entry for listeners
+                    $contact->removeDoNotContactEntry($dnc);
+
+                    // Update the entry with the latest
+                    $this->updateDncRecord($dnc, $contact, $channel, $reason, $comments);
+
+                    break;
+                }
+            }
+        }
+
+        if ($dnc && $persist) {
+            // Use model saveEntity to trigger events for DNC change
+            $this->leadModel->saveEntity($contact);
+        }
+
+        return $dnc;
+    }
+
+    /**
+     * @param Lead   $contact
+     * @param string $channel
+     *
+     * @return int
+     *
+     * @see \Mautic\LeadBundle\Entity\DoNotContact This method can return boolean false, so be
+     *                                             sure to always compare the return value against
+     *                                             the class constants of DoNotContact
+     */
+    public function isContactable(Lead $contact, $channel)
+    {
+        if (is_array($channel)) {
+            $channel = key($channel);
+        }
+
+        /** @var \Mautic\LeadBundle\Entity\DoNotContact[] $entries */
+        $dncEntries = $this->dncRepo->getEntriesByLeadAndChannel($contact, $channel);
+
+        // If the lead has no entries in the DNC table, we're good to go
+        if (empty($dncEntries)) {
+            return DNC::IS_CONTACTABLE;
+        }
+
+        foreach ($dncEntries as $dnc) {
+            if ($dnc->getReason() !== DNC::IS_CONTACTABLE) {
+                return $dnc->getReason();
+            }
+        }
+
+        return DNC::IS_CONTACTABLE;
+    }
+
+    /**
+     * @param      $channel
+     * @param      $reason
+     * @param Lead $contact
+     * @param null $comments
+     *
+     * @return DNC
+     */
+    public function createDncRecord(Lead $contact, $channel, $reason, $comments = null)
+    {
+        $dnc = new DNC();
+
+        if (is_array($channel)) {
+            $channelId = reset($channel);
+            $channel   = key($channel);
+
+            $dnc->setChannelId((int) $channelId);
+        }
+
+        $dnc->setChannel($channel);
+        $dnc->setReason($reason);
+        $dnc->setLead($contact);
+        $dnc->setDateAdded(new \DateTime());
+        $dnc->setComments($comments);
+
+        $contact->addDoNotContactEntry($dnc);
+
+        return $dnc;
+    }
+
+    /**
+     * @param DNC  $dnc
+     * @param Lead $contact
+     * @param      $channel
+     * @param      $reason
+     * @param null $comments
+     */
+    public function updateDncRecord(DNC $dnc, Lead $contact, $channel, $reason, $comments = null)
+    {
+        // Update the DNC entry
+        $dnc->setChannel($channel);
+        $dnc->setReason($reason);
+        $dnc->setLead($contact);
+        $dnc->setDateAdded(new \DateTime());
+        $dnc->setComments($comments);
+
+        // Re-add the entry to the lead
+        $contact->addDoNotContactEntry($dnc);
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? | y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This fixes two bugs with tokenized mailers that have a batch limit of 1. Mautic itself does not include such a transport and thus a custom transport is used within the unit tests. 

MauticMailer is a mess and needs to be completely refactored but can't get to that yet. 

SendEmailToContact is more or less a small step in cleaning up EmailModel. It needs more work to optimize code but limited time at the moment.

[//]: # ( As applicable: )
#### Steps to reproduce the two bugs:

Bug One:

1. Create a bad email in Mautic somehow (known places have been patched to prevent this so may have to hack in one directly into the database)
2. Add that email along with a bunch of other contacts to a broadcast/segment email and send the email
3. A BatchQueueMaxException will be thrown even though it's supposed to catch and continue processing.

Bug two:

1. Create a form with an email field
2. Add a send email to contact submit action
3. Add a send form results submit action
4. Submit the form and a BatchQueueMaxException will be thrown

#### Steps to test this PR:
1. Run the included tests

#### List deprecations along with the new alternative:
1. Starting to deprecate LeadModel's DNC methods to the DoNotContact model. 
