### PR TITLE
Saving Page Settings fix

### DIFF
--- a/app/bundles/PageBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/ConfigSubscriber.php
@@ -41,7 +41,13 @@ class ConfigSubscriber extends CommonSubscriber
             'bundle'     => 'PageBundle',
             'formAlias'  => 'pageconfig',
             'formTheme'  => 'MauticPageBundle:FormTheme\Config',
-            'parameters' => $event->getParametersFromConfig('MauticPageBundle'),
+            // parameters must be defined directly in case there are 2 config forms per bundle.
+            // $event->getParametersFromConfig('MauticPageBundle') would return all params for PageBundle
+            // and trackingconfig form would overwrote values in the pageconfig form. See #5559.
+            'parameters' => [
+                'cat_in_page_url'  => false,
+                'google_analytics' => false,
+            ],
         ]);
     }
 
@@ -51,7 +57,18 @@ class ConfigSubscriber extends CommonSubscriber
             'bundle'     => 'PageBundle',
             'formAlias'  => 'trackingconfig',
             'formTheme'  => 'MauticPageBundle:FormTheme\Config',
-            'parameters' => $event->getParametersFromConfig('MauticPageBundle'),
+            // parameters defined this way because of the reason as above.
+            'parameters' => [
+                'track_contact_by_ip'                   => false,
+                'track_by_tracking_url'                 => true,
+                'track_by_fingerprint'                  => false,
+                'facebook_pixel_id'                     => null,
+                'facebook_pixel_trackingpage_enabled'   => false,
+                'facebook_pixel_landingpage_enabled'    => false,
+                'google_analytics_id'                   => null,
+                'google_analytics_trackingpage_enabled' => false,
+                'google_analytics_landingpage_enabled'  => false,
+            ],
         ]);
     }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5559
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
PageBundle contains [2 config forms](https://github.com/mautic/mautic/commit/8dea963c426aea08a1d6e1d9980455f34738dd32). When all the config forms are merged into our massive configuration with new values after submission, the values of `pageconfig` form were overwritten by values of `trackingconfig` which happened to be the same as the previous values. So the values has never changed.

The proposed fix is not optimal since it defines the form fields on 2nd place, but I couldn't find a better solution on how to read the fields directly from the forms in the subscriber.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to Mautic's configuration.
2. Go to Landing Page Settings.
3. Change the switch.
4. Write something to the textarea.
5. Save.
6. Go to the LP Settings again and your modifications will be gone.

#### Steps to test this PR:
1. Checkout this PR.
2. Repeat the test.
3. Your changes will stick.