### PR TITLE
Fixed bug in SF that did not use the nextUrl when syncing more than 2K and use SystemModStamp instead of LastModifiedDate

### DIFF
--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -325,6 +325,11 @@ class SalesforceApi extends CrmApi
     {
         $queryUrl = $this->integration->getQueryUrl();
 
+        if (defined('MAUTIC_ENV') && MAUTIC_ENV === 'dev') {
+            // Easier for testing
+            $this->requestSettings['headers']['Sforce-Query-Options'] = 'batchSize=200';
+        }
+
         if (!is_array($query)) {
             return $this->request('queryAll', ['q' => $query], 'GET', false, null, $queryUrl);
         }

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -330,9 +330,7 @@ class SalesforceApi extends CrmApi
         }
 
         if (!empty($query['nextUrl'])) {
-            $queryType = str_replace('/services/data/v34.0/query', '', $query['nextUrl']);
-
-            return $this->request('query'.$queryType, [], 'GET', false, null, $queryUrl);
+            return $this->request(null, [], 'GET', false, null, $query['nextUrl']);
         }
 
         $organizationCreatedDate = $this->getOrganizationCreatedDate();
@@ -352,7 +350,7 @@ class SalesforceApi extends CrmApi
 
             $ignoreConvertedLeads = ($object == 'Lead') ? ' and ConvertedContactId = NULL' : '';
 
-            $getLeadsQuery = 'SELECT '.$fields.' from '.$object.' where LastModifiedDate>='.$query['start'].' and LastModifiedDate<='.$query['end']
+            $getLeadsQuery = 'SELECT '.$fields.' from '.$object.' where SystemModStamp>='.$query['start'].' and SystemModStamp<='.$query['end']
                 .$ignoreConvertedLeads;
 
             return $this->request('queryAll', ['q' => $getLeadsQuery], 'GET', false, null, $queryUrl);
@@ -421,7 +419,7 @@ class SalesforceApi extends CrmApi
 
         $query = "Select CampaignId, ContactId, LeadId, isDeleted from CampaignMember where CampaignId = '".trim($campaignId)."'";
         if ($modifiedSince) {
-            $query .= ' and LastModifiedDate >= '.$modifiedSince;
+            $query .= ' and SystemModStamp >= '.$modifiedSince;
         }
 
         $results = $this->request(null, ['q' => $query], 'GET', false, null, $queryUrl);

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -908,7 +908,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                         break;
                     }
 
-                    $params['nextUrl']  = $nextUrl;
+                    $query['nextUrl']  = $nextUrl;
                 }
 
                 if ($progress) {


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Syncing more than 2K records from SF to Mautic failed because the next URL was not used. This fixes that. This also replaces querying by LastModifiedDate, which can be manipulated causing differing results in the query, to SystemModStamp which is read only. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Hack in https://github.com/mautic/mautic/compare/staging...alanhartless:bug-sf-person-batching?expand=1#diff-6ce39f45c72f8ef1c78d747ec6426817R328 so that it'll batch in 200 (dev SF only allows 2000 records and the default batch size is 2000 so you won't be able to reproduce this in a dev SF account without this hack)
2. Import/update more than 200 records in SF
3. Run the `php app/console m:i:s -i Salesforce` command
4. Notice that it will run forever until it's past 100% (it's processing the same batch over and over)

#### Steps to test this PR:
1. Apply the PR and run the command again
2. All records should sync and the script completes
