### PR TITLE
Avoid error_log spaming

### DIFF
--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -308,9 +308,8 @@ trait CustomFieldRepositoryTrait
 
         //loop over results to put fields in something that can be assigned to the entities
         foreach ($values as $k => $r) {
-            $r = CustomFieldHelper::fixValueType($fields[$k]['type'], $r);
-
             if (isset($fields[$k])) {
+            $r = CustomFieldHelper::fixValueType($fields[$k]['type'], $r);
                 if (!is_null($r)) {
                     switch ($fields[$k]['type']) {
                         case 'number':


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
In certain case, like field delete in integration mapping, the value `$fields[$k]` is not set at https://github.com/mautic/mautic/compare/staging...Webmecanik:fix_avoid_log_spam?expand=1#diff-566711b8d4398e154df7c2775a91f886 L311

This is poping php log notice without any other effect.

#### Steps to test this PR:
1. no real test to do, read the code 
2. 