### PR TITLE
Added back empty value support for select fields

### DIFF
--- a/app/bundles/FormBundle/Views/Field/select.html.php
+++ b/app/bundles/FormBundle/Views/Field/select.html.php
@@ -36,10 +36,8 @@ if ((!empty($properties['empty_value']) || empty($field['defaultValue']) && empt
 HTML;
 endif;
 
-$options = (!empty($emptyOption)) ? [$emptyOption] : [];
-
-$optionBuilder = function (array $list) use (&$optionBuilder, $field, $view) {
-    $html = '';
+$optionBuilder = function (array $list, $emptyOptionHtml = '') use (&$optionBuilder, $field, $view) {
+    $html = $emptyOptionHtml;
     foreach ($list as $listValue => $listLabel):
         if (is_array($listLabel)) {
             // This is an option group
@@ -63,7 +61,7 @@ HTML;
     return $html;
 };
 
-$optionsHtml = $optionBuilder($list);
+$optionsHtml = $optionBuilder($list, $emptyOption);
 $html        = <<<HTML
 
             <div $containerAttr>{$label}{$help}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

2.12.1 fixed option group support for mapping values to the contact State field but with that change, broke support for empty values in lists/selects. This fixes that. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form with a List - Country field  
2. Notice that Abkhazia is the first listed with no empty option
3. Edit the form field and enter an empty value on the properties tab and update
4. Notice that Abkhazia is still the default with no empty option

#### Steps to test this PR:
1. Repeat and there should be an empty option by default
2. Enable multiple on the properties tab and the default should be removed
3. Add a custom empty value and disable multiple it should be the default
