### PR TITLE
Set PHPSTAN to 0.8.5 since 0.9 is failing on *.html.php files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - export SYMFONY_ENV="test"
 
   # install PHPSTAN for PHP 7+
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.6" ]]; then composer global require phpstan/phpstan-shim; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.6" ]]; then composer global require phpstan/phpstan-shim:0.8.5; fi
 
 install:
   - composer install


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
PHPSTAN released new version 0.9 which [is failing](https://travis-ci.org/mautic/mautic/jobs/309014471#L670) on our *.html.php files even on level 0. This PR requires the last vestion that worked.

#### Steps to test this PR:
1. See if Travis is failing or passing
