### PR TITLE
Fixes MySQL column size too large issue

### DIFF
--- a/app/config/config.php
+++ b/app/config/config.php
@@ -211,6 +211,11 @@ $dbalSettings = [
     'user'     => '%mautic.db_user%',
     'password' => '%mautic.db_password%',
     'charset'  => 'UTF8',
+    'default_table_options' => [
+        'charset'    => 'utf8',
+        'collate'    => 'utf8_unicode_ci',
+        'row_format' => 'DYNAMIC',
+    ],
     'types'    => [
         'array'    => 'Mautic\CoreBundle\Doctrine\Type\ArrayType',
         'datetime' => 'Mautic\CoreBundle\Doctrine\Type\UTCDateTimeType',

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -204,13 +204,13 @@ $container->setParameter('mautic.famework.csrf_protection', true);
 
 //Doctrine Configuration
 $dbalSettings = [
-    'driver'   => '%mautic.db_driver%',
-    'host'     => '%mautic.db_host%',
-    'port'     => '%mautic.db_port%',
-    'dbname'   => '%mautic.db_name%',
-    'user'     => '%mautic.db_user%',
-    'password' => '%mautic.db_password%',
-    'charset'  => 'UTF8',
+    'driver'                => '%mautic.db_driver%',
+    'host'                  => '%mautic.db_host%',
+    'port'                  => '%mautic.db_port%',
+    'dbname'                => '%mautic.db_name%',
+    'user'                  => '%mautic.db_user%',
+    'password'              => '%mautic.db_password%',
+    'charset'               => 'UTF8',
     'default_table_options' => [
         'charset'    => 'utf8',
         'collate'    => 'utf8_unicode_ci',


### PR DESCRIPTION
Fixes MySQL column size too large issue during installation:
https://github.com/mautic/mautic/issues/6064

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 