### PR TITLE
Fix file naming for SSH upgrades.

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -387,11 +387,12 @@ function fetch_updates()
 
         // Fetch the package
         try {
-            download_package($update->package);
+            download_package($update);
         } catch (\Exception $e) {
             return [
                 false,
-                "Could not automatically download the package. Please download {$update->package}, place it in the same directory as this upgrade script, and try again.",
+                "Could not automatically download the package. Please download {$update->package}, place it in the same directory as this upgrade script, and try again. ".
+                "When moving the file, name it `{$update->version}-update.zip`",
             ];
         }
 
@@ -402,22 +403,23 @@ function fetch_updates()
 }
 
 /**
- * @param $package
+ * @param object $update
  *
  * @throws Exception
+ *
+ * @return bool
  */
-function download_package($package)
+function download_package($update)
 {
-    if (file_exists(__DIR__.'/'.basename($package))) {
+    $packageName = $update->version.'-update.zip';
+    $target      = __DIR__.'/'.$packageName;
+
+    if (file_exists($target)) {
         return true;
     }
 
-    $data = make_request($package);
+    $data = make_request($update->package);
 
-    // Set the filesystem target
-    $target = __DIR__.'/'.basename($package);
-
-    // Write the response to the filesystem
     if (!file_put_contents($target, $data)) {
         throw new \Exception();
     }
@@ -828,7 +830,6 @@ function move_mautic_core(array $status)
 
     foreach ($fileOnlyDirectories as $dir) {
         if (copy_files($dir, $errorLog)) {
-
             // At this point, we can remove the config directory
             $deleteDir = recursive_remove_directory(MAUTIC_UPGRADE_ROOT.$dir);
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Note: We can't write tests for this without including the upgrade.php file to test, but it has side effects, so it's unable to be included. Code review & manual test should suffice.

When attempting to upgrade via the command line, the file name does not get saved properly. This is due to recent updates to the upgrade server. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
0. Change your `app/version.txt` file to an old version of Mautic. 2.10.0 will suffice.
1. Initiate a download from the command line via `php upgrade.php`
2. See that the file downloaded equals `index.php?component=...etc`
3. The upgrade will fail.

#### Steps to test this PR:
1. Apply PR
2. Rerun steps to reproduce. The file will be saved as `2.12.0-update.php`
3. The upgrade will succeed.