### PR TITLE
fixing relative date filter (eq,neq)

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -757,8 +757,9 @@ class LeadListRepository extends CommonRepository
                     $modifier        = false;
                     $requiresBetween = false;
                     if (in_array($func, ['eq', 'neq']) && $isTimestamp) {
+                        //we want to compare only 'Y-m-d', not also the hour, minute and second.
+                        $isTimestamp = false;
                         $requiresBetween = true;
-                        $isTimestamp = false; //we want to compare only 'Y-m-d', not also the hour, minute and second.
                         $modifier = '+ 1 day';
                     }
                     $timeframe       = str_replace('mautic.lead.list.', '', $key);

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -758,9 +758,9 @@ class LeadListRepository extends CommonRepository
                     $requiresBetween = false;
                     if (in_array($func, ['eq', 'neq']) && $isTimestamp) {
                         //we want to compare only 'Y-m-d', not also the hour, minute and second.
-                        $isTimestamp = false;
+                        $isTimestamp     = false;
                         $requiresBetween = true;
-                        $modifier = '+ 1 day';
+                        $modifier        = '+ 1 day';
                     }
                     $timeframe       = str_replace('mautic.lead.list.', '', $key);
                     $isRelative      = true;

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -754,9 +754,14 @@ class LeadListRepository extends CommonRepository
                 $getDate     = function (&$string) use ($isTimestamp, $relativeDateStrings, &$details, &$func) {
                     $key             = array_search($string, $relativeDateStrings);
                     $dtHelper        = new DateTimeHelper('midnight today', null, 'local');
-                    $requiresBetween = in_array($func, ['eq', 'neq']) && $isTimestamp;
-                    $timeframe       = str_replace('mautic.lead.list.', '', $key);
                     $modifier        = false;
+                    $requiresBetween = false;
+                    if (in_array($func, ['eq', 'neq']) && $isTimestamp) {
+                        $requiresBetween = true;
+                        $isTimestamp = false; //we want to compare only 'Y-m-d', not also the hour, minute and second.
+                        $modifier = '+ 1 day';
+                    }
+                    $timeframe       = str_replace('mautic.lead.list.', '', $key);
                     $isRelative      = true;
 
                     switch ($timeframe) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: Fixed bug when creating segments on leads based on relative dates using eq and neq operators (greater than, less than,.. are working well).

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new segment and filter by "`Date Added` eq `-2 days`"
2. build the segment on the command line, an error will ocurr

#### Steps to test this PR:
1. Create a new segment and filter by "`Date Added` eq `-2 days`"
2. build the segment on the command line, this time will work

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 