### PR TITLE
Webhook payload type fixed

### DIFF
--- a/app/bundles/WebhookBundle/Entity/WebhookQueue.php
+++ b/app/bundles/WebhookBundle/Entity/WebhookQueue.php
@@ -59,7 +59,7 @@ class WebhookQueue
             ->addJoinColumn('webhook_id', 'id', false, false, 'CASCADE')
             ->build();
         $builder->addNullableField('dateAdded', Type::DATETIME, 'date_added');
-        $builder->addField('payload', Type::INTEGER);
+        $builder->addField('payload', Type::TEXT);
         $builder->createManyToOne('event', 'Event')
             ->inversedBy('queues')
             ->addJoinColumn('event_id', 'id', false, false, 'CASCADE')

--- a/app/migrations/Version20180515082957.php
+++ b/app/migrations/Version20180515082957.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * @package     Mautic
+ * @copyright   2018 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\TextType;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+class Version20180515082957 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        if ($schema->getTable($this->prefix.'webhook_queue')->getColumn('payload')->getType() instanceof TextType) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql("ALTER TABLE {$this->prefix}webhook_queue CHANGE payload payload LONGTEXT NOT NULL");
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6019
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

There was a nonsensical change of webhook payload column from TEXT to INTEGER when doing refactoring. I introduced this problem in https://github.com/mautic/mautic/pull/5932/files#diff-6a9e6a51274ebd78c95c2999dab20efdR62

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run `$ app/console doctrine:schema:update --force`
2. You may get this error if you have some real time data in that column:

```
Doctrine\DBAL\Exception\DriverException]
  An exception occurred while executing 'ALTER TABLE webhook_queue CHANGE date_added date_added DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime)', CHANGE payload payload VARCHAR(255) NOT
   NULL':

  SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'payload' at row 1
```

#### Steps to test this PR:
1. Repeat the test steps
2. No error, all queries will be executed fine.
