### PR TITLE
Properly escape links in email click campaign decisions

### DIFF
--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -22,9 +22,11 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Event\EmailOpenEvent;
 use Mautic\EmailBundle\Event\EmailReplyEvent;
 use Mautic\EmailBundle\Exception\EmailCouldNotBeSentException;
+use Mautic\EmailBundle\Helper\UrlMatcher;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\EmailBundle\Model\SendEmailToUser;
 use Mautic\LeadBundle\Model\LeadModel;
+use Mautic\PageBundle\Entity\Hit;
 
 /**
  * Class CampaignSubscriber.
@@ -222,14 +224,13 @@ class CampaignSubscriber extends CommonSubscriber
         if (!empty($eventParent) && $eventParent['type'] === 'email.send') {
             // click decision
             if ($event->checkContext('email.click')) {
+                /** @var Hit $hit */
                 $hit = $eventDetails;
                 if ($eventDetails->getEmail()->getId() == (int) $eventParent['properties']['email']) {
                     if (!empty($eventConfig['urls']['list'])) {
-                        $limitToUrl = $eventConfig['urls']['list'];
-                        foreach ($limitToUrl as $url) {
-                            if (preg_match('/'.$url.'/i', $hit->getUrl())) {
-                                return $event->setResult(true);
-                            }
+                        $limitToUrls = (array) $eventConfig['urls']['list'];
+                        if (UrlMatcher::hasMatch($limitToUrls, $hit->getUrl())) {
+                            return $event->setResult(true);
                         }
                     } else {
                         return $event->setResult(true);

--- a/app/bundles/EmailBundle/Helper/UrlMatcher.php
+++ b/app/bundles/EmailBundle/Helper/UrlMatcher.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Helper;
+
+class UrlMatcher
+{
+    /**
+     * @param array $urlsToCheckAgainst
+     * @param       $urlToFind
+     *
+     * @return bool
+     */
+    public static function hasMatch(array $urlsToCheckAgainst, $urlToFind)
+    {
+        foreach ($urlsToCheckAgainst as $url) {
+            $url = str_replace('\\/', '/', $url);
+            if (preg_match('/'.preg_quote($url, '/').'/i', $urlToFind)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/bundles/EmailBundle/Helper/UrlMatcher.php
+++ b/app/bundles/EmailBundle/Helper/UrlMatcher.php
@@ -21,13 +21,40 @@ class UrlMatcher
      */
     public static function hasMatch(array $urlsToCheckAgainst, $urlToFind)
     {
+        $urlToFind = self::sanitizeUrl($urlToFind);
+
         foreach ($urlsToCheckAgainst as $url) {
-            $url = str_replace('\\/', '/', $url);
+            $url = self::sanitizeUrl($url);
+
             if (preg_match('/'.preg_quote($url, '/').'/i', $urlToFind)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * @param $url
+     *
+     * @return mixed|string
+     */
+    private static function sanitizeUrl($url)
+    {
+        // Handle escaped forward slashes as BC
+        $url = str_replace('\\/', '/', $url);
+
+        // Ignore ending slash
+        $url = rtrim($url, '/');
+
+        // Ignore http/https
+        $url = str_replace(['http://', 'https://'], '', $url);
+
+        // Remove preceding //
+        if (strpos($url, '//') === 0) {
+            $url = str_replace('//', '', $url);
+        }
+
+        return $url;
     }
 }

--- a/app/bundles/EmailBundle/Tests/Helper/UrlMatcherTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/UrlMatcherTest.php
@@ -41,4 +41,61 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(UrlMatcher::hasMatch($urls, 'https://google.com/hello'));
     }
+
+    public function testUrlWithEndingSlash()
+    {
+        $urls = [
+            'https://google.com/hello/',
+        ];
+
+        $this->assertTrue(UrlMatcher::hasMatch($urls, 'https://google.com/hello'));
+        $this->assertTrue(UrlMatcher::hasMatch($urls, 'https://google.com/hello/'));
+    }
+
+    public function testUrlWithoutHttpPrefix()
+    {
+        $urls = [
+            'google.com/hello',
+        ];
+
+        $this->assertTrue(UrlMatcher::hasMatch($urls, 'https://google.com/hello'));
+        $this->assertTrue(UrlMatcher::hasMatch($urls, 'http://google.com/hello/'));
+    }
+
+    public function testUrlWithoutHttp()
+    {
+        $urls = [
+            '//google.com/hello',
+        ];
+
+        $this->assertTrue(UrlMatcher::hasMatch($urls, 'https://google.com/hello'));
+        $this->assertTrue(UrlMatcher::hasMatch($urls, '//google.com/hello'));
+    }
+
+    public function testUrlMismatch()
+    {
+        $urls = [
+            'http://google.com',
+        ];
+
+        $this->assertFalse(UrlMatcher::hasMatch($urls, 'https://yahoo.com'));
+    }
+
+    public function testFTPSchemeMisMatch()
+    {
+        $urls = [
+            'ftp://google.com',
+        ];
+
+        $this->assertFalse(UrlMatcher::hasMatch($urls, 'https://google.com'));
+    }
+
+    public function testFTPSchemeMatch()
+    {
+        $urls = [
+            'ftp://google.com',
+        ];
+
+        $this->assertTrue(UrlMatcher::hasMatch($urls, 'ftp://google.com'));
+    }
 }

--- a/app/bundles/EmailBundle/Tests/Helper/UrlMatcherTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/UrlMatcherTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Helper;
+
+use Mautic\EmailBundle\Helper\UrlMatcher;
+
+class UrlMatcherTest extends \PHPUnit_Framework_TestCase
+{
+    public function testUrlIsFound()
+    {
+        $urls = [
+            'google.com',
+        ];
+
+        $this->assertTrue(UrlMatcher::hasMatch($urls, 'google.com'));
+    }
+
+    public function testUrlWithSlashIsMatched()
+    {
+        $urls = [
+            'https://google.com',
+        ];
+
+        $this->assertTrue(UrlMatcher::hasMatch($urls, 'https://google.com'));
+    }
+
+    public function testUrlWithEscapedSlashesIsMatched()
+    {
+        $urls = [
+            'https:\/\/google.com\/hello',
+        ];
+
+        $this->assertTrue(UrlMatcher::hasMatch($urls, 'https://google.com/hello'));
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

In the campaign's email link clicked decision, URLs require forward slashes to be escaped in order for the decision to pick up the click. This changes it so that escaping is not required although is accounted for for BC. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a template email with a link to `https://mautic.com`. 
2. Create a campaign that sends that email, then add a "clicks email" decision limiting to `https://mautic.com`, with an action on the green to tag the contact with something. 
3. Run the campaign to send the email to a contact. 
4. Open the email in a guest/anonymous browser and click the link
5. The decision is not picked up

#### Steps to test this PR:
1. Repeat with a new contact and this time the decision be picked up and the contact tagged.
