### PR TITLE
Fix SugarCRM sync priority issue

### DIFF
--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -1636,7 +1636,6 @@ class SugarcrmIntegration extends CrmAbstractIntegration
 
             foreach ($keys as $key) {
                 if (strpos($key, '__'.$obj)) {
-
                     $newKey = str_replace('__'.$obj, '', $key);
                     if ('Id' === $newKey) {
                         // Don't map Id for push

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -863,7 +863,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                             }
                         }
                     } elseif ($object == 'Accounts') {
-                        $entity                = $this->getMauticCompany($dataObject, true, null);
+                        $entity                = $this->getMauticCompany($dataObject, $object);
                         $detachClass           = Company::class;
                         $mauticObjectReference = 'company';
                     } else {
@@ -1595,7 +1595,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
 
         if (isset($fieldsToUpdate['leadFields'])) {
             // Pass in the whole config
-            $fields = $fieldsToUpdate['leadFields'];
+            $fields = $fieldsToUpdate;
         } else {
             $fields = array_flip($fieldsToUpdate);
         }
@@ -1603,6 +1603,52 @@ class SugarcrmIntegration extends CrmAbstractIntegration
         $fieldsToUpdate = $this->prepareFieldsForSync($fields, $fieldsToUpdate, $objects);
 
         return $fieldsToUpdate;
+    }
+
+    /**
+     * @param array $fields
+     * @param array $keys
+     * @param mixed $object
+     *
+     * @return array
+     */
+    public function prepareFieldsForSync($fields, $keys, $object = null)
+    {
+        $leadFields = [];
+        if (null === $object) {
+            $object = 'Lead';
+        }
+
+        $objects = (!is_array($object)) ? [$object] : $object;
+        if (is_string($object) && 'Accounts' === $object) {
+            return isset($fields['companyFields']) ? $fields['companyFields'] : $fields;
+        }
+
+        if (isset($fields['leadFields'])) {
+            $fields = $fields['leadFields'];
+            $keys   = array_keys($fields);
+        }
+
+        foreach ($objects as $obj) {
+            if (!isset($leadFields[$obj])) {
+                $leadFields[$obj] = [];
+            }
+
+            foreach ($keys as $key) {
+                if (strpos($key, '__'.$obj)) {
+
+                    $newKey = str_replace('__'.$obj, '', $key);
+                    if ('Id' === $newKey) {
+                        // Don't map Id for push
+                        continue;
+                    }
+
+                    $leadFields[$obj][$newKey] = $fields[$key];
+                }
+            }
+        }
+
+        return (is_array($object)) ? $leadFields : $leadFields[$object];
     }
 
     /**
@@ -1614,12 +1660,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
      */
     protected function getPriorityFieldsForMautic($config, $object = null, $priorityObject = 'mautic')
     {
-        if ($object == 'company') {
-            $priority = parent::getPriorityFieldsForMautic($config, $object, 'mautic_company');
-            $fields   = array_intersect_key($config['companyFields'], $priority);
-        } else {
-            $fields = parent::getPriorityFieldsForMautic($config, $object, $priorityObject);
-        }
+        $fields = parent::getPriorityFieldsForMautic($config, $object, $priorityObject);
 
         return ($object && isset($fields[$object])) ? $fields[$object] : $fields;
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Resolve wrong sync priority in SugarCRM.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Install and configure SugarCRM
2. Map fields for Contact and Lead
3. Put First name for Contact on Sugar priority
4. Put First name for Lead on Mautic priority
5. Run sync with command `mautic:integration:fetchleads`
6. Lead First name are crushed by Sugar because Contact params crush Lead params

#### Steps to test this PR:
1. Apply PR
2. Run sync with command `mautic:integration:fetchleads`
3. Sync priority are respected and First name for Lead is not crushed by Sugar