### PR TITLE
Fix email dynamic content owner lookup

### DIFF
--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -639,7 +639,7 @@ Mautic.addDynamicContentFilter = function (selectedFilter, jQueryVariant) {
         var fieldCallback = selectedOption.data("field-callback");
         if (fieldCallback && typeof Mautic[fieldCallback] == 'function') {
             fieldOptions = selectedOption.data("field-list");
-            Mautic[fieldCallback](filterIdBase + '_display', selectedFilter, fieldOptions);
+            Mautic[fieldCallback](filterIdBase + '_display', selectedFilter, fieldOptions, mQuery);
         }
     } else {
         mQuery(filter).attr('type', fieldType);

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -486,7 +486,12 @@ Mautic.updateLookupListFilter = function(field, datum) {
     }
 };
 
-Mautic.activateSegmentFilterTypeahead = function(displayId, filterId, fieldOptions) {
+Mautic.activateSegmentFilterTypeahead = function(displayId, filterId, fieldOptions, mQueryObject) {
+
+    if(typeof mQueryObject == 'function'){
+        mQuery = mQueryObject;
+    }
+
     mQuery('#' + displayId).attr('data-lookup-callback', 'updateLookupListFilter');
 
     Mautic.activateFieldTypeahead(displayId, filterId, [], 'lead:fieldList')


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5691
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Create another version of dynamic content stopped init lookup results for Owner.
This fix add update object mQuery to callback function.


[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Create an email
2. Go on the builder and add a dynamic content bloc
3. Add a variation
4. Add a filter and choose contact owner
5. The list of users does not appear

#### Steps to test this PR:
1.  Apply PR and call regenerate assets `php app/console m:a:g`
2.  Repeat steps to reproduce  
3.  See if owners are suggested

![image](https://user-images.githubusercontent.com/462477/36543493-362a4902-17e4-11e8-9b04-00aec88fc65a.png)
