### PR TITLE
Enhance Dynamic Content

### DIFF
--- a/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
@@ -288,6 +288,11 @@ MauticJS.firstDeliveryMade      = false;
 MauticJS.onFirstEventDelivery = function(f) {
     MauticJS.postEventDeliveryQueue.push(f);
 };
+MauticJS.preEventDeliveryQueue = [];
+MauticJS.beforeFirstDeliveryMade = false;
+MauticJS.beforeFirstEventDelivery = function(f) {
+    MauticJS.preEventDeliveryQueue.push(f);
+};
 document.addEventListener('mauticPageEventDelivered', function(e) {
     var detail   = e.detail;
     var isImage = detail.image;

--- a/app/bundles/DynamicContentBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/BuildJsSubscriber.php
@@ -79,7 +79,9 @@ class BuildJsSubscriber extends CommonSubscriber
                      'submittingMessage': "{$this->translator->trans('mautic.form.submission.pleasewait')}"
         };
             }
-MauticJS.replaceDynamicContent = function () {
+MauticJS.replaceDynamicContent = function (params) {
+    params = params || {};
+
     var dynamicContentSlots = document.querySelectorAll('.mautic-slot, [data-slot="dwc"]');
     if (dynamicContentSlots.length) {
         MauticJS.iterateCollection(dynamicContentSlots)(function(node, i) {
@@ -92,11 +94,18 @@ MauticJS.replaceDynamicContent = function () {
                 return;
             }
             var url = '{$dwcUrl}'.replace('slotNamePlaceholder', slotName);
-            MauticJS.makeCORSRequest('GET', url, {}, function(response, xhr) {
-                if (response.length) {
-                    node.innerHTML = response;
+
+            MauticJS.makeCORSRequest('GET', url, params, function(response, xhr) {
+                if (response.content) {
+                    var dwcContent = response.content;
+                    node.innerHTML = dwcContent;
+
+                    if (response.id && response.sid) {
+                        MauticJS.setTrackedContact(response);
+                    }
+
                     // form load library
-                    if (response.search("mauticform_wrapper") > 0) {
+                    if (dwcContent.search("mauticform_wrapper") > 0) {
                         // if doesn't exist
                         if (typeof MauticSDK == 'undefined') {
                             MauticJS.insertScript('{$this->assetsHelper->getUrl('media/js/mautic-form.js', null, null, true)}');
@@ -116,13 +125,13 @@ MauticJS.replaceDynamicContent = function () {
                     var m;
                     var regEx = /<script[^>]+src="?([^"\s]+)"?\s/g;                    
                     
-                    while (m = regEx.exec(response)) {
+                    while (m = regEx.exec(dwcContent)) {
                         if ((m[1]).search("/focus/") > 0) {
                             MauticJS.insertScript(m[1]);
                         }
                     }
 
-                    if (response.search("fr-gatedvideo") > 0) {
+                    if (dwcContent.search("fr-gatedvideo") > 0) {
                         MauticJS.initGatedVideo();
                     }
                 }
@@ -131,7 +140,7 @@ MauticJS.replaceDynamicContent = function () {
     }
 };
 
-MauticJS.onFirstEventDelivery(MauticJS.replaceDynamicContent);
+MauticJS.beforeFirstEventDelivery(MauticJS.replaceDynamicContent);
 JS;
         $event->appendJs($js, 'Mautic Dynamic Content');
     }

--- a/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
@@ -121,11 +121,23 @@ class BuildJsSubscriber extends CommonSubscriber
             
             return;
         }
-        
+
         if (m.fingerprintComponents) {
             params = m.addFingerprint(params);
         }
-        
+
+        // Pre delivery events always take all known params and should use them in the request
+        if (m.preEventDeliveryQueue.length && m.beforeFirstDeliveryMade === false) {
+            for(var i = 0; i < m.preEventDeliveryQueue.length; i++) {
+                m.preEventDeliveryQueue[i](params);
+            }
+
+            // In case the first delivery set sid, append it
+            params = m.appendTrackedContact(params);
+
+            m.beforeFirstDeliveryMade = true;
+        }
+
         MauticJS.makeCORSRequest('POST', m.pageTrackingCORSUrl, params, 
         function(response) {
             MauticJS.dispatchEvent('mauticPageEventDelivered', {'event': event, 'params': params, 'response': response});

--- a/app/middlewares/CORSMiddleware.php
+++ b/app/middlewares/CORSMiddleware.php
@@ -29,6 +29,7 @@ class CORSMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterf
         'Access-Control-Allow-Headers'     => 'Origin, X-Requested-With, Content-Type',
         'Access-Control-Allow-Methods'     => 'PUT, GET, POST, DELETE, OPTIONS',
         'Access-Control-Allow-Credentials' => 'true',
+        'Access-Control-Max-Age'           => 10 * 60 * 60, // 10 min, max age for Chrome
     ];
 
     /**


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| Enhancement | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Dynamic Web Content was slow to load due to always initializing after the page hit event being fired, which could take upwards of 1.5s. This PR moves the request for DWC to just before the page hit event being fired, but includes all the same parameters as the page hit event as well as the request for DWC. In this way, we can properly identify the contact and render the DWC on the page without having to wait for the page hit event to finish. In my testing, this resulted in a 76% increase in DWC rendering time (down to ~600ms from ~2500 ms)

Additionally, we now set the `Access-Control-Max-Age` header on response to `OPTIONS` requests made using `MauticJS.makeCORSRequest()`. This will save ~ 200ms during the page load on external pages that make CORS requests to Mautic, as the browser will now cache the `OPTIONS` response for 10 min (a hard limit set by Chrome). Previously, it was caching the response for 5s.

Additionally, a bug is fixed where Campaign events were being triggered and logged for non-campaign based DWC. Previously we were checking that a campaign "Request Dynamic Content" decision applied to the requested DWC slot name, and just bypassing it if it did not match. (If you were requesting a slot named `blog` and your campaign served a slot named `something-else`, the `something-else` decision would be logged in the `campaign_lead_event_log` for the active contact.) This PR fixes that by setting the event status to false and returning false in the check, to prevent going further down the campaign path.

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Before applying PR, set up a non-campaign based dynamic content and embed it on an external page where you mtc.js is present.
2. Load the page with your browser dev tools open, and note the response times and visual render time for the dynamic content on your page.
3. Apply PR, clear cache, then navigate to any page in your admin (to warm the Symfony cache).
4. Revisit the page on which you embedded the dynamic content. Have your developer tools open and refresh the page again and not the response times and visual render time. It should be noticeably faster.