### PR TITLE
Fixes fatal error caused by #5800 (2.13) with sending form results that contain contactfield tokens

### DIFF
--- a/app/bundles/FormBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormSubscriber.php
@@ -23,6 +23,7 @@ use Mautic\FormBundle\Event as Events;
 use Mautic\FormBundle\Exception\ValidationException;
 use Mautic\FormBundle\Form\Type\SubmitActionRepostType;
 use Mautic\FormBundle\FormEvents;
+use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -184,7 +185,7 @@ class FormSubscriber extends CommonSubscriber
         $emails    = $this->getEmailsFromString($config['to']);
 
         if (!empty($emails)) {
-            $this->setMailer($config, $tokens, $emails);
+            $this->setMailer($config, $tokens, $leadEmail, $lead);
 
             if (!empty($leadEmail)) {
                 // Reply to lead for user convenience
@@ -206,9 +207,7 @@ class FormSubscriber extends CommonSubscriber
 
         if ($config['copy_lead'] && !empty($leadEmail)) {
             // Send copy to lead
-            $this->setMailer($config, $tokens, $leadEmail);
-
-            $this->mailer->setLead($lead->getProfileFields());
+            $this->setMailer($config, $tokens, $leadEmail, $lead, false);
 
             $this->mailer->send(true);
         }
@@ -216,9 +215,7 @@ class FormSubscriber extends CommonSubscriber
         $owner = $lead !== null ? $lead->getOwner() : null;
         if (!empty($config['email_to_owner']) && $config['email_to_owner'] && null !== $owner) {
             // Send copy to owner
-            $this->setMailer($config, $tokens, $owner->getEmail());
-
-            $this->mailer->setLead($lead->getProfileFields());
+            $this->setMailer($config, $tokens, $owner->getEmail(), $lead);
 
             $this->mailer->send(true);
         }
@@ -430,11 +427,13 @@ class FormSubscriber extends CommonSubscriber
     }
 
     /**
-     * @param array $config
-     * @param array $tokens
-     * @param       $to
+     * @param array     $config
+     * @param array     $tokens
+     * @param           $to
+     * @param Lead|null $lead
+     * @param bool      $internalSend
      */
-    private function setMailer(array $config, array $tokens, $to)
+    private function setMailer(array $config, array $tokens, $to, Lead $lead = null, $internalSend = true)
     {
         $this->mailer->reset();
 
@@ -448,5 +447,9 @@ class FormSubscriber extends CommonSubscriber
         $this->mailer->addTokens($tokens);
         $this->mailer->setBody($config['message']);
         $this->mailer->parsePlainText($config['message']);
+
+        if ($lead) {
+            $this->mailer->setLead($lead->getProfileFields(), $internalSend);
+        }
     }
 }

--- a/app/bundles/LeadBundle/Helper/TokenHelper.php
+++ b/app/bundles/LeadBundle/Helper/TokenHelper.php
@@ -26,6 +26,10 @@ class TokenHelper
      */
     public static function findLeadTokens($content, $lead, $replace = false)
     {
+        if (!$lead) {
+            return $replace ? $content : [];
+        }
+
         // Search for bracket or bracket encoded
         // @deprecated BC support for leadfield
         $tokenRegex = [


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

#5800 fixed issue where company fields were not accessible through an email but it caused failures for email that didn't set a lead. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. In staging where #5800 is already merged, create a new form with an email field and with a send form results action.
2. In the send results action, insert a contact field token such as `{contactfield=email}`
3. Submit the form and note the fatal error 

#### Steps to test this PR:
1. Repeat and the email should send with the contact token enabled (company fields are currently not supported here)
