### PR TITLE
Phpstan Travis check for Config and DashboardBundles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
   - bin/phpunit -d memory_limit=2048M --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --fail-on-warning
 
   # Run PHPSTAN analysis for PHP 7+
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.6" ]]; then ~/.composer/vendor/phpstan/phpstan-shim/phpstan.phar analyse app/bundles/CampaignBundle app/bundles/WebhookBundle app/bundles/LeadBundle; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.6" ]]; then ~/.composer/vendor/phpstan/phpstan-shim/phpstan.phar analyse app/bundles/DashboardBundle app/bundles/CampaignBundle app/bundles/WebhookBundle app/bundles/LeadBundle; fi
 
   # Check if the code standards weren't broken.
   # Run it only on PHP 7.1 which should be the fastest. No need to run it for all PHP versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
   - bin/phpunit -d memory_limit=2048M --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --fail-on-warning
 
   # Run PHPSTAN analysis for PHP 7+
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.6" ]]; then ~/.composer/vendor/phpstan/phpstan-shim/phpstan.phar analyse app/bundles/DashboardBundle app/bundles/CampaignBundle app/bundles/WebhookBundle app/bundles/LeadBundle; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.6" ]]; then ~/.composer/vendor/phpstan/phpstan-shim/phpstan.phar analyse app/bundles/DashboardBundle app/bundles/ConfigBundle app/bundles/CampaignBundle app/bundles/WebhookBundle app/bundles/LeadBundle; fi
 
   # Check if the code standards weren't broken.
   # Run it only on PHP 7.1 which should be the fastest. No need to run it for all PHP versions

--- a/app/bundles/ConfigBundle/Controller/SysinfoController.php
+++ b/app/bundles/ConfigBundle/Controller/SysinfoController.php
@@ -12,6 +12,7 @@
 namespace Mautic\ConfigBundle\Controller;
 
 use Mautic\CoreBundle\Controller\FormController;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
  * Class SysinfoController.

--- a/app/bundles/ConfigBundle/Event/ConfigBuilderEvent.php
+++ b/app/bundles/ConfigBundle/Event/ConfigBuilderEvent.php
@@ -116,37 +116,6 @@ class ConfigBuilderEvent extends Event
     }
 
     /**
-     * Helper method can load $parameters array from a config file.
-     *
-     * @param string $path (relative from the root dir)
-     *
-     * @return array
-     */
-    public function getParameters($path = null)
-    {
-        $paramsFile = $this->pathsHelper->getSystemPath('app').$path;
-
-        if (file_exists($paramsFile)) {
-            // Import the bundle configuration, $parameters is defined in this file
-            include $paramsFile;
-        }
-
-        if (!isset($parameters)) {
-            $parameters = [];
-        }
-
-        $fields     = $this->getBase64EncodedFields();
-        $checkThese = array_intersect(array_keys($parameters), $fields);
-        foreach ($checkThese as $checkMe) {
-            if (!empty($parameters[$checkMe])) {
-                $parameters[$checkMe] = base64_decode($parameters[$checkMe]);
-            }
-        }
-
-        return $parameters;
-    }
-
-    /**
      * @param $bundle
      *
      * @return array

--- a/app/bundles/ConfigBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ConfigBundle/Form/Type/ConfigType.php
@@ -62,7 +62,7 @@ class ConfigType extends AbstractType
 
         $builder->addEventListener(
             FormEvents::PRE_SET_DATA,
-            function (FormEvent $event) use ($options) {
+            function (FormEvent $event) {
                 $form = $event->getForm();
 
                 foreach ($form as $config => $configForm) {

--- a/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
+++ b/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
@@ -80,12 +80,12 @@ class WidgetApiController extends CommonApiController
             'dateFormat' => InputHelper::clean($this->request->get('dateFormat', null)),
             'dateFrom'   => $fromDate,
             'dateTo'     => $toDate,
-            'limit'      => InputHelper::int($this->request->get('limit', null)),
+            'limit'      => (int) $this->request->get('limit', null),
             'filter'     => $this->request->get('filter', []),
         ];
 
-        $cacheTimeout = InputHelper::int($this->request->get('cacheTimeout', null));
-        $widgetHeight = InputHelper::int($this->request->get('height', 300));
+        $cacheTimeout = (int) $this->request->get('cacheTimeout', null);
+        $widgetHeight = (int) $this->request->get('height', 300);
 
         $widget = new Widget();
         $widget->setParams($params);

--- a/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
@@ -254,7 +254,7 @@ class WidgetDetailEvent extends CommonEvent
     /**
      * Get the Translator object.
      *
-     * @return Translator $translator
+     * @return TranslatorInterface
      */
     public function getTranslator()
     {

--- a/app/bundles/DashboardBundle/Form/Type/WidgetType.php
+++ b/app/bundles/DashboardBundle/Form/Type/WidgetType.php
@@ -94,10 +94,8 @@ class WidgetType extends AbstractType
             'required'   => false,
         ]);
 
-        $ff = $builder->getFormFactory();
-
         // function to add a form for specific widget type dynamically
-        $func = function (FormEvent $e) use ($ff, $dispatcher) {
+        $func = function (FormEvent $e) use ($dispatcher) {
             $data   = $e->getData();
             $form   = $e->getForm();
             $event  = new WidgetFormEvent();

--- a/app/bundles/DashboardBundle/Form/Type/WidgetType.php
+++ b/app/bundles/DashboardBundle/Form/Type/WidgetType.php
@@ -57,7 +57,6 @@ class WidgetType extends AbstractType
             'label'       => 'mautic.dashboard.widget.form.type',
             'choices'     => $event->getTypes(),
             'label_attr'  => ['class' => 'control-label'],
-            'attr'        => ['class' => 'form-control'],
             'empty_value' => 'mautic.core.select',
             'attr'        => [
                 'class'    => 'form-control',


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Automated tests included? | PHPSTAN
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | Hope not
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Adding `ConfigBundle` and `DashboardBundle` to be checked by PHPSTAN together with fixed issues PHPSTAN reported.

#### Steps to test this PR:
1. Make sure Travis checks are passing.
2. Do a code review.


#### List backwards compatibility breaks:
1. `ConfigBuilderEvent::getParameters()` method is removed because it contained call of undefined method (`$this->getBase64EncodedFields()`) over a year which would cause PHP error and nobody noticed. I could not find any place where that getParameters was used. I think it's save to remove this unused method for these reasons.