### PR TITLE
fix for issue #5658 - segment not public now available in campaign condition

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -268,6 +268,25 @@ class LeadListRepository extends CommonRepository
     }
 
     /**
+     * Return a list of global and non global lists.
+     *
+     * @return array
+     */
+    public function getGlobalAndNonGlobalLists()
+    {
+        $q = $this->getEntityManager()->createQueryBuilder()
+            ->from('MauticLeadBundle:LeadList', 'l', 'l.id');
+
+        $q->select('partial l.{id, name, alias}')
+            ->where($q->expr()->eq('l.isPublished', 'true'))
+            ->orderBy('l.name');
+
+        $results = $q->getQuery()->getArrayResult();
+
+        return $results;
+    }
+
+    /**
      * Get a count of leads that belong to the list.
      *
      * @param $listIds

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadSegmentsType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadSegmentsType.php
@@ -28,7 +28,7 @@ class CampaignEventLeadSegmentsType extends AbstractType
             'segments',
             'leadlist_choices',
             [
-                'global_only' => true,
+                'global_only' => false,
                 'label'       => 'mautic.lead.lead.lists',
                 'label_attr'  => ['class' => 'control-label'],
                 'multiple'    => true,

--- a/app/bundles/LeadBundle/Form/Type/LeadListType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadListType.php
@@ -40,7 +40,12 @@ class LeadListType extends AbstractType
         $model = $this->model;
         $resolver->setDefaults([
             'choices' => function (Options $options) use ($model) {
-                $lists = (empty($options['global_only'])) ? $model->getUserLists() : $model->getGlobalLists();
+                $globalParameter = $options['global_only'];
+                if ($globalParameter == true) {
+                    $lists = (empty($options['global_only'])) ? $model->getUserLists() : $model->getGlobalLists();
+                } else {
+                    $lists = (empty($options['global_only'])) ? $model->getUserLists() : $model->getGlobalAndNonGlobalLists();
+                }
 
                 $choices = [];
                 foreach ($lists as $l) {

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -753,6 +753,18 @@ class ListModel extends FormModel
     }
 
     /**
+     * Get a list of global and non global lead lists.
+     *
+     * @return mixed
+     */
+    public function getGlobalAndNonGlobalLists()
+    {
+        $lists = $this->em->getRepository('MauticLeadBundle:LeadList')->getGlobalAndNonGlobalLists();
+
+        return $lists;
+    }
+
+    /**
      * Rebuild lead lists.
      *
      * @param LeadList        $entity


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #5658
| BC breaks? | 
| Deprecations? | No

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When adding a segment contact condition during campaign building, segments not public are now available.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a segment and make it public
2. Create a campaign, start with a segment and add a condition on contact segments.
3. Find your segment on the list
4. Go back on the edition of the segment you created and make it not public
5. Go back on the contact segment condition and find your segment on the list > it is not displayed anymore

#### Steps to test this PR:
1. Apply the PR
2. Reproduce the steps above, see that all the segments are now availables
