### PR TITLE
Add field type url to work with contains, startsWith, endsWith on reports

### DIFF
--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -460,6 +460,7 @@ final class MauticReportBuilder implements ReportBuilderInterface
 
                             case 'string':
                             case 'email':
+                            case 'url':
                                 switch ($exprFunction) {
                                     case 'startsWith':
                                         $exprFunction    = 'like';


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5172
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Contains, startsWith and EndsWith report filters were failing for URL fields

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create new report based on Page Hits data
2. Add some columns to that report
3. Create filter "Hit URL contains test"
4. Save the report, see the error.

#### Steps to test this PR:
1. Refresh the report page
2. Error is gone and the results are correct.