### PR TITLE
[Bug] Email from override

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -342,18 +342,26 @@ class MailHelper
 
         // Set from email
         $ownerSignature = false;
+
         if (!$isQueueFlush) {
-            if ($useOwnerAsMailer) {
-                if ($owner = $this->getContactOwner($this->lead)) {
-                    $this->setFrom($owner['email'], $owner['first_name'].' '.$owner['last_name'], null);
-                    $ownerSignature = $this->getContactOwnerSignature($owner);
-                } else {
-                    $this->setFrom($this->from, null, null);
-                }
-            } elseif (!$from = $this->message->getFrom()) {
-                $this->setFrom($this->from, null, null);
+            $emailFrom = $this->message->getFrom();
+            if (!empty($emailFrom)) {
+                $this->setFrom($emailFrom, null, null);
             }
-        } // from is set in flushQueue
+            else {
+                if ($useOwnerAsMailer) {
+                    if ($owner = $this->getContactOwner($this->lead)) {
+                        $this->setFrom($owner['email'], $owner['first_name'].' '.$owner['last_name'], null);
+                        $ownerSignature = $this->getContactOwnerSignature($owner);
+                    } else {
+                        $this->setFrom($this->from, null, true);
+                    }
+                }
+                else {
+                    $this->setFrom($this->from, null, true);
+                }
+            }
+        }
 
         // Set system return path if applicable
         if (!$isQueueFlush && ($bounceEmail = $this->generateBounceEmail())) {
@@ -611,10 +619,15 @@ class MailHelper
 
                 $this->errors = [];
 
-                if (!$this->useGlobalFrom && $useOwnerAsMailer && 'default' !== $fromKey) {
+                $mailFrom = $this->message->getFrom();
+
+                if (!empty($mailFrom)) {
+                    $this->setFrom($mailFrom, null, null);
+                }
+                elseif ($useOwnerAsMailer) {
                     $this->setFrom($metadatum['from']['email'], $metadatum['from']['first_name'].' '.$metadatum['from']['last_name'], null);
                 } else {
-                    $this->setFrom($this->from, null, null);
+                    $this->setFrom($this->from, null, true);
                 }
 
                 foreach ($metadatum['contacts'] as $email => $contact) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y |
| New feature? | 
| Automated tests included? | Y |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | [#4170](https://github.com/mautic/mautic/issues/4170), [Forum Post 104243](https://www.mautic.org/topic/customised-sender-email-address/#post-104243)
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: From addresses set on custom emails are ignored if "Mailer Is Owner" flag is set in configuration setting. The custom email from is a more defined setting and should be used over configuration setting if available. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Set "Mailer is owner" flag to true (On) in Configuration -> Email
2. Set from address on custom email attached to campaign
3. Trigger campaign to send out email
4. Email from address is populated with owner email instead of the defined custom email

#### Steps to test this PR:
1. Set "Mailer is owner" flag to true (On) in Configuration -> Email
2. Set from address on custom email attached to campaign
3. Trigger campaign to send out email
4. Email from address uses defined custom from address if available
5. If custom from address is not populated, use owner email if available, else use system default.

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 