### PR TITLE
Do not use channel and channelId from channel_url_trackables to count…

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1737,24 +1737,23 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         }
 
         if ($flag == 'all' || $flag == 'clicked') {
-            $q = $query->prepareTimeDataQuery('page_hits', 'date_hit', [])
-                ->join('t', MAUTIC_TABLE_PREFIX.'channel_url_trackables', 'cut', 't.redirect_id = cut.redirect_id')
-                ->andWhere('cut.channel = :channel')
-                ->setParameter('channel', 'email');
+            $q = $query->prepareTimeDataQuery('page_hits', 'date_hit', []);
+            $q->andWhere('t.source = :source');
+            $q->setParameter('source', 'email');
 
             if (isset($filter['email_id'])) {
                 if (is_array($filter['email_id'])) {
-                    $q->andWhere($q->expr()->in('cut.channel_id', $filter['email_id']));
+                    $q->andWhere('t.source_id IN (:email_ids)');
+                    $q->setParameter('email_ids', $filter['email_id'], \Doctrine\DBAL\Connection::PARAM_INT_ARRAY);
                 } else {
-                    $q->andWhere('cut.channel_id = :channel_id');
-                    $q->setParameter('channel_id', $filter['email_id']);
+                    $q->andWhere('t.source_id = :email_id');
+                    $q->setParameter('email_id', $filter['email_id']);
                 }
             }
 
             if (!$canViewOthers) {
                 $this->limitQueryToCreator($q);
             }
-
             $data = $query->loadAndBuildTimeData($q);
 
             $chart->setDataset($this->translator->trans('mautic.email.clicked'), $data);


### PR DESCRIPTION
… page hits from emails. Use directly page_hits.source and sourceId

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? |  N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Here is a screenshot of the problem:
![wrong-click-stats](https://user-images.githubusercontent.com/1235442/35056623-b4dc9460-fbb2-11e7-92a3-7a01697b423f.png)

This is an example SQL query which generates the line click chart:
```
SELECT 
DATE_FORMAT(t.date_hit, '%Y-%m') AS date, 
COUNT(*) AS count 
FROM page_hits t 
INNER JOIN channel_url_trackables cut ON t.redirect_id = cut.redirect_id 
WHERE (t.date_hit BETWEEN '2016-08-01 00:00:00' AND '2018-01-17 16:22:28') 
AND (cut.channel = 'email') 
AND (cut.channel_id IN (210)) 
GROUP BY DATE_FORMAT(t.date_hit, '%Y-%m')
ORDER BY DATE_FORMAT(t.date_hit, '%Y-%m') ASC 
LIMIT 18
```

The problem here is that the `channel_url_trackables` is not reliable source of email ID. In fact, the relation between page hits and redirects exists, but with 0 hits. That is why the clicks showed up in the chart, but there actually weren't any. 

This PR removes the join with `channel_url_trackables` and counts the page hits which has `page_hits.source = 'email'` and `page_hits.source_id = [email_id]`.

#### Steps to test this PR:
I don't know how to reproduce by clicking stuff, but lets make sure it works for you.
1. Create a template email with at least 2 links.
2. Send it to your test list.
3. Open some of the emails and click some of the links (use incognito browser to do so)

You should see now in the email detail shows some clicks in the table and the same amount of click in the chart.
