### PR TITLE
Prevent points from getting reset after primary company is set

### DIFF
--- a/app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
+++ b/app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
@@ -77,6 +77,10 @@ class LeadFieldData extends AbstractFixture implements OrderedFixtureInterface, 
                 $entity->setIsListable(!empty($field['listable']));
                 $entity->setIsShortVisible(!empty($field['short']));
 
+                if (isset($field['default'])) {
+                    $entity->setDefaultValue($field['default']);
+                }
+
                 $manager->persist($entity);
                 $manager->flush();
 

--- a/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
@@ -187,6 +187,10 @@ trait CustomFieldEntityTrait
      */
     public function getFieldValue($field, $group = null)
     {
+        if (property_exists($this, $field)) {
+            return $this->{'get'.ucfirst($field)}();
+        }
+
         if (array_key_exists($field, $this->updatedFields)) {
             return $this->updatedFields[$field];
         }

--- a/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
@@ -188,7 +188,11 @@ trait CustomFieldEntityTrait
     public function getFieldValue($field, $group = null)
     {
         if (property_exists($this, $field)) {
-            return $this->{'get'.ucfirst($field)}();
+            $value = $this->{'get'.ucfirst($field)}();
+
+            if (null !== $value) {
+                return $value;
+            }
         }
 
         if (array_key_exists($field, $this->updatedFields)) {

--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -263,8 +263,9 @@ trait CustomFieldRepositoryTrait
             $fields = array_diff_key($fields, $changes);
         }
 
+        $this->prepareDbalFieldsForSave($fields);
+
         if (!empty($fields)) {
-            $this->prepareDbalFieldsForSave($fields);
             $this->getEntityManager()->getConnection()->update($table, $fields, ['id' => $entity->getId()]);
         }
 

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -27,7 +27,10 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class LeadRepository extends CommonRepository implements CustomFieldRepositoryInterface
 {
-    use CustomFieldRepositoryTrait;
+    use CustomFieldRepositoryTrait {
+        prepareDbalFieldsForSave as defaultPrepareDbalFieldsForSave;
+    }
+
     use ExpressionHelperTrait;
     use OperatorListTrait;
 
@@ -1168,5 +1171,16 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
                 $entity->setChanges($changes);
             }
         }
+    }
+
+    /**
+     * @param $fields
+     */
+    protected function prepareDbalFieldsForSave(&$fields)
+    {
+        // Do not save points as they are handled by postSaveEntity
+        unset($fields['points']);
+
+        $this->defaultPrepareDbalFieldsForSave($fields);
     }
 }

--- a/app/bundles/LeadBundle/Model/DefaultValueTrait.php
+++ b/app/bundles/LeadBundle/Model/DefaultValueTrait.php
@@ -11,22 +11,24 @@
 
 namespace Mautic\LeadBundle\Model;
 
