### PR TITLE
Prevent tracking device against a Mautic user

### DIFF
--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -364,11 +364,13 @@ class SubmissionModel extends CommonFormModel
         // Create/update lead
         $lead = null;
         if (!empty($leadFieldMatches)) {
-            $lead = $this->createLeadFromSubmit($form, $leadFieldMatches, $leadFields);
+            $this->createLeadFromSubmit($form, $leadFieldMatches, $leadFields);
         }
 
+        $lead          = $this->leadModel->getCurrentLead();
         $trackedDevice = $this->deviceTrackingService->getTrackedDevice();
         $trackingId    = ($trackedDevice === null ? null : $trackedDevice->getTrackingId());
+
         //set tracking ID for stats purposes to determine unique hits
         $submission->setTrackingId($trackingId)
             ->setLead($lead);

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -364,12 +364,9 @@ class SubmissionModel extends CommonFormModel
         // Create/update lead
         $lead = null;
         if (!empty($leadFieldMatches)) {
-            $this->createLeadFromSubmit($form, $leadFieldMatches, $leadFields);
+            $lead = $this->createLeadFromSubmit($form, $leadFieldMatches, $leadFields);
         }
 
-        // Get updated lead if applicable with tracking ID
-        /** @var Lead $lead */
-        $lead          = $this->leadModel->getCurrentLead();
         $trackedDevice = $this->deviceTrackingService->getTrackedDevice();
         $trackingId    = ($trackedDevice === null ? null : $trackedDevice->getTrackingId());
         //set tracking ID for stats purposes to determine unique hits

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -916,6 +916,7 @@ return [
                     'mautic.lead.repository.lead_device',
                     'mautic.helper.random',
                     'request_stack',
+                    'mautic.security',
                 ],
             ],
             'mautic.tracker.contact' => [

--- a/app/bundles/LeadBundle/Tests/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceTest.php
@@ -14,6 +14,7 @@ namespace Mautic\LeadBundle\Tests\Tracker\Service\DeviceTrackingService;
 use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\CookieHelper;
 use Mautic\CoreBundle\Helper\RandomHelper\RandomHelperInterface;
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadDevice;
 use Mautic\LeadBundle\Entity\LeadDeviceRepository;
@@ -51,6 +52,11 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
      */
     private $requestStackMock;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $security;
+
     protected function setUp()
     {
         $this->cookieHelperMock            = $this->createMock(CookieHelper::class);
@@ -58,6 +64,7 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
         $this->randomHelperMock            = $this->createMock(RandomHelperInterface::class);
         $this->leadDeviceRepositoryMock    = $this->createMock(LeadDeviceRepository::class);
         $this->requestStackMock            = $this->createMock(RequestStack::class);
+        $this->security                    = $this->createMock(CorePermissions::class);
     }
 
     public function testIsTrackedTrue()
@@ -363,6 +370,21 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test that a user is not tracked.
+     */
+    public function testUserIsNotTracked()
+    {
+        $this->leadDeviceRepositoryMock->expects($this->never())
+            ->method('getByTrackingId');
+
+        $this->security->expects($this->once())
+            ->method('isAnonymous')
+            ->willReturn(false);
+
+        $this->getDeviceTrackingService()->getTrackedDevice();
+    }
+
+    /**
      * @return DeviceTrackingService
      */
     private function getDeviceTrackingService()
@@ -372,7 +394,8 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
             $this->entityManagerMock,
             $this->leadDeviceRepositoryMock,
             $this->randomHelperMock,
-            $this->requestStackMock
+            $this->requestStackMock,
+            $this->security
         );
     }
 }

--- a/app/bundles/LeadBundle/Tests/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceTest.php
@@ -85,6 +85,10 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
             ->willReturn($trackingId);
         $leadDeviceMock = $this->createMock(LeadDevice::class);
 
+        $this->security->expects($this->once())
+            ->method('isAnonymous')
+            ->willReturn(true);
+
         $this->leadDeviceRepositoryMock->expects($this->at(0))
             ->method('getByTrackingId')
             ->with($trackingId)
@@ -111,6 +115,10 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
             ->with('mautic_device_id', null)
             ->willReturn($trackingId);
 
+        $this->security->expects($this->once())
+            ->method('isAnonymous')
+            ->willReturn(true);
+
         $this->leadDeviceRepositoryMock->expects($this->at(0))
             ->method('getByTrackingId')
             ->with($trackingId)
