### PR TITLE
Store tokens in redirect URLs and replace the tokens on redirect

### DIFF
--- a/app/bundles/CoreBundle/Helper/UrlHelper.php
+++ b/app/bundles/CoreBundle/Helper/UrlHelper.php
@@ -146,4 +146,75 @@ class UrlHelper
         /* absolute URL is ready! */
         return $scheme.'://'.$abs;
     }
+
+    /**
+     * Sanitize parts of the URL to make sure the URL query values are HTTP encoded.
+     *
+     * @param string $url
+     *
+     * @return string
+     */
+    public static function sanitizeAbsoluteUrl($url)
+    {
+        if (!$url) {
+            return $url;
+        }
+
+        $url = self::sanitizeUrlScheme($url);
+        $url = self::sanitizeUrlQuery($url);
+
+        return $url;
+    }
+
+    /**
+     * Make sure the URL has a scheme. Defaults to HTTP if not provided.
+     *
+     * @param string $url
+     *
+     * @return string
+     */
+    private static function sanitizeUrlScheme($url)
+    {
+        $isRelative = strpos($url, '//') === 0;
+
+        if ($isRelative) {
+            return $url;
+        }
+
+        $containSlashes = strpos($url, '://') !== false;
+
+        if (!$containSlashes) {
+            $url = sprintf('://%s', $url);
+        }
+
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+
+        // Set default scheme to http if missing
+        if (empty($scheme)) {
+            $url = sprintf('http%s', $url);
+        }
+
+        return $url;
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return string
+     */
+    private static function sanitizeUrlQuery($url)
+    {
+        $query = parse_url($url, PHP_URL_QUERY);
+
+        if (!empty($query)) {
+            parse_str($query, $parsedQuery);
+
+            if ($parsedQuery) {
+                $encodedQuery = http_build_query($parsedQuery);
+                $url          = str_replace($query, $encodedQuery, $url);
+            }
+        }
+
+        return $url;
+    }
 }

--- a/app/bundles/CoreBundle/Helper/UrlHelper.php
+++ b/app/bundles/CoreBundle/Helper/UrlHelper.php
@@ -147,6 +147,14 @@ class UrlHelper
         return $scheme.'://'.$abs;
     }
 
+    /**
+     * Takes a plaintext, finds all URLs in it and return the array of those URLs.
+     * With exception of URLs used as a token default values.
+     *
+     * @param string $text
+     *
+     * @return array
+     */
     public static function getUrlsFromPlaintext($text)
     {
         $regex = '#[-a-zA-Z0-9@:%_\+.~\#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~\#?&//=]*)?#si';

--- a/app/bundles/CoreBundle/Helper/UrlHelper.php
+++ b/app/bundles/CoreBundle/Helper/UrlHelper.php
@@ -147,6 +147,28 @@ class UrlHelper
         return $scheme.'://'.$abs;
     }
 
