### PR TITLE
Close button in segments redirect to view controller

### DIFF
--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -424,15 +424,14 @@ class ListController extends FormController
      */
     private function getPostActionVars($objectId = null)
     {
-        //set the page we came from
-        $page = $this->get('session')->get('mautic.segment.page', 1);
-
         //set the return URL
         if ($objectId != null) {
             $returnUrl       = $this->generateUrl('mautic_segment_action', ['objectAction' => 'view', 'objectId'=> $objectId]);
             $viewParameters  = ['objectAction' => 'view', 'objectId'=> $objectId];
             $contentTemplate = 'MauticLeadBundle:List:view';
         } else {
+            //set the page we came from
+            $page            = $this->get('session')->get('mautic.segment.page', 1);
             $returnUrl       = $this->generateUrl('mautic_segment_index', ['page' => $page]);
             $viewParameters  = ['page' => $page];
             $contentTemplate = 'MauticLeadBundle:List:index';

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -425,7 +425,7 @@ class ListController extends FormController
     private function getPostActionVars($objectId = null)
     {
         //set the return URL
-        if ($objectId != null) {
+        if ($objectId) {
             $returnUrl       = $this->generateUrl('mautic_segment_action', ['objectAction' => 'view', 'objectId'=> $objectId]);
             $viewParameters  = ['objectAction' => 'view', 'objectId'=> $objectId];
             $contentTemplate = 'MauticLeadBundle:List:view';

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -268,7 +268,7 @@ class ListController extends FormController
      */
     public function editAction($objectId, $ignorePost = false)
     {
-        $postActionVars = $this->getPostActionVars();
+        $postActionVars = $this->getPostActionVars($objectId);
 
         try {
             $segment = $this->getSegment($objectId);
@@ -418,20 +418,30 @@ class ListController extends FormController
     /**
      * Get variables for POST action.
      *
+     * @param null $objectId
+     *
      * @return array
      */
-    private function getPostActionVars()
+    private function getPostActionVars($objectId = null)
     {
         //set the page we came from
         $page = $this->get('session')->get('mautic.segment.page', 1);
 
         //set the return URL
-        $returnUrl = $this->generateUrl('mautic_segment_index', ['page' => $page]);
+        if ($objectId != null) {
+            $returnUrl       = $this->generateUrl('mautic_segment_action', ['objectAction' => 'view', 'objectId'=> $objectId]);
+            $viewParameters  = ['objectAction' => 'view', 'objectId'=> $objectId];
+            $contentTemplate = 'MauticLeadBundle:List:view';
+        } else {
+            $returnUrl       = $this->generateUrl('mautic_segment_index', ['page' => $page]);
+            $viewParameters  = ['page' => $page];
+            $contentTemplate = 'MauticLeadBundle:List:index';
+        }
 
         return [
             'returnUrl'       => $returnUrl,
-            'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticLeadBundle:List:index',
+            'viewParameters'  => $viewParameters,
+            'contentTemplate' => $contentTemplate,
             'passthroughVars' => [
                 'activeLink'    => '#mautic_segment_index',
                 'mauticContent' => 'leadlist',


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Just improve close behavior in segments.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Edit segment
2.  Save and close  
3. Close redirect to  list view of all segments, not to detail view expect
4. Edit segment and
5. Close
6. Close redirect to  list view of all segments, not to detail view as we expect

#### Steps to test this PR:
1.  Repeat all steps
2.  See if close button redirect to detail view in both cases