### PR TITLE
remove the hidden-xs class on Do Not Contact action on contact list mobile view

### DIFF
--- a/app/bundles/LeadBundle/Views/Lead/list.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/list.html.php
@@ -61,7 +61,7 @@ if ($permissions['lead:leads:editown'] || $permissions['lead:leads:editother']) 
         ],
         [
             'attr' => [
-                'class'       => 'hidden-xs btn btn-default btn-sm btn-nospin',
+                'class'       => 'btn btn-default btn-sm btn-nospin',
                 'data-toggle' => 'ajaxmodal',
                 'data-target' => '#MauticSharedModal',
                 'href'        => $view['router']->path('mautic_contact_action', ['objectAction' => 'batchDnc']),


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5773
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
remove the hidden-xs class on Do Not Contact action on contact list mobile view

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. display contact-list on mobile
2. select multiple contacts
3. click on dropdown list action to set Do Not Contact
4. See the action is missing

#### Steps to test this PR:
1. apply PR
2. reproduce above steps