+    public static function getUrlsFromPlaintext($text)
+    {
+        $regex = '#[-a-zA-Z0-9@:%_\+.~\#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~\#?&//=]*)?#si';
+
+        if (!preg_match_all($regex, $text, $matches)) {
+            return [];
+        }
+
+        $urls = $matches[0];
+
+        foreach ($urls as $key => $url) {
+            // We don't want to match URLs in token default values
+            // like {contactfield=website|http://ignore.this.url}
+            $isDefautlTokenValue = stripos($text, "|$url}") !== false;
+            if ($isDefautlTokenValue) {
+                unset($urls[$key]);
+            }
+        }
+
+        return $urls;
+    }
+
     /**
      * Sanitize parts of the URL to make sure the URL query values are HTTP encoded.
      *

--- a/app/bundles/CoreBundle/Tests/unit/Helper/UrlHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Helper/UrlHelperTest.php
@@ -78,4 +78,28 @@ class UrlHelperTest extends \PHPUnit_Framework_TestCase
             UrlHelper::sanitizeAbsoluteUrl('http://username:password@hostname:9090/path?ar g1=value&arg2=some+email@address.com#anchor')
         );
     }
+
+    public function testGetUrlsFromPlaintextWithHttp()
+    {
+        $this->assertEquals(
+            ['http://mautic.org'],
+            UrlHelper::getUrlsFromPlaintext('Hello there, http://mautic.org!')
+        );
+    }
+
+    public function testGetUrlsFromPlaintextSkipDefaultTokenValues()
+    {
+        $this->assertEquals(
+            ['https://find.this'],
+            UrlHelper::getUrlsFromPlaintext('Find this url: https://find.this, but ignore this one: {contactfield=website|http://skip.this}! ')
+        );
+    }
+
+    public function testGetUrlsFromPlaintextWith2Urls()
+    {
+        $this->assertEquals(
+            ['http://mautic.org', 'http://mucktick.org'],
+            UrlHelper::getUrlsFromPlaintext('Hello there, http://mautic.org is the correct URL. Not http://mucktick.org.')
+        );
+    }
 }

--- a/app/bundles/CoreBundle/Tests/unit/Helper/UrlHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Helper/UrlHelperTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * @copyright   2015 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Tests\Helper;
+
+use Mautic\CoreBundle\Helper\UrlHelper;
+
+class UrlHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSanitizeAbsoluteUrlDoesNotModifyCorrectFullUrl()
+    {
+        $this->assertEquals(
+            'http://username:password@hostname:9090/path?arg=value#anchor',
+            UrlHelper::sanitizeAbsoluteUrl('http://username:password@hostname:9090/path?arg=value#anchor')
+        );
+    }
+
+    public function testSanitizeAbsoluteUrlSetHttpIfSchemeIsMissing()
+    {
+        $this->assertEquals(
+            'http://username:password@hostname:9090/path?arg=value#anchor',
+            UrlHelper::sanitizeAbsoluteUrl('username:password@hostname:9090/path?arg=value#anchor')
+        );
+    }
+
+    public function testSanitizeAbsoluteUrlSetHttpIfSchemeIsRelative()
+    {
+        $this->assertEquals(
+            '//username:password@hostname:9090/path?arg=value#anchor',
+            UrlHelper::sanitizeAbsoluteUrl('//username:password@hostname:9090/path?arg=value#anchor')
+        );
+    }
+
+    public function testSanitizeAbsoluteUrlDoNotSetHttpIfSchemeIsRelative()
+    {
+        $this->assertEquals(
+            '//username:password@hostname:9090/path?arg=value#anchor',
+            UrlHelper::sanitizeAbsoluteUrl('//username:password@hostname:9090/path?arg=value#anchor')
+        );
+    }
+
+    public function testSanitizeAbsoluteUrlWithHttps()
+    {
+        $this->assertEquals(
+            'https://username:password@hostname:9090/path?arg=value#anchor',
+            UrlHelper::sanitizeAbsoluteUrl('https://username:password@hostname:9090/path?arg=value#anchor')
+        );
+    }
+
+    public function testSanitizeAbsoluteUrlWithHttp()
+    {
+        $this->assertEquals(
+            'http://username:password@hostname:9090/path?arg=value#anchor',
+            UrlHelper::sanitizeAbsoluteUrl('http://username:password@hostname:9090/path?arg=value#anchor')
+        );
+    }
+
+    public function testSanitizeAbsoluteUrlWithFtp()
+    {
+        $this->assertEquals(
+            'ftp://username:password@hostname:9090/path?arg=value#anchor',
+            UrlHelper::sanitizeAbsoluteUrl('ftp://username:password@hostname:9090/path?arg=value#anchor')
+        );
+    }
+
+    public function testSanitizeAbsoluteUrlSanitizeQuery()
+    {
+        $this->assertEquals(
+            'http://username:password@hostname:9090/path?ar_g1=value&arg2=some+email%40address.com#anchor',
+            UrlHelper::sanitizeAbsoluteUrl('http://username:password@hostname:9090/path?ar g1=value&arg2=some+email@address.com#anchor')
+        );
+    }
+}

--- a/app/bundles/LeadBundle/Helper/TokenHelper.php
+++ b/app/bundles/LeadBundle/Helper/TokenHelper.php
@@ -63,6 +63,23 @@ class TokenHelper
     }
 
     /**
+     * Returns correct token value from provided list of tokens and the concrete token.
+     *
+     * @param array  $tokens like ['{contactfield=website}' => 'https://mautic.org']
+     * @param string $token  like '{contactfield=website|https://default.url}'
+     *
+     * @return string empty string if no match
+     */
+    public static function getValueFromTokens(array $tokens, $token)
+    {
+        $token   = str_replace(['{', '}'], '', $token);
+        $alias   = self::getFieldAlias($token);
+        $default = self::getTokenDefaultValue($token);
+
+        return empty($tokens["{{$alias}}"]) ? $default : $tokens["{{$alias}}"];
+    }
+
+    /**
      * @param array $lead
      * @param       $alias
      * @param       $defaultValue

--- a/app/bundles/LeadBundle/Tests/Helper/TokenHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/TokenHelperTest.php
@@ -106,4 +106,52 @@ class TokenHelperTest extends \PHPUnit_Framework_TestCase
         $tokenList = TokenHelper::findLeadTokens($token, $lead);
         $this->assertEquals([$token => 'Somewhere%26Else'], $tokenList);
     }
+
+    public function testGetValueFromTokensWhenSomeValue()
+    {
+        $token  = '{contactfield=website}';
+        $tokens = [
+            '{contactfield=website}' => 'https://mautic.org',
+        ];
+        $this->assertEquals(
+            'https://mautic.org',
+            TokenHelper::getValueFromTokens($tokens, $token)
+        );
+    }
+
+    public function testGetValueFromTokensWhenSomeValueWithDefaultValue()
+    {
+        $token  = '{contactfield=website|ftp://default.url}';
+        $tokens = [
+            '{contactfield=website}' => 'https://mautic.org',
+        ];
+        $this->assertEquals(
+            'https://mautic.org',
+            TokenHelper::getValueFromTokens($tokens, $token)
+        );
+    }
+
+    public function testGetValueFromTokensWhenNoValueWithDefaultValue()
+    {
+        $token  = '{contactfield=website|ftp://default.url}';
+        $tokens = [
+            '{contactfield=website}' => '',
+        ];
+        $this->assertEquals(
+            'ftp://default.url',
+            TokenHelper::getValueFromTokens($tokens, $token)
+        );
+    }
+
+    public function testGetValueFromTokensWhenNoValueWithoutDefaultValue()
+    {
+        $token  = '{contactfield=website}';
+        $tokens = [
+            '{contactfield=website}' => '',
+        ];
+        $this->assertEquals(
+            '',
+            TokenHelper::getValueFromTokens($tokens, $token)
+        );
+    }
 }

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -423,14 +423,15 @@ class PublicController extends CommonFormController
         $redirectModel = $this->getModel('page.redirect');
         $redirect      = $redirectModel->getRedirectById($redirectId);
 
-        if (empty($redirect) || !$redirect->isPublished(false)) {
-            throw $this->createNotFoundException($this->translator->trans('mautic.core.url.error.404'));
-        }
         /** @var \Mautic\PageBundle\Model\PageModel $pageModel */
         $pageModel = $this->getModel('page');
         $pageModel->hitPage($redirect, $this->request);
 
         $url = $redirect->getUrl();
