### PR TITLE
Broadcast command params extended

### DIFF
--- a/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
+++ b/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
@@ -51,11 +51,11 @@ EOT
                         'The ID for a specifc channel to process broadcasts for pending contacts.'
                     ),
                     new InputOption(
-                        'min-contact-id', 'n', InputOption::VALUE_OPTIONAL,
+                        'min-contact-id', null, InputOption::VALUE_OPTIONAL,
                         'Min contact ID to filter recipients.'
                     ),
                     new InputOption(
-                        'max-contact-id', 'x', InputOption::VALUE_OPTIONAL,
+                        'max-contact-id', null, InputOption::VALUE_OPTIONAL,
                         'Max contact ID to filter recipients.'
                     ),
                     new InputOption(

--- a/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
+++ b/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
@@ -51,10 +51,6 @@ EOT
                         'The ID for a specifc channel to process broadcasts for pending contacts.'
                     ),
                     new InputOption(
-                        'segment-id', 'si', InputOption::VALUE_OPTIONAL,
-                        'The ID for a specifc segment to filter recipients.'
-                    ),
-                    new InputOption(
                         'min-contact-id', 'minci', InputOption::VALUE_OPTIONAL,
                         'Min contact ID to filter recipients.'
                     ),
@@ -88,7 +84,6 @@ EOT
         $channelId    = $input->getOption('id');
         $limit        = $input->getOption('limit');
         $batch        = $input->getOption('batch');
-        $segmentId    = $input->getOption('segment-id');
         $minContactId = $input->getOption('min-contact-id');
         $maxContactId = $input->getOption('max-contact-id');
         $key          = $channel.$channelId;
@@ -107,10 +102,6 @@ EOT
         $event->setBatch($batch);
         $event->setMinContactIdFilter($minContactId);
         $event->setMaxContactIdFilter($maxContactId);
-
-        if ($segmentId) {
-            $event->addSegmentFilter($this->getContainer()->get('mautic.lead.model.list')->getEntity($segmentId));
-        }
 
         $dispatcher->dispatch(ChannelEvents::CHANNEL_BROADCAST, $event);
 

