### PR TITLE
Fix for visitors not having a date created timestamp

### DIFF
--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -298,6 +298,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
             ->addLifecycleEvent('checkDateIdentified', 'prePersist')
             ->addLifecycleEvent('checkAttributionDate', 'preUpdate')
             ->addLifecycleEvent('checkAttributionDate', 'prePersist')
+            ->addLifecycleEvent('checkDateAdded', 'prePersist')
             ->addIndex(['date_added'], 'lead_date_added')
             ->addIndex(['date_identified'], 'date_identified');
 
@@ -1591,6 +1592,16 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
         if ($this->wasAnonymous()) {
             $this->dateIdentified            = new \DateTime();
             $this->changes['dateIdentified'] = ['', $this->dateIdentified];
+        }
+    }
+
+    /**
+     * Set date added if not already set.
+     */
+    public function checkDateAdded()
+    {
+        if (null === $this->getDateAdded()) {
+            $this->setDateAdded(new \DateTime());
         }
     }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Visitors created by the tracking pixel since 2.13.0 does not have a date created timestamp until they are modified. This PR fixes that by using a Doctrine lifecycle callback so that one is always hydrated regardless of using the LeadModel's saveEntity or not. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup tracking on a 3rd party page and hit it up in a guest  browser session
2. Look at the leads table for the latest created contact and note that dateAdded is empty

#### Steps to test this PR:
1. Repeat in a clean guest browser session and this time dateAdded will be hydrated
