### PR TITLE
Fixed issue with batch deleting custom fields where schema remained intact

### DIFF
--- a/app/bundles/CoreBundle/Doctrine/Helper/ColumnSchemaHelper.php
+++ b/app/bundles/CoreBundle/Doctrine/Helper/ColumnSchemaHelper.php
@@ -67,8 +67,12 @@ class ColumnSchemaHelper
     /**
      * Set the table to be manipulated.
      *
-     * @param string $table
-     * @param bool   $addPrefix
+     * @param      $table
+     * @param bool $addPrefix
+     *
+     * @return $this
+     *
+     * @throws SchemaException
      */
     public function setName($table, $addPrefix = true)
     {
@@ -80,6 +84,8 @@ class ColumnSchemaHelper
         //use the to schema to get table details so that changes will be calculated
         $this->fromTable = $this->sm->listTableDetails($this->tableName);
         $this->toTable   = clone $this->fromTable;
+
+        return $this;
     }
 
     /**
@@ -149,6 +155,8 @@ class ColumnSchemaHelper
      *                           ['options'] array  (optional) Defining options for column
      * @param bool  $checkExists Check if table exists; pass false if this has already been done
      *
+     * @return $this
+     *
      * @throws SchemaException
      */
     public function addColumn(array $column, $checkExists = true)
@@ -165,18 +173,24 @@ class ColumnSchemaHelper
         $options = (isset($column['options'])) ? $column['options'] : [];
 
         $this->toTable->addColumn($column['name'], $type, $options);
+
+        return $this;
     }
 
     /**
      * Drops a column from table.
      *
      * @param $columnName
+     *
+     * @return $this
      */
     public function dropColumn($columnName)
     {
         if ($this->checkColumnExists($columnName)) {
             $this->toTable->dropColumn($columnName);
         }
+
+        return $this;
     }
 
     /**

--- a/app/bundles/CoreBundle/Doctrine/Helper/IndexSchemaHelper.php
+++ b/app/bundles/CoreBundle/Doctrine/Helper/IndexSchemaHelper.php
@@ -78,6 +78,8 @@ class IndexSchemaHelper
     /**
      * @param $name
      *
+     * @return $this
+     *
      * @throws SchemaException
      */
     public function setName($name)
@@ -87,6 +89,8 @@ class IndexSchemaHelper
         }
 
         $this->table = $this->sm->listTableDetails($this->prefix.$name);
+
+        return $this;
     }
 
     /**
@@ -98,13 +102,13 @@ class IndexSchemaHelper
     }
 
     /**
-     * Add or update an index to the table.
-     *
      * @param       $columns
      * @param       $name
      * @param array $options
      *
-     * @throws SchemaException
+     * @return $this
+     *
+     * @throws \Doctrine\DBAL\Schema\SchemaException
      */
     public function addIndex($columns, $name, $options = [])
     {
@@ -134,6 +138,8 @@ class IndexSchemaHelper
                 $this->addedIndexes[] = $index;
             }
         }
