### PR TITLE
Fixes #5458 problem with lists. Thanks @XRaccourci

### DIFF
--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -701,7 +701,7 @@ class ListModel extends FormModel
                 } else {
                     $properties['callback'] = 'activateLeadFieldTypeahead';
                     $properties['list']     = (isset($properties['list'])) ? FormFieldHelper::formatList(
-                        FormFieldHelper::FORMAT_BAR,
+                        FormFieldHelper::FORMAT_ARRAY,
                         FormFieldHelper::parseList($properties['list'])
                     ) : '';
                 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | #5458
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
/ht @XRaccourci 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a campaign form with a field type checkbox Group. Add multiple values.
2. Create a campaign, select "Campaign forms"
3. Add a condition on "Form field value".
4. Select the previously created form.
5. Set the Field to the Group.
6. Select a value in the list
7. Add the condition
8. Return in the configuration of this condition and notice that the value is the label and that the field is a regular text field rather than a select list.

#### Steps to test this PR:
1. Apply PR
2. Repeat Steps 1-8 above
3. Notice value is correct

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 