### PR TITLE
Remove clone button from segments

### DIFF
--- a/app/bundles/LeadBundle/Views/List/details.html.php
+++ b/app/bundles/LeadBundle/Views/List/details.html.php
@@ -27,7 +27,6 @@ $view['slots']->set(
                     $permissions['lead:lists:editother'],
                     $list->getCreatedBy()
                 ),
-                'clone'  => $permissions['lead:lists:editother'],
                 'delete' => $view['security']->hasEntityAccess(
                     $permissions['lead:lists:deleteother'],
                     $permissions['lead:lists:editother'],


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

2.12 introduced a details page for segments. But segments do not currently support cloning. This merely removes the button. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Click on a segment then the dropdown actions then click Clone

#### Steps to test this PR:
1. Clone button is gone
