### PR TITLE
Support csv files with Mac legacy line endings (\r) in background imports

### DIFF
--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -294,6 +294,9 @@ class ImportModel extends FormModel
      */
     public function process(Import $import, Progress $progress, $limit = 0)
     {
+        //Auto detect line endings for the file to work around MS DOS vs Unix new line characters
+        ini_set('auto_detect_line_endings', true);
+
         try {
             $file = new \SplFileObject($import->getFilePath());
         } catch (\Exception $e) {

--- a/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
@@ -357,4 +357,22 @@ class ImportModelTest extends StandardImportTestHelper
 
         $import->end();
     }
+
+    public function testMacLineEndings()
+    {
+        $oldCsv = self::$csvPath;
+
+        // Generate a new CSV
+        self::generateSmallCSV();
+
+        $csv = file_get_contents(self::$csvPath);
+        $csv = str_replace("\n", "\r", $csv);
+        file_put_contents(self::$csvPath, $csv);
+
+        $this->testProcess();
+
+        @unlink(self::$csvPath);
+
+        self::$csvPath = $oldCsv;
+    }
 }

--- a/app/bundles/LeadBundle/Tests/StandardImportTestHelper.php
+++ b/app/bundles/LeadBundle/Tests/StandardImportTestHelper.php
@@ -41,6 +41,25 @@ abstract class StandardImportTestHelper extends CommonMocks
     {
         parent::setUpBeforeClass();
 
+        static::generateSmallCSV();
+        static::generateLargeCSV();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        if (file_exists(self::$csvPath)) {
+            unlink(self::$csvPath);
+        }
+
+        if (file_exists(self::$largeCsvPath)) {
+            unlink(self::$largeCsvPath);
+        }
+
+        parent::tearDownAfterClass();
+    }
+
+    public static function generateSmallCSV()
+    {
         $tmpFile = tempnam(sys_get_temp_dir(), 'mautic_import_test_');
         $file    = fopen($tmpFile, 'w');
 
@@ -50,7 +69,10 @@ abstract class StandardImportTestHelper extends CommonMocks
 
         fclose($file);
         self::$csvPath = $tmpFile;
+    }
 
+    public static function generateLargeCSV()
+    {
         $tmpFile = tempnam(sys_get_temp_dir(), 'mautic_import_large_test_');
         $file    = fopen($tmpFile, 'w');
         fputcsv($file, ['email', 'firstname', 'lastname']);
@@ -63,15 +85,6 @@ abstract class StandardImportTestHelper extends CommonMocks
 
         fclose($file);
         self::$largeCsvPath = $tmpFile;
-    }
-
-    public static function tearDownAfterClass()
-    {
-        if (file_exists(self::$csvPath)) {
-            unlink(self::$csvPath);
-        }
-
-        parent::tearDownAfterClass();
     }
 
     public function setup()


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? | y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

CSV files that used `\r` instead of `\n` would fail to import due to the entire file being interpreted as one row and thus the header. This fixes that by auto detecting line endings when consuming the CSV file. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Import this test file and it will fail (rename txt to csv)

[line_endings_test.txt](https://github.com/mautic/mautic/files/1522260/line_endings_test.txt)


#### Steps to test this PR:
1. Repeat and it'll import
