### PR TITLE
Fixed two segment membership based errors with companies

### DIFF
--- a/app/bundles/LeadBundle/DataFixtures/ORM/LoadCompanyData.php
+++ b/app/bundles/LeadBundle/DataFixtures/ORM/LoadCompanyData.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\DataFixtures\ORM;
+
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Mautic\CoreBundle\Helper\CsvHelper;
+use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Entity\Lead;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class LoadCompanyData.
+ */
+class LoadCompanyData extends AbstractFixture implements OrderedFixtureInterface, ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param ObjectManager $manager
+     */
+    public function load(ObjectManager $manager)
+    {
+        $repo     = $this->container->get('mautic.lead.model.company')->getRepository();
+        $today    = new \DateTime();
+
+        $companies = CsvHelper::csv_to_array(__DIR__.'/fakecompanydata.csv');
+        foreach ($companies as $count => $l) {
+            $company = new Company();
+            $company->setDateAdded($today);
+            foreach ($l as $col => $val) {
+                $company->addUpdatedField($col, $val);
+            }
+            $repo->saveEntity($company);
+
+            $this->setReference('company-'.$count, $company);
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getOrder()
+    {
+        return 4;
+    }
+}

--- a/app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadData.php
+++ b/app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadData.php
@@ -16,6 +16,7 @@ use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Helper\CsvHelper;
+use Mautic\LeadBundle\Entity\CompanyLead;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -43,7 +44,9 @@ class LoadLeadData extends AbstractFixture implements OrderedFixtureInterface, C
      */
     public function load(ObjectManager $manager)
     {
-        $leadRepo = $this->container->get('mautic.lead.model.lead')->getRepository();
+        $leadRepo        = $this->container->get('doctrine.orm.default_entity_manager')->getRepository(Lead::class);
+        $companyLeadRepo = $this->container->get('doctrine.orm.default_entity_manager')->getRepository(CompanyLead::class);
+
         $today    = new \DateTime();
 
         $leads = CsvHelper::csv_to_array(__DIR__.'/fakeleaddata.csv');
@@ -60,9 +63,20 @@ class LoadLeadData extends AbstractFixture implements OrderedFixtureInterface, C
             foreach ($l as $col => $val) {
                 $lead->addUpdatedField($col, $val);
             }
+
             $leadRepo->saveEntity($lead);
 
             $this->setReference('lead-'.$count, $lead);
+
+            // Assign to companies in a predictable way
+            $lastCharacter = (int) substr($count, -1, 1);
+            if ($lastCharacter <= 3) {
+                $companyLead = new CompanyLead();
+                $companyLead->setLead($lead);
+                $companyLead->setCompany($this->getReference('company-'.$lastCharacter));
+                $companyLead->setDateAdded($today);
+                $companyLeadRepo->saveEntity($companyLead);
+            }
         }
     }
 

--- a/app/bundles/LeadBundle/DataFixtures/ORM/fakecompanydata.csv
+++ b/app/bundles/LeadBundle/DataFixtures/ORM/fakecompanydata.csv
@@ -1,0 +1,5 @@
+companyname,companycity,companystate,companycountry,companyindustry
+Mautic,Boston,Massachusetts,United States,Software
+Apple,Cupertino,California,United states,Hardware
+Amazon,Seattle,Washington,United States,Goods
+HostGator,Houston,Texas,United States,Software

--- a/app/bundles/LeadBundle/Tests/DataFixtures/ORM/LoadSegmentsData.php
+++ b/app/bundles/LeadBundle/Tests/DataFixtures/ORM/LoadSegmentsData.php
@@ -444,6 +444,48 @@ class LoadSegmentsData extends AbstractFixture implements OrderedFixtureInterfac
                 ],
                 'populate' => true,
             ],
