### PR TITLE
Company fields selection in email sent report fix

### DIFF
--- a/app/bundles/LeadBundle/Model/CompanyReportData.php
+++ b/app/bundles/LeadBundle/Model/CompanyReportData.php
@@ -69,7 +69,7 @@ class CompanyReportData
      */
     public function eventHasCompanyColumns(ReportGeneratorEvent $event)
     {
-        $companyColumns = $this->getCompanyColumns();
+        $companyColumns = $this->getCompanyData();
         foreach ($companyColumns as $key => $column) {
             if ($event->hasColumn($key)) {
                 return true;

--- a/app/bundles/LeadBundle/Tests/Model/CompanyReportDataTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/CompanyReportDataTest.php
@@ -107,6 +107,15 @@ class CompanyReportDataTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $field = new Field;
+        $field->setType('email');
+        $field->setAlias('email');
+        $field->setLabel('Email');
+
+        $fieldModelMock->expects($this->once())
+            ->method('getEntities')
+            ->willReturn([$field]);
+
         $eventMock->expects($this->once())
             ->method('hasColumn')
             ->with('comp.id')
@@ -131,6 +140,15 @@ class CompanyReportDataTest extends \PHPUnit_Framework_TestCase
         $eventMock = $this->getMockBuilder(ReportGeneratorEvent::class)
             ->disableOriginalConstructor()
             ->getMock();
+
+        $field = new Field;
+        $field->setType('email');
+        $field->setAlias('email');
+        $field->setLabel('Email');
+
+        $fieldModelMock->expects($this->once())
+            ->method('getEntities')
+            ->willReturn([$field]);
 
         $eventMock->expects($this->any())
             ->method('hasColumn')

--- a/app/bundles/LeadBundle/Tests/Model/CompanyReportDataTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/CompanyReportDataTest.php
@@ -107,7 +107,7 @@ class CompanyReportDataTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $field = new Field;
+        $field = new Field();
         $field->setType('email');
         $field->setAlias('email');
         $field->setLabel('Email');
@@ -141,7 +141,7 @@ class CompanyReportDataTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $field = new Field;
+        $field = new Field();
         $field->setType('email');
         $field->setAlias('email');
         $field->setLabel('Email');


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y |
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
Creating report from email sent data source erroring out if you add one or more of fields from company except id. It was bad set condition. I fixed it.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to create report with email sent data source
2. Then add one of more company field except company id
3. It will error out

#### Steps to test this PR:
1. Reproduce bug (steps above)
2. It should work.
3. Try it on testing data to assure that report works properly.