### PR TITLE
Prevent array to string conversion error with form selects mapped to Contact state

### DIFF
--- a/app/bundles/FormBundle/Views/Field/select.html.php
+++ b/app/bundles/FormBundle/Views/Field/select.html.php
@@ -38,15 +38,32 @@ endif;
 
 $options = (!empty($emptyOption)) ? [$emptyOption] : [];
 
-foreach ($list as $listValue => $listLabel):
-$selected  = ($listValue === $field['defaultValue']) ? ' selected="selected"' : '';
-$options[] = <<<HTML
+$optionBuilder = function (array $list) use (&$optionBuilder, $field, $view) {
+    $html = '';
+    foreach ($list as $listValue => $listLabel):
+        if (is_array($listLabel)) {
+            // This is an option group
+            $html .= <<<HTML
 
+                    <optgroup label="$listValue">
+                    {$optionBuilder($listLabel)}
+                    </optgroup>
+
+HTML;
+
+            continue;
+        }
+
+    $selected  = ($listValue === $field['defaultValue']) ? ' selected="selected"' : '';
+    $html .= <<<HTML
                     <option value="{$view->escape($listValue)}"{$selected}>{$view->escape($listLabel)}</option>
 HTML;
-endforeach;
+    endforeach;
 
-$optionsHtml = implode('', $options);
+    return $html;
+};
+
+$optionsHtml = $optionBuilder($list);
 $html        = <<<HTML
 
             <div $containerAttr>{$label}{$help}


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When using a form field mapped to a custom field State type, an array to string error will be thrown due to state array expecting option group support. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form
2. Add a select field
3. Map it to the contact state field
4. On the Properties tab, select Yes to use the custom field's values
5. Save and note the array to string error

#### Steps to test this PR:
1. Repeat and the state dropdown will be generated
2. Also create a select custom field if you don't already have one and map a form field to it using the custom field values to ensure it generates without option groups

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 