### PR TITLE
Stop email sending when email is unpublished in the meantime

### DIFF
--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -43,7 +43,7 @@ class AjaxController extends CommonController
     {
         $response = new JsonResponse();
 
-        if ($this->factory->getEnvironment() == 'dev' && $addIgnoreWdt) {
+        if ($this->container->getParameter('kernel.environment') == 'dev' && $addIgnoreWdt) {
             $dataArray['ignore_wdt'] = 1;
         }
 

--- a/app/bundles/EmailBundle/Controller/AjaxController.php
+++ b/app/bundles/EmailBundle/Controller/AjaxController.php
@@ -49,7 +49,7 @@ class AjaxController extends CommonAjaxController
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
-    protected function sendBatchAction(Request $request)
+    public function sendBatchAction(Request $request)
     {
         $dataArray = ['success' => 0];
 
@@ -61,11 +61,12 @@ class AjaxController extends CommonAjaxController
 
         if ($objectId && $entity = $model->getEntity($objectId)) {
             $dataArray['success'] = 1;
-            $session              = $this->get('session');
+            $session              = $this->container->get('session');
             $progress             = $session->get('mautic.email.send.progress', [0, (int) $pending]);
             $stats                = $session->get('mautic.email.send.stats', ['sent' => 0, 'failed' => 0, 'failedRecipients' => []]);
+            $inProgress           = $session->get('mautic.email.send.active', false);
 
-            if ($pending && !$inProgress = $session->get('mautic.email.send.active', false)) {
+            if ($pending && !$inProgress && $entity->isPublished()) {
                 $session->set('mautic.email.send.active', true);
                 list($batchSentCount, $batchFailedCount, $batchFailedRecipients) = $model->sendEmailToLists($entity, null, $limit);
 
@@ -82,8 +83,7 @@ class AjaxController extends CommonAjaxController
                 $session->set('mautic.email.send.active', false);
             }
 
-            $dataArray['percent'] = ($progress[1]) ? ceil(($progress[0] / $progress[1]) * 100) : 100;
-
+            $dataArray['percent']  = ($progress[1]) ? ceil(($progress[0] / $progress[1]) * 100) : 100;
             $dataArray['progress'] = $progress;
             $dataArray['stats']    = $stats;
         }

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -74,29 +74,30 @@ class EmailApiController extends CommonApiController
     public function sendAction($id)
     {
         $entity = $this->model->getEntity($id);
-        if (null !== $entity) {
-            if (!$this->checkEntityAccess($entity, 'view')) {
-                return $this->accessDenied();
-            }
 
-            $lists = $this->request->request->get('lists', null);
-            $limit = $this->request->request->get('limit', null);
-
-            list($count, $failed) = $this->model->sendEmailToLists($entity, $lists, $limit);
-
-            $view = $this->view(
-                [
-                    'success'          => 1,
-                    'sentCount'        => $count,
-                    'failedRecipients' => $failed,
-                ],
-                Codes::HTTP_OK
-            );
-
-            return $this->handleView($view);
+        if (null !== $entity || !$entity->isPublished()) {
+            return $this->notFound();
         }
 
-        return $this->notFound();
+        if (!$this->checkEntityAccess($entity, 'view')) {
+            return $this->accessDenied();
+        }
+
+        $lists = $this->request->request->get('lists', null);
+        $limit = $this->request->request->get('limit', null);
+
+        list($count, $failed) = $this->model->sendEmailToLists($entity, $lists, $limit);
+
+        $view = $this->view(
+            [
+                'success'          => 1,
+                'sentCount'        => $count,
+                'failedRecipients' => $failed,
+            ],
+            Codes::HTTP_OK
+        );
+
+        return $this->handleView($view);
     }
 
     /**

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1194,6 +1194,21 @@ class EmailController extends FormController
                     ]
                 )
             );
+        } elseif (!$entity->isPublished()) {
+            return $this->postActionRedirect(
+                array_merge(
+                    $postActionVars,
+                    [
+                        'flashes' => [
+                            [
+                                'type'    => 'error',
+                                'msg'     => 'mautic.email.error.send.unpublished',
+                                'msgVars' => ['%id%' => $objectId],
+                            ],
+                        ],
+                    ]
+                )
+            );
         } elseif ($entity->getEmailType() == 'template'
             || !$this->get('mautic.security')->hasEntityAccess(
                 'email:emails:viewown',

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1162,7 +1162,7 @@ class EmailController extends FormController
         /** @var \Mautic\EmailBundle\Model\EmailModel $model */
         $model   = $this->getModel('email');
         $entity  = $model->getEntity($objectId);
-        $session = $this->get('session');
+        $session = $this->container->get('session');
         $page    = $session->get('mautic.email.page', 1);
 
         //set the return URL
@@ -1194,7 +1194,9 @@ class EmailController extends FormController
                     ]
                 )
             );
-        } elseif (!$entity->isPublished()) {
+        }
+
+        if (!$entity->isPublished()) {
             return $this->postActionRedirect(
                 array_merge(
                     $postActionVars,
@@ -1203,13 +1205,18 @@ class EmailController extends FormController
                             [
                                 'type'    => 'error',
                                 'msg'     => 'mautic.email.error.send.unpublished',
-                                'msgVars' => ['%id%' => $objectId],
+                                'msgVars' => [
+                                    '%id%'   => $objectId,
+                                    '%name%' => $entity->getName(),
+                                ],
                             ],
                         ],
                     ]
                 )
             );
