### PR TITLE
Sparkpost disable native click tracking and fixed reply to setting

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
@@ -292,6 +292,11 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
             $sparkPostMessage['content']['attachments'] = $message['attachments'];
         }
 
+        $sparkPostMessage['options'] = [
+            'open_tracking'  => false,
+            'click_tracking' => false,
+        ];
+
         return $sparkPostMessage;
     }
 

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
@@ -242,14 +242,6 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
             }
         }
 
-        if (isset($message['replyTo'])) {
-            $headers['Reply-To'] = !empty($message['replyTo']['name'])
-                ?
-                sprintf('%s <%s>', $message['replyTo']['email'], $message['replyTo']['name'])
-                :
-                $message['replyTo']['email'];
-        }
-
         $content = [
             'from'    => (!empty($message['from']['name'])) ? $message['from']['name'].' <'.$message['from']['email'].'>'
                 : $message['from']['email'],
@@ -263,6 +255,11 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
 
         if (!empty($message['text'])) {
             $content['text'] = $message['text'];
+        }
+
+        // Add Reply To
+        if (isset($message['replyTo'])) {
+            $content['reply_to'] = $message['replyTo']['email'];
         }
 
         $encoder = new \Swift_Mime_ContentEncoder_Base64ContentEncoder();


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Sparkpost's Transmissions API enables engagement tracking by default. But this interferes with Mautic's. So this PR disables their engagement tracking in favor of Mautic's. 

Also, the reply to header was not set correctly according to documentation. That is now fixed. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create an email with a link and a reply to set on the advanced tab
2. Send an email to a contact through sparkpost 
3. Notice the links are sparkpost links
4. Click on it and note that it is not registered in Mautic as being clicked 
5. Reply to the email and the reply to will not be the custom one set

#### Steps to test this PR:
1. Repeat and the links should be Mautic's click through links
2. Click on it and it should register as a click in Mautic
3. Reply to the email and it will be the custom one