+            [ // ID 24
+                'name'    => 'Segment membership based on only company fields',
+                'alias'   => 'segment-company-only-fields',
+                'public'  => true,
+                'filters' => [
+                    [
+                        'glue'     => 'and',
+                        'type'     => 'text',
+                        'object'   => 'company',
+                        'field'    => 'companycity',
+                        'operator' => '=',
+                        'filter'   => 'Houston',
+                        'display'  => '',
+                    ],
+                ],
+                'populate' => true,
+            ],
+            [ // ID 25
+                'name'    => 'Segment membership with excluded segment without other filters',
+                'alias'   => 'segment-including-segment-with-company-only-fields',
+                'public'  => true,
+                'filters' => [
+                    [
+                        'glue'     => 'and',
+                        'type'     => 'text',
+                        'object'   => 'company',
+                        'field'    => 'companyindustry',
+                        'operator' => 'in',
+                        'filter'   => ['Software', 'Hardware'],
+                        'display'  => '',
+                    ],
+                    [
+                        'glue'     => 'and',
+                        'type'     => 'leadlist',
+                        'field'    => 'leadlist',
+                        'operator' => '!in',
+                        'filter'   => [21],
+                        'display'  => '',
+                    ],
+                ],
+                'populate' => true,
+            ],
         ];
 
         foreach ($segments as $segmentConfig) {

--- a/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
@@ -28,8 +28,12 @@ class ListModelFunctionalTest extends MauticWebTestCase
         $segmentTestIncludeMembershipManualMembersRef       = $this->fixtures->getReference('segment-test-include-segment-manual-members');
         $segmentTestExcludeMembershipManualMembersRef       = $this->fixtures->getReference('segment-test-exclude-segment-manual-members');
         $segmentTestExcludeMembershipWithoutOtherFiltersRef = $this->fixtures->getReference('segment-test-exclude-segment-without-other-filters');
-        $segmentTestIncludeWithUnrelatedManualRemovalRef    = $this->fixtures->getReference('segment-test-include-segment-with-unrelated-segment-manual-removal');
+        $segmentTestIncludeWithUnrelatedManualRemovalRef    = $this->fixtures->getReference(
+            'segment-test-include-segment-with-unrelated-segment-manual-removal'
+        );
         $segmentMembershipRegex                             = $this->fixtures->getReference('segment-membership-regexp');
+        $segmentCompanyFields                               = $this->fixtures->getReference('segment-company-only-fields');
+        $segmentMembershipCompanyOnlyFields                 = $this->fixtures->getReference('segment-including-segment-with-company-only-fields');
 
         // These expect filters to be part of the $lists passed to getLeadsByList so pass the entity
         $segmentContacts = $repo->getLeadsByList(
@@ -54,6 +58,8 @@ class ListModelFunctionalTest extends MauticWebTestCase
                 $segmentTestExcludeMembershipWithoutOtherFiltersRef,
                 $segmentTestIncludeWithUnrelatedManualRemovalRef,
                 $segmentMembershipRegex,
+                $segmentCompanyFields,
+                $segmentMembershipCompanyOnlyFields,
             ],
             ['countOnly' => true]
         );
@@ -176,6 +182,18 @@ class ListModelFunctionalTest extends MauticWebTestCase
             11,
             $segmentContacts[$segmentMembershipRegex->getId()]['count'],
             'There should be 11 contacts that match the regex with dayrep.com in it'
+        );
+
+        $this->assertEquals(
+            6,
+            $segmentContacts[$segmentCompanyFields->getId()]['count'],
+            'There should only be 6 in this segment (6 contacts belong to HostGator based in Houston)'
+        );
+
+        $this->assertEquals(
+            14,
+            $segmentContacts[$segmentMembershipCompanyOnlyFields->getId()]['count'],
+            'There should be 14 in this segment.'
         );
     }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This fixes two bugs triggered by using segment membership filters that are based on segments using company fields.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a segment that has a single company field filter (i.e. company city = something)
2. Create a second segment that has a company custom field (ie. company state = something) and a second filter that is segment membership excludes the segment created above.
3. Run the 'mautic:segment:update' command for the segment in step 2. Notice the SQL error. 

#### Steps to test this PR:
1. Repeat and there will be no SQL errors
2. Run the new segment related functional tests