### PR TITLE
Fix - Emails Report Breaks when adding any Company Object Column

### DIFF
--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -178,13 +178,10 @@ class ReportSubscriber extends CommonSubscriber
             ],
         ];
 
-        $companyColumns = $this->companyReportData->getCompanyData();
-
         $columns = array_merge(
             $columns,
             $event->getStandardColumns($prefix, [], 'mautic_email_action'),
-            $event->getCategoryColumns(),
-            $companyColumns
+            $event->getCategoryColumns()
         );
         $data = [
             'display_name' => 'mautic.email.emails',
@@ -266,6 +263,8 @@ class ReportSubscriber extends CommonSubscriber
                 ],
             ];
 
+            $companyColumns = $this->companyReportData->getCompanyData();
+
             $data = [
                 'display_name' => 'mautic.email.stats.report.table',
                 'columns'      => array_merge(
@@ -273,7 +272,8 @@ class ReportSubscriber extends CommonSubscriber
                     $statColumns,
                     $event->getCampaignByChannelColumns(),
                     $event->getLeadColumns(),
-                    $event->getIpColumn()
+                    $event->getIpColumn(),
+                    $companyColumns
                 ),
             ];
             $event->addTable(self::CONTEXT_EMAIL_STATS, $data, self::CONTEXT_EMAILS);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Required: )
#### Description:

This PR removes company columns from email report. Does not make sense to have these columns in this report.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create report with Emails as the Data Source
2. Add any columns, then add a Company Object column, such as Company Company Email
3. Hit Save & Close. Error 500 will appear.
4. Create a report with Emails Sent data source
5. Make sure there are company columns. Choose at least one a save. Everything should work here

#### Steps to test this PR:
1. Apply this PR
2. Try to create an email report again. Notice there are no company related columns in Email data source.
3. There should be no change in Emails Sent data source. Company columns should still be there.

#### List deprecations along with the new alternative:


#### List backwards compatibility breaks:
