### PR TITLE
Fixed issue where integration DNC was mapped as DoNotContact entity

### DIFF
--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -2723,15 +2723,15 @@ abstract class AbstractIntegration
      */
     public function getLeadDoNotContact($leadId, $channel = 'email')
     {
-        $isContactable = 1;
+        $isDoNotContact = 0;
         if ($lead = $this->leadModel->getEntity($leadId)) {
             $isContactableReason = $this->leadModel->isContactable($lead, $channel);
             if (DoNotContact::IS_CONTACTABLE !== $isContactableReason) {
-                $isContactable = 0;
+                $isDoNotContact = 1;
             }
         }
 
-        return $isContactable;
+        return $isDoNotContact;
     }
 
     /**

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -19,6 +19,7 @@ use Mautic\CoreBundle\Helper\CacheStorageHelper;
 use Mautic\CoreBundle\Helper\EncryptionHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Model\NotificationModel;
+use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\FieldModel;
@@ -1864,7 +1865,7 @@ abstract class AbstractIntegration
                     continue;
                 }
                 if ('mauticContactIsContactableByEmail' === $leadFields[$integrationKey]) {
-                    $matched[$integrationKey] = $lead->getDoNotContact();
+                    $matched[$integrationKey] = $this->getLeadDoNotContact($leadId);
 
                     continue;
                 }
@@ -2720,13 +2721,12 @@ abstract class AbstractIntegration
      *
      * @return int
      */
