### PR TITLE
Fix SMS Do Not Contact

### DIFF
--- a/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
+++ b/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
@@ -162,7 +162,7 @@ class DoNotContactRepository extends CommonRepository
         if (null === $channel) {
             $q->select('dnc.channel, dnc.reason, l.id as lead_id');
         } else {
-            $q->select('l.id')
+            $q->select('l.id, dnc.reason')
               ->where('dnc.channel = :channel')
               ->setParameter('channel', $channel);
         }
@@ -184,7 +184,7 @@ class DoNotContactRepository extends CommonRepository
 
                 $dnc[$r['lead_id']][$r['channel']] = $r['reason'];
             } else {
-                $dnc[] = $r['id'];
+                $dnc[$r['id']] = $r['reason'];
             }
         }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  #3721 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fixes the "Do Not Contact" (DNC) setting on the 'sms' channel, which was not being honored when a text message was sent. In other words, contacts were still getting text messages when they were set to "Do Not Contact" for 'sms'

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Have a contact with "Do Not Contact" set for the 'sms' channel.
2. Send a text message via a campaign.
3. The contact receives the text message when they should not have.

#### Steps to test this PR:
1. Have at least two contacts with mobile numbers
2. Set one contact to "Do Not Contact" for SMS
3. Send a text message via a campaign.
4. Contacts set to "Do Not Contact" should not get text msg while all others should.