### PR TITLE
Multiselect - clearing all values on Company form fixed

### DIFF
--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -351,24 +351,12 @@ class CompanyController extends FormController
                     $data = $this->request->request->get('company');
                     //pull the data from the form in order to apply the form's formatting
                     foreach ($form as $f) {
-                        $name = $f->getName();
-                        if (strpos($name, 'field_') === 0) {
-                            $data[$name] = $f->getData();
-                        }
+                        $data[$f->getName()] = $f->getData();
                     }
+
                     $model->setFieldValues($entity, $data, true);
+
                     //form is valid so process the data
-                    $data = $this->request->request->get('company');
-
-                    //pull the data from the form in order to apply the form's formatting
-                    foreach ($form as $f) {
-                        $name = $f->getName();
-                        if (strpos($name, 'field_') === 0) {
-                            $data[$name] = $f->getData();
-                        }
-                    }
-
-                    $model->setFieldValues($entity, $data, true);
                     $model->saveEntity($entity, $form->get('buttons')->get('save')->isClicked());
 
                     $this->addFlash(


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Company form was ignoring fields that were not in the POST request when saving the form. This caused a bug when removing all values from a multiselect field and saving the form. The value couldn't be deleted.

_Fun Fact: HTML forms does not add multiselect fields to the POST request for some reason. So we have to find how all fields the form should have and then map all values to those fields._

When looking at the code I noticed several rows were duplicated. So I removed those. The bug is fixed by removing the `if (strpos($name, 'field_') === 0) {` condition. I can't think of any reason it was there. If it's removed then the empty multiselect is added to the form and then this field can clear its values.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Add a multiple select field to company object
2. Go into a company record and add a value from the field, save and close
3. Go back in and delete the value, save and close
4. Go back in and see the value remains

_note: this only occurs when all values are removed from the multiple select. If you have 3 values and remove 1, the remaining 2 are saved correctly. If you have 1 value and remove it, then this issue occurs._

#### Steps to test this PR:
1. Repeat the steps.
2. The multiselect field can be cleared out.
