### PR TITLE
Fix pending count on segment email

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -222,6 +222,7 @@ class EmailRepository extends CommonRepository
                 $mqQb->expr()->eq('mq.channel_id', (int) $emailId)
             );
         }
+        $statQb->andWhere($statQb->expr()->isNotNull('stat.lead_id'));
         $mqQb->where($messageExpr);
 
         // Only include those who belong to the associated lead lists


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y 
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #5553
| BC breaks? | N
| Deprecations? | N


[//]: # ( Required: )
#### Description:
When a lead is deleted, lead_id in email_stat table are set to NULL.
If one lead_id is NULL in segment email stat, pending count is not longer calculated proprely

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new segment 
2. Create a new segment email
3. Add two contacts A and B to segment
4. Shoot the email
5. add a new contact C to the segment
6. check in email interface, there is one pending email.
7. Delete Contact A
8. check in email interface, there is no pending email.

#### Steps to test this PR:
9. apply PR
10. check in email interface, there is one pending email ( contact C)