+
+        return $this;
     }
 
     /**

--- a/app/bundles/CoreBundle/Doctrine/Helper/SchemaHelperFactory.php
+++ b/app/bundles/CoreBundle/Doctrine/Helper/SchemaHelperFactory.php
@@ -13,13 +13,29 @@ namespace Mautic\CoreBundle\Doctrine\Helper;
 
 /**
  * Class SchemaHelperFactory.
+ *
+ * @deprecated 2.13.0; to be removed in 3.0. Use the appropriate schema helper service instead.
  */
 class SchemaHelperFactory
 {
+    const TYPE_TABLE  = 'table';
+    const TYPE_INDEX  = 'index';
+    const TYPE_COLUMN = 'column';
+
     /**
-     * @var array
+     * @var TableSchemaHelper
      */
-    protected $helpers = [];
+    private $tableHelper;
+
+    /**
+     * @var ColumnSchemaHelper
+     */
+    private $columnHelper;
+
+    /**
+     * @var IndexSchemaHelper
+     */
+    private $indexHelper;
 
     /**
      * SchemaHelperFactory constructor.
@@ -30,29 +46,67 @@ class SchemaHelperFactory
      */
     public function __construct(TableSchemaHelper $tableSchemaHelper, IndexSchemaHelper $indexSchemaHelper, ColumnSchemaHelper $columnSchemaHelper)
     {
-        $this->helpers['table']  = $tableSchemaHelper;
-        $this->helpers['index']  = $indexSchemaHelper;
-        $this->helpers['column'] = $columnSchemaHelper;
+        $this->tableHelper  = $tableSchemaHelper;
+        $this->indexHelper  = $indexSchemaHelper;
+        $this->columnHelper = $columnSchemaHelper;
     }
 
     /**
-     * Get a schema helper.
-     *
-     * @param $type
+     * @param      $type
      * @param null $name
      *
-     * @return mixed
+     * @return ColumnSchemaHelper|IndexSchemaHelper|TableSchemaHelper
      */
     public function getSchemaHelper($type, $name = null)
     {
-        if (!array_key_exists($type, $this->helpers)) {
-            throw new \InvalidArgumentException(sprintf('The requested helper (%s) is not a valid schema helper.', $type));
+        switch ($type) {
+            case self::TYPE_COLUMN:
+                $helper = $this->columnHelper;
+                break;
+            case self::TYPE_INDEX:
+                $helper = $this->indexHelper;
+                break;
+            case self::TYPE_TABLE:
+                $helper = $this->tableHelper;
+                break;
+            default:
+                throw new \InvalidArgumentException(sprintf('The requested helper (%s) is not a valid schema helper.', $type));
         }
 
-        if ($name && method_exists($this->helpers[$type], 'setName')) {
-            $this->helpers[$type]->setName($name);
+        if ($name && method_exists($helper, 'setName')) {
+            $helper->setName($name);
         }
 
-        return $this->helpers[$type];
+        return $helper;
+    }
+
+    /**
+     * @param null $name
+     *
+     * @return ColumnSchemaHelper
+     */
+    public function getColumnHelper($name = null)
+    {
+        return $this->getSchemaHelper(self::TYPE_COLUMN, $name);
+    }
+
+    /**
+     * @param null $name
+     *
+     * @return IndexSchemaHelper
+     */
+    public function getIndexHelper($name = null)
+    {
+        return $this->getSchemaHelper(self::TYPE_INDEX, $name);
+    }
+
+    /**
+     * @param null $name
+     *
+     * @return TableSchemaHelper
+     */
+    public function getTableHelper($name = null)
+    {
+        return $this->getSchemaHelper(self::TYPE_TABLE, $name);
     }
 }

--- a/app/bundles/CoreBundle/Doctrine/Helper/TableSchemaHelper.php
+++ b/app/bundles/CoreBundle/Doctrine/Helper/TableSchemaHelper.php
@@ -86,6 +86,8 @@ class TableSchemaHelper
      *
      * @param array $tables
      *
+     * @return $this
+     *
      * @throws SchemaException
      */
     public function addTables(array $tables)
@@ -104,6 +106,8 @@ class TableSchemaHelper
             $this->addTables[] = $table;
             $this->addTable($table, false);
         }
+
+        return $this;
     }
 
     /**
@@ -127,6 +131,8 @@ class TableSchemaHelper
      *                     )
      * @param $checkExists
      * @param $dropExisting
+     *
+     * @return $this
      *
      * @throws SchemaException
      */
@@ -174,16 +180,24 @@ class TableSchemaHelper
                 $newTable->$func($value);
             }
         }
+
+        return $this;
     }
 
     /**
-     * @param string $table
+     * @param $table
+     *
+     * @return $this
+     *
+     * @throws SchemaException
      */
     public function deleteTable($table)
     {
         if ($this->checkTableExists($table)) {
             $this->dropTables[] = $table;
         }
+
+        return $this;
     }
 
     /**

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -748,7 +748,8 @@ return [
             'mautic.lead.model.field' => [
                 'class'     => 'Mautic\LeadBundle\Model\FieldModel',
                 'arguments' => [
-                    'mautic.schema.helper.factory',
+                    'mautic.schema.helper.index',
+                    'mautic.schema.helper.column',
                 ],
             ],
             'mautic.lead.model.list' => [

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -14,7 +14,7 @@ namespace Mautic\LeadBundle\Model;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Exception\DriverException;
 use Mautic\CoreBundle\Doctrine\Helper\ColumnSchemaHelper;
-use Mautic\CoreBundle\Doctrine\Helper\SchemaHelperFactory;
+use Mautic\CoreBundle\Doctrine\Helper\IndexSchemaHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\LeadBundle\Entity\LeadField;
@@ -26,8 +26,7 @@ use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 
 /**
- * Class FieldModel
- * {@inheritdoc}
+ * Class FieldModel.
  */
 class FieldModel extends FormModel
 {
@@ -264,9 +263,14 @@ class FieldModel extends FormModel
     ];
 
     /**
-     * @var SchemaHelperFactory
+     * @var IndexSchemaHelper
      */
-    protected $schemaHelperFactory;
+    private $indexSchemaHelper;
+
+    /**
+     * @var ColumnSchemaHelper
+     */
+    private $columnSchemaHelper;
 
     /**
      * @var array
@@ -276,11 +280,13 @@ class FieldModel extends FormModel
     /**
      * FieldModel constructor.
      *
-     * @param SchemaHelperFactory $schemaHelperFactory
+     * @param IndexSchemaHelper  $indexSchemaHelper
+     * @param ColumnSchemaHelper $columnSchemaHelper
      */
