### PR TITLE
Fix: startsWith, endsWith, contains in campaign contact field condition

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -74,6 +74,34 @@ class LeadFieldRepository extends CommonRepository
     }
 
     /**
+     * @param \Doctrine\ORM\QueryBuilder|\Doctrine\DBAL\Query\QueryBuilder $q
+     * @param                                                              $filter
+     *
+     * @return array
+     */
+    protected function addCatchAllWhereClause($q, $filter)
+    {
+        return $this->addStandardCatchAllWhereClause(
+            $q,
+            $filter,
+            [
+                'f.label',
+                'f.alias',
+            ]
+        );
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDefaultOrder()
+    {
+        return [
+            ['f.order', 'ASC'],
+        ];
+    }
+
+    /**
      * Get field aliases for lead table columns.
      *
      * @param string $object name of object using the custom fields
@@ -189,7 +217,7 @@ class LeadFieldRepository extends CommonRepository
                             break;
                         case 'contains':
                             $operatorExpr   = 'like';
-                            $value          = '%'.$value.'%';
+                            $value = '%'.$value.'%';
                             break;
                     }
 
@@ -265,33 +293,5 @@ class LeadFieldRepository extends CommonRepository
         $result = $q->execute()->fetch();
 
         return !empty($result['id']);
-    }
-
-    /**
-     * @param \Doctrine\ORM\QueryBuilder|\Doctrine\DBAL\Query\QueryBuilder $q
-     * @param                                                              $filter
-     *
-     * @return array
-     */
-    protected function addCatchAllWhereClause($q, $filter)
-    {
-        return $this->addStandardCatchAllWhereClause(
-            $q,
-            $filter,
-            [
-                'f.label',
-                'f.alias',
-            ]
-        );
-    }
-
-    /**
-     * @return string
-     */
-    protected function getDefaultOrder()
-    {
-        return [
-            ['f.order', 'ASC'],
-        ];
     }
 }

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -74,6 +74,34 @@ class LeadFieldRepository extends CommonRepository
     }
 
     /**
+     * @param \Doctrine\ORM\QueryBuilder|\Doctrine\DBAL\Query\QueryBuilder $q
+     * @param                                                              $filter
+     *
+     * @return array
+     */
+    protected function addCatchAllWhereClause($q, $filter)
+    {
+        return $this->addStandardCatchAllWhereClause(
+            $q,
+            $filter,
+            [
+                'f.label',
+                'f.alias',
+            ]
+        );
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDefaultOrder()
+    {
+        return [
+            ['f.order', 'ASC'],
+        ];
+    }
+
+    /**
      * Get field aliases for lead table columns.
      *
      * @param string $object name of object using the custom fields
@@ -178,7 +206,6 @@ class LeadFieldRepository extends CommonRepository
                         )
                     );
                 } else {
-
                     switch ($operatorExpr) {
                         case 'startsWith':
                             $operatorExpr    = 'like';
@@ -190,7 +217,7 @@ class LeadFieldRepository extends CommonRepository
                             break;
                         case 'contains':
                             $operatorExpr    = 'like';
-                            $value          = '%'.$value.'%';
+                            $value = '%'.$value.'%';
                             break;
                     }
 
@@ -266,33 +293,5 @@ class LeadFieldRepository extends CommonRepository
         $result = $q->execute()->fetch();
 
         return !empty($result['id']);
-    }
-
-    /**
-     * @param \Doctrine\ORM\QueryBuilder|\Doctrine\DBAL\Query\QueryBuilder $q
-     * @param                                                              $filter
-     *
-     * @return array
-     */
-    protected function addCatchAllWhereClause($q, $filter)
-    {
-        return $this->addStandardCatchAllWhereClause(
-            $q,
-            $filter,
-            [
-                'f.label',
-                'f.alias',
-            ]
-        );
-    }
-
-    /**
-     * @return string
-     */
-    protected function getDefaultOrder()
-    {
-        return [
-            ['f.order', 'ASC'],
-        ];
     }
 }

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -213,7 +213,7 @@ class LeadFieldRepository extends CommonRepository
                             break;
                         case 'endsWith':
                             $operatorExpr    = 'like';
