### PR TITLE
Add an index on date identified for the leads table

### DIFF
--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -292,7 +292,8 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
             ->addLifecycleEvent('checkDateIdentified', 'prePersist')
             ->addLifecycleEvent('checkAttributionDate', 'preUpdate')
             ->addLifecycleEvent('checkAttributionDate', 'prePersist')
-            ->addIndex(['date_added'], 'lead_date_added');
+            ->addIndex(['date_added'], 'lead_date_added')
+            ->addIndex(['date_identified'], 'date_identified');
 
         $builder->createField('id', 'integer')
             ->makePrimaryKey()

--- a/app/migrations/Version20180404185715.php
+++ b/app/migrations/Version20180404185715.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * @package     Mautic
+ * @copyright   2018 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180404185715 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        $table = $schema->getTable("{$this->prefix}leads");
+        if ($table->hasIndex("{$this->prefix}date_identified")) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+        if (sizeof($table->getIndexes()) > 63) {
+            throw new SkipMigrationException('This table already has 64 indexes');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql("CREATE INDEX {$this->prefix}date_identified ON {$this->prefix}leads (date_identified)");
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | enhancement
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This simply adds an index onto the date identified column to make segments dependent on this field significantly faster 

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Run the migration `php app/console doctrine:migrations:migrate`
2. No errors should be thrown
3. Run `php app/console doctrine:schema:update --dump-sql` and it should not have a query modifying this index 
