### PR TITLE
Fix `FormBundle\EventListener\FormSubscriber` logic when lead is null.

### DIFF
--- a/app/bundles/FormBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormSubscriber.php
@@ -180,7 +180,7 @@ class FormSubscriber extends CommonSubscriber
 
         $config    = $event->getActionConfig();
         $lead      = $event->getSubmission()->getLead();
-        $leadEmail = $lead->getEmail();
+        $leadEmail = $lead !== null ? $lead->getEmail() : null;
         $emails    = $this->getEmailsFromString($config['to']);
 
         if (!empty($emails)) {
@@ -213,9 +213,10 @@ class FormSubscriber extends CommonSubscriber
             $this->mailer->send(true);
         }
 
-        if (!empty($config['email_to_owner']) && $config['email_to_owner'] && $lead->getOwner()) {
+        $owner = $lead !== null ? $lead->getOwner() : null;
+        if (!empty($config['email_to_owner']) && $config['email_to_owner'] && null !== $owner) {
             // Send copy to owner
-            $this->setMailer($config, $tokens, $lead->getOwner()->getEmail());
+            $this->setMailer($config, $tokens, $owner->getEmail());
 
             $this->mailer->setLead($lead->getProfileFields());
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

#### Description:

If the form doesn't retrieve a contact field, the `$event->getSubmission()->getLead()` will return null.
Then all the others calls which depends on that lead will fail with that kind of error :

```
[2017-11-14 10:55:17] mautic.ERROR: Symfony\Component\Debug\Exception\FatalThrowableError: Call to a member function getEmail() on null - in file /home/mautic/app/bundles/FormBundle/EventListener/FormSubscriber.php - at line 176 [] []
```

This is now fixed.

#### Steps to reproduce the bug:
1. Create a form with no fields attached to a lead (just store responses).
2. Try to answer the form, there is a 500 during Ajax submission process.
