### PR TITLE
Prevent reference ID error with push SF activities for point changes and other timeline events 

### DIFF
--- a/app/bundles/LeadBundle/Entity/StagesChangeLogRepository.php
+++ b/app/bundles/LeadBundle/Entity/StagesChangeLogRepository.php
@@ -33,7 +33,7 @@ class StagesChangeLogRepository extends CommonRepository
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->from(MAUTIC_TABLE_PREFIX.'lead_stages_change_log', 'ls')
-            ->select('ls.stage_id as reference, ls.event_name as eventName, ls.action_name as actionName, ls.date_added as dateAdded, ls.lead_id');
+            ->select('ls.id, ls.stage_id as reference, ls.event_name as eventName, ls.action_name as actionName, ls.date_added as dateAdded, ls.lead_id');
 
         if ($leadId) {
             $query->where('ls.lead_id = '.(int) $leadId);

--- a/app/bundles/LeadBundle/Tests/Event/LeadTimelineEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/LeadTimelineEventTest.php
@@ -9,7 +9,7 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-namespace Mautic\LeadBundle\Event;
+namespace Mautic\LeadBundle\Tests\Event;
 
 class LeadTimelineEventTest extends \PHPUnit_Framework_TestCase
 {

--- a/app/bundles/LeadBundle/Tests/Event/LeadTimelineEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/LeadTimelineEventTest.php
@@ -43,6 +43,18 @@ class LeadTimelineEventTest extends \PHPUnit_Framework_TestCase
                 'icon'      => 'fa-tachometer',
                 'contactId' => 2,
             ],
+            [
+                'event'      => 'foobar',
+                'eventId'    => 'foobar123',
+                'eventLabel' => 'Foo Bar',
+                'eventType'  => 'foobar',
+                'timestamp'  => new \DateTime(),
+                'extra'      => [
+                    'something' => 'something else',
+                ],
+                'icon'      => 'fa-tachometer',
+                'contactId' => 2,
+            ],
         ];
 
         $event = new LeadTimelineEvent();
@@ -60,5 +72,8 @@ class LeadTimelineEventTest extends \PHPUnit_Framework_TestCase
         $id2 = hash('crc32', json_encode($payload[1]), false);
         $this->assertTrue(isset($events[1]['eventId']));
         $this->assertEquals('bar'.$id2, $events[1]['eventId']);
+
+        $this->assertTrue(isset($events[2]['eventId']));
+        $this->assertEquals('foobar123', $events[2]['eventId']);
     }
 }

--- a/app/bundles/LeadBundle/Tests/Event/LeadTimelineEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/LeadTimelineEventTest.php
@@ -11,6 +11,8 @@
 
 namespace Mautic\LeadBundle\Tests\Event;
 
+use Mautic\LeadBundle\Event\LeadTimelineEvent;
+
 class LeadTimelineEventTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Event/LeadTimelineEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/LeadTimelineEventTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Event;
