### PR TITLE
Dispatch event before Report's query execution for plugins to alter query

### DIFF
--- a/app/bundles/ReportBundle/Event/ReportGraphEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportGraphEvent.php
@@ -124,4 +124,12 @@ class ReportGraphEvent extends AbstractReportEvent
     {
         return $this->queryBuilder;
     }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     */
+    public function setQueryBuilder(QueryBuilder $queryBuilder)
+    {
+        $this->queryBuilder = $queryBuilder;
+    }
 }

--- a/app/bundles/ReportBundle/Event/ReportGraphEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportGraphEvent.php
@@ -57,7 +57,7 @@ class ReportGraphEvent extends AbstractReportEvent
      * Set the graph array.
      *
      * @param string $graph
-     * @param array  $data  prepared for this chart
+     * @param array  $data prepared for this chart
      */
     public function setGraph($graph, $data)
     {

--- a/app/bundles/ReportBundle/Event/ReportGraphEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportGraphEvent.php
@@ -57,7 +57,7 @@ class ReportGraphEvent extends AbstractReportEvent
      * Set the graph array.
      *
      * @param string $graph
-     * @param array  $data prepared for this chart
+     * @param array  $data  prepared for this chart
      */
     public function setGraph($graph, $data)
     {

--- a/app/bundles/ReportBundle/Event/ReportQueryEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportQueryEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * @copyright   2014 Mautic Contributors. All rights reserved
+ * @copyright   2018 Mautic Contributors. All rights reserved
  * @author      Mautic
  *
  * @link        http://mautic.org

--- a/app/bundles/ReportBundle/Event/ReportQueryEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportQueryEvent.php
@@ -20,9 +20,9 @@ use Mautic\ReportBundle\Entity\Report;
 class ReportQueryEvent extends AbstractReportEvent
 {
     /**
-     * @var array
+     * @var QueryBuilder
      */
-    private $query = [];
+    private $query;
 
     /**
      * @var array

--- a/app/bundles/ReportBundle/Event/ReportQueryEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportQueryEvent.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\ReportBundle\Event;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Mautic\ReportBundle\Entity\Report;
+
+/**
+ * Class ReportDataEvent.
+ */
+class ReportQueryEvent extends AbstractReportEvent
+{
+    /**
+     * @var array
+     */
+    private $query = [];
+
+    /**
+     * @var array
+     */
+    private $options = [];
+
+    /**
+     * @var int
+     */
+    private $totalResults = 0;
+
+    /**
+     * ReportDataEvent constructor.
+     *
+     * @param Report       $report
+     * @param QueryBuilder $query
+     * @param              $totalResults
+     * @param array        $options
+     */
+    public function __construct(Report $report, QueryBuilder $query, $totalResults, array $options)
+    {
+        $this->context      = $report->getSource();
+        $this->report       = $report;
+        $this->query        = $query;
+        $this->options      = $options;
+        $this->totalResults = (int) $totalResults;
+    }
+
+    /**
+     * @return array
+     */
+    public function getQuery()
+    {
+        return $this->query;
+    }
+
+    /**
+     * @param QueryBuilder $query
+     *
+     * @return ReportDataEvent
+     */
+    public function setQuery($query)
+    {
+        $this->query = $query;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotalResults()
+    {
+        return $this->totalResults;
+    }
+}

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -26,6 +26,7 @@ use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportDataEvent;
 use Mautic\ReportBundle\Event\ReportEvent;
 use Mautic\ReportBundle\Event\ReportGraphEvent;
+use Mautic\ReportBundle\Event\ReportQueryEvent;
 use Mautic\ReportBundle\Generator\ReportGenerator;
 use Mautic\ReportBundle\Helper\ReportHelper;
 use Mautic\ReportBundle\ReportEvents;
@@ -172,7 +173,7 @@ class ReportModel extends FormModel
      */
     public function getEntity($id = null)
     {
-        if ($id === null) {
+        if (null === $id) {
             return new Report();
         }
 
@@ -239,7 +240,7 @@ class ReportModel extends FormModel
                 $data[$context]['graphs'] = &$data['all']['graphs'][$context];
             } else {
                 //build them
-                $eventContext = ($context == 'all') ? '' : $context;
+                $eventContext = ('all' == $context) ? '' : $context;
 
                 $event = new ReportBuilderEvent($this->translator, $this->channelListHelper, $eventContext, $this->fieldModel->getPublishedFieldArrays(), $this->reportHelper);
                 $this->dispatcher->dispatch(ReportEvents::REPORT_ON_BUILD, $event);
@@ -247,7 +248,7 @@ class ReportModel extends FormModel
                 $tables = $event->getTables();
                 $graphs = $event->getGraphs();
 
-                if ($context == 'all') {
+                if ('all' == $context) {
                     $data[$context]['tables'] = $tables;
                     $data[$context]['graphs'] = $graphs;
                 } else {
@@ -310,7 +311,7 @@ class ReportModel extends FormModel
         $return->definitions = [];
 
         foreach ($columns as $column => $data) {
-            if ($isGroupBy && ($column == 'unsubscribed' || $column == 'unsubscribed_ratio' || $column == 'unique_ratio')) {
+            if ($isGroupBy && ('unsubscribed' == $column || 'unsubscribed_ratio' == $column || 'unique_ratio' == $column)) {
                 continue;
             }
             if (isset($data['label'])) {
@@ -599,7 +600,7 @@ class ReportModel extends FormModel
                     $limit      = $options['limit'];
                     $reportPage = $options['page'];
                 }
-                $start = ($reportPage === 1) ? 0 : (($reportPage - 1) * $limit);
+                $start = (1 === $reportPage) ? 0 : (($reportPage - 1) * $limit);
                 if ($start < 0) {
                     $start = 0;
                 }
@@ -612,6 +613,12 @@ class ReportModel extends FormModel
             }
 
             $query->add('orderBy', $order);
+
+            // Allow plugin to manipulate the query
+            $event = new ReportQueryEvent($entity, $query, $totalResults, $dataOptions);
+            $this->dispatcher->dispatch(ReportEvents::REPORT_QUERY_PRE_EXECUTE, $event);
+            $query = $event->getQuery();
+
             $queryTime = microtime(true);
             $data      = $query->execute()->fetchAll();
             $queryTime = round((microtime(true) - $queryTime) * 1000);

--- a/app/bundles/ReportBundle/ReportEvents.php
+++ b/app/bundles/ReportBundle/ReportEvents.php
@@ -74,6 +74,15 @@ final class ReportEvents
     const REPORT_ON_GENERATE = 'mautic.report_on_generate';
 
     /**
+     * The mautic.report_query_pre_execute event is dispatched to allow a plugin to alter the query before execution.
+     *
+     * The event listener receives a Mautic\ReportBundle\Event\ReportQueryEvent instance.
+     *
+     * @var string
+     */
+    const REPORT_QUERY_PRE_EXECUTE = 'mautic.report_query_pre_execute';
+
+    /**
      * The mautic.report_on_display event is dispatched when displaying a report.
      *
      * The event listener receives a Mautic\ReportBundle\Event\ReportDataEvent instance.


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | NO
| New feature? | YES
| Automated tests included? | NO
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Creates a ReportQueryEvent class and registers a REPORT_QUERY_PRE_EXECUTE event that is dispatched prior to getReportData's query execution so that a plugin can alter the query.  

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. render a report view. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 