### PR TITLE
Fixing setting contact's owner and stage via API

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -662,11 +662,7 @@ class LeadApiController extends CommonApiController
     }
 
     /**
-     * @param array  $parameters
-     * @param Lead   $entity
-     * @param string $action
-     *
-     * @return mixed|void
+     * {@inheritdoc}
      */
     protected function prepareParametersForBinding($parameters, $entity, $action)
     {

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -21,7 +21,6 @@ use Mautic\LeadBundle\Controller\LeadDetailsTrait;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
-use Mautic\UserBundle\Entity\User;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
@@ -690,6 +689,12 @@ class LeadApiController extends CommonApiController
         if (isset($parameters['tags'])) {
             $this->model->modifyTags($entity, $parameters['tags']);
             unset($parameters['tags']);
+        }
+
+        if (isset($parameters['stage'])) {
+            $stage = $this->getModel('stage.stage')->getEntity((int) $parameters['stage']);
+            $entity->setStage($stage);
+            unset($parameters['stage']);
         }
 
         return $parameters;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | https://github.com/mautic/api-library/pull/152
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The current code in the LeadApiController was setting owner ID as points it seems. But it failed the validation even before that code if an owner was set.


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to create a contact via API with owner=1. You'll see it will fail.
2. Create a stage and try to create a contact with stage=[ID of your stage]. Will fail too.

#### Steps to test this PR:
1. Test again. Both should work.
2. Apply https://github.com/mautic/api-library/pull/152 and run `vendor/bin/phpunit --filter ContactsTest::testCreateGetAndDelete`