### PR TITLE
Replace the use of eval-based JavaScript

### DIFF
--- a/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
@@ -87,7 +87,7 @@ MauticJS.serialize = function(obj) {
 };
 
 MauticJS.documentReady = function(f) {
-    /in/.test(document.readyState) ? setTimeout('MauticJS.documentReady(' + f + ')', 9) : f();
+    /in/.test(document.readyState) ? setTimeout(function(){MauticJS.documentReady(f)}, 9) : f();
 };
 
 MauticJS.iterateCollection = function(collection) {
@@ -329,7 +329,7 @@ MauticJS.pixelLoaded = function(f) {
 */
 MauticJS.checkForTrackingPixel = function() {
     if (!/in/.test(document.readyState)) {
-        setTimeout('MauticJS.checkForTrackingPixel()', 9)
+        setTimeout(function(){MauticJS.checkForTrackingPixel()}, 9)
     } else {
         // Only fetch once a tracking pixel has been loaded
         var maxChecks  = 3000; // Keep it from indefinitely checking in case the pixel was never embedded


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? |n/a
| Related user documentation PR URL | n/a
| Related developer documentation PR URL | n/a
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5727
| BC breaks? | No
| Deprecations? | No 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When implementing contact monitoring on a website that has a Content Security Policy header, without the `unsafe-eval` directive, the following error prevents the script from running properly:

> Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self'"

Having to add the `unsafe-eval` directive defeats the purpose of CSP and is unsecure.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make sure your website uses a CSP header with a `script-src` policy like `script-src 'self' https://yourmauticdomain.com`.
2. Insert the contact monitoring script.

#### Steps to test this PR:
1. Open the developer console on Chrome.
2. There should be no warning about the CSP.
