### PR TITLE
Stats should not be saved for emails sent to users by default

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1357,7 +1357,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         array $lead = null,
         array $tokens = [],
         array $assetAttachments = [],
-        $saveStat = true,
+        $saveStat = false,
         array $to = [],
         array $cc = [],
         array $bcc = []


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The default for sending an email to a User was to save an email stat which shows up in the timeline as if the email was sent to the contact. This changes that behavior to not save stats by default. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form and add a "Send email to user" submit action. Choose an email and a user.
2. Submit the form in a guest session
3. View the timeline of the contact created/posted to
4. Note that the email sent to the user shows up in the timeline as if the email was sent to the contact

#### Steps to test this PR:
1. Repeat and the email should not show up
