### PR TITLE
Fix social login with automatic generate form html code

### DIFF
--- a/plugins/MauticSocialBundle/Config/config.php
+++ b/plugins/MauticSocialBundle/Config/config.php
@@ -46,6 +46,12 @@ return [
                 'controller'      => 'MauticSocialBundle:Api\TweetApi',
             ],
         ],
+        'public' => [
+            'mautic_social_js_generate' => [
+                'path'       => '/social/generate/{formName}.js',
+                'controller' => 'MauticSocialBundle:Js:generate',
+            ],
+        ],
     ],
 
     'services' => [

--- a/plugins/MauticSocialBundle/Controller/JsController.php
+++ b/plugins/MauticSocialBundle/Controller/JsController.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticSocialBundle\Controller;
+
+use Mautic\CoreBundle\Controller\CommonController;
+use Symfony\Component\HttpFoundation\Response;
+
+class JsController extends CommonController
+{
+    /**
+     * @return Response
+     */
+    public function generateAction($formName)
+    {
+        $js = <<<JS
+
+    function openOAuthWindow(authUrl){
+        if (authUrl) {
+            var generator = window.open(authUrl, 'integrationauth', 'height=500,width=500');
+            if (!generator || generator.closed || typeof generator.closed == 'undefined') {
+                alert(mauticLang.popupBlockerMessage);
+            }
+        }
+    }
+    
+    function postAuthCallback(response){
+        var elements = document.getElementById("mauticform_{$formName}").elements;
+        var field, fieldName;
+        values = JSON.parse(JSON.stringify(response));
+        
+        for (var i = 0, element; element = elements[i++];) {
+            field = element.name
+            fieldName = field.replace("mauticform[","");
+            fieldName = fieldName.replace("]","");
+            var element = document.getElementsByName("mauticform["+fieldName+"]");
+            
+            // Remove underscores, dashes, and f_ prefix for comparison
+            fieldName = fieldName.replace("f_", "").replace(/_/g,"").replace(/-/g, "");
+            for(var key in values) {
+                var compareKey = key.replace(/_/g,"").replace(/-/g, "");
+                if (key != 'id' && (key.indexOf(fieldName) >= 0 || fieldName.indexOf(key) >= 0) && element[0].value == "") {
+                    if (values[key].constructor === Array && values[key][0].value) {
+                        element[0].value = values[key][0].value;
+                    } else {
+                        element[0].value = values[key];
+                    }
+                    
+                    break;
+                }
+            }
+        }
+    }
+JS;
+
+        return new Response(
+            $js,
+            200,
+            [
+                'Content-Type'           => 'application/javascript',
+            ]
+        );
+    }
+}

--- a/plugins/MauticSocialBundle/Views/Integration/login.html.php
+++ b/plugins/MauticSocialBundle/Views/Integration/login.html.php
@@ -37,53 +37,14 @@ $label = (!$field['showLabel'])
 <label $labelAttr>{$view->escape($field['label'])}</label>
 HTML;
 
-$js = <<<JS
-    var isLive='{$action}';
+$script = '<script src="'.$view['router']->generate('mautic_social_js_generate', ['formName' => $formName], true)
+    .'" type="text/javascript" charset="utf-8" async="async"></script>';
 
-    function openOAuthWindow(authUrl){
-        if (authUrl) {
-            var generator = window.open(authUrl, 'integrationauth', 'height=500,width=500');
-            if (!generator || generator.closed || typeof generator.closed == 'undefined') {
-                alert(mauticLang.popupBlockerMessage);
-            }
-        }
-    }
-    
-    function postAuthCallback(response){
-        var elements = document.getElementById("mauticform_{$formName}").elements;
-        var field, fieldName;
-        values = JSON.parse(JSON.stringify(response));
-        
-        for (var i = 0, element; element = elements[i++];) {
-            field = element.name
-            fieldName = field.replace("mauticform[","");
-            fieldName = fieldName.replace("]","");
-            var element = document.getElementsByName("mauticform["+fieldName+"]");
-            
-            // Remove underscores, dashes, and f_ prefix for comparison
-            fieldName = fieldName.replace("f_", "").replace(/_/g,"").replace(/-/g, "");
-            for(var key in values) {
-                var compareKey = key.replace(/_/g,"").replace(/-/g, "");
-                if (key != 'id' && (key.indexOf(fieldName) >= 0 || fieldName.indexOf(key) >= 0) && element[0].value == "") {
-                    if (values[key].constructor === Array && values[key][0].value) {
-                        element[0].value = values[key][0].value;
-                    } else {
-                        element[0].value = values[key];
-                    }
-                    
-                    break;
-                }
-            }
-        }
-    }
-JS;
 $html = <<<HTML
 	<div $containerAttr>{$formButtons}{$label}
 HTML;
 ?>
-<script>
-    <?php echo $js; ?>
-</script>
+<?php echo $script; ?>
 
 <?php
 echo $html;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4511
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Issue related to https://github.com/mautic/mautic/issues/4511 
JS include in automatic generate form couldn't be executed because inline js with document.write cannot work https://github.com/mautic/mautic/blob/afb4da4491ac2f12e8500d504906bd20f8ff47ee/plugins/MauticSocialBundle/Views/Integration/login.html.php#L35
This PR put JS code to external js link. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Enable at least one social plugin
2. Create a Form with 2 fields First name and Social Login 
3. Place automatic  form html on your page
4. Visit Landing page
5. Click on the social icon.

#### Steps to test this PR:
1. Repeat all steps and don't forget rebuild form cache
2. See if social login work