### PR TITLE
Fix for saving contact's owner, tags, points via API

### DIFF
--- a/app/bundles/AssetBundle/Entity/Asset.php
+++ b/app/bundles/AssetBundle/Entity/Asset.php
@@ -160,7 +160,7 @@ class Asset extends FormEntity
     /**
      * @var bool
      */
-    private $disallow;
+    private $disallow = 0;
 
     /**
      * @param ORM\ClassMetadata $metadata

--- a/app/bundles/AssetBundle/Entity/Asset.php
+++ b/app/bundles/AssetBundle/Entity/Asset.php
@@ -160,7 +160,7 @@ class Asset extends FormEntity
     /**
      * @var bool
      */
-    private $disallow = 0;
+    private $disallow = false;
 
     /**
      * @param ORM\ClassMetadata $metadata

--- a/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
+++ b/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
@@ -104,8 +104,9 @@ trait CustomFieldsApiControllerTrait
      * @param   $entity
      * @param   $form
      * @param   $parameters
+     * @param   $overwriteWithBlank
      */
-    protected function setCustomFieldValues(&$entity, $form, $parameters)
+    protected function setCustomFieldValues($entity, $form, $parameters, $overwriteWithBlank = true)
     {
         //set the custom field values
 
@@ -114,6 +115,6 @@ trait CustomFieldsApiControllerTrait
             $parameters[$f->getName()] = $f->getData();
         }
 
-        $this->model->setFieldValues($entity, $parameters, true);
+        $this->model->setFieldValues($entity, $parameters, $overwriteWithBlank);
     }
 }

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -667,7 +667,6 @@ class LeadApiController extends CommonApiController
 
         $overwriteWithBlank = 'POST' !== $this->request->getMethod();
         $this->setCustomFieldValues($entity, $form, $parameters, $overwriteWithBlank);
-        // var_dump($entity->getTags()->count());die;
     }
 
     /**

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -610,11 +610,6 @@ class LeadApiController extends CommonApiController
             unset($parameters['stage']);
         }
 
-        if (isset($parameters['color'])) {
-            $entity->setColor($parameters['color']);
-            unset($parameters['color']);
-        }
-
         if (isset($originalParams['tags'])) {
             $this->model->modifyTags($entity, $originalParams['tags'], null, false);
         }

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -591,7 +591,27 @@ class LeadApiController extends CommonApiController
         $originalParams = $this->request->request->all();
 
         // Merge existing duplicate contact based on unique fields if exist
-        $entity = $this->model->checkForDuplicateContact($originalParams, $entity);
+        $check = $this->model->checkForDuplicateContact($originalParams, $entity);
+        if ($check !== $entity) {
+            $entity = $check;
+            if ('POST' === $this->request->getMethod()) {
+                // Don't overwrite the contacts accumulated points
+                unset($parameters['points']);
+
+                // When merging a contact because of a unique identifier match in POST /api/contacts//new, all 0 values must be unset because
+                // we have to assume 0 was not meant to overwrite an existing value. Other empty values will be caught by LeadModel::setCustomFieldValues
+                $parameters = array_filter(
+                    $parameters,
+                    function ($value) {
+                        if (is_numeric($value)) {
+                            return 0 !== (int) $value;
+                        }
+
+                        return true;
+                    }
+                );
+            }
+        }
 
         if (isset($parameters['companies'])) {
             $this->model->modifyCompanies($entity, $parameters['companies']);

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -591,27 +591,7 @@ class LeadApiController extends CommonApiController
         $originalParams = $this->request->request->all();
 
         // Merge existing duplicate contact based on unique fields if exist
-        $check = $this->model->checkForDuplicateContact($originalParams, $entity);
-        if ($check !== $entity) {
-            $entity = $check;
-            if ('POST' === $this->request->getMethod()) {
-                // Don't overwrite the contacts accumulated points
-                unset($parameters['points']);
-
-                // When merging a contact because of a unique identifier match in POST /api/contacts//new, all 0 values must be unset because
-                // we have to assume 0 was not meant to overwrite an existing value. Other empty values will be caught by LeadModel::setCustomFieldValues
-                $parameters = array_filter(
-                    $parameters,
-                    function ($value) {
-                        if (is_numeric($value)) {
-                            return 0 !== (int) $value;
-                        }
-
-                        return true;
-                    }
-                );
-            }
-        }
+        $entity = $this->model->checkForDuplicateContact($originalParams, $entity);
 
         if (isset($parameters['companies'])) {
             $this->model->modifyCompanies($entity, $parameters['companies']);
@@ -680,8 +660,7 @@ class LeadApiController extends CommonApiController
             unset($parameters['frequencyRules']);
         }
 
-        $overwriteWithBlank = 'POST' !== $this->request->getMethod();
-        $this->setCustomFieldValues($entity, $form, $parameters, $overwriteWithBlank);
+        $this->setCustomFieldValues($entity, $form, $parameters, 'POST' === $this->request->getMethod());
     }
 
     /**

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -582,31 +582,9 @@ class LeadApiController extends CommonApiController
      */
     protected function prepareParametersForBinding($parameters, $entity, $action)
     {
-        if (isset($parameters['owner'])) {
-            $owner = $this->getModel('user.user')->getEntity((int) $parameters['owner']);
-            $entity->setOwner($owner);
-            unset($parameters['owner']);
-        }
-
-        if (isset($parameters['color'])) {
-            $entity->setColor($parameters['color']);
-            unset($parameters['color']);
-        }
-
-        if (isset($parameters['points'])) {
-            $entity->setPoints((int) $parameters['points']);
-            unset($parameters['points']);
-        }
-
+        // Unset the tags from params to avoid a validation error
         if (isset($parameters['tags'])) {
-            $this->model->modifyTags($entity, $parameters['tags']);
             unset($parameters['tags']);
-        }
-
-        if (isset($parameters['stage'])) {
-            $stage = $this->getModel('stage.stage')->getEntity((int) $parameters['stage']);
-            $entity->setStage($stage);
-            unset($parameters['stage']);
         }
 
         return $parameters;
@@ -633,6 +611,27 @@ class LeadApiController extends CommonApiController
         if (isset($parameters['companies'])) {
             $this->model->modifyCompanies($entity, $parameters['companies']);
             unset($parameters['companies']);
+        }
+
+        if (isset($parameters['owner'])) {
+            $owner = $this->getModel('user.user')->getEntity((int) $parameters['owner']);
+            $entity->setOwner($owner);
+            unset($parameters['owner']);
+        }
+
+        if (isset($parameters['stage'])) {
+            $stage = $this->getModel('stage.stage')->getEntity((int) $parameters['stage']);
+            $entity->setStage($stage);
+            unset($parameters['stage']);
+        }
+
+        if (isset($parameters['color'])) {
+            $entity->setColor($parameters['color']);
+            unset($parameters['color']);
+        }
+
+        if (isset($originalParams['tags'])) {
+            $this->model->modifyTags($entity, $originalParams['tags'], null, false);
         }
 
         //Since the request can be from 3rd party, check for an IP address if included

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -604,6 +604,7 @@ class LeadApiController extends CommonApiController
 
         // Merge existing duplicate contact based on unique fields if exist
         $existingContact = $this->model->checkForDuplicateContact($originalParams, $entity);
+
         if ($action === 'edit' && $existingContact->getId()) {
             $this->model->mergeLeads($existingContact, $entity, false);
         }
@@ -680,7 +681,8 @@ class LeadApiController extends CommonApiController
             unset($parameters['frequencyRules']);
         }
 
