### PR TITLE
Fix error 500 if $lead is empty

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -181,7 +181,7 @@ class PublicController extends CommonFormController
             if ($lead) {
                 // Set the lead as current lead
                 $leadModel->setCurrentLead($lead);
-            
+
                 // Set lead lang
                 if ($lead->getPreferredLocale()) {
                     $translator->setLocale($lead->getPreferredLocale());

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -182,11 +182,11 @@ class PublicController extends CommonFormController
                 // Set the lead as current lead
                 $leadModel->setCurrentLead($lead);
             
-            	// Set lead lang
-	            if ($lead->getPreferredLocale()) {
-    	            $translator->setLocale($lead->getPreferredLocale());
-        	    }
-			}
+                // Set lead lang
+                if ($lead->getPreferredLocale()) {
+                    $translator->setLocale($lead->getPreferredLocale());
+                }
+            }
 
             if (!$this->get('mautic.helper.core_parameters')->getParameter('show_contact_preferences')) {
                 $message = $this->getUnsubscribeMessage($idHash, $model, $stat, $translator);

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -181,11 +181,12 @@ class PublicController extends CommonFormController
             if ($lead) {
                 // Set the lead as current lead
                 $leadModel->setCurrentLead($lead);
-            }
-            // Set lead lang
-            if ($lead->getPreferredLocale()) {
-                $translator->setLocale($lead->getPreferredLocale());
-            }
+            
+            	// Set lead lang
+	            if ($lead->getPreferredLocale()) {
+    	            $translator->setLocale($lead->getPreferredLocale());
+        	    }
+			}
 
             if (!$this->get('mautic.helper.core_parameters')->getParameter('show_contact_preferences')) {
                 $message = $this->getUnsubscribeMessage($idHash, $model, $stat, $translator);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| Automated tests included? |no
| Related user documentation PR URL | no
| Related developer documentation PR URL | no
| Issues addressed (#s or URLs) | no
| BC breaks? | no
| Deprecations? | no

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Throws a 500 error if $lead is empty:
```
mautic.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Call to a member function getPreferredLocale() on null" at /var/www/html/app/bundles/EmailBundle/Controller/PublicController.php line 186 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Call to a member function getPreferredLocale() on null at /var/www/html/app/bundles/EmailBundle/Controller/PublicController.php:186)"} []
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 