### PR TITLE
Dispatch events for Leads and Companies created by Pipedrive

### DIFF
--- a/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
@@ -32,6 +32,14 @@ trait CustomFieldEntityTrait
     protected $updatedFields = [];
 
     /**
+     * A place events can use to pass data around on the object to prevent issues like creating a contact and having it processed to be sent back
+     * to the origin of creation in a webhook (like Pipedrive).
+     *
+     * @var array
+     */
+    protected $eventData = [];
+
+    /**
      * @param $name
      *
      * @return bool
@@ -240,6 +248,27 @@ trait CustomFieldEntityTrait
 
             return $this->fields;
         }
+    }
+
+    /**
+     * @param $key
+     */
+    public function getEventData($key)
+    {
+        return (isset($this->eventData[$key])) ? $this->eventData[$key] : null;
+    }
+
+    /**
+     * @param $key
+     * @param $value
+     *
+     * @return $this
+     */
+    public function setEventData($key, $value)
+    {
+        $this->eventData[$key] = $value;
+
+        return $this;
     }
 
     /**

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -219,7 +219,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
     /**
      * @var string
      */
-    private $preferredProfileImage;
+    private $preferredProfileImage = 'gravatar';
 
     /**
      * @var bool

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -236,6 +236,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
             }
             $fieldValues = $fields;
         }
+
         //update existing values
         foreach ($fieldValues as $group => &$groupFields) {
             foreach ($groupFields as $alias => &$field) {

--- a/plugins/MauticCrmBundle/Config/config.php
+++ b/plugins/MauticCrmBundle/Config/config.php
@@ -110,31 +110,34 @@ return [
                 ],
             ],
             'mautic_integration.pipedrive.import.owner' => [
-                'class'     => 'MauticPlugin\MauticCrmBundle\Integration\Pipedrive\Import\OwnerImport',
+                'class'     => \MauticPlugin\MauticCrmBundle\Integration\Pipedrive\Import\OwnerImport::class,
                 'arguments' => [
                     'doctrine.orm.entity_manager',
                 ],
             ],
             'mautic_integration.pipedrive.import.company' => [
-                'class'     => 'MauticPlugin\MauticCrmBundle\Integration\Pipedrive\Import\CompanyImport',
+                'class'     => \MauticPlugin\MauticCrmBundle\Integration\Pipedrive\Import\CompanyImport::class,
                 'arguments' => [
                     'doctrine.orm.entity_manager',
+                    'mautic.lead.model.company',
                 ],
             ],
             'mautic_integration.pipedrive.import.lead' => [
-                'class'     => 'MauticPlugin\MauticCrmBundle\Integration\Pipedrive\Import\LeadImport',
+                'class'     => \MauticPlugin\MauticCrmBundle\Integration\Pipedrive\Import\LeadImport::class,
                 'arguments' => [
                     'doctrine.orm.entity_manager',
+                    'mautic.lead.model.lead',
+                    'mautic.lead.model.company',
                 ],
             ],
             'mautic_integration.pipedrive.export.company' => [
-                'class'     => 'MauticPlugin\MauticCrmBundle\Integration\Pipedrive\Export\CompanyExport',
+                'class'     => \MauticPlugin\MauticCrmBundle\Integration\Pipedrive\Export\CompanyExport::class,
                 'arguments' => [
                     'doctrine.orm.entity_manager',
                 ],
             ],
             'mautic_integration.pipedrive.export.lead' => [
-                'class'     => 'MauticPlugin\MauticCrmBundle\Integration\Pipedrive\Export\LeadExport',
+                'class'     => \MauticPlugin\MauticCrmBundle\Integration\Pipedrive\Export\LeadExport::class,
                 'arguments' => [
                     'doctrine.orm.entity_manager',
                 ],

--- a/plugins/MauticCrmBundle/Controller/PipedriveController.php
+++ b/plugins/MauticCrmBundle/Controller/PipedriveController.php
@@ -12,6 +12,9 @@
 namespace MauticPlugin\MauticCrmBundle\Controller;
 
 use Mautic\CoreBundle\Controller\CommonController;
+use MauticPlugin\MauticCrmBundle\Integration\Pipedrive\Import\CompanyImport;
+use MauticPlugin\MauticCrmBundle\Integration\Pipedrive\Import\LeadImport;
+use MauticPlugin\MauticCrmBundle\Integration\Pipedrive\Import\OwnerImport;
 use MauticPlugin\MauticCrmBundle\Integration\PipedriveIntegration;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -36,6 +39,11 @@ class PipedriveController extends CommonController
     const USER_ADD_EVENT    = 'added.user';
     const USER_UPDATE_EVENT = 'updated.user';
 
+    /**
+     * @param Request $request
+     *
+     * @return JsonResponse
+     */
     public function webhookAction(Request $request)
     {
         $integrationHelper    = $this->get('mautic.helper.integration');
@@ -103,30 +111,54 @@ class PipedriveController extends CommonController
         return new JsonResponse($response, Response::HTTP_OK);
     }
 
