### PR TITLE
Set owner_id when sending emails via campaign to support owner is mailer

### DIFF
--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -310,6 +310,12 @@ class CampaignSubscriber implements EventSubscriberInterface
          */
         foreach ($contacts as $logId => $contact) {
             $leadCredentials = $contact->getProfileFields();
+
+            // Set owner_id to support the "Owner is mailer" feature
+            if ($contact->getOwner()) {
+                $leadCredentials['owner_id'] = $contact->getOwner()->getId();
+            }
+
             if (empty($leadCredentials['email'])) {
                 // Pass with a note to the UI because no use retrying
                 $event->passWithError(


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When sending email though a campaign the mailer is owner feature did not work because the owner_id was not set.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make sure you have the "mailer is owner" feature turned on in the configuration
2. Make sure at least one of the contacts in your testing segment has an owner user other than admin. Create one if you don't have such user.
3. Create a campaign
4. Use your testing segment the source segment
5. Add the Send email action and select some bogus template email.
6. Trigger the campaign
7. Check that all emails were sent from the global email address.

#### Steps to test this PR:
1. Clone the campaign
2. Trigger the cloned campaign
3. Check that emails were sent from the correct email address.
