### PR TITLE
DateModified is set when changing tweet text or name

### DIFF
--- a/plugins/MauticSocialBundle/Entity/Tweet.php
+++ b/plugins/MauticSocialBundle/Entity/Tweet.php
@@ -12,6 +12,7 @@
 namespace MauticPlugin\MauticSocialBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping as ORM;
 use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\AssetBundle\Entity\Asset;
@@ -137,7 +138,7 @@ class Tweet extends FormEntity
         $builder = new ClassMetadataBuilder($metadata);
 
         $builder->setTable('tweets')
-            ->setCustomRepositoryClass('MauticPlugin\MauticSocialBundle\Entity\TweetRepository')
+            ->setCustomRepositoryClass(TweetRepository::class)
             ->addIndex(['text'], 'tweet_text_index')
             ->addIndex(['sent_count'], 'sent_count_index')
             ->addIndex(['favorite_count'], 'favorite_count_index')
@@ -145,39 +146,13 @@ class Tweet extends FormEntity
 
         $builder->addIdColumns();
         $builder->addCategory();
-
-        $builder->createField('mediaId', 'string')
-            ->columnName('media_id')
-            ->nullable()
-            ->build();
-
-        $builder->createField('mediaPath', 'string')
-            ->columnName('media_path')
-            ->nullable()
-            ->build();
-
-        $builder->createField('text', 'string')
-            ->build();
-
-        $builder->createField('sentCount', 'integer')
-            ->columnName('sent_count')
-            ->nullable()
-            ->build();
-
-        $builder->createField('favoriteCount', 'integer')
-            ->columnName('favorite_count')
-            ->nullable()
-            ->build();
-
-        $builder->createField('retweetCount', 'integer')
-            ->columnName('retweet_count')
-            ->nullable()
-            ->build();
-
-        $builder->createField('language', 'string')
-            ->columnName('lang')
-            ->nullable()
-            ->build();
+        $builder->addNullableField('mediaId', Type::STRING, 'media_id');
+        $builder->addNullableField('mediaPath', Type::STRING, 'media_path');
+        $builder->addField('text', Type::STRING);
+        $builder->addNullableField('sentCount', Type::INTEGER, 'sent_count');
+        $builder->addNullableField('favoriteCount', Type::INTEGER, 'favorite_count');
+        $builder->addNullableField('retweetCount', Type::INTEGER, 'retweet_count');
+        $builder->addNullableField('language', Type::STRING, 'lang');
 
         $builder->createManyToOne('page', Page::class)
             ->addJoinColumn('page_id', 'id', true, false, 'SET NULL')
@@ -260,6 +235,7 @@ class Tweet extends FormEntity
      */
     public function setName($name)
     {
+        $this->isChanged('name', $name);
         $this->name = $name;
 
         return $this;
@@ -280,6 +256,7 @@ class Tweet extends FormEntity
      */
     public function setDescription($description)
     {
+        $this->isChanged('description', $description);
         $this->description = $description;
 
         return $this;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N - it was matter of entity configuration
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
I noticed that if I change name of a tweet, the `dateModified` column value will stay `NULL`. I found out that the problem was that the `name` and `text` setters didn't call the `isChanged` method and the save method then thought that no changes were made to the entity and the `dateModified` doesn't need to be set.

I slightly refactored some code while I was editing the `Tweet` entity. Mostly syntax stuff.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to a tweet edit form.
2. Change its name.
3. Look into the `tweets` DB table that the `dateModified` value for that tweet is still `NULL`.

#### Steps to test this PR:
1. Repeat the steps above.
2. `dateModified` will be set.