### PR TITLE
Fixed a bug when combining AB testing and Translations

### DIFF
--- a/app/bundles/EmailBundle/Helper/AbTestHelper.php
+++ b/app/bundles/EmailBundle/Helper/AbTestHelper.php
@@ -139,6 +139,9 @@ class AbTestHelper
 
                 $parentId = $parent->getId();
                 foreach ($clickthroughCounts as $id => $count) {
+                    if ($id !== $parentId && !array_key_exists($id, $children)) {
+                        continue;
+                    }
                     if (!isset($sentCounts[$id])) {
                         $sentCounts[$id] = 0;
                     }

--- a/app/bundles/EmailBundle/Helper/AbTestHelper.php
+++ b/app/bundles/EmailBundle/Helper/AbTestHelper.php
@@ -43,6 +43,9 @@ class AbTestHelper
 
                 $parentId = $parent->getId();
                 foreach ($counts as $id => $stats) {
+                    if ($id !== $parentId && !array_key_exists($id, $children)) {
+                        continue;
+                    }
                     $name = ($parentId === $id) ? $parent->getName()
                         : $children[$id]->getName();
                     $support['labels'][]                                            = $name.' ('.$stats['readRate'].'%)';


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #6012 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

$counts consists of all variations (including translations) of an email
$children only has the AB test variations.
Maybe this can be done a lot cleaner, but like this it works, without creating possible other bugs

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make a new email
2. Create a translation for this email
3. Create an AB test for this email (using read rate as win condition)
4. Save and close everything
5. Try to open the origin email in the email view (it doesn't work, there will also be a log in the errors about calling getName on an object which is null)

#### Steps to test this PR:
1. Try to reproduce the bug
2. Notice it works now

#### List deprecations along with the new alternative:
1. None

#### List backwards compatibility breaks:
1. None