### PR TITLE
Sparkpost CC and BCC - tokens were not replaced in CC and BCC

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
@@ -211,6 +211,9 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
 
             $recipients[] = $recipient;
 
+            // CC and BCC fields need to be included as a normal TO address with token duplication
+            // https://www.sparkpost.com/docs/faq/cc-bcc-with-rest-api/ - token duplication is not mentioned here
+            // See test for CC and BCC too
             $substitution_data = $recipient['substitution_data'];
             if (!empty($message['recipients']['cc'])) {
                 foreach ($message['recipients']['cc'] as $cc => $content) {

--- a/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportMessageTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportMessageTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Transport;
+
+use Mautic\CoreBundle\Translation\Translator;
+use Mautic\EmailBundle\Model\TransportCallback;
+use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
+use Mautic\EmailBundle\Swiftmailer\Transport\SparkpostTransport;
+
+class SparkpostTransportMessageTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCcAndBccFields()
+    {
+        $translator        = $this->createMock(Translator::class);
+        $transportCallback = $this->createMock(TransportCallback::class);
+
+        $message = new MauticMessage('Test subject', 'First Name: {formfield=first_name}');
+        $message->addFrom('from@xx.xx');
+
+        $message->addTo('to1@xx.xx');
+        $message->addTo('to2@xx.xx');
+
+        $message->addCc('cc1@xx.xx');
+        $message->addCc('cc2@xx.xx');
+
+        $message->addBcc('bcc1@xx.xx');
+        $message->addBcc('bcc2@xx.xx');
+
+        $message->addMetadata(
+            'to1@xx.xx',
+            [
+                'tokens' => [
+                    '{formfield=first_name}' => '1',
+                ],
+            ]
+        );
+
+        $message->addMetadata(
+            'to2@xx.xx',
+            [
+                'tokens' => [
+                    '{formfield=first_name}' => '2',
+                ],
+            ]
+        );
+
+        $sparkpost = new SparkpostTransport('1234', $translator, $transportCallback);
+
+        $sparkpostMessage = $sparkpost->getSparkPostMessage($message);
+
+        $this->assertEquals('from@xx.xx', $sparkpostMessage['content']['from']);
+        $this->assertEquals('Test subject', $sparkpostMessage['content']['subject']);
+        $this->assertEquals('First Name: {{{ FORMFIELDFIRSTNAME }}}', $sparkpostMessage['content']['html']);
+
+        $this->assertCount(10, $sparkpostMessage['recipients']);
+
+        //CC and BCC fields has to be included as normal recipient with same data as TO fields has
+        $recipients = [
+            [
+                'address' => [
+                    'email' => 'to1@xx.xx',
+                    'name'  => null,
+                ],
+                'substitution_data' => [
+                    'FORMFIELDFIRSTNAME' => '1',
+                ],
+            ],
+            [
+                'address' => [
+                    'email' => 'cc1@xx.xx',
+                ],
+                'header_to'         => 'to1@xx.xx',
+                'substitution_data' => [
+                    'FORMFIELDFIRSTNAME' => '1',
+                ],
+            ],
+            [
+                'address' => [
+                    'email' => 'cc2@xx.xx',
+                ],
+                'header_to'         => 'to1@xx.xx',
+                'substitution_data' => [
+                    'FORMFIELDFIRSTNAME' => '1',
+                ],
+            ],
+            [
+                'address' => [
+                    'email' => 'bcc1@xx.xx',
+                ],
+                'header_to'         => 'to1@xx.xx',
+                'substitution_data' => [
+                    'FORMFIELDFIRSTNAME' => '1',
+                ],
+            ],
+            [
+                'address' => [
+                    'email' => 'bcc2@xx.xx',
+                ],
+                'header_to'         => 'to1@xx.xx',
+                'substitution_data' => [
+                    'FORMFIELDFIRSTNAME' => '1',
+                ],
+            ],
+            [
+                'address' => [
+                    'email' => 'to2@xx.xx',
+                    'name'  => null,
+                ],
+                'substitution_data' => [
+                    'FORMFIELDFIRSTNAME' => '2',
+                ],
+            ],
+            [
+                'address' => [
+                    'email' => 'cc1@xx.xx',
+                ],
+                'header_to'         => 'to2@xx.xx',
+                'substitution_data' => [
+                    'FORMFIELDFIRSTNAME' => '2',
+                ],
+            ],
+            [
+                'address' => [
+                    'email' => 'cc2@xx.xx',
+                ],
+                'header_to'         => 'to2@xx.xx',
+                'substitution_data' => [
+                    'FORMFIELDFIRSTNAME' => '2',
+                ],
+            ],
+            [
+                'address' => [
+                    'email' => 'bcc1@xx.xx',
+                ],
+                'header_to'         => 'to2@xx.xx',
+                'substitution_data' => [
+                    'FORMFIELDFIRSTNAME' => '2',
+                ],
+            ],
+            [
+                'address' => [
+                    'email' => 'bcc2@xx.xx',
+                ],
+                'header_to'         => 'to2@xx.xx',
+                'substitution_data' => [
+                    'FORMFIELDFIRSTNAME' => '2',
+                ],
+            ],
+        ];
+
+        $this->assertEquals($recipients, $sparkpostMessage['recipients']);
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

if you use Sparkpost as a transport layer, CC and BCC emails are not exactly same like original message. This PR fixes this issue by duplicating tokens for each CC and BCC.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Configure Sparkpost as an email transport
2. Create form that send results to an email address
3. Add an email address to CC and BCC and include the form results and a Contact token
4. Send form and notice that emails for CC and BCC do not have replaced tokens.

#### Steps to test this PR:
1. Checkout this branch
2. Repeat steps above. All emails should have same content.
3. Try to add more address to CC and BCC fields. All of them should get the correct email.

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 