### PR TITLE
Mapped company when pushing to Connectwise causes error

### DIFF
--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -366,9 +366,6 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
             $this->getCompanyLeadRepository()->saveEntities($persistCompany);
         }
 
-        // Clear CompanyLead entities from Doctrine memory
-        $this->em->clear(CompanyLead::class);
-
         if (!empty($companyName)) {
             $currentCompanyName = $lead->getCompany();
             if ($currentCompanyName !== $companyName) {
@@ -387,7 +384,8 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
             }
         }
 
-        //unset($lead, $persistCompany, $companies);
+        // Clear CompanyLead entities from Doctrine memory
+        $this->em->clear(CompanyLead::class);
 
         return $contactAdded;
     }

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -31,6 +31,7 @@ use Mautic\CoreBundle\Model\FormModel;
 use Mautic\EmailBundle\Helper\EmailValidator;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyChangeLog;
+use Mautic\LeadBundle\Entity\CompanyLead;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\FrequencyRule;
 use Mautic\LeadBundle\Entity\Lead;
@@ -508,6 +509,7 @@ class LeadModel extends FormModel
             $this->companyModel->addLeadToCompany($companyEntity, $entity);
             $this->setPrimaryCompany($companyEntity->getId(), $entity->getId());
         }
+
         $this->em->clear(CompanyChangeLog::class);
     }
 
@@ -2673,6 +2675,7 @@ class LeadModel extends FormModel
 
         $companyLeads = $this->companyModel->getCompanyLeadRepository()->getEntitiesByLead($lead);
 
+        /** @var CompanyLead $companyLead */
         foreach ($companyLeads as $companyLead) {
             $company = $companyLead->getCompany();
 
@@ -2703,6 +2706,9 @@ class LeadModel extends FormModel
             $this->em->getRepository('MauticLeadBundle:Lead')->saveEntity($lead);
             $this->companyModel->getCompanyLeadRepository()->saveEntities($companyArray, false);
         }
+
+        // Clear CompanyLead entities from Doctrine memory
+        $this->em->clear(CompanyLead::class);
 
         return ['oldPrimary' => $oldPrimaryCompany, 'newPrimary' => $companyId];
     }

--- a/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
+++ b/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
@@ -92,7 +92,6 @@ class FeatureSettingsType extends AbstractType
                 if (empty($fields)) {
                     $fields = $integrationObject->getFormLeadFields($settings);
                     $fields = (isset($fields[0])) ? $fields[0] : $fields;
-                    unset($fields['company']);
                 }
 
                 if (isset($settings['feature_settings']['objects']) and in_array('company', $settings['feature_settings']['objects'])) {
@@ -139,8 +138,6 @@ class FeatureSettingsType extends AbstractType
             );
 
             if (!empty($integrationCompanyFields)) {
-                list($specialInstructions, $alertType) = $integrationObject->getFormNotes('leadfield_match');
-
                 $form->add(
                     'companyFields',
                     'integration_company_fields',

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -434,12 +434,16 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
             'communicationItems'     => [
                 'type'     => 'array',
                 'required' => false,
-                'items'    => ['name' => ['type' => 'name'], 'value' => 'value', 'keys' => ['Email', 'Direct', 'Fax', 'Cell']],
+                'items'    => [
+                    'name'  => ['type' => 'name'],
+                    'value' => 'value',
+                    'keys'  => ['Email', 'Direct', 'Fax', 'Cell'],
+                ],
             ],
-            'Direct' => ['type' => 'string', 'required' => false, 'configOnly' => true],
-            'Cell'   => ['type' => 'string', 'required' => false, 'configOnly' => true],
-            'Email'  => ['type' => 'string', 'required' => true, 'configOnly' => true],
-            'Fax'    => ['type' => 'string', 'required' => false, 'configOnly' => true],
+            'Direct'                 => ['type' => 'string', 'required' => false, 'configOnly' => true],
+            'Cell'                   => ['type' => 'string', 'required' => false, 'configOnly' => true],
+            'Email'                  => ['type' => 'string', 'required' => true, 'configOnly' => true],
+            'Fax'                    => ['type' => 'string', 'required' => false, 'configOnly' => true],
         ];
     }
 
@@ -689,7 +693,6 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
 
         $leadFields = array_diff_key($leadFields, array_flip($fieldsToUpdateInCW));
         $leadFields = $this->getBlankFieldsToUpdate($leadFields, $cwContactExists, $objectFields, $config);
-        //check for blank fields to update here
         $mappedData = $this->populateLeadData(
             $lead,
             [
@@ -718,10 +721,8 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
     {
         if ($lead instanceof Lead) {
             $fields = $lead->getFields(true);
-            $leadId = $lead->getId();
         } else {
             $fields = $lead;
-            $leadId = $lead['id'];
         }
 
         $leadFields = $config['leadFields'];

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -261,7 +261,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
         $cwFields = [];
 
         foreach ($fields as $fieldName => $field) {
-            if ($field['type'] == 'string' || $field['type'] == 'boolean' || $field['type'] == 'ref') {
+            if (in_array($field['type'], ['string', 'boolean', 'ref'])) {
                 $cwFields[$fieldName] = [
                     'type'     => $field['type'],
                     'label'    => ucfirst($fieldName),
@@ -705,6 +705,9 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
                 'communicationItems' => $communicationItems,
             ]
         );
+
+        // @todo map company reference
+        unset($mappedData['company']);
 
         return $mappedData;
     }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Connectwise requires a company reference ID instead of company name when pushing via a campaign. But if company is not mapped, it won't be pulled from CW to Mautic. So this removes company when pushing until proper reference mapping is written. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Configure the CW plugin
2. Map required plus company
3. Create campaign to push to CW
4. Create a new contact and add to campaign
5. Run the campaign and note the CW error 

#### Steps to test this PR:
1. Repeat and this time it'll push
