### PR TITLE
Missing Type namespace added to BodyParser

### DIFF
--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/BodyParser.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/BodyParser.php
@@ -14,6 +14,7 @@ namespace Mautic\EmailBundle\MonitoredEmail\Processor\Bounce;
 use Mautic\EmailBundle\MonitoredEmail\Exception\BounceNotFound;
 use Mautic\EmailBundle\MonitoredEmail\Message;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\Definition\Category;
+use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\Definition\Type;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\Mapper\CategoryMapper;
 
 /**


### PR DESCRIPTION
#[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | /
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://mautic.slack.com/archives/C02HU8BUT/p1522403718000207
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Just saw this error message in the Slack linked above:
```
[Symfony\Component\Debug\Exception\ClassNotFoundException]                                                                                                                        
 Attempted to load class "Type" from namespace "Mautic\EmailBundle\MonitoredEmail\Processor\Bounce".                                                                                
 Did you forget a "use" statement for e.g. "JMS\Serializer\Annotation\Type", "Doctrine\DBAL\Types\Type", "Aws\DynamoDb\Enum\Type", "Symfony\Component\Validator\Constraints\Type"  
 or "Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\Definition\Type"?
```

Somewhere was clearly missing namespace. I think I found the right and only file.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Don't actually know.  Author described the bug report it like this:

> I recently started to have issues with bounce management

#### Steps to test this PR:
1. I think that a code review is enough for this PR to be merged. It's kinda obvious. And it can't break anything anyway.