+
+        if (empty($redirect) || !$redirect->isPublished(false)) {
+            throw $this->createNotFoundException($this->translator->trans('mautic.core.url.error.404', ['%url%' => $url]));
+        }
 
         // Ensure the URL does not have encoded ampersands
         $url = str_replace('&amp;', '&', $url);
@@ -455,6 +456,10 @@ class PublicController extends CommonFormController
         $leadArray = ($lead) ? $lead->getProfileFields() : [];
         $url       = TokenHelper::findLeadTokens($url, $leadArray, true);
         $url       = UrlHelper::sanitizeAbsoluteUrl($url);
+
+        if (false === filter_var($url, FILTER_VALIDATE_URL)) {
+            throw $this->createNotFoundException($this->translator->trans('mautic.core.url.error.404', ['%url%' => $url]));
+        }
 
         return $this->redirect($url);
     }

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -13,6 +13,7 @@ namespace Mautic\PageBundle\Controller;
 
 use Mautic\CoreBundle\Controller\FormController as CommonFormController;
 use Mautic\CoreBundle\Helper\TrackingPixelHelper;
+use Mautic\CoreBundle\Helper\UrlHelper;
 use Mautic\LeadBundle\Helper\TokenHelper;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingServiceInterface;
@@ -437,7 +438,8 @@ class PublicController extends CommonFormController
         // Get query string
         $query = $this->request->query->all();
 
