### PR TITLE
Remove leadfield token

### DIFF
--- a/app/bundles/LeadBundle/EventListener/EmailSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/EmailSubscriber.php
@@ -56,10 +56,6 @@ class EmailSubscriber extends CommonSubscriber
         // the permissions are for viewing contact data, not for managing contact fields
         $tokenHelper->setPermissionSet(['lead:leads:viewown', 'lead:leads:viewother']);
 
-        if ($event->tokensRequested(self::$leadFieldRegex)) {
-            $event->addTokensFromHelper($tokenHelper, self::$leadFieldRegex, 'label', 'alias', true);
-        }
-
         if ($event->tokensRequested(self::$contactFieldRegex)) {
             $event->addTokensFromHelper($tokenHelper, self::$contactFieldRegex, 'label', 'alias', true);
         }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? |N
| Related user documentation PR URL | -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | -
| BC breaks? | N
| Deprecations? | N

[//]: # ( Required: )
#### Description:
Removes {leadfield=...} tokens from builders. Tokens should still work but they should not appear in hint while typing.

#### Steps to test this PR:
See description