--- a/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
+++ b/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
@@ -51,11 +51,11 @@ EOT
                         'The ID for a specifc channel to process broadcasts for pending contacts.'
                     ),
                     new InputOption(
-                        'min-contact-id', 'minci', InputOption::VALUE_OPTIONAL,
+                        'min-contact-id', 'n', InputOption::VALUE_OPTIONAL,
                         'Min contact ID to filter recipients.'
                     ),
                     new InputOption(
-                        'max-contact-id', 'maxci', InputOption::VALUE_OPTIONAL,
+                        'max-contact-id', 'x', InputOption::VALUE_OPTIONAL,
                         'Max contact ID to filter recipients.'
                     ),
                     new InputOption(

--- a/app/bundles/ChannelBundle/Event/ChannelBroadcastEvent.php
+++ b/app/bundles/ChannelBundle/Event/ChannelBroadcastEvent.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\ChannelBundle\Event;
 
+use Mautic\LeadBundle\Entity\LeadList;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\Event;
 
@@ -46,6 +47,41 @@ class ChannelBroadcastEvent extends Event
     protected $output;
 
     /**
+     * Leave blank if you want to send to all segments defined in the channel entity at once.
+     *
+     * @var array of LeadList objects
+     */
+    private $segmentFilter = [];
+
+    /**
+     * Min contact ID filter can be used for process parallelization.
+     *
+     * @var int
+     */
+    private $minContactIdFilter;
+
+    /**
+     * Max contact ID filter can be used for process parallelization.
+     *
+     * @var int
+     */
+    private $maxContactIdFilter;
+
+    /**
+     * How many contacts to load from the database.
+     *
+     * @var int
+     */
+    private $limit = 100;
+
+    /**
+     * How big batches to use to actually send.
+     *
+     * @var int
+     */
+    private $batch = 50;
+
+    /**
      * MaintenanceEvent constructor.
      *
      * @param int  $daysOld
@@ -75,15 +111,17 @@ class ChannelBroadcastEvent extends Event
     }
 
     /**
-     * @param     $channelLabel
-     * @param int $successCount
-     * @param int $failedCount
+     * @param string $channelLabel
+     * @param int    $successCount
+     * @param int    $failedCount
+     * @param array  $failedRecipientsByList
      */
-    public function setResults($channelLabel, $successCount, $failedCount = 0)
+    public function setResults($channelLabel, $successCount, $failedCount = 0, array $failedRecipientsByList = [])
     {
         $this->results[$channelLabel] = [
-            'success' => (int) $successCount,
-            'failed'  => (int) $failedCount,
+            'success'                => (int) $successCount,
+            'failed'                 => (int) $failedCount,
+            'failedRecipientsByList' => $failedRecipientsByList,
         ];
     }
 
@@ -115,5 +153,85 @@ class ChannelBroadcastEvent extends Event
     public function getOutput()
     {
         return $this->output;
+    }
+
+    /**
+     * @param LeadList $segment
+     */
+    public function addSegmentFilter(LeadList $segment)
+    {
+        $this->segmentFilter[] = $segment;
+    }
+
+    /**
+     * @return array of LeadList objects
+     */
+    public function getSegmentFilter()
+    {
+        return $this->segmentFilter;
+    }
+
+    /**
+     * @param int $minContactIdFilter
+     */
+    public function setMinContactIdFilter($minContactIdFilter)
+    {
+        $this->minContactIdFilter = $minContactIdFilter;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMinContactIdFilter()
+    {
+        return $this->minContactIdFilter;
+    }
+
+    /**
+     * @param int $maxContactIdFilter
+     */
+    public function setMaxContactIdFilter($maxContactIdFilter)
+    {
+        $this->maxContactIdFilter = $maxContactIdFilter;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMaxContactIdFilter()
+    {
+        return $this->maxContactIdFilter;
+    }
+
+    /**
+     * @param int $limit
+     */
+    public function setLimit($limit)
+    {
+        $this->limit = $limit;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLimit()
+    {
+        return $this->limit;
+    }
+
+    /**
+     * @param int $batch
+     */
+    public function setBatch($batch)
+    {
+        $this->batch = $batch;
+    }
+
+    /**
+     * @return int
+     */
+    public function getBatch()
+    {
+        return $this->batch;
     }
 }

--- a/app/bundles/ChannelBundle/Event/ChannelBroadcastEvent.php
+++ b/app/bundles/ChannelBundle/Event/ChannelBroadcastEvent.php
@@ -11,7 +11,6 @@
 
 namespace Mautic\ChannelBundle\Event;
 
-use Mautic\LeadBundle\Entity\LeadList;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\Event;
 
@@ -45,13 +44,6 @@ class ChannelBroadcastEvent extends Event
      * @var OutputInterface
      */
     protected $output;
-
-    /**
-     * Leave blank if you want to send to all segments defined in the channel entity at once.
-     *
-     * @var array of LeadList objects
-     */
-    private $segmentFilter = [];
 
     /**
      * Min contact ID filter can be used for process parallelization.
@@ -153,22 +145,6 @@ class ChannelBroadcastEvent extends Event
     public function getOutput()
     {
         return $this->output;
-    }
-
-    /**
-     * @param LeadList $segment
-     */
-    public function addSegmentFilter(LeadList $segment)
-    {
-        $this->segmentFilter[] = $segment;
-    }
-
-    /**
-     * @return array of LeadList objects
-     */
-    public function getSegmentFilter()
-    {
-        return $this->segmentFilter;
     }
 
     /**

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -367,9 +367,9 @@ class EmailRepository extends CommonRepository
 
         $results = $q->execute()->fetchAll();
 
-        if ($count && $countWithMaxMin) {
-            // array in format ['count' => #, ['min_id' => #, 'max_id' => #]]
-            return $results;
+        if ($countOnly && $countWithMaxMin) {
+            // returns array in format ['count' => #, ['min_id' => #, 'max_id' => #]]
+            return $results[0];
         } elseif ($countOnly) {
             return (isset($results[0])) ? $results[0]['count'] : 0;
         } else {

--- a/app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
@@ -42,7 +42,9 @@ class BroadcastSubscriber implements EventSubscriberInterface
     /**
      * BroadcastSubscriber constructor.
      *
-     * @param EmailModel $emailModel
+     * @param EmailModel          $emailModel
+     * @param EntityManager       $em
+     * @param TranslatorInterface $translator
      */
     public function __construct(EmailModel $emailModel, EntityManager $em, TranslatorInterface $translator)
     {
@@ -71,17 +73,27 @@ class BroadcastSubscriber implements EventSubscriberInterface
         }
 
         // Get list of published broadcasts or broadcast if there is only a single ID
-        $id     = $event->getId();
-        $emails = $this->model->getRepository()->getPublishedBroadcasts($id);
+        $emails = $this->model->getRepository()->getPublishedBroadcasts($event->getId());
 
-        $output = $event->getOutput();
-
-        /** @var Email $email */
         while (($email = $emails->next()) !== false) {
-            list($sentCount, $failedCount, $ignore) = $this->model->sendEmailToLists($email[0], null, 100, true, $output);
+            $emailEntity                                            = $email[0];
+            list($sentCount, $failedCount, $failedRecipientsByList) = $this->model->sendEmailToLists(
+                $emailEntity,
+                $event->getSegmentFilter(),
+                $event->getLimit(),
+                $event->getBatch(),
+                $event->getOutput(),
+                $event->getMinContactIdFilter(),
+                $event->getMaxContactIdFilter()
+            );
 
-            $event->setResults($this->translator->trans('mautic.email.email').': '.$email[0]->getName(), $sentCount, $failedCount);
-            $this->em->detach($email[0]);
+            $event->setResults(
+                $this->translator->trans('mautic.email.email').': '.$emailEntity->getName(),
+                $sentCount,
+                $failedCount,
+                $failedRecipientsByList
+            );
+            $this->em->detach($emailEntity);
         }
     }
 }

--- a/app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
@@ -79,7 +79,7 @@ class BroadcastSubscriber implements EventSubscriberInterface
             $emailEntity                                            = $email[0];
             list($sentCount, $failedCount, $failedRecipientsByList) = $this->model->sendEmailToLists(
                 $emailEntity,
-                $event->getSegmentFilter(),
+                null,
                 $event->getLimit(),
                 $event->getBatch(),
                 $event->getOutput(),

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -824,8 +824,9 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
      * @param bool  $countOnly       If true, return count otherwise array of leads
      * @param int   $limit           Max number of leads to retrieve
      * @param bool  $includeVariants If false, emails sent to a variant will not be included
-     * @param int   $minContactId
-     * @param int   $maxContactId
+     * @param int   $minContactId    Filter by min contact ID
+     * @param int   $maxContactId    Filter by max contact ID
+     * @param bool  $countWithMaxMin Add min_id and max_id info to the count result
      *
      * @return int|array
      */
@@ -836,7 +837,8 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         $limit = null,
         $includeVariants = true,
         $minContactId = null,
-        $maxContactId = null
+        $maxContactId = null,
+        $countWithMaxMin = false
     ) {
         $variantIds = ($includeVariants) ? $email->getRelatedEntityIds() : null;
         $total      = $this->getRepository()->getEmailPendingLeads(
@@ -846,7 +848,8 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             $countOnly,
             $limit,
             $minContactId,
-            $maxContactId
+            $maxContactId,
+            $countWithMaxMin
         );
 
         return $total;

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryTest.php
@@ -142,7 +142,7 @@ class EmailRepositoryTest extends \PHPUnit_Framework_TestCase
             $countWithMaxMin
         );
 
-        $expectedQuery = "SELECT count(distinct(l.id)) as count, MIN(l.id) as min_id, MAX(l.id) as max_id FROM leads l INNER JOIN lead_lists_leads ll ON (ll.leadlist_id IN (22, 33)) AND (ll.lead_id = l.id) AND (ll.manually_removed = :false) WHERE (l.id NOT IN (SELECT dnc.lead_id FROM lead_donotcontact dnc WHERE dnc.channel = 'email')) AND (l.id NOT IN (SELECT stat.lead_id FROM email_stats stat WHERE stat.email_id = 5)) AND (l.id NOT IN (SELECT mq.lead_id FROM message_queue mq WHERE (mq.channel = 'email') AND (mq.status <> 'sent') AND (mq.channel_id = 5))) AND (l.id >= :minContactId) AND (l.id <= :maxContactId) AND ((l.email IS NOT NULL) AND (l.email <> '')) ORDER BY l.id ASC";
+        $expectedQuery = "SELECT count(distinct(l.id)) as count, MIN(l.id) as min_id, MAX(l.id) as max_id FROM leads l INNER JOIN lead_lists_leads ll ON (ll.leadlist_id IN (22, 33)) AND (ll.lead_id = l.id) AND (ll.manually_removed = :false) WHERE (l.id NOT IN (SELECT dnc.lead_id FROM lead_donotcontact dnc WHERE (dnc.channel = 'email') AND (dnc.lead_id >= :minContactId) AND (dnc.lead_id <= :maxContactId))) AND (l.id NOT IN (SELECT stat.lead_id FROM email_stats stat WHERE (stat.email_id = 5) AND (stat.lead_id >= :minContactId) AND (stat.lead_id <= :maxContactId))) AND (l.id NOT IN (SELECT mq.lead_id FROM message_queue mq WHERE (mq.channel = 'email') AND (mq.status <> 'sent') AND (mq.channel_id = 5) AND (mq.lead_id >= :minContactId) AND (mq.lead_id <= :maxContactId))) AND (l.id >= :minContactId) AND (l.id <= :maxContactId) AND ((l.email IS NOT NULL) AND (l.email <> ''))";
 
         $expectedParams = [
             'false'        => false,

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Entity;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Mautic\EmailBundle\Entity\EmailRepository;
+
+class EmailRepositoryTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
+
+        $mockConnection = $this->getMockBuilder(Connection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockConnection->method('createQueryBuilder')
+            ->willReturnCallback(
+                function () use ($mockConnection) {
+                    return new QueryBuilder($mockConnection);
+                }
+            );
+
+        $mockConnection->method('getExpressionBuilder')
+            ->willReturnCallback(
+                function () use ($mockConnection) {
+                    return new ExpressionBuilder($mockConnection);
+                }
+            );
+
+        $mockConnection->method('quote')
+            ->willReturnCallback(
+                function ($value) {
+                    return "'$value'";
+                }
+            );
+
+        $this->em = $this
+            ->getMockBuilder(EntityManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->cm = $this->getMockBuilder(ClassMetadata::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->em->method('getConnection')
+            ->willReturn($mockConnection);
+
+        $this->repo = new EmailRepository($this->em, $this->cm);
+    }
+
+    public function testGetEmailPendingQueryForSimpleCount()
+    {
+        $emailId         = 5;
+        $variantIds      = null;
+        $listIds         = [22, 33];
+        $countOnly       = true;
+        $limit           = null;
+        $minContactId    = null;
+        $maxContactId    = null;
+        $countWithMaxMin = false;
+
+        $query = $this->repo->getEmailPendingQuery(
+            $emailId,
+            $variantIds,
+            $listIds,
+            $countOnly,
+            $limit,
+            $minContactId,
+            $maxContactId,
+            $countWithMaxMin
+        );
+
+        $expectedQuery = "SELECT count(distinct(l.id)) as count FROM leads l INNER JOIN lead_lists_leads ll ON (ll.leadlist_id IN (22, 33)) AND (ll.lead_id = l.id) AND (ll.manually_removed = :false) WHERE (l.id NOT IN (SELECT dnc.lead_id FROM lead_donotcontact dnc WHERE dnc.channel = 'email')) AND (l.id NOT IN (SELECT stat.lead_id FROM email_stats stat WHERE stat.email_id = 5)) AND (l.id NOT IN (SELECT mq.lead_id FROM message_queue mq WHERE (mq.channel = 'email') AND (mq.status <> 'sent') AND (mq.channel_id = 5))) AND ((l.email IS NOT NULL) AND (l.email <> ''))";
+        $this->assertEquals($expectedQuery, $query->getSql());
+        $this->assertEquals(['false' => false], $query->getParameters());
+    }
+
+    public function testGetEmailPendingQueryForMaxMinIdCount()
+    {
+        $emailId         = 5;
+        $variantIds      = null;
+        $listIds         = [22, 33];
+        $countOnly       = true;
+        $limit           = null;
+        $minContactId    = null;
+        $maxContactId    = null;
+        $countWithMaxMin = true;
+
+        $query = $this->repo->getEmailPendingQuery(
+            $emailId,
+            $variantIds,
+            $listIds,
+            $countOnly,
+            $limit,
+            $minContactId,
+            $maxContactId,
+            $countWithMaxMin
+        );
+
+        $expectedQuery = "SELECT count(distinct(l.id)) as count, MIN(l.id) as min_id, MAX(l.id) as max_id FROM leads l INNER JOIN lead_lists_leads ll ON (ll.leadlist_id IN (22, 33)) AND (ll.lead_id = l.id) AND (ll.manually_removed = :false) WHERE (l.id NOT IN (SELECT dnc.lead_id FROM lead_donotcontact dnc WHERE dnc.channel = 'email')) AND (l.id NOT IN (SELECT stat.lead_id FROM email_stats stat WHERE stat.email_id = 5)) AND (l.id NOT IN (SELECT mq.lead_id FROM message_queue mq WHERE (mq.channel = 'email') AND (mq.status <> 'sent') AND (mq.channel_id = 5))) AND ((l.email IS NOT NULL) AND (l.email <> ''))";
+        $this->assertEquals($expectedQuery, $query->getSql());
+        $this->assertEquals(['false' => false], $query->getParameters());
+    }
+
+    public function testGetEmailPendingQueryForMaxMinIdCountWithMaxMinIdsDefined()
+    {
+        $emailId         = 5;
+        $variantIds      = null;
+        $listIds         = [22, 33];
+        $countOnly       = true;
+        $limit           = null;
+        $minContactId    = 10;
+        $maxContactId    = 1000;
+        $countWithMaxMin = true;
+
+        $query = $this->repo->getEmailPendingQuery(
+            $emailId,
+            $variantIds,
+            $listIds,
+            $countOnly,
+            $limit,
+            $minContactId,
+            $maxContactId,
+            $countWithMaxMin
+        );
+
+        $expectedQuery = "SELECT count(distinct(l.id)) as count, MIN(l.id) as min_id, MAX(l.id) as max_id FROM leads l INNER JOIN lead_lists_leads ll ON (ll.leadlist_id IN (22, 33)) AND (ll.lead_id = l.id) AND (ll.manually_removed = :false) WHERE (l.id NOT IN (SELECT dnc.lead_id FROM lead_donotcontact dnc WHERE dnc.channel = 'email')) AND (l.id NOT IN (SELECT stat.lead_id FROM email_stats stat WHERE stat.email_id = 5)) AND (l.id NOT IN (SELECT mq.lead_id FROM message_queue mq WHERE (mq.channel = 'email') AND (mq.status <> 'sent') AND (mq.channel_id = 5))) AND (l.id >= :minContactId) AND (l.id <= :maxContactId) AND ((l.email IS NOT NULL) AND (l.email <> '')) ORDER BY l.id ASC";
+
+        $expectedParams = [
+            'false'        => false,
+            'minContactId' => 10,
+            'maxContactId' => 1000,
+        ];
+
+        $this->assertEquals($expectedQuery, $query->getSql());
+        $this->assertEquals($expectedParams, $query->getParameters());
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | /
| Related user documentation PR URL | https://github.com/mautic/documentation/pull/254
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR adds new possibilities and better control to the `mautic:channels:brodacast` command. It implements it only to the email channel, but the parameters are available for each channel. Just to be implemented.

1. `--limit=X` is how many contacts are pulled from the database to be processed. 100 by default. So X contacts will receive their emails if this command is triggered. Next time the contact runs it will be next X contacts and so on.

2. `--batch=X` is in how big batches will the emails be sent at once. This can be different for every provider. For example Mautic has API connection to Sparkpost. Such API can send 1000 emails per 1 call. So batch should be 1000 for fastest sending speed. Not more. But SMTP providers cannot handle 1000 at 1 time.

4., 5. `--min-contact-id` and `--max-contact-id` will allow to separate email sending by smaller chunks by contact ID ranges. If those ranges won't overlap this allows to run several broadcast commands in parallel.

#### Steps to test this PR:
1. Create 2 segments with several contacts in each with an email address that goes to your inbox.
2. Create a segment email. Select both segments. Set publish up date to yesterday.
3. Execute `app/console mautic:broadcast:send --limit=2`. It will send only 2 emails even if there is more. Execute it once more. It will send 2 more emails until all emails are sent.
4. Clone the email, publish it, rename it, save it.
5. Execute `app/console mautic:broadcast:send --min-contact-id=X --max-contact-id=Y`. Replace X and Y to cover some of the contact IDs from your segments. Only those will get the email.