### PR TITLE
Adding better error messages synccontacts command

### DIFF
--- a/app/bundles/PluginBundle/Command/FetchLeadsCommand.php
+++ b/app/bundles/PluginBundle/Command/FetchLeadsCommand.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\PluginBundle\Command;
 
+use Mautic\PluginBundle\Integration\AbstractIntegration;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -88,121 +89,88 @@ class FetchLeadsCommand extends ContainerAwareCommand
         $fetchAll      = $input->getOption('fetch-all');
         $leadsExecuted = $contactsExecuted = null;
 
+        // @TODO Since integration is mandatory it should really be turned into an agument, but that would not be B.C.
+        if (!$integration) {
+            throw new \RuntimeException('An integration must be specified');
+        }
+
+        $integrationHelper = $container->get('mautic.helper.integration');
+
+        $integrationObject = $integrationHelper->getIntegrationObject($integration);
+        if (!$integrationObject instanceof AbstractIntegration) {
+            $availableIntegrations = array_filter($integrationHelper->getIntegrationObjects(), function (AbstractIntegration $availableIntegration) {
+                return $availableIntegration->isConfigured();
+            });
+            throw new \RuntimeException(sprintf('The Integration "%s" is not one of the available integrations (%s)', $integration, implode(', ', array_keys($availableIntegrations))));
+        }
+
         if (!$interval) {
             $interval = '15 minutes';
         }
         $startDate = !$startDate ? date('c', strtotime('-'.$interval)) : date('c', strtotime($startDate));
         $endDate   = !$endDate ? date('c') : date('c', strtotime($endDate));
 
