### PR TITLE
Small fix for preUp check in migration

### DIFF
--- a/app/migrations/Version20170829081048.php
+++ b/app/migrations/Version20170829081048.php
@@ -19,7 +19,7 @@ class Version20170829081048 extends AbstractMauticMigration
      */
     public function preUp(Schema $schema)
     {
-        if ($schema->hasTable(MAUTIC_TABLE_PREFIX.'email_stat_replies ')) {
+        if ($schema->hasTable(MAUTIC_TABLE_PREFIX.'email_stat_replies')) {
             throw new SkipMigrationException('Schema includes this migration');
         }
     }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL |  N
| Related developer documentation PR URL | B
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:

There is a small mistake in the preUp function of the migration for creating the "email_stat_replies" table The check includes a space at the end of the name. This causes the check to fail the when the migration was already applied.