### PR TITLE
Fixes several bugs with newly introduced device tracking and created source records

### DIFF
--- a/app/bundles/CoreBundle/Helper/ClickthroughHelper.php
+++ b/app/bundles/CoreBundle/Helper/ClickthroughHelper.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Helper;
+
+class ClickthroughHelper
+{
+    /**
+     * Encode an array to append to a URL.
+     *
+     * @param array $array
+     *
+     * @return string
+     */
+    public static function encodeArrayForUrl(array $array)
+    {
+        return urlencode(base64_encode(serialize($array)));
+    }
+
+    /**
+     * Decode a string appended to URL into an array.
+     *
+     * @param      $string
+     * @param bool $urlDecode
+     *
+     * @return mixed
+     */
+    public static function decodeArrayFromUrl($string, $urlDecode = true)
+    {
+        $raw     = $urlDecode ? urldecode($string) : $string;
+        $decoded = base64_decode($raw);
+
+        if (strpos(strtolower($decoded), 'a') !== 0) {
+            throw new \InvalidArgumentException(sprintf('The string %s is not a serialized array.', $decoded));
+        }
+
+        return unserialize($decoded);
+    }
+}

--- a/app/bundles/CoreBundle/Helper/ClickthroughHelper.php
+++ b/app/bundles/CoreBundle/Helper/ClickthroughHelper.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * @copyright   2017 Mautic Contributors. All rights reserved
+ * @copyright   2018 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
  *
  * @link        https://mautic.org

--- a/app/bundles/CoreBundle/Model/AbstractCommonModel.php
+++ b/app/bundles/CoreBundle/Model/AbstractCommonModel.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Mautic\CoreBundle\Entity\CommonRepository;
 use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\CoreBundle\Helper\ClickthroughHelper;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -257,7 +258,7 @@ abstract class AbstractCommonModel
      */
     public function encodeArrayForUrl($array)
     {
-        return urlencode(base64_encode(serialize($array)));
+        return ClickthroughHelper::encodeArrayForUrl((array) $array);
     }
 
     /**
@@ -270,14 +271,7 @@ abstract class AbstractCommonModel
      */
     public function decodeArrayFromUrl($string, $urlDecode = true)
     {
-        $raw     = $urlDecode ? urldecode($string) : $string;
-        $decoded = base64_decode($raw);
-
-        if (strpos(strtolower($decoded), 'a') !== 0) {
-            throw new \InvalidArgumentException(sprintf('The string %s is not a serialized array.', $decoded));
-        }
-
-        return unserialize($decoded);
+        return ClickthroughHelper::decodeArrayFromUrl($string, $urlDecode);
     }
 
     /**

--- a/app/bundles/CoreBundle/Tests/unit/Helper/ClickthroughHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Helper/ClickthroughHelperTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Tests\Helper;
+
+use Mautic\CoreBundle\Helper\ClickthroughHelper;
+
+class ClickthroughHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEncodingCanBeDecoded()
+    {
+        $array = ['foo' => 'bar'];
+
+        $this->assertEquals($array, ClickthroughHelper::decodeArrayFromUrl(ClickthroughHelper::encodeArrayForUrl($array)));
+    }
+
+    public function testOnlyArraysCanBeDecodedToPreventObjectWakeupVulnerability()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        ClickthroughHelper::decodeArrayFromUrl(urlencode(base64_encode(serialize(new \stdClass()))));
+    }
+}

--- a/app/bundles/DynamicContentBundle/Controller/DynamicContentApiController.php
+++ b/app/bundles/DynamicContentBundle/Controller/DynamicContentApiController.php
@@ -16,6 +16,7 @@ use Mautic\DynamicContentBundle\Helper\DynamicContentHelper;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingServiceInterface;
+use Mautic\PageBundle\Model\PageModel;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -45,18 +46,17 @@ class DynamicContentApiController extends CommonController
 
     public function getAction($objectAlias)
     {
-        // Don't store a visitor with this request
-        defined('MAUTIC_NON_TRACKABLE_REQUEST') || define('MAUTIC_NON_TRACKABLE_REQUEST', 1);
-
         /** @var LeadModel $model */
         $model = $this->getModel('lead');
         /** @var DynamicContentHelper $helper */
         $helper = $this->get('mautic.helper.dynamicContent');
         /** @var DeviceTrackingServiceInterface $deviceTrackingService */
         $deviceTrackingService = $this->get('mautic.lead.service.device_tracking_service');
+        /** @var PageModel $pageModel */
+        $pageModel = $this->getModel('page');
 
         /** @var Lead $lead */
