### PR TITLE
Fixed CRM not mapping company custom fields for new companies

### DIFF
--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -294,7 +294,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
      * @param      $data
      * @param null $object
      *
-     * @return Company|void
+     * @return Company|null
      */
     public function getMauticCompany($data, $object = null)
     {
@@ -305,23 +305,17 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
             // Assume JSON
             $data = json_decode($data, true);
         }
-        $config = $this->mergeConfigToFeatureSettings([]);
-
+        $config        = $this->mergeConfigToFeatureSettings([]);
         $matchedFields = $this->populateMauticLeadData($data, $config, 'company');
-
-        // Find unique identifier fields used by the integration
-        /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
-        $companyModel = $this->factory->getModel('lead.company');
 
         // Default to new company
         $company         = new Company();
-        $existingCompany = IdentifyCompanyHelper::identifyLeadsCompany($matchedFields, null, $companyModel);
+        $existingCompany = IdentifyCompanyHelper::identifyLeadsCompany($matchedFields, null, $this->companyModel);
         if ($existingCompany[2]) {
             $company = $existingCompany[2];
         }
 
         $companyFieldTypes = $this->fieldModel->getFieldListWithProperties('company');
-
         foreach ($matchedFields as $companyField => $value) {
             if (isset($companyFieldTypes[$companyField]['type']) && $companyFieldTypes[$companyField]['type'] == 'text') {
                 $matchedFields[$companyField] = substr($value, 0, 255);
@@ -332,15 +326,17 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
             $fieldsToUpdate = $this->getPriorityFieldsForMautic($config, $object, 'mautic_company');
             $fieldsToUpdate = array_intersect_key($config['companyFields'], $fieldsToUpdate);
             $matchedFields  = array_intersect_key($matchedFields, array_flip($fieldsToUpdate));
-            if (!isset($matchedFields['companyname'])) {
-                if (isset($matchedFields['companywebsite'])) {
-                    $matchedFields['companyname'] = $matchedFields['companywebsite'];
-                }
+        } else {
+            $matchedFields = $this->hydrateCompanyName($matchedFields);
+
+            // If we don't have an company name, don't create the company because it'll result in what looks like an "empty" company
+            if (empty($matchedFields['companyname'])) {
+                return null;
             }
-            $companyModel->setFieldValues($company, $matchedFields, false, false);
         }
 
-        $companyModel->saveEntity($company, false);
+        $this->companyModel->setFieldValues($company, $matchedFields, false);
+        $this->companyModel->saveEntity($company, false);
 
         return $company;
     }
@@ -616,5 +612,32 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
         $fieldMappings['create'] = $leadFields;
 
         return $fieldMappings;
+    }
+
+    /**
+     * @param array $matchedFields
+     *
+     * @return array
+     */
+    private function hydrateCompanyName(array $matchedFields)
+    {
+        if (!empty($matchedFields['companyname'])) {
+            return $matchedFields;
+        }
+
+        if (!empty($matchedFields['companywebsite'])) {
+            $matchedFields['companyname'] = $matchedFields['companywebsite'];
+
+            return $matchedFields;
+        }
+
+        // We need something as company name so save whatever we have
+        if ($firstMatchedField = reset($matchedFields)) {
+            $matchedFields['companyname'] = $firstMatchedField;
+
+            return $matchedFields;
+        }
+
+        return $matchedFields;
     }
 }

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -11,6 +11,7 @@
 
 namespace MauticPlugin\MauticCrmBundle\Integration;
 
+use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PluginBundle\Entity\IntegrationEntity;
 use Mautic\PluginBundle\Entity\IntegrationEntityRepository;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Companies created from SF (or any CRM) in Mautic would not map any values unless it was the ones used to identify the company (name, state, etc). If the CRM's company name was not mapped to the core Company Name field, an empty company would be created

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup the SF CRM sync
2. Create two new company custom field in Mautic
3. Create a few new Accounts in SF
4. Map the new company custom field to something from SF
5. Map the Account Name to the second custom field
6. Run the sync and notice that empty companies are created

#### Steps to test this PR:
1. Delete the empty companies
2. Apply the PR
3. Run the sync again
4. Companies will be created with the mapped data but the core Company Name is at least not empty although it may not be expected because Mautic's core Company Name wasn't mapped
5. Delete the companies
6. Map the SF Account Name to Mautic's core Company Name
7. Sync again
8. All field values should now be hydrated in the company created in Mautic
