### PR TITLE
Fix: Custom field doesn't update Mautic custom field after create/update on Pipedrive

### DIFF
--- a/plugins/MauticCrmBundle/Integration/Pipedrive/Import/LeadImport.php
+++ b/plugins/MauticCrmBundle/Integration/Pipedrive/Import/LeadImport.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManager;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyLead;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\HttpFoundation\Response;
 
 class LeadImport extends AbstractImport
@@ -39,8 +40,7 @@ class LeadImport extends AbstractImport
         $lead->setDateAdded(new \DateTime());
         $lead->setPreferredProfileImage('gravatar');
 
-        $this->em->persist($lead);
-        $this->em->flush();
+        $this->em->getRepository(Lead::class)->saveEntity($lead);
 
         $integrationEntity = $this->createIntegrationLeadEntity(new \DateTime(), $data['id'], $lead->getId());
 
@@ -63,6 +63,7 @@ class LeadImport extends AbstractImport
             return $this->create($data);
         }
 
+        /** @var $lead LeadModel */
         $lead         = $this->em->getRepository(Lead::class)->findOneById($integrationEntity->getInternalEntityId());
         $data         = $this->convertPipedriveData($data);
         $dataToUpdate = $this->getIntegration()->populateMauticLeadData($data);
@@ -81,7 +82,7 @@ class LeadImport extends AbstractImport
 
         $integrationEntity->setLastSyncDate(new \DateTime());
 
-        $this->em->persist($lead);
+        $this->em->getRepository(Lead::class)->saveEntity($lead);
         $this->em->persist($integrationEntity);
 
         if (!$this->getIntegration()->isCompanySupportEnabled()) {

--- a/plugins/MauticCrmBundle/Integration/Pipedrive/Import/LeadImport.php
+++ b/plugins/MauticCrmBundle/Integration/Pipedrive/Import/LeadImport.php
@@ -39,7 +39,6 @@ class LeadImport extends AbstractImport
 
         $lead->setDateAdded(new \DateTime());
         $lead->setPreferredProfileImage('gravatar');
-
         $this->em->getRepository(Lead::class)->saveEntity($lead);
 
         $integrationEntity = $this->createIntegrationLeadEntity(new \DateTime(), $data['id'], $lead->getId());

--- a/plugins/MauticCrmBundle/Integration/Pipedrive/Import/LeadImport.php
+++ b/plugins/MauticCrmBundle/Integration/Pipedrive/Import/LeadImport.php
@@ -61,7 +61,7 @@ class LeadImport extends AbstractImport
             return $this->create($data);
         }
 
-        /** @var $lead Lead **/
+        /** @var Lead $lead **/
         $lead         = $this->em->getRepository(Lead::class)->findOneById($integrationEntity->getInternalEntityId());
         $data         = $this->convertPipedriveData($data);
         $dataToUpdate = $this->getIntegration()->populateMauticLeadData($data);

--- a/plugins/MauticCrmBundle/Integration/Pipedrive/Import/LeadImport.php
+++ b/plugins/MauticCrmBundle/Integration/Pipedrive/Import/LeadImport.php
@@ -6,7 +6,6 @@ use Doctrine\ORM\EntityManager;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyLead;
 use Mautic\LeadBundle\Entity\Lead;
-use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\HttpFoundation\Response;
 
 class LeadImport extends AbstractImport
@@ -62,7 +61,7 @@ class LeadImport extends AbstractImport
             return $this->create($data);
         }
 
-        /** @var $lead LeadModel */
+        /** @var $lead \Mautic\LeadBundle\Entity\Lead **/
         $lead         = $this->em->getRepository(Lead::class)->findOneById($integrationEntity->getInternalEntityId());
         $data         = $this->convertPipedriveData($data);
         $dataToUpdate = $this->getIntegration()->populateMauticLeadData($data);

--- a/plugins/MauticCrmBundle/Integration/Pipedrive/Import/LeadImport.php
+++ b/plugins/MauticCrmBundle/Integration/Pipedrive/Import/LeadImport.php
@@ -61,7 +61,7 @@ class LeadImport extends AbstractImport
             return $this->create($data);
         }
 
-        /** @var $lead \Mautic\LeadBundle\Entity\Lead **/
+        /** @var $lead Lead **/
         $lead         = $this->em->getRepository(Lead::class)->findOneById($integrationEntity->getInternalEntityId());
         $data         = $this->convertPipedriveData($data);
         $dataToUpdate = $this->getIntegration()->populateMauticLeadData($data);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5195
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This bugfix/feature has been sponsored by @Webmecanik

Contacts csustom field wasn't sync after edit in Pipedrive, 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Create a custom field in Mautic and Pipedirve
2. Set the Pipedrive <> mautic integration
3. Create or update a contact in Pipedrive (using created custom fields)
4. Custom field in Mautic do not sync

#### Steps to test this PR:
1. Repeat and see update custom field in Mautic

![image](https://user-images.githubusercontent.com/462477/32985922-3531072a-ccc6-11e7-9c9b-c4e0825a9df9.png)