### PR TITLE
Fixed ConnectWise bug that fetched only 25 of anything

### DIFF
--- a/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
+++ b/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
@@ -133,7 +133,7 @@ class LeadListSubscriber extends CommonSubscriber
                     }
 
                     if (method_exists($integrationObject, 'getCampaignMembers')) {
-                        if ($integrationObject->getCampaignMembers($campaignId, [])) {
+                        if ($integrationObject->getCampaignMembers($campaignId)) {
                             $success = true;
                         }
                     }

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -526,7 +526,9 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
 
             return $executed;
         } catch (\Exception $e) {
-            $this->logIntegrationError($e);
+            if (404 !== $e->getCode()) {
+                $this->logIntegrationError($e);
+            }
         }
 
         return $executed;
@@ -951,7 +953,9 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
 
             return true;
         } catch (\Exception $e) {
-            $this->logIntegrationError($e);
+            if (404 !== $e->getCode()) {
+                $this->logIntegrationError($e);
+            }
         }
 
         return false;

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -1340,7 +1340,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
      *
      * @throws \Exception
      */
-    public function getCampaignMembers($campaignId, $settings)
+    public function getCampaignMembers($campaignId, $settings = [])
     {
         $silenceExceptions = true;
         $persistEntities   = $contactList   = $leadList   = $existingLeads   = $existingContacts   = [];

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -1336,23 +1336,19 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
     /**
      * @param $campaignId
-     * @param $settings
      *
      * @throws \Exception
      */
-    public function getCampaignMembers($campaignId, $settings)
+    public function getCampaignMembers($campaignId)
     {
-        $silenceExceptions = true;
         $persistEntities   = $contactList   = $leadList   = $existingLeads   = $existingContacts   = [];
 
         try {
             $campaignsMembersResults = $this->getApiHelper()->getCampaignMembers($campaignId);
         } catch (\Exception $e) {
             $this->logIntegrationError($e);
-            if (!$silenceExceptions) {
-                throw $e;
-            }
         }
+
         //prepare contacts to import to mautic contacts to delete from mautic
         if (isset($campaignsMembersResults['records']) && !empty($campaignsMembersResults['records'])) {
             foreach ($campaignsMembersResults['records'] as $campaignMember) {

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -307,15 +307,15 @@ class SalesforceIntegration extends CrmAbstractIntegration
                                     if ((!$fieldInfo['updateable'] && (!$fieldInfo['calculated'] && $fieldInfo['name'] != 'Id') && $fieldInfo['name'] != 'IsDeleted')
                                         || !isset($fieldInfo['name'])
                                         || (in_array(
-                                            $fieldInfo['type'],
-                                            ['reference']
-                                        ) && $fieldInfo['name'] != 'AccountId')
+                                                $fieldInfo['type'],
+                                                ['reference']
+                                            ) && $fieldInfo['name'] != 'AccountId')
                                     ) {
                                         continue;
                                     }
                                     switch ($fieldInfo['type']) {
                                         case 'boolean': $type = 'boolean';
-                                                        break;
+                                            break;
                                         case 'datetime': $type = 'datetime';
                                             break;
                                         case 'date': $type = 'date';
@@ -1336,19 +1336,23 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
     /**
      * @param $campaignId
+     * @param $settings
      *
      * @throws \Exception
      */
-    public function getCampaignMembers($campaignId)
+    public function getCampaignMembers($campaignId, $settings)
     {
+        $silenceExceptions = true;
         $persistEntities   = $contactList   = $leadList   = $existingLeads   = $existingContacts   = [];
 
         try {
             $campaignsMembersResults = $this->getApiHelper()->getCampaignMembers($campaignId);
         } catch (\Exception $e) {
             $this->logIntegrationError($e);
+            if (!$silenceExceptions) {
+                throw $e;
+            }
         }
-
         //prepare contacts to import to mautic contacts to delete from mautic
         if (isset($campaignsMembersResults['records']) && !empty($campaignsMembersResults['records'])) {
             foreach ($campaignsMembersResults['records'] as $campaignMember) {

--- a/plugins/MauticCrmBundle/Tests/Api/ConnectwiseApiTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/ConnectwiseApiTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticCrmBundle\Tests\Api;
+
+use MauticPlugin\MauticCrmBundle\Api\ConnectwiseApi;
+use MauticPlugin\MauticCrmBundle\Integration\ConnectwiseIntegration;
+use MauticPlugin\MauticCrmBundle\Tests\Integration\DataGeneratorTrait;
+
+class ConnectwiseApiTest extends \PHPUnit_Framework_TestCase
+{
+    use DataGeneratorTrait;
+
+    /**
+     * @testdox Tests that fetchAllRecords loops until all records are obtained
+     * @covers  \MauticPlugin\MauticCrmBundle\Api\ConnectwiseApi::fetchAllRecords()
+     *
+     * @throws \Mautic\PluginBundle\Exception\ApiErrorException
+     */
+    public function testResultPagination()
+    {
+        $integration = $this->getMockBuilder(ConnectwiseIntegration::class)
+            ->disableOriginalConstructor()
+            ->setMethodsExcept(['getRecords'])
+            ->getMock();
+
+        $page = 0;
+        $integration->expects($this->exactly(3))
+            ->method('makeRequest')
+            ->willReturnCallback(
+                function ($endpoint, $parameters) use (&$page) {
+                    ++$page;
+
+                    // Page should be incremented 3 times by fetchAllRecords method
+                    $this->assertEquals(['page' => $page, 'pageSize' => ConnectwiseIntegration::PAGESIZE], $parameters);
+
+                    return $this->generateData(3);
+                }
+            );
+
+        $api = new ConnectwiseApi($integration);
+
+        $records = $api->fetchAllRecords('test');
+
+        $this->assertEquals($this->generatedRecords, $records);
+    }
+}

--- a/plugins/MauticCrmBundle/Tests/Integration/ConnectwiseIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/ConnectwiseIntegrationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Tests\Integration;
+
+use MauticPlugin\MauticCrmBundle\Api\ConnectwiseApi;
+use MauticPlugin\MauticCrmBundle\Integration\ConnectwiseIntegration;
+
+class ConnectwiseIntegrationTest extends \PHPUnit_Framework_TestCase
+{
+    use DataGeneratorTrait;
+
+    /**
+     * @testdox Test that all records are fetched till last page of results are consumed
+     * @covers  \MauticPlugin\MauticCrmBundle\Integration\ConnectwiseIntegration::getRecords()
+     */
+    public function testMultiplePagesOfRecordsAreFetched()
+    {
+        $apiHelper = $this->getMockBuilder(ConnectwiseApi::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $apiHelper->expects($this->exactly(2))
+            ->method('getContacts')
+            ->willReturnCallback(
+                function () {
+                    return $this->generateData(2);
+                }
+            );
+
+        $integration = $this->getMockBuilder(ConnectwiseIntegration::class)
+            ->disableOriginalConstructor()
+            ->setMethodsExcept(['getRecords'])
+            ->getMock();
+
+        $integration->expects($this->once())
+            ->method('isAuthorized')
+            ->willReturn(true);
+
+        $integration
+            ->method('getApiHelper')
+            ->willReturn($apiHelper);
+
+        $integration->getRecords([], 'Contact');
+    }
+}

--- a/plugins/MauticCrmBundle/Tests/Integration/DataGeneratorTrait.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/DataGeneratorTrait.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Tests\Integration;
+
+use MauticPlugin\MauticCrmBundle\Integration\ConnectwiseIntegration;
+
+trait DataGeneratorTrait
+{
+    /**
+     * @var int
+     */
+    protected $page = 1;
+
+    /**
+     * @var
+     */
+    protected $id = 0;
+
+    /**
+     * @var array
+     */
+    protected $generatedRecords = [];
+
+    /**
+     * @param $maxPages
+     *
+     * @return array
+     */
+    protected function generateData($maxPages)
+    {
+        $pageSize = ($this->page === $maxPages) ? ConnectwiseIntegration::PAGESIZE / 2 : ConnectwiseIntegration::PAGESIZE;
+        $fakeData = [];
+        $counter  = 0;
+        while ($counter < $pageSize) {
+            $data                     = [
+                'id' => $this->id,
+            ];
+            $fakeData[]               = $data;
+            $this->generatedRecords[] = $data;
+
+            ++$counter;
+            ++$this->id;
+        }
+        ++$this->page;
+
+        return $fakeData;
+    }
+}

--- a/plugins/MauticCrmBundle/Tests/Integration/DataGeneratorTrait.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/DataGeneratorTrait.php
@@ -54,4 +54,11 @@ trait DataGeneratorTrait
 
         return $fakeData;
     }
+
+    protected function reset()
+    {
+        $this->id               = 0;
+        $this->page             = 1;
+        $this->generatedRecords = [];
+    }
 }

--- a/plugins/MauticCrmBundle/Tests/SalesforceIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/SalesforceIntegrationTest.php
@@ -440,7 +440,7 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
                 ]
             );
 
-        $sf->getCampaignMembers(1, []);
+        $sf->getCampaignMembers(1);
     }
 
     public function testGetCampaignMemberStatus()

--- a/plugins/MauticCrmBundle/Tests/SalesforceIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/SalesforceIntegrationTest.php
@@ -440,7 +440,7 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
                 ]
             );
 
-        $sf->getCampaignMembers(1);
+        $sf->getCampaignMembers(1, []);
     }
 
     public function testGetCampaignMemberStatus()


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? | y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

ConnectWise returns 25 items by default for any of their GET calls. This means that Mautic only consumed a max of 25 items of anything because it did not handle subsequent pages. This PR fixes that to consume until the last page. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Have more than 25 contacts in CW
2. Sync to Mautic
3. Only 25 will sync

#### Steps to test this PR:
1. Repeat above and all will sync
2. Check the push to integration action in a campaign, choose CW, and note that activities are populated (changed to fetch all if more than 25 so make sure it still works)
3. Create a new segment that has a "Integration Campaign Members" filter and choose a CW campaign (campaigns should be listed as it was changed to display more than 25)
4. Build the segment and campaign members (more than 25 if assigned in CW) should be added
5. Run new tests