### PR TITLE
Fixes the builder width issues

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -4311,7 +4311,7 @@ lesshat-selector { -lh-property: 0 ;
   position: fixed;
   left: 0;
   top: 0;
-  right: 70%;
+  width: 70%;
   height: 100%;
 }
 .code-mode .builder-panel {
@@ -4399,6 +4399,7 @@ li.CodeMirror-hint-active {
   }
   .builder .builder-content {
     right: 0;
+    width: 100%;
   }
   .builder .builder-panel-top {
     position: relative;

--- a/app/bundles/CoreBundle/Assets/css/app/less/components/builder.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/components/builder.less
@@ -52,7 +52,7 @@
   position: fixed;
   left: 0;
   top: 0;
-  right: 70%;
+  width: 70%;
   height: 100%;
 }
 
@@ -164,6 +164,7 @@ li.CodeMirror-hint-active {
     }
     .builder-content {
       right: 0;
+      width: 100%;
     }
     .builder-panel-top {
       position: relative;

--- a/app/bundles/CoreBundle/Assets/css/libraries/builder.css
+++ b/app/bundles/CoreBundle/Assets/css/libraries/builder.css
@@ -5320,15 +5320,15 @@ div[data-section-focus="left"] {
   left: 0px;
 }
 div[data-section-focus="clone"] {
-    width: 25px;
-    height: 25px;
-    bottom: 62px;
-    left: 10px;
-    background: #4e5e9e;
-    color: #fff;
-    text-align: center;
-    border: 0;
-    line-height: 25px;
+  width: 25px;
+  height: 25px;
+  bottom: 62px;
+  left: 10px;
+  background: #4e5e9e;
+  color: #fff;
+  text-align: center;
+  border: 0;
+  line-height: 25px;
 }
 div[data-section-focus="handle"] {
   width: 25px;

--- a/app/bundles/CoreBundle/Views/Helper/builder_buttons.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/builder_buttons.html.php
@@ -12,7 +12,7 @@
 ?>
 
 <div class="row">
-    <div class="col-xs-6">
+    <div class="col-xs-12">
         <button type="button" class="btn btn-primary btn-apply-builder">
             <?php echo $view['translator']->trans('mautic.core.form.apply'); ?>
         </button>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When using a LP or email builder, the preview is 30% width. This fixes that. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Edit/create a landing page and/or email
2. Choose a template that's not the blank one
3. Open the builder and notice the width issue

#### Steps to test this PR:
1. Repeat and the widths should be correct
2. Resize the browser to force the mobile view and notice the preview should go 100% while the toolbar should go landscape at the bottom. 
