### PR TITLE
Fix lead persist in form submission

### DIFF
--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -362,16 +362,14 @@ class SubmissionModel extends CommonFormModel
         $this->validateActionCallbacks($submissionEvent, $validationErrors, $alias);
 
         // Create/update lead
-        $lead = null;
         if (!empty($leadFieldMatches)) {
             $this->createLeadFromSubmit($form, $leadFieldMatches, $leadFields);
         }
 
         // Get updated lead if applicable with tracking ID
-        /** @var Lead $lead */
-        $lead          = $this->leadModel->getCurrentLead();
         $trackedDevice = $this->deviceTrackingService->getTrackedDevice();
         $trackingId    = ($trackedDevice === null ? null : $trackedDevice->getTrackingId());
+        $lead          = ($trackedDevice === null ? null : $trackedDevice->getLead());
         //set tracking ID for stats purposes to determine unique hits
         $submission->setTrackingId($trackingId)
             ->setLead($lead);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? |N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Required: )
#### Description:
When Lead is created at form submission, application try to persist Submission with linked Lead. Submission is not setup to persist Lead so there is problem.

I switched it so now Lead is provided from device tracking service and should be persisted somewhere else.