### PR TITLE
Fixed missing graph on the email reports

### DIFF
--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -406,7 +406,11 @@ class ReportSubscriber extends CommonSubscriber
     {
         $graphs = $event->getRequestedGraphs();
 
-        if (!$event->checkContext(self::CONTEXT_EMAIL_STATS) || ($event->checkContext(self::CONTEXT_EMAILS) && !in_array('mautic.email.graph.pie.read.ingored.unsubscribed.bounced', $graphs))) {
+        if (!$event->checkContext([self::CONTEXT_EMAIL_STATS, self::CONTEXT_EMAILS])) {
+            return;
+        }
+
+        if ($event->checkContext(self::CONTEXT_EMAILS) && !in_array('mautic.email.graph.pie.read.ingored.unsubscribed.bounced', $graphs)) {
             return;
         }
 

--- a/app/bundles/EmailBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Test\EventListener;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\ORM\EntityManager;
+use Mautic\CoreBundle\Helper\Chart\ChartQuery;
+use Mautic\EmailBundle\EventListener\ReportSubscriber;
+use Mautic\LeadBundle\Entity\DoNotContact;
+use Mautic\LeadBundle\Model\CompanyReportData;
+use Mautic\ReportBundle\Event\ReportGraphEvent;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class ReportSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    private $connectionMock;
+    private $companyReportDataMock;
+    private $emMock;
+
+    /**
+     * @var ReportSubscriber
+     */
+    private $subscriber;
+
+    protected function setup()
+    {
+        parent::setUp();
+
+        $this->connectionMock        = $this->createMock(Connection::class);
+        $this->companyReportDataMock = $this->createMock(CompanyReportData::class);
+        $this->emMock                = $this->createMock(EntityManager::class);
+        $this->subscriber            = new ReportSubscriber($this->connectionMock, $this->companyReportDataMock);
+        $this->subscriber->setEntityManager($this->emMock);
+    }
+
+    public function testOnReportGraphGenerateForEmailContextWithEmailGraph()
+    {
+        $eventMock        = $this->createMock(ReportGraphEvent::class);
+        $queryBuilderMock = $this->createMock(QueryBuilder::class);
+        $chartQueryMock   = $this->createMock(ChartQuery::class);
+        $statementMock    = $this->createMock(Statement::class);
+        $translatorMock   = $this->createMock(TranslatorInterface::class);
+
+        $queryBuilderMock->method('execute')->willReturn($statementMock);
+
+        $eventMock->expects($this->at(0))
+            ->method('getRequestedGraphs')
+            ->willReturn(['mautic.email.graph.pie.read.ingored.unsubscribed.bounced']);
+
+        $eventMock->expects($this->at(1))
+            ->method('checkContext')
+            ->with(['email.stats', 'emails'])
+            ->willReturn(true);
+
+        $eventMock->expects($this->at(2))
+            ->method('checkContext')
+            ->with('emails')
+            ->willReturn(true);
+
+        $eventMock->expects($this->at(3))
+            ->method('getQueryBuilder')
+            ->willReturn($queryBuilderMock);
+
+        $eventMock->expects($this->at(4))
+            ->method('getOptions')
+            ->willReturn(['chartQuery' => $chartQueryMock, 'translator' => $translatorMock]);
+
+        $queryBuilderMock->expects($this->once())
+            ->method('select')
+            ->with('SUM(DISTINCT e.sent_count) as sent_count, SUM(DISTINCT e.read_count) as read_count, count(CASE WHEN dnc.id  and dnc.reason = '.DoNotContact::UNSUBSCRIBED.' THEN 1 ELSE null END) as unsubscribed, count(CASE WHEN dnc.id  and dnc.reason = '.DoNotContact::BOUNCED.' THEN 1 ELSE null END) as bounced');
+
+        $this->subscriber->onReportGraphGenerate($eventMock);
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6052
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR is fixing chart on the Email report context. The modified condition worked only for `email.stats` context and not for the `emails` context.

While looking if there is this bug reported in issues I found https://github.com/mautic/mautic/issues/6052 to be similar. This PR fixes that too.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create new report with the Emails data source (context)
2. Add all fields to the report.
3. Add the only graph this context provide.
4. Save the report
5. Notice the graph is not in the report

#### Steps to test this PR:
1. Apply this PR
2. Refresh the report detail page.
3. The graph is there now