### PR TITLE
New themes actions fixes

### DIFF
--- a/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
@@ -456,8 +456,8 @@ class CoreSubscriber extends CommonSubscriber
                 $defaults['objectId'] = 0;
             }
             if (!isset($requirements['objectId'])) {
-                // Only allow alphanumeric for objectId
-                $requirements['objectId'] = '[a-zA-Z0-9_]+';
+                // Only allow alphanumeric and _- for objectId
+                $requirements['objectId'] = '[a-zA-Z0-9_-]+';
             }
         }
         if ($type == 'api') {

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -243,7 +243,7 @@ class InputHelper
     {
         $value = str_replace(' ', '_', $value);
 
-        return preg_replace("/[^a-z0-9\.\_]/", '', strtolower($value));
+        return preg_replace("/[^a-z0-9\.\_-]/", '', strtolower($value));
     }
 
     /**

--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -64,7 +64,23 @@ class ThemeHelper
      *
      * @var array
      */
-    protected $defaultThemes = ['sunday', 'skyline', 'oxygen', 'goldstar', 'neopolitan', 'blank', 'system'];
+    protected $defaultThemes = [
+        'aurora',
+        'blank',
+        'cards',
+        'fresh-center',
+        'fresh-fixed',
+        'fresh-left',
+        'fresh-wide',
+        'goldstar',
+        'neopolitan',
+        'oxygen',
+        'skyline',
+        'sparse',
+        'sunday',
+        'system',
+        'vibrant',
+    ];
 
     /**
      * ThemeHelper constructor.


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5492
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
There is a problem that the newly added themes (https://github.com/mautic/mautic/pull/5311) contain `-` in the directory name. This char was not allowed. If you download such theme and upload it again, you'll see that the dash will be removed.

The reason why `-` was not allowed in the first place is probably because it was not a valid char for ID regex. So if you go to the themes in the dev mode now, you'll see an error. Another issue is that such themes are not downloadable because the `-` is being stripped and the theme not found.

`Symfony\Component\Routing\Exception\InvalidParameterException: Parameter "objectId" for route "mautic_themes_action" must match "[a-zA-Z0-9_]+" ("fresh-fixed" given) to generate a corresponding URL.`

The new themes were also not listed to the default themes which are not allowed to be deleted. Because they would be added with every update again anyway.

This PR fixes all those issues. We cannot remove the dash from the theme names because it would be a BC so we have to modify the regexes.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to the Themes in dev mode to see the error or look for it in the logs.

#### Steps to test this PR:
1. Checkout this PR, clear the cache and the error is gone.
2. Check that the new themes like Sparse does not have the delete action.
3. Download works.
