### PR TITLE
Custom preference center {channelfrequency} fix

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -204,6 +204,11 @@ class PublicController extends CommonFormController
 
                 $form = $this->getFrequencyRuleForm($lead, $viewParameters, $data, true, $action);
                 if (true === $form) {
+                    // add frequencyPresent if posting custom preference center
+                    if ($email && ($prefCenter = $email->getPreferenceCenter()) && ($prefCenter->getIsPreferenceCenter())) {
+                        $html = $prefCenter->getCustomHtml();
+                        $viewParameters['frequencyPresent'] = false !== strpos($html, 'data-slot="channelfrequency"') || false !== strpos($html, BuilderSubscriber::channelfrequency);
+                    }
                     return $this->postActionRedirect(
                         [
                             'returnUrl'       => $this->generateUrl('mautic_email_unsubscribe', ['idHash' => $idHash]),
@@ -217,13 +222,8 @@ class PublicController extends CommonFormController
                 /** @var Page $prefCenter */
                 if ($email && ($prefCenter = $email->getPreferenceCenter()) && ($prefCenter->getIsPreferenceCenter())) {
                     $html = $prefCenter->getCustomHtml();
-                    // check if tokens are present
-                    $savePrefsPresent = false !== strpos($html, 'data-slot="saveprefsbutton"') ||
-                                        false !== strpos($html, BuilderSubscriber::saveprefsRegex);
-                    $frequencyPresent = false !== strpos($html, 'data-slot="channelfrequency"') ||
-                                        false !== strpos($html, BuilderSubscriber::channelfrequency);
-                    $tokensPresent = $savePrefsPresent && $frequencyPresent;
-                    if ($tokensPresent) {
+                    // check if save button present
+                    if (false !== strpos($html, 'data-slot="saveprefsbutton"') || false !== strpos($html, BuilderSubscriber::saveprefsRegex)) {
                         // set custom tag to inject end form
                         // update show pref center slots by looking for their presence in the html
                         $params = array_merge(

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -210,6 +210,7 @@ class PublicController extends CommonFormController
 
                         $viewParameters['frequencyPresent'] = false !== strpos($html, 'data-slot="channelfrequency"') || false !== strpos($html, BuilderSubscriber::channelfrequency);
                     }
+
                     return $this->postActionRedirect(
                         [
                             'returnUrl'       => $this->generateUrl('mautic_email_unsubscribe', ['idHash' => $idHash]),

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -207,6 +207,7 @@ class PublicController extends CommonFormController
                     // add frequencyPresent if posting custom preference center
                     if ($email && ($prefCenter = $email->getPreferenceCenter()) && ($prefCenter->getIsPreferenceCenter())) {
                         $html = $prefCenter->getCustomHtml();
+
                         $viewParameters['frequencyPresent'] = false !== strpos($html, 'data-slot="channelfrequency"') || false !== strpos($html, BuilderSubscriber::channelfrequency);
                     }
                     return $this->postActionRedirect(

--- a/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
+++ b/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
@@ -91,7 +91,7 @@ trait FrequencyRuleTrait
         if ('GET' !== $method) {
             if (!$this->isFormCancelled($form)) {
                 if ($this->isFormValid($form, $data)) {
-                    $this->persistFrequencyRuleFormData($lead, $form->getData(), $allChannels, $leadChannels, $currentChannelId);
+                    $this->persistFrequencyRuleFormData($lead, $form->getData(), $allChannels, $leadChannels, $currentChannelId, $viewParameters);
 
                     return true;
                 }
@@ -171,7 +171,7 @@ trait FrequencyRuleTrait
      * @param       $leadChannels
      * @param int   $currentChannelId
      */
-    protected function persistFrequencyRuleFormData(Lead $lead, array $formData, array $allChannels, $leadChannels, $currentChannelId = null)
+    protected function persistFrequencyRuleFormData(Lead $lead, array $formData, array $allChannels, $leadChannels, $currentChannelId = null, &$viewParameters = [])
     {
         /** @var LeadModel $model */
         $model = $this->getModel('lead');
@@ -186,13 +186,15 @@ trait FrequencyRuleTrait
             }
         }
 
-        $dncChannels = array_diff($allChannels, $formData['subscribed_channels']);
-        if (!empty($dncChannels)) {
-            foreach ($dncChannels as $channel) {
-                if ($currentChannelId) {
-                    $channel = [$channel => $currentChannelId];
+        if ($viewParameters['frequencyPresent']) {
+            $dncChannels = array_diff($allChannels, $formData['subscribed_channels']);
+            if (!empty($dncChannels)) {
+                foreach ($dncChannels as $channel) {
+                    if ($currentChannelId) {
+                        $channel = [$channel => $currentChannelId];
+                    }
+                    $model->addDncForLead($lead, $channel, 'user', ($this->isPublicView) ? DoNotContact::UNSUBSCRIBED : DoNotContact::MANUAL);
                 }
-                $model->addDncForLead($lead, $channel, 'user', ($this->isPublicView) ? DoNotContact::UNSUBSCRIBED : DoNotContact::MANUAL);
             }
         }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| Automated tests included? | n
| Issues addressed | #5775

**Description:**
If  {channelfrequency} isn't included in the Custom Preference Center, it will not load and fall back to the system default.

| Q   | A
| --- | ---
| Mautic version | v2.12.2 
| PHP version | v7.1.11

**Steps to reproduce bug:**
1. Create a custom landingpage, turn _is preference center_ on
2. Select a template (blank) and open the builder
3. Place _Segment List_, _Channel Frequency_, _Save Preferences_ into the builder, close builder and save page
4. Send yourself an email with the created pref. center link, open the page
5. You should now see the correct custom preference center
6. Go back to the pref. center builder, remove the _Channel Frequency_ block, and apply the change
7. Refresh the custom pref. center page. Now the system default loads instead of the custom one

**Steps to test this PR:**
1. Create a custom preference center with _Segment List_ and _Save Preferences_ blocks
2. Don't include the  _Channel Frequency_ block
3. View the custom pref. center and check / uncheck some segments and save
4. Segments get saved and you don't get DNC flag

**Additional comments:**
- Seems to work correct on our mautic install, but needs testing for sure. 
- Is _Channel Frequency_ the only DNC trigger? Otherwise it needs to include more checks
- My thanks in advance the codereview