### PR TITLE
grunt-remove is required for build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "grunt-contrib-cssmin": "^0.10.0",
     "grunt-contrib-less": "^0.11.4",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-remove": "^0.1.0",
     "load-grunt-tasks": "^0.6.0",
     "time-grunt": "^1.0.0"
   }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

Currently it's documented that ```grunt compile-less``` is sometimes needed for compiling assets. However, the grunt file depends on _grunt-remove_ which is not included by the npm setup.

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL |  N
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Update NPM's _package.json_ to require _grunt-remove_

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Clone fresh repo
2. run `composer install`, `npm install`, `grunt compile-less`
3. Note error

#### Steps to test this PR:
1. Clone fresh repo
2. run `composer install`, `npm install`, `grunt compile-less`
3. Note successful execution
