### PR TITLE
Fixed a regression bug with batch API endpoints for new contacts that led to duplicates

### DIFF
--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -1072,7 +1072,7 @@ class CommonApiController extends FOSRestController implements MauticController
                     $entity
                 );
             }
-        } elseif ($formResponse === $entity) {
+        } elseif (get_class($formResponse) === get_class($entity)) {
             // Success
             $entities[$key] = $formResponse;
         } elseif (is_array($formResponse) && isset($formResponse['code'], $formResponse['message'])) {

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -170,6 +170,11 @@ class CommonApiController extends FOSRestController implements MauticController
     protected $user;
 
     /**
+     * @var array
+     */
+    protected $entityRequestParameters = [];
+
+    /**
      * Delete a batch of entities.
      *
      * @return array|Response
@@ -1100,6 +1105,9 @@ class CommonApiController extends FOSRestController implements MauticController
             //get from request
             $parameters = $this->request->request->all();
         }
+
+        // Store the original parameters from the request so that callbacks can have access to them as needed
+        $this->entityRequestParameters = $parameters;
 
         //unset the ID in the parameters if set as this will cause the form to fail
         if (isset($parameters['id'])) {

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -588,8 +588,6 @@ class LeadApiController extends CommonApiController
      */
     protected function preSaveEntity(&$entity, $form, $parameters, $action = 'edit')
     {
-        $originalParams = $this->request->request->all();
-
         // Merge existing duplicate contact based on unique fields if exist
         $entity = $this->model->checkForDuplicateContact($parameters, $entity);
 
@@ -611,25 +609,25 @@ class LeadApiController extends CommonApiController
         }
 
         if (isset($originalParams['tags'])) {
-            $this->model->modifyTags($entity, $originalParams['tags'], null, false);
+            $this->model->modifyTags($entity, $this->entityRequestParameters['tags'], null, false);
         }
 
         //Since the request can be from 3rd party, check for an IP address if included
-        if (isset($originalParams['ipAddress'])) {
-            $ipAddress = $this->factory->getIpAddress($originalParams['ipAddress']);
+        if (isset($this->entityRequestParameters['ipAddress'])) {
+            $ipAddress = $this->get('mautic.helper.ip_lookup')->getIpAddress($this->entityRequestParameters['ipAddress']);
 
             if (!$entity->getIpAddresses()->contains($ipAddress)) {
                 $entity->addIpAddress($ipAddress);
             }
 
-            unset($originalParams['ipAddress']);
+            unset($this->entityRequestParameters['ipAddress']);
         }
 
         // Check for lastActive date
         if (isset($originalParams['lastActive'])) {
-            $lastActive = new DateTimeHelper($originalParams['lastActive']);
+            $lastActive = new DateTimeHelper($this->entityRequestParameters['lastActive']);
             $entity->setLastActive($lastActive->getDateTime());
-            unset($originalParams['lastActive']);
+            unset($this->entityRequestParameters['lastActive']);
         }
 
         if (!empty($parameters['doNotContact']) && is_array($parameters['doNotContact'])) {

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -591,7 +591,7 @@ class LeadApiController extends CommonApiController
         $originalParams = $this->request->request->all();
 
         // Merge existing duplicate contact based on unique fields if exist
-        $entity = $this->model->checkForDuplicateContact($originalParams, $entity);
+        $entity = $this->model->checkForDuplicateContact($parameters, $entity);
 
         if (isset($parameters['companies'])) {
             $this->model->modifyCompanies($entity, $parameters['companies']);

--- a/app/bundles/UserBundle/Controller/Api/UserApiController.php
+++ b/app/bundles/UserBundle/Controller/Api/UserApiController.php
@@ -133,7 +133,7 @@ class UserApiController extends CommonApiController
         return $this->processForm($entity, $parameters, $method);
     }
 
-    public function preSaveEntity(&$entity, $form, $parameters, $action = 'edit')
+    protected function preSaveEntity(&$entity, $form, $parameters, $action = 'edit')
     {
         switch ($action) {
             case 'new':


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

2.13.0 reintroduced the bug that caused duplicates with the /contacts/batch/new endpoints. This PR fixes that. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Post the following payload to api/contacts/batch/new
```
[
  {
    "email": "email1@email.com",
    "firstname": "BatchUpdate"
  },
  {
    "email": "email2@email.com",
    "firstname": "BatchUpdate2"
  },
  {
    "email": "email3@email.com",
    "firstname": "BatchUpdate3"
  }
]
```
2. Post it again and notice that the three contacts will be created again. 

#### Steps to test this PR:
1. Delete the contacts then repeat. This time the second post will update the contacts instead of creating new. 
