### PR TITLE
Fixes #5532 problem with MailjetTransport header X-MJ-CUSTOMID

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/MailjetTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/MailjetTransport.php
@@ -42,6 +42,7 @@ class MailjetTransport extends \Swift_SmtpTransport implements InterfaceCallback
         // add leadIdHash to track this email
         if (isset($message->leadIdHash)) {
             // contact leadidHeash and email to be sure not applying email stat to bcc
+            $message->getHeaders()->remove('X-MJ-CUSTOMID');
             $message->getHeaders()->addTextHeader('X-MJ-CUSTOMID', $message->leadIdHash.'-'.key($message->getTo()));
         }
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | #5532
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

#### Description:

Fixes issue #5532
Delete the header 'X-MJ-CUSTOMID' before rewriting the correct header in MailjetTransport.

#### Steps to reproduce the bug:
1. Create a segment
2. Add two leads at least in this segment
3. Create a manual email and set the precedent segment
4. Add log in Swift_Transport_AbstractSmtpTransport in the end of send function. Log this => $message->getHeaders()->get('X-MJ-CUSTOMID')->toString() before return.
5. Send this email
6. View the log. X-MJ-CUSTOMID is the same for the two differents emails. It's normally different because X-MJ-CUSTOMID is defined like this "leadIdHash-email". After fixes, the header is correct.

#### Steps to test this PR:
1. Apply PR
2. Repeat Steps 1-6 above
3. Notice value is correct
 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 