### PR TITLE
Added check to verify if leadVal is array for in and !in operator cases

### DIFF
--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -151,23 +151,36 @@ trait MatchFilterForLeadTrait
                     break;
                 case 'in':
                     $leadValMatched = false;
-                    foreach ($leadVal as $k => $v) {
-                        if (in_array($v, $filterVal)) {
+                    if (getType($leadVal) == 'array') {
+                        foreach ($leadVal as $k => $v) {
+                            if (in_array($v, $filterVal)) {
+                                $leadValMatched = true;
+                                // Break once we find a match
+                                break;
+                            }
+                        }
+                    }
+                    else {
+                        if (in_array($leadVal, $filterVal)) {
                             $leadValMatched = true;
-                            // Break once we find a match
-                            break;
                         }
                     }
                     $groups[$groupNum] = $leadValMatched;
                     break;
                 case '!in':
                     $leadValNotMatched = true;
-
-                    foreach ($leadVal as $k => $v) {
-                        if (in_array($v, $filterVal)) {
+                    if (getType($leadVal) == 'array') {
+                        foreach ($leadVal as $k => $v) {
+                            if (in_array($v, $filterVal)) {
+                                $leadValNotMatched = false;
+                                // Break once we find a match
+                                break;
+                            }
+                        }
+                    }
+                    else {
+                        if (in_array($leadVal, $filterVal)) {
                             $leadValNotMatched = false;
-                            // Break once we find a match
-                            break;
                         }
                     }
 

--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -159,8 +159,7 @@ trait MatchFilterForLeadTrait
                                 break;
                             }
                         }
-                    }
-                    else {
+                    } else {
                         if (in_array($leadVal, $filterVal)) {
                             $leadValMatched = true;
                         }
@@ -177,8 +176,7 @@ trait MatchFilterForLeadTrait
                                 break;
                             }
                         }
-                    }
-                    else {
+                    } else {
                         if (in_array($leadVal, $filterVal)) {
                             $leadValNotMatched = false;
                         }

--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -151,7 +151,7 @@ trait MatchFilterForLeadTrait
                     break;
                 case 'in':
                     $leadValMatched = false;
-                    if (getType($leadVal) == 'array') {
+                    if (is_array($leadVal)) {
                         foreach ($leadVal as $k => $v) {
                             if (in_array($v, $filterVal)) {
                                 $leadValMatched = true;
@@ -169,7 +169,7 @@ trait MatchFilterForLeadTrait
                     break;
                 case '!in':
                     $leadValNotMatched = true;
-                    if (getType($leadVal) == 'array') {
+                    if (is_array($leadVal)) {
                         foreach ($leadVal as $k => $v) {
                             if (in_array($v, $filterVal)) {
                                 $leadValNotMatched = false;

--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -151,37 +151,30 @@ trait MatchFilterForLeadTrait
                     break;
                 case 'in':
                     $leadValMatched = false;
-                    if (is_array($leadVal)) {
-                        foreach ($leadVal as $k => $v) {
-                            if (in_array($v, $filterVal)) {
-                                $leadValMatched = true;
-                                // Break once we find a match
-                                break;
-                            }
-                        }
-                    } else {
-                        if (in_array($leadVal, $filterVal)) {
+                    if (!is_array($leadVal)) {
+                        $leadVal = [$leadVal];
+                    }
+                    foreach ($leadVal as $k => $v) {
+                        if (in_array($v, $filterVal)) {
                             $leadValMatched = true;
+                            // Break once we find a match
+                            break;
                         }
                     }
                     $groups[$groupNum] = $leadValMatched;
                     break;
                 case '!in':
                     $leadValNotMatched = true;
-                    if (is_array($leadVal)) {
-                        foreach ($leadVal as $k => $v) {
-                            if (in_array($v, $filterVal)) {
-                                $leadValNotMatched = false;
-                                // Break once we find a match
-                                break;
-                            }
-                        }
-                    } else {
-                        if (in_array($leadVal, $filterVal)) {
+                    if (!is_array($leadVal)) {
+                        $leadVal = [$leadVal];
+                    }
+                    foreach ($leadVal as $k => $v) {
+                        if (in_array($v, $filterVal)) {
                             $leadValNotMatched = false;
+                            // Break once we find a match
+                            break;
                         }
                     }
-
                     $groups[$groupNum] = $leadValNotMatched;
                     break;
                 case 'regexp':


### PR DESCRIPTION
closes https://github.com/mautic/mautic/issues/5904

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? | n
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #5904 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When using dynamic content in an email you can select contact fields to use as filters. If you chose the includes option it would error out as the code assumed that the input value would be an array however my input was a string. 

This failure would result in the emails being sent without populating the dynamic content. People would receive emails with "Hi {contactfield=firstname}"

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create email
2. Add Dynamic Content
3. Create a Variation
4. Choose a filter using a Select type field
5. Choose includes and select two or three options
6. Add the email to a campaign
7. Run the campaign
8. Error: PHP Warning:  Invalid argument supplied for foreach() in /opt/bitnami/apps/mautic/htdocs/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php on line 159

The contact value is a string but the code assumed it was an array.  

#### Steps to test this PR:
1. Follow the steps above
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 