### PR TITLE
Escape backslashes in company names (and just in case, contact emails)

### DIFF
--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -488,6 +488,39 @@ class SalesforceApi extends CrmApi
     }
 
     /**
+     * @param array $names
+     * @param null  $requiredFieldString
+     *
+     * @return mixed|string
+     *
+     * @throws ApiErrorException
+     */
+    public function getCompaniesByName(array $names, $requiredFieldString)
+    {
+        $names     = array_map([$this, 'escapeQueryValue'], $names);
+        $queryUrl  = $this->integration->getQueryUrl();
+        $findQuery = 'select Id, '.$requiredFieldString.' from Account where isDeleted = false and Name in (\''.implode("','", $names).'\')';
+
+        return $this->request('query', ['q' => $findQuery], 'GET', false, null, $queryUrl);
+    }
+
+    /**
+     * @param array $ids
+     * @param       $requiredFieldString
+     *
+     * @return mixed|string
+     *
+     * @throws ApiErrorException
+     */
+    public function getCompaniesById(array $ids, $requiredFieldString)
+    {
+        $findQuery = 'select isDeleted, Id, '.$requiredFieldString.' from Account where  Id in (\''.implode("','", $ids).'\')';
+        $queryUrl  = $this->integration->getQueryUrl();
+
+        return $this->request('queryAll', ['q' => $findQuery], 'GET', false, null, $queryUrl);
+    }
+
+    /**
      * @param mixed $response
      * @param bool  $isRetry
      *

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -108,7 +108,7 @@ class SalesforceApi extends CrmApi
             $fields      = $this->integration->getFieldsForQuery('Contact');
             $fields[]    = 'Id';
             $fields      = implode(', ', array_unique($fields));
-            $findContact = 'select '.$fields.' from Contact where email = \''.str_replace("'", "\'", $this->integration->cleanPushData($data['Contact']['Email'])).'\'';
+            $findContact = 'select '.$fields.' from Contact where email = \''.$this->escapeQueryValue($data['Contact']['Email']).'\'';
             $response    = $this->request('query', ['q' => $findContact], 'GET', false, null, $queryUrl);
 
             if (!empty($response['records'])) {
@@ -120,7 +120,7 @@ class SalesforceApi extends CrmApi
             $fields   = $this->integration->getFieldsForQuery('Lead');
             $fields[] = 'Id';
             $fields   = implode(', ', array_unique($fields));
-            $findLead = 'select '.$fields.' from Lead where email = \''.str_replace("'", "\'", $this->integration->cleanPushData($data['Lead']['Email'])).'\' and ConvertedContactId = NULL';
+            $findLead = 'select '.$fields.' from Lead where email = \''.$this->escapeQueryValue($data['Lead']['Email']).'\' and ConvertedContactId = NULL';
             $response = $this->request('queryAll', ['q' => $findLead], 'GET', false, null, $queryUrl);
 
             if (!empty($response['records'])) {
@@ -152,20 +152,20 @@ class SalesforceApi extends CrmApi
         if (isset($config['objects']) && false !== array_search('company', $config['objects']) && !empty($data['company']['Name'])) {
             $fields = $this->integration->getFieldsForQuery('Account');
 
-            if (isset($data['company']['BillingCountry']) && !empty($data['company']['BillingCountry'])) {
-                $appendToQuery .= ' and BillingCountry =  \''.str_replace("'", "\'", $this->integration->cleanPushData($data['company']['BillingCountry'])).'\'';
+            if (!empty($data['company']['BillingCountry'])) {
+                $appendToQuery .= ' and BillingCountry =  \''.$this->escapeQueryValue($data['company']['BillingCountry']).'\'';
             }
-            if (isset($data['company']['BillingCity']) && !empty($data['company']['BillingCity'])) {
-                $appendToQuery .= ' and BillingCity =  \''.str_replace("'", "\'", $this->integration->cleanPushData($data['company']['BillingCity'])).'\'';
+            if (!empty($data['company']['BillingCity'])) {
+                $appendToQuery .= ' and BillingCity =  \''.$this->escapeQueryValue($data['company']['BillingCity']).'\'';
             }
-            if (isset($data['company']['BillingState']) && !empty($data['company']['BillingState'])) {
-                $appendToQuery .= ' and BillingState =  \''.str_replace("'", "\'", $this->integration->cleanPushData($data['company']['BillingState'])).'\'';
+            if (!empty($data['company']['BillingState'])) {
+                $appendToQuery .= ' and BillingState =  \''.$this->escapeQueryValue($data['company']['BillingState']).'\'';
             }
 
-            $fields[]    = 'Id';
-            $fields      = implode(', ', array_unique($fields));
-            $findContact = 'select '.$fields.' from Account where Name = \''.str_replace("'", "\'", $this->integration->cleanPushData($data['company']['Name'])).'\''.$appendToQuery;
-            $response    = $this->request('queryAll', ['q' => $findContact], 'GET', false, null, $queryUrl);
+            $fields[] = 'Id';
+            $fields   = implode(', ', array_unique($fields));
+            $query    = 'select '.$fields.' from Account where Name = \''.$this->escapeQueryValue($data['company']['Name']).'\''.$appendToQuery;
+            $response = $this->request('queryAll', ['q' => $query], 'GET', false, null, $queryUrl);
 
             if (!empty($response['records'])) {
                 $sfRecords['company'] = $response['records'];
@@ -573,5 +573,25 @@ class SalesforceApi extends CrmApi
         $this->requestCounter = 1;
 
         return false;
+    }
+
+    /**
+     * @param $value
+     *
+     * @return bool|float|mixed|string
+     */
+    private function escapeQueryValue($value)
+    {
+        // SF uses backslashes as escape delimeter
+        // Remember that PHP uses \ as an escape. Therefore, to replace a single backslash with 2, must use 2 and 4
+        $value = str_replace('\\', '\\\\', $value);
+
+        // Escape single quotes
+        $value = str_replace("'", "\'", $value);
+
+        // Apply general formatting/cleanup
+        $value = $this->integration->cleanPushData($value);
+
+        return $value;
     }
 }

