### PR TITLE
Fix reports when a column is added to aggregator and not to select

### DIFF
--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentReportSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentReportSubscriberTest.php
@@ -213,7 +213,7 @@ class SegmentReportSubscriberTest extends \PHPUnit_Framework_TestCase
             ->willReturn('segment.membership');
 
         $reportMock->expects($this->exactly(3))
-            ->method('getColumns')
+            ->method('getSelectAndAggregatorColumns')
             ->with()
             ->willReturn([]);
 

--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -443,6 +443,24 @@ class Report extends FormEntity implements SchedulerInterface
     }
 
     /**
+     * @return array
+     */
+    public function getAggregatorColumns()
+    {
+        return array_map(function ($aggregator) {
+            return $aggregator['column'];
+        }, $this->getAggregators());
+    }
+
+    /**
+     * @return array
+     */
+    public function getSelectAndAggregatorColumns()
+    {
+        return array_merge($this->getColumns(), $this->getAggregatorColumns());
+    }
+
+    /**
      * @param array $aggregator
      */
     public function setAggregators(array $aggregators)

--- a/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
@@ -388,7 +388,7 @@ class ReportGeneratorEvent extends AbstractReportEvent
     {
         if (is_array($column)) {
             foreach ($column as $checkMe) {
-                if (in_array($checkMe, $this->getReport()->getColumns(), true)) {
+                if (in_array($checkMe, $this->getReport()->getSelectAndAggregatorColumns(), true)) {
                     return true;
                 }
             }
@@ -396,7 +396,7 @@ class ReportGeneratorEvent extends AbstractReportEvent
             return false;
         }
 
-        return in_array($column, $this->getReport()->getColumns(), true);
+        return in_array($column, $this->getReport()->getSelectAndAggregatorColumns(), true);
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Adding aggregator columns to the hasColumn check so joins would be prepared. Reports were throwing errors if an aggregator column was selected without selecting it in the select clause.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
![screen shot 2018-06-06 at 14 41 08](https://user-images.githubusercontent.com/1235442/41038809-bfddea8c-6997-11e8-920e-7b38375ed822.png)

1. Create similar Email Sends report as in the screenshot
2. Save - error

#### Steps to test this PR:
1. Refresh - report shows correct data.