### PR TITLE
Fixed issue that caused points to be lost when merging contacts

### DIFF
--- a/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\LeadBundle\Tests\Model;
 
+use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\Test\MauticWebTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 
@@ -64,5 +65,63 @@ class LeadModelFunctionalTest extends MauticWebTestCase
         $this->assertNull($bob);
         $jane = $model->getEntity($janeId);
         $this->assertNull($jane);
+    }
+
+    public function testMergedContactsPointsAreAccurate()
+    {
+        $model = $this->container->get('mautic.lead.model.lead');
+        /** @var EntityManager $em */
+        $em   = $this->container->get('doctrine.orm.entity_manager');
+
+        // Startout Jane with 50 points
+        $jane = new Lead();
+        $jane->setFirstname('Jane')
+            ->setLastname('Smith')
+            ->setEmail('jane.smith@test.com')
+            ->setPoints(50);
+        $model->saveEntity($jane);
+        $em->clear(Lead::class);
+        $jane = $model->getEntity($jane->getId());
+        $this->assertEquals(50, $jane->getPoints());
+        $janeId = $jane->getId();
+
+        // Jane is currently a visitor on a different device with 3 points
+        $visitor = new Lead();
+        $visitor->setPoints(3);
+        $model->saveEntity($visitor);
+        $em->clear(Lead::class);
+        $visitor = $model->getEntity($visitor->getId());
+        $this->assertEquals(3, $visitor->getPoints());
+
+        // Jane submits a form or something that identifies her so the visitor should be merged into Jane giving her 53 points
+        $jane = $model->getEntity($janeId);
+        // Jane should start out with 50 points
+        $this->assertEquals(50, $jane->getPoints());
+        // Jane should come out of the merge as Jane
+        $jane = $model->mergeLeads($visitor, $jane, false);
+        $this->assertEquals($janeId, $jane->getId());
+        // Jane should now have 53 points
+        $this->assertEquals(53, $jane->getPoints());
+        $em->clear(Lead::class);
+        // Jane should still have 53 points
+        $jane = $model->getEntity($janeId);
+        $this->assertEquals(53, $jane->getPoints());
+
+        // Jane is on another device again and gets 3 points
+        $visitor2 = new Lead();
+        $visitor2->setPoints(3);
+        $model->saveEntity($visitor2);
+        $em->clear(Lead::class);
+        $visitor2 = $model->getEntity($visitor2->getId());
+        $this->assertEquals(3, $visitor2->getPoints());
+
+        // Jane again identifies herself, gets merged into the new visitor and so should now have a total of 56 points
+        $jane = $model->getEntity($janeId);
+        $jane = $model->mergeLeads($visitor2, $jane, false);
+        $this->assertEquals($janeId, $jane->getId());
+        $em->clear(Lead::class);
+        $jane = $model->getEntity($jane->getId());
+
+        $this->assertEquals(56, $jane->getPoints());
     }
 }


### PR DESCRIPTION

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When contacts are merged, the points of the victor were reset to those of the winner before points could be summed. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Edit a contact and set their points to 50
2. Edit a second contact and set their points to 100
3. On the details page of the second contact, click the action drop down -> Merge -> find the first contact and merge into it
4. Notice the resulting details page says 200. Refresh and now it's 100. Both are wrong as it should be 150. 

#### Steps to test this PR:
1. Repeat the process with two different contacts and the points should now be 150
2. Run the new unit test
