### PR TITLE
Prevent Id from being part of the mapped fields when pushing to prevent errors

### DIFF
--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -669,13 +669,13 @@ class SalesforceIntegration extends CrmAbstractIntegration
             }
 
             foreach ($keys as $key) {
-                if ('Id' === $key) {
-                    // Don't map Id for push
-                    continue;
-                }
-
                 if (strpos($key, '__'.$obj)) {
-                    $newKey                    = str_replace('__'.$obj, '', $key);
+                    $newKey = str_replace('__'.$obj, '', $key);
+                    if ('Id' === $newKey) {
+                        // Don't map Id for push
+                        continue;
+                    }
+
                     $leadFields[$obj][$newKey] = $fields[$key];
                 }
             }

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -669,6 +669,11 @@ class SalesforceIntegration extends CrmAbstractIntegration
             }
 
             foreach ($keys as $key) {
+                if ('Id' === $key) {
+                    // Don't map Id for push
+                    continue;
+                }
+
                 if (strpos($key, '__'.$obj)) {
                     $newKey                    = str_replace('__'.$obj, '', $key);
                     $leadFields[$obj][$newKey] = $fields[$key];


### PR DESCRIPTION


[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When the SF field Contact ID or Lead ID is mapped to a Mautic field, an error is generated when trying to create a new lead because the field Id is included twice in the query used to determine if the lead already exists. This prevents that from happening.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup SF integration and map Lead ID to a Mautic custom field
2. Create a new contact in Mautic
3. Run the `php app/console m:i:s -i Salesforce -a "5 minutes"
4. Note the error ```
 [Mautic\PluginBundle\Exception\ApiErrorException]
  select Id, Company,Email,LastName,Id, ConvertedContactId from Lead
                                    ^
  ERROR at Row:1:Column:35
  duplicate field selected: Id```

#### Steps to test this PR:
1. Repeat and the contact will be created a lead in SF
2. Create a lead in SF and run the command again. The contact created in Mautic should have SF's ID mapped to the selected field
