### PR TITLE
Fix for #5403 problem with DNC email graphs

### DIFF
--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -547,8 +547,15 @@ class ReportSubscriber extends CommonSubscriber
                         ->having(
                             'count(CASE WHEN dnc.id and dnc.reason = '.DoNotContact::UNSUBSCRIBED.' THEN 1 ELSE null END) > 0'
                         )
+                        ->leftJoin(
+                            'e',
+                            MAUTIC_TABLE_PREFIX.'lead_donotcontact',
+                            'dnc',
+                            'e.id = dnc.channel_id AND dnc.channel=\'email\' AND es.lead_id = dnc.lead_id'
+                        )
                         ->groupBy('e.id, e.subject')
                         ->orderBy('unsubscribed', 'DESC');
+
                     $limit                  = 10;
                     $offset                 = 0;
                     $items                  = $statRepo->getMostEmails($queryBuilder, $limit, $offset);
@@ -566,6 +573,12 @@ class ReportSubscriber extends CommonSubscriber
                     )
                         ->having(
                             'count(CASE WHEN dnc.id and dnc.reason = '.DoNotContact::BOUNCED.' THEN 1 ELSE null END) > 0'
+                        )
+                        ->leftJoin(
+                            'e',
+                            MAUTIC_TABLE_PREFIX.'lead_donotcontact',
+                            'dnc',
+                            'e.id = dnc.channel_id AND dnc.channel=\'email\' AND es.lead_id = dnc.lead_id'
                         )
                         ->groupBy('e.id, e.subject')
                         ->orderBy('bounced', 'DESC');


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
This fixes #5403 problem with reports including graphs that request information from the Do Not Contact table. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Report --> new
2. Details: emails sent in Data Source
3. Graph: Select "Most Emails bounced(Table)" or "Most Emails unsuscribed(Table)"
4. Save and Close --> 500

#### Steps to test this PR:
1. Apply the PR
2. Repeat steps above.