### PR TITLE
Fix connectwise API to map contact company.

### DIFF
--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -993,7 +993,7 @@ abstract class AbstractIntegration
         // Check for custom content-type header
         if (!empty($settings['content_type'])) {
             $settings['encoding_headers_set'] = true;
-            $headers[]                        = "Content-type: {$settings['content_type']}";
+            $headers[]                        = "Content-Type: {$settings['content_type']}";
         }
 
         if ($method !== 'GET') {
@@ -1061,6 +1061,7 @@ abstract class AbstractIntegration
                 case 'POST':
                 case 'PUT':
                 case 'PATCH':
+                    var_dump($parameters);
                     $connectorMethod = strtolower($method);
                     $result          = $connector->$connectorMethod($url, $parameters, $headers, $timeout);
                     break;

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -1061,7 +1061,6 @@ abstract class AbstractIntegration
                 case 'POST':
                 case 'PUT':
                 case 'PATCH':
-                    var_dump($parameters);
                     $connectorMethod = strtolower($method);
                     $result          = $connector->$connectorMethod($url, $parameters, $headers, $timeout);
                     break;

--- a/plugins/MauticCrmBundle/Api/ConnectwiseApi.php
+++ b/plugins/MauticCrmBundle/Api/ConnectwiseApi.php
@@ -83,9 +83,14 @@ class ConnectwiseApi extends CrmApi
             'page'     => $page,
             'pageSize' => ConnectwiseIntegration::PAGESIZE,
         ];
+        $conditions = isset($params['conditions']) ? $params['conditions'] : [];
 
         if (isset($params['start'])) {
-            $query['conditions'] = 'lastUpdated > ['.$params['start'].']';
+            $conditions[] = 'lastUpdated > ['.$params['start'].']';
+        }
+
+        if ($conditions) {
+            $query['conditions'] = implode(' AND ', $conditions)];
         }
 
         return $this->request('company/companies', $query);

--- a/plugins/MauticCrmBundle/Api/ConnectwiseApi.php
+++ b/plugins/MauticCrmBundle/Api/ConnectwiseApi.php
@@ -90,7 +90,7 @@ class ConnectwiseApi extends CrmApi
         }
 
         if ($conditions) {
-            $query['conditions'] = implode(' AND ', $conditions)];
+            $query['conditions'] = implode(' AND ', $conditions);
         }
 
         return $this->request('company/companies', $query);

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -803,7 +803,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
                 }
             }
 
-            if ($integrationKey === 'company' && isset($fields['company']) && !empty($fields['company']['value'])) {
+            if ($integrationKey === 'company' && !empty($fields['company']['value'])) {
                 try {
                     $foundCompanies = $this->getApiHelper()->getCompanies([
                         'conditions' => [

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -132,14 +132,6 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @return \MauticPlugin\MauticCrmBundle\Api\ConnectwiseApi
-     */
-    public function getApiHelper()
-    {
-        return parent::getApiHelper();
-    }
-
-    /**
      * {@inheritdoc}
      *
      * @return string

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -821,12 +821,13 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
                             sprintf('Name = "%s"', $fields['company']['value']),
                         ],
                     ]);
+
+                    $matched['company'] = ['identifier' => $foundCompanies[0]['identifier']];
                 } catch (ApiErrorException $e) {
                     // No matching companies were found
-                    continue;
                 }
 
-                $matched['company'] = ['identifier' => $foundCompanies[0]['identifier']];
+                continue;
             }
 
             if (isset($leadFields[$integrationKey])) {

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -741,9 +741,6 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
             ]
         );
 
-        // @todo map company reference
-        unset($mappedData['company']);
-
         return $mappedData;
     }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Mautic was not successfully associating a Contact with their company in Connectwise when updating Connectwise via campaign actions. This PR addresses that. When pushing leads, it will now try to find a matching company (based on Name in Connectwise) and if one is found, use that to associate it. 

This PR also addresses an issue with the Connectwise integration where the UserDefinedFieldX fields were not present on Contacts to allow mapping in the integration settings.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
0. Set up the connectwise integration
1. Create a contact and assign it to a company (one that exists in your Connectwise instance)
2. Create a segment that contains just that contact
3. Create a segment campaign using the created segment to push the campaign members to your Connectwise integration. 
4. Trigger the campaign, and see that the contact is not associated to the company in Connectwise.

#### Steps to test this PR:
1. Apply PR and retest
2. Contact will be subscribed

3. When mapping fields for the Connectwise integration, ensure that `UserDefinedFieldX`, where X is 1-10, is available for mapping.