### PR TITLE
Inconsistency between api and dashboard on event email.read and email.sent

### DIFF
--- a/app/bundles/EmailBundle/Entity/StatRepository.php
+++ b/app/bundles/EmailBundle/Entity/StatRepository.php
@@ -342,6 +342,8 @@ class StatRepository extends CommonRepository
                     $query->expr()->eq('s.is_read', 1)
                 );
             } elseif ('sent' == $state) {
+                // Inconsistency between api and dashboard
+
                 // Get only those that have not been read yet
                 $query->andWhere(
                     $query->expr()->eq('s.is_read', 0)

--- a/app/bundles/EmailBundle/Entity/StatRepository.php
+++ b/app/bundles/EmailBundle/Entity/StatRepository.php
@@ -341,25 +341,13 @@ class StatRepository extends CommonRepository
                 $query->andWhere(
                     $query->expr()->eq('s.is_read', 1)
                 );
-            } elseif ('sent' == $state) {
-                // Inconsistency between api and dashboard
-
-                // Get only those that have not been read yet
-                $query->andWhere(
-                    $query->expr()->eq('s.is_read', 0)
-                );
-                $query->andWhere(
-                    $query->expr()->eq('s.is_failed', 0)
-                );
             } elseif ('failed' == $state) {
                 $query->andWhere(
                     $query->expr()->eq('s.is_failed', 1)
                 );
-                $state = 'sent';
             }
-        } else {
-            $state = 'sent';
         }
+        $state = 'sent';
 
         if (isset($options['search']) && $options['search']) {
             $query->andWhere(
@@ -544,7 +532,7 @@ class StatRepository extends CommonRepository
 
     /**
      * @param $contacts
-     * @param   $emailId
+     * @param $emailId
      *
      * @return mixed
      */

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1131,15 +1131,15 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
     /**
      * Send an email to lead(s).
      *
-     * @param   $email
-     * @param   $leads
-     * @param   $options = array()
-     *                   array source array('model', 'id')
-     *                   array emailSettings
-     *                   int   listId
-     *                   bool  allowResends     If false, exact emails (by id) already sent to the lead will not be resent
-     *                   bool  ignoreDNC        If true, emails listed in the do not contact table will still get the email
-     *                   array assetAttachments Array of optional Asset IDs to attach
+     * @param $email
+     * @param $leads
+     * @param $options = array()
+     *                  array source array('model', 'id')
+     *                  array emailSettings
+     *                  int   listId
+     *                  bool  allowResends     If false, exact emails (by id) already sent to the lead will not be resent
+     *                  bool  ignoreDNC        If true, emails listed in the do not contact table will still get the email
+     *                  array assetAttachments Array of optional Asset IDs to attach
      *
      * @return mixed
      *
@@ -1854,7 +1854,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         $read   = $query->fetchCount($readQ);
         $failed = $query->fetchCount($failedQ);
 
-        $chart->setDataset($this->translator->trans('mautic.email.graph.pie.ignored.read.failed.ignored'), ($sent - $read));
+        $chart->setDataset($this->translator->trans('mautic.email.graph.pie.ignored.read.failed.ignored'), ($sent - $read - $failed));
         $chart->setDataset($this->translator->trans('mautic.email.graph.pie.ignored.read.failed.read'), $read);
         $chart->setDataset($this->translator->trans('mautic.email.graph.pie.ignored.read.failed.failed'), $failed);
 
@@ -1864,8 +1864,8 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
     /**
      * Get pie chart data of ignored vs opened emails.
      *
-     * @param   $dateFrom
-     * @param   $dateTo
+     * @param $dateFrom
+     * @param $dateTo
      *
      * @return array
      */


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
I have found an inconsistency between API and dashboard:
- Event `email.read`, on dashboard the request is filtered on the `date_sent` field but on API it's filtered on the `date_read` field
- Event `email.sent`, on dashboard the request is filtered only on the `date_sent` but on API it's filtered on `date_sent`, `is_read = 0` and `is_failed = 0`

Which of the two, the API or the dashboard is correct to make corrections?
______________

**EDIT: We have chosen the dashboard view which is more logic according to @npracht comment.**
______________

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. On API Tester, launch a request on `/api/contacts/activity` URL and a `filters[includeEvents][]` on `email.sent`
2. Compare the result with `email.sent` from the dashboard graph "Emails sent / opened" (Only sent emails)