### PR TITLE
Inject new custom content hooks below graphs

### DIFF
--- a/app/bundles/AssetBundle/Views/Asset/details.html.php
+++ b/app/bundles/AssetBundle/Views/Asset/details.html.php
@@ -151,7 +151,7 @@ $view['slots']->set(
             <!--/ stats -->
         </div>
 
-        <?php echo $view['content']->getCustomContent('asset.stats.graph', $mauticTemplateVars); ?>
+        <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); ?>
 
         <!-- start: tab-content -->
         <div class="tab-content pa-md preview-detail">

--- a/app/bundles/AssetBundle/Views/Asset/details.html.php
+++ b/app/bundles/AssetBundle/Views/Asset/details.html.php
@@ -151,6 +151,8 @@ $view['slots']->set(
             <!--/ stats -->
         </div>
 
+        <?php echo $view['content']->getCustomContent('asset.stats.graph', $mauticTemplateVars); ?>
+
         <!-- start: tab-content -->
         <div class="tab-content pa-md preview-detail">
             <?php echo $view->render(

--- a/app/bundles/CampaignBundle/Views/Campaign/details.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/details.html.php
@@ -153,6 +153,8 @@ switch (true) {
             </div>
             <!--/ stats -->
 
+            <?php echo $view['content']->getCustomContent('campaign.stats.graph', $mauticTemplateVars); ?>
+
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">
                 <?php if ($preview): ?>

--- a/app/bundles/CampaignBundle/Views/Campaign/details.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/details.html.php
@@ -153,7 +153,7 @@ switch (true) {
             </div>
             <!--/ stats -->
 
-            <?php echo $view['content']->getCustomContent('campaign.stats.graph', $mauticTemplateVars); ?>
+            <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); ?>
 
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/ChannelBundle/Views/Message/details.html.php
+++ b/app/bundles/ChannelBundle/Views/Message/details.html.php
@@ -92,7 +92,7 @@ $view['slots']->set(
                 </div>
                 <!--/ stats -->
 
-                <?php echo $view['content']->getCustomContent('channel.stats.graph', $mauticTemplateVars); ?>
+                <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); ?>
 
                 <!-- tabs controls -->
                 <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/ChannelBundle/Views/Message/details.html.php
+++ b/app/bundles/ChannelBundle/Views/Message/details.html.php
@@ -92,6 +92,8 @@ $view['slots']->set(
                 </div>
                 <!--/ stats -->
 
+                <?php echo $view['content']->getCustomContent('channel.stats.graph', $mauticTemplateVars); ?>
+
                 <!-- tabs controls -->
                 <ul class="nav nav-tabs pr-md pl-md">
                     <?php $active = 'active'; ?>

--- a/app/bundles/DynamicContentBundle/Views/DynamicContent/details.html.php
+++ b/app/bundles/DynamicContentBundle/Views/DynamicContent/details.html.php
@@ -170,6 +170,8 @@ if (!$isEmbedded) {
             </div>
             <!--/ stats -->
 
+            <?php echo $view['content']->getCustomContent('dynamiccontent.stats.graph', $mauticTemplateVars); ?>
+
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">
                 <li class="active">

--- a/app/bundles/DynamicContentBundle/Views/DynamicContent/details.html.php
+++ b/app/bundles/DynamicContentBundle/Views/DynamicContent/details.html.php
@@ -170,7 +170,7 @@ if (!$isEmbedded) {
             </div>
             <!--/ stats -->
 
-            <?php echo $view['content']->getCustomContent('dynamiccontent.stats.graph', $mauticTemplateVars); ?>
+            <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); ?>
 
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -226,6 +226,8 @@ if (!$isEmbedded) {
                 ]
             ); ?>
 
+            <?php echo $view['content']->getCustomContent('email.stats.graph', $mauticTemplateVars); ?>
+
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">
                 <li class="active">

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -226,7 +226,7 @@ if (!$isEmbedded) {
                 ]
             ); ?>
 
-            <?php echo $view['content']->getCustomContent('email.stats.graph', $mauticTemplateVars); ?>
+            <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); ?>
 
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/FormBundle/Views/Form/details.html.php
+++ b/app/bundles/FormBundle/Views/Form/details.html.php
@@ -152,6 +152,8 @@ $showActions = count($activeFormActions);
             </div>
             <!--/ stats -->
 
+            <?php echo $view['content']->getCustomContent('form.stats.graph', $mauticTemplateVars); ?>
+
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">
                 <?php if ($showActions): ?>

--- a/app/bundles/FormBundle/Views/Form/details.html.php
+++ b/app/bundles/FormBundle/Views/Form/details.html.php
@@ -152,7 +152,7 @@ $showActions = count($activeFormActions);
             </div>
             <!--/ stats -->
 
-            <?php echo $view['content']->getCustomContent('form.stats.graph', $mauticTemplateVars); ?>
+            <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); ?>
 
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/LeadBundle/Views/List/details.html.php
+++ b/app/bundles/LeadBundle/Views/List/details.html.php
@@ -126,7 +126,7 @@ $view['slots']->set(
                 </div>
             </div>
 
-            <?php echo $view['content']->getCustomContent('segment.stats.graph', $mauticTemplateVars); ?>
+            <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); ?>
 
             <!-- tabs controls -->
             <!-- search bar-->

--- a/app/bundles/LeadBundle/Views/List/details.html.php
+++ b/app/bundles/LeadBundle/Views/List/details.html.php
@@ -125,6 +125,9 @@ $view['slots']->set(
                     </div>
                 </div>
             </div>
+
+            <?php echo $view['content']->getCustomContent('segment.stats.graph', $mauticTemplateVars); ?>
+
             <!-- tabs controls -->
             <!-- search bar-->
             <form method="post" action="<?php echo $view['router']->path('mautic_segment_contacts', ['objectId' => $list->getId()]); ?>" class="panel" id="segment-contact-filters">

--- a/app/bundles/PageBundle/Views/Page/details.html.php
+++ b/app/bundles/PageBundle/Views/Page/details.html.php
@@ -171,6 +171,8 @@ $view['slots']->set(
             </div>
             <!--/ stats -->
 
+            <?php echo $view['content']->getCustomContent('page.stats.graph', $mauticTemplateVars); ?>
+
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">
                 <?php if ($showVariants): ?>

--- a/app/bundles/PageBundle/Views/Page/details.html.php
+++ b/app/bundles/PageBundle/Views/Page/details.html.php
@@ -171,7 +171,7 @@ $view['slots']->set(
             </div>
             <!--/ stats -->
 
-            <?php echo $view['content']->getCustomContent('page.stats.graph', $mauticTemplateVars); ?>
+            <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); ?>
 
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/SmsBundle/Views/Sms/details.html.php
+++ b/app/bundles/SmsBundle/Views/Sms/details.html.php
@@ -121,7 +121,7 @@ if (!$isEmbedded) {
             </div>
             <!--/ stats -->
 
-            <?php echo $view['content']->getCustomContent('sms.stats.graph', $mauticTemplateVars); ?>
+            <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); ?>
 
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/SmsBundle/Views/Sms/details.html.php
+++ b/app/bundles/SmsBundle/Views/Sms/details.html.php
@@ -121,6 +121,8 @@ if (!$isEmbedded) {
             </div>
             <!--/ stats -->
 
+            <?php echo $view['content']->getCustomContent('sms.stats.graph', $mauticTemplateVars); ?>
+
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">
                 <li class="active">

--- a/plugins/MauticFocusBundle/Views/Focus/details.html.php
+++ b/plugins/MauticFocusBundle/Views/Focus/details.html.php
@@ -116,6 +116,7 @@ $view['slots']->set(
             </div>
             <!--/ stats -->
 
+            <?php echo $view['content']->getCustomContent('focus.stats.graph', $mauticTemplateVars); ?>
 
             <!-- tabs controls -->
             <?php if (!empty($trackables)): ?>

--- a/plugins/MauticFocusBundle/Views/Focus/details.html.php
+++ b/plugins/MauticFocusBundle/Views/Focus/details.html.php
@@ -116,7 +116,7 @@ $view['slots']->set(
             </div>
             <!--/ stats -->
 
-            <?php echo $view['content']->getCustomContent('focus.stats.graph', $mauticTemplateVars); ?>
+            <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); ?>
 
             <!-- tabs controls -->
             <?php if (!empty($trackables)): ?>

--- a/plugins/MauticSocialBundle/Views/Monitoring/details.html.php
+++ b/plugins/MauticSocialBundle/Views/Monitoring/details.html.php
@@ -86,6 +86,8 @@ echo $view['assets']->includeScript('plugins/MauticSocialBundle/Assets/js/social
             </div>
             <!--/ stats -->
 
+            <?php echo $view['content']->getCustomContent('campaign.stats.graph', $mauticTemplateVars); ?>
+
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">
                 <li class="active">

--- a/plugins/MauticSocialBundle/Views/Monitoring/details.html.php
+++ b/plugins/MauticSocialBundle/Views/Monitoring/details.html.php
@@ -86,7 +86,7 @@ echo $view['assets']->includeScript('plugins/MauticSocialBundle/Assets/js/social
             </div>
             <!--/ stats -->
 
-            <?php echo $view['content']->getCustomContent('campaign.stats.graph', $mauticTemplateVars); ?>
+            <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); ?>
 
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Based on @alanhartless  comment (https://github.com/mautic/mautic/pull/5288) and my current plugin I required new custom content below graph in details.html.php 
This PR allow added own graph, statistics or any content to all Mautic channels like email, sms etc..



#### Steps to test this PR:
1.  Create listener based on https://github.com/mautic/mautic/pull/5288#issuecomment-380266254
2. Test If content from context are displayed on the related place, below the email stats in details for example
