### PR TITLE
Use appropriate for loop on preEventDeliveryQueue array instead of for…in

### DIFF
--- a/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
@@ -310,8 +310,8 @@ document.addEventListener('mauticPageEventDelivered', function(e) {
     
     if (!MauticJS.firstDeliveryMade) {
         MauticJS.firstDeliveryMade = true;
-        for (var i in MauticJS.postEventDeliveryQueue) {
-            if (typeof MauticJS.postEventDeliveryQueue[i] == 'function') {
+        for (var i = 0; i < MauticJS.postEventDeliveryQueue.length; i++) {
+            if (typeof MauticJS.postEventDeliveryQueue[i] === 'function') {
                 MauticJS.postEventDeliveryQueue[i](detail);
             }
             delete MauticJS.postEventDeliveryQueue[i];


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in
| Issues addressed (#s or URLs) | Pending
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
`for...in` loops do not work consistently across browsers when using them to iterate over an array. They are not guaranteed to always return in the same order and doing that style of loop on an array returns all properties of the array, not just the numeric indexed items.

This bug was introduced with this commit: https://github.com/mautic/mautic/commit/a6150e8b8c77e45ff40abee8865dae1a6c9d2264#diff-33b07c1d837daff498f70f652062659eR215

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create Dynamic Content and embed it in a page where you have loaded the `mtc.js`
2. Load the page in the Safari or Chrome browsers, and see the console error `#<Object> is not a function`

#### Steps to test this PR:
1. Apply PR
2. Retest and see the error no longer appears.