### PR TITLE
Fix api activity date filters

### DIFF
--- a/app/bundles/LeadBundle/Entity/TimelineTrait.php
+++ b/app/bundles/LeadBundle/Entity/TimelineTrait.php
@@ -57,7 +57,7 @@ trait TimelineTrait
                 ->setParameter('dateFrom', $options['fromDate']->format('Y-m-d H:i:s'))
                 ->setParameter('dateTo', $options['toDate']->format('Y-m-d H:i:s'));
         } elseif (!empty($options['fromDate'])) {
-            $query->andWhere($query->expr()->gte('fs.date_submitted', ':dateFrom'))
+            $query->andWhere($query->expr()->gte($timestampColumn, ':dateFrom'))
                 ->setParameter('dateFrom', $options['fromDate']->format('Y-m-d H:i:s'));
         } elseif (!empty($options['toDate'])) {
             $query->andWhere($query->expr()->lte('fs.date_submitted', ':dateTo'))

--- a/app/bundles/LeadBundle/Entity/TimelineTrait.php
+++ b/app/bundles/LeadBundle/Entity/TimelineTrait.php
@@ -60,7 +60,7 @@ trait TimelineTrait
             $query->andWhere($query->expr()->gte($timestampColumn, ':dateFrom'))
                 ->setParameter('dateFrom', $options['fromDate']->format('Y-m-d H:i:s'));
         } elseif (!empty($options['toDate'])) {
-            $query->andWhere($query->expr()->lte('fs.date_submitted', ':dateTo'))
+            $query->andWhere($query->expr()->lte($timestampColumn, ':dateTo'))
                 ->setParameter('dateTo', $options['toDate']->format('Y-m-d H:i:s'));
         }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The date filters for an Api request is now working. Before the fix, when you added a date filter pour the activity of all the contacts, all the activities were returned without filter.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Open an API tester
2. send a request built on this format after the http:// or https:// :
`yourDomainName/api/contacts/activity`
and count the number of events that are returned
3. make the same test that step 2 but adding `?filters[dateFrom]=2018-02-01T00:00:00`
or any other date in this format. You can also try with [dateTo] in the request.
Count the number of events and notice that there's exactly the same number of events that are returned. You can also note that if  you search for an event on a date not included in the request, you can still find it.
#### Steps to test this PR:
1. Apply the PR
2. Reproduce the steps above. You can notice that the date filter is now working.

