### PR TITLE
Email Stat Limit: limit number of Stat 'openDetails'

### DIFF
--- a/app/bundles/EmailBundle/Entity/Stat.php
+++ b/app/bundles/EmailBundle/Entity/Stat.php
@@ -21,6 +21,9 @@ use Mautic\LeadBundle\Entity\LeadList;
 
 class Stat
 {
+    /** @var int Limit number of stored 'openDetails' */
+    const MAX_OPEN_DETAILS = 1000;
+
     /**
      * @var int|null
      */
@@ -543,7 +546,9 @@ class Stat
      */
     public function addOpenDetails($details)
     {
-        $this->openDetails[] = $details;
+        if (self::MAX_OPEN_DETAILS > $this->getOpenCount()) {
+            $this->openDetails[] = $details;
+        }
 
         ++$this->openCount;
     }

--- a/app/bundles/EmailBundle/Tests/Entity/StatTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/StatTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Entity;
+
+use Mautic\EmailBundle\Entity\Stat;
+use PHPUnit\Framework\TestCase;
+
+class StatTest extends TestCase
+{
+    /**
+     * @param int $count How many openDetails to add to the entity
+     * @dataProvider addOpenDetailsTestProvider
+     */
+    public function testAddOpenDetails(int $count)
+    {
+        $stat = new Stat();
+
+        // Add as many openDetails entries as specified in $count
+        for ($i = 0; $i < $count; ++$i) {
+            $stat->addOpenDetails(sprintf('Open %d of %d', $i + 1, $count));
+        }
+
+        // Assert that the openCount reflects the total number of openDetails
+        $this->assertEquals($count, $stat->getOpenCount());
+
+        // Assert that the number of entries stored in the openDetails array
+        // is equal to the lower of the two values openCount and
+        // Stat::MAX_OPEN_DETAILS
+        $this->assertEquals(
+            min(Stat::MAX_OPEN_DETAILS, $stat->getOpenCount()),
+            count($stat->getOpenDetails())
+        );
+    }
+
+    /**
+     * Data provider for addOpenDetails.
+     */
+    public function addOpenDetailsTestProvider(): array
+    {
+        return [
+            'no openDetails'            => [0],
+            'one openDetail'            => [1],
+            'low number of openDetails' => [10],
+            'one away from threshold'   => [Stat::MAX_OPEN_DETAILS - 1],
+            'exactly at threshold'      => [Stat::MAX_OPEN_DETAILS],
+            'one past threshold'        => [Stat::MAX_OPEN_DETAILS + 1],
+            'slightly above threshold'  => [Stat::MAX_OPEN_DETAILS + 10],
+            'well beyond threshold'     => [Stat::MAX_OPEN_DETAILS * 10],
+        ];
+    }
+}


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? |  Y
| New feature? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

#### Description:

We observed an email client that was sending multiple consecutive open requests. With each request being added to the **Stat** `openDetails` array, the persisted JSON eventually grew too large to be saved to the database. Eventually, MySQL becomes overloaded attempting to deal with so many erroneous (and huge) queries.

To prevent this, we impose a hard limit on the number of entries that can be added to the `openDetails` array.

When calling `Stat#addOpenDetails()`, the argument will only be added to the `openDetails` array if the **Stat**'s `openCount` is less than **Stat::MAX_OPEN_DETAILS** (`1000`). The `openCount` will be incremented regardless.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Request the same tracking pixel thousands of times. ~20,000 was how many went to our server.
2. Watch your webserver and MySQL logs.

#### Steps to test this PR:
1. Request the same tracking pixel more than a thousand times.
2. Watch the resulting **Stat**'s `openCount` increase beyond `1000` while the size of the `openDetails` array's JSON value ceases to change after the thousandth hit.

##### _or_ #####

Run unit test for `Stat#addOpenDetails()`, e.g.:

```
$ bin/phpunit \
    --testdox \
    --bootstrap vendor/autoload.php \
    --configuration app/phpunit.xml.dist \
    --filter StatTest
```

> ```
> PHPUnit 7.5.20 by Sebastian Bergmann and contributors.
>
> Mautic\EmailBundle\Tests\Entity\Stat
>  ✔ Add open details with data set "no openDetails"
>  ✔ Add open details with data set "one openDetail"
>  ✔ Add open details with data set "low number of openDetails"
>  ✔ Add open details with data set "one away from threshold"
>  ✔ Add open details with data set "exactly at threshold"
>  ✔ Add open details with data set "one past threshold"
>  ✔ Add open details with data set "slightly above threshold"
>  ✔ Add open details with data set "well beyond threshold"
>
> Time: 311 ms, Memory: 48.00 MB
> ```

