### PR TITLE
Bug api entities order

### DIFF
--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -405,6 +405,10 @@ class CommonApiController extends FOSRestController implements MauticController
             $args['filter']['where'] = $where;
         }
 
+        if ($order = $this->getOrderFromRequest()) {
+            $args['filter']['order'] = $order;
+        }
+
         $results = $this->model->getEntities($args);
 
         list($entities, $totalCount) = $this->prepareEntitiesForView($results);
@@ -433,6 +437,16 @@ class CommonApiController extends FOSRestController implements MauticController
         $this->sanitizeWhereClauseArrayFromRequest($where);
 
         return $where;
+    }
+
+    /**
+     * Sanitizes and returns an array of ORDER statements from the request.
+     *
+     * @return array
+     */
+    protected function getOrderFromRequest()
+    {
+        return InputHelper::cleanArray($this->request->get('order', []));
     }
 
     /**

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -866,7 +866,7 @@ class CommonRepository extends EntityRepository
         }
 
         $clause['dir'] = $this->sanitize(strtoupper($clause['dir']));
-        $clause['col'] = $this->sanitize($clause['col'], ['_']);
+        $clause['col'] = $this->sanitize($clause['col'], ['_.']);
 
         return $clause;
     }
@@ -1188,7 +1188,7 @@ class CommonRepository extends EntityRepository
      *
      * @return bool
      */
