### PR TITLE
Fix: Error on remote asset download from form

### DIFF
--- a/app/bundles/AssetBundle/Controller/PublicController.php
+++ b/app/bundles/AssetBundle/Controller/PublicController.php
@@ -83,7 +83,7 @@ class PublicController extends CommonFormController
             if (!empty($clickthrough)) {
                 $clickthrough = $model->decodeArrayFromUrl($clickthrough);
             }
-            if ($entity->isRemote() && (empty($clickthrough) || $clickthrough[0] != 'form')) {
+            if ($entity->isRemote() && (empty($clickthrough[0]) || $clickthrough[0] != 'form')) {
                 $model->trackDownload($entity, $this->request, 200);
 
                 // Redirect to remote URL

--- a/app/bundles/FormBundle/Controller/ResultController.php
+++ b/app/bundles/FormBundle/Controller/ResultController.php
@@ -230,6 +230,7 @@ class ResultController extends CommonFormController
         if (!$fs->exists($file)) {
             throw $this->createNotFoundException();
         }
+
         $response = new BinaryFileResponse($file);
         $response::trustXSendfileTypeHeader();
         $response->setContentDisposition(

--- a/app/bundles/FormBundle/Controller/ResultController.php
+++ b/app/bundles/FormBundle/Controller/ResultController.php
@@ -230,7 +230,6 @@ class ResultController extends CommonFormController
         if (!$fs->exists($file)) {
             throw $this->createNotFoundException();
         }
-
         $response = new BinaryFileResponse($file);
         $response::trustXSendfileTypeHeader();
         $response->setContentDisposition(


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4116
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This bugfix/feature has been sponsored by @Webmecanik

Fixed for https://github.com/mautic/mautic/issues/4116
It's CORS issue iframe try work with different domains name.
This fix just chek if source = form a then download force throught header stream.
Condition start here https://github.com/mautic/mautic/pull/5335/files#diff-f959066916c9e89e761580926d74e8e9L76

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Be sure your general configuration is in HTTPS
2. Create a remote asset in HTTPS
3. Create a form
4. Add download asset action with this asset
5. Submit form and notice that it does not work

If application in HTTPS + Configuration HTTP ---> It works 👍
If application in HTTP + Configuration HTTP ---> It works 👍
If application in HTTPS + Configuration HTTPs ---> It does not work 👎 ⚔️

#### Steps to test this PR:
1. Repeat all steps
2. Download should via php header 
3. Also tests embed form  and inline form 
