### PR TITLE
Fixed filter in contacts activity api

### DIFF
--- a/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
@@ -152,8 +152,14 @@ class LeadSubscriber extends CommonSubscriber
     {
         $eventTypeKey  = 'email.replied';
         $eventTypeName = $this->translator->trans('mautic.email.replied');
-        $event->addSerializerGroup('emailList');
         $event->addEventType($eventTypeKey, $eventTypeName);
+        $event->addSerializerGroup('emailList');
+
+        // Decide if those events are filtered
+        if (!$event->isApplicable($eventTypeKey)) {
+            return;
+        }
+
         $options          = $event->getQueryOptions();
         $replies          = $this->emailReplyRepository->getByLeadIdForTimeline($event->getLeadId(), $options);
         if (!$event->isEngagementCount()) {

--- a/app/bundles/LeadBundle/EventListener/TimelineEventLogSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/TimelineEventLogSubscriber.php
@@ -75,6 +75,10 @@ class TimelineEventLogSubscriber implements EventSubscriberInterface
         $eventTypeName = $this->translator->trans($eventTypeName);
         $event->addEventType($eventType, $eventTypeName);
 
+        if (!$event->isApplicable($eventType)) {
+            return;
+        }
+
         $action = str_replace('lead.source.', '', $eventType).'_contact';
         $events = $this->leadEventLogRepository->getEventsByAction($action, $event->getLead(), $event->getQueryOptions());
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Some contact activity was never filtered in Api. The following activities were always returned without taking into account filters includeEvents or excludeEvents : 
lead.source.created
lead.source.identified

Second commit : 
Event email.replied was never filtered in Api

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. On API Tester, launch a request on /api/contacts/activity URL and a filters[includeEvents][] on email.read (https://developer.mautic.org/#get-activity-events-for-all-contacts)
2. We received email.read, lead.source.created, lead.source.identified events and email.replied

#### Steps to test this PR:
1. Relaunch same request as before
2. We received only email.read events