### PR TITLE
Reports - fix for items per page bug (when report contains group by)

### DIFF
--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -604,25 +604,11 @@ class ReportModel extends FormModel
                     $start = 0;
                 }
 
-                // Must make two queries here, one to get count and one to select data
-                $select = $parts['select'];
-
-                // Get the count
-                $query->select('COUNT(*) as count');
-                $countQuery = clone $query;
-                $countQuery->resetQueryPart('groupBy');
-
-                $result       = $countQuery->execute()->fetchAll();
-                $totalResults = (!empty($result[0]['count'])) ? $result[0]['count'] : 0;
-                unset($countQuery);
-
-                // Set the limit and get the results
+                $totalResults = $query->execute()->rowCount();
                 if ($limit > 0) {
                     $query->setFirstResult($start)
                         ->setMaxResults($limit);
                 }
-
-                $query->select($select);
             }
 
             $query->add('orderBy', $order);

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -592,7 +592,7 @@ class ReportModel extends FormModel
         }
 
         if (empty($options['ignoreTableData']) && !empty($selectedColumns)) {
-            if ($paginate && !$entity->getGroupBy()) {
+            if ($paginate) {
                 // Build the options array to pass into the query
                 $limit = $this->session->get('mautic.report.'.$entity->getId().'.limit', $this->defaultPageLimit);
                 if (!empty($options['limit'])) {
@@ -638,7 +638,7 @@ class ReportModel extends FormModel
                 $queryTime .= 'ms';
             }
 
-            if (!$paginate || $entity->getGroupBy()) {
+            if (!$paginate) {
                 $totalResults = count($data);
             }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | -
| Related user documentation PR URL | -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | -
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Pagination for report does not work if Report contains `Group by`.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create report with data type Segment Membership
2. Add one column, then filter the one Segment you'd like in the report
3. Group by the one column you chose
4. In "Calculated Columns" add "Count" to the Function and "Emails" to the "Column"

- Expected Result: with the Items per page set to 5, only 5 items should show.
- Actual Result: All results show
- It is possible to paginate if the report does not contain "Group By" and "Calculated Columns".

#### Steps to test this PR:
1. Try to create a few different reports to test this function.
2. Checkout this branch and refresh report. You should be able to set pagination for every report.
3. Check that total result count is correct and all pages have data (last ones mainly).

Please really try to test at least 5 different reports. Not sure if removing the condition has any side effect.

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 