### PR TITLE
change the way tags are define for SMS Transport, no need for duplica…

### DIFF
--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/SmsTransportPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/SmsTransportPass.php
@@ -16,8 +16,19 @@ use Symfony\Component\DependencyInjection\Compiler\RepeatedPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
+/**
+ * Class SmsTransportPass.
+ */
 class SmsTransportPass implements CompilerPassInterface, RepeatablePassInterface
 {
+    /**
+     * @var RepeatedPass
+     */
+    private $repeatedPass;
+
+    /**
+     * @param ContainerBuilder $container
+     */
     public function process(ContainerBuilder $container)
     {
         if (!$container->has('mautic.sms.transport_chain')) {
@@ -41,6 +52,9 @@ class SmsTransportPass implements CompilerPassInterface, RepeatablePassInterface
         }
     }
 
+    /**
+     * @param RepeatedPass $repeatedPass
+     */
     public function setRepeatedPass(RepeatedPass $repeatedPass)
     {
         $this->repeatedPass = $repeatedPass;

--- a/app/bundles/SmsBundle/Config/config.php
+++ b/app/bundles/SmsBundle/Config/config.php
@@ -112,9 +112,7 @@ return [
                     'monolog.logger.mautic',
                 ],
                 'alias' => 'mautic.sms.transport.twilio',
-                'tags'  => [
-                    'name' => 'mautic.sms_transport', 'Twilio',
-                ],
+                'tag'   => 'mautic.sms_transport',
             ],
         ],
         'models' => [


### PR DESCRIPTION
This is minor change for SMS Transport PR
https://github.com/mautic-internal/mautic-internal/issues/79

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | Y
| Related user documentation PR URL |  https://github.com/mautic/developer-documentation/pull/100
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/100
| Issues addressed (#s or URLs) | 
| BC breaks? | no
| Deprecations? | Deprecates previous PR as tags definition is changed

Please look at: https://github.com/mautic-internal/mautic-internal/issues/79