### PR TITLE
Replace create_function with anonymous function

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1881,7 +1881,10 @@ class LeadModel extends FormModel
 
         $this->logger->debug('CONTACT: Adding '.implode(', ', $tags).' to contact ID# '.$lead->getId());
 
-        array_walk($tags, create_function('&$val', '$val = trim($val); \Mautic\CoreBundle\Helper\InputHelper::clean($val);'));
+        array_walk($tags, function (&$val) {
+            $val = trim($val);
+            InputHelper::clean($val);
+        });
 
         // See which tags already exist
         $foundTags = $this->getTagRepository()->getTagsByName($tags);
@@ -1916,7 +1919,10 @@ class LeadModel extends FormModel
         if (!empty($removeTags)) {
             $this->logger->debug('CONTACT: Removing '.implode(', ', $removeTags).' for contact ID# '.$lead->getId());
 
-            array_walk($removeTags, create_function('&$val', '$val = trim($val); \Mautic\CoreBundle\Helper\InputHelper::clean($val);'));
+            array_walk($removeTags, function (&$val) {
+                $val = trim($val);
+                InputHelper::clean($val);
+            });
 
             // See which tags really exist
             $foundRemoveTags = $this->getTagRepository()->getTagsByName($removeTags);


### PR DESCRIPTION
[As per the php docs](https://secure.php.net/manual/en/function.create-function.php), create_function creates a function in the outer scope, with each call. So with large CSV imports, it creates a case where thousands of functions gets created, causing the error
```
Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 32768 bytes) in /var/www/html/app/bundles/LeadBundle/Model/LeadModel.php(1884) : runtime-created function on line 1
```
To keep everything consistent, I removed the string and added the code as an exact match, so there shouldn't be any errors from this commit. Although the "InputHelper::clean" function should be looked at considering it's not being passed by reference

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Automated tests included? | n
| Related user documentation PR URL | n
| Related developer documentation PR URL | n
| Issues addressed (#s or URLs) | n/a
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
As the commit says, if you import a large CSV, you might get this error message
```
Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 32768 bytes) in /var/www/html/app/bundles/LeadBundle/Model/LeadModel.php(1884) : runtime-created function on line 1
```
This is because with each call of create_function, a new function gets created in the global scope and never destroyed
Anonymous functions can be garbage collected and should be preferred

Also as said in the commit, InputHelper::clean isn't being passed by reference, so both in this commit and before this commit, that function call is useless. But adding an assignment to "val" might make tests break

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Import a large CSV and you'll run into a fatal error

#### Steps to test this PR:
1. 

#### List backwards compatibility breaks:
1. You can no longer use lambda_1 to call this function :)