@@ -136,6 +144,10 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
             ->method('getCookie')
             ->with('mautic_device_id', null)
             ->willReturn($trackingId);
+
+        $this->security->expects($this->once())
+            ->method('isAnonymous')
+            ->willReturn(true);
 
         $leadDeviceMock = $this->createMock(LeadDevice::class);
         $this->leadDeviceRepositoryMock->expects($this->at(0))
@@ -168,6 +180,10 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
             ->with('mautic_device_id', null)
             ->willReturn($trackingId);
 
+        $this->security->expects($this->once())
+            ->method('isAnonymous')
+            ->willReturn(true);
+
         $leadDeviceMock = $this->createMock(LeadDevice::class);
         $this->leadDeviceRepositoryMock->expects($this->at(0))
             ->method('getByTrackingId')
@@ -195,6 +211,10 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->with('mautic_device_id', null)
             ->willReturn(null);
+
+        $this->security->expects($this->once())
+            ->method('isAnonymous')
+            ->willReturn(true);
 
         $this->leadDeviceRepositoryMock->expects($this->never())
             ->method('getByTrackingId');
@@ -237,6 +257,10 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
             ->with('mautic_device_id', null)
             ->willReturn($trackingId);
 
+        $this->security->expects($this->once())
+            ->method('isAnonymous')
+            ->willReturn(true);
+
         $this->leadDeviceRepositoryMock->expects($this->at(0))
             ->method('getByTrackingId')
             ->with($trackingId)
@@ -270,6 +294,10 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
             ->method('getCookie')
             ->with('mautic_device_id', null)
             ->willReturn($trackingId);
+
+        $this->security->expects($this->once())
+            ->method('isAnonymous')
+            ->willReturn(true);
 
         $this->leadDeviceRepositoryMock->expects($this->at(0))
             ->method('getByTrackingId')
@@ -345,6 +373,10 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
             ->with(23)
             ->willReturn($uniqueTrackingIdentifier);
 
+        $this->security->expects($this->once())
+            ->method('isAnonymous')
+            ->willReturn(true);
+
         // index 0-3 for leadDeviceRepository::findOneBy
         $leadDeviceMock->expects($this->at(4))
             ->method('getTrackingId')
@@ -376,6 +408,11 @@ final class DeviceTrackingServiceTest extends \PHPUnit_Framework_TestCase
     {
         $this->leadDeviceRepositoryMock->expects($this->never())
             ->method('getByTrackingId');
+
+        $requestMock = $this->createMock(Request::class);
+        $this->requestStackMock->expects($this->at(0))
+            ->method('getCurrentRequest')
+            ->willReturn($requestMock);
 
         $this->security->expects($this->once())
             ->method('isAnonymous')

--- a/app/bundles/LeadBundle/Tracker/ContactTracker.php
+++ b/app/bundles/LeadBundle/Tracker/ContactTracker.php
@@ -134,13 +134,13 @@ class ContactTracker
         }
 
         if ($this->request) {
-            $this->logger->addDebug('LEAD: Tracking session for contact ID# '.$this->trackedContact->getId().' through '.$this->request->getMethod().' '.$this->request->getRequestUri());
+            $this->logger->addDebug('CONTACT: Tracking session for contact ID# '.$this->trackedContact->getId().' through '.$this->request->getMethod().' '.$this->request->getRequestUri());
         }
 
         // Log last active for the tracked contact