-                            $value = '%'.$value;
+                            $value                              = '%'.$value;
                             break;
                         case 'contains':
                             $operatorExpr   = 'like';

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -206,7 +206,6 @@ class LeadFieldRepository extends CommonRepository
                         )
                     );
                 } else {
-
                     switch ($operatorExpr) {
                         case 'startsWith':
                             $operatorExpr    = 'like';
@@ -221,8 +220,6 @@ class LeadFieldRepository extends CommonRepository
                             $value = '%'.$value.'%';
                             break;
                     }
-
-
                     $expr->add(
                         $q->expr()->$operatorExpr('l.'.$field, ':value')
                     );

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -209,15 +209,15 @@ class LeadFieldRepository extends CommonRepository
                     switch ($operatorExpr) {
                         case 'startsWith':
                             $operatorExpr    = 'like';
-                            $value = $value.'%';
+                            $value           = $value.'%';
                             break;
                         case 'endsWith':
-                            $operatorExpr    = 'like';
-                            $value                              = '%'.$value;
+                            $operatorExpr                      = 'like';
+                            $value                             = '%'.$value;
                             break;
                         case 'contains':
                             $operatorExpr   = 'like';
-                            $value = '%'.$value.'%';
+                            $value          = '%'.$value.'%';
                             break;
                     }
 

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -212,8 +212,8 @@ class LeadFieldRepository extends CommonRepository
                             $value           = $value.'%';
                             break;
                         case 'endsWith':
-                            $operatorExpr                      = 'like';
-                            $value                             = '%'.$value;
+                            $operatorExpr   = 'like';
+                            $value          = '%'.$value;
                             break;
                         case 'contains':
                             $operatorExpr   = 'like';

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -216,8 +216,8 @@ class LeadFieldRepository extends CommonRepository
                             $value = '%'.$value;
                             break;
                         case 'contains':
-                            $operatorExpr    = 'like';
-                            $value = '%'.$value.'%';
+                            $operatorExpr   = 'like';
+                            $value          = '%'.$value.'%';
                             break;
                     }
 

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -206,6 +206,7 @@ class LeadFieldRepository extends CommonRepository
                         )
                     );
                 } else {
+
                     switch ($operatorExpr) {
                         case 'startsWith':
                             $operatorExpr    = 'like';

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -74,34 +74,6 @@ class LeadFieldRepository extends CommonRepository
     }
 
     /**
-     * @param \Doctrine\ORM\QueryBuilder|\Doctrine\DBAL\Query\QueryBuilder $q
-     * @param                                                              $filter
-     *
-     * @return array
-     */
-    protected function addCatchAllWhereClause($q, $filter)
-    {
-        return $this->addStandardCatchAllWhereClause(
-            $q,
-            $filter,
-            [
-                'f.label',
-                'f.alias',
-            ]
-        );
-    }
-
-    /**
-     * @return string
-     */
-    protected function getDefaultOrder()
-    {
-        return [
-            ['f.order', 'ASC'],
-        ];
-    }
-
-    /**
      * Get field aliases for lead table columns.
      *
      * @param string $object name of object using the custom fields
@@ -293,5 +265,33 @@ class LeadFieldRepository extends CommonRepository
         $result = $q->execute()->fetch();
 
         return !empty($result['id']);
+    }
+
+    /**
+     * @param \Doctrine\ORM\QueryBuilder|\Doctrine\DBAL\Query\QueryBuilder $q
+     * @param                                                              $filter
+     *
+     * @return array
+     */
+    protected function addCatchAllWhereClause($q, $filter)
+    {
+        return $this->addStandardCatchAllWhereClause(
+            $q,
+            $filter,
+            [
+                'f.label',
+                'f.alias',
+            ]
+        );
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDefaultOrder()
+    {
+        return [
+            ['f.order', 'ASC'],
+        ];
     }
 }

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -74,34 +74,6 @@ class LeadFieldRepository extends CommonRepository
     }
 
     /**
-     * @param \Doctrine\ORM\QueryBuilder|\Doctrine\DBAL\Query\QueryBuilder $q
-     * @param                                                              $filter
-     *
-     * @return array
-     */
-    protected function addCatchAllWhereClause($q, $filter)
-    {
-        return $this->addStandardCatchAllWhereClause(
-            $q,
-            $filter,
-            [
-                'f.label',
-                'f.alias',
-            ]
-        );
-    }
-
-    /**
-     * @return string
-     */
-    protected function getDefaultOrder()
-    {
-        return [
-            ['f.order', 'ASC'],
-        ];
-    }
-
-    /**
      * Get field aliases for lead table columns.
      *
      * @param string $object name of object using the custom fields
@@ -218,7 +190,7 @@ class LeadFieldRepository extends CommonRepository
                             break;
                         case 'contains':
                             $operatorExpr    = 'like';
-                            $value = '%'.$value.'%';
+                            $value          = '%'.$value.'%';
                             break;
                     }
 
@@ -294,5 +266,33 @@ class LeadFieldRepository extends CommonRepository
         $result = $q->execute()->fetch();
 
         return !empty($result['id']);
+    }
+
+    /**
+     * @param \Doctrine\ORM\QueryBuilder|\Doctrine\DBAL\Query\QueryBuilder $q
+     * @param                                                              $filter
+     *
+     * @return array
+     */
+    protected function addCatchAllWhereClause($q, $filter)
+    {
+        return $this->addStandardCatchAllWhereClause(
+            $q,
+            $filter,
+            [
+                'f.label',
+                'f.alias',
+            ]
+        );
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDefaultOrder()
+    {
+        return [
+            ['f.order', 'ASC'],
+        ];
     }
 }

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -206,6 +206,23 @@ class LeadFieldRepository extends CommonRepository
                         )
                     );
                 } else {
+
+                    switch ($operatorExpr) {
+                        case 'startsWith':
+                            $operatorExpr    = 'like';
+                            $value = $value.'%';
+                            break;
+                        case 'endsWith':
+                            $operatorExpr    = 'like';
+                            $value = '%'.$value;
+                            break;
+                        case 'contains':
+                            $operatorExpr    = 'like';
+                            $value = '%'.$value.'%';
+                            break;
+                    }
+
+
                     $expr->add(
                         $q->expr()->$operatorExpr('l.'.$field, ':value')
                     );

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -220,6 +220,7 @@ class LeadFieldRepository extends CommonRepository
                             $value = '%'.$value.'%';
                             break;
                     }
+
                     $expr->add(
                         $q->expr()->$operatorExpr('l.'.$field, ':value')
                     );


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create campaign contact field condition  with startsWith, endsWith, contains 
2. Run app/console mautic:campaign:trigger
3. See error:   Call to undefined method Doctrine\DBAL\Query\Expression\ExpressionBuilder::startsWith() 

#### Steps to test this PR:
1. Repeat and see no error
2.  Look to campaign if condition works properly