-        // Unset the clickthrough
+        // Unset the clickthrough from the URL query
+        $ct = $query['ct'];
         unset($query['ct']);
 
         // Tak on anything left to the URL
@@ -449,9 +451,10 @@ class PublicController extends CommonFormController
         // Search replace lead fields in the URL
         /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
         $leadModel = $this->getModel('lead');
-        $lead      = $leadModel->getCurrentLead();
+        $lead      = $leadModel->getContactFromRequest([$ct]);
         $leadArray = ($lead) ? $lead->getProfileFields() : [];
         $url       = TokenHelper::findLeadTokens($url, $leadArray, true);
+        $url       = UrlHelper::sanitizeAbsoluteUrl($url);
 
         return $this->redirect($url);
     }

--- a/app/bundles/PageBundle/Event/UntrackableUrlsEvent.php
+++ b/app/bundles/PageBundle/Event/UntrackableUrlsEvent.php
@@ -25,9 +25,6 @@ class UntrackableUrlsEvent extends Event
         '{webview_url}',
         '{unsubscribe_url}',
         '{trackable=(.*?)}',
-        // Ignore lead fields with URLs for tracking since each is unique
-        '^{leadfield=(.*?)}',
-        '^{contactfield=(.*?)}',
     ];
 
     /**

--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -409,10 +409,7 @@ class TrackableModel extends AbstractCommonModel
                 continue;
             }
 
-            if ($preparedUrl = $this->prepareUrlForTracking($url)) {
-                list($urlKey, $urlValue) = $preparedUrl;
-                $trackableUrls[$urlKey]  = $urlValue;
-            }
+            $trackableUrls[$url] = $url;
         }
 
         return $trackableUrls;
@@ -588,13 +585,6 @@ class TrackableModel extends AbstractCommonModel
      */
     protected function validateTokenIsTrackable($token, $tokenizedHost = null)
     {
-        // Token as URL
-        if ($tokenizedHost && !preg_match('/^(\{\S+?\})$/', $tokenizedHost)) {
-            // Currently this does not apply to something like "{leadfield=firstname}.com" since that could result in URL per lead
-
-            return false;
-        }
-
         // Validate if this token is listed as not to be tracked
         if ($this->isInDoNotTrack($token)) {
             return false;

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
@@ -13,6 +13,7 @@ namespace Mautic\CoreBundle\Test;
 
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\Trackable;
+use Mautic\PageBundle\Model\RedirectModel;
 use Mautic\PageBundle\Model\TrackableModel;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -196,7 +197,7 @@ class TrackableModelTest extends WebTestCase
     public function testStandardLinkWithTokenizedQuery()
     {
         $url   = 'https://foo-bar.com?foo={contactfield=bar}&bar=foo';
-        $model = $this->getModel($url, 'https://foo-bar.com?bar=foo');
+        $model = $this->getModel($url, 'https://foo-bar.com?foo={contactfield=bar}&bar=foo');
 
         list($content, $trackables) = $model->parseContentForTrackables(
             $this->generateContent($url, 'html'),
@@ -207,7 +208,7 @@ class TrackableModelTest extends WebTestCase
             1
         );
 
-        $tokenFound = preg_match('/\{trackable=(.*?)\}&foo=\{contactfield=bar\}/', $content, $match);
+        $tokenFound = preg_match('/\{trackable=(.*?)\}/', $content, $match);
 
         // Assert that a trackable token exists
         $this->assertTrue((bool) $tokenFound, $content);
@@ -217,13 +218,13 @@ class TrackableModelTest extends WebTestCase
     }
 
     /**
-     * @testdox Test that a token used in place of a URL is not parsed
+     * @testdox Test that a token used in place of a URL is parsed properly
      *
      * @covers \Mautic\PageBundle\Model\TrackableModel::validateTokenIsTrackable
      * @covers \Mautic\PageBundle\Model\TrackableModel::parseContentForTrackables
      * @covers \Mautic\PageBundle\Model\TrackableModel::prepareUrlForTracking
      */
-    public function testTokenizedHostIsIgnored()
+    public function testTokenizedHost()
     {
         $url   = 'http://{contactfield=foo}.com';
         $model = $this->getModel($url, 'http://{contactfield=foo}.com');
@@ -237,7 +238,13 @@ class TrackableModelTest extends WebTestCase
             1
         );
 
-        $this->assertEmpty($trackables, $content);
+        $tokenFound = preg_match('/\{trackable=(.*?)\}/', $content, $match);
+
+        // Assert that a trackable token exists
+        $this->assertTrue((bool) $tokenFound, $content);
+
+        // Assert the Trackable exists
+        $this->assertArrayHasKey('{trackable='.$match[1].'}', $trackables);
     }
 
     /**
@@ -245,7 +252,7 @@ class TrackableModelTest extends WebTestCase
      * @covers \Mautic\PageBundle\Model\TrackableModel::parseContentForTrackables
      * @covers \Mautic\PageBundle\Model\TrackableModel::prepareUrlForTracking
      */
-    public function testTokenizedHostWithSchemeIsIgnored()
+    public function testTokenizedHostWithScheme()
     {
         $url   = '{contactfield=foo}';
         $model = $this->getModel($url, '{contactfield=foo}');
@@ -259,17 +266,23 @@ class TrackableModelTest extends WebTestCase
             1
         );
 
-        $this->assertEmpty($trackables, $content);
+        $tokenFound = preg_match('/\{trackable=(.*?)\}/', $content, $match);
+
+        // Assert that a trackable token exists
+        $this->assertTrue((bool) $tokenFound, $content);
+
+        // Assert the Trackable exists
+        $this->assertArrayHasKey('{trackable='.$match[1].'}', $trackables);
     }
 
     /**
-     * @testdox Test that a token used in place of a URL is not parsed
+     * @testdox Test that a token used in place of a URL is parsed
      *
      * @covers \Mautic\PageBundle\Model\TrackableModel::validateTokenIsTrackable
      * @covers \Mautic\PageBundle\Model\TrackableModel::parseContentForTrackables
      * @covers \Mautic\PageBundle\Model\TrackableModel::prepareUrlForTracking
      */
