### PR TITLE
Sparkpost attachment - fixed bug when attachment was not send

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
@@ -270,7 +270,11 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
         }
 
         if (!empty($message['attachments'])) {
-            $sparkPostMessage['attachments'] = $message['attachments'];
+            foreach ($message['attachments'] as $key => $attachment) {
+                $message['attachments'][$key]['data'] = $attachment['content'];
+                unset($message['attachments'][$key]['content']);
+            }
+            $sparkPostMessage['content']['attachments'] = $message['attachments'];
         }
 
         return $sparkPostMessage;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR fixes issue with Sparkpost transport - emails were delivered without attachments.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Configure Sparkpost as a transport in your settings.
2. Create an email with attachment and send it.
3. Create a report with scheduler, edit date in database and send a scheduler: `app/console mautic:reports:scheduler`.
4. Emails will be delivered with no attachment.

![screen shot 2017-12-21 at 13 32 30](https://user-images.githubusercontent.com/1649279/34256002-7ca81458-e653-11e7-8674-ddc64a587018.png)

#### Steps to test this PR:
1. Apply the PR
2. Repeat steps and there will be an attachment in both emails.

![screen shot 2017-12-21 at 13 32 42](https://user-images.githubusercontent.com/1649279/34256014-8890ce18-e653-11e7-81a4-480d44b03b6d.png)