-    public function __construct(SchemaHelperFactory $schemaHelperFactory)
+    public function __construct(IndexSchemaHelper $indexSchemaHelper, ColumnSchemaHelper $columnSchemaHelper)
     {
-        $this->schemaHelperFactory = $schemaHelperFactory;
+        $this->indexSchemaHelper  = $indexSchemaHelper;
+        $this->columnSchemaHelper = $columnSchemaHelper;
     }
 
     /**
@@ -372,12 +378,13 @@ class FieldModel extends FormModel
     }
 
     /**
-     * @param   $entity
-     * @param   $unlock
+     * @param object $entity
+     * @param bool   $unlock
      *
      * @throws DBALException
-     *
-     * @return mixed
+     * @throws DriverException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     * @throws \Mautic\CoreBundle\Exception\SchemaException
      */
     public function saveEntity($entity, $unlock = true)
     {
@@ -396,10 +403,6 @@ class FieldModel extends FormModel
         if ($isNew) {
             if (empty($alias)) {
                 $alias = $entity->getName();
-            }
-
-            if (empty($object)) {
-                $object = $objects[$entity->getObject()];
             }
 
             // clean the alias
@@ -441,7 +444,7 @@ class FieldModel extends FormModel
 
         // Create the field as its own column in the leads table.
         /** @var ColumnSchemaHelper $leadsSchema */
-        $leadsSchema = $this->schemaHelperFactory->getSchemaHelper('column', $object);
+        $leadsSchema = $this->columnSchemaHelper->setName($object);
         $isUnique    = $entity->getIsUniqueIdentifier();
 
         // If the column does not exist in the contacts table, add it
@@ -452,12 +455,10 @@ class FieldModel extends FormModel
 
             try {
                 $leadsSchema->executeChanges();
-                $isCreated = true;
             } catch (DriverException $e) {
                 $this->logger->addWarning($e->getMessage());
 
                 if ($e->getErrorCode() === 1118 /* ER_TOO_BIG_ROWSIZE */) {
-                    $isCreated = false;
                     throw new DBALException($this->translator->trans('mautic.core.error.max.field'));
                 } else {
                     throw $e;
@@ -473,7 +474,7 @@ class FieldModel extends FormModel
 
             // Update the unique_identifier_search index and add an index for this field
             /** @var \Mautic\CoreBundle\Doctrine\Helper\IndexSchemaHelper $modifySchema */
-            $modifySchema = $this->schemaHelperFactory->getSchemaHelper('index', $object);
+            $modifySchema = $this->indexSchemaHelper->setName($object);
 
             if ('string' == $schemaDefinition['type']) {
                 try {
@@ -510,21 +511,42 @@ class FieldModel extends FormModel
     }
 
     /**
-     * {@inheritdoc}
+     * Build schema for each entity.
      *
-     * @param  $entity
+     * @param array $entities
+     * @param bool  $unlock
+     *
+     * @return array|void
+     *
+     * @throws DBALException
+     * @throws DriverException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     * @throws \Mautic\CoreBundle\Exception\SchemaException
+     */
+    public function saveEntities($entities, $unlock = true)
+    {
+        foreach ($entities as $entity) {
+            $this->saveEntity($entity, $unlock);
+        }
+    }
+
+    /**
+     * @param object $entity
+     *
+     * @throws \Mautic\CoreBundle\Exception\SchemaException
      */
     public function deleteEntity($entity)
     {
         parent::deleteEntity($entity);
 
-        $objects = ['lead' => 'leads', 'company' => 'companies'];
-        $object  = $objects[$entity->getObject()];
-
-        //remove the column from the leads table
-        $leadsSchema = $this->schemaHelperFactory->getSchemaHelper('column', $object);
-        $leadsSchema->dropColumn($entity->getAlias());
-        $leadsSchema->executeChanges();
+        switch ($entity->getObject()) {
+            case 'lead':
+                $this->columnSchemaHelper->setName('leads')->dropColumn($entity->getAlias())->executeChanges();
+                break;
+            case 'company':
+                $this->columnSchemaHelper->setName('companies')->dropColumn($entity->getAlias())->executeChanges();
+                break;
+        }
     }
 
     /**
@@ -533,17 +555,26 @@ class FieldModel extends FormModel
      * @param array $ids
      *
      * @return array
+     *
+     * @throws \Mautic\CoreBundle\Exception\SchemaException
      */
     public function deleteEntities($ids)
     {
         $entities = parent::deleteEntities($ids);
 
-        //remove the column from the leads table
-        $leadsSchema = $this->schemaHelperFactory->getSchemaHelper('column', 'leads');
-        foreach ($entities as $e) {
-            $leadsSchema->dropColumn($e->getAlias());
+        /** @var LeadField $entity */
+        foreach ($entities as $entity) {
+            switch ($entity->getObject()) {
+                case 'lead':
+                    $this->columnSchemaHelper->setName('leads')->dropColumn($entity->getAlias())->executeChanges();
+                    break;
+                case 'company':
+                    $this->columnSchemaHelper->setName('companies')->dropColumn($entity->getAlias())->executeChanges();
+                    break;
+            }
         }
-        $leadsSchema->executeChanges();
+
+        return $entities;
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Model/FieldModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/FieldModelTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Model;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\LeadField;
+
+class FieldModelTest extends MauticMysqlTestCase
+{
+    public function testSingleContactFieldIsCreatedAndDeleted()
+    {
+        $fieldModel = $this->container->get('mautic.lead.model.field');
+
+        $field = new LeadField();
+        $field->setName('Test Field')
+            ->setAlias('test_field')
+            ->setType('string')
+            ->setObject('lead');
+
+        $fieldModel->saveEntity($field);
+        $fieldModel->deleteEntity($field);
+
+        $this->assertCount(0, $this->getColumns('leads', $field->getAlias()));
+    }
+
+    public function testSingleCompanyFieldIsCreatedAndDeleted()
+    {
+        $fieldModel = $this->container->get('mautic.lead.model.field');
+
+        $field = new LeadField();
+        $field->setName('Test Field')
+            ->setAlias('test_field')
+            ->setType('string')
+            ->setObject('company');
+
+        $fieldModel->saveEntity($field);
+        $fieldModel->deleteEntity($field);
+
+        $this->assertCount(0, $this->getColumns('companies', $field->getAlias()));
+    }
+
+    public function testMultipleFieldsAreCreatedAndDeleted()
+    {
+        $fieldModel = $this->container->get('mautic.lead.model.field');
+
+        $leadField = new LeadField();
+        $leadField->setName('Test Field')
+            ->setAlias('test_field')
+            ->setType('string')
+            ->setObject('lead');
+
+        $leadField2 = new LeadField();
+        $leadField2->setName('Test Field')
+            ->setAlias('test_field2')
+            ->setType('string')
+            ->setObject('lead');
+
+        $companyField = new LeadField();
+        $companyField->setName('Test Field')
+            ->setAlias('test_field')
+            ->setType('string')
+            ->setObject('company');
+
+        $companyField2 = new LeadField();
+        $companyField2->setName('Test Field')
+            ->setAlias('test_field2')
+            ->setType('string')
+            ->setObject('company');
+
+        $fieldModel->saveEntities([$leadField, $leadField2, $companyField, $companyField2]);
+
+        $this->assertCount(1, $this->getColumns('leads', $leadField->getAlias()));
+        $this->assertCount(1, $this->getColumns('leads', $leadField2->getAlias()));
+        $this->assertCount(1, $this->getColumns('companies', $companyField->getAlias()));
+        $this->assertCount(1, $this->getColumns('companies', $companyField2->getAlias()));
+
+        $fieldModel->deleteEntities([$leadField->getId(), $leadField2->getId(), $companyField->getId(), $companyField2->getId()]);
+
+        $this->assertCount(0, $this->getColumns('leads', $leadField->getAlias()));
+        $this->assertCount(0, $this->getColumns('leads', $leadField2->getAlias()));
+        $this->assertCount(0, $this->getColumns('companies', $companyField->getAlias()));
+        $this->assertCount(0, $this->getColumns('companies', $companyField2->getAlias()));
+    }
+
+    /**
+     * @param $table
+     * @param $column
+     *
+     * @return array
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    private function getColumns($table, $column)
+    {
+        $connection = $this->container->get('doctrine.dbal.default_connection');
+        $stmt       = $connection->executeQuery(
+            "SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '{$connection->getDatabase()}' AND TABLE_NAME = '".MAUTIC_TABLE_PREFIX
+            ."$table' AND COLUMN_NAME = '$column'"
+        );
+        $stmt->execute();
+
+        return $stmt->fetchAll();
+    }
+}


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If deleting multiple custom fields at once, the columns in the table were not deleted from the companies table. If enough custom fields are then created and deleted, the lingering columns in the table would result in hitting mysql's row byte limit preventing creating new fields.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a couple company custom fields
2. Check them in the list view then select Delete from the batch action dropdown
3. Look at the companies table and note that the columns still exist

#### Steps to test this PR:
1. Repeat and the columns should be removed along with the custom field entry
2. Run the new tests
