### PR TITLE
Stat api optimisation

### DIFF
--- a/app/bundles/CoreBundle/EventListener/CommonStatsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CommonStatsSubscriber.php
@@ -100,7 +100,7 @@ abstract class CommonStatsSubscriber extends CommonSubscriber
                     continue;
                 }
 
-                throw new AccessDeniedException(sprintf('You do not have the view permission to load data from %s table', $tableAlias));
+                throw new AccessDeniedException(sprintf('You do not have the view permission to load data from the %s table', $tableAlias));
             }
 
             $select = (isset($this->selects[$table])) ? $this->selects[$table] : null;

--- a/app/bundles/CoreBundle/EventListener/CommonStatsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CommonStatsSubscriber.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Entity\CommonRepository;
 use Mautic\CoreBundle\Event\StatsEvent;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
  * Class CommonStatsSubscriber.
@@ -54,47 +55,56 @@ abstract class CommonStatsSubscriber extends CommonSubscriber
         /** @var CommonRepository $repository */
         foreach ($this->repositories as $repoName => $repository) {
             $table = $repository->getTableName();
-            if ($event->isLookingForTable($table, $repository)) {
-                $permissions  = (isset($this->permissions[$table])) ? $this->permissions[$table] : [];
-                $allowedJoins = [];
-                foreach ($permissions as $tableAlias => $permBase) {
-                    if ('admin' === $permBase) {
-                        if (!$this->security->isAdmin()) {
-                            continue;
-                        }
-                    } else {
-                        if ($this->security->checkPermissionExists($permBase.':view') && !$this->security->isGranted($permBase.':view')) {
-                            continue;
-                        }
 
-                        if ($this->security->checkPermissionExists($permBase.':viewother') && !$this->security->isGranted($permBase.':viewother')
-                        ) {
-                            $userId = $event->getUser()->getId();
-                            $where  = [
-                                'internal' => true,
-                                'expr'     => 'formula',
-                            ];
+            if (!$event->isLookingForTable($table, $repository)) {
+                continue;
+            }
 
-                            // In case the table alias is defined as an association such as stat.email
-                            $aliasParts = explode('.', $tableAlias);
-                            $tableAlias = array_pop($aliasParts);
+            $permissions  = (isset($this->permissions[$table])) ? $this->permissions[$table] : [];
+            $allowedJoins = [];
+            $canLoad      = false;
 
-                            if ('lead:leads' === $permBase) {
-                                // Acknowledge owner then created_by
-                                $where['value'] = "IF ($tableAlias.owner_id IS NOT NULL, $tableAlias.owner_id, $tableAlias.created_by) = $userId";
-                            } else {
-                                $where['value'] = "$tableAlias.created_by = $userId";
-                            }
-                            $event->addWhere($where);
-
-                            $allowedJoins[] = $tableAlias;
-                        }
-                    }
+            foreach ($permissions as $tableAlias => $permBase) {
+                // It's an admin, don't check any further
+                if ('admin' === $permBase && $this->security->isAdmin()) {
+                    continue;
                 }
 
-                $select = (isset($this->selects[$table])) ? $this->selects[$table] : null;
-                $event->setSelect($select)->setRepository($repository, $allowedJoins);
+                // This user can view everything from this entity, don't check any furher
+                if ($this->security->checkPermissionExists($permBase.':view') && $this->security->isGranted($permBase.':view')) {
+                    continue;
+                }
+
+                // This user can view own entities, limit the search
+                if ($this->security->checkPermissionExists($permBase.':viewother') && $this->security->isGranted($permBase.':viewother')
+                ) {
+                    $userId = $event->getUser()->getId();
+                    $where  = [
+                        'internal' => true,
+                        'expr'     => 'formula',
+                    ];
+
+                    // In case the table alias is defined as an association such as stat.email
+                    $aliasParts = explode('.', $tableAlias);
+                    $tableAlias = array_pop($aliasParts);
+
+                    if ('lead:leads' === $permBase) {
+                        // Acknowledge owner then created_by
+                        $where['value'] = "IF ($tableAlias.owner_id IS NOT NULL, $tableAlias.owner_id, $tableAlias.created_by) = $userId";
+                    } else {
+                        $where['value'] = "$tableAlias.created_by = $userId";
+                    }
+                    $event->addWhere($where);
+
+                    $allowedJoins[] = $tableAlias;
+                    continue;
+                }
+
+                throw new AccessDeniedException(sprintf('You do not have the view permission to load data from %s table', $tableAlias));
             }
+
+            $select = (isset($this->selects[$table])) ? $this->selects[$table] : null;
+            $event->setSelect($select)->setRepository($repository, $allowedJoins);
         }
     }
 

--- a/app/bundles/CoreBundle/Tests/unit/EventListener/CommonStatSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/EventListener/CommonStatSubscriberTest.php
@@ -1,0 +1,228 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Tests\EventListener;
+
+use Mautic\CoreBundle\Entity\CommonRepository;
+use Mautic\CoreBundle\Event\StatsEvent;
+use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
+use Mautic\UserBundle\Entity\User;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+class CommonStatsSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $security;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $user;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $repository;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $statsEvent;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $subscirber;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->security   = $this->createMock(CorePermissions::class);
+        $this->user       = $this->createMock(User::class);
+        $this->repository = $this->createMock(CommonRepository::class);
+        $this->statsEvent = $this->createMock(StatsEvent::class);
+        $this->subscirber = $this->getMockForAbstractClass(CommonStatsSubscriber::class);
+        $this->subscirber->setSecurity($this->security);
+    }
+
+    public function testOnStatsFetchForRestrictedUsers()
+    {
+        $this->setProperty($this->subscirber, 'repositories', [$this->repository]);
+        $this->setProperty($this->subscirber, 'permissions', ['emails_stats' => ['lead' => 'lead:leads']]);
+
+        $this->user->expects($this->once())
+            ->method('getId')
+            ->willReturn(9);
+
+        $this->security->expects($this->at(0))
+            ->method('checkPermissionExists')
+            ->with('lead:leads:view')
+            ->willReturn(true);
+
+        $this->security->expects($this->at(1))
+            ->method('isGranted')
+            ->with('lead:leads:view')
+            ->willReturn(false);
+
+        $this->security->expects($this->at(2))
+            ->method('checkPermissionExists')
+            ->with('lead:leads:viewother')
+            ->willReturn(true);
+
+        $this->security->expects($this->at(3))
+            ->method('isGranted')
+            ->with('lead:leads:viewother')
+            ->willReturn(true);
+
+        $this->repository->expects($this->once())
+            ->method('getTableName')
+            ->willReturn('emails_stats');
+
+        $this->statsEvent->expects($this->once())
+            ->method('isLookingForTable')
+            ->with('emails_stats', $this->repository)
+            ->willReturn(true);
+
+        $this->statsEvent->expects($this->once())
+            ->method('addWhere')
+            ->with([
+                'internal' => true,
+                'expr'     => 'formula',
+                'value'    => 'IF (lead.owner_id IS NOT NULL, lead.owner_id, lead.created_by) = 9',
+            ]);
+
+        $this->statsEvent->expects($this->once())
+            ->method('getUser')
+            ->willReturn($this->user);
+
+        $this->statsEvent->expects($this->once())
+            ->method('setRepository')
+            ->with($this->repository, ['lead']);
+
+        $this->statsEvent->expects($this->once())
+            ->method('setSelect')
+            ->willReturnSelf();
+
+        $this->subscirber->onStatsFetch($this->statsEvent);
+    }
+
+    public function testOnStatsFetchForViewAllUsers()
+    {
+        $this->setProperty($this->subscirber, 'repositories', [$this->repository]);
+        $this->setProperty($this->subscirber, 'permissions', ['emails_stats' => ['lead' => 'lead:leads']]);
+
+        $this->security->expects($this->at(0))
+            ->method('checkPermissionExists')
+            ->with('lead:leads:view')
+            ->willReturn(true);
+
+        $this->security->expects($this->at(1))
+            ->method('isGranted')
+            ->with('lead:leads:view')
+            ->willReturn(true);
+
+        $this->repository->expects($this->once())
+            ->method('getTableName')
+            ->willReturn('emails_stats');
+
+        $this->statsEvent->expects($this->once())
+            ->method('isLookingForTable')
+            ->with('emails_stats', $this->repository)
+            ->willReturn(true);
+
+        $this->statsEvent->expects($this->once())
+            ->method('setRepository')
+            ->with($this->repository, []);
+
+        $this->statsEvent->expects($this->once())
+            ->method('setSelect')
+            ->willReturnSelf();
+
+        $this->subscirber->onStatsFetch($this->statsEvent);
+    }
+
+    public function testOnStatsFetchForAdminUsers()
+    {
+        $this->setProperty($this->subscirber, 'repositories', [$this->repository]);
+        $this->setProperty($this->subscirber, 'permissions', ['emails_stats' => ['lead' => 'admin']]);
+
+        $this->security->expects($this->at(0))
+            ->method('isAdmin')
+            ->willReturn(true);
+
+        $this->repository->expects($this->once())
+            ->method('getTableName')
+            ->willReturn('emails_stats');
+
+        $this->statsEvent->expects($this->once())
+            ->method('isLookingForTable')
+            ->with('emails_stats', $this->repository)
+            ->willReturn(true);
+
+        $this->statsEvent->expects($this->once())
+            ->method('setSelect')
+            ->willReturnSelf();
+
+        $this->subscirber->onStatsFetch($this->statsEvent);
+    }
+
+    public function testOnStatsFetchForNoPermissionUsers()
+    {
+        $this->setProperty($this->subscirber, 'repositories', [$this->repository]);
+        $this->setProperty($this->subscirber, 'permissions', ['emails_stats' => ['lead' => 'lead:leads']]);
+
+        $this->repository->expects($this->once())
+            ->method('getTableName')
+            ->willReturn('emails_stats');
+
+        $this->security->expects($this->at(0))
+            ->method('checkPermissionExists')
+            ->with('lead:leads:view')
+            ->willReturn(true);
+
+        $this->security->expects($this->at(1))
+            ->method('isGranted')
+            ->with('lead:leads:view')
+            ->willReturn(false);
+
+        $this->security->expects($this->at(2))
+            ->method('checkPermissionExists')
+            ->with('lead:leads:viewother')
+            ->willReturn(true);
+
+        $this->security->expects($this->at(3))
+            ->method('isGranted')
+            ->with('lead:leads:viewother')
+            ->willReturn(false);
+
+        $this->statsEvent->expects($this->once())
+            ->method('isLookingForTable')
+            ->with('emails_stats', $this->repository)
+            ->willReturn(true);
+
+        $this->statsEvent->expects($this->never())
+            ->method('setSelect');
+
+        $this->expectException(AccessDeniedException::class);
+        $this->subscirber->onStatsFetch($this->statsEvent);
+    }
+
+    private function setProperty($object, $property, $value)
+    {
+        $reflection         = new \ReflectionClass($object);
+        $reflectionProperty = $reflection->getProperty($property);
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($object, $value);
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The stats API endpoint was creating SQL queries such as
```
SELECT count(*) FROM mautic_email_stats s LEFT JOIN mautic_leads lead ON s.lead_id = lead.id WHERE s.date_read > '2017-06-28'
```
Notice the JOIN is there unnecessary. On an instance with 2.5M rows it was taking 11 minutes to finish. When I remove the count it takes 5 seconds. The join is added in case there is a permission restriction. So this PR is adding the join only if there really need for it.

While writing unit test for the updated method I they were failing on permissions. They weren't right in my opinion. So I fixed them too.

Example for tests:
<img width="485" alt="screen shot 2018-04-06 at 18 26 37" src="https://user-images.githubusercontent.com/1235442/38432558-1f1c9318-39c8-11e8-9f54-f448c8634f4f.png">

Or as the link: `GET http://yourmautic.test/index_dev.php/api/stats/email_stats?limit=500&order%5B0%5D%5Bcol%5D=id&order%5B0%5D%5Bdir%5D=ASC&where%5B0%5D%5Bcol%5D=date_read&where%5B0%5D%5Bexpr%5D=gt&where%5B0%5D%5Bval%5D=2016-06-28`

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
You'll need to have a lot of rows to notice the lag, but you can test with several rows too. Just won't see the speedup.
1. Create a new Mautic user which does not have any permissions.
2. Access the endpoint from above.

- You'll get all data. But you shouldn't.

3. Access the endpoint with your admin user.

- You get all the data. As you should. Remember the count.

#### Steps to test this PR:
1. Checkout this PR
2. Repeat the test.

In the first case you get error:
```
{
  "errors": [
    {
      "message": "You do not have the view permission to load data from the lead table",
      "code": 403
    }
  ]
}
```
As your user does not have permission to view contact info.

In the second case (as admin) you get all the data as before. The counts must match.