### PR TITLE
Fixed double return : unreachable code after return statement

### DIFF
--- a/plugins/MauticFocusBundle/Views/Builder/generate.js.php
+++ b/plugins/MauticFocusBundle/Views/Builder/generate.js.php
@@ -577,7 +577,7 @@ switch ($style) {
                 Focus.iframeResizerEnabled = true;
 
                 return true;
-                <?php else; ?>
+                <?php else: ?>
 
                 return false;
                 <?php endif; ?>

--- a/plugins/MauticFocusBundle/Views/Builder/generate.js.php
+++ b/plugins/MauticFocusBundle/Views/Builder/generate.js.php
@@ -577,9 +577,10 @@ switch ($style) {
                 Focus.iframeResizerEnabled = true;
 
                 return true;
-                <?php endif; ?>
+                <?php else; ?>
 
                 return false;
+                <?php endif; ?>
             },
 
             // Disable iframe resizer


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The file generatejs.php contains a condition that could write two return statement. Javascript don't like this
Tested on firefox 57.0.4 (64 bits)


#### Steps to reproduce the bug:
1. Create a focus
2. Open the website that call the focus
2. Firefox complaint about : ```unreachable code after return statement  1.js:266``` (in minified version)
3. the js source contains (in non minified version)
```
line 317                return true;
line 318                return false;
```


#### Steps to test this PR:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 