### PR TITLE
Prevent SQL error when processing bad email address

### DIFF
--- a/app/bundles/EmailBundle/Model/SendEmailToContact.php
+++ b/app/bundles/EmailBundle/Model/SendEmailToContact.php
@@ -382,8 +382,8 @@ class SendEmailToContact
                 $this->dncModel->addDncForContact(
                     $contactId,
                     ['email' => $this->emailEntityId],
-                    $this->translator->trans('mautic.email.bounce.reason.bad_email'),
                     DNC::BOUNCED,
+                    $this->translator->trans('mautic.email.bounce.reason.bad_email'),
                     true,
                     false
                 );


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Sending a segment email with a bad email address will fail with a SQL error due to the integer reason and comments arguments being switched. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Hack the database with a bad email address and add the contact to a segment
2. Create a segment email and send it
3. Not the SQL error

#### Steps to test this PR:
1. Repeat and there should be no error and the contact marked as DNC