-        if ($integration && $startDate && $endDate) {
-            /** @var \Mautic\PluginBundle\Helper\IntegrationHelper $integrationHelper */
-            $integrationHelper = $container->get('mautic.helper.integration');
+        if (!$startDate || !$endDate) {
+            $output->writeln(sprintf('<info>Invalid date rage given %s -> %s</info>', $startDate, $endDate));
 
-            $integrationObject = $integrationHelper->getIntegrationObject($integration);
+            return 255;
+        }
 
-            if (!$integrationObject->isAuthorized()) {
-                $output->writeln(sprintf('<error>ERROR:</error> <info>'.$translator->trans('mautic.plugin.command.notauthorized').'</info>', $integration));
+        /** @var \Mautic\PluginBundle\Helper\IntegrationHelper $integrationHelper */
+        $integrationHelper = $container->get('mautic.helper.integration');
 
-                return null;
-            }
+        $integrationObject = $integrationHelper->getIntegrationObject($integration);
 
-            // Tell audit log to use integration name
-            define('MAUTIC_AUDITLOG_USER', $integration);
+        if (!$integrationObject->isAuthorized()) {
+            $output->writeln(sprintf('<error>ERROR:</error> <info>'.$translator->trans('mautic.plugin.command.notauthorized').'</info>', $integration));
 
-            $config            = $integrationObject->mergeConfigToFeatureSettings();
-            $supportedFeatures = $integrationObject->getIntegrationSettings()->getSupportedFeatures();
+            return 255;
+        }
 
-            defined('MAUTIC_CONSOLE_VERBOSITY') or define('MAUTIC_CONSOLE_VERBOSITY', $output->getVerbosity());
+        // Tell audit log to use integration name
+        define('MAUTIC_AUDITLOG_USER', $integration);
 
-            if (!isset($config['objects'])) {
-                $config['objects'] = [];
-            }
+        $config            = $integrationObject->mergeConfigToFeatureSettings();
+        $supportedFeatures = $integrationObject->getIntegrationSettings()->getSupportedFeatures();
 
-            $params['start']    = $startDate;
-            $params['end']      = $endDate;
-            $params['limit']    = $limit;
-            $params['fetchAll'] = $fetchAll;
-            $params['output']   = $output;
+        defined('MAUTIC_CONSOLE_VERBOSITY') or define('MAUTIC_CONSOLE_VERBOSITY', $output->getVerbosity());
+
+        if (!isset($config['objects'])) {
+            $config['objects'] = [];
+        }
+
+        $params['start']    = $startDate;
+        $params['end']      = $endDate;
+        $params['limit']    = $limit;
+        $params['fetchAll'] = $fetchAll;
+        $params['output']   = $output;
 
             $integrationObject->setCommandParameters($params);
 
             // set this constant to ensure that all contacts have the same date modified time and date synced time to prevent a pull/push loop
             define('MAUTIC_DATE_MODIFIED_OVERRIDE', time());
 
-            if (isset($supportedFeatures) && in_array('get_leads', $supportedFeatures)) {
-                if ($integrationObject !== null && method_exists($integrationObject, 'getLeads') && isset($config['objects'])) {
-                    $output->writeln('<info>'.$translator->trans('mautic.plugin.command.fetch.leads', ['%integration%' => $integration]).'</info>');
-                    $output->writeln('<comment>'.$translator->trans('mautic.plugin.command.fetch.leads.starting').'</comment>');
+        if (isset($supportedFeatures) && in_array('get_leads', $supportedFeatures)) {
+            if ($integrationObject !== null && method_exists($integrationObject, 'getLeads') && isset($config['objects'])) {
+                $output->writeln('<info>'.$translator->trans('mautic.plugin.command.fetch.leads', ['%integration%' => $integration]).'</info>');
+                $output->writeln('<comment>'.$translator->trans('mautic.plugin.command.fetch.leads.starting').'</comment>');
 
-                    //Handle case when integration object are named "Contacts" and "Leads"
-                    $leadObjectName = 'Lead';
-                    if (in_array('Leads', $config['objects'])) {
-                        $leadObjectName = 'Leads';
-                    }
-                    $contactObjectName = 'Contact';
-                    if (in_array(strtolower('Contacts'), array_map(function ($i) {
-                        return strtolower($i);
-                    }, $config['objects']), true)) {
-                        $contactObjectName = 'Contacts';
-                    }
-
-                    $updated = $created = $processed = 0;
-                    if (in_array($leadObjectName, $config['objects'])) {
-                        $leadList = [];
-                        $results  = $integrationObject->getLeads($params, null, $leadsExecuted, $leadList, $leadObjectName);
-                        if (is_array($results)) {
-                            list($justUpdated, $justCreated) = $results;
-                            $updated += (int) $justUpdated;
-                            $created += (int) $justCreated;
-                        } else {
-                            $processed += (int) $results;
-                        }
-                    }
-                    if (in_array(strtolower($contactObjectName), array_map(function ($i) {
-                        return strtolower($i);
-                    }, $config['objects']), true)) {
-                        $output->writeln('');
-                        $output->writeln('<comment>'.$translator->trans('mautic.plugin.command.fetch.contacts.starting').'</comment>');
-                        $contactList = [];
-                        $results     = $integrationObject->getLeads($params, null, $contactsExecuted, $contactList, $contactObjectName);
-                        if (is_array($results)) {
-                            list($justUpdated, $justCreated) = $results;
-                            $updated += (int) $justUpdated;
-                            $created += (int) $justCreated;
-                        } else {
-                            $processed += (int) $results;
-                        }
-                    }
-
-                    $output->writeln('');
-
-                    if ($processed) {
-                        $output->writeln(
-                            '<comment>'.$translator->trans('mautic.plugin.command.fetch.leads.events_executed', ['%events%' => $processed])
-                            .'</comment>'."\n"
-                        );
-                    } else {
-                        $output->writeln(
-                            '<comment>'.$translator->trans(
-                                'mautic.plugin.command.fetch.leads.events_executed_breakout',
-                                ['%updated%' => $updated, '%created%' => $created]
-                            )
-                            .'</comment>'."\n"
-                        );
-                    }
+                //Handle case when integration object are named "Contacts" and "Leads"
+                $leadObjectName = 'Lead';
+                if (in_array('Leads', $config['objects'])) {
+                    $leadObjectName = 'Leads';
+                }
+                $contactObjectName = 'Contact';
+                if (in_array(strtolower('Contacts'), array_map(function ($i) {
+                    return strtolower($i);
+                }, $config['objects']), true)) {
+                    $contactObjectName = 'Contacts';
                 }
 
-                if ($integrationObject !== null && method_exists($integrationObject, 'getCompanies') && isset($config['objects'])
-                    && in_array(
-                        'company',
-                        $config['objects']
-                    )
-                ) {
-                    $updated = $created = $processed = 0;
-                    $output->writeln('<info>'.$translator->trans('mautic.plugin.command.fetch.companies', ['%integration%' => $integration]).'</info>');
-                    $output->writeln('<comment>'.$translator->trans('mautic.plugin.command.fetch.companies.starting').'</comment>');
-
-                    $results = $integrationObject->getCompanies($params);
+                $updated = $created = $processed = 0;
+                if (in_array($leadObjectName, $config['objects'])) {
+                    $leadList = [];
+                    $results  = $integrationObject->getLeads($params, null, $leadsExecuted, $leadList, $leadObjectName);
                     if (is_array($results)) {
                         list($justUpdated, $justCreated) = $results;
                         $updated += (int) $justUpdated;
@@ -210,79 +178,131 @@ class FetchLeadsCommand extends ContainerAwareCommand
                     } else {
                         $processed += (int) $results;
                     }
+                }
+                if (in_array(strtolower($contactObjectName), array_map(function ($i) {
+                    return strtolower($i);
+                }, $config['objects']), true)) {
                     $output->writeln('');
-                    if ($processed) {
-                        $output->writeln(
-                            '<comment>'.$translator->trans('mautic.plugin.command.fetch.companies.events_executed', ['%events%' => $processed])
-                            .'</comment>'."\n"
-                        );
+                    $output->writeln('<comment>'.$translator->trans('mautic.plugin.command.fetch.contacts.starting').'</comment>');
+                    $contactList = [];
+                    $results     = $integrationObject->getLeads($params, null, $contactsExecuted, $contactList, $contactObjectName);
+                    if (is_array($results)) {
+                        list($justUpdated, $justCreated) = $results;
+                        $updated += (int) $justUpdated;
+                        $created += (int) $justCreated;
                     } else {
-                        $output->writeln(
-                            '<comment>'.$translator->trans(
-                                'mautic.plugin.command.fetch.companies.events_executed_breakout',
-                                ['%updated%' => $updated, '%created%' => $created]
-                            )
-                            .'</comment>'."\n"
-                        );
+                        $processed += (int) $results;
                     }
                 }
-            }
 
-            if (isset($supportedFeatures) && in_array('push_leads', $supportedFeatures) && method_exists($integrationObject, 'pushLeads')) {
-                $output->writeln('<info>'.$translator->trans('mautic.plugin.command.pushing.leads', ['%integration%' => $integration]).'</info>');
-                $result  = $integrationObject->pushLeads($params);
-                $ignored = 0;
+                $output->writeln('');
 
-                if (4 === count($result)) {
-                    list($updated, $created, $errored, $ignored) = $result;
-                } elseif (3 === count($result)) {
-                    list($updated, $created, $errored) = $result;
+                if ($processed) {
+                    $output->writeln(
+                        '<comment>'.$translator->trans('mautic.plugin.command.fetch.leads.events_executed', ['%events%' => $processed])
+                        .'</comment>'."\n"
+                    );
                 } else {
-                    $errored                 = '?';
-                    list($updated, $created) = $result;
+                    $output->writeln(
+                        '<comment>'.$translator->trans(
+                            'mautic.plugin.command.fetch.leads.events_executed_breakout',
+                            ['%updated%' => $updated, '%created%' => $created]
+                        )
+                        .'</comment>'."\n"
+                    );
                 }
-                $output->writeln(
-                    '<comment>'.$translator->trans(
-                        'mautic.plugin.command.fetch.pushing.leads.events_executed',
-                        [
-                            '%updated%' => $updated,
-                            '%created%' => $created,
-                            '%errored%' => $errored,
-                            '%ignored%' => $ignored,
-                        ]
-                    )
-                    .'</comment>'."\n"
-                );
             }
 
-            if (method_exists($integrationObject, 'pushCompanies')) {
-                $output->writeln('<info>'.$translator->trans('mautic.plugin.command.pushing.companies', ['%integration%' => $integration]).'</info>');
-                $result  = $integrationObject->pushCompanies($params);
-                $ignored = 0;
+            if ($integrationObject !== null && method_exists($integrationObject, 'getCompanies') && isset($config['objects'])
+                && in_array(
+                    'company',
+                    $config['objects']
+                )
+            ) {
+                $updated = $created = $processed = 0;
+                $output->writeln('<info>'.$translator->trans('mautic.plugin.command.fetch.companies', ['%integration%' => $integration]).'</info>');
+                $output->writeln('<comment>'.$translator->trans('mautic.plugin.command.fetch.companies.starting').'</comment>');
 
-                if (4 === count($result)) {
-                    list($updated, $created, $errored, $ignored) = $result;
-                } elseif (3 === count($result)) {
-                    list($updated, $created, $errored) = $result;
+                $results = $integrationObject->getCompanies($params);
+                if (is_array($results)) {
+                    list($justUpdated, $justCreated) = $results;
+                    $updated += (int) $justUpdated;
+                    $created += (int) $justCreated;
                 } else {
-                    $errored                 = '?';
-                    list($updated, $created) = $result;
+                    $processed += (int) $results;
                 }
-                $output->writeln(
-                    '<comment>'.$translator->trans(
-                        'mautic.plugin.command.fetch.pushing.companies.events_executed',
-                        [
-                            '%updated%' => $updated,
-                            '%created%' => $created,
-                            '%errored%' => $errored,
-                            '%ignored%' => $ignored,
-                        ]
-                    )
-                    .'</comment>'."\n"
-                );
+                $output->writeln('');
+                if ($processed) {
+                    $output->writeln(
+                        '<comment>'.$translator->trans('mautic.plugin.command.fetch.companies.events_executed', ['%events%' => $processed])
+                        .'</comment>'."\n"
+                    );
+                } else {
+                    $output->writeln(
+                        '<comment>'.$translator->trans(
+                            'mautic.plugin.command.fetch.companies.events_executed_breakout',
+                            ['%updated%' => $updated, '%created%' => $created]
+                        )
+                        .'</comment>'."\n"
+                    );
+                }
             }
-
-            return true;
         }
+
+        if (isset($supportedFeatures) && in_array('push_leads', $supportedFeatures) && method_exists($integrationObject, 'pushLeads')) {
+            $output->writeln('<info>'.$translator->trans('mautic.plugin.command.pushing.leads', ['%integration%' => $integration]).'</info>');
+            $result  = $integrationObject->pushLeads($params);
+            $ignored = 0;
+
+            if (4 === count($result)) {
+                list($updated, $created, $errored, $ignored) = $result;
+            } elseif (3 === count($result)) {
+                list($updated, $created, $errored) = $result;
+            } else {
+                $errored                 = '?';
+                list($updated, $created) = $result;
+            }
+            $output->writeln(
+                '<comment>'.$translator->trans(
+                    'mautic.plugin.command.fetch.pushing.leads.events_executed',
+                    [
+                        '%updated%' => $updated,
+                        '%created%' => $created,
+                        '%errored%' => $errored,
+                        '%ignored%' => $ignored,
+                    ]
+                )
+                .'</comment>'."\n"
+            );
+        }
+
+        if (method_exists($integrationObject, 'pushCompanies')) {
+            $output->writeln('<info>'.$translator->trans('mautic.plugin.command.pushing.companies', ['%integration%' => $integration]).'</info>');
+            $result  = $integrationObject->pushCompanies($params);
+            $ignored = 0;
+
+            if (4 === count($result)) {
+                list($updated, $created, $errored, $ignored) = $result;
+            } elseif (3 === count($result)) {
+                list($updated, $created, $errored) = $result;
+            } else {
+                $errored                 = '?';
+                list($updated, $created) = $result;
+            }
+            $output->writeln(
+                '<comment>'.$translator->trans(
+                    'mautic.plugin.command.fetch.pushing.companies.events_executed',
+                    [
+                        '%updated%' => $updated,
+                        '%created%' => $created,
+                        '%errored%' => $errored,
+                        '%ignored%' => $ignored,
+                    ]
+                )
+                .'</comment>'."\n"
+            );
+        }
+
+        return 0;
     }
 }

--- a/app/bundles/PluginBundle/Command/FetchLeadsCommand.php
+++ b/app/bundles/PluginBundle/Command/FetchLeadsCommand.php
@@ -145,10 +145,10 @@ class FetchLeadsCommand extends ContainerAwareCommand
         $params['fetchAll'] = $fetchAll;
         $params['output']   = $output;
 
-            $integrationObject->setCommandParameters($params);
+        $integrationObject->setCommandParameters($params);
 
-            // set this constant to ensure that all contacts have the same date modified time and date synced time to prevent a pull/push loop
-            define('MAUTIC_DATE_MODIFIED_OVERRIDE', time());
+        // set this constant to ensure that all contacts have the same date modified time and date synced time to prevent a pull/push loop
+        define('MAUTIC_DATE_MODIFIED_OVERRIDE', time());
 
         if (isset($supportedFeatures) && in_array('get_leads', $supportedFeatures)) {
             if ($integrationObject !== null && method_exists($integrationObject, 'getLeads') && isset($config['objects'])) {

--- a/app/bundles/PluginBundle/Command/FetchLeadsCommand.php
+++ b/app/bundles/PluginBundle/Command/FetchLeadsCommand.php
@@ -59,7 +59,7 @@ class FetchLeadsCommand extends ContainerAwareCommand
                 '--time-interval',
                 '-a',
                 InputOption::VALUE_OPTIONAL,
-                'Send time interval to check updates on Salesforce, it should be a correct php formatted time interval in the past eg:(-10 minutes)'
+                'Send time interval to check updates on Salesforce, it should be a correct php formatted time interval in the past eg:(10 minutes)'
             )
             ->addOption(
                 '--limit',


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Adding better error messages when the command does not complete. Giving a list of available integrations which can be specified.

Removing some warnings from the file.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. run `./app/console mautic:integration:synccontacts`, notice no output
2. run `./app/console mautic:integration:synccontacts -i SugarCrm -a '2 hours'`, notice error for authorization

#### Steps to test this PR:

Run above commands and notice nice errors and warnings and examples.
