### PR TITLE
Fixed headers in contact CSV export

### DIFF
--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -800,25 +800,9 @@ class CommonController extends Controller implements MauticController
         $writer      = $type === 'xlsx' ? new XlsWriter('php://output') : new CsvWriter('php://output');
         $contentType = $type === 'xlsx' ? 'application/vnd.ms-excel' : 'text/csv';
         $filename    = strtolower($filename.'_'.((new \DateTime())->format($dateFormat)).'.'.$type);
-        if ($writer instanceof CsvWriter) {
-            $securedData = [];
-            foreach ($sourceIterator as $row) {
-                $securedRow = [];
-                foreach ($row as $cell) {
-                    if (in_array($cell[0], ['+', '-', '=', '@'])) {
-                        $securedCell = ' '.$cell;
-                    } else {
-                        $securedCell = $cell;
-                    }
-                    $securedRow[] = $securedCell;
-                }
-                $securedData[] = $securedRow;
-            }
-            $sourceIterator = new ArraySourceIterator($securedData);
-        }
         $handler     = Handler::create($sourceIterator, $writer);
 
-        return new StreamedResponse(function () use ($handler, $sourceIterator, $writer) {
+        return new StreamedResponse(function () use ($handler) {
             $handler->export();
         }, 200, ['Content-Type' => $contentType, 'Content-Disposition' => sprintf('attachment; filename=%s', $filename)]);
     }

--- a/app/bundles/CoreBundle/Helper/DataExporterHelper.php
+++ b/app/bundles/CoreBundle/Helper/DataExporterHelper.php
@@ -65,7 +65,7 @@ class DataExporterHelper
      *
      * @return array
      */
-    public function secureAgainstCsvInjection(array $row)
+    private function secureAgainstCsvInjection(array $row)
     {
         foreach ($row as $colNum => $colVal) {
             if ($colVal && in_array(str_split($colVal)[0], ['+', '-', '=', '@'])) {

--- a/app/bundles/CoreBundle/Helper/DataExporterHelper.php
+++ b/app/bundles/CoreBundle/Helper/DataExporterHelper.php
@@ -43,18 +43,36 @@ class DataExporterHelper
 
         if (is_callable($resultsCallback)) {
             foreach ($items as $item) {
-                $toExport[] = array_map(function ($itemEncode) {
+                $row = array_map(function ($itemEncode) {
                     return html_entity_decode($itemEncode, ENT_QUOTES);
                 }, $resultsCallback($item));
+
+                $toExport[] = $this->secureAgainstCsvInjection($row);
             }
         } else {
             foreach ($items as $item) {
-                $toExport[] = (array) $item;
+                $toExport[] = $this->secureAgainstCsvInjection((array) $item);
             }
         }
 
         $model->getRepository()->clear();
 
         return $toExport;
+    }
+
+    /**
+     * @param array $row
+     *
+     * @return array
+     */
+    public function secureAgainstCsvInjection(array $row)
+    {
+        foreach ($row as $colNum => $colVal) {
+            if ($colVal && in_array(str_split($colVal)[0], ['+', '-', '=', '@'])) {
+                $row[$colNum] = ' '.$colVal;
+            }
+        }
+
+        return $row;
     }
 }

--- a/app/bundles/CoreBundle/Helper/DataExporterHelper.php
+++ b/app/bundles/CoreBundle/Helper/DataExporterHelper.php
@@ -68,7 +68,7 @@ class DataExporterHelper
     private function secureAgainstCsvInjection(array $row)
     {
         foreach ($row as $colNum => $colVal) {
-            if ($colVal && in_array(str_split($colVal)[0], ['+', '-', '=', '@'])) {
+            if ($colVal && in_array(substr($colVal, 0, 1), ['+', '-', '=', '@'])) {
                 $row[$colNum] = ' '.$colVal;
             }
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

2.13.0 closed a CSV injection vulnerability in contact exports but in doing so caused the headers to be replaced with numbers. This PR fixes it. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to the contacts view, click the action dropdown -> Export
2. Look a the CSV file and notice the headers are 0,1,2,3...

#### Steps to test this PR:
1. Repeat and the headers are restored
2. Edit a contact profile and place a `=` in the front of a field  value (phone number, address, whatever)
3. Export again and notice that the CSV injection vulnerability is still closed due to the space inserted before the =.