+    /**
+     * @param $integration
+     *
+     * @return LeadImport
+     */
     private function getLeadImport($integration)
     {
+        /** @var LeadImport $leadImport */
         $leadImport = $this->get('mautic_integration.pipedrive.import.lead');
         $leadImport->setIntegration($integration);
 
         return $leadImport;
     }
 
+    /**
+     * @param $integration
+     *
+     * @return CompanyImport
+     */
     private function getCompanyImport($integration)
     {
+        /** @var CompanyImport $companyImport */
         $companyImport = $this->get('mautic_integration.pipedrive.import.company');
         $companyImport->setIntegration($integration);
 
         return $companyImport;
     }
 
+    /**
+     * @param $integration
+     *
+     * @return OwnerImport
+     */
     private function getOwnerImport($integration)
     {
+        /** @var OwnerImport $ownerImport */
         $ownerImport = $this->get('mautic_integration.pipedrive.import.owner');
         $ownerImport->setIntegration($integration);
 
         return $ownerImport;
     }
 
+    /**
+     * @param Request              $request
+     * @param PipedriveIntegration $pipedriveIntegration
+     *
+     * @return bool
+     */
     private function validCredential(Request $request, PipedriveIntegration $pipedriveIntegration)
     {
         $headers = $request->headers->all();

--- a/plugins/MauticCrmBundle/EventListener/CompanySubscriber.php
+++ b/plugins/MauticCrmBundle/EventListener/CompanySubscriber.php
@@ -60,6 +60,13 @@ class CompanySubscriber extends CommonSubscriber
      */
     public function onCompanyPostSave(Events\CompanyEvent $event)
     {
+        $company = $event->getCompany();
+        if ($company->getEventData('pipedrive.webhook')) {
+            // Don't export what was just imported
+            return;
+        }
+
+        /** @var PipedriveIntegration $integrationObject */
         $integrationObject = $this->integrationHelper->getIntegrationObject(PipedriveIntegration::INTEGRATION_NAME);
 
         if (false === $integrationObject || !$integrationObject->getIntegrationSettings()->getIsPublished()) {
@@ -67,7 +74,7 @@ class CompanySubscriber extends CommonSubscriber
         }
 
         $this->companyExport->setIntegration($integrationObject);
-        $this->companyExport->pushCompany($event->getCompany());
+        $this->companyExport->pushCompany($company);
     }
 
     /**
@@ -75,6 +82,13 @@ class CompanySubscriber extends CommonSubscriber
      */
     public function onCompanyPreDelete(Events\CompanyEvent $event)
     {
+        $company = $event->getCompany();
+        if ($company->getEventData('pipedrive.webhook')) {
+            // Don't export what was just imported
+            return;
+        }
+
+        /** @var PipedriveIntegration $integrationObject */
         $integrationObject = $this->integrationHelper->getIntegrationObject(PipedriveIntegration::INTEGRATION_NAME);
 
         if (false === $integrationObject || !$integrationObject->getIntegrationSettings()->getIsPublished()) {
@@ -82,6 +96,6 @@ class CompanySubscriber extends CommonSubscriber
         }
 
         $this->companyExport->setIntegration($integrationObject);
-        $this->companyExport->delete($event->getCompany());
+        $this->companyExport->delete($company);
     }
 }

