### PR TITLE
PHP Notice - Undefined variable: companyFields fixed

### DIFF
--- a/app/bundles/FormBundle/Views/Field/checkboxgrp.html.php
+++ b/app/bundles/FormBundle/Views/Field/checkboxgrp.html.php
@@ -18,5 +18,6 @@ echo $view->render(
         'type'          => 'checkbox',
         'formName'      => (isset($formName)) ? $formName : '',
         'contactFields' => (isset($contactFields)) ? $contactFields : [],
+        'companyFields' => (isset($companyFields)) ? $companyFields : [],
     ]
 );

--- a/app/bundles/FormBundle/Views/Field/radiogrp.html.php
+++ b/app/bundles/FormBundle/Views/Field/radiogrp.html.php
@@ -18,5 +18,6 @@ echo $view->render(
         'formName'      => (isset($formName)) ? $formName : '',
         'type'          => 'radio',
         'contactFields' => (isset($contactFields)) ? $contactFields : [],
+        'companyFields' => (isset($companyFields)) ? $companyFields : [],
     ]
 );


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | /
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
I noticed a PHP notice when creating the radio or checkbox form fields.
![screen shot 2018-02-05 at 10 42 38](https://user-images.githubusercontent.com/1235442/35797849-545203ba-0a61-11e8-90ef-b97b1cb29216.png)


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create/edit a form
2. Try to add a radio field.
3. Try to add a checkbox field.

The PHP notice will be visible in the dev mode or logged in prod.

#### Steps to test this PR:
1. Checkout and test again
