### PR TITLE
Fixes some things with merged #6060 custom headers

### DIFF
--- a/app/bundles/CoreBundle/Templating/Helper/FormatterHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/FormatterHelper.php
@@ -152,6 +152,22 @@ class FormatterHelper extends Helper
     }
 
     /**
+     * @param array  $array
+     * @param string $delimeter
+     *
+     * @return string
+     */
+    public function simpleArrayToHtml(array $array, $delimeter = '<br />')
+    {
+        $pairs = [];
+        foreach ($array as $key => $value) {
+            $pairs[] = "$key: $value";
+        }
+
+        return implode($delimeter, $pairs);
+    }
+
+    /**
      * @return string
      */
     public function getName()

--- a/app/bundles/EmailBundle/Form/Type/ConfigType.php
+++ b/app/bundles/EmailBundle/Form/Type/ConfigType.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\EmailBundle\Form\Type;
 
+use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\Type\SortableListType;
 use Mautic\EmailBundle\Model\TransportType;
 use Symfony\Component\Form\AbstractType;
@@ -53,6 +54,8 @@ class ConfigType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $builder->addEventSubscriber(new CleanFormSubscriber(['mailer_custom_headers' => 'clean']));
+
         $builder->add(
             'unsubscribe_text',
             'textarea',

--- a/app/bundles/EmailBundle/Form/Type/ConfigType.php
+++ b/app/bundles/EmailBundle/Form/Type/ConfigType.php
@@ -64,6 +64,7 @@ class ConfigType extends AbstractType
                     'unsubscribe_message'    => 'html',
                     'resubscribe_message'    => 'html',
                     'webview_text'           => 'html',
+                    // Encode special chars to keep congruent with Email entity custom headers
                     'mailer_custom_headers'  => 'clean',
                 ]
             )

--- a/app/bundles/EmailBundle/Form/Type/ConfigType.php
+++ b/app/bundles/EmailBundle/Form/Type/ConfigType.php
@@ -54,7 +54,20 @@ class ConfigType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->addEventSubscriber(new CleanFormSubscriber(['mailer_custom_headers' => 'clean']));
+        $builder->addEventSubscriber(
+            new CleanFormSubscriber(
+                [
+                    'mailer_from_email'      => 'email',
+                    'mailer_return_path'     => 'email',
+                    'default_signature_text' => 'html',
+                    'unsubscribe_text'       => 'html',
+                    'unsubscribe_message'    => 'html',
+                    'resubscribe_message'    => 'html',
+                    'webview_text'           => 'html',
+                    'mailer_custom_headers'  => 'clean',
+                ]
+            )
+        );
 
         $builder->add(
             'unsubscribe_text',

--- a/app/bundles/EmailBundle/Form/Type/EmailType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailType.php
@@ -73,7 +73,7 @@ class EmailType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->addEventSubscriber(new CleanFormSubscriber(['content' => 'html', 'customHtml' => 'html']));
+        $builder->addEventSubscriber(new CleanFormSubscriber(['content' => 'html', 'customHtml' => 'html', 'headers' => 'clean']));
         $builder->addEventSubscriber(new FormExitSubscriber('email.email', $options));
 
         $builder->add(

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -534,9 +534,6 @@ class MailHelper
             // Reset recipients
             $this->queuedRecipients = [];
 
-            // Reset hash which is unique to the recipient
-            $this->idHash = null;
-
             // Assume success
             return (self::QUEUE_RETURN_ERRORS) ? [true, []] : true;
         } else {

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -534,6 +534,9 @@ class MailHelper
             // Reset recipients
             $this->queuedRecipients = [];
 
+            // Reset hash which is unique to the recipient
+            $this->idHash = null;
+
             // Assume success
             return (self::QUEUE_RETURN_ERRORS) ? [true, []] : true;
         } else {
@@ -1485,10 +1488,17 @@ class MailHelper
      */
     private function getUnsubscribeHeader()
     {
-        $unsubscribeLink = ($this->idHash) ? $this->factory->getRouter()->generate('mautic_email_unsubscribe', ['idHash' => $this->idHash], true) :
-            '<{unsubscribe_url}>';
+        if ($this->idHash) {
+            $url = $this->factory->getRouter()->generate('mautic_email_unsubscribe', ['idHash' => $this->idHash], true);
 
-        return ['List-Unsubscribe' => "<$unsubscribeLink>"];
+            return ['List-Unsubscribe' => "<$url>"];
+        }
+
+        if (!empty($this->queuedRecipients) || !empty($this->lead)) {
+            return ['List-Unsubscribe' => '<{unsubscribe_url}>'];
+        }
+
+        return [];
     }
 
     /**

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1477,28 +1477,37 @@ class MailHelper
      */
     public function getCustomHeaders()
     {
-        $headers       = $this->headers;
-        $systemHeaders = $this->getSystemHeaders();
+        $headers = array_merge($this->headers, $this->getSystemHeaders());
 
-        return array_merge($this->getUnsubscribeHeader(), $headers, $systemHeaders);
+        $listUnsubscribeHeader = $this->getUnsubscribeHeader();
+        if ($listUnsubscribeHeader) {
+            if (!empty($headers['List-Unsubscribe'])) {
+                // Ensure Mautic's is always part of this header
+                $headers['List-Unsubscribe'] .= ','.$listUnsubscribeHeader;
+            } else {
+                $headers['List-Unsubscribe'] = $listUnsubscribeHeader;
+            }
+        }
+
+        return $headers;
     }
 
     /**
-     * @return array
+     * @return bool|string
      */
     private function getUnsubscribeHeader()
     {
         if ($this->idHash) {
             $url = $this->factory->getRouter()->generate('mautic_email_unsubscribe', ['idHash' => $this->idHash], true);
 
-            return ['List-Unsubscribe' => "<$url>"];
+            return "<$url>";
         }
 
         if (!empty($this->queuedRecipients) || !empty($this->lead)) {
-            return ['List-Unsubscribe' => '<{unsubscribe_url}>'];
+            return '<{unsubscribe_url}>';
         }
 
-        return [];
+        return false;
     }
 
     /**

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -193,6 +193,14 @@ if (!$isEmbedded) {
                                     <td><?php echo $bccAddress; ?></td>
                                 </tr>
                             <?php endif; ?>
+                            <?php if ($headers = $email->getHeaders()): ?>
+                                <tr>
+                                    <td width="20%">
+                                        <span class="fw-b"><?php echo $view['translator']->trans('mautic.email.custom_headers'); ?></span>
+                                    </td>
+                                    <td><?php echo $view['formatter']->simpleArrayToHtml($headers); ?></td>
+                                </tr>
+                            <?php endif; ?>
                             </tbody>
                         </table>
                     </div>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This fixes a few issues with #6060 that was already merged. 

1. List-Unsubscribe header was only set on an outgoing email if the monitored email was setup even though we could use Mautic's unsubscribe_url token. So set that when appropriate.
2. Custom headers with <> were stripped because they were seen as tags such as a custom List-Unsubscribe header `<mailto:somemail@test.com>`
3. Added the headers to the details UI
4. Non-tokenized transports did not have tokens replaced in the headers

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new email (based on staging code) and add a new header `List-Unsubscribe` = `<mailto:somebody@somewhere.com>`
2. Click apply and notice that the header value is now empty
3. Using a SMTP transport, send an email with a `{unsubscribe_url}` as a header value and notice that it's not replaced

#### Steps to test this PR:
1. Repeat the above and the List-Subscribe header should save with <> tags and using tokens for headers in SMTP transports should work while still working for tokenized transports such as Sendgrid or Sparkpost.