### PR TITLE
Added missing reports filters columns

### DIFF
--- a/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
@@ -678,7 +678,7 @@ class ReportSubscriber extends CommonSubscriber
         $data = [
             'display_name' => 'mautic.lead.report.points.table',
             'columns'      => array_merge($columns, $pointColumns, $event->getIpColumn()),
-            'filters'      => $filters,
+            'filters'      => array_merge($filters, $pointColumns),
         ];
         $event->addTable(self::CONTEXT_LEAD_POINT_LOG, $data, self::GROUP_CONTACTS);
 
@@ -733,7 +733,7 @@ class ReportSubscriber extends CommonSubscriber
         $data = [
             'display_name' => 'mautic.lead.report.frequency.messages',
             'columns'      => array_merge($columns, $frequencyColumns),
-            'filters'      => $filters,
+            'filters'      => array_merge($filters, $frequencyColumns),
         ];
         $event->addTable(self::CONTEXT_CONTACT_FREQUENCYRULES, $data, self::GROUP_CONTACTS);
     }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/pull/5580#issuecomment-358354864
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

This bugfix/feature has been sponsored by @MaxWebmecanik 

[//]: # ( Required: )
#### Description:
Based on this report and PR https://github.com/mautic/mautic/pull/5580 and follow up comment https://github.com/mautic/mautic/pull/5580#issuecomment-358354864 This PR added forgot columns in reports. Maybe @Maxell92  can confirm an test these changes

Reported by @johbuch  (please test it)

#### Steps to test this PR:
1.  Create new reports Contacts Point log and Frequency Rules
2. Test new filters start with Point and Frequency