--- a/plugins/MauticCrmBundle/EventListener/LeadSubscriber.php
+++ b/plugins/MauticCrmBundle/EventListener/LeadSubscriber.php
@@ -61,6 +61,13 @@ class LeadSubscriber extends CommonSubscriber
      */
     public function onLeadPostSave(Events\LeadEvent $event)
     {
+        $lead = $event->getLead();
+        if ($lead->getEventData('pipedrive.webhook')) {
+            // Don't export what was just imported
+            return;
+        }
+
+        /** @var PipedriveIntegration $integrationObject */
         $integrationObject = $this->integrationHelper->getIntegrationObject(PipedriveIntegration::INTEGRATION_NAME);
 
         if (false === $integrationObject || !$integrationObject->getIntegrationSettings()->getIsPublished()) {
@@ -68,7 +75,7 @@ class LeadSubscriber extends CommonSubscriber
         }
 
         $this->leadExport->setIntegration($integrationObject);
-        $this->leadExport->update($event->getLead());
+        $this->leadExport->update($lead);
     }
 
     /**
@@ -76,6 +83,13 @@ class LeadSubscriber extends CommonSubscriber
      */
     public function onLeadPostDelete(Events\LeadEvent $event)
     {
+        $lead = $event->getLead();
+        if ($lead->getEventData('pipedrive.webhook')) {
+            // Don't export what was just imported
+            return;
+        }
+
+        /** @var PipedriveIntegration $integrationObject */
         $integrationObject = $this->integrationHelper->getIntegrationObject(PipedriveIntegration::INTEGRATION_NAME);
 
         if (false === $integrationObject || !$integrationObject->getIntegrationSettings()->getIsPublished()) {
@@ -83,7 +97,7 @@ class LeadSubscriber extends CommonSubscriber
         }
 
         $this->leadExport->setIntegration($integrationObject);
-        $this->leadExport->delete($event->getLead());
+        $this->leadExport->delete($lead);
     }
 
     /**
@@ -91,6 +105,13 @@ class LeadSubscriber extends CommonSubscriber
      */
     public function onLeadCompanyChange(Events\LeadChangeCompanyEvent $event)
     {
+        $lead = $event->getLead();
+        if ($lead->getEventData('pipedrive.webhook')) {
+            // Don't export what was just imported
+            return;
+        }
+
+        /** @var PipedriveIntegration $integrationObject */
         $integrationObject = $this->integrationHelper->getIntegrationObject(PipedriveIntegration::INTEGRATION_NAME);
 
         if (false === $integrationObject || !$integrationObject->getIntegrationSettings()->getIsPublished()) {
@@ -98,6 +119,6 @@ class LeadSubscriber extends CommonSubscriber
         }
 
         $this->leadExport->setIntegration($integrationObject);
-        $this->leadExport->update($event->getLead());
+        $this->leadExport->update($lead);
     }
 }

