### PR TITLE
Changed pending email query structure to improve speed

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -205,7 +205,7 @@ class EmailRepository extends CommonRepository
 
         // Do not include leads that have already been emailed
         $statQb = $this->getEntityManager()->getConnection()->createQueryBuilder()
-            ->select('null')
+            ->select('stat.lead_id')
             ->from(MAUTIC_TABLE_PREFIX.'email_stats', 'stat');
 
         if ($variantIds) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | #2449 #3826 #3358
| BC breaks? | N
| Deprecations? | N

#### Description:
This fixes a performance bottleneck when loading the Channels -> Emails page with a large number of contacts in Mautic.  The old code uses an inefficient NOT EXISTS query, and the new code uses a more efficient NOT IN query.

See an analysis of the different types of queries in MySQL [here](https://explainextended.com/2009/09/18/not-in-vs-not-exists-vs-left-join-is-null-mysql/)

To summarise, the query is going from the form:

```
SELECT  l.*
FROM    t_left l
WHERE   NOT EXISTS
        (
        SELECT  NULL
        FROM    t_right r
        WHERE   r.value = l.value
        )
```
to
```
SELECT  l.*
FROM    t_left l
WHERE   l.value NOT IN
        (
        SELECT  value
        FROM    t_right r
        )
```

It should be noted that the NOT EXISTS and NOT IN queries are slightly different in how they handle NULL values.  However, this is irrelevant in our scenario, as the `lead_list_leads.lead_id` field to which we are comparing the subqueries IDs are set to NOT NULL, so the results will always be equivalent.

Tests with 500,000 contacts show a 200x speed improvement for this query, from 200.5s down to 1.04s.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Import 500,000+ customer emails
2. Add at least one email and assign it to a segment with the 500,000+ customer emails
3. Visit Channels -> Emails
4. Experience loading times of 10+ minutes

#### Steps to test this PR:
1. Import 500,000+ customer emails
2. Add at least one email and assign it to a segment with the 500,000+ customer emails
3. Visit Channels -> Emails
4. Experience loading times of < 10 seconds