### PR TITLE
Fixed PHP notice during contact merging and redirects with asset and page link tokens

### DIFF
--- a/app/bundles/LeadBundle/Deduplicate/ContactMerger.php
+++ b/app/bundles/LeadBundle/Deduplicate/ContactMerger.php
@@ -174,6 +174,15 @@ class ContactMerger
         $newest = ($loserDate > $winnerDate) ? $loser : $winner;
         $oldest = ($newest->getId() === $winner->getId()) ? $loser : $winner;
 
+        // It may happen that the Lead entities doesn't have fields fill in. Fill them in if not.
+        if (!$newest->hasFields()) {
+            $newest->setFields($this->leadModel->getRepository()->getFieldValues($newest->getId()));
+        }
+
+        if (!$oldest->hasFields()) {
+            $oldest->setFields($this->leadModel->getRepository()->getFieldValues($oldest->getId()));
+        }
+
         $newestFields = $newest->getProfileFields();
         $oldestFields = $oldest->getProfileFields();
 

--- a/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
@@ -264,6 +264,14 @@ trait CustomFieldEntityTrait
     }
 
     /**
+     * @return bool
+     */
+    public function hasFields()
+    {
+        return !empty($this->fields);
+    }
+
+    /**
      * @param $key
      */
     public function getEventData($key)

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -16,6 +16,7 @@ use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\LeadBundle\Deduplicate\ContactMerger;
 use Mautic\LeadBundle\Deduplicate\Exception\SameContactException;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\MergeRecordRepository;
 use Mautic\LeadBundle\Entity\Tag;
 use Mautic\LeadBundle\Model\LeadModel;
@@ -29,6 +30,11 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
      * @var \PHPUnit_Framework_MockObject_MockObject|LeadModel
      */
     private $leadModel;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|MergeRecordRepository
+     */
+    private $leadRepo;
 
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|MergeRecordRepository
@@ -51,6 +57,10 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->leadRepo = $this->getMockBuilder(LeadRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->mergeRecordRepo = $this->getMockBuilder(MergeRecordRepository::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -62,6 +72,8 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
         $this->logger = $this->getMockBuilder(Logger::class)
             ->disableOriginalConstructor()
             ->getMock();
+
+        $this->leadModel->method('getRepository')->willReturn($this->leadRepo);
     }
 
     public function testMergeTimestamps()
@@ -140,11 +152,11 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
             ->with('email')
             ->willReturn('winner@test.com');
 
-        $winner->expects($this->exactly(2))
+        $winner->expects($this->exactly(3))
             ->method('getId')
             ->willReturn(1);
 
-        $loser->expects($this->once())
+        $loser->expects($this->exactly(2))
             ->method('getId')
             ->willReturn(2);
 
@@ -199,11 +211,11 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
             ->method('getDateModified')
             ->willReturn($loserDateModified);
 
-        $winner->expects($this->exactly(3))
+        $winner->expects($this->exactly(4))
             ->method('getId')
             ->willReturn(1);
 
-        $loser->expects($this->never())
+        $loser->expects($this->once())
             ->method('getId');
 
         // Winner values are newest so should be kept
@@ -259,11 +271,11 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
             ->method('getDateAdded')
             ->willReturn($loserDateModified);
 
-        $winner->expects($this->exactly(2))
+        $winner->expects($this->exactly(3))
             ->method('getId')
             ->willReturn(1);
 
-        $loser->expects($this->once())
+        $loser->expects($this->exactly(2))
             ->method('getId')
             ->willReturn(2);
 
@@ -321,11 +333,11 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
             ->method('getDateModified')
             ->willReturn($loserDateModified);
 
-        $winner->expects($this->exactly(3))
+        $winner->expects($this->exactly(4))
             ->method('getId')
             ->willReturn(1);
 
-        $loser->expects($this->never())
+        $loser->expects($this->once())
             ->method('getId');
 
         // Winner values are newest so should be kept

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -455,6 +455,8 @@ class PublicController extends CommonFormController
         $lead      = $leadModel->getContactFromRequest([$ct]);
         $leadArray = ($lead) ? $lead->getProfileFields() : [];
         $url       = TokenHelper::findLeadTokens($url, $leadArray, true);
+        $url       = $this->replacePageTokenUrl($url);
+        $url       = $this->replaceAssetTokenUrl($url);
         $url       = UrlHelper::sanitizeAbsoluteUrl($url);
 
         if (false === filter_var($url, FILTER_VALIDATE_URL)) {
@@ -462,6 +464,48 @@ class PublicController extends CommonFormController
         }
 
         return $this->redirect($url);
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return string
+     */
+    private function replaceAssetTokenUrl($url)
+    {
+        if ($this->urlIsToken($url)) {
+            $tokens = $this->get('mautic.asset.helper.token')->findAssetTokens($url);
+
+            return isset($tokens[$url]) ? $tokens[$url] : $url;
+        }
+
+        return $url;
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return string
+     */
+    private function replacePageTokenUrl($url)
+    {
+        if ($this->urlIsToken($url)) {
+            $tokens = $this->get('mautic.page.helper.token')->findPageTokens($url);
+
+            return isset($tokens[$url]) ? $tokens[$url] : $url;
+        }
+
+        return $url;
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return bool
+     */
+    private function urlIsToken($url)
+    {
+        return substr($url, 0, 1) === '{';
     }
 
     /**


### PR DESCRIPTION

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When an email contained a redirect from landing page or asset tokens it caused this issue:

`PHP Notice - Undefined index: title`

The problem was that the Lead entity loaded from the Stat entity did not have custom fields loaded and they were missing when merging. This PR makes sure that the fields are loaded before merging.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create an email with 2 links. One to a landing page the second to an asset.
2. Send the email to a contact.
3. Open the links in the incognito browser and notice there is a problem.

#### Steps to test this PR:
1. Open the links again. It will redirect correctly.
