### PR TITLE
Sendgrid or the API rejects the message with 400 bad request if the substitution value is not a string

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailPersonalization.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailPersonalization.php
@@ -55,7 +55,7 @@ class SendGridMailPersonalization
             }
 
             foreach ($metadata[$recipientEmail]['tokens'] as $token => $value) {
-                $personalization->addSubstitution($token, $value);
+                $personalization->addSubstitution($token, (string) $value);
             }
 
             $mail->addPersonalization($personalization);


### PR DESCRIPTION


[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Either sendgrid does not like receiving integers as substitutions or the API is converting something wonky, but Sendgrid will reject a request with 400 bad request if a substitution is an integer. Converting to a string makes Sendgrid happy. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup sendgrid api in Mautic's configuration
2. Go to contacts and click the dropdown beside a contact then click send email
3. Simply add {contactfield=id} in the body of the message, give it a subject, and send
4. Note the message `Failed to send to xyz@xyz.com: Invalid type. Expected: object, given: null.`

#### Steps to test this PR:
1. Apply the PR and repeat
2. This time it'll send and the field will be replaced
