### PR TITLE
Fix for Emails Sent Report with Graphs

### DIFF
--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -44,8 +44,7 @@ class ReportSubscriber extends CommonSubscriber
     private $companyReportData;
 
     /**
-     * @var bool
-     *           Property is used to avoid Joining DNC table more times
+     * @var bool Property is used to avoid Joining DNC table more times
      */
     private $dncWasAddedToQb = false;
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | -
| Related user documentation PR URL | -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | -
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When creating a report with Emails Sent as the Data Source, adding the following graphs breaks the report:

Most emails bounced (Table)
Most emails unsubscribed (Table)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a report with the following columns: ID, Name, Bounced, Unsubscribed.
2. Add Most emails bounced (Table) and Most emails unsubscribed (Table) in the Graphs tab.
3. Save report and go to the detail - Error will be thrown.

#### Steps to test this PR:
1. Checkout this branch.
2. Check created report, everything should work.

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 