### PR TITLE
Refactored mail transport callbacks (fixes Sparkpost issue with immediate feedback)

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -523,6 +523,7 @@ return [
                 'arguments' => [
                     'mautic.lead.model.dnc',
                     'mautic.message.search.contact',
+                    'mautic.email.repository.stat',
                 ],
             ],
         ],

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -322,6 +322,9 @@ return [
                 'arguments'    => [
                     '%mautic.mailer_amazon_region%',
                     'mautic.http.connector',
+                    'monolog.logger.mautic',
+                    'translator',
+                    'mautic.email.model.transport_callback',
                 ],
                 'methodCalls' => [
                     'setUsername' => ['%mautic.mailer_user%'],
@@ -331,19 +334,20 @@ return [
             'mautic.transport.mandrill' => [
                 'class'        => 'Mautic\EmailBundle\Swiftmailer\Transport\MandrillTransport',
                 'serviceAlias' => 'swiftmailer.mailer.transport.%s',
+                'arguments'    => [
+                    'translator',
+                    'mautic.email.model.transport_callback',
+                ],
                 'methodCalls'  => [
                     'setUsername'      => ['%mautic.mailer_user%'],
                     'setPassword'      => ['%mautic.mailer_api_key%'],
-                    'setMauticFactory' => ['mautic.factory'],
                 ],
             ],
             'mautic.transport.mailjet' => [
                 'class'        => 'Mautic\EmailBundle\Swiftmailer\Transport\MailjetTransport',
                 'serviceAlias' => 'swiftmailer.mailer.transport.%s',
                 'arguments'    => [
-                    '',
-                    '',
-                    '',
+                    'mautic.email.model.transport_callback',
                     '%mautic.mailer_mailjet_sandbox%',
                     '%mautic.mailer_mailjet_sandbox_default_mail%',
                 ],
@@ -362,6 +366,11 @@ return [
             ],
             'mautic.transport.elasticemail' => [
                 'class'        => 'Mautic\EmailBundle\Swiftmailer\Transport\ElasticemailTransport',
+                'arguments'    => [
+                    'translator',
+                    'monolog.logger.mautic',
+                    'mautic.email.model.transport_callback',
+                ],
                 'serviceAlias' => 'swiftmailer.mailer.transport.%s',
                 'methodCalls'  => [
                     'setUsername' => ['%mautic.mailer_user%'],
@@ -382,9 +391,7 @@ return [
                 'arguments'    => [
                     '%mautic.mailer_api_key%',
                     'translator',
-                ],
-                'methodCalls' => [
-                    'setMauticFactory' => ['mautic.factory'],
+                    'mautic.email.model.transport_callback',
                 ],
             ],
             'mautic.helper.mailbox' => [
@@ -471,6 +478,14 @@ return [
                     'event_dispatcher',
                 ],
             ],
+            'mautic.email.fetcher' => [
+                'class'     => \Mautic\EmailBundle\MonitoredEmail\Fetcher::class,
+                'arguments' => [
+                    'mautic.helper.mailbox',
+                    'event_dispatcher',
+                    'translator',
+                ],
+            ],
         ],
         'models' => [
             'mautic.email.model.email' => [
@@ -503,12 +518,11 @@ return [
                     'translator',
                 ],
             ],
-            'mautic.email.fetcher' => [
-                'class'     => \Mautic\EmailBundle\MonitoredEmail\Fetcher::class,
+            'mautic.email.model.transport_callback' => [
+                'class'     => \Mautic\EmailBundle\Model\TransportCallback::class,
                 'arguments' => [
-                    'mautic.helper.mailbox',
-                    'event_dispatcher',
-                    'translator',
+                    'mautic.lead.model.dnc',
+                    'mautic.message.search.contact',
                 ],
             ],
         ],

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -413,7 +413,7 @@ class PublicController extends CommonFormController
                     $model->processMailerCallback($response);
                 }
             } elseif ($currentTransport instanceof CallbackTransportInterface) {
-                $currentTransport->processCallbackResponse($this->request);
+                $currentTransport->processCallbackRequest($this->request);
             }
 
             return new Response('success');

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -19,6 +19,7 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\EmailBundle\Model\EmailModel;
+use Mautic\EmailBundle\Swiftmailer\Transport\CallbackTransportInterface;
 use Mautic\EmailBundle\Swiftmailer\Transport\InterfaceCallbackTransport;
 use Mautic\LeadBundle\Controller\FrequencyRuleTrait;
 use Mautic\LeadBundle\Entity\DoNotContact;
@@ -399,14 +400,20 @@ class PublicController extends CommonFormController
         $transportParam   = $this->get('mautic.helper.core_parameters')->getParameter(('mailer_transport'));
         $currentTransport = $this->get('swiftmailer.mailer.transport.'.$transportParam);
 
-        if ($currentTransport instanceof InterfaceCallbackTransport && $currentTransport->getCallbackPath() == $transport) {
-            $response = $currentTransport->handleCallbackResponse($this->request, $this->factory);
+        $isCallbackInterface = $currentTransport instanceof InterfaceCallbackTransport || $currentTransport instanceof CallbackTransportInterface;
+        if ($isCallbackInterface && $currentTransport->getCallbackPath() == $transport) {
+            // @deprecated support to be removed in 3.0
+            if ($currentTransport instanceof InterfaceCallbackTransport) {
+                $response = $currentTransport->handleCallbackResponse($this->request, $this->factory);
 
-            if (is_array($response)) {
-                /** @var \Mautic\EmailBundle\Model\EmailModel $model */
-                $model = $this->getModel('email');
+                if (is_array($response)) {
+                    /** @var \Mautic\EmailBundle\Model\EmailModel $model */
+                    $model = $this->getModel('email');
 
-                $model->processMailerCallback($response);
+                    $model->processMailerCallback($response);
+                }
+            } elseif ($currentTransport instanceof CallbackTransportInterface) {
+                $currentTransport->processCallbackResponse($this->request);
             }
 
             return new Response('success');

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1576,6 +1576,8 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
     /**
      * Processes the callback response from a mailer for bounces and unsubscribes.
      *
+     * @deprecated 2.13.0 to be removed in 3.0; use TransportWebhook::processCallback() instead
+     *
      * @param array $response
      *
      * @return array|void

--- a/app/bundles/EmailBundle/Model/TransportCallback.php
+++ b/app/bundles/EmailBundle/Model/TransportCallback.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Model;
+
+use Mautic\EmailBundle\MonitoredEmail\Search\ContactFinder;
+use Mautic\LeadBundle\Entity\DoNotContact as DNC;
+use Mautic\LeadBundle\Model\DoNotContact;
+
+class TransportCallback
+{
+    /**
+     * @var DoNotContact
+     */
+    private $dncModel;
+
+    /**
+     * @var ContactFinder
+     */
+    private $finder;
+
+    /**
+     * TransportCallback constructor.
+     *
+     * @param DoNotContact  $dncModel
+     * @param ContactFinder $finder
+     */
+    public function __construct(DoNotContact $dncModel, ContactFinder $finder)
+    {
+        $this->dncModel = $dncModel;
+        $this->finder   = $finder;
+    }
+
+    /**
+     * @param string $hashId
+     * @param string $comments
+     * @param int    $dncReason
+     */
+    public function addFailureByHashId($hashId, $comments, $dncReason = DNC::BOUNCED)
+    {
+        $result = $this->finder->findByHash($hashId);
+
+        if ($contacts = $result->getContacts()) {
+            $email   = $result->getStat()->getEmail();
+            $channel = ($email) ? ['email' => $email->getId()] : 'email';
+            foreach ($contacts as $contact) {
+                $this->dncModel->addDncForContact($contact->getId(), $channel, $dncReason, $comments);
+            }
+        }
+    }
+
+    /**
+     * @param string   $address
+     * @param string   $comments
+     * @param int      $dncReason
+     * @param int|null $channelId
+     */
+    public function addFailureByAddress($address, $comments, $dncReason = DNC::BOUNCED, $channelId = null)
+    {
+        $result = $this->finder->findByAddress($address);
+
+        if ($contacts = $result->getContacts()) {
+            foreach ($contacts as $contact) {
+                $channel = ($channelId) ? ['email' => $channelId] : 'email';
+                $this->dncModel->addDncForContact($contact->getId(), $channel, $dncReason, $comments);
+            }
+        }
+    }
+
+    /**
+     * @param          $id
+     * @param          $comments
+     * @param int      $dncReason
+     * @param int|null $channelId
+     */
+    public function addFailureByContactId($id, $comments, $dncReason = DNC::BOUNCED, $channelId = null)
+    {
+        $channel = ($channelId) ? ['email' => $channelId] : 'email';
+        $this->dncModel->addDncForContact($id, $channel, $dncReason, $comments);
+    }
+}

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce.php
@@ -157,6 +157,10 @@ class Bounce implements ProcessorInterface
         $dtHelper    = new DateTimeHelper();
         $openDetails = $stat->getOpenDetails();
 
+        if (!isset($openDetails['bounces'])) {
+            $openDetails['bounces'] = [];
+        }
+
         $openDetails['bounces'][] = [
             'datetime' => $dtHelper->toUtcString(),
             'reason'   => $bouncedEmail->getRuleCategory(),

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/AbstractTokenArrayTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/AbstractTokenArrayTransport.php
@@ -37,6 +37,8 @@ abstract class AbstractTokenArrayTransport implements TokenTransportInterface
 
     /**
      * @var MauticFactory
+     *
+     * @deprecated 2.13.0 to be removed in 3.0; register transport as a service and pass dependencies
      */
     protected $factory;
 
@@ -261,6 +263,8 @@ abstract class AbstractTokenArrayTransport implements TokenTransportInterface
 
     /**
      * @param MauticFactory $factory
+     *
+     * @deprecated 2.13.0 to be removed in 3.0; register transport as a service and pass dependencies
      */
     public function setMauticFactory(MauticFactory $factory)
     {

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/AbstractTokenSmtpTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/AbstractTokenSmtpTransport.php
@@ -24,11 +24,6 @@ abstract class AbstractTokenSmtpTransport extends \Swift_SmtpTransport implement
     protected $message;
 
     /**
-     * @var MauticFactory
-     */
-    protected $factory;
-
-    /**
      * Do whatever is necessary to $this->message in order to deliver a batched payload. i.e. add custom headers, etc.
      */
     abstract protected function prepareMessage();
@@ -68,13 +63,5 @@ abstract class AbstractTokenSmtpTransport extends \Swift_SmtpTransport implement
     public function getAttachments()
     {
         return ($this->message instanceof MauticMessage) ? $this->message->getAttachments() : [];
-    }
-
-    /**
-     * @param MauticFactory $factory
-     */
-    public function setMauticFactory(MauticFactory $factory)
-    {
-        $this->factory = $factory;
     }
 }

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
@@ -13,7 +13,7 @@ namespace Mautic\EmailBundle\Swiftmailer\Transport;
 
 use Joomla\Http\Exception\UnexpectedResponseException;
 use Joomla\Http\Http;
-use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\EmailBundle\Model\TransportCallback;
 use Mautic\EmailBundle\MonitoredEmail\Exception\BounceNotFound;
 use Mautic\EmailBundle\MonitoredEmail\Exception\UnsubscriptionNotFound;
 use Mautic\EmailBundle\MonitoredEmail\Message;
@@ -22,13 +22,15 @@ use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\Definition\Category;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\Definition\Type;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Unsubscription\UnsubscribedEmail;
 use Mautic\LeadBundle\Entity\DoNotContact;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class AmazonTransport.
  */
-class AmazonTransport extends \Swift_SmtpTransport implements InterfaceCallbackTransport, BounceProcessorInterface, UnsubscriptionProcessorInterface
+class AmazonTransport extends \Swift_SmtpTransport implements CallbackTransportInterface, BounceProcessorInterface, UnsubscriptionProcessorInterface
 {
     /**
      * From address for SNS email.
@@ -41,13 +43,38 @@ class AmazonTransport extends \Swift_SmtpTransport implements InterfaceCallbackT
     private $httpClient;
 
     /**
-     * {@inheritdoc}
+     * @var TransportCallback
      */
-    public function __construct($host, Http $httpClient)
+    private $transportCallback;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * AmazonTransport constructor.
+     *
+     * @param string              $host
+     * @param Http                $httpClient
+     * @param LoggerInterface     $logger
+     * @param TranslatorInterface $translator
+     * @param TransportCallback   $transportCallback
+     */
+    public function __construct($host, Http $httpClient, LoggerInterface $logger, TranslatorInterface $translator, TransportCallback $transportCallback)
     {
         parent::__construct($host, 2587, 'tls');
         $this->setAuthMode('login');
-        $this->httpClient = $httpClient;
+
+        $this->logger            = $logger;
+        $this->translator        = $translator;
+        $this->httpClient        = $httpClient;
+        $this->transportCallback = $transportCallback;
     }
 
     /**
@@ -63,20 +90,17 @@ class AmazonTransport extends \Swift_SmtpTransport implements InterfaceCallbackT
     /**
      * Handle bounces & complaints from Amazon.
      *
-     * @param Request       $request
-     * @param MauticFactory $factory
+     * @param Request $request
      *
      * @return array
      */
-    public function handleCallbackResponse(Request $request, MauticFactory $factory)
+    public function processCallbackRequest(Request $request)
     {
-        $translator = $factory->getTranslator();
-        $logger     = $factory->getLogger();
-        $logger->debug('Receiving webhook from Amazon');
+        $this->logger->debug('Receiving webhook from Amazon');
 
         $payload = json_decode($request->getContent(), true);
 
-        return $this->processJsonPayload($payload, $logger, $translator);
+        return $this->processJsonPayload($payload);
     }
 
     /**
@@ -85,49 +109,34 @@ class AmazonTransport extends \Swift_SmtpTransport implements InterfaceCallbackT
      * http://docs.aws.amazon.com/ses/latest/DeveloperGuide/best-practices-bounces-complaints.html
      *
      * @param array $payload from Amazon SES
-     * @param $logger
-     * @param $translator
-     *
-     * @return array with bounced and unsubscribed email addresses
      */
-    public function processJsonPayload(array $payload, $logger, $translator)
+    public function processJsonPayload(array $payload)
     {
-        // Data structure that Mautic expects to be returned from this callback
-        $rows = [
-            DoNotContact::BOUNCED => [
-                'hashIds' => [],
-                'emails'  => [],
-            ],
-            DoNotContact::UNSUBSCRIBED => [
-                'hashIds' => [],
-                'emails'  => [],
-            ],
-        ];
-
         if (!isset($payload['Type'])) {
             throw new HttpException(400, "Key 'Type' not found in payload ");
         }
 
         if ($payload['Type'] == 'SubscriptionConfirmation') {
             // Confirm Amazon SNS subscription by calling back the SubscribeURL from the playload
-            $requestFailed = false;
             try {
                 $response = $this->httpClient->get($payload['SubscribeURL']);
                 if ($response->code == 200) {
-                    $logger->info('Callback to SubscribeURL from Amazon SNS successfully');
-                } else {
-                    $requestFailed = true;
-                    $reason        = 'HTTP Code '.$response->code.', '.$response->body;
+                    $this->logger->info('Callback to SubscribeURL from Amazon SNS successfully');
+
+                    return;
                 }
+
+                $reason = 'HTTP Code '.$response->code.', '.$response->body;
             } catch (UnexpectedResponseException $e) {
-                $requestFailed = true;
-                $reason        = $e->getMessage();
+                $reason = $e->getMessage();
             }
 
-            if ($requestFailed) {
-                $logger->error('Callback to SubscribeURL from Amazon SNS failed, reason: '.$reason);
-            }
-        } elseif ($payload['Type'] == 'Notification') {
+            $this->logger->error('Callback to SubscribeURL from Amazon SNS failed, reason: '.$reason);
+
+            return;
+        }
+
+        if ($payload['Type'] == 'Notification') {
             $message = json_decode($payload['Message'], true);
 
             // only deal with hard bounces
@@ -135,40 +144,42 @@ class AmazonTransport extends \Swift_SmtpTransport implements InterfaceCallbackT
                 // Get bounced recipients in an array
                 $bouncedRecipients = $message['bounce']['bouncedRecipients'];
                 foreach ($bouncedRecipients as $bouncedRecipient) {
-                    $rows[DoNotContact::BOUNCED]['emails'][$bouncedRecipient['emailAddress']] = $bouncedRecipient['diagnosticCode'];
-                    $logger->debug("Mark email '".$bouncedRecipient['emailAddress']."' as bounced, reason: ".$bouncedRecipient['diagnosticCode']);
+                    $this->transportCallback->addFailureByAddress($bouncedRecipient['emailAddress'], $bouncedRecipient['diagnosticCode']);
+                    $this->logger->debug("Mark email '".$bouncedRecipient['emailAddress']."' as bounced, reason: ".$bouncedRecipient['diagnosticCode']);
                 }
+
+                return;
             }
+
             // unsubscribe customer that complain about spam at their mail provider
-            elseif ($message['notificationType'] == 'Complaint') {
+            if ($message['notificationType'] == 'Complaint') {
                 foreach ($message['complaint']['complainedRecipients'] as $complainedRecipient) {
                     $reason = null;
                     if (isset($message['complaint']['complaintFeedbackType'])) {
                         // http://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html#complaint-object
                         switch ($message['complaint']['complaintFeedbackType']) {
                             case 'abuse':
-                                $reason = $translator->trans('mautic.email.complaint.reason.abuse');
+                                $reason = $this->translator->trans('mautic.email.complaint.reason.abuse');
                                 break;
                             case 'fraud':
-                                $reason = $translator->trans('mautic.email.complaint.reason.fraud');
+                                $reason = $this->translator->trans('mautic.email.complaint.reason.fraud');
                                 break;
                             case 'virus':
-                                $reason = $translator->trans('mautic.email.complaint.reason.virus');
+                                $reason = $this->translator->trans('mautic.email.complaint.reason.virus');
                                 break;
                         }
                     }
 
                     if ($reason == null) {
-                        $reason = $translator->trans('mautic.email.complaint.reason.unknown');
+                        $reason = $this->translator->trans('mautic.email.complaint.reason.unknown');
                     }
 
-                    $rows[DoNotContact::UNSUBSCRIBED]['emails'][$complainedRecipient['emailAddress']] = $reason;
-                    $logger->debug("Unsubscribe email '".$complainedRecipient['emailAddress']."'");
+                    $this->transportCallback->addFailureByAddress($complainedRecipient['emailAddress'], $reason, DoNotContact::UNSUBSCRIBED);
+
+                    $this->logger->debug("Unsubscribe email '".$complainedRecipient['emailAddress']."'");
                 }
             }
         }
-
-        return $rows;
     }
 
     /**

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/CallbackTransportInterface.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/CallbackTransportInterface.php
@@ -27,5 +27,5 @@ interface CallbackTransportInterface
      *
      * @param Request $request
      */
-    public function processCallbackResponse(Request $request);
+    public function processCallbackRequest(Request $request);
 }

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/CallbackTransportInterface.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/CallbackTransportInterface.php
@@ -11,15 +11,9 @@
 
 namespace Mautic\EmailBundle\Swiftmailer\Transport;
 
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Symfony\Component\HttpFoundation\Request;
 
-/**
- * Interface InterfaceCallbackTransport.
- *
- * @deprecated 2.12.1 to be removed in 3.0; use CallbackTransportInterface
- */
-interface InterfaceCallbackTransport
+interface CallbackTransportInterface
 {
     /**
      * Returns a "transport" string to match the URL path /mailer/{transport}/callback.
@@ -29,12 +23,9 @@ interface InterfaceCallbackTransport
     public function getCallbackPath();
 
     /**
-     * Handle response.
+     * Processes the response.
      *
-     * @param Request       $request
-     * @param MauticFactory $factory
-     *
-     * @return array array('bounces' => array('hashID' => 'reason', ...));
+     * @param Request $request
      */
-    public function handleCallbackResponse(Request $request, MauticFactory $factory);
+    public function processCallbackResponse(Request $request);
 }

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/ElasticemailTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/ElasticemailTransport.php
@@ -11,28 +11,58 @@
 
 namespace Mautic\EmailBundle\Swiftmailer\Transport;
 
-use Joomla\Http\Http;
-use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\EmailBundle\Model\TransportCallback;
 use Mautic\LeadBundle\Entity\DoNotContact;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class ElasticEmailTransport.
  */
-class ElasticemailTransport extends \Swift_SmtpTransport implements InterfaceCallbackTransport
+class ElasticemailTransport extends \Swift_SmtpTransport implements CallbackTransportInterface
 {
-    private $httpClient;
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
 
     /**
-     * {@inheritdoc}
+     * @var LoggerInterface
      */
-    public function __construct($host = 'localhost', $port = 25, $security = null)
+    private $logger;
+
+    /**
+     * @var TransportCallback
+     */
+    private $transportCallback;
+
+    /**
+     * ElasticemailTransport constructor.
+     *
+     * @param TranslatorInterface $translator
+     * @param LoggerInterface     $logger
+     * @param TransportCallback   $transportCallback
+     */
+    public function __construct(TranslatorInterface $translator, LoggerInterface $logger, TransportCallback $transportCallback)
     {
+        $this->translator        = $translator;
+        $this->logger            = $logger;
+        $this->transportCallback = $transportCallback;
+
         parent::__construct('smtp.elasticemail.com', 2525, null);
 
         $this->setAuthMode('login');
     }
 
+    /**
+     * @param \Swift_Mime_Message $message
+     * @param null                $failedRecipients
+     *
+     * @return int|void
+     *
+     * @throws \Exception
+     */
     public function send(\Swift_Mime_Message $message, &$failedRecipients = null)
     {
         // IsTransactional header for all non bulk messages
@@ -57,31 +87,23 @@ class ElasticemailTransport extends \Swift_SmtpTransport implements InterfaceCal
     /**
      * Handle bounces & complaints from ElasticEmail.
      *
-     * @param Request       $request
-     * @param MauticFactory $factory
-     *
-     * @return mixed
+     * @param Request $request
      */
-    public function handleCallbackResponse(Request $request, MauticFactory $factory)
+    public function processCallbackRequest(Request $request)
     {
-        $translator = $factory->getTranslator();
-        $logger     = $factory->getLogger();
-        $logger->debug('Receiving webhook from ElasticEmail');
+        $this->logger->debug('Receiving webhook from ElasticEmail');
 
-        $rows     = [];
         $email    = rawurldecode($request->get('to'));
         $status   = rawurldecode($request->get('status'));
         $category = rawurldecode($request->get('category'));
         // https://elasticemail.com/support/delivery/http-web-notification
         if (in_array($status, ['AbuseReport', 'Unsubscribed'])) {
-            $rows[DoNotContact::UNSUBSCRIBED]['emails'][$email] = $status;
+            $this->transportCallback->addFailureByAddress($email, $status, DoNotContact::UNSUBSCRIBED);
         } elseif (in_array($category, ['NotDelivered', 'NoMailbox', 'AccountProblem', 'DNSProblem', 'Unknown', 'Spam'])) {
             // just hard bounces https://elasticemail.com/support/user-interface/activity/bounced-category-filters
-            $rows[DoNotContact::BOUNCED]['emails'][$email] = $category;
+            $this->transportCallback->addFailureByAddress($email, $category);
         } elseif ($status == 'Error') {
-            $rows[DoNotContact::BOUNCED]['emails'][$email] = $translator->trans('mautic.email.complaint.reason.unknown');
+            $this->transportCallback->addFailureByAddress($email, $this->translator->trans('mautic.email.complaint.reason.unknown'));
         }
-
-        return $rows;
     }
 }

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/ElasticemailTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/ElasticemailTransport.php
@@ -97,9 +97,9 @@ class ElasticemailTransport extends \Swift_SmtpTransport implements CallbackTran
         $status   = rawurldecode($request->get('status'));
         $category = rawurldecode($request->get('category'));
         // https://elasticemail.com/support/delivery/http-web-notification
-        if (in_array($status, ['AbuseReport', 'Unsubscribed'])) {
+        if (in_array($status, ['AbuseReport', 'Unsubscribed']) || 'Spam' === $category) {
             $this->transportCallback->addFailureByAddress($email, $status, DoNotContact::UNSUBSCRIBED);
-        } elseif (in_array($category, ['NotDelivered', 'NoMailbox', 'AccountProblem', 'DNSProblem', 'Unknown', 'Spam'])) {
+        } elseif (in_array($category, ['NotDelivered', 'NoMailbox', 'AccountProblem', 'DNSProblem', 'Unknown'])) {
             // just hard bounces https://elasticemail.com/support/user-interface/activity/bounced-category-filters
             $this->transportCallback->addFailureByAddress($email, $category);
         } elseif ($status == 'Error') {

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/MandrillTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/MandrillTransport.php
@@ -426,8 +426,8 @@ class MandrillTransport extends AbstractTokenHttpTransport implements CallbackTr
 
         if (is_array($mandrillEvents)) {
             foreach ($mandrillEvents as $event) {
-                $isBounce      = in_array($event['event'], ['hard_bounce', 'soft_bounce', 'reject', 'spam', 'invalid']);
-                $isUnsubscribe = ('unsub' === $event['event']);
+                $isBounce      = in_array($event['event'], ['hard_bounce', 'reject']);
+                $isUnsubscribe = in_array($event['event'], ['spam', 'unsub']);
                 if ($isBounce || $isUnsubscribe) {
                     $type = ($isBounce) ? DoNotContact::BOUNCED : DoNotContact::UNSUBSCRIBED;
 

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/MandrillTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/MandrillTransport.php
@@ -11,16 +11,39 @@
 
 namespace Mautic\EmailBundle\Swiftmailer\Transport;
 
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\EmailBundle\Helper\MailHelper;
+use Mautic\EmailBundle\Model\TransportCallback;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class MandrillTransport.
  */
-class MandrillTransport extends AbstractTokenHttpTransport implements InterfaceCallbackTransport
+class MandrillTransport extends AbstractTokenHttpTransport implements CallbackTransportInterface
 {
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var TransportCallback
+     */
+    private $transportCallback;
+
+    /**
+     * MandrillTransport constructor.
+     *
+     * @param TranslatorInterface $translator
+     * @param TransportCallback   $transportCallback
+     */
+    public function __construct(TranslatorInterface $translator, TransportCallback $transportCallback)
+    {
+        $this->translator        = $translator;
+        $this->transportCallback = $transportCallback;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -75,8 +98,6 @@ class MandrillTransport extends AbstractTokenHttpTransport implements InterfaceC
 
         // Generate the recipients
         $recipients = $rcptMergeVars = $rcptMetadata = [];
-
-        $translator = $this->factory->getTranslator();
 
         foreach ($message['recipients'] as $type => $typeRecipients) {
             foreach ($typeRecipients as $rcpt) {
@@ -143,7 +164,7 @@ class MandrillTransport extends AbstractTokenHttpTransport implements InterfaceC
                                 [
                                     [
                                         'name'    => 'HTMLCCEMAILHEADER',
-                                        'content' => $translator->trans(
+                                        'content' => $this->translator->trans(
                                                 'mautic.core.email.cc.copy',
                                                 [
                                                     '%email%' => $rcpt['email'],
@@ -152,7 +173,7 @@ class MandrillTransport extends AbstractTokenHttpTransport implements InterfaceC
                                     ],
                                     [
                                         'name'    => 'TEXTCCEMAILHEADER',
-                                        'content' => $translator->trans(
+                                        'content' => $this->translator->trans(
                                                 'mautic.core.email.cc.copy',
                                                 [
                                                     '%email%' => $rcpt['email'],
@@ -315,20 +336,11 @@ class MandrillTransport extends AbstractTokenHttpTransport implements InterfaceC
                 $this->throwException($message);
             }
 
-            return true;
+            return [];
         }
 
         $return     = [];
-        $hasBounces = false;
-        $bounces    = [
-            DoNotContact::BOUNCED => [
-                'emails' => [],
-            ],
-            DoNotContact::UNSUBSCRIBED => [
-                'emails' => [],
-            ],
-        ];
-        $metadata = $this->getMetadata();
+        $metadata   = $this->getMetadata();
 
         if (is_array($response)) {
             if (isset($response['status']) && $response['status'] == 'error') {
@@ -348,13 +360,9 @@ class MandrillTransport extends AbstractTokenHttpTransport implements InterfaceC
                         $leadId = (!empty($metadata[$stat['email']]['leadId'])) ? $metadata[$stat['email']]['leadId'] : null;
 
                         if (in_array($stat['reject_reason'], ['hard-bounce', 'soft-bounce', 'reject', 'spam', 'invalid', 'unsub'])) {
-                            $hasBounces = true;
-                            $type       = ('unsub' == $stat['reject_reason']) ? DoNotContact::UNSUBSCRIBED : DoNotContact::BOUNCED;
-
-                            $bounces[$type]['emails'][$stat['email']] = [
-                                'leadId' => $leadId,
-                                'reason' => ('unsubscribed' == $type) ? $type : str_replace('-', '_', $stat['reject_reason']),
-                            ];
+                            $type     = ('unsub' == $stat['reject_reason']) ? DoNotContact::UNSUBSCRIBED : DoNotContact::BOUNCED;
+                            $comments = ('unsubscribed' == $type) ? $type : str_replace('-', '_', $stat['reject_reason']);
+                            $this->transportCallback->addFailureByContactId($leadId, $comments, $type);
                         }
                     }
                 }
@@ -363,13 +371,6 @@ class MandrillTransport extends AbstractTokenHttpTransport implements InterfaceC
 
         if ($evt = $this->getDispatcher()->createResponseEvent($this, $parsedResponse, ($info['http_code'] == 200))) {
             $this->getDispatcher()->dispatchEvent($evt, 'responseReceived');
-        }
-
-        // Parse bounces if applicable
-        if ($hasBounces) {
-            /** @var \Mautic\EmailBundle\Model\EmailModel $emailModel */
-            $emailModel = $this->factory->getModel('email');
-            $emailModel->processMailerCallback($bounces);
         }
 
         if ($response === false) {
@@ -416,25 +417,12 @@ class MandrillTransport extends AbstractTokenHttpTransport implements InterfaceC
     /**
      * Handle response.
      *
-     * @param Request       $request
-     * @param MauticFactory $factory
-     *
-     * @return mixed
+     * @param Request $request
      */
-    public function handleCallbackResponse(Request $request, MauticFactory $factory)
+    public function processCallbackRequest(Request $request)
     {
         $mandrillEvents = $request->request->get('mandrill_events');
         $mandrillEvents = json_decode($mandrillEvents, true);
-        $rows           = [
-            DoNotContact::BOUNCED => [
-                'hashIds' => [],
-                'emails'  => [],
-            ],
-            DoNotContact::UNSUBSCRIBED => [
-                'hashIds' => [],
-                'emails'  => [],
-            ],
-        ];
 
         if (is_array($mandrillEvents)) {
             foreach ($mandrillEvents as $event) {
@@ -452,14 +440,12 @@ class MandrillTransport extends AbstractTokenHttpTransport implements InterfaceC
                     }
 
                     if (isset($event['msg']['metadata']['hashId'])) {
-                        $rows[$type]['hashIds'][$event['msg']['metadata']['hashId']] = $reason;
+                        $this->transportCallback->addFailureByHashId($event['msg']['metadata']['hashId'], $reason, $type);
                     } else {
-                        $rows[$type]['emails'][$event['msg']['email']] = $reason;
+                        $this->transportCallback->addFailureByAddress($event['msg']['email'], $reason, $type);
                     }
                 }
             }
         }
-
-        return $rows;
     }
 }

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
@@ -349,8 +349,7 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
                     }
                     break;
                 case 'spam_complaint':
-                    $this->transportCallback->addFailureByHashId($hashId, $event['fbtype']);
-
+                    $this->transportCallback->addFailureByHashId($hashId, $event['fbtype'], DoNotContact::UNSUBSCRIBED);
                     break;
                 case 'out_of_band':
                 case 'policy_rejection':

--- a/app/bundles/EmailBundle/Tests/Transport/AmazonTransportTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/AmazonTransportTest.php
@@ -160,10 +160,7 @@ PAYLOAD;
         $jsonPayload = json_decode($payload, true);
 
         $transport = new AmazonTransport('localhost', new Http(), $this->logger, $this->translator, $transportCallback);
-        $rows      = $transport->processJsonPayload($jsonPayload);
-
-        $this->assertArrayHasKey('richard@example.com', $rows[1]['emails']);
-        $this->assertEquals($this->translator->trans('mautic.email.complaint.reason.unknown'), $rows[1]['emails']['richard@example.com']);
+        $transport->processJsonPayload($jsonPayload);
     }
 
     /**
@@ -197,9 +194,6 @@ PAYLOAD;
         $jsonPayload = json_decode($payload, true);
 
         $transport = new AmazonTransport('localhost', new Http(), $this->logger, $this->translator, $transportCallback);
-        $rows      = $transport->processJsonPayload($jsonPayload);
-
-        $this->assertArrayHasKey('richard@example.com', $rows[1]['emails']);
-        $this->assertEquals($this->translator->trans('mautic.email.complaint.reason.abuse'), $rows[1]['emails']['richard@example.com']);
+        $transport->processJsonPayload($jsonPayload);
     }
 }

--- a/app/bundles/EmailBundle/Tests/Transport/AmazonTransportTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/AmazonTransportTest.php
@@ -12,21 +12,42 @@
 namespace Mautic\EmailBundle\Tests\Transport;
 
 use Joomla\Http\Http;
+use Mautic\CoreBundle\Translation\Translator;
+use Mautic\EmailBundle\Model\TransportCallback;
 use Mautic\EmailBundle\Swiftmailer\Transport\AmazonTransport;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Monolog\Logger;
 
 /**
  * Class AmazonTransportTest.
  */
-class AmazonTransportTest extends KernelTestCase
+class AmazonTransportTest extends \PHPUnit_Framework_TestCase
 {
-    private $container;
+    /**
+     * @var Logger
+     */
+    private $logger;
+
+    /**
+     * @var Translator
+     */
+    private $translator;
 
     public function setUp()
     {
-        self::bootKernel();
+        $this->logger = $this->getMockBuilder(Logger::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $this->container = self::$kernel->getContainer();
+        $this->translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->translator->method('trans')
+            ->willReturnCallback(
+                function ($key) {
+                    return $key;
+                }
+            );
     }
 
     /**
@@ -34,8 +55,9 @@ class AmazonTransportTest extends KernelTestCase
      */
     public function testConfirmationCallbackSuccessfull()
     {
-        $logger     = $this->container->get('logger');
-        $translator = $this->container->get('translator');
+        $transportCallback = $this->getMockBuilder(TransportCallback::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         // Mock http connector
         $mockHttp = $this->getMockBuilder('Joomla\Http\Http')
@@ -43,7 +65,7 @@ class AmazonTransportTest extends KernelTestCase
             ->getMock();
 
         // Mock a successful response
-        $mockResponse = $this->getMockBuilder('Joomla\Http\Response')
+        $mockResponse       = $this->getMockBuilder('Joomla\Http\Response')
             ->getMock();
         $mockResponse->code = 200;
 
@@ -69,8 +91,8 @@ PAYLOAD;
 
         $jsonPayload = json_decode($payload, true);
 
-        $transport = new AmazonTransport('localhost', $mockHttp);
-        $transport->processJsonPayload($jsonPayload, $logger, $translator);
+        $transport = new AmazonTransport('localhost', $mockHttp, $this->logger, $this->translator, $transportCallback);
+        $transport->processJsonPayload($jsonPayload);
     }
 
     /**
@@ -78,8 +100,13 @@ PAYLOAD;
      */
     public function testSingleBounceCallbackSuccessfull()
     {
-        $logger     = $this->container->get('logger');
-        $translator = $this->container->get('translator');
+        $transportCallback = $this->getMockBuilder(TransportCallback::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $transportCallback->expects($this->once())
+            ->method('addFailureByAddress')
+            ->with($this->equalTo('nope@nope.com'), $this->equalTo('smtp; 550 5.1.1 <nope@nope.com>: Recipient address rejected: User unknown in virtual alias table'), $this->equalTo(2));
 
         // payload which is sent by Amazon SES
         $payload = <<<PAYLOAD
@@ -98,11 +125,8 @@ PAYLOAD;
 
         $jsonPayload = json_decode($payload, true);
 
-        $transport = new AmazonTransport('localhost', new Http());
-        $rows      = $transport->processJsonPayload($jsonPayload, $logger, $translator);
-
-        $this->assertArrayHasKey('nope@nope.com', $rows[2]['emails']);
-        $this->assertContains('Recipient address rejected', $rows[2]['emails']['nope@nope.com']);
+        $transport = new AmazonTransport('localhost', new Http(), $this->logger, $this->translator, $transportCallback);
+        $transport->processJsonPayload($jsonPayload);
     }
 
     /**
@@ -110,8 +134,13 @@ PAYLOAD;
      */
     public function testSingleComplaintWithoutFeedbackCallbackSuccessfull()
     {
-        $logger     = $this->container->get('logger');
-        $translator = $this->container->get('translator');
+        $transportCallback = $this->getMockBuilder(TransportCallback::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $transportCallback->expects($this->once())
+            ->method('addFailureByAddress')
+            ->with($this->equalTo('richard@example.com'), $this->equalTo('mautic.email.complaint.reason.unknown'), $this->equalTo(1));
 
         // payload which is sent by Amazon SES
         $payload = <<<PAYLOAD
@@ -130,11 +159,11 @@ PAYLOAD;
 
         $jsonPayload = json_decode($payload, true);
 
-        $transport = new AmazonTransport('localhost', new Http());
-        $rows      = $transport->processJsonPayload($jsonPayload, $logger, $translator);
+        $transport = new AmazonTransport('localhost', new Http(), $this->logger, $this->translator, $transportCallback);
+        $rows      = $transport->processJsonPayload($jsonPayload);
 
         $this->assertArrayHasKey('richard@example.com', $rows[1]['emails']);
-        $this->assertEquals($translator->trans('mautic.email.complaint.reason.unknown'), $rows[1]['emails']['richard@example.com']);
+        $this->assertEquals($this->translator->trans('mautic.email.complaint.reason.unknown'), $rows[1]['emails']['richard@example.com']);
     }
 
     /**
@@ -142,8 +171,13 @@ PAYLOAD;
      */
     public function testSingleComplaintWithFeedbackCallbackSuccessfull()
     {
-        $logger     = $this->container->get('logger');
-        $translator = $this->container->get('translator');
+        $transportCallback = $this->getMockBuilder(TransportCallback::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $transportCallback->expects($this->once())
+            ->method('addFailureByAddress')
+            ->with($this->equalTo('richard@example.com'), $this->equalTo('mautic.email.complaint.reason.abuse'), $this->equalTo(1));
 
         // payload which is sent by Amazon SES
         $payload = <<<PAYLOAD
@@ -162,10 +196,10 @@ PAYLOAD;
 
         $jsonPayload = json_decode($payload, true);
 
-        $transport = new AmazonTransport('localhost', new Http());
-        $rows      = $transport->processJsonPayload($jsonPayload, $logger, $translator);
+        $transport = new AmazonTransport('localhost', new Http(), $this->logger, $this->translator, $transportCallback);
+        $rows      = $transport->processJsonPayload($jsonPayload);
 
         $this->assertArrayHasKey('richard@example.com', $rows[1]['emails']);
-        $this->assertEquals($translator->trans('mautic.email.complaint.reason.abuse'), $rows[1]['emails']['richard@example.com']);
+        $this->assertEquals($this->translator->trans('mautic.email.complaint.reason.abuse'), $rows[1]['emails']['richard@example.com']);
     }
 }

--- a/app/bundles/EmailBundle/Tests/Transport/ElasticemailTransportTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/ElasticemailTransportTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Transport;
+
+use Mautic\CoreBundle\Translation\Translator;
+use Mautic\EmailBundle\Model\TransportCallback;
+use Mautic\EmailBundle\Swiftmailer\Transport\ElasticemailTransport;
+use Mautic\LeadBundle\Entity\DoNotContact;
+use Monolog\Logger;
+use Symfony\Component\HttpFoundation\Request;
+
+class ElasticemailTransportTest extends \PHPUnit_Framework_TestCase
+{
+    private $translator;
+    private $transportCallback;
+    private $logger;
+
+    public function setUp()
+    {
+        $this->translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->translator->method('trans')
+            ->willReturnCallback(
+                function ($key) {
+                    return $key;
+                }
+            );
+
+        $this->transportCallback = $this->getMockBuilder(TransportCallback::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->logger = new Logger('test');
+    }
+
+    public function testUnsubscribedIsProcessed()
+    {
+        $status = 'AbuseReport';
+        $this->transportCallback->expects($this->never())
+            ->method('addFailureByHashId');
+
+        $this->transportCallback->expects($this->once())
+            ->method('addFailureByAddress')
+            ->with(
+                'test@test.com',
+                $status,
+                DoNotContact::UNSUBSCRIBED
+            );
+
+        $transport = new ElasticemailTransport($this->translator, $this->logger, $this->transportCallback);
+
+        $transport->processCallbackRequest($this->getRequestWithPayload($status));
+    }
+
+    public function testAbuseReportIsProcessed()
+    {
+        $status = 'Unsubscribed';
+        $this->transportCallback->expects($this->never())
+            ->method('addFailureByHashId');
+
+        $this->transportCallback->expects($this->once())
+            ->method('addFailureByAddress')
+            ->with(
+                'test@test.com',
+                $status,
+                DoNotContact::UNSUBSCRIBED
+            );
+
+        $transport = new ElasticemailTransport($this->translator, $this->logger, $this->transportCallback);
+
+        $transport->processCallbackRequest($this->getRequestWithPayload($status));
+    }
+
+    public function testSpamReportIsProcessed()
+    {
+        $status = 'Something';
+        $this->transportCallback->expects($this->never())
+            ->method('addFailureByHashId');
+
+        $this->transportCallback->expects($this->once())
+            ->method('addFailureByAddress')
+            ->with(
+                'test@test.com',
+                $status,
+                DoNotContact::UNSUBSCRIBED
+            );
+
+        $transport = new ElasticemailTransport($this->translator, $this->logger, $this->transportCallback);
+
+        $transport->processCallbackRequest($this->getRequestWithPayload($status, 'Spam'));
+    }
+
+    public function testBounceReportIsProcessed()
+    {
+        $bounceCategories = ['NotDelivered', 'NoMailbox', 'AccountProblem', 'DNSProblem', 'Unknown'];
+
+        $this->transportCallback->expects($this->never())
+            ->method('addFailureByHashId');
+
+        $this->transportCallback->expects($this->exactly(5))
+            ->method('addFailureByAddress')
+            ->withConsecutive(
+                ['test@test.com', 'NotDelivered', DoNotContact::BOUNCED],
+                ['test@test.com', 'NoMailbox', DoNotContact::BOUNCED],
+                ['test@test.com', 'AccountProblem', DoNotContact::BOUNCED],
+                ['test@test.com', 'DNSProblem', DoNotContact::BOUNCED],
+                ['test@test.com', 'Unknown', DoNotContact::BOUNCED]
+            );
+
+        $transport = new ElasticemailTransport($this->translator, $this->logger, $this->transportCallback);
+
+        foreach ($bounceCategories as $cat) {
+            $transport->processCallbackRequest($this->getRequestWithPayload('Bounce', $cat));
+        }
+    }
+
+    public function testErrorReportIsProcessed()
+    {
+        $status = 'Error';
+        $this->transportCallback->expects($this->never())
+            ->method('addFailureByHashId');
+
+        $this->transportCallback->expects($this->once())
+            ->method('addFailureByAddress')
+            ->with(
+                'test@test.com',
+                'mautic.email.complaint.reason.unknown',
+                DoNotContact::BOUNCED
+            );
+
+        $transport = new ElasticemailTransport($this->translator, $this->logger, $this->transportCallback);
+
+        $transport->processCallbackRequest($this->getRequestWithPayload($status));
+    }
+
+    /**
+     * @param        $status
+     * @param string $category
+     *
+     * @return Request
+     */
+    private function getRequestWithPayload($status, $category = 'Ignore')
+    {
+        $query   = [
+            'status'      => $status,
+            'category'    => $category,
+            'account'     => 'account@test.com',
+            'transaction' => '486de632-e3b1-40fd-ba29-807b8b13aa22',
+            'to'          => 'test@test.com',
+            'date'        => '12/22/2017 9:03:39 PM',
+            'channel'     => 'testchannel',
+            'subject'     => 'test',
+        ];
+
+        return new Request($query);
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Transport/MailjetTransportTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/MailjetTransportTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Transport;
+
+use Mautic\EmailBundle\Model\TransportCallback;
+use Mautic\EmailBundle\Swiftmailer\Transport\MailjetTransport;
+use Mautic\LeadBundle\Entity\DoNotContact;
+use Symfony\Component\HttpFoundation\Request;
+
+class MailjetTransportTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWebhookPayloadIsProcessed()
+    {
+        $transportCallback = $this->getMockBuilder(TransportCallback::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $transportCallback->expects($this->exactly(4))
+            ->method('addFailureByHashId')
+            ->withConsecutive(
+                [$this->equalTo('1'), 'User unsubscribed', DoNotContact::UNSUBSCRIBED],
+                [$this->equalTo('2'), 'blocked: blocked', DoNotContact::BOUNCED],
+                [$this->equalTo('3'), 'User reported email as spam, source: spam button', DoNotContact::UNSUBSCRIBED],
+                [$this->equalTo('4'), 'bounced: bounced', DoNotContact::BOUNCED]
+            );
+
+        $transportCallback->expects($this->once())
+            ->method('addFailureByAddress')
+            ->with(
+                'bounce2@test.com',
+                'bounced: bounce without hash',
+                DoNotContact::BOUNCED
+            );
+
+        $transport = new MailjetTransport($transportCallback);
+
+        $transport->processCallbackRequest($this->getRequestWithPayload());
+    }
+
+    /**
+     * @return Request
+     */
+    private function getRequestWithPayload()
+    {
+        $json = <<<JSON
+    [
+  {
+    "event": "unsub",
+    "time": 1513975381,
+    "MessageID": 0,
+    "email": "unsub@test.com",
+    "mj_campaign_id": 0,
+    "mj_contact_id": 0,
+    "customcampaign": "",
+    "CustomID": "1-unsub@test.com",
+    "Payload": "",
+    "mj_list_id": "",
+    "ip": "",
+    "geo": "",
+    "agent": ""
+  },
+  {
+    "event": "blocked",
+    "time": 1513975379,
+    "MessageID": 0,
+    "email": "blocked@test.com",
+    "mj_campaign_id": 0,
+    "mj_contact_id": 0,
+    "customcampaign": "",
+    "CustomID": "2-blocked@test.com",
+    "Payload": "",
+    "error_related_to": "blocked",
+    "error": "blocked"
+  },
+  {
+    "event": "spam",
+    "time": 1513975376,
+    "MessageID": 0,
+    "email": "spam@test.com",
+    "mj_campaign_id": 0,
+    "mj_contact_id": 0,
+    "customcampaign": "",
+    "CustomID": "3-spam@test.com",
+    "Payload": "",
+    "source": "spam button"
+  },
+  {
+    "event": "bounce",
+    "time": 1513975374,
+    "MessageID": 0,
+    "email": "bounce@test.com",
+    "mj_campaign_id": 0,
+    "mj_contact_id": 0,
+    "customcampaign": "",
+    "CustomID": "4-bounce@test.com",
+    "Payload": "",
+    "blocked": "",
+    "hard_bounce": "",
+    "error_related_to": "bounced",
+    "error": "bounced"
+  },
+  {
+    "event": "bounce",
+    "time": 1513975374,
+    "MessageID": 0,
+    "email": "bounce2@test.com",
+    "mj_campaign_id": 0,
+    "mj_contact_id": 0,
+    "customcampaign": "",
+    "CustomID": "",
+    "Payload": "",
+    "blocked": "",
+    "hard_bounce": "",
+    "error_related_to": "bounced",
+    "error": "bounce without hash"
+  }
+]
+JSON;
+
+        return new Request([], [], [], [], [], [], $json);
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Transport/MandrillTransportTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/MandrillTransportTest.php
@@ -1,0 +1,209 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Transport;
+
+use Mautic\CoreBundle\Translation\Translator;
+use Mautic\EmailBundle\Model\TransportCallback;
+use Mautic\EmailBundle\Swiftmailer\Transport\MandrillTransport;
+use Mautic\LeadBundle\Entity\DoNotContact;
+use Symfony\Component\HttpFoundation\Request;
+
+class MandrillTransportTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWebhookPayloadIsProcessed()
+    {
+        $translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $translator->method('trans')
+            ->willReturnCallback(
+                function ($key) {
+                    return $key;
+                }
+            );
+
+        $transportCallback = $this->getMockBuilder(TransportCallback::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $transportCallback->expects($this->exactly(4))
+            ->method('addFailureByHashId')
+            ->withConsecutive(
+                [$this->equalTo('1'), "smtp;550 5.1.1 The email account that you tried to reach does not exist. Please try double-checking the recipient's email address for typos or unnecessary spaces.", DoNotContact::BOUNCED],
+                [$this->equalTo('2'), 'unsubscribed', DoNotContact::UNSUBSCRIBED],
+                [$this->equalTo('3'), 'unsubscribed', DoNotContact::UNSUBSCRIBED],
+                [$this->equalTo('4'), 'reject', DoNotContact::BOUNCED]
+            );
+
+        $transportCallback->expects($this->once())
+            ->method('addFailureByAddress')
+            ->with(
+                'bounce@mandrill.test',
+                'reject',
+                DoNotContact::BOUNCED
+            );
+
+        $mandrill = new MandrillTransport($translator, $transportCallback);
+
+        $mandrill->processCallbackRequest($this->getRequestWithPayload());
+    }
+
+    /**
+     * @return Request
+     */
+    private function getRequestWithPayload()
+    {
+        $json = <<<JSON
+    [
+       {
+          "event":"hard_bounce",
+          "msg":{
+             "ts":1365109999,
+             "subject":"This an example webhook message",
+             "email":"example.webhook@mandrillapp.com",
+             "sender":"example.sender@mandrillapp.com",
+             "tags":[
+                "webhook-example"
+             ],
+             "state":"bounced",
+             "metadata":{
+                "hashId":1
+             },
+             "_id":"exampleaaaaaaaaaaaaaaaaaaaaaaaaa",
+             "_version":"exampleaaaaaaaaaaaaaaa",
+             "bounce_description":"bad_mailbox",
+             "bgtools_code":10,
+             "diag":"smtp;550 5.1.1 The email account that you tried to reach does not exist. Please try double-checking the recipient's email address for typos or unnecessary spaces."
+          },
+          "_id":"exampleaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "ts":1513974230
+       },
+       {
+          "event":"spam",
+          "msg":{
+             "ts":1365109999,
+             "subject":"This an example webhook message",
+             "email":"example.webhook@mandrillapp.com",
+             "sender":"example.sender@mandrillapp.com",
+             "tags":[
+                "webhook-example"
+             ],
+             "opens":[
+                {
+                   "ts":1365111111
+                }
+             ],
+             "clicks":[
+                {
+                   "ts":1365111111,
+                   "url":"http:\/\/mandrill.com"
+                }
+             ],
+             "state":"sent",
+             "metadata":{
+                "hashId":2
+             },
+             "_id":"exampleaaaaaaaaaaaaaaaaaaaaaaaaa1",
+             "_version":"exampleaaaaaaaaaaaaaaa"
+          },
+          "_id":"exampleaaaaaaaaaaaaaaaaaaaaaaaaa1",
+          "ts":1513974230
+       },
+       {
+          "event":"unsub",
+          "msg":{
+             "ts":1365109999,
+             "subject":"This an example webhook message",
+             "email":"example.webhook@mandrillapp.com",
+             "sender":"example.sender@mandrillapp.com",
+             "tags":[
+                "webhook-example"
+             ],
+             "opens":[
+                {
+                   "ts":1365111111
+                }
+             ],
+             "clicks":[
+                {
+                   "ts":1365111111,
+                   "url":"http:\/\/mandrill.com"
+                }
+             ],
+             "state":"sent",
+             "metadata":{
+                "hashId":3
+             },
+             "_id":"exampleaaaaaaaaaaaaaaaaaaaaaaaaa2",
+             "_version":"exampleaaaaaaaaaaaaaaa"
+          },
+          "_id":"exampleaaaaaaaaaaaaaaaaaaaaaaaaa2",
+          "ts":1513974230
+       },
+       {
+          "event":"reject",
+          "msg":{
+             "ts":1365109999,
+             "subject":"This an example webhook message",
+             "email":"example.webhook@mandrillapp.com",
+             "sender":"example.sender@mandrillapp.com",
+             "tags":[
+                "webhook-example"
+             ],
+             "opens":[
+    
+             ],
+             "clicks":[
+    
+             ],
+             "state":"rejected",
+             "metadata":{
+                "hashId":4
+             },
+             "_id":"exampleaaaaaaaaaaaaaaaaaaaaaaaaa3",
+             "_version":"exampleaaaaaaaaaaaaaaa"
+          },
+          "_id":"exampleaaaaaaaaaaaaaaaaaaaaaaaaa3",
+          "ts":1513974230
+       },
+       {
+          "event":"reject",
+          "msg":{
+             "ts":1365109999,
+             "subject":"This an example webhook message",
+             "email":"bounce@mandrill.test",
+             "sender":"example.sender@mandrillapp.com",
+             "tags":[
+                "webhook-example"
+             ],
+             "opens":[
+    
+             ],
+             "clicks":[
+    
+             ],
+             "state":"rejected",
+             "metadata":{
+                "custom":1
+             },
+             "_id":"exampleaaaaaaaaaaaaaaaaaaaaaaaaa3",
+             "_version":"exampleaaaaaaaaaaaaaaa"
+          },
+          "_id":"exampleaaaaaaaaaaaaaaaaaaaaaaaaa3",
+          "ts":1513974230
+       }
+    ]
+JSON;
+
+        return new Request([], ['mandrill_events' => $json]);
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportTest.php
@@ -1,0 +1,456 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Transport;
+
+use Mautic\CoreBundle\Translation\Translator;
+use Mautic\EmailBundle\Model\TransportCallback;
+use Mautic\EmailBundle\Swiftmailer\Transport\SparkpostTransport;
+use Mautic\LeadBundle\Entity\DoNotContact;
+use Symfony\Component\HttpFoundation\Request;
+
+class SparkpostTransportTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWebhookPayloadIsProcessed()
+    {
+        $translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $translator->method('trans')
+            ->willReturnCallback(
+                function ($key) {
+                    return $key;
+                }
+            );
+
+        $transportCallback = $this->getMockBuilder(TransportCallback::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $transportCallback->expects($this->exactly(6))
+            ->method('addFailureByHashId')
+            ->withConsecutive(
+                [$this->equalTo('1'), 'MAIL REFUSED - IP (17.99.99.99) is in black list', DoNotContact::BOUNCED],
+                [$this->equalTo('2'), 'abuse', DoNotContact::UNSUBSCRIBED],
+                [$this->equalTo('3'), 'MAIL REFUSED - IP (18.99.99.99) is in black list', DoNotContact::BOUNCED],
+                [$this->equalTo('4'), 'MAIL REFUSED - IP (19.99.99.99) is in black list', DoNotContact::BOUNCED],
+                [$this->equalTo('5'), 'unsubscribed', DoNotContact::UNSUBSCRIBED],
+                [$this->equalTo('6'), 'unsubscribed', DoNotContact::UNSUBSCRIBED]
+                // cc recipient type is ignored so addFailureByHashId should not be called
+        );
+
+        $transportCallback->expects($this->once())
+            ->method('addFailureByAddress')
+            ->with(
+                'bounce@example.com',
+                'MAIL REFUSED - IP (17.99.99.99) is in black list',
+                DoNotContact::BOUNCED
+            );
+
+        $sparkpost = new SparkpostTransport('1234', $translator, $transportCallback);
+
+        $sparkpost->processCallbackRequest($this->getRequestWithPayload());
+    }
+
+    private function getRequestWithPayload()
+    {
+        $json = <<<JSON
+[
+    {
+      "msys": {
+        "message_event": {
+          "type": "bounce",
+          "bounce_class": "10",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "delv_method": "esmtp",
+          "device_token": "45c19189783f867973f6e6a5cca60061ffe4fa77c547150563a1192fa9847f8a",
+          "error_code": "554",
+          "event_id": "92356927693813856",
+          "friendly_from": "sender@example.com",
+          "ip_address": "127.0.0.1",
+          "ip_pool": "Example-Ip-Pool",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "msg_size": "1337",
+          "num_retries": "2",
+          "rcpt_meta": {
+            "hashId": "1"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "recipient@example.com",
+          "raw_rcpt_to": "recipient@example.com",
+          "rcpt_type": "to",
+          "raw_reason": "MAIL REFUSED - IP (17.99.99.99) is in black list",
+          "reason": "MAIL REFUSED - IP (a.b.c.d) is in black list",
+          "routing_domain": "example.com",
+          "sending_ip": "127.0.0.1",
+          "sms_coding": "ASCII",
+          "sms_dst": "7876712656",
+          "sms_dst_npi": "E164",
+          "sms_dst_ton": "International",
+          "sms_src": "1234",
+          "sms_src_npi": "E164",
+          "sms_src_ton": "Unknown",
+          "subaccount_id": "101",
+          "subject": "Summer deals are here!",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138"
+        }
+      }
+    },
+    {
+      "msys": {
+        "message_event": {
+          "type": "spam_complaint",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "delv_method": "esmtp",
+          "event_id": "92356927693813856",
+          "fbtype": "abuse",
+          "friendly_from": "sender@example.com",
+          "ip_address": "127.0.0.1",
+          "ip_pool": "Example-Ip-Pool",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "msg_size": "1337",
+          "num_retries": "2",
+          "queue_time": "12",
+          "rcpt_meta": {
+            "hashId": "2"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "recipient@example.com",
+          "raw_rcpt_to": "recipient@example.com",
+          "rcpt_type": "to",
+          "report_by": "server.email.com",
+          "report_to": "abuse.example.com",
+          "routing_domain": "example.com",
+          "sending_ip": "127.0.0.1",
+          "subaccount_id": "101",
+          "subject": "Summer deals are here!",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138",
+          "user_str": "Additional Example Information"
+        }
+      }
+    },
+    {
+      "msys": {
+        "message_event": {
+          "type": "out_of_band",
+          "bounce_class": "1",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "delv_method": "esmtp",
+          "device_token": "45c19189783f867973f6e6a5cca60061ffe4fa77c547150563a1192fa9847f8a",
+          "error_code": "554",
+          "event_id": "92356927693813856",
+          "friendly_from": "sender@example.com",
+          "ip_address": "127.0.0.1",
+          "ip_pool": "Example-Ip-Pool",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "msg_size": "1337",
+          "num_retries": "2",
+          "queue_time": "12",
+          "raw_rcpt_to": "recipient@example.com",
+          "raw_reason": "MAIL REFUSED - IP (18.99.99.99) is in black list",
+          "rcpt_meta": {
+            "hashId": "3"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "recipient@example.com",
+          "reason": "MAIL REFUSED - IP (a.b.c.d) is in black list",
+          "routing_domain": "example.com",
+          "sending_ip": "127.0.0.1",
+          "subaccount_id": "101",
+          "subject": "Summer deals are here!",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138"
+        }
+      }
+    },
+    {
+      "msys": {
+        "message_event": {
+          "type": "policy_rejection",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "error_code": "554",
+          "event_id": "92356927693813856",
+          "friendly_from": "sender@example.com",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "rcpt_meta": {
+            "hashId": "4"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "recipient@example.com",
+          "raw_rcpt_to": "recipient@example.com",
+          "rcpt_type": "to",
+          "raw_reason": "MAIL REFUSED - IP (19.99.99.99) is in black list",
+          "reason": "MAIL REFUSED - IP (a.b.c.d) is in black list",
+          "remote_addr": "127.0.0.1",
+          "subaccount_id": "101",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138",
+          "bounce_class": "25"
+        }
+      }
+    },
+    {
+      "msys": {
+        "unsubscribe_event": {
+          "type": "list_unsubscribe",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "delv_method": "esmtp",
+          "event_id": "92356927693813856",
+          "friendly_from": "sender@example.com",
+          "ip_address": "127.0.0.1",
+          "ip_pool": "Example-Ip-Pool",
+          "mailfrom": "recipient@example.com",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "msg_size": "1337",
+          "num_retries": "2",
+          "queue_time": "12",
+          "rcpt_meta": {
+            "hashId": "5"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "recipient@example.com",
+          "raw_rcpt_to": "recipient@example.com",
+          "rcpt_type": "to",
+          "routing_domain": "example.com",
+          "sending_ip": "127.0.0.1",
+          "subaccount_id": "101",
+          "subject": "Summer deals are here!",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138"
+        }
+      }
+    },
+    {
+      "msys": {
+        "unsubscribe_event": {
+          "type": "link_unsubscribe",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "delv_method": "esmtp",
+          "event_id": "92356927693813856",
+          "friendly_from": "sender@example.com",
+          "ip_address": "127.0.0.1",
+          "ip_pool": "Example-Ip-Pool",
+          "mailfrom": "recipient@example.com",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "msg_size": "1337",
+          "num_retries": "2",
+          "queue_time": "12",
+          "rcpt_meta": {
+            "hashId": "6"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "recipient@example.com",
+          "raw_rcpt_to": "recipient@example.com",
+          "rcpt_type": "to",
+          "routing_domain": "example.com",
+          "sending_ip": "127.0.0.1",
+          "subaccount_id": "101",
+          "subject": "Summer deals are here!",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138",
+          "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36"
+        }
+      }
+    },
+    {
+      "msys": {
+        "message_event": {
+          "type": "bounce",
+          "bounce_class": "10",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "delv_method": "esmtp",
+          "device_token": "45c19189783f867973f6e6a5cca60061ffe4fa77c547150563a1192fa9847f8a",
+          "error_code": "554",
+          "event_id": "92356927693813856",
+          "friendly_from": "sender@example.com",
+          "ip_address": "127.0.0.1",
+          "ip_pool": "Example-Ip-Pool",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "msg_size": "1337",
+          "num_retries": "2",
+          "rcpt_meta": {
+            "hashId": "7"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "recipient@example.com",
+          "raw_rcpt_to": "recipient@example.com",
+          "rcpt_type": "cc",
+          "raw_reason": "MAIL REFUSED - IP (17.99.99.99) is in black list",
+          "reason": "MAIL REFUSED - IP (a.b.c.d) is in black list",
+          "routing_domain": "example.com",
+          "sending_ip": "127.0.0.1",
+          "sms_coding": "ASCII",
+          "sms_dst": "7876712656",
+          "sms_dst_npi": "E164",
+          "sms_dst_ton": "International",
+          "sms_src": "1234",
+          "sms_src_npi": "E164",
+          "sms_src_ton": "Unknown",
+          "subaccount_id": "101",
+          "subject": "Summer deals are here!",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138"
+        }
+      }
+    },
+    {
+      "msys": {
+        "message_event": {
+          "type": "bounce",
+          "bounce_class": "10",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "delv_method": "esmtp",
+          "device_token": "45c19189783f867973f6e6a5cca60061ffe4fa77c547150563a1192fa9847f8a",
+          "error_code": "554",
+          "event_id": "92356927693813856",
+          "friendly_from": "sender@example.com",
+          "ip_address": "127.0.0.1",
+          "ip_pool": "Example-Ip-Pool",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "msg_size": "1337",
+          "num_retries": "2",
+          "rcpt_meta": {
+            "customField": "customValue"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "recipient@example.com",
+          "raw_rcpt_to": "recipient@example.com",
+          "rcpt_type": "cc",
+          "raw_reason": "MAIL REFUSED - IP (17.99.99.99) is in black list",
+          "reason": "MAIL REFUSED - IP (a.b.c.d) is in black list",
+          "routing_domain": "example.com",
+          "sending_ip": "127.0.0.1",
+          "sms_coding": "ASCII",
+          "sms_dst": "7876712656",
+          "sms_dst_npi": "E164",
+          "sms_dst_ton": "International",
+          "sms_src": "1234",
+          "sms_src_npi": "E164",
+          "sms_src_ton": "Unknown",
+          "subaccount_id": "101",
+          "subject": "Summer deals are here!",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138"
+        }
+      }
+    },
+    {
+      "msys": {
+        "message_event": {
+          "type": "bounce",
+          "bounce_class": "10",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "delv_method": "esmtp",
+          "device_token": "45c19189783f867973f6e6a5cca60061ffe4fa77c547150563a1192fa9847f8a",
+          "error_code": "554",
+          "event_id": "92356927693813856",
+          "friendly_from": "sender@example.com",
+          "ip_address": "127.0.0.1",
+          "ip_pool": "Example-Ip-Pool",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "msg_size": "1337",
+          "num_retries": "2",
+          "rcpt_meta": {
+            "customField": "customValue"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "bounce@example.com",
+          "raw_rcpt_to": "recipient@example.com",
+          "rcpt_type": "to",
+          "raw_reason": "MAIL REFUSED - IP (17.99.99.99) is in black list",
+          "reason": "MAIL REFUSED - IP (a.b.c.d) is in black list",
+          "routing_domain": "example.com",
+          "sending_ip": "127.0.0.1",
+          "sms_coding": "ASCII",
+          "sms_dst": "7876712656",
+          "sms_dst_npi": "E164",
+          "sms_dst_ton": "International",
+          "sms_src": "1234",
+          "sms_src_npi": "E164",
+          "sms_src_ton": "Unknown",
+          "subaccount_id": "101",
+          "subject": "Summer deals are here!",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138"
+        }
+      }
+    }
+]
+JSON;
+
+        return new Request([], json_decode($json, true));
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | Y

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR refactors the transport callback process to get away from passing around an array. This also fixes Sparkpost to mark a DNC for an immediately rejected recipient since that will not be sent via a webhook. 

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Amazon, Mailjet, Mandrill, ElasticeMail and Sparkpost has been refactored to use this. Test their callbacks. 
2. Run the tests.

#### List deprecations along with the new alternative:
1. InterfaceCallbackTransport is deprecated in favor of CallbackTransportInterface