-        $this->setCustomFieldValues($entity, $form, $parameters);
+        $overwriteWithBlank = 'POST' !== $this->request->getMethod();
+        $this->setCustomFieldValues($entity, $form, $parameters, $overwriteWithBlank);
     }
 
     /**

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -52,18 +52,6 @@ class LeadApiController extends CommonApiController
     }
 
     /**
-     * Creates new entity from provided params.
-     *
-     * @param array $parameters
-     *
-     * @return Lead
-     */
-    public function getNewEntity(array $parameters)
-    {
-        return $this->getModel(self::MODEL_ID)->checkForDuplicateContact($parameters);
-    }
-
-    /**
      * Get existing duplicated contact based on unique fields and the request data.
      *
      * @param array $parameters
@@ -603,11 +591,7 @@ class LeadApiController extends CommonApiController
         $originalParams = $this->request->request->all();
 
         // Merge existing duplicate contact based on unique fields if exist
-        $existingContact = $this->model->checkForDuplicateContact($originalParams, $entity);
-
-        if ($action === 'edit' && $existingContact->getId()) {
-            $this->model->mergeLeads($existingContact, $entity, false);
-        }
+        $entity = $this->model->checkForDuplicateContact($originalParams, $entity);
 
         if (isset($parameters['companies'])) {
             $this->model->modifyCompanies($entity, $parameters['companies']);
@@ -683,6 +667,7 @@ class LeadApiController extends CommonApiController
 
         $overwriteWithBlank = 'POST' !== $this->request->getMethod();
         $this->setCustomFieldValues($entity, $form, $parameters, $overwriteWithBlank);
+        // var_dump($entity->getTags()->count());die;
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -654,7 +654,7 @@ class LeadModel extends FormModel
                         $newValue = implode('|', $newValue);
                     }
 
-                    $isEmpty = (null === $newValue || '' === $newValue);
+                    $isEmpty = (null === $newValue || '' === $newValue || 0 === $newValue || 0.0 === $newValue);
                     if ($curValue !== $newValue && (!$isEmpty || ($isEmpty && $overwriteWithBlank))) {
                         $field['value'] = $newValue;
                         $lead->addUpdatedField($alias, $newValue, $curValue);

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -654,7 +654,7 @@ class LeadModel extends FormModel
                         $newValue = implode('|', $newValue);
                     }
 
-                    $isEmpty = (null === $newValue || '' === $newValue || 0 === $newValue || 0.0 === $newValue);
+                    $isEmpty = (null === $newValue || '' === $newValue);
                     if ($curValue !== $newValue && (!$isEmpty || ($isEmpty && $overwriteWithBlank))) {
                         $field['value'] = $newValue;
                         $lead->addUpdatedField($alias, $newValue, $curValue);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | on the mautic-api side
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

1. Some API Library tests are failing for 2.13.0 pre-relase so sending fixes in this PR.

2. Also [this PR](https://github.com/mautic/mautic/pull/5667) introduced an issue that the new `disallow` database column did not have a default value and was not nullable so the API calls were failing.

3. Another issue was that when creating new contact via API with the email address that already existed in Mautic overwrote existing values with empty values if the fields weren't specified. This PR fixed that. 

4. Tags on the original contact were being cleared if they were missing in the request.

5. Some methods were called multiple times. Now the process is simpler and a bit faster.

6. Removes setting up contact's color since it's not a column in the database. So this value will never stick.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run `vendor/bin/phpunit` on the API library repo: https://github.com/mautic/api-library
2. You'll see some tests failing

#### Steps to test this PR:
1. Checkout this PR 
2. Make sure the API library is up to date and contains https://github.com/mautic/api-library/pull/159
3. Run the tests again - all should pass.