-        } elseif ($entity->getEmailType() == 'template'
+        }
+
+        if ($entity->getEmailType() == 'template'
             || !$this->get('mautic.security')->hasEntityAccess(
                 'email:emails:viewown',
                 'email:emails:viewother',
@@ -1228,6 +1235,7 @@ class EmailController extends FormController
                 ]
             ));
         }
+
         if ($translationParent = $entity->getTranslationParent()) {
             return $this->redirect($this->generateUrl('mautic_email_action',
                 [
@@ -1235,28 +1243,6 @@ class EmailController extends FormController
                     'objectId'     => $translationParent->getId(),
                 ]
             ));
-        }
-
-        // Make sure email and category are published
-        $category     = $entity->getCategory();
-        $catPublished = (!empty($category)) ? $category->isPublished() : true;
-        $published    = $entity->isPublished();
-
-        if (!$catPublished || !$published) {
-            return $this->postActionRedirect(
-                array_merge(
-                    $postActionVars,
-                    [
-                        'flashes' => [
-                            [
-                                'type'    => 'error',
-                                'msg'     => 'mautic.email.error.send',
-                                'msgVars' => ['%name%' => $entity->getName()],
-                            ],
-                        ],
-                    ]
-                )
-            );
         }
 
         $action   = $this->generateUrl('mautic_email_action', ['objectAction' => 'send', 'objectId' => $objectId]);

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -884,6 +884,12 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             return [0, 0, []];
         }
 
