### PR TITLE
Update WebhookQueueEvent.php

### DIFF
--- a/app/bundles/WebhookBundle/Event/WebhookQueueEvent.php
+++ b/app/bundles/WebhookBundle/Event/WebhookQueueEvent.php
@@ -44,7 +44,7 @@ class WebhookQueueEvent extends CommonEvent
      */
     public function getWebhookQueue()
     {
-        return $this->getWebhookQueue();
+        return $this->entity;
     }
 
     /**
@@ -64,7 +64,7 @@ class WebhookQueueEvent extends CommonEvent
      */
     public function getWebhook()
     {
-        return $this->getWebhook();
+        return $this->webhook;
     }
 
     /**


### PR DESCRIPTION
fixed wrong return statements of getWebhookQueue() and getWebhook() methods.

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
There was a bug in the webhook bundle's WebhookQueueEvent.php file. A couple of methods were returning wrong information which was causing errors recursively. I have fixed those issues. 
