### PR TITLE
Validate time units for data API endpoint

### DIFF
--- a/app/bundles/CoreBundle/Helper/DateTimeHelper.php
+++ b/app/bundles/CoreBundle/Helper/DateTimeHelper.php
@@ -397,11 +397,8 @@ class DateTimeHelper
     public static function validateMysqlDateTimeUnit($unit)
     {
         $possibleUnits   = ['s', 'i', 'H', 'd', 'W', 'm', 'Y'];
-        $timeUnitInArray = array_filter($possibleUnits, function ($possibleUnit) use ($unit) {
-            return $unit === $possibleUnit;
-        });
 
-        if (!$timeUnitInArray) {
+        if (!in_array($unit, $possibleUnits, true)) {
             $possibleUnitsString = implode(', ', $possibleUnits);
             throw new \InvalidArgumentException("Unit '$unit' is not supported. Use one of these: $possibleUnitsString");
         }

--- a/app/bundles/CoreBundle/Helper/DateTimeHelper.php
+++ b/app/bundles/CoreBundle/Helper/DateTimeHelper.php
@@ -388,4 +388,22 @@ class DateTimeHelper
 
         return $timezone;
     }
+
+    /**
+     * @param string $unit
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function validateMysqlDateTimeUnit($unit)
+    {
+        $possibleUnits   = ['s', 'i', 'H', 'd', 'W', 'm', 'Y'];
+        $timeUnitInArray = array_filter($possibleUnits, function ($possibleUnit) use ($unit) {
+            return $unit === $possibleUnit;
+        });
+
+        if (!$timeUnitInArray) {
+            $possibleUnitsString = implode(', ', $possibleUnits);
+            throw new \InvalidArgumentException("Unit '$unit' is not supported. Use one of these: $possibleUnitsString");
+        }
+    }
 }

--- a/app/bundles/CoreBundle/Tests/unit/Helper/DateTimeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Helper/DateTimeHelperTest.php
@@ -55,4 +55,21 @@ class DateTimeHelperTest extends \PHPUnit_Framework_TestCase
         $interval = $helper->buildInterval(4, 'S');
         $this->assertEquals(new \DateInterval('PT4S'), $interval);
     }
+
+    public function testvalidateMysqlDateTimeUnitWillThrowExceptionOnBadUnit()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        DateTimeHelper::validateMysqlDateTimeUnit('D');
+    }
+
+    public function testvalidateMysqlDateTimeUnitWillNotThrowExceptionOnExpectedUnit()
+    {
+        DateTimeHelper::validateMysqlDateTimeUnit('s');
+        DateTimeHelper::validateMysqlDateTimeUnit('i');
+        DateTimeHelper::validateMysqlDateTimeUnit('H');
+        DateTimeHelper::validateMysqlDateTimeUnit('d');
+        DateTimeHelper::validateMysqlDateTimeUnit('W');
+        DateTimeHelper::validateMysqlDateTimeUnit('m');
+        DateTimeHelper::validateMysqlDateTimeUnit('Y');
+    }
 }

--- a/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
+++ b/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
@@ -13,6 +13,7 @@ namespace Mautic\DashboardBundle\Controller\Api;
 
 use FOS\RestBundle\Util\Codes;
 use Mautic\ApiBundle\Controller\CommonApiController;
+use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\DashboardBundle\DashboardEvents;
 use Mautic\DashboardBundle\Entity\Widget;
@@ -65,7 +66,14 @@ class WidgetApiController extends CommonApiController
         $from       = InputHelper::clean($this->request->get('dateFrom', null));
         $to         = InputHelper::clean($this->request->get('dateTo', null));
         $dataFormat = InputHelper::clean($this->request->get('dataFormat', null));
+        $unit       = InputHelper::clean($this->request->get('timeUnit', 'Y'));
         $response   = ['success' => 0];
+
+        try {
+            DateTimeHelper::validateMysqlDateTimeUnit($unit);
+        } catch (\InvalidArgumentException $e) {
+            return $this->returnError($e->getMessage(), Codes::HTTP_BAD_REQUEST);
+        }
 
         if ($timezone) {
             $fromDate = new \DateTime($from, new \DateTimeZone($timezone));

--- a/app/bundles/DashboardBundle/Model/DashboardModel.php
+++ b/app/bundles/DashboardBundle/Model/DashboardModel.php
@@ -234,11 +234,11 @@ class DashboardModel extends FormModel
      * @param Widget $widget
      * @param array  $filter
      */
-    public function populateWidgetContent(Widget &$widget, $filter = [])
+    public function populateWidgetContent(Widget $widget, $filter = [])
     {
         $cacheDir = $this->coreParametersHelper->getParameter('cached_data_dir', $this->pathsHelper->getSystemPath('cache', true));
 
-        if ($widget->getCacheTimeout() == null || $widget->getCacheTimeout() == -1) {
+        if ($widget->getCacheTimeout() === null || $widget->getCacheTimeout() === -1) {
             $widget->setCacheTimeout($this->coreParametersHelper->getParameter('cached_data_timeout'));
         }
 
@@ -262,7 +262,6 @@ class DashboardModel extends FormModel
 
         $event = new WidgetDetailEvent($this->translator);
         $event->setWidget($widget);
-
         $event->setCacheDir($cacheDir, $this->userHelper->getUser()->getId());
         $event->setSecurity($this->security);
         $this->dispatcher->dispatch(DashboardEvents::DASHBOARD_ON_MODULE_DETAIL_GENERATE, $event);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The `/api/data/` endpoint returned nonsensical responses if the date/time unit was invalid.

Test request: `GET http://mautic.test/api/data/emails.in.time?dateFrom=2018-04-01&dateTo=2018-05-01&timeUnit=D&cacheTimeout=0`

Another fix is that the `cacheTimeout` option takes 0 values. It was not possible before because `== null` was working for zeroes too.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to get response from the test request above.
2. Note the labels in the response - they are wrong.

#### Steps to test this PR:
1. Test again.
2. You will get error message `"Unit 'D' is not supported. Use one of these: s, i, H, d, W, m, Y"` with error code 400.
3. Use `timeUnit=d` and you should get the right response.
