### PR TITLE
Display correct percentage for negative campaign actions

### DIFF
--- a/app/bundles/CampaignBundle/Views/Campaign/events.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/events.html.php
@@ -13,14 +13,21 @@
 <!-- start: trigger type event -->
 <ul class="list-group campaign-event-list">
     <?php foreach ($events as $event) : ?>
+        <?php $typeClass    = ('action' === $event['eventType'] && 'no' === $event['decisionPath']) ? 'danger' : 'success'; ?>
+        <?php $percentLabel = ($typeClass === 'danger') ? 'mautic.report.campaign.no.percent' : 'mautic.report.campaign.yes.percent'; ?>
+        <?php $percentProp  = ($typeClass === 'danger') ? 'noPercent' : 'yesPercent'; ?>
         <li class="list-group-item bg-auto bg-light-xs">
-            <?php $yesClass = ('action' === $event['eventType'] && 'no' === $event['decisionPath']) ? 'danger' : 'success'; ?>
-            <div class="progress-bar progress-bar-<?php echo $yesClass; ?>" style="width:<?php echo $event['yesPercent']; ?>%; left: 0;"></div>
+            <div class="progress-bar progress-bar-<?php echo $typeClass; ?>" style="width:<?php echo $event['yesPercent']; ?>%; left: 0;"></div>
             <div class="progress-bar progress-bar-danger" style="width:<?php echo $event['noPercent']; ?>%; left: <?php echo $event['yesPercent']; ?>%"></div>
             <div class="box-layout">
                 <div class="visible-sm visible-md visible-lg col-stats">
-                    <span class="mt-xs label label-<?php echo $yesClass; ?>" data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.report.campaign.yes.percent'); ?>"><?php echo $event['yesPercent'].'%'; ?></span> <?php if ('action' !== $event['eventType']): ?>
-                        <span class="label label-danger" data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.report.campaign.no.percent'); ?>"><?php echo $event['noPercent'].'%'; ?></span>
+                    <span class="mt-xs label label-<?php echo $typeClass; ?>" data-toggle="tooltip" title="<?php echo $view['translator']->trans($percentLabel); ?>">
+                        <?php echo $event[$percentProp].'%'; ?>
+                    </span>
+                    <?php if ('action' !== $event['eventType']): ?>
+                    <span class="label label-danger" data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.report.campaign.no.percent'); ?>">
+                        <?php echo $event['noPercent'].'%'; ?>
+                    </span>
                     <?php endif; ?>
                 <span class="mt-xs label label-warning" data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.report.campaign.completed.actions'); ?>"><?= $event['logCount']; ?></span> <span class="mt-xs label label-default"  data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.report.campaign.pending.actions'); ?>"><?= $event['leadCount'] - $event['logCount']; ?></span>
                 </div>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | /
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Negative action percentages on campaign detail were always 0% like this:
![screen shot 2018-05-18 at 17 30 33](https://user-images.githubusercontent.com/1235442/40244533-6654f6c8-5ac3-11e8-80e6-9a43ca423cd4.png)

This PR fixes that so the correct percentages and tooltips would show up:
![screen shot 2018-05-18 at 17 38 38](https://user-images.githubusercontent.com/1235442/40244562-7696bf26-5ac3-11e8-8089-b103d9a64290.png)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Open a campaign detail where you have some decisions, conditions and actions. Create one if you don't have such campaign.
2. Run the campaign. Fake some decisions so there would be different percentages shown for each action, decision and conditions.
3. See that the negative actions are showing 0% even if there some contacts going through them. The labels are also showing "Success percent" instead of "Failed percent"

#### Steps to test this PR:
1. Refresh the campaign detail page
2. All percentages and labels are correct for all decisions, conditions and actions.
