### PR TITLE
Report fix -Campaign field is in groupBy but no in columns nor filters

### DIFF
--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentReportSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentReportSubscriberTest.php
@@ -212,7 +212,7 @@ class SegmentReportSubscriberTest extends \PHPUnit_Framework_TestCase
             ->with()
             ->willReturn('segment.membership');
 
-        $reportMock->expects($this->exactly(2))
+        $reportMock->expects($this->exactly(3))
             ->method('getColumns')
             ->with()
             ->willReturn([]);

--- a/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
@@ -279,8 +279,10 @@ class ReportGeneratorEvent extends AbstractReportEvent
 
         if ($this->hasColumn($cmpName)
             || $this->hasFilter($cmpName)
+            || $this->hasGroupByColumn($cmpName)
             || $this->hasColumn($cmpId)
             || $this->hasFilter($cmpId)
+            || $this->hasGroupByColumn($cmpId)
             || (!empty($options['order'][0]
                     && ($options['order'][0] === $cmpName
                         || $options['order'][0] === $cmpId)))) {
@@ -378,25 +380,15 @@ class ReportGeneratorEvent extends AbstractReportEvent
     /**
      * Check if the report has a specific column.
      *
-     * @param $column
+     * @param array|string $column
      *
      * @return bool
      */
     public function hasColumn($column)
     {
-        static $sorted;
-
-        if (null === $sorted) {
-            $columns = $this->getReport()->getColumns();
-
-            foreach ($columns as $field) {
-                $sorted[$field] = true;
-            }
-        }
-
         if (is_array($column)) {
             foreach ($column as $checkMe) {
-                if (isset($sorted[$checkMe])) {
+                if (in_array($checkMe, $this->getReport()->getColumns(), true)) {
                     return true;
                 }
             }
@@ -404,13 +396,13 @@ class ReportGeneratorEvent extends AbstractReportEvent
             return false;
         }
 
-        return isset($sorted[$column]);
+        return in_array($column, $this->getReport()->getColumns(), true);
     }
 
     /**
      * Check if the report has a specific filter.
      *
-     * @param $column
+     * @param array|string $column
      *
      * @return bool
      */
@@ -452,6 +444,18 @@ class ReportGeneratorEvent extends AbstractReportEvent
         }
 
         return false;
+    }
+
+    /**
+     * Check if the report has a specific column.
+     *
+     * @param string $column
+     *
+     * @return bool
+     */
+    private function hasGroupByColumn($column)
+    {
+        return in_array($column, $this->getReport()->getGroupBy(), true);
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | -
| Related user documentation PR URL | -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | -
| BC breaks? | -
| Deprecations? | -

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When building new report and adding Campaign Name and/or Campaign ID to "Group By" throws error 500 message for data types: Asset Downloads, Emails Sent, Form Submissions, and Page Hits.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Build a separate report for each of the following data types: Asset Downloads, Emails Sent, Form Submissions and Page Hits.
2. Add First Name, Last Name, and Contact Email for Columns.
3. Under Group By, add Campaign ID and Campaign Name.
4. Click save and close and Mautic will throw an error 500 message.

#### Steps to test this PR:
1. Checkout this PR
2. Open all reports you created and no error should occur.
3. Try several other report too - there is a small refactoring.

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 