### PR TITLE
Form action Send Result recipient fix

### DIFF
--- a/app/bundles/FormBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormSubscriber.php
@@ -185,7 +185,7 @@ class FormSubscriber extends CommonSubscriber
         $emails    = $this->getEmailsFromString($config['to']);
 
         if (!empty($emails)) {
-            $this->setMailer($config, $tokens, $leadEmail, $lead);
+            $this->setMailer($config, $tokens, $emails, $lead);
 
             if (!empty($leadEmail)) {
                 // Reply to lead for user convenience


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | /
| Deprecations? | /

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The Send Result form action was sending results to the contact email address instead of the email address specified in the action. Even if the send to contact switch was off.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form with the email address field
2. Add the Send Result action
3. Set yours To email address
4. Turn off the send to contact switch.
5. Save the form.
6. Go to the preview.
7. Fill in another email address of yours than in step 3.
8. Submit the form

The email address from step 5 will get the email instead of the email address in step 5.

#### Steps to test this PR:
1. Checkout this PR
2. Submit the form again

The email address from the form action will get the email