### PR TITLE
Fix user permission class for BuilderTokenHelper

### DIFF
--- a/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
+++ b/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
@@ -28,6 +28,8 @@ class BuilderTokenHelper
 
     /**
      * @var MauticFactory
+     *
+     * @deprecated 2.12 To be removed in 3.0 Inject dependencies in your constructor instead
      */
     private $factory;
 

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -119,7 +119,7 @@ class BuilderSubscriber extends CommonSubscriber
             $event->addTokensFromHelper($tokenHelper, $this->pageTokenRegex, 'title', 'id', false, true);
 
             // add only filter based dwc tokens
-            $dwcTokenHelper = new BuilderTokenHelper($this->factory, 'dynamicContent');
+            $dwcTokenHelper = new BuilderTokenHelper($this->factory, 'dynamicContent', 'dynamiccontent:dynamiccontents');
             $expr           = $this->factory->getDatabase()->getExpressionBuilder()->andX('e.is_campaign_based <> 1 and e.slot_name is not null');
             $tokens         = $dwcTokenHelper->getTokens(
                 $this->dwcTokenRegex,


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #5225 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Users with restricted permissions, including permission to edit own & create landing pages, were not able to do so because of a bug with the permissions key naming. This PR addresses it.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new user role with permissions mirroring the screenshot below.
2. Assign a new user to that role, then login as that user.
3. Try to create a landing page. You get an error alert if in dev mode, or simply no response (page doesn't change) if in production.

#### Steps to test this PR:
1. Apply PR and retest
2. You can now create a landing page.

![screen shot 2017-11-22 at 8 12 23 am](https://user-images.githubusercontent.com/718028/33129137-e9001c62-cf5c-11e7-9b6c-e47572505926.png)
