### PR TITLE
Remove maxmind as default iplookup

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -981,7 +981,7 @@ return [
         'date_format_short'    => 'D, M d',
         'date_format_dateonly' => 'F j, Y',
         'date_format_timeonly' => 'g:i a',
-        'ip_lookup_service'    => 'maxmind_download',
+        'ip_lookup_service'    => '',
         'ip_lookup_auth'       => '',
         'ip_lookup_config'     => [],
         'transifex_username'   => '',


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5764
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Recently maxmind is the default iplookup service. This generates tones of logs error and make very slow the application.
I simply propose to put back the empty value as default configuration and if people want to enable it they'll have to activate it from the configuration page.