### PR TITLE
Prevent creating duplicate contacts in the contacts/batch/new

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -22,6 +22,7 @@ use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
 /**
@@ -54,14 +55,70 @@ class LeadApiController extends CommonApiController
      */
     public function newEntityAction()
     {
-        $existingLeads = $this->getExistingLeads();
-        if (!empty($existingLeads)) {
+        if ($existingLead = $this->getExistingLead($this->request->request->all())) {
             $this->request->setMethod('PATCH');
 
-            return parent::editEntityAction($existingLeads[0]->getId());
+            return parent::editEntityAction($existingLead->getId());
         }
 
         return parent::newEntityAction();
+    }
+
+    /**
+     * @return array|\Symfony\Component\HttpFoundation\Response
+     */
+    public function newEntitiesAction()
+    {
+        $entity = $this->model->getEntity();
+
+        if (!$this->checkEntityAccess($entity, 'create')) {
+            return $this->accessDenied();
+        }
+
+        $parameters = $this->request->request->all();
+
+        $valid = $this->validateBatchPayload($parameters);
+        if ($valid instanceof Response) {
+            return $valid;
+        }
+
+        $this->inBatchMode = true;
+        $entities          = [];
+        $errors            = [];
+        $statusCodes       = [];
+        foreach ($parameters as $key => $params) {
+            $method     = 'POST';
+            $entity     = $this->getNewEntity($params);
+            $statusCode = Codes::HTTP_CREATED;
+
+            if ($existingLead = $this->getExistingLead($params)) {
+                $method     = 'PATCH';
+                $entity     = $existingLead;
+                $statusCode = Codes::HTTP_OK;
+            }
+
+            $this->processBatchForm($key, $entity, $params, $method, $errors, $entities);
+
+            if (isset($errors[$key])) {
+                $statusCodes[$key] = $errors[$key]['code'];
+            } else {
+                $statusCodes[$key] = $statusCode;
+            }
+        }
+
+        $payload = [
+            $this->entityNameMulti => $entities,
+            'statusCodes'          => $statusCodes,
+        ];
+
+        if (!empty($errors)) {
+            $payload['errors'] = $errors;
+        }
+
+        $view = $this->view($payload, Codes::HTTP_CREATED);
+        $this->setSerializationContext($view);
+
+        return $this->handleView($view);
     }
 
     /**
@@ -69,26 +126,25 @@ class LeadApiController extends CommonApiController
      */
     public function editEntityAction($id)
     {
-        $existingLeads = $this->getExistingLeads();
-        if (isset($existingLeads[0]) && $existingLeads[0] instanceof Lead) {
+        if ($existingLead = $this->getExistingLead($this->request->request->all(), $id)) {
             $entity = $this->model->getEntity($id);
-            if ($entity instanceof Lead && $existingLeads[0]->getId() != $entity->getId()) {
-                $this->model->mergeLeads($existingLeads[0], $entity, false);
-            }
+            $this->model->mergeLeads($existingLead, $entity, false);
         }
 
         return parent::editEntityAction($id);
     }
 
     /**
-     * Get existing duplicated contacts based on unique fields and the request data.
+     * Get existing duplicated contact based on unique fields and the request data.
      *
-     * @return array
+     * @param array $parameters
+     * @param null  $id
+     *
+     * @return null|Lead
      */
-    protected function getExistingLeads()
+    protected function getExistingLead(array $parameters, $id = null)
     {
-        // Check for an email to see if the lead already exists
-        $parameters          = $this->request->request->all();
+        // Check to see if contacts exist based on unique identifiers
         $uniqueLeadFields    = $this->getModel('lead.field')->getUniqueIdentiferFields();
         $uniqueLeadFieldData = [];
 
@@ -99,12 +155,14 @@ class LeadApiController extends CommonApiController
         }
 
         if (count($uniqueLeadFieldData)) {
-            return $this->get('doctrine.orm.entity_manager')->getRepository(
+            $leads = $this->get('doctrine.orm.entity_manager')->getRepository(
                 'MauticLeadBundle:Lead'
-            )->getLeadsByUniqueFields($uniqueLeadFieldData, null, 1);
+            )->getLeadsByUniqueFields($uniqueLeadFieldData, $id, 1);
+
+            return ($leads) ? $leads[0] : null;
         }
 
-        return [];
+        return null;
     }
 
     /**

--- a/app/bundles/PluginBundle/Helper/IntegrationHelper.php
+++ b/app/bundles/PluginBundle/Helper/IntegrationHelper.php
@@ -668,7 +668,7 @@ class IntegrationHelper
                         }
                     }
                 }
-            } elseif ($identifierField == $f || strpos($f, $identifierField) !== false) {
+            } elseif ($identifierField === $f || strpos($f, $identifierField) !== false) {
                 $matchFound = true;
                 $identifier = (is_array($fields[$f])) ? $fields[$f]['value'] : $fields[$f];
             }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The api/contact/new endpoint will update a contact if a unique identifier field matched instead of creating a new. But the batch endpoint created all new contacts regardless. This PR makes the batch endpoint act the same as the single contact endpoint.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Post the following payload to api/contacts/batch/new
```
[
  {
    "email": "email1@email.com",
    "firstname": "BatchUpdate"
  },
  {
    "email": "email2@email.com",
    "firstname": "BatchUpdate2"
  },
  {
    "email": "email3@email.com",
    "firstname": "BatchUpdate3"
  }
]
```
2. Post it again and notice that the three contacts will be created again. 

#### Steps to test this PR:
1. Delete the contacts then repeat. This time the second post will update the contacts instead of creating new. 