### PR TITLE
Fixing duplicated tracking hashes

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1264,7 +1264,13 @@ class MailHelper
     public function setIdHash($idHash = null, $statToBeGenerated = true)
     {
         if ($idHash === null) {
-            $idHash = uniqid();
+            /*
+            18.05.2018 - hammad-tfg: 
+                         fixed issue # 6093 by using more_entropy parameter to PHP uniqid. 
+                         Read more here: http://php.net/manual/en/function.uniqid.php
+                         Issue link: https://github.com/mautic/mautic/issues/6093
+            */
+            $idHash = str_replace('.','',uniqid('',true));//uniqid();
         }
 
         $this->idHash      = $idHash;

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1264,13 +1264,7 @@ class MailHelper
     public function setIdHash($idHash = null, $statToBeGenerated = true)
     {
         if ($idHash === null) {
-            /*
-            18.05.2018 - hammad-tfg: 
-                         fixed issue # 6093 by using more_entropy parameter to PHP uniqid. 
-                         Read more here: http://php.net/manual/en/function.uniqid.php
-                         Issue link: https://github.com/mautic/mautic/issues/6093
-            */
-            $idHash = str_replace('.','',uniqid('',true));//uniqid();
+            $idHash = str_replace('.','',uniqid('',true));
         }
 
         $this->idHash      = $idHash;

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1264,7 +1264,7 @@ class MailHelper
     public function setIdHash($idHash = null, $statToBeGenerated = true)
     {
         if ($idHash === null) {
-            $idHash = str_replace('.','',uniqid('',true));
+            $idHash = str_replace('.', '', uniqid('', true));
         }
 
         $this->idHash      = $idHash;


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Yes
| Issues addressed (#s or URLs) | 6093

[//]: # ( Required: )
#### Description: 
PHP `uniqid` function as it was used in the code does **not** guarantee uniqueness. Read more [here](http://php.net/manual/en/function.uniqid.php). One solution is to use the `more_entropy` parameter to ensure uniqueness.

As the type of column in MySQL is:
`tracking_hash varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,`

the length of string returned by `uniqid` when using `more_entropy` will probably have no domino effect.