### PR TITLE
Escape input values

### DIFF
--- a/app/bundles/ApiBundle/Views/Authorize/oAuth1/authorize.html.php
+++ b/app/bundles/ApiBundle/Views/Authorize/oAuth1/authorize.html.php
@@ -16,9 +16,9 @@ $msg  = (!empty($name)) ? $view['translator']->trans('mautic.api.oauth.clientwit
 ?>
 <h4 class="mb-lg"><?php echo $msg; ?></h4>
 <form class="form-login text-center" role="form" name="bazinga_oauth_server_authorize" action="<?php echo $view['router']->path('bazinga_oauth_server_authorize') ?>" method="post">
-    <input type="hidden" name="oauth_token" value="<?php echo  $oauth_token; ?>" />
-    <input type="hidden" name="oauth_callback" value="<?php echo $oauth_callback; ?>" />
+    <input type="hidden" name="oauth_token" value="<?php echo $view->escape($oauth_token); ?>" />
+    <input type="hidden" name="oauth_callback" value="<?php echo $view->escape($oauth_callback); ?>" />
 
-    <input type="submit" class="btn btn-primary btn-accept" name="submit_true" value="<?php echo $view['translator']->trans('mautic.api.oauth.accept'); ?>" />
-    <input type="submit" class="btn btn-danger btn-deny" name="submit_false" value="<?php echo $view['translator']->trans('mautic.api.oauth.deny'); ?>" />
+    <input type="submit" class="btn btn-primary btn-accept" name="submit_true" value="<?php echo $view->escape($view['translator']->trans('mautic.api.oauth.accept')); ?>" />
+    <input type="submit" class="btn btn-danger btn-deny" name="submit_false" value="<?php echo $view->escape($view['translator']->trans('mautic.api.oauth.deny')); ?>" />
 </form>

--- a/app/bundles/ApiBundle/Views/Authorize/oAuth2/authorize.html.php
+++ b/app/bundles/ApiBundle/Views/Authorize/oAuth2/authorize.html.php
@@ -17,8 +17,8 @@ $msg  = (!empty($name)) ? $view['translator']->trans('mautic.api.oauth.clientwit
 <h4 class="mb-lg"><?php echo $msg; ?></h4>
 <form class="form-login text-center" role="form" name="fos_oauth_server_authorize_form" action="<?php echo $view['router']->path('fos_oauth_server_authorize') ?>" method="post">
 
-<input type="submit" class="btn btn-primary btn-accept" name="accepted" value="<?php echo $view['translator']->trans('mautic.api.oauth.accept'); ?>" />
-<input type="submit" class="btn btn-danger btn-deny" name="rejected" value="<?php echo $view['translator']->trans('mautic.api.oauth.deny'); ?>" />
+<input type="submit" class="btn btn-primary btn-accept" name="accepted" value="<?php echo $view->escape($view['translator']->trans('mautic.api.oauth.accept')); ?>" />
+<input type="submit" class="btn btn-danger btn-deny" name="rejected" value="<?php echo $view->escape($view['translator']->trans('mautic.api.oauth.deny')); ?>" />
 
 <?php
 echo $view['form']->row($form['client_id']);

--- a/app/bundles/ApiBundle/Views/Client/list.html.php
+++ b/app/bundles/ApiBundle/Views/Client/list.html.php
@@ -80,12 +80,10 @@ endif;
                     <?php echo $item->getName(); ?>
                 </td>
                 <td class="visible-md visible-lg">
-                    <input onclick="this.setSelectionRange(0, this.value.length);" type="text" class="form-control" readonly value="<?php echo $item->getPublicId(
-                    ); ?>"/>
+                    <input onclick="this.setSelectionRange(0, this.value.length);" type="text" class="form-control" readonly value="<?php echo $view->escape($item->getPublicId()); ?>"/>
                 </td>
                 <td class="visible-md visible-lg">
-                    <input onclick="this.setSelectionRange(0, this.value.length);" type="text" class="form-control" readonly value="<?php echo $item->getSecret(
-                    ); ?>"/>
+                    <input onclick="this.setSelectionRange(0, this.value.length);" type="text" class="form-control" readonly value="<?php echo $view->escape($item->getSecret()); ?>"/>
                 </td>
                 <td class="visible-md visible-lg"><?php echo $item->getId(); ?></td>
             </tr>

