### PR TITLE
Fixed typos. Fixes #3762. Thanks @mtahiue

### DIFF
--- a/app/bundles/CampaignBundle/CampaignEvents.php
+++ b/app/bundles/CampaignBundle/CampaignEvents.php
@@ -116,7 +116,7 @@ final class CampaignEvents
      *
      * @var string
      */
-    const ON_EVENT_DECISION_TRIGGER = 'matuic.campaign_on_event_decision_trigger';
+    const ON_EVENT_DECISION_TRIGGER = 'mautic.campaign_on_event_decision_trigger';
 
     /**
      * The mautic.campaign_on_event_scheduled event is dispatched when a campaign event is scheduled or scheduling is modified.
@@ -126,5 +126,5 @@ final class CampaignEvents
      *
      * @var string
      */
-    const ON_EVENT_SCHEDULED = 'matuic.campaign_on_event_scheduled';
+    const ON_EVENT_SCHEDULED = 'mautic.campaign_on_event_scheduled';
 }

--- a/app/bundles/FormBundle/Config/config.php
+++ b/app/bundles/FormBundle/Config/config.php
@@ -282,7 +282,7 @@ return [
                 'class' => FormFieldCaptchaType::class,
                 'alias' => 'formfield_captcha',
             ],
-            'muatic.form.type.field_propertypagebreak' => [
+            'mautic.form.type.field_propertypagebreak' => [
                 'class'     => FormFieldPageBreakType::class,
                 'arguments' => [
                     'translator',

--- a/app/bundles/FormBundle/FormEvents.php
+++ b/app/bundles/FormBundle/FormEvents.php
@@ -101,5 +101,5 @@ final class FormEvents
      *
      * @var string
      */
-    const ON_EXECUTE_SUBMIT_ACTION = 'matuic.form.on_execute_submit_action';
+    const ON_EXECUTE_SUBMIT_ACTION = 'mautic.form.on_execute_submit_action';
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
www/app/bundles  # grep -ri matuic *

CampaignBundle/CampaignEvents.php:    const ON_EVENT_DECISION_TRIGGER = 'matuic.campaign_on_event_decision_trigger';
CampaignBundle/CampaignEvents.php:    const ON_EVENT_SCHEDULED = 'matuic.campaign_on_event_scheduled';
FormBundle/FormEvents.php:    const ON_EXECUTE_SUBMIT_ACTION = 'matuic.form.on_execute_submit_action';

#### Steps to test this PR:
1. Apply PR
2. Search for `matuic`
3. Find zero results.

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 