### PR TITLE
Fix: Some report filters show just company fields

### DIFF
--- a/app/bundles/AssetBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/ReportSubscriber.php
@@ -141,7 +141,6 @@ class ReportSubscriber extends CommonSubscriber
                         $event->getIpColumn(),
                         $companyColumns
                     ),
-                    'filters' => $companyColumns,
                 ],
                 self::CONTEXT_ASSET
             );

--- a/app/bundles/CampaignBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/ReportSubscriber.php
@@ -166,7 +166,6 @@ class ReportSubscriber extends CommonSubscriber
         $data = [
             'display_name' => 'mautic.campaign.events',
             'columns'      => $columns,
-            'filters'      => $companyColumns,
         ];
         $event->addTable(self::CONTEXT_CAMPAIGN_LEAD_EVENT_LOG, $data);
 

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -932,7 +932,7 @@ class EventModel extends CommonFormModel
                         false,
                         null,
                         true,
-                        false,
+                        $log['id'],
                         $evaluatedEventCount,
                         $executedEventCount,
                         $totalEventCount

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -932,7 +932,7 @@ class EventModel extends CommonFormModel
                         false,
                         null,
                         true,
-                        $log['id'],
+                        false,
                         $evaluatedEventCount,
                         $executedEventCount,
                         $totalEventCount

--- a/app/bundles/ChannelBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/ChannelBundle/EventListener/ReportSubscriber.php
@@ -120,7 +120,6 @@ class ReportSubscriber extends CommonSubscriber
             [
                 'display_name' => 'mautic.message.queue',
                 'columns'      => $columns,
-                'filters'      => $companyColumns,
             ]
         );
     }

--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -189,7 +189,6 @@ class ReportSubscriber extends CommonSubscriber
         $data = [
             'display_name' => 'mautic.email.emails',
             'columns'      => $columns,
-            'filters'      => $companyColumns,
         ];
         $event->addTable(self::CONTEXT_EMAILS, $data);
         $context = self::CONTEXT_EMAILS;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5515
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This update https://github.com/mautic/mautic/pull/5331 added support for company fields in report. But some data reports (emails, campaign events) show in filter just company fields. This update remove some unnecessary filters. Maybe @Maxell92 know more about this issue.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Go to Reports
2. Click +New
3. Change Data Source to Campaign Events
4. Click the Data tab
5. Click Add Filters
6. Click the drop-down under Column and only Company fields are present

#### Steps to test this PR:
1. Go to Reports
2. Click +New
3. Change Data Source to Campaign Events
4. Click the Data tab
5. Click Add Filters
6. Click the drop-down under Column and see all filters