### PR TITLE
Do not generate company name from email address domain

### DIFF
--- a/app/bundles/LeadBundle/Helper/IdentifyCompanyHelper.php
+++ b/app/bundles/LeadBundle/Helper/IdentifyCompanyHelper.php
@@ -75,9 +75,8 @@ class IdentifyCompanyHelper
             $companyName = filter_var($parameters['company']);
         } elseif (isset($parameters['companyname'])) {
             $companyName = filter_var($parameters['companyname']);
-        } elseif (isset($parameters['email']) || isset($parameters['companyemail'])) {
-            $companyName = isset($parameters['email']) ? self::domainExists($parameters['email']) : self::domainExists($parameters['companyemail']);
         }
+
         if (empty($parameters['companywebsite']) && !empty($parameters['companyemail'])) {
             $companyDomain = self::domainExists($parameters['companyemail']);
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | /
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Mautic was generating company name from email address domains in some cases. Many users find this feature confusing and inaccurate in most cases. This PR removes that.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new form
2. Add contact email field to it.
3. Add company email to it. Don't forget to map it as such.
4. Save this form.
5. Open this form on its public URL in an anonymous window `https://[yourmauticdomain]/form/[formID]`
6. Fill in some functional email addresses. For example `john@gmail.com`. The domain must exist.
7. Submit it.
8. Open the contact which was just created. Notice it has a company `gmail.com` associated.

#### Steps to test this PR:
1. Submit the form with another functional email addresses.
2. Notice that no company had been created from the email domain.

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 