-        $lead    = $model->getContactFromRequest();
+        $lead    = $model->getContactFromRequest($pageModel->getHitQuery($this->request));
         $content = $helper->getDynamicContentForLead($objectAlias, $lead);
 
         if (empty($content)) {

--- a/app/bundles/LeadBundle/Exception/ContactNotFoundException.php
+++ b/app/bundles/LeadBundle/Exception/ContactNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Exception;
+
+class ContactNotFoundException extends \Exception
+{
+}

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -1,0 +1,303 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Helper;
+
+use Mautic\CoreBundle\Helper\ClickthroughHelper;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\LeadBundle\DataObject\LeadManipulator;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadDeviceRepository;
+use Mautic\LeadBundle\Model\LeadModel;
+use Mautic\LeadBundle\Tracker\ContactTracker;
+use Monolog\Logger;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class ContactRequestHelper
+{
+    /**
+     * @var LeadModel
+     */
+    private $leadModel;
+
+    /**
+     * @var CoreParametersHelper
+     */
+    private $coreParametersHelper;
+
+    /**
+     * @var StatRepository
+     */
+    private $emailStatRepository;
+
+    /**
+     * @var LeadDeviceRepository
+     */
+    private $leadDeviceRepository;
+
+    /**
+     * @var IpLookupHelper
+     */
+    private $ipLookupHelper;
+
+    /**
+     * @var ContactTracker
+     */
+    private $contactTracker;
+
+    /**
+     * @var null|\Symfony\Component\HttpFoundation\Request
+     */
+    private $request;
+
+    /**
+     * @var Logger
+     */
+    private $logger;
+
+    /**
+     * @var Lead
+     */
+    private $trackedContact;
+
+    /**
+     * @var array
+     */
+    private $queryFields = [];
+
+    /**
+     * @var array
+     */
+    private $publiclyUpdatableFieldValues = [];
+
+    /**
+     * ContactRequestHelper constructor.
+     *
+     * @param LeadModel            $leadModel
+     * @param ContactTracker       $contactTracker
+     * @param CoreParametersHelper $coreParametersHelper
+     * @param StatRepository       $emailStatRepository
+     * @param LeadDeviceRepository $leadDeviceRepository
+     * @param RequestStack         $requestStack
+     * @param Logger               $logger
+     */
+    public function __construct(
+        LeadModel $leadModel,
+        ContactTracker $contactTracker,
+        CoreParametersHelper $coreParametersHelper,
+        IpLookupHelper $ipLookupHelper,
+        StatRepository $emailStatRepository,
+        LeadDeviceRepository $leadDeviceRepository,
+        RequestStack $requestStack,
+        Logger $logger
+    ) {
+        $this->leadModel            = $leadModel;
+        $this->contactTracker       = $contactTracker;
+        $this->coreParametersHelper = $coreParametersHelper;
+        $this->ipLookupHelper       = $ipLookupHelper;
+        $this->emailStatRepository  = $emailStatRepository;
+        $this->leadDeviceRepository = $leadDeviceRepository;
+        $this->request              = $requestStack->getCurrentRequest();
+        $this->logger               = $logger;
+    }
+
+    /**
+     * @param Lead  $trackedContact
+     * @param array $queryFields
+     *
+     * @return Lead
+     */
+    public function getContactFromQuery(array $queryFields = [])
+    {
+        $this->trackedContact = $this->contactTracker->getContact();
+        $this->queryFields    = $queryFields;
+
+        if ($foundContact = $this->getContactFromUrl()) {
+            $this->trackedContact = $foundContact;
+            $this->contactTracker->setTrackedContact($this->trackedContact);
+        }
+
+        $this->prepareContactFromRequest();
+
+        return $this->trackedContact;
+    }
+
+    /**
+     * @return Lead|null
+     */
+    private function getContactFromUrl()
+    {
+        // Check for a lead requested through clickthrough query parameter
+        if (isset($this->queryFields['ct'])) {
+            $clickthrough = $this->queryFields['ct'];
+        } elseif ($clickthrough = $this->request->get('ct', [])) {
+            $clickthrough = ClickthroughHelper::decodeArrayFromUrl($clickthrough);
+        }
+
+        if (!is_array($clickthrough)) {
+            return null;
+        }
+
+        if ($contact = $this->getContactFromEmailClickthrough()) {
+            return $contact;
+        }
+
+        $this->setEmailFromClickthroughIdentification();
+
+        /** @var Lead $foundContact */
+        list($foundContact, $this->publiclyUpdatableFieldValues) = $this->leadModel->checkForDuplicateContact(
+            $this->queryFields,
+            $this->trackedContact,
+            true,
+            true
+        );
+        if ($foundContact->getId() !== $this->trackedContact->getId()) {
+            // A contact was found by a publicly updatable field
+            return $foundContact;
+        }
+
+        if ($contact = $this->getContactByFingerprint()) {
+            return $contact;
+        }
+
+        return null;
+    }
+
+    /**
+     * Identify a contact through a clickthrough URL in an email.
+     *
+     * @return Lead|null
+     */
+    private function getContactFromEmailClickthrough()
+    {
+        if (empty($clickthrough['channel']['email']) && empty($clickthrough['stat'])) {
+            return null;
+        }
+
+        // Nothing left to identify by so stick to the tracked lead
+        /** @var Stat $stat */
+        $stat = $this->emailStatRepository->findOneBy(['trackingHash' => $clickthrough['stat']]);
+
+        if (!$stat) {
+            // Stat doesn't exist so use the tracked lead
+            return null;
+        }
+
+        if ((int) $stat->getEmail()->getId() !== (int) $clickthrough['channel']['email']) {
+            // Email ID mismatch - fishy so use tracked lead
+            return null;
+        }
+
+        if ($statLead = $stat->getLead()) {
+            $this->logger->addDebug("LEAD: Contact ID# {$statLead->getId()} tracked through clickthrough query from email.");
+
+            // Merge tracked visitor into the clickthrough contact
+            return $this->mergeWithTrackedContact($statLead);
+        }
+
+        return null;
+    }
+
+    private function setEmailFromClickthroughIdentification()
+    {
+        if (!$this->coreParametersHelper->getParameter('track_by_tracking_url') || !empty($queryFields['email'])) {
+            return;
+        }
+
+        if (empty($clickthrough['lead']) || !$foundContact = $this->leadModel->getEntity($clickthrough['lead'])) {
+            return;
+        }
+
+        // Identify contact from link if email field is set as publicly updateable
+        if ($email = $foundContact->getEmail()) {
+            // Add email to query for checkForDuplicateContact to pick up and merge
+            $this->queryFields['email'] = $email;
+            $this->logger->addDebug("LEAD: Contact ID# {$clickthrough['lead']} tracked through clickthrough query.");
+
+            return;
+        }
+    }
+
+    /**
+     * @return Lead|null
+     */
+    private function getContactByFingerprint()
+    {
+        if (!$this->coreParametersHelper->getParameter('track_by_fingerprint')) {
+            // Track by fingerprint is disabled so just use tracked lead
+            return null;
+        }
+
+        if (!$this->trackedContact->isAnonymous() || empty($this->queryFields['fingerprint'])) {
+            // We already know who this is or fingerprint is not available so just use tracked lead
+            return null;
+        }
+
+        if ($device = $this->leadDeviceRepository->getDeviceByFingerprint($this->queryFields['fingerprint'])) {
+            $deviceLead = $this->leadModel->getEntity($device['lead_id']);
+
+            $this->logger->addDebug("LEAD: Contact ID# {$deviceLead->getId()} tracked through fingerprint.");
+
+            // Merge tracked visitor into the contact found by fingerprint
+            return $this->mergeWithTrackedContact($deviceLead);
+        }
+
+        return null;
+    }
+
+    private function prepareContactFromRequest()
+    {
+        $ipAddress          = $this->ipLookupHelper->getIpAddress();
+        $contactIpAddresses = $this->trackedContact->getIpAddresses();
+        if (!$contactIpAddresses->contains($ipAddress)) {
+            $this->trackedContact->addIpAddress($ipAddress);
+        }
+
+        $this->leadModel->setFieldValues(
+            $this->trackedContact,
+            $this->publiclyUpdatableFieldValues,
+            false,
+            true,
+            true
+        );
+
+        // Assume a web request as this is likely a tracking request from DWC or tracking code
+        $this->trackedContact->setManipulator(
+            new LeadManipulator(
+                'page',
+                'hit',
+                null,
+                (isset($this->queryFields['page_url'])) ? $this->queryFields['page_url'] : ''
+            )
+        );
+
+        if (isset($this->queryFields['tags'])) {
+            $this->leadModel->modifyTags($this->trackedContact, $this->queryFields['tags']);
+        }
+    }
+
+    /**
+     * @param Lead $foundContact
+     *
+     * @return Lead
+     */
+    private function mergeWithTrackedContact(Lead $foundContact)
+    {
+        if ($this->trackedContact->getId() && $this->trackedContact->isAnonymous()) {
+            return $this->leadModel->mergeLeads($this->trackedContact, $foundContact, false);
+        }
+
+        return $foundContact;
+    }
+}

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -161,7 +161,7 @@ class ContactRequestHelper
         } catch (ContactNotFoundException $exception) {
         }
 
