### PR TITLE
Send SMS to contact API

### DIFF
--- a/app/bundles/SmsBundle/Config/config.php
+++ b/app/bundles/SmsBundle/Config/config.php
@@ -137,6 +137,11 @@ return [
                 'path'            => '/smses',
                 'controller'      => 'MauticSmsBundle:Api\SmsApi',
             ],
+            'mautic_api_sendcontactsms' => [
+                'path'       => '/smses/{id}/contact/{leadId}/send',
+                'controller' => 'MauticSMSBundle:Api\SmsApi:sendContact',
+                'method'     => 'POST',
+            ],
         ],
     ],
     'menu' => [

--- a/app/bundles/SmsBundle/Config/config.php
+++ b/app/bundles/SmsBundle/Config/config.php
@@ -139,7 +139,7 @@ return [
             ],
             'mautic_api_sendcontactsms' => [
                 'path'       => '/smses/{id}/contact/{leadId}/send',
-                'controller' => 'MauticSMSBundle:Api\SmsApi:sendContact',
+                'controller' => 'MauticSmsBundle:Api\SmsApi:sendContact',
                 'method'     => 'POST',
             ],
         ],

--- a/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
+++ b/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
@@ -49,8 +49,13 @@ class SmsApiController extends CommonApiController
      */
     public function sendContactAction($id, $leadId)
     {
+        $integration =  $this->get('mautic.helper.integration')->getIntegrationObject('Twilio');
+
+        if (!$integration || !$integration->getIntegrationSettings()->getIsPublished()) {
+            return $this->notFound();
+        }
+
         $success = 0;
-        $error   = '';
         $entity  = $this->model->getEntity($id);
         if (null !== $entity) {
             if (!$this->checkEntityAccess($entity, 'view')) {

--- a/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
+++ b/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
@@ -71,7 +71,6 @@ class SmsApiController extends CommonApiController
                 [
                     'success'           => $success,
                     'status'            => $this->get('translator')->trans($result['status']),
-                    'result'            => $result,
                 ],
                 Codes::HTTP_OK
             );

--- a/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
+++ b/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
@@ -76,6 +76,7 @@ class SmsApiController extends CommonApiController
                 [
                     'success'           => $success,
                     'status'            => $this->get('translator')->trans($result['status']),
+                    'result'            => $result,
                 ],
                 Codes::HTTP_OK
             );

--- a/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
+++ b/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
@@ -11,7 +11,9 @@
 
 namespace Mautic\SmsBundle\Controller\Api;
 
+use FOS\RestBundle\Util\Codes;
 use Mautic\ApiBundle\Controller\CommonApiController;
+use Mautic\LeadBundle\Controller\LeadAccessTrait;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
@@ -20,6 +22,8 @@ use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
  */
 class SmsApiController extends CommonApiController
 {
+    use LeadAccessTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -58,18 +62,16 @@ class SmsApiController extends CommonApiController
                 return $lead;
             }
 
-            $result = $this->model->sendSms($entity, $lead, ['channel' => 'api']);
-
+            $result = $this->model->sendSms($entity, $lead, ['channel' => 'api'])[$lead->getId()];
             if (!empty($result['sent'])) {
                 $success = 1;
-            } else {
-                $error = $result['status'];
             }
 
             $view = $this->view(
                 [
-                    'success'          => $success,
-                    'error'            => $error,
+                    'success'           => $success,
+                    'status'            => $this->get('translator')->trans($result['status']),
+                    'result'            => $result,
                 ],
                 Codes::HTTP_OK
             );

--- a/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
+++ b/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
@@ -12,7 +12,6 @@
 namespace Mautic\SmsBundle\Controller\Api;
 
 use Mautic\ApiBundle\Controller\CommonApiController;
-use Mautic\CampaignBundle\Entity\Lead;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
@@ -37,8 +36,8 @@ class SmsApiController extends CommonApiController
     /**
      * Send sms to contact.
      *
-     * @param int  $id     Email ID
-     * @param Lead $leadId Contct ID
+     * @param int $id     Email ID
+     * @param int $leadId Contact ID
      *
      * @return \Symfony\Component\HttpFoundation\Response
      *
@@ -54,7 +53,6 @@ class SmsApiController extends CommonApiController
                 return $this->accessDenied();
             }
 
-            /** @var Lead $lead */
             $lead = $this->checkLeadAccess($leadId, 'edit');
             if ($lead instanceof Response) {
                 return $lead;

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -324,7 +324,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface
             $this->getStatRepository()->saveEntities($stats);
             /** @var Stat $stat */
             foreach ($stats as $stat) {
-                $results[$stat->getLead()->getId()]['stat_id'] = $stat->getId();
+                $results[$stat->getLead()->getId()]['statId'] = $stat->getId();
             }
             $this->em->clear(Stat::class);
         }

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -322,6 +322,10 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface
         if ($sentCount) {
             $this->getRepository()->upCount($sms->getId(), 'sent', $sentCount);
             $this->getStatRepository()->saveEntities($stats);
+            /** @var Stat $stat */
+            foreach ($stats as $stat) {
+                $results[$stat->getLead()->getId()]['stat_id'] = $stat->getId();
+            }
             $this->em->clear(Stat::class);
         }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Yes
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/99
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Added support send SMS to concact by API. 
Similar to Send Email to contact API https://developer.mautic.org/#send-email-to-contact

#### Steps to test this PR:
1.  Apply PR, install API https://github.com/mautic/api-library and apply PR to API library https://github.com/mautic/api-library/pull/154 . Clear Mautic cache
2.  Setup Twillio integration https://mautic.org/docs/en/sms/index.html
3. Create contact with phone number and create text message in Mautic 
4. Test API something like:

```
<?php
use Mautic\MauticApi;
use Mautic\Auth\ApiAuth;

// ...
$initAuth = new ApiAuth();
$auth     = $initAuth->newAuth($settings);
$apiUrl   = "https://your-mautic.com";
$api      = new MauticApi();
$smsApi   = $api->newApi("smses", $auth, $apiUrl);
$result = $smsApi->sendToContact($smsId, $cotactId);
print_r($result);
```
5. Works If sms sent and response is success=1