### PR TITLE
Retry updating SF locked records several times before giving up and fixed campaign segment sync

### DIFF
--- a/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
+++ b/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\PluginBundle\Entity;
 
+use Doctrine\DBAL\Connection;
 use Mautic\CoreBundle\Entity\CommonRepository;
 
 /**
@@ -35,7 +36,7 @@ class IntegrationEntityRepository extends CommonRepository
         $integration,
         $integrationEntity,
         $internalEntity,
-        $internalEntityId = null,
+        $internalEntityIds = null,
         $startDate = null,
         $endDate = null,
         $push = false,
@@ -62,28 +63,42 @@ class IntegrationEntityRepository extends CommonRepository
                 ->setParameter('startDate', $startDate);
         }
 
-        if ($internalEntityId) {
-            $q->andWhere('i.internal_entity_id = :internalEntityId')
-                ->setParameter('internalEntityId', $internalEntityId);
+        if ($internalEntityIds) {
+            if (is_array($internalEntityIds)) {
+                $q->andWhere('i.internal_entity_id in (:internalEntityIds)')
+                    ->setParameter('internalEntityIds', $internalEntityIds, Connection::PARAM_STR_ARRAY);
+            } else {
+                $q->andWhere('i.internal_entity_id = :internalEntityId')
+                    ->setParameter('internalEntityId', $internalEntityIds);
+            }
         }
 
         if ($startDate and !$push) {
             $q->andWhere('i.last_sync_date >= :startDate')
                 ->setParameter('startDate', $startDate);
         }
+
         if ($endDate and !$push) {
             $q->andWhere('i.last_sync_date <= :endDate')
                 ->setParameter('endDate', $endDate);
         }
 
+        if ($integrationEntityIds) {
+            if (is_array($integrationEntityIds)) {
+                $q->andWhere('i.integration_entity_id in (:integrationEntityIds)')
+                    ->setParameter('integrationEntityIds', $integrationEntityIds, Connection::PARAM_STR_ARRAY);
+            } else {
+                $q->andWhere('i.integration_entity_id = :integrationEntityId')
+                    ->setParameter('integrationEntityId', $integrationEntityIds);
+            }
+        }
+
         if ($start) {
             $q->setFirstResult((int) $start);
         }
+
         if ($limit) {
             $q->setMaxResults((int) $limit);
-        }
-        if ($integrationEntityIds) {
-            $q->andWhere('i.integration_entity_id in ('.$integrationEntityIds.')');
         }
 
         $results = $q->execute()->fetchAll();

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -1052,6 +1052,7 @@ abstract class AbstractIntegration
                 $headers[$key] = $value;
             }
         }
+
         try {
             $timeout = (isset($settings['request_timeout'])) ? (int) $settings['request_timeout'] : 10;
             switch ($method) {

--- a/plugins/MauticCrmBundle/Api/Salesforce/Exception/RetryRequestException.php
+++ b/plugins/MauticCrmBundle/Api/Salesforce/Exception/RetryRequestException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Api\Salesforce\Exception;
+
+class RetryRequestException extends \Exception
+{
+}

--- a/plugins/MauticCrmBundle/Api/Salesforce/Helper/RequestUrl.php
+++ b/plugins/MauticCrmBundle/Api/Salesforce/Helper/RequestUrl.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Api\Salesforce\Helper;
+
+/**
+ * Class RequestUrl.
+ */
+class RequestUrl
+{
+    /**
+     * Correctly generate the URL based on given URL parts.
+     *
+     * @param      $apiUrl
+     * @param      $queryUrl
+     * @param null $operation
+     * @param null $object
+     *
+     * @return string
+     */
+    public static function get($apiUrl, $queryUrl, $operation = null, $object = null)
+    {
+        if ($queryUrl) {
+            return ($operation) ? sprintf($queryUrl.'/%s', $operation) : $queryUrl;
+        }
+
+        return sprintf($apiUrl.'/%s/%s', $object, $operation);
+    }
+}

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -524,12 +524,12 @@ class SalesforceApi extends CrmApi
      */
     private function revalidateSession($isRetry)
     {
-        if (!$isRetry) {
-            throw new RetryRequestException();
-        }
-
         if ($refreshError = $this->integration->authCallback(['use_refresh_token' => true])) {
             throw new ApiErrorException($refreshError);
+        }
+
+        if (!$isRetry) {
+            throw new RetryRequestException();
         }
     }
 

