### PR TITLE
fix relative year segment filter

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -868,7 +868,7 @@ class LeadListRepository extends CommonRepository
                         case 'year_next':
                         case 'year_this':
                             $interval = substr($key, -4);
-                            $dtHelper->setDateTime('midnight first day of '.$interval.' year', null);
+                            $dtHelper->setDateTime('midnight first day of January '.$interval.' year', null);
 
                             // This year: 2015-01-01 00:00:00
                             if ($requiresBetween) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? |N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fix segment filter with "last year", "next year" and "this year" value

#### Steps to reproduce the bug:
1. Create on custom field with date format
2. Create 2 contacts, one with date in 2015-02-01, second with date 2017-02-01
3. Create one segment, with critea "greater than last year"
4. Update segment --> no contact

#### Steps to test this PR:
1. Apply this PR
2. update segment --> one contact

More details on this bug : https://stackoverflow.com/questions/25906836/how-to-get-the-first-day-of-the-current-year