### PR TITLE
Broken links in tracking results

### DIFF
--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -1211,9 +1211,9 @@ class PageModel extends FormModel
     {
         foreach ($query as $key => $value) {
             if (filter_var($value, FILTER_VALIDATE_URL)) {
-                $query[$value] = InputHelper::url($value);
+                $query[$key] = InputHelper::url($value);
             } else {
-                $query[$value] = InputHelper::clean($value);
+                $query[$key] = InputHelper::clean($value);
             }
         }
 

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -603,11 +603,11 @@ class PageModel extends FormModel
             $lead->setTimezone($this->dateTimeHelper->guessTimezoneFromOffset($timezone));
         }
 
-        // Set info from request
-        $query = InputHelper::cleanArray($query);
+        $query = $this->cleanQuery($query);
 
         $hit->setQuery($query);
         $hit->setUrl((isset($query['page_url'])) ? $query['page_url'] : $request->getRequestUri());
+
         if (isset($query['page_referrer'])) {
             $hit->setReferer($query['page_referrer']);
         }
@@ -815,7 +815,6 @@ class PageModel extends FormModel
                         $query   = $this->decodeArrayFromUrl($query['d'], false);
                         $decoded = true;
                     }
-
                     if (is_array($query) && !empty($query)) {
                         if (isset($query['page_url'])) {
                             $pageURL = $query['page_url'];
@@ -1199,5 +1198,25 @@ class PageModel extends FormModel
      */
     public function setTrackByFingerprint($trackByFingerprint)
     {
+    }
+
+    /**
+     * Cleans query params saving url values.
+     *
+     * @param $query array
+     *
+     * @return array
+     */
+    private function cleanQuery($query)
+    {
+        foreach ($query as $key => $value) {
+            if (filter_var($value, FILTER_VALIDATE_URL)) {
+                $query[$value] = InputHelper::url($value);
+            } else {
+                $query[$value] = InputHelper::clean($value);
+            }
+        }
+
+        return $query;
     }
 }

--- a/app/bundles/PageBundle/Tests/Model/PageModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/PageModelTest.php
@@ -13,6 +13,7 @@ namespace Mautic\PageBundle\Tests\Model;
 
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Tests\PageTestAbstract;
+use ReflectionClass;
 
 class PageModelTest extends PageTestAbstract
 {
@@ -23,5 +24,25 @@ class PageModelTest extends PageTestAbstract
         $pageModel = $this->getPageModel();
         $url       = $pageModel->generateUrl($page);
         $this->assertContains('/this-is-a-test', $url);
+    }
+
+    public function testCleanQuery_WhenCalled_ReturnsSafeAndValidData()
+    {
+        $pageModel           = $this->getPageModel();
+        $pageModelReflection = new ReflectionClass(get_class($pageModel));
+        $cleanQueryMethod    = $pageModelReflection->getMethod('cleanQuery');
+        $cleanQueryMethod->setAccessible(true);
+        $res = $cleanQueryMethod->invokeArgs($pageModel, [
+            [
+                'page_title'    => 'Mautic & PHP',
+                'page_url'      => 'http://mautic.com/page/test?hello=world&lorem=ipsum',
+                'page_language' => 'en',
+            ],
+        ]);
+        $this->assertEquals($res, [
+            'page_title'    => 'Mautic &#38; PHP',
+            'page_url'      => 'http://mautic.com/page/test?hello=world&lorem=ipsum',
+            'page_language' => 'en',
+        ]);
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #3599
| BC breaks? | x
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to page with ampersands in url
2. Url will be stored as test.com/test?first_name=John&#38;last_name=Smith&#38;utm_campaign=test

#### Steps to test this PR:
1. Go to page with ampersands in url
2. Url must be stored without it breaking and clean from xss injections

# BC Breaks
Solved by https://github.com/mautic/mautic/pull/6712