--- a/plugins/MauticCrmBundle/Integration/Salesforce/CampaignMember/Fetcher.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/CampaignMember/Fetcher.php
@@ -1,0 +1,252 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce\CampaignMember;
+
+use Mautic\PluginBundle\Entity\IntegrationEntityRepository;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Exception\InvalidObjectException;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Exception\NoObjectsToFetchException;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object\CampaignMember;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object\Contact;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object\Lead;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\QueryBuilder;
+
+class Fetcher
+{
+    /**
+     * @var IntegrationEntityRepository
+     */
+    private $repo;
+
+    /**
+     * @var Organizer
+     */
+    private $organizer;
+
+    /**
+     * @var string
+     */
+    private $campaignId;
+
+    /**
+     * @var array
+     */
+    private $leads = [];
+
+    /**
+     * @var array
+     */
+    private $knownLeadIds = [];
+
+    /**
+     * @var array
+     */
+    private $unknownLeadIds = [];
+
+    /**
+     * @var array
+     */
+    private $contacts = [];
+
+    /**
+     * @var array
+     */
+    private $knownContactIds = [];
+
+    /**
+     * @var array
+     */
+    private $unknownContactIds = [];
+
+    /**
+     * @var array
+     */
+    private $mauticIds = [];
+
+    /**
+     * @var array
+     */
+    private $knownCampaignMembers = [];
+
+    /**
+     * Fetcher constructor.
+     *
+     * @param IntegrationEntityRepository $repo
+     * @param Organizer                   $organizer
+     * @param string                      $campaignId
+     */
+    public function __construct(IntegrationEntityRepository $repo, Organizer $organizer, $campaignId)
+    {
+        $this->repo       = $repo;
+        $this->organizer  = $organizer;
+        $this->campaignId = $campaignId;
+
+        $this->fetchLeads();
+        $this->fetchContacts();
+    }
+
+    /**
+     * Return SF query to fetch the object information for a CampaignMember.
+     *
+     * @param array $fields
+     * @param       $object
+     *
+     * @return string
+     *
+     * @throws NoObjectsToFetchException
+     * @throws InvalidObjectException
+     */
+    public function getQueryForUnknownObjects(array $fields, $object)
+    {
+        switch ($object) {
+            case Lead::OBJECT:
+                return QueryBuilder::getLeadQuery($fields, $this->unknownLeadIds);
+            case Contact::OBJECT:
+                return QueryBuilder::getContactQuery($fields, $this->unknownContactIds);
+            default:
+                throw new InvalidObjectException();
+        }
+    }
+
+    /**
+     * Fetch the Mautic contact IDs that are not already tracked as SF campaign members.
+     *
+     * @return array
+     */
+    public function getUnknownCampaignMembers()
+    {
+        // First, find those already tracked as part of this campaign
+        $this->fetchCampaignMembers();
+
+        // Second, find newly created objects
+        $this->fetchNewlyCreated();
+
+        $mauticLeadIds = array_map(
+            function ($entity) {
+                return $entity['internal_entity_id'];
+            },
+            $this->knownCampaignMembers
+        );
+
+        return array_values(array_diff($this->mauticIds, $mauticLeadIds));
+    }
+
+    /**
+     * Fetch SF leads already identified.
+     */
+    private function fetchLeads()
+    {
+        if (!$campaignMembers = $this->organizer->getLeadIds()) {
+            return;
+        }
+
+        $this->leads = $this->repo->getIntegrationsEntityId(
+            'Salesforce',
+            Lead::OBJECT,
+            'lead',
+            null,
+            null,
+            null,
+            false,
+            0,
+            0,
+            $campaignMembers
+        );
+
+        foreach ($this->leads as $lead) {
+            $this->knownLeadIds[] = $lead['integration_entity_id'];
+            $this->mauticIds[]    = $lead['internal_entity_id'];
+        }
+
+        $this->unknownLeadIds = array_values(array_diff($campaignMembers, $this->knownLeadIds));
+    }
+
+    /**
+     * Fetch SF contacts already identified.
+     */
+    private function fetchContacts()
+    {
+        if (!$campaignMembers = $this->organizer->getContactIds()) {
+            return;
+        }
+
+        $this->contacts = $this->repo->getIntegrationsEntityId(
+            'Salesforce',
+            Contact::OBJECT,
+            'lead',
+            null,
+            null,
+            null,
+            false,
+            0,
+            0,
+            $campaignMembers
+        );
+
+        foreach ($this->contacts as $contact) {
+            $this->knownContactIds[] = $contact['integration_entity_id'];
+            $this->mauticIds[]       = $contact['internal_entity_id'];
+        }
+
+        $this->unknownContactIds = array_values(array_diff($campaignMembers, $this->knownContactIds));
+    }
+
+    /**
+     * Fetch SF campaign members already identified.
+     */
+    private function fetchCampaignMembers()
+    {
+        if (!$this->mauticIds) {
+            return;
+        }
+
+        $this->knownCampaignMembers = $this->repo->getIntegrationsEntityId(
+            'Salesforce',
+            CampaignMember::OBJECT,
+            'lead',
+            $this->mauticIds,
+            null,
+            null,
+            false,
+            0,
+            0,
+            $this->campaignId
+        );
+    }
+
+    /**
+     * Fetch a list of all identified objects for SF contacts and leads.
+     */
+    private function fetchNewlyCreated()
+    {
+        if (!$allUnknownContacts = array_merge($this->unknownLeadIds, $this->unknownContactIds)) {
+            return;
+        }
+
+        $newlyCreated = $this->repo->getIntegrationsEntityId(
+            'Salesforce',
+            null,
+            'lead',
+            null,
+            null,
+            null,
+            false,
+            0,
+            0,
+            $allUnknownContacts
+        );
+
+        foreach ($newlyCreated as $contact) {
+            $this->knownContactIds[] = $contact['integration_entity_id'];
+            $this->mauticIds[]       = $contact['internal_entity_id'];
+        }
+    }
+}

--- a/plugins/MauticCrmBundle/Integration/Salesforce/CampaignMember/Organizer.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/CampaignMember/Organizer.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce\CampaignMember;
+
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object\Contact;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object\Lead;
+
+class Organizer
+{
+    /**
+     * @var array
+     */
+    private $records;
+
+    /**
+     * @var array
+     */
+    private $leads = [];
+
+    /**
+     * @var array
+     */
+    private $contacts = [];
+
+    /**
+     * ObjectOrganizer constructor.
+     *
+     * @param array $records
+     */
+    public function __construct(array $records)
+    {
+        $this->records = $records;
+
+        $this->organize();
+    }
+
+    /**
+     * @return array
+     */
+    public function getLeads()
+    {
+        return $this->leads;
+    }
+
+    /**
+     * @return array
+     */
+    public function getLeadIds()
+    {
+        return array_keys($this->leads);
+    }
+
+    /**
+     * @return array
+     */
+    public function getContacts()
+    {
+        return $this->contacts;
+    }
+
+    /**
+     * @return array
+     */
+    public function getContactIds()
+    {
+        return array_keys($this->contacts);
+    }
+
+    private function organize()
+    {
+        foreach ($this->records as $campaignMember) {
+            $object    = !empty($campaignMember['LeadId']) ? 'Lead' : 'Contact';
+            $objectId  = !empty($campaignMember['LeadId']) ? $campaignMember['LeadId'] : $campaignMember['ContactId'];
+            $isDeleted = ($campaignMember['IsDeleted']) ? true : false;
+
+            switch ($object) {
+                case Lead::OBJECT:
+                    $this->leads[$objectId] = new Lead($objectId, $campaignMember['CampaignId'], $isDeleted);
+                    break;
+
+                case Contact::OBJECT:
+                    $this->contacts[$objectId] = new Contact($objectId, $campaignMember['CampaignId'], $isDeleted);
+                    break;
+            }
+        }
+    }
+}

--- a/plugins/MauticCrmBundle/Integration/Salesforce/Exception/InvalidObjectException.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/Exception/InvalidObjectException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce\Exception;
+
+class InvalidObjectException extends \InvalidArgumentException
+{
+}

--- a/plugins/MauticCrmBundle/Integration/Salesforce/Exception/NoObjectsToFetchException.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/Exception/NoObjectsToFetchException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce\Exception;
+
+class NoObjectsToFetchException extends \Exception
+{
+}

--- a/plugins/MauticCrmBundle/Integration/Salesforce/Object/CampaignMember.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/Object/CampaignMember.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object;
+
+class CampaignMember
+{
+    const OBJECT = 'CampaignMember';
+}

