### PR TITLE
Fix lost files after form delete

### DIFF
--- a/app/bundles/FormBundle/Helper/FormUploader.php
+++ b/app/bundles/FormBundle/Helper/FormUploader.php
@@ -136,10 +136,20 @@ class FormUploader
         return $formUploadDir.DIRECTORY_SEPARATOR.$fieldId;
     }
 
+    /**
+     * @param Form $form
+     *
+     * @return string
+     *
+     * @throws \LogicException If formId is null
+     */
     private function getUploadDirOfForm(Form $form)
     {
         $formId    = $form->getId();
         $uploadDir = $this->coreParametersHelper->getParameter('form_upload_dir');
+        if ($formId === null) {
+            throw new \LogicException('FormID can\'t be null');
+        }
 
         return $uploadDir.DIRECTORY_SEPARATOR.$formId;
     }

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -613,8 +613,6 @@ class FormModel extends CommonFormModel
     public function deleteEntity($entity)
     {
         /* @var Form $entity */
-        parent::deleteEntity($entity);
-
         $this->deleteFormFiles($entity);
 
         if (!$entity->getId()) {
@@ -623,6 +621,7 @@ class FormModel extends CommonFormModel
             $schemaHelper->deleteTable('form_results_'.$entity->deletedId.'_'.$entity->getAlias());
             $schemaHelper->executeChanges();
         }
+        parent::deleteEntity($entity);
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? |N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | -
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If we had multiple forms with file upload and removed one, content of all others got removed. It was due to entity remove before content remove, so when we wanted remove content based on entity's ID it wasn't there anymore.

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Create 2 forms with file upload
2. Send something in both of them
3. Remove only one
4. You should still have data from other one