--- a/plugins/MauticCrmBundle/Integration/Pipedrive/Import/AbstractImport.php
+++ b/plugins/MauticCrmBundle/Integration/Pipedrive/Import/AbstractImport.php
@@ -8,6 +8,12 @@ use MauticPlugin\MauticCrmBundle\Integration\Pipedrive\AbstractPipedrive;
 
 abstract class AbstractImport extends AbstractPipedrive
 {
+    /**
+     * @param $params
+     * @param $endpoint
+     *
+     * @return array
+     */
     public function getData($params, $endpoint)
     {
         $result = [
@@ -43,8 +49,16 @@ abstract class AbstractImport extends AbstractPipedrive
         return $result;
     }
 
+    /**
+     * @param array $data
+     *
+     * @return bool
+     */
     abstract protected function create(array $data = []);
 
+    /**
+     * @param $id
+     */
     protected function getOwnerByIntegrationId($id)
     {
         $pipedriveOwner = $this->em->getRepository(PipedriveOwner::class)->findOneByOwnerId($id);

--- a/plugins/MauticCrmBundle/Integration/Pipedrive/Import/LeadImport.php
+++ b/plugins/MauticCrmBundle/Integration/Pipedrive/Import/LeadImport.php
@@ -4,17 +4,46 @@ namespace MauticPlugin\MauticCrmBundle\Integration\Pipedrive\Import;
 
 use Doctrine\ORM\EntityManager;
 use Mautic\LeadBundle\Entity\Company;
-use Mautic\LeadBundle\Entity\CompanyLead;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\CompanyModel;
+use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\HttpFoundation\Response;
 
 class LeadImport extends AbstractImport
 {
-    public function __construct(EntityManager $em)
+    /**
+     * @var LeadModel
+     */
+    private $leadModel;
+
+    /**
+     * @var CompanyModel
+     */
+    private $companyModel;
+
+    /**
+     * LeadImport constructor.
+     *
+     * @param EntityManager $em
+     * @param LeadModel     $leadModel
+     */
+    public function __construct(EntityManager $em, LeadModel $leadModel, CompanyModel $companyModel)
     {
         parent::__construct($em);
+
+        $this->leadModel    = $leadModel;
+        $this->companyModel = $companyModel;
     }
 
+    /**
+     * @param array $data
+     *
+     * @return bool
+     *
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws \Exception
+     */
     public function create(array $data = [])
     {
         $integrationEntity = $this->getLeadIntegrationEntity(['integrationEntityId' => $data['id']]);
@@ -28,17 +57,15 @@ class LeadImport extends AbstractImport
 
         $lead = new Lead();
 
-        foreach ($dataToUpdate as $field => $value) {
-            $lead->addUpdatedField($field, $value);
-        }
+        // prevent listeners from exporting
+        $lead->setEventData('pipedrive.webhook', 1);
+
+        $this->leadModel->setFieldValues($lead, $dataToUpdate);
 
         if (isset($data['owner_id'])) {
             $this->addOwnerToLead($data['owner_id'], $lead);
         }
-
-        $lead->setDateAdded(new \DateTime());
-        $lead->setPreferredProfileImage('gravatar');
-        $this->em->getRepository(Lead::class)->saveEntity($lead);
+        $this->leadModel->saveEntity($lead);
 
         $integrationEntity = $this->createIntegrationLeadEntity(new \DateTime(), $data['id'], $lead->getId());
 
@@ -53,6 +80,15 @@ class LeadImport extends AbstractImport
         return true;
     }
 
+    /**
+     * @param array $data
+     *
+     * @return bool
+     *
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws \Exception
+     */
     public function update(array $data = [])
     {
         $integrationEntity = $this->getLeadIntegrationEntity(['integrationEntityId' => $data['id']]);
@@ -63,25 +99,25 @@ class LeadImport extends AbstractImport
 
         /** @var Lead $lead * */
         $lead         = $this->em->getRepository(Lead::class)->findOneById($integrationEntity->getInternalEntityId());
+
+        // prevent listeners from exporting
+        $lead->setEventData('pipedrive.webhook', 1);
+
         $data         = $this->convertPipedriveData($data);
         $dataToUpdate = $this->getIntegration()->populateMauticLeadData($data);
 
-        foreach ($dataToUpdate as $field => $value) {
-            $lead->addUpdatedField($field, $value);
-        }
-
-        $lead->setDateModified(new \DateTime());
+        $this->leadModel->setFieldValues($lead, $dataToUpdate);
 
         if (!isset($data['owner_id']) && $lead->getOwner()) {
             $lead->setOwner(null);
         } elseif (isset($data['owner_id'])) {
             $this->addOwnerToLead($data['owner_id'], $lead);
         }
+        $this->leadModel->saveEntity($lead);
 
         $integrationEntity->setLastSyncDate(new \DateTime());
-
-        $this->em->getRepository(Lead::class)->saveEntity($lead);
         $this->em->persist($integrationEntity);
+        $this->em->flush();
 
         if (!$this->getIntegration()->isCompanySupportEnabled()) {
             return;
@@ -93,9 +129,14 @@ class LeadImport extends AbstractImport
             $this->addLeadToCompany($data['org_id'], $lead);
         }
 
-        $this->em->flush();
+        return true;
     }
 
+    /**
+     * @param array $data
+     *
+     * @throws \Exception
+     */
     public function delete(array $data = [])
     {
         $integrationEntity = $this->getLeadIntegrationEntity(['integrationEntityId' => $data['id']]);
@@ -104,24 +145,39 @@ class LeadImport extends AbstractImport
             throw new \Exception('Lead doesn\'t have integration', Response::HTTP_NOT_FOUND);
         }
 
+        /** @var Lead $lead */
         $lead = $this->em->getRepository(Lead::class)->findOneById($integrationEntity->getInternalEntityId());
 
         if (!$lead) {
             throw new \Exception('Lead doesn\'t exists in Mautic', Response::HTTP_NOT_FOUND);
         }
 
-        $this->em->transactional(function ($em) use ($lead, $integrationEntity) {
-            $em->remove($lead);
-            $em->remove($integrationEntity);
-        });
+        // prevent listeners from exporting
+        $lead->setEventData('pipedrive.webhook', 1);
+
+        $this->leadModel->deleteEntity($lead);
+
+        if (!empty($lead->deletedId)) {
+            $this->em->remove($integrationEntity);
+        }
     }
 
+    /**
+     * @param      $integrationOwnerId
+     * @param Lead $lead
+     */
     private function addOwnerToLead($integrationOwnerId, Lead $lead)
     {
         $mauticOwner = $this->getOwnerByIntegrationId($integrationOwnerId);
         $lead->setOwner($mauticOwner);
     }
 
+    /**
+     * @param      $companyName
+     * @param Lead $lead
+     *
+     * @throws \Doctrine\ORM\ORMException
+     */
     private function removeLeadFromCompany($companyName, Lead $lead)
     {
         $company = $this->em->getRepository(Company::class)->findOneByName($companyName);
@@ -130,18 +186,15 @@ class LeadImport extends AbstractImport
             return;
         }
 
-        $companyLead = $this->em->getRepository(CompanyLead::class)->findOneBy([
-            'lead'    => $lead,
-            'company' => $company->getId(),
-        ]);
-
-        if (!$companyLead) {
-            return;
-        }
-
-        $this->em->remove($companyLead);
+        $this->companyModel->removeLeadFromCompany($company, $lead);
     }
 
+    /**
+     * @param      $integrationCompanyId
+     * @param Lead $lead
+     *
+     * @throws \Doctrine\ORM\ORMException
+     */
     private function addLeadToCompany($integrationCompanyId, Lead $lead)
     {
         $integrationEntityCompany = $this->getCompanyIntegrationEntity(['integrationEntityId' => $integrationCompanyId]);
@@ -150,24 +203,10 @@ class LeadImport extends AbstractImport
             return;
         }
 
-        $company = $this->em->getRepository(Company::class)->findOneById($integrationEntityCompany->getInternalEntityId());
-
-        $companyLead = $this->em->getRepository(CompanyLead::class)->findOneBy([
-            'lead'    => $lead,
-            'company' => $company->getId(),
-        ]);
-
-        if ($companyLead) {
+        if (!$company = $this->companyModel->getEntity($integrationEntityCompany->getInternalEntityId())) {
             return;
         }
 
-        $companyLead = new CompanyLead();
-        $companyLead->setCompany($company);
-        $companyLead->setLead($lead);
-        $companyLead->setManuallyAdded(false);
-        $companyLead->setDateAdded(new \DateTime());
-
-        $this->em->persist($companyLead);
-        $lead->setCompany($company->getName());
+        $this->companyModel->addLeadToCompany($company, $lead);
     }
 }

--- a/plugins/MauticCrmBundle/Integration/Pipedrive/Import/OwnerImport.php
+++ b/plugins/MauticCrmBundle/Integration/Pipedrive/Import/OwnerImport.php
@@ -6,6 +6,13 @@ use MauticPlugin\MauticCrmBundle\Entity\PipedriveOwner;
 
 class OwnerImport extends AbstractImport
 {
+    /**
+     * @param array $data
+     *
+     * @return bool
+     *
+     * @throws \Doctrine\ORM\OptimisticLockException
+     */
     public function create(array $data = [])
     {
         $pipedriveOwner = $this->em->getRepository(PipedriveOwner::class)->findOneByOwnerId($data['id']);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? | y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Contacts and companies created by Pipedrive's webhook (import) did not dispatch events so plugins and other listeners were not notified of changes made. This fixes that. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup Pipedrive CRM webhook according to https://mautic.org/docs/en/plugins/pipedrive.html. 
2. Create a contact in Pipedrive
3. The contact should be created in Mautic
4. Go to the contact record and note that there are no entries under the Audit log

#### Steps to test this PR:
1. Repeat and this time the audit log should have entries
2. Run the automated tests
