### PR TITLE
Support for PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
   - 5.6.19
   - 7.0
   - 7.1
+  - 7.2
 
 before_install:
   # Create mautictest database

--- a/app/bundles/CoreBundle/Helper/EncryptionHelper.php
+++ b/app/bundles/CoreBundle/Helper/EncryptionHelper.php
@@ -50,9 +50,11 @@ class EncryptionHelper
             }
             $this->availableCiphers[] = $possibleCipher;
         }
-        if (count($this->availableCiphers) === 0) {
+
+        if (!$this->availableCiphers || count($this->availableCiphers) === 0) {
             throw new \RuntimeException('None of possible cryptography libraries is supported');
         }
+
         $this->key = $coreParametersHelper->getParameter('mautic.secret_key');
     }
 

--- a/app/bundles/CoreBundle/Security/Cryptography/Cipher/Symmetric/McryptCipher.php
+++ b/app/bundles/CoreBundle/Security/Cryptography/Cipher/Symmetric/McryptCipher.php
@@ -20,11 +20,26 @@ use Mautic\CoreBundle\Security\Exception\Cryptography\Symmetric\InvalidDecryptio
  */
 class McryptCipher implements SymmetricCipherInterface
 {
-    /** @var string */
-    private $cipher = MCRYPT_RIJNDAEL_256;
+    /**
+     * @var string
+     */
+    private $cipher;
 
-    /** @var string */
-    private $mode = MCRYPT_MODE_CBC;
+    /**
+     * @var string
+     */
+    private $mode;
+
+    public function __construct()
+    {
+        // Do not use Mcrypt constants if the extension is not installed
+        if (!$this->isSupported()) {
+            return;
+        }
+
+        $this->cipher = MCRYPT_RIJNDAEL_256;
+        $this->mode   = MCRYPT_MODE_CBC;
+    }
 
     /**
      * @param string $secretMessage
@@ -35,6 +50,8 @@ class McryptCipher implements SymmetricCipherInterface
      */
     public function encrypt($secretMessage, $key, $randomInitVector)
     {
+        $this->checkSupport();
+
         $key  = pack('H*', $key);
         $data = $secretMessage.$this->getHash($secretMessage, $this->getHashKey($key));
 
@@ -52,6 +69,8 @@ class McryptCipher implements SymmetricCipherInterface
      */
     public function decrypt($encryptedMessage, $key, $originalInitVector)
     {
+        $this->checkSupport();
+
         if (strlen($originalInitVector) !== $this->getInitVectorSize()) {
             throw new InvalidDecryptionException();
         }
@@ -74,6 +93,8 @@ class McryptCipher implements SymmetricCipherInterface
      */
     public function getRandomInitVector()
     {
+        $this->checkSupport();
+
         return mcrypt_create_iv($this->getInitVectorSize(), MCRYPT_DEV_URANDOM);
     }
 
@@ -114,5 +135,17 @@ class McryptCipher implements SymmetricCipherInterface
         $hexKey = bin2hex($binaryKey);
         // Get second half of hexKey version (stable but different than original key)
         return substr($hexKey, -32);
+    }
+
+    /**
+     * Throws an exception if Mcrypt is not supported.
+     *
+     * @throws \BadMethodCallException
+     */
+    private function checkSupport()
+    {
+        if (!$this->isSupported()) {
+            throw new \BadMethodCallException('Mcrypt PHP extension is not installed. Use OpenSSL.');
+        }
     }
 }

--- a/app/middlewares/VersionCheckMiddleware.php
+++ b/app/middlewares/VersionCheckMiddleware.php
@@ -20,7 +20,7 @@ class VersionCheckMiddleware implements HttpKernelInterface, PrioritizedMiddlewa
     const PRIORITY = 10;
 
     const MAUTIC_MINIMUM_PHP = '5.6.19';
-    const MAUTIC_MAXIMUM_PHP = '7.1.999';
+    const MAUTIC_MAXIMUM_PHP = '7.2.999';
 
     /**
      * @var HttpKernelInterface


### PR DESCRIPTION

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Already covered
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5769 (closed)
| BC breaks? | N
| Deprecations? | Y

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
It's about time to prepare Mautic for PHP 7.2. This PR upgrades the maximum PHP contstants and fixes PHP warning about Mcrypt constants.

# WARNING
**If you have some plugin credentials stored by Mcrypt they cannot be decrypted by OpenSSL. Make sure you have both libraries installed and enabled. Then re-save all plugins so the credentials are encrypted by OpenSSL and then you can upgrade to PHP 7.2.**

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Upgrade your PHP to 7.2.
2. You'll see a message that this version is not supported.
3. Hack `MAUTIC_MAXIMUM_PHP` in VersionCheckMiddleware.php to `7.2.999` to overcome the message.
4. Clear the cache.
5. In dev mode you'll see warning everywhere.

#### Steps to test this PR:
1. Apply this PR
2. No warnings are visible. Everything looks normal and little faster :)

#### List deprecations along with the new alternative:
1. Mcrypt extension does not exist on PHP 7.2. Use OpenSSL instead.