### PR TITLE
fix time with seconds in forms

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -1204,7 +1204,7 @@ Mautic.activateDateTimeInputs = function(el, type) {
     var format = mQuery(el).data('format');
     if (type == 'datetime') {
         mQuery(el).datetimepicker({
-            format: (format) ? format : 'Y-m-d H:i:s',
+            format: (format) ? format : 'Y-m-d H:i',
             lazyInit: true,
             validateOnBlur: false,
             allowBlank: true,
@@ -1223,7 +1223,7 @@ Mautic.activateDateTimeInputs = function(el, type) {
     } else if (type == 'time') {
         mQuery(el).datetimepicker({
             datepicker: false,
-            format: (format) ? format : 'H:i:s',
+            format: (format) ? format : 'H:i',
             lazyInit: true,
             validateOnBlur: false,
             allowBlank: true,


### PR DESCRIPTION


[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5275
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
In some environnement conditions, it was impossible to submit the form because the seconds were rejected by the form validator. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a campaign
2. Add publishUp date (be sure that seconds are written in the field)
3. Save and close
![](https://user-images.githubusercontent.com/14194414/30204700-ad6ea968-9486-11e7-8206-d6c34e9afa37.png)

#### Steps to test this PR:
1. Apply the PR
2. Redo previous steps

#### No deprecation
@alanhartless in database, seconds are saved with `:00` even if in the interface we don't see the seconds anymore. All previous created campaigns with seconds are stil working.

I've done the reverts you adviced me to do in the js file and take a look at the mautic/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php. 
After consulting the code, it seems to me that no changes were necessary so I decided to let it as it is.
I tried to reproduce the bug with these changes and it works well. We also tested the changes on a mautic version that doesn't have the bug to see if it breaks something and no problems appears.
If you still think that changes are necessary in the EntityFieldsBuildFormTrait.php,  let me know.