### PR TITLE
Fix: Add data to addFormField 

### DIFF
--- a/app/bundles/FormBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/PageSubscriber.php
@@ -107,10 +107,9 @@ class PageSubscriber extends CommonSubscriber
 
                     //pouplate get parameters
                     $this->formModel->populateValuesWithGetParameters($form, $formHtml);
-
-                    $content = preg_replace('#{form='.$id.'}#', $formHtml, $content);
+                    $content = str_replace('{form='.$id.'}', $formHtml, $content);
                 } else {
-                    $content = preg_replace('#{form='.$id.'}#', '', $content);
+                    $content = str_replace('{form='.$id.'}', '', $content);
                 }
             }
         }

--- a/app/bundles/FormBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/PageSubscriber.php
@@ -107,9 +107,10 @@ class PageSubscriber extends CommonSubscriber
 
                     //pouplate get parameters
                     $this->formModel->populateValuesWithGetParameters($form, $formHtml);
-                    $content = str_replace('{form='.$id.'}', $formHtml, $content);
+
+                    $content = preg_replace('#{form='.$id.'}#', $formHtml, $content);
                 } else {
-                    $content = str_replace('{form='.$id.'}', '', $content);
+                    $content = preg_replace('#{form='.$id.'}#', '', $content);
                 }
             }
         }

--- a/app/bundles/FormBundle/Form/Type/FieldType.php
+++ b/app/bundles/FormBundle/Form/Type/FieldType.php
@@ -422,7 +422,7 @@ class FieldType extends AbstractType
         // Put properties last so that the other values are available to form events
         $propertiesData = (isset($options['data']['properties'])) ? $options['data']['properties'] : [];
         if (!empty($options['customParameters'])) {
-            // $formTypeOptions = array_merge($formTypeOptions, ['data'=>$propertiesData]);
+            $formTypeOptions = array_merge($formTypeOptions, ['data'=>$propertiesData]);
             $builder->add('properties', $customParams['formType'], $formTypeOptions);
         } else {
             switch ($type) {

--- a/app/bundles/FormBundle/Form/Type/FieldType.php
+++ b/app/bundles/FormBundle/Form/Type/FieldType.php
@@ -422,7 +422,7 @@ class FieldType extends AbstractType
         // Put properties last so that the other values are available to form events
         $propertiesData = (isset($options['data']['properties'])) ? $options['data']['properties'] : [];
         if (!empty($options['customParameters'])) {
-            $formTypeOptions = array_merge($formTypeOptions, ['data'=>$propertiesData]);
+            $formTypeOptions = array_merge($formTypeOptions, ['data' => $propertiesData]);
             $builder->add('properties', $customParams['formType'], $formTypeOptions);
         } else {
             switch ($type) {

--- a/app/bundles/FormBundle/Form/Type/FieldType.php
+++ b/app/bundles/FormBundle/Form/Type/FieldType.php
@@ -420,10 +420,11 @@ class FieldType extends AbstractType
         );
 
         // Put properties last so that the other values are available to form events
+        $propertiesData = (isset($options['data']['properties'])) ? $options['data']['properties'] : [];
         if (!empty($options['customParameters'])) {
+            // $formTypeOptions = array_merge($formTypeOptions, ['data'=>$propertiesData]);
             $builder->add('properties', $customParams['formType'], $formTypeOptions);
         } else {
-            $propertiesData = (isset($options['data']['properties'])) ? $options['data']['properties'] : [];
             switch ($type) {
                 case 'select':
                 case 'country':

--- a/app/bundles/FormBundle/Form/Type/FieldType.php
+++ b/app/bundles/FormBundle/Form/Type/FieldType.php
@@ -422,7 +422,7 @@ class FieldType extends AbstractType
         // Put properties last so that the other values are available to form events
         $propertiesData = (isset($options['data']['properties'])) ? $options['data']['properties'] : [];
         if (!empty($options['customParameters'])) {
-            $formTypeOptions = array_merge($formTypeOptions, ['data'=>$propertiesData]);
+            // $formTypeOptions = array_merge($formTypeOptions, ['data'=>$propertiesData]);
             $builder->add('properties', $customParams['formType'], $formTypeOptions);
         } else {
             switch ($type) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
I notice If we use  $event->addFormField in plugin (https://developer.mautic.org/#extending-forms), the event don't pass data to formType via $options.
This PR should fix it.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Install test plugin with form field https://1drv.ms/u/s!AvXHYm0qUE5it5RJ27rhBVUX4MxczQ based on documentation  https://developer.mautic.org/#extending-forms
2.  Create form and add form field from plugin
3.  Edit **properties tab** of new form field from plugin
4. Save and open. See value of input disappeared


#### Steps to test this PR:
1.  Apply PR and repeat all steps
2.  See value of test field appeared

Before

![image](https://user-images.githubusercontent.com/462477/37725953-77601900-2d34-11e8-979d-b14ddd349b0e.png)

After

![image](https://user-images.githubusercontent.com/462477/37725980-89507ede-2d34-11e8-9a71-fff952bbf9d4.png)