-    public function testTokenizedHostWithQueryIsIgnored()
+    public function testTokenizedHostWithQuery()
     {
         $url   = 'http://{contactfield=foo}.com?foo=bar';
         $model = $this->getModel($url, 'http://{contactfield=foo}.com?foo=bar');
@@ -283,7 +296,13 @@ class TrackableModelTest extends WebTestCase
             1
         );
 
-        $this->assertEmpty($trackables, $content);
+        $tokenFound = preg_match('/\{trackable=(.*?)\}/', $content, $match);
+
+        // Assert that a trackable token exists
+        $this->assertTrue((bool) $tokenFound, $content);
+
+        // Assert the Trackable exists
+        $this->assertArrayHasKey('{trackable='.$match[1].'}', $trackables);
     }
 
     /**
@@ -291,7 +310,7 @@ class TrackableModelTest extends WebTestCase
      * @covers \Mautic\PageBundle\Model\TrackableModel::parseContentForTrackables
      * @covers \Mautic\PageBundle\Model\TrackableModel::prepareUrlForTracking
      */
-    public function testTokenizedHostWithTokenizedQueryIsIgnored()
+    public function testTokenizedHostWithTokenizedQuery()
     {
         $url   = 'http://{contactfield=foo}.com?foo={contactfield=bar}';
         $model = $this->getModel($url, 'http://{contactfield=foo}.com?foo={contactfield=bar}');
@@ -306,7 +325,13 @@ class TrackableModelTest extends WebTestCase
             1
         );
 
