### PR TITLE
Clearfix for field properties tab

### DIFF
--- a/app/bundles/FormBundle/Views/Builder/field.html.php
+++ b/app/bundles/FormBundle/Views/Builder/field.html.php
@@ -200,6 +200,7 @@ $propertiesTabError = (isset($form['properties']) && ($view['form']->containsErr
                 <?php endif; ?>
                 <div class="row">
                     <?php
+                    $i = 0;
                     foreach ($properties as $name => $property):
                     if ($form['properties'][$name]->isRendered() || $name == 'labelAttributes') {
                         continue;
@@ -213,7 +214,16 @@ $propertiesTabError = (isset($form['properties']) && ($view['form']->containsErr
                     <div class="col-md-<?php echo $col; ?>">
                         <?php echo $view['form']->row($form['properties'][$name]); ?>
                     </div>
-                    <?php endif; ?>
+                    <?php
+                        if (6 == $col) :
+                            $i++;
+                          if (0 == $i % 2) :
+                              ?>
+                            <div class="clearfix"></div>
+                              <?php
+                          endif;
+                        endif;
+                    endif; ?>
                     <?php endforeach; ?>
                 </div>
             </div>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Required fields in properties tab crash UX.
This PR added clearfix every second col-md-6 column

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Install test plugin https://1drv.ms/u/s!AvXHYm0qUE5it5RPFD7CJdWNAGhgMQ)
2. Create form and add _field test_ fromplugin
3. Open properties tab fill just Field test 2  and try save field
4. See UX mess
![image](https://user-images.githubusercontent.com/462477/37879891-1cfb8248-3080-11e8-9291-95a7848bf40c.png)

#### Steps to test this PR:
1. Repeat all steps
2. See properties tab with correct UX

![image](https://user-images.githubusercontent.com/462477/37879879-cee8c048-307f-11e8-9e64-edd79df1e0f7.png)

