### PR TITLE
Fixes push to Zoho errors

### DIFF
--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -862,7 +862,7 @@ class ZohoIntegration extends CrmAbstractIntegration
         $config['object'] = 'Leads';
         $mappedData       = parent::populateLeadData($lead, $config);
         $writer           = (new Writer($config['object']));
-        $row              = $writer->row($lead['id']);
+        $row              = $writer->row($lead->id);
 
         foreach ($mappedData as $name => $value) {
             $row->add($name, $value);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? |N 
| Automated tests included? |N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | #5485 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Current Zoho plugn isn't able to push contacts.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Set up the Zoho integration.
2.  Add a push to integration action in either a campaign or form and select Zoho.
3. Test the form/campaign.
4. Nothing will be pushed to Zoho and you should see related errors in the logs.

#### Steps to test this PR:
1. Update with the fix and then test again, the contact should now be listed in Zoho under leads.