--- a/plugins/MauticCrmBundle/Integration/Salesforce/Object/Contact.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/Object/Contact.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object;
+
+class Contact
+{
+    const OBJECT = 'Contact';
+
+    private $id;
+    private $campaignId;
+    private $isDeleted;
+
+    public function __construct($id, $campaignId, $isDeleted)
+    {
+        $this->id         = $id;
+        $this->campaignId = $campaignId;
+        $this->isDeleted  = $isDeleted;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCampaignId()
+    {
+        return $this->campaignId;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getisDeleted()
+    {
+        return $this->isDeleted;
+    }
+}

--- a/plugins/MauticCrmBundle/Integration/Salesforce/Object/Lead.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/Object/Lead.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object;
+
+class Lead
+{
+    const OBJECT = 'Lead';
+
+    private $id;
+    private $campaignId;
+    private $isDeleted;
+
+    public function __construct($id, $campaignId, $isDeleted)
+    {
+        $this->id         = $id;
+        $this->campaignId = $campaignId;
+        $this->isDeleted  = $isDeleted;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCampaignId()
+    {
+        return $this->campaignId;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getisDeleted()
+    {
+        return $this->isDeleted;
+    }
+}

--- a/plugins/MauticCrmBundle/Integration/Salesforce/QueryBuilder.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/QueryBuilder.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce;
+
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Exception\NoObjectsToFetchException;
+
+class QueryBuilder
+{
+    /**
+     * @param array $fields
+     * @param array $ids
+     *
+     * @return string
+     *
+     * @throws NoObjectsToFetchException
+     */
+    public static function getLeadQuery(array $fields, array $ids)
+    {
+        if (empty($ids)) {
+            throw new NoObjectsToFetchException();
+        }
+
+        $fieldString = self::getFieldString($fields);
+        $idString    = implode("','", $ids);
+
+        return ($idString) ? "SELECT $fieldString from Lead where Id in ('$idString') and ConvertedContactId = NULL" : '';
+    }
+
+    /**
+     * @param array $fields
+     * @param array $ids
+     *
+     * @return string
+     *
+     * @throws NoObjectsToFetchException
+     */
+    public static function getContactQuery(array $fields, array $ids)
+    {
+        if (empty($ids)) {
+            throw new NoObjectsToFetchException();
+        }
+
+        $fieldString = self::getFieldString($fields);
+        $idString    = implode("','", $ids);
+
+        return ($idString) ? "SELECT $fieldString from Contact where Id in ('$idString')" : '';
+    }
+
+    /**
+     * @param array $fields
+     *
+     * @return string
+     */
+    private static function getFieldString(array $fields)
+    {
+        $fields[] = 'Id';
+
+        return implode(', ', array_unique($fields));
+    }
+}

--- a/plugins/MauticCrmBundle/Integration/Salesforce/ResultsPaginator.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/ResultsPaginator.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce;
+
+use Mautic\PluginBundle\Exception\ApiErrorException;
+use Psr\Log\LoggerInterface;
+
+class ResultsPaginator
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var array
+     */
+    private $results;
+
+    /**
+     * @var int
+     */
+    private $totalRecords = 0;
+
+    /**
+     * @var int
+     */
+    private $recordCount = 0;
+
+    /**
+     * @var
+     */
+    private $retryCount = 0;
+
+    /**
+     * @var
+     */
+    private $nextRecordsUrl;
+
+    /**
+     * @var string
+     */
+    private $salesforceBaseUrl;
+
+    /**
+     * ResultsPaginator constructor.
+     *
+     * @param LoggerInterface $logger
+     * @param string          $salesforceBaseUrl
+     */
+    public function __construct(LoggerInterface $logger, $salesforceBaseUrl)
+    {
+        $this->logger            = $logger;
+        $this->salesforceBaseUrl = $salesforceBaseUrl;
+    }
+
+    /**
+     * @param array $results
+     *
+     * @return $this
+     *
+     * @throws ApiErrorException
+     */
+    public function setResults(array $results)
+    {
+        if (!isset($results['records'])) {
+            throw new ApiErrorException(var_export($results, true));
+        }
+
+        $this->results      = $results;
+        $this->totalRecords = $results['totalSize'];
+        $this->recordCount += count($results['records']);
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     *
+     * @throws ApiErrorException
+     */
+    public function getNextResultsUrl()
+    {
+        if (isset($this->results['nextRecordsUrl'])) {
+            $this->retryCount     = 0;
+            $this->nextRecordsUrl = $this->results['nextRecordsUrl'];
+
+            if (strpos($this->nextRecordsUrl, $this->salesforceBaseUrl) === false) {
+                $this->nextRecordsUrl = $this->salesforceBaseUrl.$this->nextRecordsUrl;
+            }
+
+            return $this->nextRecordsUrl;
+        }
+
+        if ($this->recordCount < $this->totalRecords) {
+            // Something has gone wrong so try a few more times before giving up
+            if ($this->retryCount <= 5) {
+                $this->logger->debug("SALESFORCE: Processed less than total but didn't get a nextRecordsUrl in the response: ".var_export($this->results, true));
+
+                usleep(500);
+                ++$this->retryCount;
+
+                // Try again
+                return $this->nextRecordsUrl;
+            }
+
+            // Throw an exception cause something isn't right
+            throw new ApiErrorException("Expected to process {$this->totalRecords} but only processed {$this->recordCount}: ".var_export($this->results, true));
+        }
+
+        $this->nextRecordsUrl = null;
+
+        return '';
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotal()
+    {
+        return (int) $this->totalRecords;
+    }
+}

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -19,6 +19,11 @@ use Mautic\PluginBundle\Entity\IntegrationEntity;
 use Mautic\PluginBundle\Entity\IntegrationEntityRepository;
 use Mautic\PluginBundle\Exception\ApiErrorException;
 use MauticPlugin\MauticCrmBundle\Api\SalesforceApi;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\CampaignMember\Fetcher;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\CampaignMember\Organizer;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Exception\NoObjectsToFetchException;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object\CampaignMember;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\ResultsPaginator;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -874,53 +879,31 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
         try {
             if ($this->isAuthorized()) {
-                $total     = null;
                 $progress  = null;
-                $processed = 0;
-                $retry     = 0;
+                $paginator = new ResultsPaginator($this->logger, $this->keys['instance_url']);
+
                 while (true) {
                     $result = $this->getApiHelper()->getLeads($query, $object);
-                    if (!isset($result['records'])) {
-                        throw new ApiErrorException(var_export($result, true));
-                    }
+                    $paginator->setResults($result);
 
-                    if (null === $total) {
-                        $total = $result['totalSize'];
+                    if (isset($params['output']) && !isset($params['progress'])) {
+                        $progress = new ProgressBar($params['output'], $paginator->getTotal());
+                        $progress->setFormat(' %current%/%max% [%bar%] %percent:3s%% ('.$object.')');
 
-                        if (isset($params['output'])) {
-                            $progress = new ProgressBar($params['output'], $total);
-                            $progress->setFormat(' %current%/%max% [%bar%] %percent:3s%% ('.$object.')');
-
-                            $params['progress'] = $progress;
-                        }
+                        $params['progress'] = $progress;
                     }
 
                     list($justUpdated, $justCreated) = $this->amendLeadDataBeforeMauticPopulate($result, $object, $params);
 
                     $executed[0] += $justUpdated;
                     $executed[1] += $justCreated;
-                    $processed += count($result['records']);
 
-                    if (isset($result['nextRecordsUrl'])) {
-                        $query['nextUrl'] = $result['nextRecordsUrl'];
-                        $retry            = 0;
-                    } else {
-                        if ($processed < $total) {
-                            // Something has gone wrong so try a few more times before giving up
-                            if ($retry <= 5) {
-                                $this->logger->debug("SALESFORCE: Processed less than total but didn't get a nextRecordsUrl in the response for getLeads ($object): ".var_export($result, true));
-
-                                usleep(500);
-                                ++$retry;
-
-                                continue;
-                            } else {
-                                // Throw an exception cause something isn't right
-                                throw new ApiErrorException("Expected to process $total but only processed $processed: ".var_export($result, true));
-                            }
-                        }
+                    if (!$nextUrl = $paginator->getNextResultsUrl()) {
+                        // No more records to fetch
                         break;
                     }
+
+                    $params['nextUrl']  = $nextUrl;
                 }
 
                 if ($progress) {
@@ -1322,6 +1305,8 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
     /**
      * @return array
+     *
+     * @throws \Exception
      */
     public function getCampaignChoices()
     {
@@ -1342,158 +1327,97 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
     /**
      * @param $campaignId
-     * @param $settings
      *
      * @throws \Exception
      */
-    public function getCampaignMembers($campaignId, $settings = [])
+    public function getCampaignMembers($campaignId)
     {
-        $silenceExceptions = true;
-        $persistEntities   = $contactList   = $leadList   = $existingLeads   = $existingContacts   = [];
+        /** @var IntegrationEntityRepository $integrationEntityRepo */
+        $integrationEntityRepo = $this->em->getRepository('MauticPluginBundle:IntegrationEntity');
+        $mixedFields           = $this->getIntegrationSettings()->getFeatureSettings();
 
-        try {
-            $campaignsMembersResults = $this->getApiHelper()->getCampaignMembers($campaignId);
-        } catch (\Exception $e) {
-            $this->logIntegrationError($e);
-            if (!$silenceExceptions) {
-                throw $e;
-            }
+        // Get the last time the campaign was synced to prevent resyncing the entire SF campaign
+        $cacheKey     = $this->getName().'.CampaignSync.'.$campaignId;
+        $lastSyncDate = $this->getCache()->get($cacheKey);
+        $syncStarted  = (new \DateTime())->format('c');
+
+        if (false === $lastSyncDate) {
+            // Sync all records
+            $lastSyncDate = null;
         }
-        //prepare contacts to import to mautic contacts to delete from mautic
-        if (isset($campaignsMembersResults['records']) && !empty($campaignsMembersResults['records'])) {
-            foreach ($campaignsMembersResults['records'] as $campaignMember) {
-                $contactType = !empty($campaignMember['LeadId']) ? 'Lead' : 'Contact';
-                $contactId   = !empty($campaignMember['LeadId']) ? $campaignMember['LeadId'] : $campaignMember['ContactId'];
-                $isDeleted   = ($campaignMember['IsDeleted']) ? true : false;
-                if ($contactType == 'Lead') {
-                    $leadList[$contactId] = [
-                        'type'       => $contactType,
-                        'id'         => $contactId,
-                        'campaignId' => $campaignMember['CampaignId'],
-                        'isDeleted'  => $isDeleted,
-                    ];
-                }
-                if ($contactType == 'Contact') {
-                    $contactList[$contactId] = [
-                        'type'       => $contactType,
-                        'id'         => $contactId,
-                        'campaignId' => $campaignMember['CampaignId'],
-                        'isDeleted'  => $isDeleted,
-                    ];
-                }
-            }
 
-            /** @var IntegrationEntityRepository $integrationEntityRepo */
-            $integrationEntityRepo = $this->em->getRepository('MauticPluginBundle:IntegrationEntity');
-            //update lead/contact records
-            $listOfLeads = implode('", "', array_keys($leadList));
-            $listOfLeads = '"'.$listOfLeads.'"';
-            $leads       = $integrationEntityRepo->getIntegrationsEntityId('Salesforce', 'Lead', 'lead', null, null, null, false, 0, 0, $listOfLeads);
+        // Consume in batches
+        $paginator      = new ResultsPaginator($this->logger, $this->keys['instance_url']);
+        $nextRecordsUrl = null;
 
-            $listOfContacts = implode('", "', array_keys($contactList));
-            $listOfContacts = '"'.$listOfContacts.'"';
-            $contacts       = $integrationEntityRepo->getIntegrationsEntityId(
-                'Salesforce',
-                'Contact',
-                'lead',
-                null,
-                null,
-                null,
-                false,
-                0,
-                0,
-                $listOfContacts
-            );
+        while (true) {
+            try {
+                $results = $this->getApiHelper()->getCampaignMembers($campaignId, $lastSyncDate, $nextRecordsUrl);
+                $paginator->setResults($results);
 
-            if (!empty($leads)) {
-                $existingLeads = array_map(
-                    function ($lead) {
-                        if (($lead['integration_entity'] == 'Lead')) {
-                            return $lead['integration_entity_id'];
-                        }
-                    },
-                    $leads
-                );
-            }
-            if (!empty($contacts)) {
-                $existingContacts = array_map(
-                    function ($lead) {
-                        return ($lead['integration_entity'] == 'Contact') ? $lead['integration_entity_id'] : [];
-                    },
-                    $contacts
-                );
-            }
-            //record campaigns in integration entity for segment to process
-            $allCampaignMembers = array_merge(array_values($existingLeads), array_values($existingContacts));
-            //Leads
-            $leadsToFetch = array_diff_key($leadList, $existingLeads);
-            $mixedFields  = $this->getIntegrationSettings()->getFeatureSettings();
-            $executed     = 0;
-            if (!empty($leadsToFetch)) {
-                $listOfLeadsToFetch = implode("','", array_keys($leadsToFetch));
-                $listOfLeadsToFetch = "'".$listOfLeadsToFetch."'";
+                $organizer = new Organizer($results['records']);
+                $fetcher   = new Fetcher($integrationEntityRepo, $organizer, $campaignId);
 
-                $fields    = $this->getMixedLeadFields($mixedFields, 'Lead');
-                $fields[]  = 'Id';
-                $fields    = implode(', ', array_unique($fields));
-                $leadQuery = 'SELECT '.$fields.' from Lead where Id in ('.$listOfLeadsToFetch.') and ConvertedContactId = NULL';
+                // Create Mautic contacts from Campaign Members if they don't already exist
+                foreach (['Contact', 'Lead'] as $object) {
+                    $fields = $this->getMixedLeadFields($mixedFields, $object);
 
-                $this->getLeads([], $leadQuery, $executed, [], 'Lead');
-
-                $allCampaignMembers = array_merge($allCampaignMembers, array_keys($leadsToFetch));
-            }
-            //Contacts
-            $contactsToFetch = array_diff_key($contactList, $existingContacts);
-            if (!empty($contactsToFetch)) {
-                $listOfContactsToFetch = implode("','", array_keys($contactsToFetch));
-                $listOfContactsToFetch = "'".$listOfContactsToFetch."'";
-                $fields                = $this->getMixedLeadFields($mixedFields, 'Contact');
-                $fields[]              = 'Id';
-                $fields                = implode(', ', array_unique($fields));
-                $contactQuery          = 'SELECT '.$fields.' from Contact where Id in ('.$listOfContactsToFetch.')';
-                $this->getLeads([], $contactQuery, $executed, [], 'Contact');
-                $allCampaignMembers = array_merge($allCampaignMembers, array_keys($contactsToFetch));
-            }
-            if (!empty($allCampaignMembers)) {
-                $internalLeadIds = implode('", "', $allCampaignMembers);
-                $internalLeadIds = '"'.$internalLeadIds.'"';
-                $leads           = $integrationEntityRepo->getIntegrationsEntityId(
-                    'Salesforce',
-                    null,
-                    'lead',
-                    null,
-                    null,
-                    null,
-                    false,
-                    0,
-                    0,
-                    $internalLeadIds
-                );
-                //first find existing campaign members.
-                foreach ($leads as $campaignMember) {
-                    $existingCampaignMember = $integrationEntityRepo->getIntegrationsEntityId(
-                        'Salesforce',
-                        'CampaignMember',
-                        'lead',
-                        $campaignMember['internal_entity_id']
-                    );
-                    if (empty($existingCampaignMember)) {
-                        $persistEntities[] = $this->createIntegrationEntity(
-                            'CampaignMember',
-                            $campaignId,
-                            'lead',
-                            $campaignMember['internal_entity_id'],
-                            [],
-                            false
-                        );
+                    try {
+                        $query = $fetcher->getQueryForUnknownObjects($fields, $object);
+                        $this->getLeads([], $query, $executed, [], $object);
+                    } catch (NoObjectsToFetchException $exception) {
+                        // No more IDs to fetch so break and continue on
+                        continue;
                     }
                 }
 
+                // Create integration entities for members we aren't already tracking
+                $unknownMembers  = $fetcher->getUnknownCampaignMembers();
+                $persistEntities = [];
+                $counter         = 0;
+
+                foreach ($unknownMembers as $mauticContactId) {
+                    $persistEntities[] = $this->createIntegrationEntity(
+                        CampaignMember::OBJECT,
+                        $campaignId,
+                        'lead',
+                        $mauticContactId,
+                        [],
+                        false
+                    );
+
+                    ++$counter;
+
+                    if (20 === $counter) {
+                        // Batch to control RAM use
+                        $this->em->getRepository('MauticPluginBundle:IntegrationEntity')->saveEntities($persistEntities);
+                        $this->em->clear(IntegrationEntity::class);
+                        $persistEntities = [];
+                        $counter         = 0;
+                    }
+                }
+
+                // Catch left overs
                 if ($persistEntities) {
                     $this->em->getRepository('MauticPluginBundle:IntegrationEntity')->saveEntities($persistEntities);
-                    unset($persistEntities);
                     $this->em->clear(IntegrationEntity::class);
                 }
+
+                unset($unknownMembers, $fetcher, $organizer, $persistEntities);
+
+                // Do we continue?
+                if (!$nextRecordsUrl = $paginator->getNextResultsUrl()) {
+                    // No more results to fetch
+
+                    // Store the latest sync date at the end in case something happens during the actual sync process and it needs to be re-ran
+                    $this->cache->set($cacheKey, $syncStarted);
+
+                    break;
+                }
+            } catch (\Exception $e) {
+                $this->logIntegrationError($e);
+
+                break;
             }
         }
     }
@@ -1832,7 +1756,6 @@ class SalesforceIntegration extends CrmAbstractIntegration
     ) {
         $body         = [];
         $updateEntity = [];
-        $companies    = [];
         $company      = null;
         $config       = $this->mergeConfigToFeatureSettings([]);
 
@@ -1875,7 +1798,8 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
             foreach ($fields as $sfField => $mauticField) {
                 if (isset($entity[$mauticField])) {
-                    $fieldType = (isset($objectFields['types']) && isset($objectFields['types'][$sfField])) ? $objectFields['types'][$sfField] : 'string';
+                    $fieldType = (isset($objectFields['types']) && isset($objectFields['types'][$sfField])) ? $objectFields['types'][$sfField]
+                        : 'string';
                     if (!empty($entity[$mauticField]) and $fieldType != 'boolean') {
                         $body[$sfField] = $this->cleanPushData($entity[$mauticField], $fieldType);
                     } elseif ($fieldType == 'boolean') {
@@ -1914,8 +1838,6 @@ class SalesforceIntegration extends CrmAbstractIntegration
                         'Sforce-Auto-Assign' => ($objectId) ? 'FALSE' : 'TRUE',
                     ],
                 ];
-
-                //$this->logger->debug('SALESFORCE: Composite '.$method.' subrequest: '.$entity['email']);
             }
         }
 

--- a/plugins/MauticCrmBundle/Tests/Api/SalesforceApiTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/SalesforceApiTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\MauticCrmBundle\Tests\Api;
+
+use Mautic\PluginBundle\Exception\ApiErrorException;
+use MauticPlugin\MauticCrmBundle\Api\SalesforceApi;
+use MauticPlugin\MauticCrmBundle\Integration\SalesforceIntegration;
+
+class SalesforceApiTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @testdox Test that a locked record request is retried up to 3 times
+     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::analyzeResponse()
+     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::processError()
+     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::checkIfLockedRequestShouldBeRetried()
+     */
+    public function testRecordLockedErrorIsRetriedThreeTimes()
+    {
+        $integration = $this->getMockBuilder(SalesforceIntegration::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $message = 'unable to obtain exclusive access to this record or 1 records: 70137000000Ugy3AAC';
+        $integration->expects($this->exactly(3))
+            ->method('makeRequest')
+            ->willReturn(
+                [
+                    [
+                        'errorCode' => 'UNABLE_TO_LOCK_ROW',
+                        'message'   => $message,
+                    ],
+                ]
+            );
+
+        $api = new SalesforceApi($integration);
+
+        try {
+            $api->request('/test');
+
+            $this->fail('ApiErrorException not thrown');
+        } catch (ApiErrorException $exception) {
+            $this->assertEquals($message, $exception->getMessage());
+        }
+    }
+
+    /**
+     * @testdox Test that a locked record request is retried 2 times with 3rd being successful
+     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::analyzeResponse()
+     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::processError()
+     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::checkIfLockedRequestShouldBeRetried()
+     */
+    public function testRecordLockedErrorIsRetriedTwoTimesWithThirdSuccess()
+    {
+        $integration = $this->getMockBuilder(SalesforceIntegration::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $message = 'unable to obtain exclusive access to this record or 1 records: 70137000000Ugy3AAC';
+        $integration->expects($this->at(0))
+            ->method('makeRequest')
+            ->willReturn(
+                [
+                    [
+                        'errorCode' => 'UNABLE_TO_LOCK_ROW',
+                        'message'   => $message,
+                    ],
+                ]
+            );
+        $integration->expects($this->at(1))
+            ->method('makeRequest')
+            ->willReturn(
+                [
+                    [
+                        ['success' => true],
+                    ],
+                ]
+            );
+        $api = new SalesforceApi($integration);
+
+        try {
+            $api->request('/test');
+        } catch (ApiErrorException $exception) {
+            $this->fail('ApiErrorException should not have been thrown');
+        }
+    }
+
+    /**
+     * @testdox Test that a session expired should attempt a refresh before failing
+     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::analyzeResponse()
+     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::processError()
+     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::revalidateSession()
+     */
+    public function testSessionExpiredIsRefreshed()
+    {
+        $integration = $this->getMockBuilder(SalesforceIntegration::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $integration->expects($this->once())
+            ->method('authCallback');
+
+        $message = 'Session expired';
+        $integration->expects($this->exactly(2))
+            ->method('makeRequest')
+            ->willReturn(
+                [
+                    [
+                        'errorCode' => 'INVALID_SESSION_ID',
+                        'message'   => $message,
+                    ],
+                ]
+            );
+
+        $api = new SalesforceApi($integration);
+
+        try {
+            $api->request('/test');
+
+            $this->fail('ApiErrorException not thrown');
+        } catch (ApiErrorException $exception) {
+            $this->assertEquals($message, $exception->getMessage());
+        }
+    }
+
+    /**
+     * @testdox Test that an exception is thrown for all other errors
+     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::analyzeResponse()
+     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::processError()
+     */
+    public function testErrorDoesNotRetryRequest()
+    {
+        $integration = $this->getMockBuilder(SalesforceIntegration::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $message = 'Fatal error';
+        $integration->expects($this->exactly(1))
+            ->method('makeRequest')
+            ->willReturn(
+                [
+                    [
+                        'errorCode' => 'FATAL_ERROR',
+                        'message'   => $message,
+                    ],
+                ]
+            );
+
+        $api = new SalesforceApi($integration);
+
+        try {
+            $api->request('/test');
+
+            $this->fail('ApiErrorException not thrown');
+        } catch (ApiErrorException $exception) {
+            $this->assertEquals($message, $exception->getMessage());
+        }
+    }
+}

--- a/plugins/MauticCrmBundle/Tests/Integration/Salesforce/CampaignMember/FetcherTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/Salesforce/CampaignMember/FetcherTest.php
@@ -1,0 +1,250 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Tests\Integration\Salesforce\CampaignMember;
+
+use Mautic\PluginBundle\Entity\IntegrationEntityRepository;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\CampaignMember\Fetcher;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\CampaignMember\Organizer;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object\CampaignMember;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object\Contact;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object\Lead;
+
+class FetcherTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEntitiesAreFetchedFromOrganizerResults()
+    {
+        $organizer = $this->getOrgnanizer();
+        $repo      = $this->getMockBuilder(IntegrationEntityRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $repo->expects($this->exactly(2))
+            ->method('getIntegrationsEntityId')
+            ->withConsecutive(
+                ['Salesforce', Lead::OBJECT, 'lead', null, null, null, false, 0, 0, $organizer->getLeadIds()],
+                ['Salesforce', Contact::OBJECT, 'lead', null, null, null, false, 0, 0, $organizer->getContactIds()]
+            )
+            ->willReturn([]);
+
+        new Fetcher($repo, $organizer, '701f10000021UnkAAE');
+    }
+
+    public function testThatCampaignMembersAreFetched()
+    {
+        $organizer = $this->getOrgnanizer();
+        $repo      = $this->getMockBuilder(IntegrationEntityRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $repo->expects($this->exactly(4))
+            ->method('getIntegrationsEntityId')
+            ->withConsecutive(
+                ['Salesforce', Lead::OBJECT, 'lead', null, null, null, false, 0, 0, $organizer->getLeadIds()],
+                ['Salesforce', Contact::OBJECT, 'lead', null, null, null, false, 0, 0, $organizer->getContactIds()],
+                ['Salesforce', CampaignMember::OBJECT, 'lead', [1, 2, 3, 4, 5, 6], null, null, false, 0, 0, '701f10000021UnkAAE'],
+                ['Salesforce', null, 'lead', null, null, null, false, 0, 0, ['00Qf100000YjYv4EAF', '00Qf100000YjYv9EAF', '00Qf100000YjYvTEAV', '00Qf100000X1NR5EAN']]
+            )
+            ->willReturnOnConsecutiveCalls(
+                [
+                    [
+                        'integration_entity_id' => '00Qf100000YjYvEEAV',
+                        'internal_entity_id'    => 1,
+                    ],
+                    [
+                        'integration_entity_id' => '00Qf100000YjYvJEAV',
+                        'internal_entity_id'    => 2,
+                    ],
+                    [
+                        'integration_entity_id' => '00Qf100000YjYvOEAV',
+                        'internal_entity_id'    => 3,
+                    ],
+                ],
+                [
+                    [
+                        'integration_entity_id' => '00Qf100000YjYvYEAV',
+                        'internal_entity_id'    => 4,
+                    ],
+                    [
+                        'integration_entity_id' => '00Qf100000YjYvdEAF',
+                        'internal_entity_id'    => 5,
+                    ],
+                    [
+                        'integration_entity_id' => '00Qf100000YjYviEAF',
+                        'internal_entity_id'    => 6,
+                    ],
+                ],
+                [
+                    [
+                        'integration_entity'    => CampaignMember::OBJECT,
+                        'integration_entity_id' => '701f10000021UnkAAE',
+                        'internal_entity_id'    => 1,
+                    ],
+                    [
+                        'integration_entity'    => CampaignMember::OBJECT,
+                        'integration_entity_id' => '701f10000021UnkAAE',
+                        'internal_entity_id'    => 4,
+                    ],
+                ],
+                [
+                    [
+                        'integration_entity_id' => '00Qf100000YjYv4EAF',
+                        'internal_entity_id'    => 7,
+                    ],
+                    [
+                        'integration_entity_id' => '00Qf100000YjYv9EAF',
+                        'internal_entity_id'    => 8,
+                    ],
+                    [
+                        'integration_entity_id' => '00Qf100000YjYvTEAV',
+                        'internal_entity_id'    => 9,
+                    ],
+                    [
+                        'integration_entity_id' => '00Qf100000X1NR5EAN',
+                        'internal_entity_id'    => 10,
+                    ],
+                ]
+            );
+
+        $fetcher = new Fetcher($repo, $organizer, '701f10000021UnkAAE');
+
+        // The query to fetch unknown members should be the 2 Leads not returned by at(0)
+        $this->assertEquals(
+            "SELECT Test, Id from Lead where Id in ('00Qf100000YjYv4EAF','00Qf100000YjYv9EAF') and ConvertedContactId = NULL",
+            $fetcher->getQueryForUnknownObjects(['Test'], Lead::OBJECT)
+        );
+
+        // The query to fetch unknown members should be the 2 Contacts not returned by at(1)
+        $this->assertEquals(
+            "SELECT Test, Id from Contact where Id in ('00Qf100000YjYvTEAV','00Qf100000X1NR5EAN')",
+            $fetcher->getQueryForUnknownObjects(['Test'], Contact::OBJECT)
+        );
+
+        // Should include all but the two we are already tracking as campaign members
+        $unknown = $fetcher->getUnknownCampaignMembers();
+
+        $this->assertEquals(
+            [2, 3, 5, 6, 7, 8, 9, 10],
+            $unknown
+        );
+    }
+
+    /**
+     * @return Organizer
+     */
+    private function getOrgnanizer()
+    {
+        $records = [
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQe2AAG',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => null,
+                'LeadId'     => '00Qf100000YjYv4EAF',
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQe7AAG',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => null,
+                'LeadId'     => '00Qf100000YjYv9EAF',
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQeCAAW',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => null,
+                'LeadId'     => '00Qf100000YjYvEEAV',
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQeHAAW',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => null,
+                'LeadId'     => '00Qf100000YjYvJEAV',
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQeMAAW',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => null,
+                'LeadId'     => '00Qf100000YjYvOEAV',
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQeRAAW',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => '00Qf100000YjYvTEAV',
+                'LeadId'     => null,
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQeWAAW',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => '00Qf100000X1NR5EAN',
+                'LeadId'     => null,
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQebAAG',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => '00Qf100000YjYvYEAV',
+                'LeadId'     => null,
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQegAAG',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => '00Qf100000YjYvdEAF',
+                'LeadId'     => null,
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQelAAG',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => '00Qf100000YjYviEAF',
+                'LeadId'     => null,
+                'IsDeleted'  => false,
+            ],
+        ];
+
+        return new Organizer($records);
+    }
+}

--- a/plugins/MauticCrmBundle/Tests/Integration/Salesforce/CampaignMember/OrganizerTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/Salesforce/CampaignMember/OrganizerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Tests\Integration\Salesforce\CampaignMember;
+
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\CampaignMember\Organizer;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object\Contact;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object\Lead;
+
+class OrganizerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRecordsAreOrganizedIntoLeadsAndContacts()
+    {
+        $records = [
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQe2AAG',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => null,
+                'LeadId'     => '00Qf100000YjYv4EAF',
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQe7AAG',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => null,
+                'LeadId'     => '00Qf100000YjYv9EAF',
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQeCAAW',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => null,
+                'LeadId'     => '00Qf100000YjYvEEAV',
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQeHAAW',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => null,
+                'LeadId'     => '00Qf100000YjYvJEAV',
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQeMAAW',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => null,
+                'LeadId'     => '00Qf100000YjYvOEAV',
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQeRAAW',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => '00Qf100000YjYvTEAV',
+                'LeadId'     => null,
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQeWAAW',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => '00Qf100000X1NR5EAN',
+                'LeadId'     => null,
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQebAAG',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => '00Qf100000YjYvYEAV',
+                'LeadId'     => null,
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQegAAG',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => '00Qf100000YjYvdEAF',
+                'LeadId'     => null,
+                'IsDeleted'  => false,
+            ],
+            [
+                'attributes' => [
+                        'type' => 'CampaignMember',
+                        'url'  => '/services/data/v34.0/sobjects/CampaignMember/00vf100000gFQelAAG',
+                    ],
+                'CampaignId' => '701f10000021UnkAAE',
+                'ContactId'  => '00Qf100000YjYviEAF',
+                'LeadId'     => null,
+                'IsDeleted'  => false,
+            ],
+        ];
+
+        $organizer = new Organizer($records);
+
+        $leads     = ['00Qf100000YjYv4EAF', '00Qf100000YjYv9EAF', '00Qf100000YjYvEEAV', '00Qf100000YjYvJEAV', '00Qf100000YjYvOEAV'];
+        $this->assertEquals($leads, $organizer->getLeadIds());
+
+        /** @var Lead[] $organizedLeads */
+        $organizedLeads = $organizer->getLeads();
+        foreach ($leads as $id) {
+            $this->assertArrayHasKey($id, $organizedLeads);
+            $this->assertInstanceOf(Lead::class, $organizedLeads[$id]);
+            $this->assertEquals($id, $organizedLeads[$id]->getId());
+        }
+
+        $contacts  = ['00Qf100000YjYvTEAV', '00Qf100000X1NR5EAN', '00Qf100000YjYvYEAV', '00Qf100000YjYvdEAF', '00Qf100000YjYviEAF'];
+        $this->assertEquals($contacts, $organizer->getContactIds());
+
+        /** @var Contact[] $organizedLeads */
+        $organizedContacts = $organizer->getContacts();
+        foreach ($contacts as $id) {
+            $this->assertArrayHasKey($id, $organizedContacts);
+            $this->assertInstanceOf(Contact::class, $organizedContacts[$id]);
+            $this->assertEquals($id, $organizedContacts[$id]->getId());
+        }
+    }
+}

--- a/plugins/MauticCrmBundle/Tests/Integration/SalesforceIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/SalesforceIntegrationTest.php
@@ -188,10 +188,6 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(4, count($sfEntities));
     }
 
-    public function testThatMultipleMauticContactsAreNotDuplicatedInSF()
-    {
-    }
-
     public function testThatLeadsAreOnlyCreatedIfEnabled()
     {
         $this->sfObjects     = ['Contact'];
@@ -318,10 +314,6 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($lastSync instanceof \DateTime);
     }
 
-    public function testThatMissingRequiredDataIsPulledFromSfAndHydrated()
-    {
-    }
-
     public function testLeadsAreNotCreatedInSfIfFoundToAlreadyExistAsContacts()
     {
         $this->sfObjects     = ['Lead', 'Contact'];
@@ -374,14 +366,6 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
         $sf->pushLeads();
     }
 
-    public function testIntegrationEntityRecordIsCreatedForFoundSfContacts()
-    {
-    }
-
-    public function testNonMatchingMauticContactsAreCreated()
-    {
-    }
-
     public function testExceptionIsThrownIfSfReturnsErrorOnEmailLookup()
     {
         $this->sfObjects     = ['Lead'];
@@ -394,22 +378,6 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(ApiErrorException::class);
 
         $sf->pushLeads();
-    }
-
-    public function testIntegrationPushFindsDuplicate()
-    {
-    }
-
-    public function testIntegrationPushCreatesNew()
-    {
-    }
-
-    public function testApostropheInEmailDoesNotCauseDuplicates()
-    {
-    }
-
-    public function testExistingEntityRecordsDoesNotCreate()
-    {
     }
 
     public function testGetCampaigns()
@@ -781,8 +749,6 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
      */
     protected function getMockFactory()
     {
-        defined('IN_MAUTIC_CONSOLE') or define('IN_MAUTIC_CONSOLE', 1);
-
         $mockFactory = $this->getMockBuilder(MauticFactory::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/plugins/MauticCrmBundle/Tests/Integration/SalesforceIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/SalesforceIntegrationTest.php
@@ -9,7 +9,7 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-namespace MauticPlugin\MauticCrmBundle\Tests;
+namespace MauticPlugin\MauticCrmBundle\Tests\Integration;
 
 use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\Entity\AuditLogRepository;
@@ -123,6 +123,11 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
      * @var int
      */
     protected $leadsCreatedCounter = 0;
+
+    public function setUp()
+    {
+        defined('MAUTIC_ENV') or define('MAUTIC_ENV', 'test');
+    }
 
     /**
      * Reset.
@@ -440,7 +445,7 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
                 ]
             );
 
-        $sf->getCampaignMembers(1, []);
+        $sf->getCampaignMembers(1);
     }
 
     public function testGetCampaignMemberStatus()
@@ -1119,9 +1124,15 @@ class SalesforceIntegrationTest extends \PHPUnit_Framework_TestCase
                                 if (isset($args[1]['q']) && strpos($args[0], 'from CampaignMember') !== false) {
                                     return [];
                                 } elseif (isset($args[1]['q']) && strpos($args[1]['q'], 'from Campaign') !== false) {
-                                    return 'fetched campaigns';
+                                    return [
+                                        'totalSize' => 0,
+                                        'records'   => [],
+                                    ];
                                 } elseif (isset($args[1]['q']) && strpos($args[1]['q'], 'from Account') !== false) {
-                                    return 'fetched accounts';
+                                    return [
+                                        'totalSize' => 0,
+                                        'records'   => [],
+                                    ];
                                 } elseif (isset($args[1]['q']) && $args[1]['q'] === 'SELECT CreatedDate from Organization') {
                                     return [
                                         'records' => [

--- a/plugins/MauticFocusBundle/Views/Builder/form.html.php
+++ b/plugins/MauticFocusBundle/Views/Builder/form.html.php
@@ -114,7 +114,7 @@ if (empty($preview)):
 
 <?php
 $formExtra = <<<EXTRA
-<input type="hidden" name="mauticform[focusId]" id="mauticform<?php echo $formName ?>_focus_id" value="$focusId"/>
+<input type="hidden" name="mauticform[focusId]" id="mauticform{$formName}_focus_id" value="$focusId"/>
 EXTRA;
 
 echo $view->render('MauticFormBundle:Builder:form.html.php', [


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR fixes two issues. One is when a SF entity is locked, such as a SF campaign, we immediately fail trying. This PR will retry the update several times before giving up, each time with a little more time in between to give the record a chance to become editable again. 

Also, when syncing SF campaigns, we synced all of it's members every time we built Mautic's segment. When the SF campaign becomes large, we run into resource issues on Mautic's side and may also hit a URL is too long error when we send the query for all the IDs of the campaign members. This PR will store the last time campaign members were synced and only fetch those that have been modified since that date on subsequent syncs. It will also limit the number of campaign members we fetch at a time to control resources and the length of the SOQL query required to get information about the campaign members. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. The lock issue is difficult to reproduce. Run the test which simulate the response. 
2. Create a new Mautic campaign with a push to integration action. Choose Salesforce, choose a SF campaign and a campaign state.
3. Run the campaign `php app/console m:c:t -i ID` and check SF to ensure all contacts were pushed into the SF campaign. 
4. The campaign sync issue can reproduced by syncing a large number of campaign members (1000+). Add all of your contacts (at least 1000) to the Mautic campaign above) and run it to push all the contacts into the SF campaign.
5. Create a new segment and add a "integration campaign member" filter. Choose Salesforce and the SF campaign pushed to above. 
6. Run `php app/console m:s:u -i ID` to build the membership of the segment. All the contacts pushed to the SF campaign should be pulled into the segment. 

#### Steps to test this PR:
1. Run the tests
2. Make sure the integration campaign member segment filter still finds and inserts newly added campaign members. If you already reproduced the bug, you'll need to repeat all with a new SF campaign. 
 
  