### PR TITLE
changed length for the varchar's redirect_url column of Page entity.

### DIFF
--- a/app/bundles/PageBundle/Entity/Page.php
+++ b/app/bundles/PageBundle/Entity/Page.php
@@ -200,7 +200,7 @@ class Page extends FormEntity implements TranslationEntityInterface, VariantEnti
         $builder->createField('redirectUrl', 'string')
             ->columnName('redirect_url')
             ->nullable()
-            ->length(100)
+            ->length(2048)
             ->build();
 
         $builder->addCategory();

--- a/app/migrations/Version20180105090000.php
+++ b/app/migrations/Version20180105090000.php
@@ -35,6 +35,5 @@ class Version20180105090000 extends AbstractMauticMigration
     public function up(Schema $schema)
     {
         $this->addSql("ALTER TABLE {$this->prefix}pages CHANGE redirect_url redirect_url VARCHAR(2048) DEFAULT NULL;");
-
     }
 }

--- a/app/migrations/Version20180105090000.php
+++ b/app/migrations/Version20180105090000.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * @package     Mautic
+ * @copyright   2017 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Auto-generated Migration.
+ */
+class Version20180105090000 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql("ALTER TABLE {$this->prefix}pages CHANGE redirect_url redirect_url VARCHAR(2048) DEFAULT NULL;");
+
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | [#5482](https://github.com/mautic/mautic/issues/5482)
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Adding an url longer than 100 characters for a 301 redirection (when creating a landing page) was not possible. When persisting in db, url was troncated to 100 characters.

#### Steps to test this PR:
1. Apply the PR and Update database schema
2. create a landing page with 301 permanent redirection and add an url longer than 100 characters.
3. Save and close.

#### No Deprecation