+        // Doesn't make sense to send unpublished emails. Probably a user error.
+        // @todo throw an exception in Mautic 3 here.
+        if (!$email->isPublished()) {
+            return [0, 0, []];
+        }
+
         $options = [
             'source'        => ['email', $email->getId()],
             'allowResends'  => false,

--- a/app/bundles/EmailBundle/Tests/Controller/AjaxControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/AjaxControllerTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Controller;
+
+use Mautic\CoreBundle\Factory\ModelFactory;
+use Mautic\EmailBundle\Controller\AjaxController;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Model\EmailModel;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class AjaxControllerTest extends \PHPUnit_Framework_TestCase
+{
+    private $translatorMock;
+    private $sessionMock;
+    private $modelFactoryMock;
+    private $containerMock;
+    private $modelMock;
+    private $emailMock;
+    private $controller;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->translatorMock   = $this->createMock(TranslatorInterface::class);
+        $this->sessionMock      = $this->createMock(Session::class);
+        $this->modelFactoryMock = $this->createMock(ModelFactory::class);
+        $this->containerMock    = $this->createMock(Container::class);
+        $this->modelMock        = $this->createMock(EmailModel::class);
+        $this->emailMock        = $this->createMock(Email::class);
+        $this->controller       = new AjaxController();
+        $this->controller->setContainer($this->containerMock);
+        $this->controller->setTranslator($this->translatorMock);
+    }
+
+    public function testSendBatchActionWhenNoIdProvided()
+    {
+        $this->containerMock
+            ->expects($this->at(0))
+            ->method('get')
+            ->with('mautic.model.factory')
+            ->willReturn($this->modelFactoryMock);
+
+        $this->modelFactoryMock
+            ->expects($this->at(0))
+            ->method('getModel')
+            ->with('email')
+            ->willReturn($this->modelMock);
+
+        $response = $this->controller->sendBatchAction(new Request([], []));
+
+        $this->assertEquals('{"success":0}', $response->getContent());
+    }
+
+    public function testSendBatchActionWhenIdProvidedButEmailNotPublished()
+    {
+        $this->containerMock->expects($this->at(0))
+            ->method('get')
+            ->with('mautic.model.factory')
+            ->willReturn($this->modelFactoryMock);
+
+        $this->containerMock->expects($this->at(1))
+            ->method('get')
+            ->with('session')
+            ->willReturn($this->sessionMock);
+
+        $this->modelFactoryMock->expects($this->at(0))
+            ->method('getModel')
+            ->with('email')
+            ->willReturn($this->modelMock);
+
+        $this->modelMock->expects($this->once())
+            ->method('getEntity')
+            ->with(5)
+            ->willReturn($this->emailMock);
+
+        $this->modelMock->expects($this->never())
+            ->method('sendEmailToLists');
+
+        $this->sessionMock->expects($this->at(0))
+            ->method('get')
+            ->with('mautic.email.send.progress')
+            ->willReturn([0, 100]);
+
+        $this->sessionMock->expects($this->at(1))
+            ->method('get')
+            ->with('mautic.email.send.stats')
+            ->willReturn(['sent' => 0, 'failed' => 0, 'failedRecipients' => []]);
+
+        $this->sessionMock->expects($this->at(2))
+            ->method('get')
+            ->with('mautic.email.send.active')
+            ->willReturn(false);
+
+        $this->emailMock->expects($this->once())
+            ->method('isPublished')
+            ->willReturn(false);
+
+        $response = $this->controller->sendBatchAction(new Request([], ['id' => 5, 'pending' => 100]));
+        $expected = '{"success":1,"percent":0,"progress":[0,100],"stats":{"sent":0,"failed":0,"failedRecipients":[]}}';
+        $this->assertEquals($expected, $response->getContent());
+    }
+
+    public function testSendBatchActionWhenIdProvidedAndEmailIsPublished()
+    {
+        $this->containerMock->expects($this->at(0))
+            ->method('get')
+            ->with('mautic.model.factory')
+            ->willReturn($this->modelFactoryMock);
+
+        $this->containerMock->expects($this->at(1))
+            ->method('get')
+            ->with('session')
+            ->willReturn($this->sessionMock);
+
+        $this->modelFactoryMock->expects($this->at(0))
+            ->method('getModel')
+            ->with('email')
+            ->willReturn($this->modelMock);
+
+        $this->modelMock->expects($this->once())
+            ->method('getEntity')
+            ->with(5)
+            ->willReturn($this->emailMock);
+
+        $this->modelMock->expects($this->once())
+            ->method('sendEmailToLists')
+            ->with($this->emailMock, null, 50)
+            ->willReturn([50, 0, []]);
+
+        $this->sessionMock->expects($this->at(0))
+            ->method('get')
+            ->with('mautic.email.send.progress')
+            ->willReturn([0, 100]);
+
+        $this->sessionMock->expects($this->at(1))
+            ->method('get')
+            ->with('mautic.email.send.stats')
+            ->willReturn(['sent' => 0, 'failed' => 0, 'failedRecipients' => []]);
+
+        $this->sessionMock->expects($this->at(2))
+            ->method('get')
+            ->with('mautic.email.send.active')
+            ->willReturn(false);
+
+        $this->emailMock->expects($this->once())
+            ->method('isPublished')
+            ->willReturn(true);
+
+        $response = $this->controller->sendBatchAction(new Request([], ['id' => 5, 'pending' => 100, 'batchlimit' => 50]));
+        $expected = '{"success":1,"percent":50,"progress":[50,100],"stats":{"sent":50,"failed":0,"failedRecipients":[]}}';
+        $this->assertEquals($expected, $response->getContent());
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Controller/AjaxControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/AjaxControllerTest.php
@@ -18,11 +18,9 @@ use Mautic\EmailBundle\Model\EmailModel;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class AjaxControllerTest extends \PHPUnit_Framework_TestCase
 {
-    private $translatorMock;
     private $sessionMock;
     private $modelFactoryMock;
     private $containerMock;
@@ -34,7 +32,6 @@ class AjaxControllerTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->translatorMock   = $this->createMock(TranslatorInterface::class);
         $this->sessionMock      = $this->createMock(Session::class);
         $this->modelFactoryMock = $this->createMock(ModelFactory::class);
         $this->containerMock    = $this->createMock(Container::class);
@@ -42,19 +39,16 @@ class AjaxControllerTest extends \PHPUnit_Framework_TestCase
         $this->emailMock        = $this->createMock(Email::class);
         $this->controller       = new AjaxController();
         $this->controller->setContainer($this->containerMock);
-        $this->controller->setTranslator($this->translatorMock);
     }
 
     public function testSendBatchActionWhenNoIdProvided()
     {
-        $this->containerMock
-            ->expects($this->at(0))
+        $this->containerMock->expects($this->at(0))
             ->method('get')
             ->with('mautic.model.factory')
             ->willReturn($this->modelFactoryMock);
 
-        $this->modelFactoryMock
-            ->expects($this->at(0))
+        $this->modelFactoryMock->expects($this->at(0))
             ->method('getModel')
             ->with('email')
             ->willReturn($this->modelMock);

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Controller;
+
+use Mautic\CoreBundle\Factory\ModelFactory;
+use Mautic\EmailBundle\Controller\EmailController;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Model\EmailModel;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Routing\Router;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class EmailControllerTest extends \PHPUnit_Framework_TestCase
+{
+    private $translatorMock;
+    private $sessionMock;
+    private $modelFactoryMock;
+    private $containerMock;
+    private $modelMock;
+    private $emailMock;
+    private $controller;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->translatorMock   = $this->createMock(TranslatorInterface::class);
+        $this->sessionMock      = $this->createMock(Session::class);
+        $this->modelFactoryMock = $this->createMock(ModelFactory::class);
+        $this->containerMock    = $this->createMock(Container::class);
+        $this->routerMock       = $this->createMock(Router::class);
+        $this->modelMock        = $this->createMock(EmailModel::class);
+        $this->emailMock        = $this->createMock(Email::class);
+        $this->flashBagMock     = $this->createMock(FlashBagInterface::class);
+        $this->controller       = new EmailController();
+        $this->controller->setContainer($this->containerMock);
+        $this->controller->setTranslator($this->translatorMock);
+        $this->sessionMock->method('getFlashBag')->willReturn($this->flashBagMock);
+        $this->controller->setRequest(new Request());
+    }
+
+    public function testSendActionWhenNoEntityFound()
+    {
+        $this->containerMock->expects($this->at(0))
+            ->method('get')
+            ->with('mautic.model.factory')
+            ->willReturn($this->modelFactoryMock);
+
+        $this->modelFactoryMock->expects($this->at(0))
+            ->method('getModel')
+            ->with('email')
+            ->willReturn($this->modelMock);
+
+        $this->modelMock->expects($this->at(0))
+            ->method('getEntity')
+            ->with(5)
+            ->willReturn(null);
+
+        $this->containerMock->expects($this->at(1))
+            ->method('get')
+            ->with('session')
+            ->willReturn($this->sessionMock);
+
+        $this->containerMock->expects($this->at(2))
+            ->method('get')
+            ->with('router')
+            ->willReturn($this->routerMock);
+
+        $this->containerMock->expects($this->at(3))
+            ->method('get')
+            ->with('translator')
+            ->willReturn($this->translatorMock);
+
+        $this->containerMock->expects($this->at(4))
+            ->method('get')
+            ->with('session')
+            ->willReturn($this->sessionMock);
+
+        $this->routerMock->expects($this->any())
+            ->method('generate')
+            ->willReturn('https://some.url');
+
+        $this->emailMock->expects($this->never())
+            ->method('isPublished');
+
+        $response = $this->controller->sendAction(5);
+        $this->assertEquals(302, $response->getStatusCode());
+    }
+
+    public function testSendActionWhenEnityFoundButNotPublished()
+    {
+        $this->containerMock->expects($this->at(0))
+            ->method('get')
+            ->with('mautic.model.factory')
+            ->willReturn($this->modelFactoryMock);
+
+        $this->modelFactoryMock->expects($this->at(0))
+            ->method('getModel')
+            ->with('email')
+            ->willReturn($this->modelMock);
+
+        $this->modelMock->expects($this->at(0))
+            ->method('getEntity')
+            ->with(5)
+            ->willReturn($this->emailMock);
+
+        $this->containerMock->expects($this->at(1))
+            ->method('get')
+            ->with('session')
+            ->willReturn($this->sessionMock);
+
+        $this->containerMock->expects($this->at(2))
+            ->method('get')
+            ->with('router')
+            ->willReturn($this->routerMock);
+
+        $this->containerMock->expects($this->at(3))
+            ->method('get')
+            ->with('translator')
+            ->willReturn($this->translatorMock);
+
+        $this->containerMock->expects($this->at(4))
+            ->method('get')
+            ->with('session')
+            ->willReturn($this->sessionMock);
+
+        $this->routerMock->expects($this->any())
+            ->method('generate')
+            ->willReturn('https://some.url');
+
+        $this->emailMock->expects($this->once())
+            ->method('isPublished')
+            ->willReturn(false);
+
+        $this->emailMock->expects($this->never())
+            ->method('getEmailType');
+
+        $response = $this->controller->sendAction(5);
+        $this->assertEquals(302, $response->getStatusCode());
+    }
+}

--- a/app/bundles/EmailBundle/Translations/en_US/flashes.ini
+++ b/app/bundles/EmailBundle/Translations/en_US/flashes.ini
@@ -1,6 +1,7 @@
 mautic.email.error.list_type.sent="Once a list email has been sent, it cannot be edited. Consider cloning the email."
 mautic.email.error.notfound="No email with an id of %id% was found!"
 mautic.email.error.send="%name% cannot be sent because it is unpublished, in a category that is unpublished, and/or the action cannot be initiated directly via a URL."
+mautic.email.error.send.unpublished="The email is unpublished, the publish Up/Down dates are off or the email category is unpublished. You cannot send this email until published."
 mautic.email.notice.activated="<a href='%url%' data-toggle='ajax' data-menu-link='mautic_email_index'><strong>%name%</strong></a> is now active as the main email!"
 mautic.email.notice.batch_deleted="%count% emails have been deleted!"
 mautic.email.notice.test_sent.success="A test email has been sent to your email."

--- a/app/bundles/EmailBundle/Translations/en_US/flashes.ini
+++ b/app/bundles/EmailBundle/Translations/en_US/flashes.ini
@@ -1,7 +1,6 @@
 mautic.email.error.list_type.sent="Once a list email has been sent, it cannot be edited. Consider cloning the email."
 mautic.email.error.notfound="No email with an id of %id% was found!"
-mautic.email.error.send="%name% cannot be sent because it is unpublished, in a category that is unpublished, and/or the action cannot be initiated directly via a URL."
-mautic.email.error.send.unpublished="The email is unpublished, the publish Up/Down dates are off or the email category is unpublished. You cannot send this email until published."
+mautic.email.error.send.unpublished="The email %name% is unpublished, the publish Up/Down dates are off or the email category is unpublished. You cannot send this email until published."
 mautic.email.notice.activated="<a href='%url%' data-toggle='ajax' data-menu-link='mautic_email_index'><strong>%name%</strong></a> is now active as the main email!"
 mautic.email.notice.batch_deleted="%count% emails have been deleted!"
 mautic.email.notice.test_sent.success="A test email has been sent to your email."


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Mautic will throw 403 error if a contact tries to access unpublished email's web view. So it doesn't make sense if Mautic allows to send unpublished emails because it's an obvious user error. Let's prevent users to do this error.

This PR will display notification `The email [name] is unpublished, the publish Up/Down dates are off or the email category is unpublished. You cannot send this email until published.` if user tries to send an upublished email.

Unpublished means:
- Email is unpublished.
- Current date is not within the unpublish Up/Down range.
- Email's category is unpublished.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a segment email with 1000+ contacts in the published state.
2. Send it via command or via browser send.
3. Unpublish while sending email is in progress. The send should stop, but it won't.

#### Steps to test this PR:
1. Checkout this PR
2. Send it from the detail view or the table view. - The notification will appear instead of sending.
3. Publish the email.
4. Send the email - yep, published emails can be sent.
5. Repeat the test to reproduce - the sending will stop until published again.
