### PR TITLE
Fix characters in forms on landing page

### DIFF
--- a/app/bundles/FormBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/PageSubscriber.php
@@ -107,10 +107,9 @@ class PageSubscriber extends CommonSubscriber
 
                     //pouplate get parameters
                     $this->formModel->populateValuesWithGetParameters($form, $formHtml);
-
-                    $content = preg_replace('#{form='.$id.'}#', $formHtml, $content);
+                    $content = str_replace('{form='.$id.'}', $formHtml, $content);
                 } else {
-                    $content = preg_replace('#{form='.$id.'}#', '', $content);
+                    $content = str_replace('{form='.$id.'}', '', $content);
                 }
             }
         }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If you use special characters in forms like $100m, then on landing page preg_replace can't handle it. 
This PR use str_replace and fix this issue.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Create form with radio group  options with values ($100m and $200m)
2.  Create landing page and insert form to landing page
3. See preview of landing page 
4. Values are displayed wrongs

#### Steps to test this PR:
1.  Repeat all steps to reproduce
2.  Form on landing page now should looks properly

Before:

![image](https://user-images.githubusercontent.com/462477/36781531-686eee90-1c76-11e8-9171-ed87c0dab571.png)

After

![image](https://user-images.githubusercontent.com/462477/36781548-765801c2-1c76-11e8-861a-4bd6185d77d5.png)