-        $this->setEmailFromClickthroughIdentification();
+        $this->setEmailFromClickthroughIdentification($clickthrough);
 
         /** @var Lead $foundContact */
         list($foundContact, $this->publiclyUpdatableFieldValues) = $this->leadModel->checkForDuplicateContact(
@@ -217,7 +217,7 @@ class ContactRequestHelper
         throw new ContactNotFoundException();
     }
 
-    private function setEmailFromClickthroughIdentification()
+    private function setEmailFromClickthroughIdentification(array $clickthrough)
     {
         if (!$this->coreParametersHelper->getParameter('track_by_tracking_url') || !empty($queryFields['email'])) {
             return;

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -897,6 +897,16 @@ class LeadModel extends FormModel
 
             $this->setFieldValues($lead, $inQuery, false, true, true);
 
+            // Assume a web request as this is likely a tracking request from DWC or tracking code
+            $lead->setManipulator(
+                new LeadManipulator(
+                    'page',
+                    'hit',
+                    null,
+                    (isset($queryFields['page_url'])) ? $queryFields['page_url'] : ''
+                )
+            );
+
             if (isset($queryFields['tags'])) {
                 $this->modifyTags($lead, $queryFields['tags']);
             }

--- a/app/bundles/LeadBundle/Tests/Helper/ContactRequestHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/ContactRequestHelperTest.php
@@ -1,0 +1,439 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Helper;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Mautic\CoreBundle\Entity\IpAddress;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadDeviceRepository;
+use Mautic\LeadBundle\Helper\ContactRequestHelper;
+use Mautic\LeadBundle\Model\LeadModel;
+use Mautic\LeadBundle\Tracker\ContactTracker;
+use Monolog\Logger;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class ContactRequestHelperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|LeadModel
+     */
+    private $leadModel;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|ContactTracker
+     */
+    private $contactTracker;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|CoreParametersHelper
+     */
+    private $coreParametersHelper;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|IpLookupHelper
+     */
+    private $ipLookupHelper;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|StatRepository
+     */
+    private $emailStatRepository;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|LeadDeviceRepository
+     */
+    private $leadDeviceRepository;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|Logger
+     */
+    private $logger;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|Lead
+     */
+    private $trackedContact;
+
+    protected function setUp()
+    {
+        $this->leadModel            = $this->createMock(LeadModel::class);
+        $this->contactTracker       = $this->createMock(ContactTracker::class);
+        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+        $this->ipLookupHelper       = $this->createMock(IpLookupHelper::class);
+        $this->emailStatRepository  = $this->createMock(StatRepository::class);
+        $this->leadDeviceRepository = $this->createMock(LeadDeviceRepository::class);
+        $this->requestStack         = $this->createMock(RequestStack::class);
+        $this->logger               = $this->createMock(Logger::class);
+
+        $this->trackedContact = $this->createMock(Lead::class);
+        $this->trackedContact->method('getId')
+            ->willReturn(1);
+
+        $this->trackedContact->method('getIpAddresses')
+            ->willReturn(new ArrayCollection());
+
+        $this->contactTracker->method('getContact')
+            ->willReturn($this->trackedContact);
+
+        $this->ipLookupHelper->method('getIpAddress')
+            ->willReturn(new IpAddress());
+    }
+
+    public function testIdentifyContactByEmailStat()
+    {
+        $query = [
+            'ct' => [
+                'lead'    => 2,
+                'channel' => [
+                    'email' => 1,
+                ],
+                'stat'    => 'abc123',
+            ],
+        ];
+
+        $email = $this->createMock(Email::class);
+        $email->method('getId')
+            ->willReturn(1);
+
+        $lead = $this->createMock(Lead::class);
+        $lead->method('getId')
+            ->willReturn(2);
+        $lead->method('getIpAddresses')
+            ->willReturn(new ArrayCollection());
+
+        $stat = new Stat();
+        $stat->setEmail($email);
+        $stat->setLead($lead);
+
+        $this->emailStatRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['trackingHash' => 'abc123'])
+            ->willReturn($stat);
+
+        $this->leadModel->expects($this->once())
+            ->method('mergeLeads')
+            ->willReturn($lead);
+
+        $this->trackedContact->method('isAnonymous')
+            ->willReturn(true);
+
+        $helper = $this->getContactRequestHelper();
+        $this->assertEquals($lead->getId(), $helper->getContactFromQuery($query)->getId());
+    }
+
+    public function testEmailStatWithMisMatchingEmailIdDoesNotIdentifyContact()
+    {
+        $query = [
+            'ct' => [
+                'lead'    => 2,
+                'channel' => [
+                    'email' => 1,
+                ],
+                'stat'    => 'abc123',
+            ],
+        ];
+
+        $email = $this->createMock(Email::class);
+        $email->method('getId')
+            ->willReturn(2);
+
+        $stat = new Stat();
+        $stat->setEmail($email);
+
+        $this->emailStatRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['trackingHash' => 'abc123'])
+            ->willReturn($stat);
+
+        $this->leadModel->expects($this->never())
+            ->method('mergeLeads');
+
+        $this->leadModel->expects($this->once())
+            ->method('checkForDuplicateContact')
+            ->willReturn([$this->trackedContact, []]);
+
+        $helper = $this->getContactRequestHelper();
+        $this->assertEquals($this->trackedContact->getId(), $helper->getContactFromQuery($query)->getId());
+    }
+
+    public function testTrackedIdentifiedContactIsNotMergedIntoIdentifiedByEmailStat()
+    {
+        $query = [
+            'ct' => [
+                'lead'    => 2,
+                'channel' => [
+                    'email' => 1,
+                ],
+                'stat'    => 'abc123',
+            ],
+        ];
+
+        $email = $this->createMock(Email::class);
+        $email->method('getId')
+            ->willReturn(2);
+
+        $lead = $this->createMock(Lead::class);
+        $lead->method('getId')
+            ->willReturn(2);
+        $lead->method('getIpAddresses')
+            ->willReturn(new ArrayCollection());
+
+        $stat = new Stat();
+        $stat->setEmail($email);
+        $stat->setLead($lead);
+
+        $this->emailStatRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['trackingHash' => 'abc123'])
+            ->willReturn($stat);
+
+        $this->leadModel->expects($this->never())
+            ->method('mergeLeads');
+
+        $this->leadModel->expects($this->once())
+            ->method('checkForDuplicateContact')
+            ->willReturn([$lead, []]);
+
+        $helper = $this->getContactRequestHelper();
+        $this->assertEquals($lead->getId(), $helper->getContactFromQuery($query)->getId());
+    }
+
+    public function testLandingPageClickthroughIdentifiesLeadIfEnabled()
+    {
+        $this->coreParametersHelper->expects($this->once())
+            ->method('getParameter')
+            ->with('track_by_tracking_url')
+            ->willReturn(true);
+
+        $query = [
+            'ct' => [
+                'lead'    => 2,
+                'channel' => [
+                    'email' => 1,
+                ],
+                'stat'    => 'abc123',
+            ],
+        ];
+
+        $lead = $this->createMock(Lead::class);
+        $lead->method('getId')
+            ->willReturn(2);
+        $lead->method('getIpAddresses')
+            ->willReturn(new ArrayCollection());
+        $lead->expects($this->once())
+            ->method('getEmail')
+            ->willReturn('test@test.com');
+
+        $this->leadModel->expects($this->once())
+            ->method('getEntity')
+            ->with(2)
+            ->willReturn($lead);
+
+        $queryWithEmail          = $query;
+        $queryWithEmail['email'] = 'test@test.com';
+
+        $this->leadModel->expects($this->once())
+            ->method('checkForDuplicateContact')
+            ->with($queryWithEmail, $this->trackedContact, true, true)
+            ->willReturn([$lead, ['email' => 'test@test.com']]);
+
+        $helper = $this->getContactRequestHelper();
+        $this->assertEquals($lead->getId(), $helper->getContactFromQuery($query)->getId());
+    }
+
+    public function testLandingPageClickthroughDoesNotIdentifyLeadIfDisabled()
+    {
+        $this->coreParametersHelper->expects($this->at(0))
+            ->method('getParameter')
+            ->with('track_by_tracking_url')
+            ->willReturn(false);
+
+        $this->coreParametersHelper->expects($this->at(1))
+            ->method('getParameter')
+            ->with('track_by_fingerprint')
+            ->willReturn(false);
+
+        $query = [
+            'ct' => [
+                'lead'    => 2,
+                'channel' => [
+                    'email' => 1,
+                ],
+                'stat'    => 'abc123',
+            ],
+        ];
+
+        $this->leadModel->expects($this->never())
+            ->method('getEntity');
+
+        $this->leadModel->expects($this->once())
+            ->method('checkForDuplicateContact')
+            ->with($query, $this->trackedContact, true, true)
+            ->willReturn([$this->trackedContact, []]);
+
+        $helper = $this->getContactRequestHelper();
+        $this->assertEquals($this->trackedContact->getId(), $helper->getContactFromQuery($query)->getId());
+    }
+
+    public function testIdentifyContactByFingerprintIfEnabled()
+    {
+        $this->coreParametersHelper->expects($this->at(0))
+            ->method('getParameter')
+            ->with('track_by_tracking_url')
+            ->willReturn(false);
+
+        $this->coreParametersHelper->expects($this->at(1))
+            ->method('getParameter')
+            ->with('track_by_fingerprint')
+            ->willReturn(true);
+
+        $lead = $this->createMock(Lead::class);
+        $lead->method('getId')
+            ->willReturn(2);
+        $lead->method('getIpAddresses')
+            ->willReturn(new ArrayCollection());
+
+        $this->leadModel->expects($this->once())
+            ->method('getEntity')
+            ->with(2)
+            ->willReturn($lead);
+
+        $this->trackedContact->method('isAnonymous')
+            ->willReturn(true);
+
+        $query = [
+            'ct'          => [],
+            'fingerprint' => 'abc123',
+        ];
+
+        $this->leadDeviceRepository->expects($this->once())
+            ->method('getDeviceByFingerprint')
+            ->with('abc123')
+            ->willReturn(['lead_id' => 2]);
+
+        $this->leadModel->expects($this->once())
+            ->method('mergeLeads')
+            ->with($this->trackedContact, $lead, false)
+            ->willReturn($lead);
+
+        $this->leadModel->expects($this->once())
+            ->method('checkForDuplicateContact')
+            ->with($query, $lead, true, true)
+            ->willReturn([$this->trackedContact, []]);
+
+        $helper = $this->getContactRequestHelper();
+        $this->assertEquals($lead->getId(), $helper->getContactFromQuery($query)->getId());
+    }
+
+    public function testTrackedIdentifiedVisitorIsNotTrackedByFingerprint()
+    {
+        $this->coreParametersHelper->expects($this->at(0))
+            ->method('getParameter')
+            ->with('track_by_tracking_url')
+            ->willReturn(false);
+
+        $this->coreParametersHelper->expects($this->at(1))
+            ->method('getParameter')
+            ->with('track_by_fingerprint')
+            ->willReturn(true);
+
+        $this->leadModel->expects($this->never())
+            ->method('getEntity');
+
+        $this->trackedContact->method('isAnonymous')
+            ->willReturn(false);
+
+        $query = [
+            'ct'          => [],
+            'fingerprint' => 'abc123',
+        ];
+
+        $this->leadDeviceRepository->expects($this->never())
+            ->method('getDeviceByFingerprint');
+
+        $this->leadModel->expects($this->never())
+            ->method('mergeLeads');
+
+        $this->leadModel->expects($this->once())
+            ->method('checkForDuplicateContact')
+            ->with($query, $this->trackedContact, true, true)
+            ->willReturn([$this->trackedContact, []]);
+
+        $helper = $this->getContactRequestHelper();
+        $this->assertEquals($this->trackedContact->getId(), $helper->getContactFromQuery($query)->getId());
+    }
+
+    public function testFingerprintIsNotUsedToIdentifyLeadIfDisabled()
+    {
+        $this->coreParametersHelper->expects($this->at(0))
+            ->method('getParameter')
+            ->with('track_by_tracking_url')
+            ->willReturn(false);
+
+        $this->coreParametersHelper->expects($this->at(1))
+            ->method('getParameter')
+            ->with('track_by_fingerprint')
+            ->willReturn(false);
+
+        $this->leadModel->expects($this->never())
+            ->method('getEntity');
+
+        $this->trackedContact->method('isAnonymous')
+            ->willReturn(true);
+
+        $query = [
+            'ct'          => [],
+            'fingerprint' => 'abc123',
+        ];
+
+        $this->leadDeviceRepository->expects($this->never())
+            ->method('getDeviceByFingerprint');
+
+        $this->leadModel->expects($this->never())
+            ->method('mergeLeads');
+
+        $this->leadModel->expects($this->once())
+            ->method('checkForDuplicateContact')
+            ->with($query, $this->trackedContact, true, true)
+            ->willReturn([$this->trackedContact, []]);
+
+        $helper = $this->getContactRequestHelper();
+        $this->assertEquals($this->trackedContact, $helper->getContactFromQuery($query));
+    }
+
+    /**
+     * @return ContactRequestHelper
+     */
+    private function getContactRequestHelper()
+    {
+        return new ContactRequestHelper(
+            $this->leadModel,
+            $this->contactTracker,
+            $this->coreParametersHelper,
+            $this->ipLookupHelper,
+            $this->emailStatRepository,
+            $this->leadDeviceRepository,
+            $this->requestStack,
+            $this->logger
+        );
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceTest.php
@@ -293,7 +293,7 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
         $leadDeviceMock->expects($this->exactly(3))
             ->method('getLead')
             ->willReturn(new Lead());
-        $this->cookieHelperMock->expects($this->at(2))
+        $this->cookieHelperMock->expects($this->at(3))
             ->method('setCookie')
             ->with('mautic_device_id', $uniqueTrackingIdentifier, 31536000);
 
@@ -353,7 +353,7 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
             ->method('getLead')
             ->willReturn(new Lead());
 
-        $this->cookieHelperMock->expects($this->at(2))
+        $this->cookieHelperMock->expects($this->at(3))
             ->method('setCookie')
             ->with('mautic_device_id', $uniqueTrackingIdentifier, 31536000);
 

--- a/app/bundles/LeadBundle/Tests/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceTest.php
@@ -263,6 +263,7 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
             ->method('getCookie')
             ->with('mautic_device_id', null)
             ->willReturn($trackingId);
+
         $this->leadDeviceRepositoryMock->expects($this->at(0))
             ->method('getByTrackingId')
             ->with($trackingId)
@@ -292,7 +293,7 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
         $leadDeviceMock->expects($this->exactly(3))
             ->method('getLead')
             ->willReturn(new Lead());
-        $this->cookieHelperMock->expects($this->at(1))
+        $this->cookieHelperMock->expects($this->at(2))
             ->method('setCookie')
             ->with('mautic_device_id', $uniqueTrackingIdentifier, 31536000);
 
@@ -321,6 +322,7 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
             ->method('getCookie')
             ->with('mautic_device_id', null)
             ->willReturn(null);
+
         $requestMock->expects($this->at(0))
             ->method('get')
             ->with('mautic_device_id', null)
@@ -351,7 +353,7 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
             ->method('getLead')
             ->willReturn(new Lead());
 
-        $this->cookieHelperMock->expects($this->at(1))
+        $this->cookieHelperMock->expects($this->at(2))
             ->method('setCookie')
             ->with('mautic_device_id', $uniqueTrackingIdentifier, 31536000);
 

--- a/app/bundles/LeadBundle/Tracker/ContactTracker.php
+++ b/app/bundles/LeadBundle/Tracker/ContactTracker.php
@@ -321,7 +321,7 @@ class ContactTracker
             $lead->addIpAddress($ip);
         }
 
