### PR TITLE
Fixed BC break where property changes were no longer included in the fields array for getChanges()

### DIFF
--- a/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
@@ -130,6 +130,12 @@ trait CustomFieldEntityTrait
         $field    = $this->getField($alias);
         $setter   = 'set'.ucfirst($property);
 
+        if (null == $oldValue) {
+            $oldValue = $this->getFieldValue($alias);
+        } elseif ($field) {
+            $oldValue = CustomFieldHelper::fixValueType($field['type'], $oldValue);
+        }
+
         if (property_exists($this, $property) && method_exists($this, $setter)) {
             // Fixed custom field so use the setter but don't get caught in a loop such as a custom field called "notes"
             // Set empty value as null
@@ -137,12 +143,6 @@ trait CustomFieldEntityTrait
                 $value = null;
             }
             $this->$setter($value);
-        }
-
-        if (null == $oldValue) {
-            $oldValue = $this->getFieldValue($alias);
-        } elseif ($field) {
-            $oldValue = CustomFieldHelper::fixValueType($field['type'], $oldValue);
         }
 
         if (is_string($value)) {

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -58,6 +58,11 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
     protected $emailValidator;
 
     /**
+     * @var array
+     */
+    private $fields = [];
+
+    /**
      * CompanyModel constructor.
      *
      * @param FieldModel     $leadFieldModel
@@ -244,17 +249,16 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
 
         if (empty($fieldValues)) {
             // Lead is new or they haven't been populated so let's build the fields now
-            static $fields;
-            if (empty($fields)) {
-                $fields = $this->leadFieldModel->getEntities(
+            if (empty($this->fields)) {
+                $this->fields = $this->leadFieldModel->getEntities(
                     [
                         'filter'         => ['object' => 'company'],
                         'hydration_mode' => 'HYDRATE_ARRAY',
                     ]
                 );
-                $fields = $this->organizeFieldsByGroup($fields);
+                $this->fields = $this->organizeFieldsByGroup($this->fields);
             }
-            $fieldValues = $fields;
+            $fieldValues = $this->fields;
         }
 
         //update existing values

--- a/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
@@ -266,6 +266,20 @@ class LeadTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($lead->getChanges());
     }
 
+    public function testChangingPropertiesHydratesFieldChanges()
+    {
+        $email = 'foo@bar.com';
+        $lead  = new Lead();
+        $lead->addUpdatedField('email', $email);
+        $changes = $lead->getChanges();
+
+        $this->assertFalse(empty($changes['email']));
+        $this->assertFalse(empty($changes['fields']['email']));
+
+        $this->assertEquals($email, $changes['email'][1]);
+        $this->assertEquals($email, $changes['fields']['email'][1]);
+    }
+
     /**
      * @param      $points
      * @param      $expected


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Introduced in https://github.com/mautic/mautic/pull/6118, property fields (core fields) on the Lead entity no longer showed up in the `fields` array of getChanges because the value for properties were obtained after it had already been set in addUpdatedField. This broke listeners that were dependent on that `fields` array. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new contact
2. View the audit log's details
3. Note that email is no part of the `fields` array in the serialized details
4. Copy the new test over to staging and run it which will fail

#### Steps to test this PR:
1. Repeat the above and `email` will be in the `fields` array in the audit log's details and the test will pass
