### PR TITLE
Save email stats before sending to ensure stat is available for emails sent immediately

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -567,6 +567,12 @@ return [
                     'translator',
                 ],
             ],
+            'mautic.email.helper.stat' => [
+                'class'     => \Mautic\EmailBundle\Stat\StatHelper::class,
+                'arguments' => [
+                    'mautic.email.repository.stat',
+                ],
+            ],
         ],
         'models' => [
             'mautic.email.model.email' => [
@@ -594,7 +600,7 @@ return [
                 'class'     => \Mautic\EmailBundle\Model\SendEmailToContact::class,
                 'arguments' => [
                     'mautic.helper.mailer',
-                    'mautic.email.repository.stat',
+                    'mautic.email.helper.stat',
                     'mautic.lead.model.dnc',
                     'translator',
                 ],

--- a/app/bundles/EmailBundle/Entity/CopyRepository.php
+++ b/app/bundles/EmailBundle/Entity/CopyRepository.php
@@ -51,8 +51,8 @@ class CopyRepository extends CommonRepository
     }
 
     /**
-     * @param      $string  md5 hash or content
-     * @param null $subject If $string is the content, pass the subject to include it in the hash
+     * @param string $string  md5 hash or content
+     * @param null   $subject If $string is the content, pass the subject to include it in the hash
      *
      * @return array
      */

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -531,6 +531,10 @@ class EmailRepository extends CommonRepository
      */
     public function upCount($id, $type = 'sent', $increaseBy = 1, $variant = false)
     {
+        if (!$increaseBy) {
+            return;
+        }
+
         $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
         $q->update(MAUTIC_TABLE_PREFIX.'emails')

--- a/app/bundles/EmailBundle/Entity/StatRepository.php
+++ b/app/bundles/EmailBundle/Entity/StatRepository.php
@@ -500,8 +500,21 @@ class StatRepository extends CommonRepository
      */
     public function deleteStat($id)
     {
-        $this->_em->getConnection()->delete(MAUTIC_TABLE_PREFIX.'email_stats', ['id' => (int) $id]);
-        $this->_em->getConnection()->delete(MAUTIC_TABLE_PREFIX.'email_stats_devices', ['stat_id' => (int) $id]);
+        $this->getEntityManager()->getConnection()->delete(MAUTIC_TABLE_PREFIX.'email_stats', ['id' => (int) $id]);
+    }
+
+    /**
+     * @param array $ids
+     */
+    public function deleteStats(array $ids)
+    {
+        $qb = $this->getEntityManager()->getConnection()->createQueryBuilder();
+
+        $qb->delete(MAUTIC_TABLE_PREFIX.'email_stats')
+            ->where(
+                $qb->expr()->in('id', $ids)
+            )
+            ->execute();
     }
 
     /**

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\EmailBundle\Helper;
 
+use Doctrine\ORM\ORMException;
 use Mautic\AssetBundle\Entity\Asset;
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Helper\EmojiHelper;
@@ -496,7 +497,7 @@ class MailHelper
      *                                  NOTHING_IF_FAILED  leaves the current errors array MauticMessage instance intact if it fails, otherwise reset_to
      *                                  RETURN_ERROR       return an array of [success, $errors]; only one applicable if message is queued
      *
-     * @return bool
+     * @return bool|array
      */
     public function queue($dispatchSendEvent = false, $returnMode = self::QUEUE_RESET_TO)
     {
@@ -1795,9 +1796,7 @@ class MailHelper
      * @param string|null $emailAddress
      * @param null        $listId
      *
-     * @return Stat|void
-     *
-     * @throws \Doctrine\ORM\ORMException
+     * @return Stat
      */
     public function createEmailStat($persist = true, $emailAddress = null, $listId = null)
     {
@@ -1808,7 +1807,11 @@ class MailHelper
 
         // Note if a lead
         if (null !== $this->lead) {
-            $stat->setLead($this->factory->getEntityManager()->getReference('MauticLeadBundle:Lead', $this->lead['id']));
+            try {
+                $stat->setLead($this->factory->getEntityManager()->getReference('MauticLeadBundle:Lead', $this->lead['id']));
+            } catch (ORMException $exception) {
+                // keep IDE happy
+            }
             $emailAddress = $this->lead['email'];
         }
 
@@ -1826,7 +1829,11 @@ class MailHelper
 
         // Note if sent from a lead list
         if (null !== $listId) {
-            $stat->setList($this->factory->getEntityManager()->getReference('MauticLeadBundle:LeadList', $listId));
+            try {
+                $stat->setList($this->factory->getEntityManager()->getReference('MauticLeadBundle:LeadList', $listId));
+            } catch (ORMException $exception) {
+                // keep IDE happy
+            }
         }
 
         $stat->setTrackingHash($this->idHash);
@@ -1862,7 +1869,11 @@ class MailHelper
         }
 
         if (isset($this->copies[$id])) {
-            $stat->setStoredCopy($this->factory->getEntityManager()->getReference('MauticEmailBundle:Copy', $this->copies[$id]));
+            try {
+                $stat->setStoredCopy($this->factory->getEntityManager()->getReference('MauticEmailBundle:Copy', $this->copies[$id]));
+            } catch (ORMException $exception) {
+                // keep IDE happy
+            }
         }
 
         if ($persist) {

--- a/app/bundles/EmailBundle/Stat/Exception/StatNotFoundException.php
+++ b/app/bundles/EmailBundle/Stat/Exception/StatNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Stat\Exception;
+
+class StatNotFoundException extends \Exception
+{
+}

--- a/app/bundles/EmailBundle/Stat/Reference.php
+++ b/app/bundles/EmailBundle/Stat/Reference.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Stat;
+
+use Mautic\EmailBundle\Entity\Stat;
+
+class Reference
+{
+    /**
+     * @var int
+     */
+    private $emailId;
+
+    /**
+     * @var int
+     */
+    private $leadId = 0;
+
+    /**
+     * @var
+     */
+    private $statId;
+
+    /**
+     * Reference constructor.
+     *
+     * @param Stat $stat
+     */
+    public function __construct(Stat $stat)
+    {
+        $this->statId  = $stat->getId();
+        $this->emailId = $stat->getEmail()->getId();
+        if ($lead = $stat->getLead()) {
+            $this->leadId = $stat->getLead()->getId();
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getEmailId()
+    {
+        return $this->emailId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLeadId()
+    {
+        return $this->leadId;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getStatId()
+    {
+        return $this->statId;
+    }
+}

--- a/app/bundles/EmailBundle/Stat/StatHelper.php
+++ b/app/bundles/EmailBundle/Stat/StatHelper.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Stat;
+
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\EmailBundle\Stat\Exception\StatNotFoundException;
+
+class StatHelper
+{
+    /**
+     * @var StatRepository
+     */
+    private $repo;
+
+    /**
+     * Just store email ID and lead ID to avoid doctrine RAM issues with entities.
+     *
+     * @var Reference[]
+     */
+    private $stats = [];
+
+    /**
+     * @var array
+     */
+    private $deleteUs = [];
+
+    /**
+     * StatHelper constructor.
+     *
+     * @param StatRepository $statRepository
+     */
+    public function __construct(StatRepository $statRepository)
+    {
+        $this->repo = $statRepository;
+    }
+
+    /**
+     * @param Stat $stat
+     * @param      $emailAddress
+     */
+    public function storeStat(Stat $stat, $emailAddress)
+    {
+        $this->repo->saveEntity($stat);
+
+        // to avoid Doctrine RAM issues, we're just going to hold onto ID references
+        $this->stats[$emailAddress] = new Reference($stat);
+
+        // clear stat from doctrine memory
+        $this->repo->clear();
+    }
+
+    public function deletePending()
+    {
+        if (count($this->deleteUs)) {
+            $this->repo->deleteStats($this->deleteUs);
+        }
+    }
+
+    /**
+     * @param Reference $stat
+     */
+    public function markForDeletion(Reference $stat)
+    {
+        $this->deleteUs[] = $stat->getStatId();
+    }
+
+    /**
+     * @param $emailAddress
+     *
+     * @return Reference
+     *
+     * @throws StatNotFoundException
+     */
+    public function getStat($emailAddress)
+    {
+        if (!isset($this->stats[$emailAddress])) {
+            throw new StatNotFoundException();
+        }
+
+        return $this->stats[$emailAddress];
+    }
+
+    public function reset()
+    {
+        $this->deleteUs = [];
+        $this->stats    = [];
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Helper/Transport/BatchTransport.php
+++ b/app/bundles/EmailBundle/Tests/Helper/Transport/BatchTransport.php
@@ -41,7 +41,7 @@ class BatchTransport extends AbstractTokenArrayTransport implements \Swift_Trans
     {
         $this->message         = $message;
         $this->fromAddresses[] = key($message->getFrom());
-        $this->metadatas       = array_merge($this->metadatas, $this->getMetadata());
+        $this->metadatas[]     = $this->getMetadata();
 
         $messageArray = $this->messageToArray();
 

--- a/app/bundles/EmailBundle/Tests/Helper/Transport/BatchTransport.php
+++ b/app/bundles/EmailBundle/Tests/Helper/Transport/BatchTransport.php
@@ -41,7 +41,7 @@ class BatchTransport extends AbstractTokenArrayTransport implements \Swift_Trans
     {
         $this->message         = $message;
         $this->fromAddresses[] = key($message->getFrom());
-        $this->metadatas[]     = $this->getMetadata();
+        $this->metadatas       = array_merge($this->metadatas, $this->getMetadata());
 
         $messageArray = $this->messageToArray();
 

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -26,6 +26,7 @@ use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\EmailBundle\Model\SendEmailToContact;
 use Mautic\EmailBundle\MonitoredEmail\Mailbox;
+use Mautic\EmailBundle\Stat\StatHelper;
 use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\FrequencyRuleRepository;
 use Mautic\LeadBundle\Entity\Lead;
@@ -222,7 +223,9 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $sendToContactModel = new SendEmailToContact($mailHelper, $statRepository, $dncModel, $translator);
+        $statHelper = new StatHelper($statRepository);
+
+        $sendToContactModel = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
 
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,
@@ -457,7 +460,9 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $sendToContactModel = new SendEmailToContact($mailHelper, $statRepository, $dncModel, $translator);
+        $statHelper = new StatHelper($statRepository);
+
+        $sendToContactModel = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
 
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
@@ -19,6 +19,7 @@ use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\Exception\FailedToSendToContactException;
 use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\EmailBundle\Model\SendEmailToContact;
+use Mautic\EmailBundle\Stat\StatHelper;
 use Mautic\EmailBundle\Swiftmailer\Exception\BatchQueueMaxException;
 use Mautic\EmailBundle\Tests\Helper\Transport\BatchTransport;
 use Mautic\LeadBundle\Entity\Lead;
@@ -94,7 +95,9 @@ class SendEmailToContactTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $model = new SendEmailToContact($mailHelper, $statRepository, $dncModel, $translator);
+        $statHelper = new StatHelper($statRepository);
+
+        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
 
         $email = new Email();
         $model->setEmail($email);
@@ -166,7 +169,9 @@ class SendEmailToContactTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $model = new SendEmailToContact($mailHelper, $statRepository, $dncModel, $translator);
+        $statHelper = new StatHelper($statRepository);
+
+        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
         $model->setEmail($emailMock);
 
         $contacts             = $this->contacts;
@@ -286,7 +291,9 @@ class SendEmailToContactTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $model = new SendEmailToContact($mailHelper, $statRepository, $dncModel, $translator);
+        $statHelper = new StatHelper($statRepository);
+
+        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
         $model->setEmail($emailMock);
 
         $contacts             = $this->contacts;
@@ -399,8 +406,8 @@ class SendEmailToContactTest extends \PHPUnit_Framework_TestCase
         $statRepository = $this->getMockBuilder(StatRepository::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $statRepository->expects($this->exactly(2))
-            ->method('saveEntities');
+        $statRepository->expects($this->exactly(21))
+            ->method('saveEntity');
 
         $dncModel = $this->getMockBuilder(DoNotContact::class)
             ->disableOriginalConstructor()
@@ -413,7 +420,9 @@ class SendEmailToContactTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $model = new SendEmailToContact($mailHelper, $statRepository, $dncModel, $translator);
+        $statHelper = new StatHelper($statRepository);
+
+        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
         $model->setEmail($emailMock);
 
         // Let's generate 20 bogus contacts
@@ -544,7 +553,9 @@ class SendEmailToContactTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $model = new SendEmailToContact($mailHelper, $statRepository, $dncModel, $translator);
+        $statHelper = new StatHelper($statRepository);
+
+        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
         $model->setEmail($emailMock);
 
         foreach ($this->contacts as $contact) {

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
@@ -460,7 +460,6 @@ class SendEmailToContactTest extends \PHPUnit_Framework_TestCase
 
         $model->finalFlush();
 
-        // Our fake transport should have processed 3 metadatas
         $this->assertCount(4, $transport->getMetadatas());
     }
 

--- a/app/bundles/EmailBundle/Tests/Stat/StatHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Stat/StatHelperTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Stat;
+
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\EmailBundle\Stat\Exception\StatNotFoundException;
+use Mautic\EmailBundle\Stat\StatHelper;
+use Mautic\LeadBundle\Entity\Lead;
+
+class StatHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testStatsAreCreatedAndDeleted()
+    {
+        $mockStatRepository = $this->getMockBuilder(StatRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockStatRepository->expects($this->once())
+            ->method('deleteStats')
+            ->withConsecutive([[1, 2, 3, 4, 5]]);
+
+        $statHelper = new StatHelper($mockStatRepository);
+
+        $mockEmail = $this->getMockBuilder(Email::class)
+            ->getMock();
+        $mockEmail->method('getId')
+            ->willReturn(15);
+
+        $counter = 1;
+        while ($counter <= 5) {
+            $stat = $this->getMockBuilder(Stat::class)
+                ->getMock();
+
+            $stat->method('getId')
+                ->willReturn($counter);
+
+            $stat->method('getEmail')
+                ->willReturn($mockEmail);
+
+            $lead = $this->getMockBuilder(Lead::class)
+                ->getMock();
+
+            $lead->method('getId')
+                ->willReturn($counter * 10);
+
+            $stat->method('getLead')
+                ->willReturn($lead);
+
+            $emailAddress = "contact{$counter}@test.com";
+            $statHelper->storeStat($stat, $emailAddress);
+
+            // Delete it
+            try {
+                $reference = $statHelper->getStat($emailAddress);
+                $this->assertEquals($reference->getLeadId(), $counter * 10);
+                $statHelper->markForDeletion($reference);
+            } catch (StatNotFoundException $exception) {
+                $this->fail("Stat not found for $emailAddress");
+            }
+
+            ++$counter;
+        }
+
+        $statHelper->deletePending();
+    }
+
+    public function testExceptionIsThrownIfEmailAddressIsNotFound()
+    {
+        $this->expectException(StatNotFoundException::class);
+        $mockStatRepository = $this->getMockBuilder(StatRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $statHelper = new StatHelper($mockStatRepository);
+
+        $reference = $statHelper->getStat('nada@nada.com');
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? | todo
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR saves email stats individually and prior to sending the email as there are very rare occasions that the stat is not available for the sent email.

It also fixes an issue where issues with the transport would cause the contact to be marked as DNC with a bad email address. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Configure a bad port for the SMTP transport
2. Send the email
3. View the profile of the contact and note the DNC entry with a message that the email was badly formatted

#### Steps to test this PR:
1. Send emails through SMTP and an API mailer such as Sparkpost
2. All stats should save. If an email fails to send, the stat should be deleted
3. Repeat the steps above, and no DNC record should be created
