### PR TITLE
Changed label from sent to opened

### DIFF
--- a/app/bundles/EmailBundle/Helper/AbTestHelper.php
+++ b/app/bundles/EmailBundle/Helper/AbTestHelper.php
@@ -146,7 +146,7 @@ class AbTestHelper
                     $support['labels'][] = $name.' ('.$rates[$id].'%)';
 
                     $data[$translator->trans('mautic.email.abtest.label.clickthrough')][] = $count;
-                    $data[$translator->trans('mautic.email.abtest.label.sent')][]         = $sentCounts[$id];
+                    $data[$translator->trans('mautic.email.abtest.label.opened')][]       = $sentCounts[$id];
                     $hasResults[]                                                         = $id;
                 }
 
@@ -155,7 +155,7 @@ class AbTestHelper
                     $support['labels'][] = $parent->getName().' (0%)';
 
                     $data[$translator->trans('mautic.email.abtest.label.clickthrough')][] = 0;
-                    $data[$translator->trans('mautic.email.abtest.label.sent')][]         = 0;
+                    $data[$translator->trans('mautic.email.abtest.label.opened')][]       = 0;
                 }
 
                 foreach ($children as $c) {
@@ -164,7 +164,7 @@ class AbTestHelper
                             //make sure that parent and published children are included
                             $support['labels'][]                                                  = $c->getName().' (0%)';
                             $data[$translator->trans('mautic.email.abtest.label.clickthrough')][] = 0;
-                            $data[$translator->trans('mautic.email.abtest.label.sent')][]         = 0;
+                            $data[$translator->trans('mautic.email.abtest.label.opened')][]       = 0;
                         }
                     }
                 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The function getSentCounts for email AB tests return email read count and not email sent count.
It is more common to compare a number of clicks compared to the number of readings so only the label has been modified.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to `AB test stats` on email view
2. The label is `Number sent`

#### Steps to test this PR:
1. Apply PR
2. Go to `AB test stats` on email view
3. The label is `Number read`