### PR TITLE
Fix: Builder Froala popup scroll issue

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -94,7 +94,7 @@ Mautic.launchBuilder = function (formName, actionName) {
         });
     }
 
-        var builderPanel = mQuery('.builder-panel');
+    var builderPanel = mQuery('.builder-panel');
     var builderContent = mQuery('.builder-content');
     var btnCloseBuilder = mQuery('.btn-close-builder');
     var applyBtn = mQuery('.btn-apply-builder');

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -94,7 +94,7 @@ Mautic.launchBuilder = function (formName, actionName) {
         });
     }
 
-    var builderPanel = mQuery('.builder-panel');
+        var builderPanel = mQuery('.builder-panel');
     var builderContent = mQuery('.builder-content');
     var btnCloseBuilder = mQuery('.btn-close-builder');
     var applyBtn = mQuery('.btn-apply-builder');
@@ -127,7 +127,17 @@ Mautic.launchBuilder = function (formName, actionName) {
 
     // Blur and focus the focussed inputs to fix the browser autocomplete bug on scroll
     builderPanel.on('scroll', function(e) {
-        builderPanel.find('input:focus').blur();
+        // If Froala popup window open
+        if(mQuery.find('.fr-popup:visible').length){
+            if(!Mautic.isInViewport(builderPanel.find('.fr-view:visible'))) {
+                console.log(builderPanel.find('.fr-view:visible'));
+                builderPanel.find('.fr-view:visible').blur();
+                builderPanel.find('input:focus').blur();
+            }
+        }else{
+            builderPanel.find('input:focus').blur();
+
+        }
     });
 
     var overlay = mQuery('<div id="builder-overlay" class="modal-backdrop fade in"><div style="position: absolute; top:' + spinnerTop + 'px; left:' + spinnerLeft + 'px" class="builder-spinner"><i class="fa fa-spinner fa-spin fa-5x"></i></div></div>').css(builderCss).appendTo('.builder-content');
@@ -141,6 +151,16 @@ Mautic.launchBuilder = function (formName, actionName) {
     themeHtml = themeHtml.replace('</head>', assets+'</head>');
 
     Mautic.initBuilderIframe(themeHtml, btnCloseBuilder, applyBtn);
+};
+
+Mautic.isInViewport = function(el) {
+    var elementTop = mQuery(el).offset().top;
+    var elementBottom = elementTop + mQuery(el).outerHeight();
+
+    var viewportTop = mQuery(window).scrollTop();
+    var viewportBottom = viewportTop + mQuery(window).height();
+
+    return elementBottom > viewportTop && elementTop < viewportBottom;
 };
 
 /**

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -130,7 +130,6 @@ Mautic.launchBuilder = function (formName, actionName) {
         // If Froala popup window open
         if(mQuery.find('.fr-popup:visible').length){
             if(!Mautic.isInViewport(builderPanel.find('.fr-view:visible'))) {
-                console.log(builderPanel.find('.fr-view:visible'));
                 builderPanel.find('.fr-view:visible').blur();
                 builderPanel.find('input:focus').blur();
             }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4058
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

This bugfix/feature has been sponsored by @Webmecanik

[//]: # ( Required: )
#### Description:
Builder  disable focus on input on scroll.
This caused error, If you use Froala and width popup - for example edit link.
This bugfix prevent just when Froala is not view on screen.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Go to builder and edit text part with Froala editor
2.  Try create link on some word and the little scroll
3. Popup with link edit window should close

#### Steps to test this PR:
1.  Apply PR and run php app/console mautic:assets:generate
2.  Then repeat steps to reproduce
3. Popup for edit link should close just if editor is not on sceen