### PR TITLE
Correct the method used to clean URL

### DIFF
--- a/app/bundles/CoreBundle/Templating/Helper/AssetsHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/AssetsHelper.php
@@ -567,7 +567,7 @@ class AssetsHelper
     public function makeLinks($text, $protocols = ['http', 'mail'], array $attributes = [])
     {
         // clear tags in text
-        $text = InputHelper::clean($text);
+        $text = InputHelper::url($text, false, $protocols);
 
         // Link attributes
         $attr = '';


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6167
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Correction for the issue https://github.com/mautic/mautic/issues/6167
The wrong cleaning function was used on the links.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create an email, add a link and use the caracter & in the link
2. Send the email
3. Open the email and click on the link
4. Check the contact history
5. See that the caracter in the link has been encoded as &#38;

#### Steps to test this PR:
1. Apply the PR
2. Check the contact history
3. See that the caracter in the link is good