### PR TITLE
Fix url for installer

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -90,6 +90,7 @@ class AppKernel extends Kernel
             $uri = $request->getRequestUri();
             if (strpos($uri, 'installer') === false) {
                 $base = $request->getBaseUrl();
+                $prefix = '';
                 //check to see if the .htaccess file exists or if not running under apache
                 if ((strpos(strtolower($_SERVER['SERVER_SOFTWARE']), 'apache') === false
                     || !file_exists(__DIR__.'../.htaccess')
@@ -98,10 +99,10 @@ class AppKernel extends Kernel
                         'index'
                     ) === false)
                 ) {
-                    $base .= '/index.php';
+                    $prefix .= '/index.php';
                 }
 
-                return new RedirectResponse($base.'/installer');
+                return new RedirectResponse($request->getUriForPath($prefix.'/installer'));
             }
         }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Mautic can be run on a different port than 80.  If it is not yet installed, it is redirected to the wrong url address.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run fresh mautic on localhost:8088
2. Mautis is redirected to wrong url localhost/installer