### PR TITLE
Fixes bounces on Mailjet #3807

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/MailjetTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/MailjetTransport.php
@@ -127,9 +127,10 @@ class MailjetTransport extends \Swift_SmtpTransport implements CallbackTransport
 
             if (isset($event['CustomID']) && $event['CustomID'] !== '' && strpos($event['CustomID'], '-', 0) !== false) {
                 list($leadIdHash, $leadEmail) = explode('-', $event['CustomID']);
-                if ($event['email'] == $leadEmail) {
-                    $this->transportCallback->addFailureByHashId($leadIdHash, $reason, $type);
-                }
+            }
+
+            if ( isset($leadEmail) && $event['email'] == $leadEmail) {
+                $this->transportCallback->addFailureByHashId($leadIdHash, $reason, $type);
             } else {
                 $this->transportCallback->addFailureByAddress($event['email'], $reason, $type);
             }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
We have configured MailJet to report back bounce data to Mautic via webhook (as documented here https://mautic.org/docs/en/emails/bounce_management.html).

The connection test in Mailjet is successful (OK, Code 200).

However, contacts are not updated accordingly and e-mail statistics do not show any bounced messages in Mautic.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Connect MailJet via Webhook
2. Send e-mail to non-existing e-mail address to trigger bounce event
3. Monitor contact history and e-mail stats

#### Steps to test this PR:
1. Apply PR
2. Repeat steps above
3. Check for properly marked bounced message.

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 