+use Mautic\LeadBundle\Entity\CustomFieldEntityInterface;
+
 trait DefaultValueTrait
 {
     /**
      * @param        $entity
      * @param string $object
      */
-    protected function setEntityDefaultValues($entity, $object = 'lead')
+    protected function setEntityDefaultValues(CustomFieldEntityInterface $entity, $object = 'lead')
     {
         if (!$entity->getId()) {
-            // New contact so default values if not already set
-            $updatedFields = $entity->getUpdatedFields();
-
             /** @var FieldModel $fieldModel */
             $fields = $this->leadFieldModel->getFieldListWithProperties($object);
             foreach ($fields as $alias => $field) {
-                if (!isset($updatedFields[$alias]) && '' !== $field['defaultValue'] && null !== $field['defaultValue']) {
+                // Prevent defaults from overwriting values already set
+                $value = $entity->getFieldValue($alias);
+
+                if ((null === $value || '' === $value) && '' !== $field['defaultValue'] && null !== $field['defaultValue']) {
                     $entity->addUpdatedField($alias, $field['defaultValue']);
                 }
             }

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -86,6 +86,7 @@ class FieldModel extends FormModel
             'fixed'    => true,
             'listable' => true,
             'object'   => 'lead',
+            'default'  => 0,
         ],
         'fax' => [
             'type'     => 'tel',

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
@@ -14,9 +14,15 @@ namespace Mautic\LeadBundle\Tests\Model;
 use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\Test\MauticWebTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Event\LeadEvent;
+use Mautic\LeadBundle\LeadEvents;
+use Mautic\LeadBundle\Model\LeadModel;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class LeadModelFunctionalTest extends MauticWebTestCase
 {
+    private $pointsAdded = false;
+
     public function testMergedContactFound()
     {
         $model = $this->container->get('mautic.lead.model.lead');
@@ -123,5 +129,53 @@ class LeadModelFunctionalTest extends MauticWebTestCase
         $jane = $model->getEntity($jane->getId());
 
         $this->assertEquals(56, $jane->getPoints());
+    }
+
+    public function testSavingPrimaryCompanyAfterPointsAreSetByListenerAreNotResetToDefaultOf0BecauseOfPointsFieldDefaultIs0()
+    {
+        /** @var EventDispatcher $eventDispatcher */
+        $eventDispatcher = $this->container->get('event_dispatcher');
+        $eventDispatcher->addListener(LeadEvents::LEAD_POST_SAVE, [$this, 'addPointsListener']);
+
+        /** @var LeadModel $model */
+        $model = $this->container->get('mautic.lead.model.lead');
+        /** @var EntityManager $em */
+        $em   = $this->container->get('doctrine.orm.entity_manager');
+
+        // Set company to trigger setPrimaryCompany()
+        $lead = new Lead();
+        $data = ['email' => 'pointtest@test.com', 'company' => 'PointTest'];
+        $model->setFieldValues($lead, $data, false, true, true);
+
+        // Save to trigger points listener and setting primary company
+        $model->saveEntity($lead);
+
+        // Clear from doctrine memory so we get a fresh entity to ensure the points are definitely saved
+        $em->clear(Lead::class);
+        $lead = $model->getEntity($lead->getId());
+
+        $this->assertEquals(10, $lead->getPoints());
+    }
+
+    /**
+     * Simulate a PointModel::triggerAction.
+     *
+     * @param LeadEvent $event
+     */
+    public function addPointsListener(LeadEvent $event)
+    {
+        // Prevent a loop
+        if ($this->pointsAdded) {
+            return;
+        }
+
+        $this->pointsAdded = true;
+
+        $lead = $event->getLead();
+        $lead->adjustPoints(10);
+
+        /** @var LeadModel $model */
+        $model = $this->container->get('mautic.lead.model.lead');
+        $model->saveEntity($lead);
     }
 }

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
@@ -12,14 +12,14 @@
 namespace Mautic\LeadBundle\Tests\Model;
 
 use Doctrine\ORM\EntityManager;
-use Mautic\CoreBundle\Test\MauticWebTestCase;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Event\LeadEvent;
 use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
-class LeadModelFunctionalTest extends MauticWebTestCase
+class LeadModelFunctionalTest extends MauticMysqlTestCase
 {
     private $pointsAdded = false;
 
@@ -75,6 +75,7 @@ class LeadModelFunctionalTest extends MauticWebTestCase
 
     public function testMergedContactsPointsAreAccurate()
     {
+        /** @var LeadModel $model */
         $model = $this->container->get('mautic.lead.model.lead');
         /** @var EntityManager $em */
         $em   = $this->container->get('doctrine.orm.entity_manager');
@@ -85,7 +86,9 @@ class LeadModelFunctionalTest extends MauticWebTestCase
             ->setLastname('Smith')
             ->setEmail('jane.smith@test.com')
             ->setPoints(50);
+
         $model->saveEntity($jane);
+
         $em->clear(Lead::class);
         $jane = $model->getEntity($jane->getId());
         $this->assertEquals(50, $jane->getPoints());


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This was an annoying bug to track down! There are three things required to trigger the bug. 

1. A form field must have a field mapped to the contact `company` field
2. The custom field `points` must have a default value of 0 set (installations from before 2.9.0 had the default value set to 0 through a migration where new installations since defaulted to null). 
3. A point action listening to form submits

Now when the form is submitted, a new Lead entity has the default values applied which inserts the values into the `$updatedFields` property. Because `points` is treated as a custom field, this adds `"points" => 0` to the array.

The form saves the new lead triggering the on post lead save events. Here the point action picks up the lead and adds 10 points via adjustPoints(). 

At the end of LeadModel::saveEntity, the lead is then added to the company created from the form payload. This calls setPrimaryCompany() where the repository's saveEntity() which is done on purpose to keep from re-dispatching the lead save events. But because `points` was in the $updatedFields array, the query that updates non-ORM/custom field values overwrites the lead's points in the database. 

This PR hacks it by simply making sure points are not part of the custom field data that is directly written to the database as points are handled outside of the ORM and custom field handling due to the need to prevent concurrent updates from overwriting the other due to doing math in PHP memory. 

A bit of a cluster. 

Note this PR also installs points with a default of 0 to help keep schema in sync with updates. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new form that has email and company fields mapped (the Contact -> Company field; not the Company -> Company Name field).  
2. Go to Custom Fields and edit Points. Check that default value is 0. If not, set it to 0.
3. Create a new Point Action to add 10 points on a form submit  (Points -> Manage Actions -> New -> When a contact...submits a form give 10 points)
4. Open the form (/form/ID replace ID) in a guest window and submit the form with a non-existing contact email
5. Go to the contact's profile and notice they have a points change entry in their timeline/history but their points are 0

#### Steps to test this PR:
1. Repeat the above and now it should work 
2. Run the new functional test that simulates the process
