### PR TITLE
Bug 280 chars for twitter

### DIFF
--- a/app/migrations/Version20180117141613.php
+++ b/app/migrations/Version20180117141613.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * @package     Mautic
+ * @copyright   2018 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+class Version20180117141613 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        $table = $schema->getTable(MAUTIC_TABLE_PREFIX.'tweets');
+        if ($table->hasColumn('text')
+            && $table->getColumn('text')->getLength() === 280
+        ) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql("ALTER TABLE {$this->prefix}tweets CHANGE text text VARCHAR(280) NOT NULL");
+    }
+}

--- a/plugins/MauticSocialBundle/Assets/js/social.js
+++ b/plugins/MauticSocialBundle/Assets/js/social.js
@@ -73,7 +73,7 @@ Mautic.composeSocialWatcher = function() {
  * gets the count of the text area and returns (140 - count)
  */
 Mautic.getCharacterCount = function() {
-    var tweetLenght = 140;
+    var tweetLenght = 280;
 
     var currentLength = mQuery('textarea#twitter_tweet_text');
 

--- a/plugins/MauticSocialBundle/Entity/Tweet.php
+++ b/plugins/MauticSocialBundle/Entity/Tweet.php
@@ -20,6 +20,8 @@ use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\CoreBundle\Entity\FormEntity;
 use Mautic\PageBundle\Entity\Page;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 /**
  * @ORM\Entity
@@ -148,7 +150,7 @@ class Tweet extends FormEntity
         $builder->addCategory();
         $builder->addNullableField('mediaId', Type::STRING, 'media_id');
         $builder->addNullableField('mediaPath', Type::STRING, 'media_path');
-        $builder->addField('text', Type::STRING);
+        $builder->addField('text', Type::STRING, ['length' => 280]);
         $builder->addNullableField('sentCount', Type::INTEGER, 'sent_count');
         $builder->addNullableField('favoriteCount', Type::INTEGER, 'favorite_count');
         $builder->addNullableField('retweetCount', Type::INTEGER, 'retweet_count');
@@ -198,6 +200,20 @@ class Tweet extends FormEntity
                 ]
             )
             ->build();
+    }
+
+    /**
+     * Constraints for required fields.
+     *
+     * @param ClassMetadata $metadata
+     */
+    public static function loadValidatorMetadata(ClassMetadata $metadata)
+    {
+        $metadata->addPropertyConstraint('text', new Assert\Length(
+            [
+                'max' => 280,
+            ]
+        ));
     }
 
     /**


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Twitter [changed](https://blog.twitter.com/official/en_us/topics/product/2017/tweetingmadeeasier.html) the tweet length limit from 140 to 280 characters. This PR updates this and also fixes an SQL error if the tweet contains more than 255 characters and actually requires to be 280 characters or more with new constraint.

Since the VARCHAR default length is 255 this PR also sets the limit of 280 characters to the text column in the Tweet entity and adds migration which does the same thing for old Mautic instances.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make sure you have the twitter plugin enabled. Doesn't have to be configured correctly.
2. Create new or edit a tweet.
3. Try to save a tweet with more than 280 characters. You will see that the counter went to negative values, but you get a SQL error that the value is too long.

#### Steps to test this PR:
1. Checkout this PR.
2. Run migrations.
3. Repeat the test. Now you'll get a user friendly message that the tweet text must be 280 chars or less. 
4. Try to save a tweet with text length between 255 and 280 chars. It will save correctly.