### PR TITLE
Import command when delayed will return success instead of failure

### DIFF
--- a/app/bundles/LeadBundle/Command/ImportCommand.php
+++ b/app/bundles/LeadBundle/Command/ImportCommand.php
@@ -88,8 +88,6 @@ EOT
         try {
             $model->beginImport($import, $progress, $limit);
         } catch (ImportFailedException $e) {
-            $model->logDebug($e->getMessage(), $import);
-
             $output->writeln('<error>'.$translator->trans(
                 'mautic.lead.import.failed',
                 [
@@ -99,8 +97,6 @@ EOT
 
             return 1;
         } catch (ImportDelayedException $e) {
-            $model->logDebug($e->getMessage());
-
             $output->writeln('<info>'.$translator->trans(
                 'mautic.lead.import.delayed',
                 [

--- a/app/bundles/LeadBundle/Command/ImportCommand.php
+++ b/app/bundles/LeadBundle/Command/ImportCommand.php
@@ -11,6 +11,8 @@
 
 namespace Mautic\LeadBundle\Command;
 
+use Mautic\LeadBundle\Exception\ImportDelayedException;
+use Mautic\LeadBundle\Exception\ImportFailedException;
 use Mautic\LeadBundle\Helper\Progress;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -97,7 +99,7 @@ EOT
 
             return 1;
         } catch (ImportDelayedException $e) {
-            $this->logDebug($e->getMessage());
+            $model->logDebug($e->getMessage());
 
             $output->writeln('<info>'.$translator->trans(
                 'mautic.lead.import.delayed',

--- a/app/bundles/LeadBundle/Exception/ImportDelayedException.php
+++ b/app/bundles/LeadBundle/Exception/ImportDelayedException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Exception;
+
+class ImportDelayedException extends \Exception
+{
+}

--- a/app/bundles/LeadBundle/Exception/ImportFailedException.php
+++ b/app/bundles/LeadBundle/Exception/ImportFailedException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Exception;
+
+class ImportFailedException extends \Exception
+{
+}

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -27,6 +27,8 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadEventLog;
 use Mautic\LeadBundle\Entity\LeadEventLogRepository;
 use Mautic\LeadBundle\Event\ImportEvent;
+use Mautic\LeadBundle\Exception\ImportDelayedException;
+use Mautic\LeadBundle\Exception\ImportFailedException;
 use Mautic\LeadBundle\Helper\Progress;
 use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\Event;
@@ -188,6 +190,8 @@ class ImportModel extends FormModel
      * Start import. This is meant for the CLI command since it will import
      * the whole file at once.
      *
+     * @deprecated in 2.13.0. To be removed in 3.0.0. Use beginImport instead
+     *
      * @param Import   $import
      * @param Progress $progress
      * @param int      $limit    Number of records to import before delaying the import. 0 will import all
@@ -196,19 +200,36 @@ class ImportModel extends FormModel
      */
     public function startImport(Import $import, Progress $progress, $limit = 0)
     {
+        try {
+            return $this->beginImport($import, $progress, $limit);
+        } catch (\Exception $e) {
+            $this->logDebug($e->getMessage());
+
+            return false;
+        }
+    }
+
+    /**
+     * Start import. This is meant for the CLI command since it will import
+     * the whole file at once.
+     *
+     * @param Import   $import
+     * @param Progress $progress
+     * @param int      $limit    Number of records to import before delaying the import. 0 will import all
+     *
+     * @throws \Exception
+     */
+    public function beginImport(Import $import, Progress $progress, $limit = 0)
+    {
         $this->setGhostImportsAsFailed();
 
         if (!$import) {
-            $this->logDebug('import is empty, closing the import process');
-
-            return false;
+            throw new ImportFailedException('import is empty, closing the import process');
         }
 
         if (!$import->canProceed()) {
             $this->saveEntity($import);
-            $this->logDebug('import cannot be processed because '.$import->getStatusInfo(), $import);
-
-            return false;
+            throw new ImportFailedException('import cannot be processed because '.$import->getStatusInfo());
         }
 
         if (!$this->checkParallelImportLimit()) {
@@ -218,9 +239,7 @@ class ImportModel extends FormModel
             );
             $import->setStatus($import::DELAYED)->setStatusInfo($info);
             $this->saveEntity($import);
-            $this->logDebug('import cannot be processed because '.$import->getStatusInfo(), $import);
-
-            return false;
+            throw new ImportDelayedException('import cannot be processed because '.$import->getStatusInfo());
         }
 
         $processed = $import->getProcessedRows();
@@ -243,7 +262,7 @@ class ImportModel extends FormModel
 
         try {
             if (!$this->process($import, $progress, $limit)) {
-                return false;
+                throw new ImportFailedException($import->getStatusInfo());
             }
         } catch (ORMException $e) {
             // The EntityManager is probably closed. The entity cannot be saved.
@@ -254,9 +273,7 @@ class ImportModel extends FormModel
 
             $import->setStatus($import::DELAYED)->setStatusInfo($info);
 
-            $this->logDebug('Database had been overloaded', $import);
-
-            return false;
+            throw new ImportFailedException('Database had been overloaded');
         }
 
         $import->end();
@@ -279,8 +296,6 @@ class ImportModel extends FormModel
                 $this->em->getReference('MauticUserBundle:User', $import->getCreatedBy())
             );
         }
-
-        return true;
     }
 
     /**
@@ -300,7 +315,7 @@ class ImportModel extends FormModel
         try {
             $file = new \SplFileObject($import->getFilePath());
         } catch (\Exception $e) {
-            $import->setStatusInfo('SplFileObject cannot read the file');
+            $import->setStatusInfo('SplFileObject cannot read the file. '.$e->getMessage());
             $import->setStatus(Import::FAILED);
             $this->logDebug('import cannot be processed because '.$import->getStatusInfo(), $import);
 
@@ -703,7 +718,7 @@ class ImportModel extends FormModel
      * @param string $msg
      * @param Import $import
      */
-    protected function logDebug($msg, Import $import = null)
+    public function logDebug($msg, Import $import = null)
     {
         if (MAUTIC_ENV === 'dev') {
             $importId = $import ? '('.$import->getId().')' : '';

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -217,19 +217,24 @@ class ImportModel extends FormModel
      * @param Progress $progress
      * @param int      $limit    Number of records to import before delaying the import. 0 will import all
      *
-     * @throws \Exception
+     * @throws ImportFailedException
+     * @throws ImportDelayedException
      */
     public function beginImport(Import $import, Progress $progress, $limit = 0)
     {
         $this->setGhostImportsAsFailed();
 
         if (!$import) {
-            throw new ImportFailedException('import is empty, closing the import process');
+            $msg = 'import is empty, closing the import process';
+            $this->logDebug($msg, $import);
+            throw new ImportFailedException($msg);
         }
 
         if (!$import->canProceed()) {
             $this->saveEntity($import);
-            throw new ImportFailedException('import cannot be processed because '.$import->getStatusInfo());
+            $msg = 'import cannot be processed because '.$import->getStatusInfo();
+            $this->logDebug($msg, $import);
+            throw new ImportFailedException($msg);
         }
 
         if (!$this->checkParallelImportLimit()) {
@@ -239,7 +244,9 @@ class ImportModel extends FormModel
             );
             $import->setStatus($import::DELAYED)->setStatusInfo($info);
             $this->saveEntity($import);
-            throw new ImportDelayedException('import cannot be processed because '.$import->getStatusInfo());
+            $msg = 'import is delayed because parrallel limit was hit. '.$import->getStatusInfo();
+            $this->logDebug($msg, $import);
+            throw new ImportDelayedException($msg);
         }
 
         $processed = $import->getProcessedRows();
@@ -718,7 +725,7 @@ class ImportModel extends FormModel
      * @param string $msg
      * @param Import $import
      */
-    public function logDebug($msg, Import $import = null)
+    protected function logDebug($msg, Import $import = null)
     {
         if (MAUTIC_ENV === 'dev') {
             $importId = $import ? '('.$import->getId().')' : '';

--- a/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
@@ -162,7 +162,7 @@ class ImportModelTest extends StandardImportTestHelper
             ->method('getParallelImportLimit')
             ->will($this->returnValue(1));
 
-        $model->expects($this->once())
+        $model->expects($this->exactly(2))
             ->method('logDebug');
 
         $model->setTranslator($this->getTranslatorMock());
@@ -204,6 +204,7 @@ class ImportModelTest extends StandardImportTestHelper
 
         try {
             $model->beginImport($entity, new Progress());
+            $this->fail();
         } catch (ImportDelayedException $e) {
             // This is expected
         }
@@ -274,6 +275,7 @@ class ImportModelTest extends StandardImportTestHelper
 
         try {
             $model->beginImport($entity, new Progress());
+            $this->fail();
         } catch (ImportFailedException $e) {
             // This is expected
         }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | 1

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The `app/console mautic:import` command returned 1 (failure) when the import was delayed due to another import running already. Lets keep our logs clean and our sysadmins sane.

The trick is to throw an exception which can be type of failed or delayed instead of returning just boolean. This would have been a BC break so I moved the content of `startImport` method into new `beginImport` method. `beginImport` method throws the right exceptions and `startImport` method calls the `beginImport` method, catches those exceptions and returns a boolean.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
Use this command to ensure you'll see if the command returned 1 or 0:
`app/console mautic:import  && echo OK || echo Failed`

1. Import a large CSV file on background.
2. While the first command is still running import it again. 

The first command will write OK, the second Failed.

#### Steps to test this PR:
1. Repeat the test

Both of the commands will write OK now.

#### List deprecations along with the new alternative:
1. `ImportModel::startImport()` Use `beginImport()` method instead.
