### PR TITLE
Fixes #5227 Rearranged call to fixValueType

### DIFF
--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -310,7 +310,7 @@ trait CustomFieldRepositoryTrait
         foreach ($values as $k => $r) {
             if (isset($fields[$k])) {
                 $r = CustomFieldHelper::fixValueType($fields[$k]['type'], $r);
-                
+
                 if (!is_null($r)) {
                     switch ($fields[$k]['type']) {
                         case 'number':

--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -308,9 +308,9 @@ trait CustomFieldRepositoryTrait
 
         //loop over results to put fields in something that can be assigned to the entities
         foreach ($values as $k => $r) {
-            $r = CustomFieldHelper::fixValueType($fields[$k]['type'], $r);
-
             if (isset($fields[$k])) {
+                $r = CustomFieldHelper::fixValueType($fields[$k]['type'], $r);
+                
                 if (!is_null($r)) {
                     switch ($fields[$k]['type']) {
                         case 'number':


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fixes an issue with unnecessary notices being logged based on missing indexes. See Issue #5227 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Unpublish a custom field (like fax or foursquare)
2. Import a csv file without the unpublished custom fields

#### Steps to test this PR:
1. Apply PR
2. Check logs (undefined index notices should not be added)