-        if ($persist) {
+        if ($persist && !defined('MAUTIC_NON_TRACKABLE_REQUEST')) {
             // Dispatch events for new lead to write create log, ip address change, etc
             $event = new LeadEvent($lead, true);
             $this->dispatcher->dispatch(LeadEvents::LEAD_PRE_SAVE, $event);

--- a/app/bundles/LeadBundle/Tracker/ContactTracker.php
+++ b/app/bundles/LeadBundle/Tracker/ContactTracker.php
@@ -178,17 +178,16 @@ class ContactTracker
 
         // If for whatever reason this contact has not been saved yet, don't generate tracking cookies
         if (!$trackedContact->getId()) {
-            return;
-        }
-
-        if (!$previouslyTrackedContact) {
-            // New lead, set the tracking cookie
-            $this->generateTrackingCookies();
+            // Delete existing cookies to prevent tracking as someone else
+            $this->deviceTracker->clearTrackingCookies();
 
             return;
         }
 
-        if ($previouslyTrackedContact->getId() != $this->trackedContact->getId()) {
+        // Generate cookies for the newly tracked contact
+        $this->generateTrackingCookies();
+
+        if ($previouslyTrackedContact && $previouslyTrackedContact->getId() != $this->trackedContact->getId()) {
             $this->dispatchContactChangeEvent($previouslyTrackedContact, $previouslyTrackedId);
         }
     }

--- a/app/bundles/LeadBundle/Tracker/DeviceTracker.php
+++ b/app/bundles/LeadBundle/Tracker/DeviceTracker.php
@@ -130,4 +130,9 @@ class DeviceTracker
     {
         return $this->deviceWasChanged;
     }
+
+    public function clearTrackingCookies()
+    {
+        $this->deviceTrackingService->clearTrackingCookies();
+    }
 }

--- a/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingService.php
+++ b/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingService.php
@@ -50,6 +50,11 @@ final class DeviceTrackingService implements DeviceTrackingServiceInterface
     private $request;
 
     /**
+     * @var LeadDevice
+     */
+    private $trackedDevice;
+
+    /**
      * DeviceTrackingService constructor.
      *
      * @param CookieHelper           $cookieHelper
@@ -85,6 +90,10 @@ final class DeviceTrackingService implements DeviceTrackingServiceInterface
      */
     public function getTrackedDevice()
     {
+        if ($this->trackedDevice) {
+            return $this->trackedDevice;
+        }
+
         $trackingId = $this->getTrackedIdentifier();
         if ($trackingId === null) {
             return null;
@@ -129,6 +138,9 @@ final class DeviceTrackingService implements DeviceTrackingServiceInterface
 
         $this->createTrackingCookies($device);
 
+        // Store the device in case a service uses this within the same session
+        $this->trackedDevice = $device;
+
         return $device;
     }
 
@@ -140,6 +152,12 @@ final class DeviceTrackingService implements DeviceTrackingServiceInterface
         if ($this->request === null) {
             return null;
         }
+
+        if ($this->trackedDevice) {
+            // Use the device tracked in case the cookies were just created
+            return $this->trackedDevice->getTrackingId();
+        }
+
         $deviceTrackingId = $this->cookieHelper->getCookie('mautic_device_id', null);
         if ($deviceTrackingId === null) {
             $deviceTrackingId = $this->request->get('mautic_device_id', null);

--- a/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingService.php
+++ b/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingService.php
@@ -166,6 +166,11 @@ final class DeviceTrackingService implements DeviceTrackingServiceInterface
      */
     private function createTrackingCookies(LeadDevice $device)
     {
+        // Delete old cookies
+        if ($deviceTrackingId = $this->getTrackedIdentifier()) {
+            $this->cookieHelper->deleteCookie($deviceTrackingId);
+        }
+
         // Device cookie
         $this->cookieHelper->setCookie('mautic_device_id', $device->getTrackingId(), 31536000);
 

--- a/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceInterface.php
+++ b/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceInterface.php
@@ -35,4 +35,6 @@ interface DeviceTrackingServiceInterface
      * @return LeadDevice
      */
     public function trackCurrentDevice(LeadDevice $device, $replaceExistingTracking = false);
+
+    public function clearTrackingCookies();
 }

--- a/app/bundles/PageBundle/Config/config.php
+++ b/app/bundles/PageBundle/Config/config.php
@@ -280,9 +280,6 @@ return [
                     'setCatInUrl' => [
                         '%mautic.cat_in_page_url%',
                     ],
-                    'setTrackByFingerprint' => [
-                        '%mautic.track_by_fingerprint%',
-                    ],
                 ],
             ],
             'mautic.page.model.redirect' => [
@@ -327,7 +324,7 @@ return [
         'google_analytics'      => false,
         'track_contact_by_ip'   => false,
         'track_by_fingerprint'  => false,
-        'track_by_tracking_url' => true,
+        'track_by_tracking_url' => false,
         'redirect_list_types'   => [
             '301' => 'mautic.page.form.redirecttype.permanent',
             '302' => 'mautic.page.form.redirecttype.temporary',

--- a/app/bundles/PageBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/ConfigSubscriber.php
@@ -60,7 +60,7 @@ class ConfigSubscriber extends CommonSubscriber
             // parameters defined this way because of the reason as above.
             'parameters' => [
                 'track_contact_by_ip'                   => false,
-                'track_by_tracking_url'                 => true,
+                'track_by_tracking_url'                 => false,
                 'track_by_fingerprint'                  => false,
                 'facebook_pixel_id'                     => null,
                 'facebook_pixel_trackingpage_enabled'   => false,


### PR DESCRIPTION
PR'ed this against the release branch: https://github.com/mautic/mautic/pull/5941

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This addresses several issues found with 2.13.0 beta around tracking contacts with email clickthroughs, dynamic web content, creating audit log entries for new visitors, lost feature to track by device fingerprint and recording created source records.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

A. This PR ensures that email clickthroughs generate tracking cookies based on the email stat than the value of `lead` stored in the clickthrough array and that a tracked identified contact is not merged with a clickthrough contact if different

1. Create a Mautic landing page or set up tracking through a 3rd party page
2. Create an email that links to the landing page
3. Send the email to two contacts
4. Visit the web page in a guest session or a different browser to ensure you are tracked as a visitor
5. view the developer console of the browser to see the cookies you are being tracked with
6. Open the email for one contact and copy the clickthrough URL 
7. Paste it the guest session/different browser and go to it
8. Check the cookies and they are still the visitor ID 
9. Check that the visitor was merged into the contact from the email (the first page hit should be in the sent email contact's timeline)
10. Now copy the clickthrough link from the second contact's email
11. Paste it and go to it in the guest session/separate browser
12. Note the cookies should have been updated to the contact from the second email
13. Check and note that the two identified contacts were merged

B. This PR fixed an issue where first time tracked visitors did not get a created audit log entry and the mtc_device_id and mtc_sid stored in local storage are null

1. Be sure you're working from a clean session in a guest session or different browser than logged into Mautic
2. Visit a page tracked by Mautic (landing page or tracking code)
3. Open the developer console and view the localStorage values 
4. Notice that mtc_id and mtc_device_id are null
5. Note the mtc_id and view the contact in Mautic. Notice that the created entry in the timeline will always be the current date/time because no entry was saved to the database (can verify by viewing the audit log and filtering object_id = the contact ID

C. 3rd party pages with dynamic web content embedded did not have a created by source logged in the lead event table

1. Create a dynamic web content per https://mautic.org/docs/en/dwc/index.html
2. Be sure you're working from a clean session in a guest session or different browser than logged into Mautic
3. Browse to the page with dynamic web content embedded
4. Look for the contact ID in the cookies
5. View the contact's timeline in Mautic
6. Note that there is no "created by source" entry

D. The feature to track by device fingerprint was lost

1. Enable "track by device fingerprint" in the Tracking Settings of Mautic's configuration
2. Be sure you're working from a clean session in a guest session or different browser than logged into Mautic
3. Browse to the page tracked by Mautic
4. Clear the browsers cache or delete all cookies and localStorage values
5. Refresh the page
7. Note that a new visitor will be created

#### Steps to test this PR:
A. This PR ensures that email clickthroughs generate tracking cookies based on the email stat than the value of `lead` stored in the clickthrough array and that a tracked identified contact is not merged with a clickthrough contact if different

1. Create a Mautic landing page or set up tracking through a 3rd party page
2. Create an email that links to the landing page
3. Send the email to two contacts
4. Visit the web page in a guest session or a different browser to ensure you are tracked as a visitor
5. view the developer console of the browser to see the cookies you are being tracked with
6. Open the email for one contact and copy the clickthrough URL 
7. Paste it the guest session/different browser and go to it
8. Check the cookies and they should be updated to the contact from the email
9. Check that the visitor was merged into the contact from the email (the first page hit should be in the sent email contact's timeline)
10. Now copy the clickthrough link from the second contact's email
11. Paste it and go to it in the guest session/separate browser
12. Note the cookies should have been updated to the contact from the second email
13. Check that the two identified contacts were _NOT_ merged

B. This PR fixed an issue where first time tracked visitors did not get a created audit log entry and the mtc_device_id and mtc_sid stored in local storage are null

1. Be sure you're working from a clean session in a guest session or different browser than logged into Mautic
2. Visit a page tracked by Mautic (landing page or tracking code)
3. Open the developer console and view the localStorage values 
4. Notice that mtc_id and mtc_device_id are populated
5. Note the mtc_id and view the contact in Mautic. Notice that the created entry in the timeline will have a fixed created entry (confirm by viewing the audit lot table in the database)

C. 3rd party pages with dynamic web content embedded did not have a created by source logged in the lead event table

1. Create a dynamic web content per https://mautic.org/docs/en/dwc/index.html
2. Be sure you're working from a clean session in a guest session or different browser than logged into Mautic
3. Browse to the page with dynamic web content embedded
4. Look for the contact ID in the cookies
5. View the contact's timeline in Mautic
6. Note that there is a "created by source" entry recorded as the URL

D. The feature to track by device fingerprint was lost

1. Enable "track by device fingerprint" in the Tracking Settings of Mautic's configuration
2. Be sure you're working from a clean session in a guest session or different browser than logged into Mautic
3. Browse to the page tracked by Mautic and note the visitor's ID stored in the cookies
4. Clear the browsers cache or delete all cookies and localStorage values
5. Refresh the page
7. Note that the same visitor is identified by the fingerprint (if it's a different contact, check your lead_devices table as you likely have other contacts with the same fingerprint since deving from a local environment. As long as the fingerprint matches, then it's a good test).