### PR TITLE
Change default behavior for Send form results action

### DIFF
--- a/app/bundles/FormBundle/Form/Type/SubmitActionEmailType.php
+++ b/app/bundles/FormBundle/Form/Type/SubmitActionEmailType.php
@@ -100,7 +100,7 @@ class SubmitActionEmailType extends AbstractType
         );
 
         if ($this->coreParametersHelper->getParameter('mailer_spool_type') == 'file') {
-            $default = (isset($options['data']['immediately'])) ? $options['data']['immediately'] : false;
+            $default = isset($options['data']['immediately']) ? $options['data']['immediately'] : false;
             $builder->add(
                 'immediately',
                 YesNoButtonGroupType::class,
@@ -122,7 +122,7 @@ class SubmitActionEmailType extends AbstractType
             );
         }
 
-        $default = (isset($options['data']['copy_lead'])) ? $options['data']['copy_lead'] : true;
+        $default = isset($options['data']['copy_lead']) ? $options['data']['copy_lead'] : false;
         $builder->add(
             'copy_lead',
             YesNoButtonGroupType::class,
@@ -132,7 +132,7 @@ class SubmitActionEmailType extends AbstractType
             ]
         );
 
-        $default = (isset($options['data']['set_replyto'])) ? $options['data']['set_replyto'] : true;
+        $default = isset($options['data']['set_replyto']) ? $options['data']['set_replyto'] : true;
         $builder->add(
             'set_replyto',
             'yesno_button_group',
@@ -145,7 +145,7 @@ class SubmitActionEmailType extends AbstractType
             ]
         );
 
-        $default = (isset($options['data']['email_to_owner'])) ? $options['data']['email_to_owner'] : false;
+        $default = isset($options['data']['email_to_owner']) ? $options['data']['email_to_owner'] : false;
         $builder->add(
             'email_to_owner',
             YesNoButtonGroupType::class,


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR changes the default behavior for the "Send form results" action. Previously, form results would be sent to the contact which submitted the form in addition to the Mautic user selected to receive the form results. We found most users would toggle this setting to No, so it's correct to change the default setting to No as well.

This also includes minor code style updates, as it's not required to wrap `isset()` calls in parenthesis when executing a ternary in PHP.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new form
2. Without adding any fields (as it's not a requirement), go to the Actions tab, then select "Send form results" from the actions dropdown. The modal will open and the "Send to contact" toggle is defaulted to Yes. 

#### Steps to test this PR:
1. Apply PR and go through reproduction steps. 
2. Instead of defaulting to Yes, the "Send to contact" toggle will be defaulted to No. 
