### PR TITLE
Lead entity must be persisted so Doctrine saves campaign LeadEventLog properly

### DIFF
--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -436,12 +436,13 @@ class EventModel extends CommonFormModel
             $this->triggerConditions($campaigns[$campaignId]);
         }
 
-        if (count($logs)) {
-            $this->getLeadEventLogRepository()->saveEntities($logs);
+        if ($lead->getChanges()) {
+            $this->leadModel->saveEntity($lead);
         }
 
-        if ($lead->getChanges()) {
-            $this->leadModel->saveEntity($lead, false);
+        if (count($logs)) {
+            $this->em->persist($lead);
+            $this->getLeadEventLogRepository()->saveEntities($logs);
         }
 
         if ($this->dispatcher->hasListeners(CampaignEvents::ON_EVENT_DECISION_TRIGGER)) {

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -437,7 +437,7 @@ class EventModel extends CommonFormModel
         }
 
         if ($lead->getChanges()) {
-            $this->leadModel->saveEntity($lead);
+            $this->leadModel->saveEntity($lead, false);
         }
 
         if (count($logs)) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | /
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | #5639, #5391, #4726, #4688, #4988, #4164
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The error message:
```
A new entity was found through the relationship 'Mautic\CampaignBundle\Entity\LeadEventLog#lead' that was not configured to cascade persist operations for entity: Mautic\LeadBundle\Entity\Lead with ID #360. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist this association in the mapping for example @ManyToOne(..,cascade={"persist"}).
```

was reported in several issues (linked above), but I was finally able to replicate with steps in #https://github.com/mautic/mautic/issues/5639. The problem is that the Lead entity is not persisted to entity manager and it fails because of it. My first thought was to move the Lead save before the LeadEventLog save. But it didn't help because the Lead got flushed. So my suggestion is to persist Lead once again before saving LeadEventLog.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

Note: I discovered https://github.com/mautic/mautic/pull/5676 following these steps. Please test and merge that one first.

1. Create a Campaign Form with a radio group that can simply be 1 or 0 as values and email address (also connect it to the relevant contact field) and first name (connect to contact field also).
1b. Create a URL redirect in the Campaign Form settings.
2. Create two different emails to be sent which include twig field contact first name
3. Create a new Campaign
4. Select the new Campaign Form as source
5. Add a decision based on Contact Submitting the form
6. Below that add a condition that works immediately and looks for an equal value to 1 in the radio group of the form you initially created
7. For success add an action to send the user one of the emails
8. For failure add an action to send the user one of the other emails
9. Submit the form externally or at the ID url on the mautic install (provides time out and error in log)

Right Emails will send, contact is created, but 500 error or time out occurs.

#### Steps to test this PR:
1. Checkout this PR
2. Submit the form again. It will be successful this time.