-        $this->assertCount(0, $trackables, $content);
+        $tokenFound = preg_match('/\{trackable=(.*?)\}/', $content, $match);
+
+        // Assert that a trackable token exists
+        $this->assertTrue((bool) $tokenFound, $content);
+
+        // Assert the Trackable exists
+        $this->assertArrayHasKey('{trackable='.$match[1].'}', $trackables);
     }
 
     /**
@@ -481,17 +506,14 @@ class TrackableModelTest extends WebTestCase
                 '{webview_url}',
                 '{unsubscribe_url}',
                 '{trackable=(.*?)}',
-                // Ignore lead fields as URL hosts for tracking since each is unique
-                '[^=]{leadfield=(.*?)}',
-                '[^=]{contactfield=(.*?)}',
             ]
         );
 
-        $mockRedirectModel = $this->getMockBuilder('Mautic\PageBundle\Model\RedirectModel')
+        $mockRedirectModel = $this->getMockBuilder(RedirectModel::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mockModel = $this->getMockBuilder('Mautic\PageBundle\Model\TrackableModel')
+        $mockModel = $this->getMockBuilder(TrackableModel::class)
             ->setConstructorArgs([$mockRedirectModel])
             ->setMethods(['getDoNotTrackList', 'getEntitiesFromUrls'])
             ->getMock();


### PR DESCRIPTION

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | Y
| Automated tests included? | Y
| Related user documentation PR URL | N
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5345, https://github.com/mautic/mautic/issues/3825, https://github.com/mautic/mautic/issues/6013
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The links containing tokens aren't being tracked. The reason is that each such link can be different and the click stats would be messy then.

This PR ignores the tokens in the links on email send so the URLs with tokens are saved to the `page_redirects` table. The tokens are translated to the contact values during the redirect.

This is how the URLs that contain tokens are displayed with some clicks:
![screen shot 2018-05-08 at 13 30 38](https://user-images.githubusercontent.com/1235442/39754908-0ccab3ba-52c4-11e8-8d8c-846ba39017fb.png)

#### Steps to test this PR:
1. Create a segment email.
2. Create some different button/link variants.
    2.1. One link which consist entirely from a token. Like `href="{contactfield=website}`
    2.2. One link which use a token in the path. Like `href="http://mautic.org/{contactfield=firstname}`
    2.3. One link which use a token in the URL query. Like `href="https://mautic.org?email={contactfield=email}`
    2.4. One link which use a token with default value. Like `href="{contactfield=nofield|http://johnlinhart.com}`
    2.5. Try some other variation that can cause a problem that I didn't think of. Just try to break it!
3. Go to the Advanced tab and auto-generate the text message from the HTML message.
4. Ensure at least on contact from your test segment has a website, one has a firstname value.
5. Send the email to a list of your test contacts. 
6. Try to open the links from the emails you got in a incognito browser and see where it redirect. Ensure it's the right URL and that URL query (the email address) is URL-encoded. 
7. Don't forget to check the text version of the email and that the links in it are working too.