### PR TITLE
Prevent `.1` from appending to theme filepath resulting in inability to download

### DIFF
--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -137,7 +137,7 @@ class ThemeHelper
      */
     private function getDirectoryName($newName)
     {
-        return InputHelper::filename($newName, true);
+        return InputHelper::filename($newName);
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
2.13.1 introduced a change that resulted in an inability to download themes. This PR fixes it. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to Themes -> click the dropdown action for any theme -> Download
2. Notice the alert that the theme could not be found

#### Steps to test this PR:
1. Repeat and the theme will download
