### PR TITLE
Fix: Reports bounced columns

### DIFF
--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -287,7 +287,7 @@ class ReportSubscriber extends CommonSubscriber
         // channel_url_trackables subquery
         $qbcut        = $this->db->createQueryBuilder();
         $clickColumns = ['hits', 'unique_hits', 'hits_ratio', 'unique_ratio', 'is_hit'];
-        $dncColumns   = ['unsubscribed', 'unsubscribed_ratio'];
+        $dncColumns   = ['unsubscribed', 'unsubscribed_ratio', 'bounced', 'bounced_ratio'];
 
         switch ($context) {
             case 'emails':


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5332
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This bugfix/feature has been sponsored by @Webmecanik

Just forgotten  dnc columns

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Create new report
2. Select email as the source
3. Select "bounce ratio" as the column to display
4. Save and close
5. Error 500

#### Steps to test this PR:
1. Repeat steps and see if works
