### PR TITLE
Add FormBuilder to CustomFormEvent so plugins could modify Mautic forms

### DIFF
--- a/app/bundles/CoreBundle/Event/CustomFormEvent.php
+++ b/app/bundles/CoreBundle/Event/CustomFormEvent.php
@@ -13,6 +13,7 @@ namespace Mautic\CoreBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * Class CustomFormEvent.
@@ -20,12 +21,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class CustomFormEvent extends Event
 {
     /**
-     * @var
+     * @var string
      */
     protected $formName;
 
     /**
-     * @var
+     * @var string
      */
     protected $formType;
 
@@ -40,18 +41,26 @@ class CustomFormEvent extends Event
     protected $subscribers = [];
 
     /**
+     * @var FormBuilderInterface
+     */
+    private $formBuilder;
+
+    /**
      * CustomFormEvent constructor.
      *
-     * @param $formName
+     * @param string               $formName
+     * @param string               $formType
+     * @param FormBuilderInterface $formBuilder
      */
-    public function __construct($formName, $formType)
+    public function __construct($formName, $formType, FormBuilderInterface $formBuilder)
     {
-        $this->formName = $formName;
-        $this->formType = $formType;
+        $this->formName    = $formName;
+        $this->formType    = $formType;
+        $this->formBuilder = $formBuilder;
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getFormName()
     {
@@ -59,11 +68,19 @@ class CustomFormEvent extends Event
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getFormType()
     {
         return $this->formType;
+    }
+
+    /**
+     * @return FormBuilderInterface
+     */
+    public function getFormBuilder()
+    {
+        return $this->formBuilder;
     }
 
     /**

--- a/app/bundles/CoreBundle/Form/Extension/CustomFormExtension.php
+++ b/app/bundles/CoreBundle/Form/Extension/CustomFormExtension.php
@@ -45,7 +45,7 @@ class CustomFormExtension extends AbstractTypeExtension
         if ($this->dispatcher->hasListeners(CoreEvents::ON_FORM_TYPE_BUILD)) {
             $event = $this->dispatcher->dispatch(
                 CoreEvents::ON_FORM_TYPE_BUILD,
-                new CustomFormEvent($builder->getName(), $builder->getType()->getName())
+                new CustomFormEvent($builder->getName(), $builder->getType()->getName(), $builder)
             );
 
             if ($listeners = $event->getListeners()) {

--- a/app/bundles/LeadBundle/Views/List/list.html.php
+++ b/app/bundles/LeadBundle/Views/List/list.html.php
@@ -67,6 +67,7 @@ $listCommand = $view['translator']->trans('mautic.lead.lead.searchcommand.list')
             </thead>
             <tbody>
             <?php foreach ($items as $item): ?>
+                <?php $mauticTemplateVars['item'] = $item; ?>
                 <tr>
                     <td>
                         <?php
@@ -123,6 +124,7 @@ $listCommand = $view['translator']->trans('mautic.lead.lead.searchcommand.list')
                             <?php if ($item->isGlobal()): ?>
                                 <i class="fa fa-fw fa-globe"></i>
                             <?php endif; ?>
+                            <?php echo $view['content']->getCustomContent('segment.name', $mauticTemplateVars); ?>
                         </div>
                         <?php if ($description = $item->getDescription()): ?>
                             <div class="text-muted mt-4">


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Enhancement
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Plugins did not have any option (event) to modify forms before they are rendered. This change will allow that.

#### Steps to test this PR:
1. A code review will be enough.