--- a/app/bundles/ApiBundle/Views/Security/login.html.php
+++ b/app/bundles/ApiBundle/Views/Security/login.html.php
@@ -18,7 +18,7 @@ $view['slots']->set('header', $view['translator']->trans('mautic.api.oauth.heade
         <span class="input-group-addon"><i class="fa fa-user"></i></span>
         <label for="username" class="sr-only"><?php echo $view['translator']->trans('mautic.user.auth.form.loginusername'); ?></label>
         <input type="text" id="username" name="_username"
-               class="form-control input-lg" value="<?php echo $last_username ?>" required autofocus
+               class="form-control input-lg" value="<?php echo $view->escape($last_username) ?>" required autofocus
                placeholder="<?php echo $view['translator']->trans('mautic.user.auth.form.loginusername'); ?>" />
     </div>
     <div class="input-group mb-md">

--- a/app/bundles/AssetBundle/Views/Asset/details.html.php
+++ b/app/bundles/AssetBundle/Views/Asset/details.html.php
@@ -175,7 +175,7 @@ $view['slots']->set(
             <div class="panel-body pt-xs">
                 <div class="input-group">
                     <input onclick="this.setSelectionRange(0, this.value.length);" type="text" class="form-control"
-                           readonly value="<?php echo $assetDownloadUrl; ?>"/>
+                           readonly value="<?php echo $view->escape($assetDownloadUrl); ?>"/>
                 <span class="input-group-btn">
                     <button class="btn btn-default btn-nospin"
                             onclick="window.open('<?php echo $assetDownloadUrl; ?>', '_blank');">
@@ -193,6 +193,6 @@ $view['slots']->set(
         <?php echo $view->render('MauticCoreBundle:Helper:recentactivity.html.php', ['logs' => $logs]); ?>
     </div>
     <!--/ right section -->
-    <input name="entityId" id="entityId" type="hidden" value="<?php echo $activeAsset->getId(); ?>"/>
+    <input name="entityId" id="entityId" type="hidden" value="<?php echo $view->escape($activeAsset->getId()); ?>"/>
 </div>
 <!--/ end: box layout -->

--- a/app/bundles/CampaignBundle/Views/Campaign/Builder/event_list.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/Builder/event_list.html.php
@@ -35,7 +35,7 @@
                         ); ?>"
                         data-target="#CampaignEventModal"
                         title="<?php echo $view->escape($e['description']); ?>"
-                        value="<?php echo $k; ?>">
+                        value="<?php echo $view->escape($k); ?>">
                     <span><?php echo $e['label']; ?></span>
                 </option>
             <?php endforeach; ?>

--- a/app/bundles/CampaignBundle/Views/Campaign/Builder/source_list.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/Builder/source_list.html.php
@@ -26,7 +26,7 @@
                     ); ?>"
                     data-target="#CampaignEventModal"
                     title="<?php echo $view->escape($view['translator']->trans('mautic.campaign.leadsource.'.$option.'.tooltip')); ?>"
-                    value="<?php echo $option; ?>"
+                    value="<?php echo $view->escape($option); ?>"
                 <?php if (!empty($campaignSources[$option])) {
                         echo 'disabled';
                     } ?>>

--- a/app/bundles/CampaignBundle/Views/Campaign/builder.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/builder.html.php
@@ -59,7 +59,7 @@
 <!-- dropped coordinates -->
 <input type="hidden" value="" id="droppedX"/>
 <input type="hidden" value="" id="droppedY"/>
-<input type="hidden" value="<?php echo $campaignId; ?>" id="campaignId"/>
+<input type="hidden" value="<?php echo $view->escape($campaignId); ?>" id="campaignId"/>
 
 <?php echo $view->render(
     'MauticCoreBundle:Helper:modal.html.php',

--- a/app/bundles/CampaignBundle/Views/Campaign/preview.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/preview.html.php
@@ -81,7 +81,7 @@
 <!-- dropped coordinates -->
 <input type="hidden" value="" id="droppedX"/>
 <input type="hidden" value="" id="droppedY"/>
-<input type="hidden" value="<?php echo $campaignId; ?>" id="campaignId"/>
+<input type="hidden" value="<?php echo $view->escape($campaignId); ?>" id="campaignId"/>
 
 <?php echo $view->render(
     'MauticCoreBundle:Helper:modal.html.php',

--- a/app/bundles/CoreBundle/Templating/Helper/FormatterHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/FormatterHelper.php
@@ -31,7 +31,9 @@ class FormatterHelper extends Helper
      */
     private $dateHelper;
 
-    /** @var TranslatorInterface */
+    /**
+     * @var TranslatorInterface
+     */
     private $translator;
 
     /**

--- a/app/bundles/CoreBundle/Views/FormTheme/Custom/form_start.html.php
+++ b/app/bundles/CoreBundle/Views/FormTheme/Custom/form_start.html.php
@@ -4,7 +4,7 @@
     printf(' %s="%s"', $view->escape($k), $view->escape($v));
 } ?><?php if ($multipart): ?> enctype="multipart/form-data"<?php endif ?>>
 <?php if ($form_method !== $method): ?>
-    <input type="hidden" name="_method" value="<?php echo $method ?>" />
+    <input type="hidden" name="_method" value="<?php echo $view->escape($method) ?>" />
 <?php endif ?>
 <?php if (count($form->vars['errors'])): ?>
 <div class="has-error pa-10">

--- a/app/bundles/CoreBundle/Views/GlobalSearch/globalsearch.html.php
+++ b/app/bundles/CoreBundle/Views/GlobalSearch/globalsearch.html.php
@@ -33,6 +33,6 @@
         <a href="javascript: void(0);" class="search-button">
             <i class="fa fa-search fs-16"></i>
         </a>
-        <input type="search" value="<?php echo $searchString; ?>" class="form-control search" id="globalSearchInput" name="global_search" placeholder="<?php echo $view['translator']->trans('mautic.core.search.everything.placeholder'); ?>" value="" autocomplete="false" data-toggle="livesearch" data-target="#globalSearchResults" data-action="<?php echo $view['router']->path('mautic_core_ajax', ['action' => 'globalSearch']); ?>" data-overlay="true" data-overlay-text="<?php echo $view['translator']->trans('mautic.core.search.livesearch'); ?>" />
+        <input type="search" value="<?php echo $view->escape($searchString); ?>" class="form-control search" id="globalSearchInput" name="global_search" placeholder="<?php echo $view['translator']->trans('mautic.core.search.everything.placeholder'); ?>" value="" autocomplete="false" data-toggle="livesearch" data-target="#globalSearchResults" data-action="<?php echo $view['router']->path('mautic_core_ajax', ['action' => 'globalSearch']); ?>" data-overlay="true" data-overlay-text="<?php echo $view['translator']->trans('mautic.core.search.livesearch'); ?>" />
     </div>
 </li>

--- a/app/bundles/CoreBundle/Views/Helper/list_actions.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/list_actions.html.php
@@ -24,7 +24,7 @@ if (is_array($item)) {
 ?>
 <div class="input-group input-group-sm">
     <span class="input-group-addon">
-        <input type="checkbox" data-target="tbody" data-toggle="selectrow" class="list-checkbox" name="cb<?php echo $id; ?>" value="<?php echo $id; ?>"/>
+        <input type="checkbox" data-target="tbody" data-toggle="selectrow" class="list-checkbox" name="cb<?php echo $id; ?>" value="<?php echo $view->escape($id); ?>"/>
     </span>
 
     <div class="input-group-btn">

--- a/app/bundles/CoreBundle/Views/Helper/list_filters.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/list_filters.html.php
@@ -63,7 +63,7 @@
                     }
 
                 ?>
-                <option value="<?php echo $value; ?>"<?php echo $selected; ?>><?php echo $label; ?></option>
+                <option value="<?php echo $view->escape($value); ?>"<?php echo $selected; ?>><?php echo $label; ?></option>
                 <?php endforeach; ?>
                 <?php endif; ?>
             </optgroup>
@@ -78,7 +78,7 @@
 
                 $selected = (isset($filter['values']) && in_array($value, $filter['values'])) ? ' selected' : '';
                 ?>
-                <option value="<?php echo $value; ?>"<?php echo $selected; ?>>
+                <option value="<?php echo $view->escape($value); ?>"<?php echo $selected; ?>>
                     <?php echo empty($filter['translateLabels']) ? $label : $view['translator']->trans($label); ?>
                 </option>
             <?php endforeach; ?>

--- a/app/bundles/CoreBundle/Views/Helper/pagination.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/pagination.html.php
@@ -105,7 +105,7 @@ foreach ($responsiveViewports as $viewport):
                 <select autocomplete="false" class="form-control not-chosen pagination-limit<?php echo $class; ?>" onchange="Mautic.limitTableData('<?php echo $sessionVar; ?>',this.value,'<?php echo $tmpl; ?>','<?php echo $target; ?>'<?php if (!empty($baseUrl)): ?>, '<?php echo $baseUrl; ?>'<?php endif; ?>);">
                     <?php foreach ($limitOptions as $value => $label): ?>
                         <?php $selected = ($limit === $value) ? ' selected="selected"' : ''; ?>
-                        <option<?php echo $selected; ?> value="<?php echo $value; ?>">
+                        <option<?php echo $selected; ?> value="<?php echo $view->escape($value); ?>">
                             <?php echo $view['translator']->trans('mautic.core.pagination.'.$label); ?>
                         </option>
                     <?php endforeach; ?>

--- a/app/bundles/CoreBundle/Views/Helper/tableheader.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/tableheader.html.php
@@ -82,7 +82,7 @@ $tmpl         = (!empty($tmpl)) ? $tmpl : 'list';
         <?php $value = (isset($filters[$filterBy])) ? $filters[$filterBy]['value'] : ''; ?>
         <div class="input-group input-group-sm">
             <?php $toggle = (!empty($dataToggle)) ? ' data-toggle="'.$dataToggle.'"' : ''; ?>
-            <input type="text" placeholder="<?php echo $view['translator']->trans('mautic.core.form.thead.filter'); ?>" autocomplete="false" class="form-control input-sm" value="<?php echo $value; ?>"<?php echo $toggle; ?> onchange="Mautic.filterTableData('<?php echo $sessionVar; ?>','<?php echo $filterBy; ?>',this.value,'<?php echo $tmpl; ?>','<?php echo $target; ?>'<?php if (!empty($baseUrl)): ?>, '<?php echo $baseUrl; ?>'<?php endif; ?>);" />
+            <input type="text" placeholder="<?php echo $view['translator']->trans('mautic.core.form.thead.filter'); ?>" autocomplete="false" class="form-control input-sm" value="<?php echo $view->escape($value); ?>"<?php echo $toggle; ?> onchange="Mautic.filterTableData('<?php echo $sessionVar; ?>','<?php echo $filterBy; ?>',this.value,'<?php echo $tmpl; ?>','<?php echo $target; ?>'<?php if (!empty($baseUrl)): ?>, '<?php echo $baseUrl; ?>'<?php endif; ?>);" />
             <?php $inputClass = (!empty($value)) ? 'fa-times' : 'fa-filter'; ?>
             <span class="input-group-btn">
                 <button class="btn btn-default btn-xs" onclick="Mautic.filterTableData('<?php echo $sessionVar; ?>','<?php echo $filterBy; ?>',<?php echo (!empty($value)) ? "''," : 'mQuery(this).parent().prev().val(),'; ?>'<?php echo $tmpl; ?>','<?php echo $target; ?>'<?php if (!empty($baseUrl)): ?>, '<?php echo $baseUrl; ?>'<?php endif; ?>);">

--- a/app/bundles/CoreBundle/Views/Notification/notifications.html.php
+++ b/app/bundles/CoreBundle/Views/Notification/notifications.html.php
@@ -38,7 +38,7 @@
                 </div>
             </div>
             <?php $lastNotification = reset($notifications); ?>
-            <input id="mauticLastNotificationId" type="hidden" value="<?php echo $lastNotification['id']; ?>" />
+            <input id="mauticLastNotificationId" type="hidden" value="<?php echo $view->escape($lastNotification['id']); ?>" />
         </div>
     </div>
 </li>

--- a/app/bundles/CoreBundle/Views/Slots/channelfrequency.html.php
+++ b/app/bundles/CoreBundle/Views/Slots/channelfrequency.html.php
@@ -24,7 +24,7 @@ $channelNumber = 0;
                     <input type="checkbox" id="<?php echo $channel->value ?>"
                            name="lead_contact_frequency_rules[subscribed_channels][]"
                            onclick="togglePreferredChannel(this.value);"
-                           value="<?php echo $channel->value ?>" <?php echo $checked; ?>>
+                           value="<?php echo $view->escape($channel->value) ?>" <?php echo $checked; ?>>
                     <label for="<?php echo $channel->value ?>" id="is-contactable-<?php echo $channel->value ?>" data-channel="<?php echo $channelName; ?>">
                         <?php echo $view['translator']->trans('mautic.lead.contact.me.label', ['%channel%' => $channelName]); ?>
                     </label>
@@ -97,4 +97,3 @@ $channelNumber = 0;
     </tbody>
 </table>
 <?php endif; ?>
-

--- a/app/bundles/CoreBundle/Views/SortablePanels/container.html.php
+++ b/app/bundles/CoreBundle/Views/SortablePanels/container.html.php
@@ -64,7 +64,7 @@ if (!isset($colSize)) {
                         ?>
                         <?php if ($optionGroup): ?><optgroup label="<?php echo $view['translator']->trans($groupId); ?>"><?php endif; ?>
                         <?php foreach ($groupPanels as $panelId => $panel): ?>
-                        <option id="<?php echo $panelId; ?>" value="<?php echo $panel['value']; ?>"
+                        <option id="<?php echo $panelId; ?>" value="<?php echo $view->escape($panel['value']); ?>"
                                 data-default-label="<?php echo $view->escape($panel['label']); ?>"
                             <?php if (isset($panel['attr'])): echo $panel['attr']; endif ?>
                             <?php if (!empty($panel['prototypeTemplatePlaceholders'])):

--- a/app/bundles/DynamicContentBundle/Views/DynamicContent/form.html.php
+++ b/app/bundles/DynamicContentBundle/Views/DynamicContent/form.html.php
@@ -120,7 +120,7 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
                                                                 json_encode($params['operators'])
                                                             ) : '{}';
                                                             ?>
-                                                            <option value="<?php echo $value; ?>"
+                                                            <option value="<?php echo $view->escape($value); ?>"
                                                                     id="available_<?php echo $value; ?>"
                                                                     data-field-object="<?php echo $object; ?>"
                                                                     data-field-type="<?php echo $params['properties']['type']; ?>"

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1561,7 +1561,7 @@ class EmailController extends FormController
 
         //add builder toolbar
         $slotsHelper->start('builder'); ?>
-        <input type="hidden" id="builder_entity_id" value="<?php echo $entity->getSessionId(); ?>"/>
+        <input type="hidden" id="builder_entity_id" value="<?php echo $view->escape($entity->getSessionId()); ?>"/>
         <?php
         $slotsHelper->stop();
     }

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -296,7 +296,7 @@ if (!$isEmbedded) {
                 <div class="input-group">
                     <input onclick="this.setSelectionRange(0, this.value.length);" type="text" class="form-control"
                            readonly
-                           value="<?php echo $previewUrl; ?>"/>
+                           value="<?php echo $view->escape($previewUrl); ?>"/>
                     <span class="input-group-btn">
                         <button class="btn btn-default btn-nospin" onclick="window.open('<?php echo $previewUrl; ?>', '_blank');">
                             <i class="fa fa-external-link"></i>
@@ -310,5 +310,5 @@ if (!$isEmbedded) {
         <?php echo $view->render('MauticCoreBundle:Helper:recentactivity.html.php', ['logs' => $logs]); ?>
     </div>
     <!--/ right section -->
-    <input name="entityId" id="entityId" type="hidden" value="<?php echo $email->getId(); ?>"/>
+    <input name="entityId" id="entityId" type="hidden" value="<?php echo $view->escape($email->getId()); ?>"/>
 </div>

--- a/app/bundles/EmailBundle/Views/FormTheme/Email/dynamic_content_filter_entry_widget.html.php
+++ b/app/bundles/EmailBundle/Views/FormTheme/Email/dynamic_content_filter_entry_widget.html.php
@@ -47,7 +47,7 @@
                                     $callback  = (!empty($params['properties']['callback'])) ? $params['properties']['callback'] : '';
                                     $operators = (!empty($params['operators'])) ? $view->escape(json_encode($params['operators'])) : '{}';
                                     ?>
-                                    <option value="<?php echo $value; ?>" data-mautic="available_<?php echo $value; ?>" data-field-object="<?php echo $object; ?>" data-field-type="<?php echo $params['properties']['type']; ?>" data-field-list="<?php echo $view->escape($list); ?>" data-field-callback="<?php echo $callback; ?>" data-field-operators='<?php echo $operators; ?>' class="segment-filter fa <?php echo $icon; ?>"><?php echo $view['translator']->trans($params['label']); ?></option>
+                                    <option value="<?php echo $view->escape($value); ?>" data-mautic="available_<?php echo $value; ?>" data-field-object="<?php echo $object; ?>" data-field-type="<?php echo $params['properties']['type']; ?>" data-field-list="<?php echo $view->escape($list); ?>" data-field-callback="<?php echo $callback; ?>" data-field-operators='<?php echo $operators; ?>' class="segment-filter fa <?php echo $icon; ?>"><?php echo $view['translator']->trans($params['label']); ?></option>
                                 <?php endforeach; ?>
                             </optgroup>
                         <?php endforeach; ?>

--- a/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
+++ b/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
@@ -56,7 +56,7 @@ JS;
                                 <input type="checkbox" id="<?php echo $channel->value ?>"
                                        name="lead_contact_frequency_rules[subscribed_channels][]"
                                        onclick="togglePreferredChannel(this.value);"
-                                       value="<?php echo $channel->value ?>" <?php echo $checked; ?>>
+                                       value="<?php echo $view->escape($channel->value) ?>" <?php echo $checked; ?>>
                                 <label for="<?php echo $channel->value ?>" id="is-contactable-<?php echo $channel->value ?>">
                                     <?php echo $view['translator']->trans('mautic.lead.contact.me.label', ['%channel%' => $channelName]); ?>
                                 </label>

--- a/app/bundles/FormBundle/Views/Builder/field.html.php
+++ b/app/bundles/FormBundle/Views/Builder/field.html.php
@@ -151,7 +151,7 @@ $propertiesTabError = (isset($form['properties']) && ($view['form']->containsErr
                                         $label = $field->label;
                                         $value = $field->value;
                                         ?>
-                                        <option value="<?php echo $value?>" class="segment-filter <?php echo $icon; ?>" <?php if ($data === $value) {
+                                        <option value="<?php echo $view->escape($value) ?>" class="segment-filter <?php echo $icon; ?>" <?php if ($data === $value) {
                                             echo 'Selected';
                                         } ?> <?php echo $attrString; ?> ><?php echo $label; ?></option>
                                     <?php endforeach; ?>

--- a/app/bundles/FormBundle/Views/Builder/form.html.php
+++ b/app/bundles/FormBundle/Views/Builder/form.html.php
@@ -96,9 +96,9 @@ if (!isset($isAjax)) {
             ?>
         </div>
 
-        <input type="hidden" name="mauticform[formId]" id="mauticform<?php echo $formName ?>_id" value="<?php echo $form->getId(); ?>"/>
+        <input type="hidden" name="mauticform[formId]" id="mauticform<?php echo $formName ?>_id" value="<?php echo $view->escape($form->getId()); ?>"/>
         <input type="hidden" name="mauticform[return]" id="mauticform<?php echo $formName ?>_return" value=""/>
-        <input type="hidden" name="mauticform[formName]" id="mauticform<?php echo $formName ?>_name" value="<?php echo ltrim($formName, '_'); ?>"/>
+        <input type="hidden" name="mauticform[formName]" id="mauticform<?php echo $formName ?>_name" value="<?php echo $view->escape(ltrim($formName, '_')); ?>"/>
 
         <?php echo (isset($formExtra)) ? $formExtra : ''; ?>
 </form>

--- a/app/bundles/FormBundle/Views/Form/details.html.php
+++ b/app/bundles/FormBundle/Views/Form/details.html.php
@@ -374,4 +374,4 @@ $showActions = count($activeFormActions);
 </div>
 <!--/ end: box layout -->
 
-<input type="hidden" name="entityId" id="entityId" value="<?php echo $activeForm->getId(); ?>"/>
+<input type="hidden" name="entityId" id="entityId" value="<?php echo $view->escape($activeForm->getId()); ?>"/>

--- a/app/bundles/LeadBundle/Views/Auditlog/index.html.php
+++ b/app/bundles/LeadBundle/Views/Auditlog/index.html.php
@@ -13,7 +13,7 @@
 <!-- filter form -->
 <form method="post" action="<?php echo $view['router']->path('mautic_contact_auditlog_action', ['leadId' => $lead->getId()]); ?>" class="panel" id="auditlog-filters">
     <div class="form-control-icon pa-xs">
-        <input type="text" class="form-control bdr-w-0" name="search" id="search" placeholder="<?php echo $view['translator']->trans('mautic.core.search.placeholder'); ?>" value="<?php echo $events['filters']['search']; ?>">
+        <input type="text" class="form-control bdr-w-0" name="search" id="search" placeholder="<?php echo $view['translator']->trans('mautic.core.search.placeholder'); ?>" value="<?php echo $view->escape($events['filters']['search']); ?>">
         <span class="the-icon fa fa-search text-muted mt-xs"></span>
     </div>
     <?php if (isset($events['types']) && is_array($events['types'])) : ?>
@@ -21,7 +21,7 @@
             <div class="col-sm-5">
                 <select name="includeEvents[]" multiple="multiple" class="form-control bdr-w-0" data-placeholder="<?php echo $view['translator']->trans('mautic.lead.lead.filter.bundles.include.placeholder'); ?>">
                     <?php foreach ($events['types'] as $typeKey => $typeName) : ?>
-                        <option value="<?php echo $typeKey; ?>"<?php echo in_array($typeKey, $events['filters']['includeEvents']) ? ' selected' : ''; ?> >
+                        <option value="<?php echo $view->escape($typeKey); ?>"<?php echo in_array($typeKey, $events['filters']['includeEvents']) ? ' selected' : ''; ?> >
                             <?php echo $typeName; ?>
                         </option>
                     <?php endforeach; ?>
@@ -30,7 +30,7 @@
             <div class="col-sm-5">
                 <select name="excludeEvents[]" multiple="multiple" class="form-control bdr-w-0" data-placeholder="<?php echo $view['translator']->trans('mautic.lead.lead.filter.bundles.exclude.placeholder'); ?>">
                     <?php foreach ($events['types'] as $typeKey => $typeName) : ?>
-                        <option value="<?php echo $typeKey; ?>"<?php echo in_array($typeKey, $events['filters']['excludeEvents']) ? ' selected' : ''; ?> >
+                        <option value="<?php echo $view->escape($typeKey); ?>"<?php echo in_array($typeKey, $events['filters']['excludeEvents']) ? ' selected' : ''; ?> >
                             <?php echo $typeName; ?>
                         </option>
                     <?php endforeach; ?>
@@ -46,7 +46,7 @@
         </div>
     <?php endif; ?>
 
-    <input type="hidden" name="leadId" id="leadId" value="<?php echo $lead->getId(); ?>" />
+    <input type="hidden" name="leadId" id="leadId" value="<?php echo $view->escape($lead->getId()); ?>" />
 </form>
 
 <script>

--- a/app/bundles/LeadBundle/Views/Field/properties_boolean.html.php
+++ b/app/bundles/LeadBundle/Views/Field/properties_boolean.html.php
@@ -20,7 +20,7 @@ $no  = (isset($no)) ? $no : $view['translator']->trans('mautic.core.form.no');
                 <span class="input-group-addon text-danger">
                     <i class="fa fa-lg fa-fw fa-times"></i>
                 </span>
-                <input type="text" autocomplete="false" class="form-control" name="leadfield[properties][no]" value="<?php echo $no; ?>" onkeyup="Mautic.updateLeadFieldBooleanLabels(this, 0);">
+                <input type="text" autocomplete="false" class="form-control" name="leadfield[properties][no]" value="<?php echo $view->escape($no); ?>" onkeyup="Mautic.updateLeadFieldBooleanLabels(this, 0);">
             </div>
         </div>
         <div class="form-group col-xs-12 col-sm-8 col-md-6">
@@ -28,7 +28,7 @@ $no  = (isset($no)) ? $no : $view['translator']->trans('mautic.core.form.no');
                 <span class="input-group-addon text-success">
                     <i class="fa fa-lg fa-fw fa-check"></i>
                 </span>
-                <input type="text" autocomplete="false" class="form-control" name="leadfield[properties][yes]" value="<?php echo $yes; ?>" onkeyup="Mautic.updateLeadFieldBooleanLabels(this, 1);">
+                <input type="text" autocomplete="false" class="form-control" name="leadfield[properties][yes]" value="<?php echo $view->escape($yes); ?>" onkeyup="Mautic.updateLeadFieldBooleanLabels(this, 1);">
             </div>
         </div>
     </div>

--- a/app/bundles/LeadBundle/Views/Field/properties_number.html.php
+++ b/app/bundles/LeadBundle/Views/Field/properties_number.html.php
@@ -30,7 +30,7 @@ $options = [
             <div class="input-group">
                 <select class="form-control not-chosen" autocomplete="false" name="leadfield[properties][roundmode]">
                     <?php foreach ($options as $v => $l): ?>
-                    <option value="<?php echo $v; ?>"<?php if ($roundMode == $v) {
+                    <option value="<?php echo $view->escape($v); ?>"<?php if ($roundMode == $v) {
     echo ' selected="selected"';
 } ?>><?php echo $view['translator']->trans($l); ?></option>
                     <?php endforeach; ?>
@@ -45,7 +45,7 @@ $options = [
         <div class="form-group col-xs-12 col-sm-8 col-md-6">
             <label class="control-label"><?php echo $view['translator']->trans('mautic.lead.field.form.properties.numberprecision'); ?></label>
             <div class="input-group">
-                <input autocomplete="false" name="leadfield[properties][precision]" class="form-control" value="<?php echo $precision; ?>" type="number" />
+                <input autocomplete="false" name="leadfield[properties][precision]" class="form-control" value="<?php echo $view->escape($precision); ?>" type="number" />
                 <span class="input-group-addon" data-toggle="tooltip" data-container="body"
                       data-placement="top" data-original-title="<?php echo $view['translator']->trans('mautic.lead.field.help.numberprecision'); ?>">
                     <i class="fa fa-question-circle"></i>

--- a/app/bundles/LeadBundle/Views/FormTheme/FieldValueCondition/campaignevent_lead_field_value_widget.html.php
+++ b/app/bundles/LeadBundle/Views/FormTheme/FieldValueCondition/campaignevent_lead_field_value_widget.html.php
@@ -41,7 +41,7 @@
                 <select id="lead-field-custom-date-unit" class="form-control chosen" autocomplete="false" onchange="Mautic.updateLeadFieldValueOptions(mQuery('#campaignevent_properties_value'), true)">
                     <?php foreach (['i', 'h', 'd', 'm', 'y'] as $interval): ?>
                     <?php $selected = ('d' === $interval) ? ' selected' : ''; ?>
-                    <option<?php echo $selected; ?> value="<?php echo $interval; ?>">
+                    <option<?php echo $selected; ?> value="<?php echo $view->escape($interval); ?>">
                         <?php echo $view['translator']->trans('mautic.campaign.event.intervalunit.choice.'.$interval); ?>
                     </option>
                     <?php endforeach; ?>

--- a/app/bundles/LeadBundle/Views/Import/details.html.php
+++ b/app/bundles/LeadBundle/Views/Import/details.html.php
@@ -224,6 +224,6 @@ $detailRowTmpl = 'MauticCoreBundle:Helper:detail_row.html.php';
         <?php echo $view->render('MauticCoreBundle:Helper:recentactivity.html.php', ['logs' => $logs]); ?>
     </div>
     <!--/ right section -->
-    <input name="entityId" id="entityId" type="hidden" value="<?php echo $item->getId(); ?>"/>
+    <input name="entityId" id="entityId" type="hidden" value="<?php echo $view->escape($item->getId()); ?>"/>
 </div>
 <!--/ end: box layout -->

--- a/app/bundles/LeadBundle/Views/Lead/frequency.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/frequency.html.php
@@ -51,7 +51,7 @@ $leadName = $lead->getPrimaryIdentifier();
                         <input type="checkbox" id="<?php echo $channel->value ?>"
                                name="lead_contact_frequency_rules[subscribed_channels][]" class="control-label"
                                onclick="Mautic.togglePreferredChannel(this.value);"
-                               value="<?php echo $channel->value ?>" <?php echo $checked; ?>>
+                               value="<?php echo $view->escape($channel->value) ?>" <?php echo $checked; ?>>
                     </th>
                     <td class="col-md-1" style="vertical-align: top">
                         <div id="is-contactable-<?php echo $channel->value ?>" class="<?php echo $isContactable; ?> fw-sb">
@@ -74,7 +74,7 @@ $leadName = $lead->getPrimaryIdentifier();
                 <td class="col-md-1" style="vertical-align: top;" align="center">
                         <input type="radio" id="preferred_<?php echo $channel->value ?>"
                                name="lead_contact_frequency_rules[preferred_channel]" class="contact"
-                               value="<?php echo $channel->value ?>" <?php if ($form['preferred_channel']->vars['value'] == $channel->value) {
+                               value="<?php echo $view->escape($channel->value) ?>" <?php if ($form['preferred_channel']->vars['value'] == $channel->value) {
                                         echo $checked;
                                     } ?> <?php echo $disabled; ?>>
 
@@ -131,4 +131,3 @@ $leadName = $lead->getPrimaryIdentifier();
     </div>
 </div>
 <?php echo $view['form']->end($form); ?>
-

--- a/app/bundles/LeadBundle/Views/List/details.html.php
+++ b/app/bundles/LeadBundle/Views/List/details.html.php
@@ -128,7 +128,7 @@ $view['slots']->set(
                         <div class="col-sm-5">
                             <select name="includeEvents[]" multiple="multiple" class="form-control bdr-w-0" data-placeholder="<?php echo $view['translator']->trans('mautic.lead.lead.filter.bundles.include.placeholder'); ?>">
                                 <?php foreach ($events['types'] as $typeKey => $typeName) : ?>
-                                    <option value="<?php echo $typeKey; ?>">
+                                    <option value="<?php echo $view->escape($typeKey); ?>">
                                         <?php echo $typeName; ?>
                                     </option>
                                 <?php endforeach; ?>
@@ -165,6 +165,6 @@ $view['slots']->set(
         <?php // echo $view->render('MauticCoreBundle:Helper:recentactivity.html.php', ['logs' => $logs]);?>
     </div>
     <!--/ right section -->
-    <input name="entityId" id="entityId" type="hidden" value="<?php echo $list->getId(); ?>" />
+    <input name="entityId" id="entityId" type="hidden" value="<?php echo $view->escape($list->getId()); ?>" />
 </div>
 <!--/ end: box layout -->

--- a/app/bundles/LeadBundle/Views/List/form.html.php
+++ b/app/bundles/LeadBundle/Views/List/form.html.php
@@ -101,7 +101,7 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
                                             $callback  = (!empty($params['properties']['callback'])) ? $params['properties']['callback'] : '';
                                             $operators = (!empty($params['operators'])) ? $view->escape(json_encode($params['operators'])) : '{}';
                                             ?>
-                                            <option value="<?php echo $value; ?>"
+                                            <option value="<?php echo $view->escape($value); ?>"
                                                     id="available_<?php echo $value; ?>"
                                                     data-field-object="<?php echo $object; ?>"
                                                     data-field-type="<?php echo $params['properties']['type']; ?>"

--- a/app/bundles/LeadBundle/Views/Note/index.html.php
+++ b/app/bundles/LeadBundle/Views/Note/index.html.php
@@ -13,15 +13,15 @@
 	<div class="col-xs-10 va-m">
         <form action="<?php echo $view['router']->path('mautic_contactnote_index', ['page' => $page, 'leadId' => $lead->getId(), 'tmpl' => 'list']); ?>" class="panel" id="note-filters" method="post">
             <div class="form-control-icon pa-xs">
-                <input type="text" name="search" value="<?php echo $search; ?>" id="NoteFilter" class="form-control bdr-w-0" placeholder="<?php echo $view['translator']->trans('mautic.core.search.placeholder'); ?>" data-toggle="livesearch" data-target="#NoteList" data-action="<?php echo $view['router']->path('mautic_contactnote_index', ['leadId' => $lead->getId(), 'page' => 1]); ?>">
+                <input type="text" name="search" value="<?php echo $view->escape($search); ?>" id="NoteFilter" class="form-control bdr-w-0" placeholder="<?php echo $view['translator']->trans('mautic.core.search.placeholder'); ?>" data-toggle="livesearch" data-target="#NoteList" data-action="<?php echo $view['router']->path('mautic_contactnote_index', ['leadId' => $lead->getId(), 'page' => 1]); ?>">
                 <span class="the-icon fa fa-search text-muted mt-xs"></span><!-- must below `form-control` -->
             </div>
-            <input type="hidden" name="leadId" id="leadId" value="<?php echo $lead->getId(); ?>" />
+            <input type="hidden" name="leadId" id="leadId" value="<?php echo $view->escape($lead->getId()); ?>" />
             <div class="panel-footer text-muted">
                 <?php foreach ($noteTypes as $typeKey => $typeName) : ?>
                     <div class="checkbox-inline custom-primary">
                         <label class="mb-0">
-                            <input name="noteTypes[]" type="checkbox" value="<?php echo $typeKey; ?>"<?php echo in_array($typeKey, $noteType) ? ' checked' : ''; ?> />
+                            <input name="noteTypes[]" type="checkbox" value="<?php echo $view->escape($typeKey); ?>"<?php echo in_array($typeKey, $noteType) ? ' checked' : ''; ?> />
                             <span class="mr-0"></span>
                             <?php echo $view['translator']->trans($typeName); ?>
                         </label>

--- a/app/bundles/LeadBundle/Views/Timeline/index.html.php
+++ b/app/bundles/LeadBundle/Views/Timeline/index.html.php
@@ -13,7 +13,7 @@
 <!-- filter form -->
 <form method="post" action="<?php echo $view['router']->path('mautic_contacttimeline_action', ['leadId' => $lead->getId()]); ?>" class="panel" id="timeline-filters">
     <div class="form-control-icon pa-xs">
-        <input type="text" class="form-control bdr-w-0" name="search" id="search" placeholder="<?php echo $view['translator']->trans('mautic.core.search.placeholder'); ?>" value="<?php echo $events['filters']['search']; ?>">
+        <input type="text" class="form-control bdr-w-0" name="search" id="search" placeholder="<?php echo $view['translator']->trans('mautic.core.search.placeholder'); ?>" value="<?php echo $view->escape($events['filters']['search']); ?>">
         <span class="the-icon fa fa-search text-muted mt-xs"></span>
     </div>
     <?php if (isset($events['types']) && is_array($events['types'])) : ?>
@@ -21,7 +21,7 @@
             <div class="col-sm-5">
                 <select name="includeEvents[]" multiple="multiple" class="form-control bdr-w-0" data-placeholder="<?php echo $view['translator']->trans('mautic.lead.lead.filter.bundles.include.placeholder'); ?>">
                     <?php foreach ($events['types'] as $typeKey => $typeName) : ?>
-                        <option value="<?php echo $typeKey; ?>"<?php echo in_array($typeKey, $events['filters']['includeEvents']) ? ' selected' : ''; ?> >
+                        <option value="<?php echo $view->escape($typeKey); ?>"<?php echo in_array($typeKey, $events['filters']['includeEvents']) ? ' selected' : ''; ?> >
                             <?php echo $typeName; ?>
                         </option>
                     <?php endforeach; ?>
@@ -30,7 +30,7 @@
             <div class="col-sm-5">
                 <select name="excludeEvents[]" multiple="multiple" class="form-control bdr-w-0" data-placeholder="<?php echo $view['translator']->trans('mautic.lead.lead.filter.bundles.exclude.placeholder'); ?>">
                     <?php foreach ($events['types'] as $typeKey => $typeName) : ?>
-                        <option value="<?php echo $typeKey; ?>"<?php echo in_array($typeKey, $events['filters']['excludeEvents']) ? ' selected' : ''; ?> >
+                        <option value="<?php echo $view->escape($typeKey); ?>"<?php echo in_array($typeKey, $events['filters']['excludeEvents']) ? ' selected' : ''; ?> >
                             <?php echo $typeName; ?>
                         </option>
                     <?php endforeach; ?>
@@ -46,7 +46,7 @@
         </div>
     <?php endif; ?>
 
-    <input type="hidden" name="leadId" id="leadId" value="<?php echo $lead->getId(); ?>" />
+    <input type="hidden" name="leadId" id="leadId" value="<?php echo $view->escape($lead->getId()); ?>" />
 </form>
 
 <script>

--- a/app/bundles/LeadBundle/Views/Timeline/plugin_index.html.php
+++ b/app/bundles/LeadBundle/Views/Timeline/plugin_index.html.php
@@ -20,7 +20,7 @@ $view->extend('MauticCoreBundle:Default:slim.html.php');
     'mautic_plugin_timeline_view', ['leadId' => $lead->getId(), 'integration' => $integration]
 ) : $view['router']->path('mautic_plugin_timeline_index', ['integration' => $integration]); ?>" class="panel" id="timeline-filters">
     <div class="form-control-icon pa-xs">
-        <input type="text" class="form-control bdr-w-0" name="search" id="search" placeholder="<?php echo $view['translator']->trans('mautic.core.search.placeholder'); ?>" value="<?php echo $events['filters']['search']; ?>">
+        <input type="text" class="form-control bdr-w-0" name="search" id="search" placeholder="<?php echo $view['translator']->trans('mautic.core.search.placeholder'); ?>" value="<?php echo $view->escape($events['filters']['search']); ?>">
         <span class="the-icon fa fa-search text-muted mt-xs"></span>
     </div>
     <?php if (isset($events['types']) && is_array($events['types'])) : ?>
@@ -28,7 +28,7 @@ $view->extend('MauticCoreBundle:Default:slim.html.php');
             <div class="col-xs-6">
                 <select name="includeEvents[]" multiple="multiple" class="form-control bdr-w-0" data-placeholder="<?php echo $view['translator']->trans('mautic.lead.lead.filter.bundles.include.placeholder'); ?>">
                     <?php foreach ($events['types'] as $typeKey => $typeName) : ?>
-                        <option value="<?php echo $typeKey; ?>"<?php echo in_array($typeKey, $events['filters']['includeEvents']) ? ' selected' : ''; ?> >
+                        <option value="<?php echo $view->escape($typeKey); ?>"<?php echo in_array($typeKey, $events['filters']['includeEvents']) ? ' selected' : ''; ?> >
                             <?php echo $typeName; ?>
                         </option>
                     <?php endforeach; ?>
@@ -37,7 +37,7 @@ $view->extend('MauticCoreBundle:Default:slim.html.php');
             <div class="col-xs-6">
                 <select name="excludeEvents[]" multiple="multiple" class="form-control bdr-w-0" data-placeholder="<?php echo $view['translator']->trans('mautic.lead.lead.filter.bundles.exclude.placeholder'); ?>">
                     <?php foreach ($events['types'] as $typeKey => $typeName) : ?>
-                        <option value="<?php echo $typeKey; ?>"<?php echo in_array($typeKey, $events['filters']['excludeEvents']) ? ' selected' : ''; ?> >
+                        <option value="<?php echo $view->escape($typeKey); ?>"<?php echo in_array($typeKey, $events['filters']['excludeEvents']) ? ' selected' : ''; ?> >
                             <?php echo $typeName; ?>
                         </option>
                     <?php endforeach; ?>
@@ -47,7 +47,7 @@ $view->extend('MauticCoreBundle:Default:slim.html.php');
     <?php endif; ?>
 
     <?php if (isset($lead)) : ?>
-        <input type="hidden" name="leadId" id="leadId" value="<?php echo $lead->getId(); ?>"/>
+        <input type="hidden" name="leadId" id="leadId" value="<?php echo $view->escape($lead->getId()); ?>"/>
     <?php endif; ?>
 </form>
 

--- a/app/bundles/NotificationBundle/Views/MobileNotification/details.html.php
+++ b/app/bundles/NotificationBundle/Views/MobileNotification/details.html.php
@@ -122,6 +122,6 @@ $view['slots']->set(
         <?php echo $view->render('MauticCoreBundle:Helper:recentactivity.html.php', ['logs' => $logs]); ?>
     </div>
     <!--/ right section -->
-    <input name="entityId" id="entityId" type="hidden" value="<?php echo $notification->getId(); ?>" />
+    <input name="entityId" id="entityId" type="hidden" value="<?php echo $view->escape($notification->getId()); ?>" />
 </div>
 <!--/ end: box layout -->

--- a/app/bundles/NotificationBundle/Views/Notification/details.html.php
+++ b/app/bundles/NotificationBundle/Views/Notification/details.html.php
@@ -122,6 +122,6 @@ $view['slots']->set(
         <?php echo $view->render('MauticCoreBundle:Helper:recentactivity.html.php', ['logs' => $logs]); ?>
     </div>
     <!--/ right section -->
-    <input name="entityId" id="entityId" type="hidden" value="<?php echo $notification->getId(); ?>" />
+    <input name="entityId" id="entityId" type="hidden" value="<?php echo $view->escape($notification->getId()); ?>" />
 </div>
 <!--/ end: box layout -->

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -1094,7 +1094,7 @@ class PageController extends FormController
 
         //add builder toolbar
         $slotsHelper->start('builder'); ?>
-        <input type="hidden" id="builder_entity_id" value="<?php echo $entity->getSessionId(); ?>"/>
+        <input type="hidden" id="builder_entity_id" value="<?php echo $view->escape($entity->getSessionId()); ?>"/>
         <?php
         $slotsHelper->stop();
     }

--- a/app/bundles/PageBundle/Views/Page/details.html.php
+++ b/app/bundles/PageBundle/Views/Page/details.html.php
@@ -236,7 +236,7 @@ $view['slots']->set(
                 <div class="input-group">
                     <input onclick="this.setSelectionRange(0, this.value.length);" type="text" class="form-control"
                            readonly
-                           value="<?php echo $pageUrl; ?>"/>
+                           value="<?php echo $view->escape($pageUrl); ?>"/>
                     <span class="input-group-btn">
                         <button class="btn btn-default btn-nospin" onclick="window.open('<?php echo $pageUrl; ?>', '_blank');">
                             <i class="fa fa-external-link"></i>
@@ -254,7 +254,7 @@ $view['slots']->set(
                 <div class="input-group">
                     <input onclick="this.setSelectionRange(0, this.value.length);" type="text" class="form-control"
                            readonly
-                           value="<?php echo $previewUrl; ?>"/>
+                           value="<?php echo $view->escape($previewUrl); ?>"/>
                     <span class="input-group-btn">
                     <button class="btn btn-default btn-nospin"
                             onclick="window.open('<?php echo $previewUrl; ?>', '_blank');">

--- a/app/bundles/PluginBundle/Views/FormTheme/Integration/_integration_details_supportedFeatures_row.html.php
+++ b/app/bundles/PluginBundle/Views/FormTheme/Integration/_integration_details_supportedFeatures_row.html.php
@@ -33,7 +33,7 @@ $showLabel = (count($builtin) !== count($form->children));
             </div>
             <?php else: ?>
                 <?php $child->isRendered(); ?>
-                <input type="hidden" id="<?php echo $child->vars['id']; ?>" name="<?php echo $child->vars['full_name']; ?>" value="<?php echo $child->vars['value']; ?>" />
+                <input type="hidden" id="<?php echo $child->vars['id']; ?>" name="<?php echo $child->vars['full_name']; ?>" value="<?php echo $view->escape($child->vars['value']); ?>" />
             <?php endif; ?>
         <?php endforeach; ?>
     </div>

--- a/app/bundles/PluginBundle/Views/FormTheme/Integration/fields_row.html.php
+++ b/app/bundles/PluginBundle/Views/FormTheme/Integration/fields_row.html.php
@@ -71,7 +71,7 @@ $indexCount = 1;
                                id="<?php echo $child->vars['id']; ?>"
                                name="<?php echo $child->vars['full_name']; ?>"
                                class="<?php echo $child->vars['attr']['class']; ?>"
-                               value="<?php echo $child->vars['attr']['data-label']; ?>"
+                               value="<?php echo $view->escape($child->vars['attr']['data-label']); ?>"
                                readonly />
                     </div>
                 </div>
@@ -131,14 +131,14 @@ $indexCount = 1;
                     <?php if (is_array($options)) : ?>
                     <optgroup label="<?php echo $keyLabel; ?>">
                         <?php foreach ($options as $keyValue => $o): ?>
-                        <option value="<?php echo $keyValue; ?>" <?php if ($keyValue === $child->vars['data']): echo 'selected'; $selected = true; elseif (empty($selected) && $keyValue == '-1'): echo 'selected'; endif; ?>>
+                        <option value="<?php echo $view->escape($keyValue); ?>" <?php if ($keyValue === $child->vars['data']): echo 'selected'; $selected = true; elseif (empty($selected) && $keyValue == '-1'): echo 'selected'; endif; ?>>
                             <?php echo $o; ?>
                         </option>
                         <?php endforeach; ?>
 
                     </optgroup>
                     <?php else : ?>
-                    <option value="<?php echo $keyLabel; ?>" <?php if ($keyLabel === $child->vars['data']): echo 'selected'; $selected = true; elseif (empty($selected) && $keyLabel == '-1'): echo 'selected'; endif; ?>>
+                    <option value="<?php echo $view->escape($keyLabel); ?>" <?php if ($keyLabel === $child->vars['data']): echo 'selected'; $selected = true; elseif (empty($selected) && $keyLabel == '-1'): echo 'selected'; endif; ?>>
                         <?php echo $options; ?>
                     </option>
                     <?php endif; ?>

--- a/app/bundles/PluginBundle/Views/Integration/form.html.php
+++ b/app/bundles/PluginBundle/Views/Integration/form.html.php
@@ -106,7 +106,7 @@ $hasFeatureErrors =
         <?php if (count($form['apiKeys']) && !empty($callbackUrl)): ?>
             <div class="well well-sm">
                 <?php echo $view['translator']->trans('mautic.integration.callbackuri'); ?><br/>
-                <input type="text" readonly onclick="this.setSelectionRange(0, this.value.length);" value="<?php echo $callbackUrl; ?>" class="form-control"/>
+                <input type="text" readonly onclick="this.setSelectionRange(0, this.value.length);" value="<?php echo $view->escape($callbackUrl); ?>" class="form-control"/>
             </div>
         <?php endif; ?>
         <?php if (isset($form['authButton'])): ?>

--- a/app/bundles/PluginBundle/Views/Integration/index.html.php
+++ b/app/bundles/PluginBundle/Views/Integration/index.html.php
@@ -43,7 +43,9 @@ $view['slots']->set('actions', $view->render('MauticCoreBundle:Helper:page_actio
                     <select id="integrationFilter" onchange="Mautic.filterIntegrations(true);" class="form-control" data-placeholder="<?php echo $view['translator']->trans('mautic.integration.filter.all'); ?>">
                         <option value=""></option>
                         <?php foreach ($plugins as $a): ?>
-                        <option<?php echo ($filterValue === $a['id']) ? ' selected' : ''; ?> value="<?php echo $a['id']; ?>"><?php echo $a['name']; ?></option>
+                        <option<?php echo ($filterValue === $a['id']) ? ' selected' : ''; ?> value="<?php echo $view->escape($a['id']); ?>">
+                            <?php echo $a['name']; ?>
+                        </option>
                         <?php endforeach; ?>
                     </select>
                 </div>

--- a/app/bundles/ReportBundle/Views/FormTheme/Report/_report_aggregators_entry_column_row.html.php
+++ b/app/bundles/ReportBundle/Views/FormTheme/Report/_report_aggregators_entry_column_row.html.php
@@ -1,8 +1,12 @@
 <div class="choice-wrapper col-xs-6">
-<label class="<?php echo $form->vars['label_attr']['class']; ?>" for="<?php echo $form->vars['id']; ?>"><?php echo $view['translator']->trans($form->vars['label']); ?></label>
-<select id="<?php echo $form->vars['id']; ?>" name="<?php echo $form->vars['full_name']; ?>" class="<?php echo $form->vars['attr']['class']; ?>">
-    <?php foreach ($form->vars['choices'] as $column):?>
-        <option value="<?php echo $column->value; ?>"<?php echo ($column->value == $form->vars['data']) ? ' selected' : ''; ?>><?php echo $column->label; ?></option>
-    <?php endforeach; ?>
-</select>
+    <label class="<?php echo $form->vars['label_attr']['class']; ?>" for="<?php echo $form->vars['id']; ?>">
+        <?php echo $view['translator']->trans($form->vars['label']); ?>
+    </label>
+    <select id="<?php echo $form->vars['id']; ?>" name="<?php echo $form->vars['full_name']; ?>" class="<?php echo $form->vars['attr']['class']; ?>">
+        <?php foreach ($form->vars['choices'] as $column):?>
+            <option value="<?php echo $view->escape($column->value); ?>"<?php echo ($column->value == $form->vars['data']) ? ' selected' : ''; ?>>
+                <?php echo $column->label; ?>
+            </option>
+        <?php endforeach; ?>
+    </select>
 </div>

--- a/app/bundles/ReportBundle/Views/FormTheme/Report/_report_aggregators_entry_function_row.html.php
+++ b/app/bundles/ReportBundle/Views/FormTheme/Report/_report_aggregators_entry_function_row.html.php
@@ -1,10 +1,10 @@
 <div class="choice-wrapper col-xs-4">
     <label class="<?php echo $form->vars['label_attr']['class']; ?>" for="<?php echo $form->vars['id']; ?>"><?php echo $view['translator']->trans($form->vars['label']); ?></label>
     <select id="<?php echo $form->vars['id']; ?>" name="<?php echo $form->vars['full_name']; ?>" class="<?php echo $form->vars['attr']['class']; ?>" onchange="Mautic.checkReportCondition('<?php echo $form->vars['id']; ?>')">
-        <?php foreach ($form->vars['choices'] as $function) {
-    ?>
-            <option value="<?php echo $function->value; ?>"<?php echo ($function->value == $form->vars['data']) ? ' selected' : '' ?>><?php echo $function->label; ?></option>
-            <?php
-} ?>
+        <?php foreach ($form->vars['choices'] as $function) : ?>
+            <option value="<?php echo $view->escape($function->value); ?>"<?php echo ($function->value == $form->vars['data']) ? ' selected' : '' ?>>
+                <?php echo $function->label; ?>
+            </option>
+        <?php endforeach; ?>
     </select>
 </div>

--- a/app/bundles/ReportBundle/Views/FormTheme/Report/_report_filters_entry_column_row.html.php
+++ b/app/bundles/ReportBundle/Views/FormTheme/Report/_report_filters_entry_column_row.html.php
@@ -2,6 +2,8 @@
 <label class="<?php echo $form->vars['label_attr']['class']; ?>" for="<?php echo $form->vars['id']; ?>"><?php echo $view['translator']->trans($form->vars['label']); ?></label>
 <select id="<?php echo $form->vars['id']; ?>" name="<?php echo $form->vars['full_name']; ?>" class="<?php echo $form->vars['attr']['class']; ?>">
     <?php foreach ($form->vars['choices'] as $column): ?>
-    <option value="<?php echo $column->value; ?>"<?php echo ($column->value == $form->vars['data']) ? ' selected' : ''; ?>><?php echo $column->label; ?></option>
+    <option value="<?php echo $view->escape($column->value); ?>"<?php echo ($column->value == $form->vars['data']) ? ' selected' : ''; ?>>
+        <?php echo $column->label; ?>
+    </option>
     <?php endforeach; ?>
 </select>

--- a/app/bundles/ReportBundle/Views/FormTheme/Report/_report_filters_entry_condition_row.html.php
+++ b/app/bundles/ReportBundle/Views/FormTheme/Report/_report_filters_entry_condition_row.html.php
@@ -1,8 +1,8 @@
 <label class="<?php echo $form->vars['label_attr']['class']; ?>" for="<?php echo $form->vars['id']; ?>"><?php echo $view['translator']->trans($form->vars['label']); ?></label>
 <select id="<?php echo $form->vars['id']; ?>" name="<?php echo $form->vars['full_name']; ?>" class="<?php echo $form->vars['attr']['class']; ?>" onchange="Mautic.checkReportCondition('<?php echo $form->vars['id']; ?>')">
-    <?php foreach ($form->vars['choices'] as $condition) {
-    ?>
-    <option value="<?php echo $condition->value; ?>"<?php echo ($condition->value == $form->vars['data']) ? ' selected' : '' ?>><?php echo $condition->label; ?></option>
-    <?php
-} ?>
+    <?php foreach ($form->vars['choices'] as $condition) : ?>
+    <option value="<?php echo $view->escape($condition->value); ?>"<?php echo ($condition->value == $form->vars['data']) ? ' selected' : '' ?>>
+        <?php echo $condition->label; ?>
+    </option>
+    <?php endforeach; ?>
 </select>

--- a/app/bundles/ReportBundle/Views/FormTheme/Report/_report_filters_entry_value_row.html.php
+++ b/app/bundles/ReportBundle/Views/FormTheme/Report/_report_filters_entry_value_row.html.php
@@ -1,5 +1,5 @@
 <?php $condition = $form->parent->children['condition']->vars['value']; ?>
 <div class="form-group mb-0">
     <label class="<?php echo $form->vars['label_attr']['class']; ?>" for="<?php echo $form->vars['id']; ?>"><?php echo $view['translator']->trans($form->vars['label']); ?></label>
-    <input type="text" id="<?php echo $form->vars['id']; ?>" name="<?php echo $form->vars['full_name']; ?>" class="<?php echo $form->vars['attr']['class']; ?>" value="<?php echo $form->vars['data']; ?>"<?php echo (in_array($condition, ['empty', 'notEmpty'])) ? ' disabled' : ''; ?> />
+    <input type="text" id="<?php echo $form->vars['id']; ?>" name="<?php echo $form->vars['full_name']; ?>" class="<?php echo $form->vars['attr']['class']; ?>" value="<?php echo $view->escape($form->vars['data']); ?>"<?php echo (in_array($condition, ['empty', 'notEmpty'])) ? ' disabled' : ''; ?> />
 </div>

--- a/app/bundles/ReportBundle/Views/FormTheme/Report/_report_tableOrder_entry_column_row.html.php
+++ b/app/bundles/ReportBundle/Views/FormTheme/Report/_report_tableOrder_entry_column_row.html.php
@@ -1,10 +1,10 @@
 <div class="choice-wrapper col-xs-6">
     <label class="<?php echo $form->vars['label_attr']['class']; ?>" for="<?php echo $form->vars['id']; ?>"><?php echo $view['translator']->trans($form->vars['label']); ?></label>
     <select id="<?php echo $form->vars['id']; ?>" name="<?php echo $form->vars['full_name']; ?>" class="<?php echo $form->vars['attr']['class']; ?>">
-        <?php foreach ($form->vars['choices'] as $column) {
-    ?>
-        <option value="<?php echo $column->value; ?>"<?php echo ($column->value == $form->vars['data']) ? ' selected' : ''; ?>><?php echo $column->label; ?></option>
-        <?php
-} ?>
+        <?php foreach ($form->vars['choices'] as $column) : ?>
+        <option value="<?php echo $view->escape($column->value); ?>"<?php echo ($column->value == $form->vars['data']) ? ' selected' : ''; ?>>
+            <?php echo $column->label; ?>
+        </option>
+        <?php endforeach; ?>
     </select>
 </div>

--- a/app/bundles/ReportBundle/Views/FormTheme/Report/_report_tableOrder_entry_direction_row.html.php
+++ b/app/bundles/ReportBundle/Views/FormTheme/Report/_report_tableOrder_entry_direction_row.html.php
@@ -1,10 +1,10 @@
 <div class="choice-wrapper col-xs-4">
     <label class="<?php echo $form->vars['label_attr']['class']; ?>" for="<?php echo $form->vars['id']; ?>"><?php echo $view['translator']->trans($form->vars['label']); ?></label>
     <select id="<?php echo $form->vars['id']; ?>" name="<?php echo $form->vars['full_name']; ?>" class="<?php echo $form->vars['attr']['class']; ?>">
-        <?php foreach ($form->vars['choices'] as $direction) {
-    ?>
-        <option value="<?php echo $direction->value; ?>"<?php echo ($direction->value == $form->vars['data']) ? ' selected' : '' ?>><?php echo $direction->label; ?></option>
-        <?php
-} ?>
+        <?php foreach ($form->vars['choices'] as $direction) : ?>
+        <option value="<?php echo $view->escape($direction->value); ?>"<?php echo ($direction->value == $form->vars['data']) ? ' selected' : '' ?>>
+            <?php echo $direction->label; ?>
+        </option>
+        <?php endforeach ?>
     </select>
 </div>

--- a/app/bundles/ReportBundle/Views/Report/details.html.php
+++ b/app/bundles/ReportBundle/Views/Report/details.html.php
@@ -176,4 +176,4 @@ if ($tmpl == 'index') {
 </div>
 <?php endif; ?>
 <!--/ end: box layout -->
-<input type="hidden" name="entityId" id="entityId" value="<?php echo $report->getId(); ?>"/>
+<input type="hidden" name="entityId" id="entityId" value="<?php echo $view->escape($report->getId()); ?>"/>

--- a/app/bundles/SmsBundle/Views/Sms/details.html.php
+++ b/app/bundles/SmsBundle/Views/Sms/details.html.php
@@ -157,6 +157,6 @@ if (!$isEmbedded) {
         <?php echo $view->render('MauticCoreBundle:Helper:recentactivity.html.php', ['logs' => $logs]); ?>
     </div>
     <!--/ right section -->
-    <input name="entityId" id="entityId" type="hidden" value="<?php echo $sms->getId(); ?>" />
+    <input name="entityId" id="entityId" type="hidden" value="<?php echo $view->escape($sms->getId()); ?>" />
 </div>
 <!--/ end: box layout -->

--- a/app/bundles/UserBundle/Views/Security/login.html.php
+++ b/app/bundles/UserBundle/Views/Security/login.html.php
@@ -29,7 +29,7 @@ $last_username = InputHelper::clean($last_username);
         <span class="input-group-addon"><i class="fa fa-user"></i></span>
         <label for="username" class="sr-only"><?php echo $view['translator']->trans('mautic.user.auth.form.loginusername'); ?></label>
         <input type="text" id="username" name="_username"
-               class="form-control input-lg" value="<?php echo $last_username ?>" required autofocus
+               class="form-control input-lg" value="<?php echo $view->escape($last_username) ?>" required autofocus
                placeholder="<?php echo $view['translator']->trans('mautic.user.auth.form.loginusername'); ?>" />
     </div>
     <div class="input-group mb-md">
@@ -48,7 +48,7 @@ $last_username = InputHelper::clean($last_username);
         </label>
     </div>
 
-    <input type="hidden" name="_csrf_token" value="<?php echo $view['form']->csrfToken('authenticate') ?>" />
+    <input type="hidden" name="_csrf_token" value="<?php echo $view->escape($view['form']->csrfToken('authenticate')) ?>" />
     <button class="btn btn-lg btn-primary btn-block" type="submit"><?php echo $view['translator']->trans('mautic.user.auth.form.loginbtn'); ?></button>
 
     <div class="mt-sm text-right">

--- a/app/bundles/UserBundle/Views/Security/login.html.php
+++ b/app/bundles/UserBundle/Views/Security/login.html.php
@@ -9,8 +9,6 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-use Mautic\CoreBundle\Helper\InputHelper;
-
 if (!$app->getRequest()->isXmlHttpRequest()):
     //load base template
     $view->extend('MauticUserBundle:Security:base.html.php');
@@ -18,9 +16,6 @@ if (!$app->getRequest()->isXmlHttpRequest()):
 else:
     $view->extend('MauticUserBundle:Security:ajax.html.php');
 endif;
-
-// clean tags and quotes
-$last_username = InputHelper::clean($last_username);
 ?>
 
 <form class="form-group login-form" name="login" data-toggle="ajax" role="form" action="<?php echo $view['router']->path('mautic_user_logincheck') ?>" method="post">

--- a/app/bundles/WebhookBundle/Views/Webhook/details.html.php
+++ b/app/bundles/WebhookBundle/Views/Webhook/details.html.php
@@ -118,7 +118,7 @@ $view['slots']->set('actions', $view->render('MauticCoreBundle:Helper:page_actio
             <div class="panel-body pt-xs">
                 <div class="input-group">
                     <input onclick="this.setSelectionRange(0, this.value.length);" type="text" class="form-control" readonly
-                           value="<?php echo $item->getWebhookUrl(); ?>" />
+                           value="<?php echo $view->escape($item->getWebhookUrl()); ?>" />
                     <span class="input-group-btn">
                         <button class="btn btn-default btn-nospin" onclick="window.open('<?php echo $item->getWebhookUrl(); ?>', '_blank');">
                             <i class="fa fa-external-link"></i>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If a form field value contains double quotes it breaks the form. Therefore the value must be escaped.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to a contact detail.
2. Open the Notes tab.
3. Try to search for `">` string.
4. Wait for the ajax call to end so the value is stored to session.
5. Refresh the page.
6. Go to the Notes tab again. You should see
<img width="750" alt="screen shot 2018-01-02 at 14 06 11" src="https://user-images.githubusercontent.com/1235442/34484640-5322c75a-efc6-11e7-9c3f-aed8c335ed70.png">

#### Steps to test this PR:
1. Checkout this PR
2. Refresh the page again.
3. Go to the Notes tab and the value is correctly in the search input again.

This is one example of many. Make code review for other code changes which does the same thing.