-    protected function buildClauses(&$q, array $args)
+    protected function buildClauses($q, array $args)
     {
         $this->buildSelectClause($q, $args);
         $this->buildIndexByClause($q, $args);
@@ -1311,20 +1311,22 @@ class CommonRepository extends EntityRepository
      * @param \Doctrine\ORM\QueryBuilder $q
      * @param array                      $args
      */
-    protected function buildOrderByClause(&$q, array $args)
+    protected function buildOrderByClause($q, array $args)
     {
-        $orderBy    = array_key_exists('orderBy', $args) ? $args['orderBy'] : '';
-        $orderByDir = $this->sanitize(
-            array_key_exists('orderByDir', $args) ? $args['orderByDir'] : ''
-        );
+        $orderBy = array_key_exists('orderBy', $args) ? $args['orderBy'] : '';
 
-        if (empty($orderBy)) {
+        if (!empty($args['filter']['order'])) {
+            $this->buildOrderByClauseFromArray($q, $args['filter']['order']);
+        } elseif (empty($orderBy)) {
             $defaultOrder = $this->getDefaultOrder();
 
             foreach ($defaultOrder as $order) {
                 $q->addOrderBy($order[0], $order[1]);
             }
         } else {
+            $orderByDir = $this->sanitize(
+                array_key_exists('orderByDir', $args) ? $args['orderByDir'] : ''
+            );
             //add direction after each column
             $parts = explode(',', $orderBy);
             foreach ($parts as $order) {
@@ -1433,7 +1435,7 @@ class CommonRepository extends EntityRepository
      * @param \Doctrine\ORM\QueryBuilder $q
      * @param array                      $args
      */
-    protected function buildWhereClause(&$q, array $args)
+    protected function buildWhereClause($q, array $args)
     {
         $filter                    = array_key_exists('filter', $args) ? $args['filter'] : '';
         $filterHelper              = new SearchStringHelper();

--- a/app/bundles/CoreBundle/Tests/unit/Entity/CommonRepositoryTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Entity/CommonRepositoryTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Tests\Entity;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\QueryBuilder;
+use Mautic\CoreBundle\Entity\CommonRepository;
+
+class CommonRepositoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CommonRepository
+     */
+    private $repo;
+
+    /**
+     * @var QueryBuilder
+     */
+    private $qb;
+
+    /**
+     * Sets up objects used in the tests.
+     */
+    protected function setUp()
+    {
+        $emMock = $this->getMockBuilder(EntityManager::class)
+            ->setMethods(['none'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $metaMock = $this->getMockBuilder(ClassMetadata::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->repo = new CommonRepository($emMock, $metaMock);
+        $this->qb   = new QueryBuilder($emMock);
+    }
+
+    /**
+     * @testdox Check that the query is being build without providing any order statements
+     *
+     * @covers  \Mautic\CoreBundle\Entity\CommonRepository::buildClauses
+     * @covers  \Mautic\CoreBundle\Entity\CommonRepository::buildOrderByClause
+     */
+    public function testBuildingQueryWithUndefinedOrder()
+    {
+        $this->callProtectedMethod('buildClauses', [$this->qb, []]);
+        $this->assertSame('SELECT e', (string) $this->qb);
+    }
+
+    /**
+     * @testdox Check that providing orderBy and orderByDir builds the query correctly
+     *
+     * @covers  \Mautic\CoreBundle\Entity\CommonRepository::buildClauses
+     * @covers  \Mautic\CoreBundle\Entity\CommonRepository::buildOrderByClause
+     */
+    public function testBuildingQueryWithBasicOrder()
+    {
+        $args = [
+            'orderBy'    => 'e.someCol',
+            'orderByDir' => 'DESC',
+        ];
+        $this->callProtectedMethod('buildClauses', [$this->qb, $args]);
+        $this->assertSame('SELECT e ORDER BY e.someCol DESC', (string) $this->qb);
+    }
+
+    /**
+     * @testdox Check that array of ORDER statements is correct
+     *
+     * @covers  \Mautic\CoreBundle\Entity\CommonRepository::buildClauses
+     * @covers  \Mautic\CoreBundle\Entity\CommonRepository::buildOrderByClause
+     * @covers  \Mautic\CoreBundle\Entity\CommonRepository::buildOrderByClauseFromArray
+     */
+    public function testBuildingQueryWithOrderArray()
+    {
+        $args = [
+            'filter' => [
+                'order' => [
+                    [
+                        'col' => 'e.someCol',
+                        'dir' => 'DESC',
+                    ],
+                ],
+            ],
+        ];
+        $this->callProtectedMethod('buildClauses', [$this->qb, $args]);
+        $this->assertSame('SELECT e ORDER BY e.someCol DESC', (string) $this->qb);
+    }
+
+    /**
+     * @testdox Check that order by validation will allow dots in the column name
+     *
+     * @covers  \Mautic\CoreBundle\Entity\CommonRepository::validateOrderByClause
+     */
+    public function testValidateOrderByClauseWithColContainingAliasWillNotRemoveTheDot()
+    {
+        $provided = [
+            'col' => 'e.someCol',
+            'dir' => 'DESC',
+        ];
+
+        $expected = [
+            'col' => 'e.someCol',
+            'dir' => 'DESC',
+        ];
+
+        $result = $this->callProtectedMethod('validateOrderByClause', [$provided]);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @testdox Check that order validation will remove funky characters that can be used in an attack
+     *
+     * @covers  \Mautic\CoreBundle\Entity\CommonRepository::validateOrderByClause
+     */
+    public function testValidateOrderByClauseWillRemoveFunkyChars()
+    {
+        $provided = [
+            'col' => '" DELETE * FROM users',
+        ];
+
+        $expected = [
+            'col' => 'DELETEFROMusers',
+            'dir' => 'ASC',
+        ];
+
+        $result = $this->callProtectedMethod('validateOrderByClause', [$provided]);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @testdox Check that order validation will throw an exception if column name is missing
+     *
+     * @covers  \Mautic\CoreBundle\Entity\CommonRepository::validateOrderByClause
+     */
+    public function testValidateOrderByClauseWithMissingCol()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->callProtectedMethod('validateOrderByClause', [[]]);
+    }
+
+    /**
+     * Calls a protected method from CommonRepository with provided argumetns.
+     *
+     * @param string $method name
+     * @param array  $args   added to the method
+     *
+     * @return mixed result of the method
+     */
+    private function callProtectedMethod($method, $args)
+    {
+        $reflection = new \ReflectionClass(CommonRepository::class);
+        $method     = $reflection->getMethod($method);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($this->repo, $args);
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Mautic API Library has a QueryBuilder which generates order queries as array like this:
```
[
    [
        'col' => 'someCol',
        'dir' => 'DESC',
    ]
]
```
This array will be URL encoded and sen as a GET query param. The problem is that Mautic didn't have handling of such ordering definition implemented for getEntities methods.

This PR also fix a small issue where the `validateOrderByClause` removed dots from the column names. So `e.dateModified` would be changed to `edateModified` and then the `buildOrderByClauseFromArray` would add it again because it's missing the dot and so the column name would become `e.edateModified` instead of `e.dateModified`. I don't know if this caused some real world bug, but it was causing new unit tests to fail.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to get a list of entities via API. For example segments.
2. Order them with GET query params `order[0][col]=dateModified&order[0][dir]=DESC`

You should get a list of segments with random order.

#### Steps to test this PR:
1. Checkout this PR.
2. Test again. You should get list of your segments ordered by dateModified in descendent direction.