-    public function getLeadDonotContact($leadId, $channel = 'email',  $sfObject = 'Lead', $sfIds = [])
+    public function getLeadDoNotContact($leadId, $channel = 'email')
     {
         $isContactable = 1;
-        $lead          = $this->leadModel->getEntity($leadId);
-        if ($lead) {
+        if ($lead = $this->leadModel->getEntity($leadId)) {
             $isContactableReason = $this->leadModel->isContactable($lead, $channel);
-            if ($isContactableReason === 0) {
+            if (DoNotContact::IS_CONTACTABLE !== $isContactableReason) {
                 $isContactable = 0;
             }
         }
@@ -2741,11 +2741,11 @@ abstract class AbstractIntegration
      *
      * @return mixed
      */
-    public function getCompoundMauticFields($lead, $sfObject = 'Lead')
+    public function getCompoundMauticFields($lead)
     {
         if ($lead['internal_entity_id']) {
             $lead['mauticContactTimelineLink']         = $this->getContactTimelineLink($lead['internal_entity_id']);
-            $lead['mauticContactIsContactableByEmail'] = $this->getLeadDonotContact($lead['internal_entity_id']);
+            $lead['mauticContactIsContactableByEmail'] = $this->getLeadDoNotContact($lead['internal_entity_id']);
         }
 
         return $lead;

--- a/app/bundles/PluginBundle/Tests/ConfigFormTest.php
+++ b/app/bundles/PluginBundle/Tests/ConfigFormTest.php
@@ -9,7 +9,7 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-namespace Mautic\PluginBundle\Test;
+namespace Mautic\PluginBundle\Tests;
 
 use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\Helper\BundleHelper;

--- a/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
+++ b/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
@@ -54,7 +54,7 @@ class AbstractIntegrationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             [
-                'dnc' => 1,
+                'dnc' => 0,
             ],
             $matched
         );

--- a/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
+++ b/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\PluginBundle\Tests\Integration;
+
+use Mautic\CoreBundle\Translation\Translator;
+use Mautic\LeadBundle\Model\LeadModel;
+use Mautic\PluginBundle\Integration\AbstractIntegration;
+
+class AbstractIntegrationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testPopulatedLeadDataReturnsIntAndNotDncEntityForMauticContactIsContactableByEmail()
+    {
+        $integration = $this->getMockBuilder(AbstractIntegration::class)
+            ->disableOriginalConstructor()
+            ->setMethodsExcept(['convertLeadFieldKey', 'getLeadDoNotContact', 'populateLeadData', 'setTranslator', 'setLeadModel'])
+            ->getMock();
+
+        $translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $integration->setTranslator($translator);
+
+        $leadModel = $this->getMockBuilder(LeadModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $integration->setLeadModel($leadModel);
+
+        $config = [
+            'leadFields' => [
+                'dnc' => 'mauticContactIsContactableByEmail',
+            ],
+        ];
+
+        $integration->method('getAvailableLeadFields')
+            ->willReturn(
+                [
+                    'dnc' => [
+                        'type'     => 'bool',
+                        'required' => false,
+                        'label'    => 'DNC',
+                    ],
+                ]
+            );
+        $matched = $integration->populateLeadData(['id' => 1], $config);
+
+        $this->assertEquals(
+            [
+                'dnc' => 1,
+            ],
+            $matched
+        );
+    }
+}

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -659,12 +659,12 @@ class SalesforceIntegration extends CrmAbstractIntegration
             $keys   = array_keys($fields);
         }
 
-        foreach ($keys as $key) {
-            foreach ($objects as $obj) {
-                if (!isset($leadFields[$obj])) {
-                    $leadFields[$obj] = [];
-                }
+        foreach ($objects as $obj) {
+            if (!isset($leadFields[$obj])) {
+                $leadFields[$obj] = [];
+            }
 
+            foreach ($keys as $key) {
                 if (strpos($key, '__'.$obj)) {
                     $newKey                    = str_replace('__'.$obj, '', $key);
                     $leadFields[$obj][$newKey] = $fields[$key];
@@ -2708,6 +2708,10 @@ class SalesforceIntegration extends CrmAbstractIntegration
         }
 
         foreach ($sfRecords as $leadEmail => $record) {
+            if (empty($record['integration_entity_id'])) {
+                continue;
+            }
+
             $leadIds[$record['internal_entity_id']]    = $record['integration_entity_id'];
             $leadEmails[$record['internal_entity_id']] = $record['email'];
         }

--- a/plugins/MauticCrmBundle/Tests/Api/Zoho/MapperTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/Zoho/MapperTest.php
@@ -11,8 +11,6 @@
 
 namespace MauticPlugin\MauticCrmBundle\Tests\Api\Zoho;
 
-use MauticPlugin\MauticCrmBundle\Api\Zoho\Mapper;
-
 class MapperTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -95,8 +93,8 @@ class MapperTest extends \PHPUnit_Framework_TestCase
     /**
      * @testdox Test that xml is generated according to the mapping
      *
-     * @covers  \Mapper::map()
-     * @covers  \Mapper::getXml()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Mapper::map()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Mapper::getXml()
      */
     public function testXmlIsGeneratedBasedOnMapping()
     {
@@ -134,8 +132,8 @@ XML;
     /**
      * @testdox Test that contacts do not inherit previous contact information
      *
-     * @covers  \Mapper::map()
-     * @covers  \Mapper::getXml()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Mapper::map()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Mapper::getXml()
      */
     public function testContactDoesNotInheritPrevioudContactData()
     {

--- a/plugins/MauticCrmBundle/Tests/Api/Zoho/MapperTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/Zoho/MapperTest.php
@@ -11,6 +11,8 @@
 
 namespace MauticPlugin\MauticCrmBundle\Tests\Api\Zoho;
 
+use MauticPlugin\MauticCrmBundle\Api\Zoho\Mapper;
+
 class MapperTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -174,8 +176,8 @@ XML;
     /**
      * @testdox Test that xml is generated according to the mapping
      *
-     * @covers  \Mapper::map()
-     * @covers  \Mapper::getXml()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Mapper::map()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Mapper::getXml()
      */
     public function testXmlIsGeneratedBasedOnMappingWithId()
     {

--- a/plugins/MauticCrmBundle/Tests/Api/Zoho/Xml/WriterTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/Zoho/Xml/WriterTest.php
@@ -18,9 +18,10 @@ class WriterTest extends \PHPUnit_Framework_TestCase
     /**
      * @testdox Test that a single row is generated correctly with numerical index
      *
-     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Writer:row()
-     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Writer:add()
-     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Writer:write()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Writer::row()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Writer::write()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Object::add()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Object::write()
      */
     public function testXmlWithSingleRow()
     {
@@ -46,9 +47,10 @@ XML;
     /**
      * @testdox Test that multiple rows are generated correctly with specified indexes
      *
-     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Writer:row()
-     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Writer:add()
-     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Writer:write()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Writer::row()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Writer::write()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Object::add()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Object::write()
      */
     public function testXmlWithMultipleRows()
     {
@@ -92,9 +94,10 @@ XML;
     /**
      * @testdox Test that empty row is not included
      *
-     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Writer:row()
-     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Writer:add()
-     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Writer:write()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Writer::row()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Writer::write()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Object::add()
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\Zoho\Xml\Object::write()
      */
     public function testXmlWithEmptyRow()
     {

--- a/plugins/MauticCrmBundle/Tests/SalesforceIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/SalesforceIntegrationTest.php
@@ -497,6 +497,7 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
 
         $sf->pushLeadToCampaign($lead, 1, 'Active', ['Lead' => [1]]);
     }
+
     public function testPushCompany()
     {
         $this->sfObjects     = ['Account'];


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The mapped DNC that is pushed to an integration (Salesforce) was using `$lead->getDoNotContact()` which returns a DoNotContact entity. This PR fixes that to use the correct method. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Map a salesforce boolean field to Mautic's Do Not Contact by Email field in salesforce config
2. Enable push to integration for Salesforce
3. Create a campaign that pushes to salesforce
4. Add a contact and execute. It'll error (it manifested itself in a var_export didn't support circular references for me)

#### Steps to test this PR:
1. Repeat and the contact field will push