-        if (!defined('MAUTIC_LEAD_LASTACTIVE_LOGGED')) {
+        if (!defined('MAUTIC_CONTACT_LASTACTIVE_LOGGED')) {
             $this->leadRepository->updateLastActive($this->trackedContact->getId());
-            define('MAUTIC_LEAD_LASTACTIVE_LOGGED', 1);
+            define('MAUTIC_CONTACT_LASTACTIVE_LOGGED', 1);
         }
 
         return $this->trackedContact;
@@ -153,7 +153,7 @@ class ContactTracker
      */
     public function setTrackedContact(Lead $trackedContact)
     {
-        $this->logger->addDebug("LEAD: {$trackedContact->getId()} set as current lead.");
+        $this->logger->addDebug("CONTACT: {$trackedContact->getId()} set as current lead.");
 
         if ($this->useSystemContact()) {
             // Overwrite system current lead
@@ -223,19 +223,14 @@ class ContactTracker
      */
     private function getSystemContact()
     {
-        if ($this->isUserSession()) {
-            $this->logger->addDebug('LEAD: In a Mautic user session');
-
-            return null;
-        }
-
-        if ($this->useSystemContact()) {
-            $this->logger->addDebug('LEAD: System lead is being used');
-            if (null === $this->systemContact) {
-                $this->systemContact = new Lead();
-            }
+        if ($this->useSystemContact() && $this->systemContact) {
+            $this->logger->addDebug('CONTACT: System lead is being used');
 
             return $this->systemContact;
+        }
+
+        if ($this->isUserSession()) {
+            $this->logger->addDebug('CONTACT: In a Mautic user session');
         }
 
         return null;
@@ -274,7 +269,7 @@ class ContactTracker
         }
 
         if ($lead) {
-            $this->logger->addDebug("LEAD: Existing lead found with ID# {$lead->getId()}.");
+            $this->logger->addDebug("CONTACT: Existing lead found with ID# {$lead->getId()}.");
         }
 
         return $lead;
@@ -297,7 +292,7 @@ class ContactTracker
             $leads = $this->leadRepository->getLeadsByIp($ip->getIpAddress());
             if (count($leads)) {
                 $lead = $leads[0];
-                $this->logger->addDebug("LEAD: Existing lead found with ID# {$lead->getId()}.");
+                $this->logger->addDebug("CONTACT: Existing lead found with ID# {$lead->getId()}.");
 
                 return $lead;
             }
@@ -325,14 +320,14 @@ class ContactTracker
         if ($persist && !defined('MAUTIC_NON_TRACKABLE_REQUEST')) {
             // Dispatch events for new lead to write create log, ip address change, etc
             $event = new LeadEvent($lead, true);
-            $this->dispatcher->dispatch(LeadEvents::LEAD_PRE_SAVE, $event);
+            $this->dispatcher->dispatch(LeadEvents::CONTACT_PRE_SAVE, $event);
 
             $this->leadRepository->saveEntity($lead);
             $this->hydrateCustomFieldData($lead);
 
-            $this->dispatcher->dispatch(LeadEvents::LEAD_POST_SAVE, $event);
+            $this->dispatcher->dispatch(LeadEvents::CONTACT_POST_SAVE, $event);
 
-            $this->logger->addDebug("LEAD: New lead created with ID# {$lead->getId()}.");
+            $this->logger->addDebug("CONTACT: New lead created with ID# {$lead->getId()}.");
         }
 
         return $lead;
@@ -376,13 +371,13 @@ class ContactTracker
     {
         $newTrackingId = $this->getTrackingId();
         $this->logger->addDebug(
-            "LEAD: Tracking code changed from $previouslyTrackedId for contact ID# {$previouslyTrackedContact->getId()} to $newTrackingId for contact ID# {$this->trackedContact->getId()}"
+            "CONTACT: Tracking code changed from $previouslyTrackedId for contact ID# {$previouslyTrackedContact->getId()} to $newTrackingId for contact ID# {$this->trackedContact->getId()}"
         );
 
         if ($previouslyTrackedId !== null) {
-            if ($this->dispatcher->hasListeners(LeadEvents::CURRENT_LEAD_CHANGED)) {
+            if ($this->dispatcher->hasListeners(LeadEvents::CURRENT_CONTACT_CHANGED)) {
                 $event = new LeadChangeEvent($previouslyTrackedContact, $previouslyTrackedId, $this->trackedContact, $newTrackingId);
-                $this->dispatcher->dispatch(LeadEvents::CURRENT_LEAD_CHANGED, $event);
+                $this->dispatcher->dispatch(LeadEvents::CURRENT_CONTACT_CHANGED, $event);
             }
         }
     }

--- a/app/bundles/LeadBundle/Tracker/ContactTracker.php
+++ b/app/bundles/LeadBundle/Tracker/ContactTracker.php
@@ -124,6 +124,8 @@ class ContactTracker
     {
         if ($systemContact = $this->getSystemContact()) {
             return $systemContact;
+        } elseif ($this->isUserSession()) {
+            return null;
         }
 
         if (empty($this->trackedContact)) {

--- a/app/bundles/LeadBundle/Tracker/ContactTracker.php
+++ b/app/bundles/LeadBundle/Tracker/ContactTracker.php
@@ -138,9 +138,9 @@ class ContactTracker
         }
 
         // Log last active for the tracked contact
-        if (!defined('MAUTIC_CONTACT_LASTACTIVE_LOGGED')) {
+        if (!defined('MAUTIC_LEAD_LASTACTIVE_LOGGED')) {
             $this->leadRepository->updateLastActive($this->trackedContact->getId());
-            define('MAUTIC_CONTACT_LASTACTIVE_LOGGED', 1);
+            define('MAUTIC_LEAD_LASTACTIVE_LOGGED', 1);
         }
 
         return $this->trackedContact;
@@ -320,12 +320,12 @@ class ContactTracker
         if ($persist && !defined('MAUTIC_NON_TRACKABLE_REQUEST')) {
             // Dispatch events for new lead to write create log, ip address change, etc
             $event = new LeadEvent($lead, true);
-            $this->dispatcher->dispatch(LeadEvents::CONTACT_PRE_SAVE, $event);
+            $this->dispatcher->dispatch(LeadEvents::LEAD_PRE_SAVE, $event);
 
             $this->leadRepository->saveEntity($lead);
             $this->hydrateCustomFieldData($lead);
 
-            $this->dispatcher->dispatch(LeadEvents::CONTACT_POST_SAVE, $event);
+            $this->dispatcher->dispatch(LeadEvents::LEAD_POST_SAVE, $event);
 
             $this->logger->addDebug("CONTACT: New lead created with ID# {$lead->getId()}.");
         }
@@ -375,9 +375,9 @@ class ContactTracker
         );
 
         if ($previouslyTrackedId !== null) {
-            if ($this->dispatcher->hasListeners(LeadEvents::CURRENT_CONTACT_CHANGED)) {
+            if ($this->dispatcher->hasListeners(LeadEvents::CURRENT_LEAD_CHANGED)) {
                 $event = new LeadChangeEvent($previouslyTrackedContact, $previouslyTrackedId, $this->trackedContact, $newTrackingId);
-                $this->dispatcher->dispatch(LeadEvents::CURRENT_CONTACT_CHANGED, $event);
+                $this->dispatcher->dispatch(LeadEvents::CURRENT_LEAD_CHANGED, $event);
             }
         }
     }

--- a/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingService.php
+++ b/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingService.php
@@ -14,6 +14,7 @@ namespace Mautic\LeadBundle\Tracker\Service\DeviceTrackingService;
 use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\CookieHelper;
 use Mautic\CoreBundle\Helper\RandomHelper\RandomHelperInterface;
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\LeadBundle\Entity\LeadDevice;
 use Mautic\LeadBundle\Entity\LeadDeviceRepository;
 use Symfony\Component\BrowserKit\Request;
@@ -55,6 +56,11 @@ final class DeviceTrackingService implements DeviceTrackingServiceInterface
     private $trackedDevice;
 
     /**
+     * @var CorePermissions
+     */
+    private $security;
+
+    /**
      * DeviceTrackingService constructor.
      *
      * @param CookieHelper           $cookieHelper
@@ -62,19 +68,22 @@ final class DeviceTrackingService implements DeviceTrackingServiceInterface
      * @param LeadDeviceRepository   $leadDeviceRepository
      * @param RandomHelperInterface  $randomHelper
      * @param RequestStack           $requestStack
+     * @param CorePermissions        $security
      */
     public function __construct(
         CookieHelper $cookieHelper,
         EntityManagerInterface $entityManager,
         LeadDeviceRepository $leadDeviceRepository,
         RandomHelperInterface $randomHelper,
-        RequestStack $requestStack
+        RequestStack $requestStack,
+        CorePermissions $security
     ) {
         $this->cookieHelper           = $cookieHelper;
         $this->entityManager          = $entityManager;
         $this->randomHelper           = $randomHelper;
         $this->leadDeviceRepository   = $leadDeviceRepository;
         $this->request                = $requestStack->getCurrentRequest();
+        $this->security               = $security;
     }
 
     /**
@@ -90,6 +99,11 @@ final class DeviceTrackingService implements DeviceTrackingServiceInterface
      */
     public function getTrackedDevice()
     {
+        if (!$this->security->isAnonymous()) {
+            // Do not track Mautic users
+            return;
+        }
+
         if ($this->trackedDevice) {
             return $this->trackedDevice;
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The device tracker would check for a device of a user. If a user submits a form multiple times, all submissions would be put under the user's name rather than new contacts being created. This fixes that. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form with at least email mapped
2. Go to /s/forms/preview/ID (click the Preview button on the form details page
3. Submit the form a few times 
4. Go to results and notice all the results are under the same contact

#### Steps to test this PR:
1. Repeat and each new email will be a new contact
