### PR TITLE
Mautic #5321 - Captivea #13778 - Resolve permission issues about dynamicContent

### DIFF
--- a/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
+++ b/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
@@ -42,7 +42,8 @@ class BuilderTokenHelper
     {
         $this->factory            = $factory;
         $this->modelName          = $modelName;
-        $this->viewPermissionBase = (!empty($viewPermissionBase)) ? $viewPermissionBase : "$modelName:{$modelName}s";
+        $lowerModelName           = strtolower($modelName);
+        $this->viewPermissionBase = (!empty($viewPermissionBase)) ? $viewPermissionBase : "$modelName:{$lowerModelName}s";
         $this->bundleName         = (!empty($bundleName)) ? $bundleName : 'Mautic'.ucfirst($modelName).'Bundle';
         $this->langVar            = (!empty($langVar)) ? $langVar : $modelName;
 

--- a/app/bundles/DynamicContentBundle/Config/config.php
+++ b/app/bundles/DynamicContentBundle/Config/config.php
@@ -15,7 +15,7 @@ return [
             'items' => [
                 'mautic.dynamicContent.dynamicContent' => [
                     'route'    => 'mautic_dynamicContent_index',
-                    'access'   => ['dynamiccontent:dynamiccontents:viewown', 'dynamiccontent:dynamiccontents:viewother'],
+                    'access'   => ['dynamicContent:dynamiccontents:viewown', 'dynamicContent:dynamiccontents:viewother'],
                     'parent'   => 'mautic.core.components',
                     'priority' => 90,
                 ],
@@ -46,7 +46,7 @@ return [
         'api' => [
             'mautic_api_dynamicContent_standard' => [
                 'standard_entity' => true,
-                'name'            => 'dynamicContents',
+                'name'            => 'dynamiccontents',
                 'path'            => '/dynamiccontents',
                 'controller'      => 'MauticDynamicContentBundle:Api\DynamicContentApi',
             ],
@@ -138,6 +138,7 @@ return [
             'mautic.dynamicContent.model.dynamicContent' => [
                 'class'     => 'Mautic\DynamicContentBundle\Model\DynamicContentModel',
                 'arguments' => [
+
                 ],
             ],
         ],

--- a/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
+++ b/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
@@ -25,15 +25,15 @@ class DynamicContentController extends FormController
     {
         return (array) $this->get('mautic.security')->isGranted(
             [
-                'dynamiccontent:dynamiccontents:viewown',
-                'dynamiccontent:dynamiccontents:viewother',
-                'dynamiccontent:dynamiccontents:create',
-                'dynamiccontent:dynamiccontents:editown',
-                'dynamiccontent:dynamiccontents:editother',
-                'dynamiccontent:dynamiccontents:deleteown',
-                'dynamiccontent:dynamiccontents:deleteother',
-                'dynamiccontent:dynamiccontents:publishown',
-                'dynamiccontent:dynamiccontents:publishother',
+                'dynamicContent:dynamiccontents:viewown',
+                'dynamicContent:dynamiccontents:viewother',
+                'dynamicContent:dynamiccontents:create',
+                'dynamicContent:dynamiccontents:editown',
+                'dynamicContent:dynamiccontents:editother',
+                'dynamicContent:dynamiccontents:deleteown',
+                'dynamicContent:dynamiccontents:deleteother',
+                'dynamicContent:dynamiccontents:publishown',
+                'dynamicContent:dynamiccontents:publishother',
             ],
             'RETURN_ARRAY'
         );
@@ -48,7 +48,7 @@ class DynamicContentController extends FormController
 
         $permissions = $this->getPermissions();
 
-        if (!$permissions['dynamiccontent:dynamiccontents:viewown'] && !$permissions['dynamiccontent:dynamiccontents:viewother']) {
+        if (!$permissions['dynamicContent:dynamiccontents:viewown'] && !$permissions['dynamicContent:dynamiccontents:viewother']) {
             return $this->accessDenied();
         }
 
@@ -123,7 +123,7 @@ class DynamicContentController extends FormController
      */
     public function newAction($entity = null)
     {
-        if (!$this->accessGranted('dynamiccontent:dynamiccontents:viewown')) {
+        if (!$this->accessGranted('dynamicContent:dynamiccontents:viewown')) {
             return $this->accessDenied();
         }
 
@@ -270,7 +270,7 @@ class DynamicContentController extends FormController
                     ]
                 )
             );
-        } elseif (!$this->get('mautic.security')->hasEntityAccess(true, 'dynamiccontent:dynamiccontents:editother', $entity->getCreatedBy())) {
+        } elseif (!$this->get('mautic.security')->hasEntityAccess(true, 'dynamicContent:dynamiccontents:editother', $entity->getCreatedBy())) {
             return $this->accessDenied();
         } elseif ($model->isLocked($entity)) {
             //deny access if the entity is locked
@@ -378,8 +378,8 @@ class DynamicContentController extends FormController
                 ]
             );
         } elseif (!$security->hasEntityAccess(
-            'dynamiccontent:dynamiccontents:viewown',
-            'dynamiccontent:dynamiccontents:viewother',
+            'dynamicContent:dynamiccontents:viewown',
+            'dynamicContent:dynamiccontents:viewother',
             $entity->getCreatedBy()
         )
         ) {
@@ -445,10 +445,10 @@ class DynamicContentController extends FormController
         $entity = $model->getEntity($objectId);
 
         if ($entity != null) {
-            if (!$this->get('mautic.security')->isGranted('dynamiccontent:dynamiccontents:create')
+            if (!$this->get('mautic.security')->isGranted('dynamicContent:dynamiccontents:create')
                 || !$this->get('mautic.security')->hasEntityAccess(
-                    'dynamiccontent:dynamiccontents:viewown',
-                    'dynamiccontent:dynamiccontents:viewother',
+                    'dynamicContent:dynamiccontents:viewown',
+                    'dynamicContent:dynamiccontents:viewother',
                     $entity->getCreatedBy()
                 )
             ) {

--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -39,7 +39,7 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface
      */
     public function getPermissionBase()
     {
-        return 'dynamiccontent:dynamiccontents';
+        return 'dynamicContent:dynamiccontents';
     }
 
     /**

--- a/app/bundles/DynamicContentBundle/Security/Permissions/DynamicContentPermissions.php
+++ b/app/bundles/DynamicContentBundle/Security/Permissions/DynamicContentPermissions.php
@@ -37,7 +37,7 @@ class DynamicContentPermissions extends AbstractPermissions
      */
     public function getName()
     {
-        return 'dynamiccontent';
+        return 'dynamicContent';
     }
 
     /**
@@ -48,7 +48,7 @@ class DynamicContentPermissions extends AbstractPermissions
      */
     public function buildForm(FormBuilderInterface &$builder, array $options, array $data)
     {
-        $this->addStandardFormFields('dynamiccontent', 'categories', $builder, $data);
-        $this->addExtendedFormFields('dynamiccontent', 'dynamiccontents', $builder, $data);
+        $this->addStandardFormFields('dynamicContent', 'categories', $builder, $data);
+        $this->addExtendedFormFields('dynamicContent', 'dynamiccontents', $builder, $data);
     }
 }

--- a/app/bundles/DynamicContentBundle/Views/DynamicContent/details.html.php
+++ b/app/bundles/DynamicContentBundle/Views/DynamicContent/details.html.php
@@ -38,19 +38,19 @@ if (!$isEmbedded) {
                 'customButtons'   => (isset($customButtons)) ? $customButtons : [],
                 'templateButtons' => [
                     'edit' => $view['security']->hasEntityAccess(
-                        $permissions['dynamiccontent:dynamiccontents:editown'],
-                        $permissions['dynamiccontent:dynamiccontents:editother'],
+                        $permissions['dynamicContent:dynamiccontents:editown'],
+                        $permissions['dynamicContent:dynamiccontents:editother'],
                         $entity->getCreatedBy()
                     ),
-                    'clone'  => $permissions['dynamiccontent:dynamiccontents:create'],
+                    'clone'  => $permissions['dynamicContent:dynamiccontents:create'],
                     'delete' => $view['security']->hasEntityAccess(
-                        $permissions['dynamiccontent:dynamiccontents:deleteown'],
-                        $permissions['dynamiccontent:dynamiccontents:deleteother'],
+                        $permissions['dynamicContent:dynamiccontents:deleteown'],
+                        $permissions['dynamicContent:dynamiccontents:deleteother'],
                         $entity->getCreatedBy()
                     ),
                     'close' => $view['security']->hasEntityAccess(
-                        $permissions['dynamiccontent:dynamiccontents:viewown'],
-                        $permissions['dynamiccontent:dynamiccontents:viewother'],
+                        $permissions['dynamicContent:dynamiccontents:viewown'],
+                        $permissions['dynamicContent:dynamiccontents:viewother'],
                         $entity->getCreatedBy()
                     ),
                 ],

--- a/app/bundles/DynamicContentBundle/Views/DynamicContent/index.html.php
+++ b/app/bundles/DynamicContentBundle/Views/DynamicContent/index.html.php
@@ -19,7 +19,7 @@ $view['slots']->set(
         'MauticCoreBundle:Helper:page_actions.html.php',
         [
             'templateButtons' => [
-                'new' => $permissions['dynamiccontent:dynamiccontents:create'],
+                'new' => $permissions['dynamicContent:dynamiccontents:create'],
             ],
             'routeBase' => 'dynamicContent',
         ]

--- a/app/bundles/DynamicContentBundle/Views/DynamicContent/list.html.php
+++ b/app/bundles/DynamicContentBundle/Views/DynamicContent/list.html.php
@@ -27,8 +27,8 @@ if ($tmpl == 'index') {
                         'target'          => '#dwcTable',
                         'routeBase'       => 'dynamicContent',
                         'templateButtons' => [
-                            'delete' => $permissions['dynamiccontent:dynamiccontents:deleteown']
-                                || $permissions['dynamiccontent:dynamiccontents:deleteother'],
+                            'delete' => $permissions['dynamicContent:dynamiccontents:deleteown']
+                                || $permissions['dynamicContent:dynamiccontents:deleteother'],
                         ],
                     ]
                 );
@@ -87,14 +87,14 @@ if ($tmpl == 'index') {
                                 'item'            => $item,
                                 'templateButtons' => [
                                     'edit' => $view['security']->hasEntityAccess(
-                                        $permissions['dynamiccontent:dynamiccontents:editown'],
-                                        $permissions['dynamiccontent:dynamiccontents:editother'],
+                                        $permissions['dynamicContent:dynamiccontents:editown'],
+                                        $permissions['dynamicContent:dynamiccontents:editother'],
                                         $item->getCreatedBy()
                                     ),
-                                    'clone'  => $permissions['dynamiccontent:dynamiccontents:create'],
+                                    'clone'  => $permissions['dynamicContent:dynamiccontents:create'],
                                     'delete' => $view['security']->hasEntityAccess(
-                                        $permissions['dynamiccontent:dynamiccontents:deleteown'],
-                                        $permissions['dynamiccontent:dynamiccontents:deleteother'],
+                                        $permissions['dynamicContent:dynamiccontents:deleteown'],
+                                        $permissions['dynamicContent:dynamiccontents:deleteother'],
                                         $item->getCreatedBy()
                                     ),
                                 ],


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | -
| Related user documentation PR URL | -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | #5321 
| BC breaks? | -
| Deprecations? | -

#### Description:
There is a bug in 7.10+ versions about non-admin users that cannot create and/or modify landing pages (and some other elements like Notes).
That issue came from DynamicContent bundle.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Log in as a non-admin user
2. Go on Components > Landing Pages
3. Click on Create