+
+class LeadTimelineEventTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @testdox Every event in the timeline should have a unique eventId so test that one is generated if the subscriber forgets
+     */
+    public function testEventIdIsGeneratedIfNotSetBySubscriber()
+    {
+        $payload = [
+            [
+                'event'      => 'foo',
+                'eventLabel' => 'Foo',
+                'eventType'  => 'foo',
+                'timestamp'  => new \DateTime(),
+                'extra'      => [
+                    'something' => 'something',
+                ],
+                'icon'      => 'fa-tachometer',
+                'contactId' => 1,
+            ],
+            [
+                'event'      => 'bar',
+                'eventLabel' => 'Bar',
+                'eventType'  => 'bar',
+                'timestamp'  => new \DateTime(),
+                'extra'      => [
+                    'something' => 'something else',
+                ],
+                'icon'      => 'fa-tachometer',
+                'contactId' => 2,
+            ],
+        ];
+
+        $event = new LeadTimelineEvent();
+
+        foreach ($payload as $data) {
+            $event->addEvent($data);
+        }
+
+        $events = $event->getEvents();
+
+        $id1 = hash('crc32', json_encode($payload[0]), false);
+        $this->assertTrue(isset($events[0]['eventId']));
+        $this->assertEquals('foo'.$id1, $events[0]['eventId']);
+
+        $id2 = hash('crc32', json_encode($payload[1]), false);
+        $this->assertTrue(isset($events[1]['eventId']));
+        $this->assertEquals('bar'.$id2, $events[1]['eventId']);
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Event/LeadTimelineEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/LeadTimelineEventTest.php
@@ -17,6 +17,7 @@ class LeadTimelineEventTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @testdox Every event in the timeline should have a unique eventId so test that one is generated if the subscriber forgets
+     *
      * @covers \Mautic\LeadBundle\Event\LeadTimelineEvent::addEvent()
      * @covers \Mautic\LeadBundle\Event\LeadTimelineEvent::getEvents()
      * @covers \Mautic\LeadBundle\Event\LeadTimelineEvent::generateEventId()

--- a/app/bundles/LeadBundle/Tests/Event/LeadTimelineEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/LeadTimelineEventTest.php
@@ -17,6 +17,9 @@ class LeadTimelineEventTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @testdox Every event in the timeline should have a unique eventId so test that one is generated if the subscriber forgets
+     * @covers \Mautic\LeadBundle\Event\LeadTimelineEvent::addEvent()
+     * @covers \Mautic\LeadBundle\Event\LeadTimelineEvent::getEvents()
+     * @covers \Mautic\LeadBundle\Event\LeadTimelineEvent::generateEventId()
      */
     public function testEventIdIsGeneratedIfNotSetBySubscriber()
     {

--- a/app/bundles/PageBundle/Entity/HitRepository.php
+++ b/app/bundles/PageBundle/Entity/HitRepository.php
@@ -85,7 +85,7 @@ class HitRepository extends CommonRepository
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
-        $query->select('h.page_id, h.user_agent as userAgent, h.date_hit as dateHit, h.date_left as dateLeft, h.referer, h.source, h.source_id as sourceId, h.url, h.url_title as urlTitle, h.query, ds.client_info as clientInfo, ds.device, ds.device_os_name as deviceOsName, ds.device_brand as deviceBrand, ds.device_model as deviceModel, h.lead_id')
+        $query->select('h.id as hitId, h.page_id, h.user_agent as userAgent, h.date_hit as dateHit, h.date_left as dateLeft, h.referer, h.source, h.source_id as sourceId, h.url, h.url_title as urlTitle, h.query, ds.client_info as clientInfo, ds.device, ds.device_os_name as deviceOsName, ds.device_brand as deviceBrand, ds.device_model as deviceModel, h.lead_id')
             ->from(MAUTIC_TABLE_PREFIX.'page_hits', 'h')
             ->leftJoin('h', MAUTIC_TABLE_PREFIX.'pages', 'p', 'h.page_id = p.id');
 

--- a/app/bundles/PageBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/LeadSubscriber.php
@@ -153,6 +153,7 @@ class LeadSubscriber extends CommonSubscriber
                 $event->addEvent(
                     [
                         'event'      => $eventTypeKey,
+                        'eventId'    => $hit['hitId'],
                         'eventLabel' => $eventLabel,
                         'eventType'  => $eventTypeName,
                         'timestamp'  => $hit['dateHit'],

--- a/app/bundles/PointBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/LeadSubscriber.php
@@ -105,6 +105,7 @@ class LeadSubscriber extends CommonSubscriber
                 $event->addEvent(
                     [
                         'event'      => $eventTypeKey,
+                        'eventId'    => $eventTypeKey.$log['id'],
                         'eventLabel' => $log['eventName'].' / '.$log['delta'],
                         'eventType'  => $eventTypeName,
                         'timestamp'  => $log['dateAdded'],

--- a/app/bundles/StageBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/LeadSubscriber.php
@@ -74,6 +74,7 @@ class LeadSubscriber extends CommonSubscriber
                 $event->addEvent(
                     [
                         'event'      => $eventTypeKey,
+                        'eventId'    => $eventTypeKey.$log['id'],
                         'eventLabel' => $eventLabel,
                         'eventType'  => $eventTypeName,
                         'timestamp'  => $log['dateAdded'],

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -958,7 +958,6 @@ class SalesforceIntegration extends CrmAbstractIntegration
     public function pushLeadActivity($params = [])
     {
         $executed = null;
-        $filters  = [];
 
         $query  = $this->getFetchQuery($params);
         $config = $this->mergeConfigToFeatureSettings([]);
@@ -971,6 +970,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
             $salesForceObjects = $config['objects'];
         }
 
+        // Ensure that Contact is attempted before Lead
+        sort($salesForceObjects);
+
         /** @var IntegrationEntityRepository $integrationEntityRepo */
         $integrationEntityRepo = $this->em->getRepository('MauticPluginBundle:IntegrationEntity');
         $startDate             = new \DateTime($query['start']);
@@ -978,6 +980,10 @@ class SalesforceIntegration extends CrmAbstractIntegration
         $limit                 = 100;
 
         foreach ($salesForceObjects as $object) {
+            if (!in_array($object, ['Contact', 'Lead'])) {
+                continue;
+            }
+
             try {
                 if ($this->isAuthorized()) {
                     // Get first batch


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? | y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Some of the time line events did not have an eventId assigned by the subscriber which was used by the SF activity sync to generate a reference ID. If this was not set, the SF activity sync would generate a reference id of `-SOMESTRING` which triggered the error `provided reference ID must start with an alphanumeric character and can not contain a period`. This PR fixes that by fixing the few timeline events that were missing an eventId but also generates one if the subscriber forgets to generate one. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup SF Activity syncing
2. Ensure that a Mautic contact is being tracked against a SF lead or contact
3. Create a form with a point change submit action
4. Submit the form with the email of the contact in step 2
5. Run the `m:i:pushactivity` command and not the reference ID error

#### Steps to test this PR:
1. Repeat and activity will be synced