--- a/plugins/MauticCrmBundle/Tests/Api/SalesforceApiTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/SalesforceApiTest.php
@@ -263,4 +263,141 @@ class SalesforceApiTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($message, $exception->getMessage());
         }
     }
+
+    /**
+     * @testdox Test that a backslash and a single quote are escaped for SF queries
+     *
+     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::escapeQueryValue()
+     */
+    public function testCompanyQueryIsEscapedCorrectly()
+    {
+        $integration = $this->getMockBuilder(SalesforceIntegration::class)
+            ->disableOriginalConstructor()
+            ->setMethodsExcept(['cleanPushData'])
+            ->getMock();
+
+        $integration->expects($this->exactly(1))
+            ->method('mergeConfigToFeatureSettings')
+            ->willReturn(
+                [
+                    'objects' => [
+                        'company',
+                    ],
+                ]
+            );
+
+        $integration->expects($this->exactly(1))
+            ->method('makeRequest')
+            ->willReturnCallback(
+                function ($url, $parameters = [], $method = 'GET', $settings = []) {
+                    $this->assertEquals(
+                        $parameters,
+                        [
+                            'q' => 'select Id from Account where Name = \'Some\\\\thing E\\\'lse\' and BillingCountry =  \'Some\\\\Where E\\\'lse\' and BillingCity =  \'Some\\\\Where E\\\'lse\' and BillingState =  \'Some\\\\Where E\\\'lse\'',
+                        ]
+                    );
+                }
+            );
+
+        $api = new SalesforceApi($integration);
+
+        $api->getCompany(
+            [
+                'company' => [
+                    'BillingCountry' => 'Some\\Where E\'lse',
+                    'BillingCity'    => 'Some\\Where E\'lse',
+                    'BillingState'   => 'Some\\Where E\'lse',
+                    'Name'           => 'Some\\thing E\'lse',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @testdox Test that a backslash and a single quote are escaped for SF queries
+     *
+     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::escapeQueryValue()
+     */
+    public function testContactQueryIsEscapedCorrectly()
+    {
+        $integration = $this->getMockBuilder(SalesforceIntegration::class)
+            ->disableOriginalConstructor()
+            ->setMethodsExcept(['cleanPushData'])
+            ->getMock();
+
+        $integration->expects($this->exactly(1))
+            ->method('mergeConfigToFeatureSettings')
+            ->willReturn(
+                [
+                    'objects' => [
+                        'Contact',
+                    ],
+                ]
+            );
+
+        $integration->expects($this->exactly(1))
+            ->method('makeRequest')
+            ->willReturnCallback(
+                function ($url, $parameters = [], $method = 'GET', $settings = []) {
+                    $this->assertEquals(
+                        $parameters,
+                        [
+                            'q' => 'select Id from Contact where email = \'con\\\\tact\\\'email@email.com\'',
+                        ]
+                    );
+                }
+            );
+
+        $api = new SalesforceApi($integration);
+
+        $api->getPerson([
+            'Contact' => [
+                'Email' => 'con\\tact\'email@email.com',
+            ],
+        ]);
+    }
+
+    /**
+     * @testdox Test that a backslash and a single quote are escaped for SF queries
+     *
+     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::escapeQueryValue()
+     */
+    public function testLeadQueryIsEscapedCorrectly()
+    {
+        $integration = $this->getMockBuilder(SalesforceIntegration::class)
+            ->disableOriginalConstructor()
+            ->setMethodsExcept(['cleanPushData'])
+            ->getMock();
+
+        $integration->expects($this->exactly(1))
+            ->method('mergeConfigToFeatureSettings')
+            ->willReturn(
+                [
+                    'objects' => [
+                        'Lead',
+                    ],
+                ]
+            );
+
+        $integration->expects($this->exactly(1))
+            ->method('makeRequest')
+            ->willReturnCallback(
+                function ($url, $parameters = [], $method = 'GET', $settings = []) {
+                    $this->assertEquals(
+                        $parameters,
+                        [
+                            'q' => 'select Id from Lead where email = \'con\\\\tact\\\'email@email.com\' and ConvertedContactId = NULL',
+                        ]
+                    );
+                }
+            );
+
+        $api = new SalesforceApi($integration);
+
+        $api->getPerson([
+            'Lead' => [
+                'Email' => 'con\\tact\'email@email.com',
+            ],
+        ]);
+    }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #5249
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If a company name has a backslash, the sync will fail with a SF SQL error. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a company in Mautic where the name has a backslash in it
2. Setup SF sync per the documentation enabling push to integration and enable the Company object
3. Run the `php app/console m:i:s -i Salesforce -a "5 min"` command
4. Note the error

#### Steps to test this PR:
1. Run the command again the company should push to SF
2. Run the updated unit tests
