### PR TITLE
Don't return unpublished dynamic content when displaying on site.

### DIFF
--- a/app/bundles/DynamicContentBundle/Helper/DynamicContentHelper.php
+++ b/app/bundles/DynamicContentBundle/Helper/DynamicContentHelper.php
@@ -95,7 +95,7 @@ class DynamicContentHelper
         if ($lead instanceof Lead) {
             $leadArray = $this->convertLeadToArray($lead);
         }
-        $dwcs = $this->getDwcsBySlotName($slotName);
+        $dwcs = $this->getDwcsBySlotName($slotName, true);
         /** @var DynamicContent $dwc */
         foreach ($dwcs as $dwc) {
             if ($dwc->getIsCampaignBased()) {
@@ -203,22 +203,33 @@ class DynamicContentHelper
 
     /**
      * @param string $slotName
+     * @param bool   $publishedOnly
      *
      * @return array|\Doctrine\ORM\Tools\Pagination\Paginator
      */
-    public function getDwcsBySlotName($slotName)
+    public function getDwcsBySlotName($slotName, $publishedOnly = false)
     {
+        $filter = [
+            'where' => [
+                [
+                    'col'  => 'e.slotName',
+                    'expr' => 'eq',
+                    'val'  => $slotName,
+                ],
+            ],
+        ];
+
+        if ($publishedOnly) {
+            $filter['where'][] = [
+                'col'  => 'e.isPublished',
+                'expr' => 'eq',
+                'val'  => 1,
+            ];
+        }
+
         return $this->dynamicContentModel->getEntities(
             [
-                'filter' => [
-                    'where' => [
-                        [
-                            'col'  => 'e.slotName',
-                            'expr' => 'eq',
-                            'val'  => $slotName,
-                        ],
-                    ],
-                ],
+                'filter'           => $filter,
                 'ignore_paginator' => true,
             ]
         );

--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -160,6 +160,7 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface
             ->leftJoin('dc', MAUTIC_TABLE_PREFIX.'dynamic_content_lead_data', 'dcld', 'dcld.dynamic_content_id = dc.id')
             ->andWhere($qb->expr()->eq('dcld.slot', ':slot'))
             ->andWhere($qb->expr()->eq('dcld.lead_id', ':lead_id'))
+            ->andWhere($qb->expr()->eq('dc.is_published', 1))
             ->setParameter('slot', $slot)
             ->setParameter('lead_id', $id)
             ->orderBy('dcld.date_added', 'DESC')

--- a/app/bundles/DynamicContentBundle/Tests/Helper/DynamicContentHelperTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Helper/DynamicContentHelperTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\DynamicContentBundle\Tests\Helper;
+
+use Mautic\CampaignBundle\Model\EventModel;
+use Mautic\DynamicContentBundle\Helper\DynamicContentHelper;
+use Mautic\DynamicContentBundle\Model\DynamicContentModel;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class DynamicContentHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetDwcBySlotNameWithPublished()
+    {
+        $mockModel = $this->getMockBuilder(DynamicContentModel::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getEntities'])
+            ->getMock();
+
+        $mockModel->expects($this->at(0))
+            ->method('getEntities')
+            ->with([
+                'filter' => [
+                    'where' => [
+                        [
+                            'col'  => 'e.slotName',
+                            'expr' => 'eq',
+                            'val'  => 'test',
+                        ],
+                        [
+                            'col'  => 'e.isPublished',
+                            'expr' => 'eq',
+                            'val'  => 1,
+                        ],
+                    ],
+                ],
+                'ignore_paginator' => true,
+            ])
+            ->willReturn(true);
+
+        $mockModel->expects($this->at(1))
+            ->method('getEntities')
+            ->with([
+                'filter' => [
+                    'where' => [
+                        [
+                            'col'  => 'e.slotName',
+                            'expr' => 'eq',
+                            'val'  => 'secondtest',
+                        ],
+                    ],
+                ],
+                'ignore_paginator' => true,
+            ])
+            ->willReturn(false);
+
+        $mockEventModel = $this->createMock(EventModel::class);
+        $mockDispatcher = $this->createMock(EventDispatcher::class);
+
+        $fixture = new DynamicContentHelper($mockModel, $mockEventModel, $mockDispatcher);
+
+        // Only get published
+        $this->assertTrue($fixture->getDwcsBySlotName('test', true));
+
+        // Get all
+        $this->assertFalse($fixture->getDwcsBySlotName('secondtest'));
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When requesting dynamic content, it is possible to return unpublished entities. This fixes that and adds a test to ensure that we filter out unpublished entities when returning them.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a standalone dynamic content item (not campaign based) and embed it in a page where you have mtc.js tracking via `<div class="mautic-slot" data-slot-name="SLOTNAME">default</div>`. Replace SLOTNAME with the one you created.
2. Navigate to that page, and see that your dynamic content is returned.
3. Unpublish the dynamic content item in Mautic.
4. Refresh the page, the dynamic content item is still returned.

#### Steps to test this PR:
1. Redo testing, but at step 4, it won't displayed.
2. Ensure unit tests pass.