### PR TITLE
Email sent upCount update will re-try 3 times before erroring out

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\EmailBundle\Entity;
 
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Tools\Pagination\Paginator;
@@ -586,15 +587,29 @@ class EmailRepository extends CommonRepository
 
         $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
-        $q->update(MAUTIC_TABLE_PREFIX.'emails')
-            ->set($type.'_count', $type.'_count + '.(int) $increaseBy)
-            ->where('id = '.(int) $id);
+        $q->update(MAUTIC_TABLE_PREFIX.'emails');
+        $q->set($type.'_count', $type.'_count + '.(int) $increaseBy);
+        $q->where('id = '.(int) $id);
 
         if ($variant) {
             $q->set('variant_'.$type.'_count', 'variant_'.$type.'_count + '.(int) $increaseBy);
         }
 
-        $q->execute();
+        // Try to execute 3 times before throwing the exception
+        // to increase the chance the update will do its stuff.
+        $retrialLimit = 3;
+        while ($retrialLimit >= 0) {
+            try {
+                $q->execute();
+
+                return;
+            } catch (DBALException $e) {
+                --$retrialLimit;
+                if (0 === $retrialLimit) {
+                    throw $e;
+                }
+            }
+        }
     }
 
     /**

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryTest.php
@@ -20,50 +20,49 @@ use Mautic\EmailBundle\Entity\EmailRepository;
 
 class EmailRepositoryTest extends \PHPUnit_Framework_TestCase
 {
+    private $mockConnection;
+    private $em;
+    private $cm;
+
+    /**
+     * @var EmailRepository
+     */
+    private $repo;
+
     protected function setUp()
     {
         parent::setUp();
 
         defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
 
-        $mockConnection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->mockConnection = $this->createMock(Connection::class);
+        $this->em             = $this->createMock(EntityManager::class);
+        $this->cm             = $this->createMock(ClassMetadata::class);
+        $this->repo           = new EmailRepository($this->em, $this->cm);
 
-        $mockConnection->method('createQueryBuilder')
+        $this->mockConnection->method('createQueryBuilder')
             ->willReturnCallback(
-                function () use ($mockConnection) {
-                    return new QueryBuilder($mockConnection);
+                function () {
+                    return new QueryBuilder($this->mockConnection);
                 }
             );
 
-        $mockConnection->method('getExpressionBuilder')
+        $this->mockConnection->method('getExpressionBuilder')
             ->willReturnCallback(
-                function () use ($mockConnection) {
-                    return new ExpressionBuilder($mockConnection);
+                function () {
+                    return new ExpressionBuilder($this->mockConnection);
                 }
             );
 
-        $mockConnection->method('quote')
+        $this->mockConnection->method('quote')
             ->willReturnCallback(
                 function ($value) {
                     return "'$value'";
                 }
             );
 
-        $this->em = $this
-            ->getMockBuilder(EntityManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->cm = $this->getMockBuilder(ClassMetadata::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $this->em->method('getConnection')
-            ->willReturn($mockConnection);
-
-        $this->repo = new EmailRepository($this->em, $this->cm);
+            ->willReturn($this->mockConnection);
     }
 
     public function testGetEmailPendingQueryForSimpleCount()

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryUpCountTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryUpCountTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Entity;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Mautic\EmailBundle\Entity\EmailRepository;
+
+class EmailRepositoryUpCountTest extends \PHPUnit_Framework_TestCase
+{
+    private $mockConnection;
+    private $queryBuilderMock;
+    private $em;
+    private $cm;
+
+    /**
+     * @var EmailRepository
+     */
+    private $repo;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
+
+        $this->queryBuilderMock = $this->createMock(QueryBuilder::class);
+        $this->mockConnection   = $this->createMock(Connection::class);
+        $this->em               = $this->createMock(EntityManager::class);
+        $this->cm               = $this->createMock(ClassMetadata::class);
+        $this->repo             = new EmailRepository($this->em, $this->cm);
+
+        $this->mockConnection->method('createQueryBuilder')->willReturn($this->queryBuilderMock);
+        $this->em->method('getConnection')->willReturn($this->mockConnection);
+    }
+
+    public function testUpCountWithNoIncrease()
+    {
+        $this->queryBuilderMock->expects($this->never())
+            ->method('update');
+
+        $this->repo->upCount(45, 'sent', 0);
+    }
+
+    public function testUpCountWithId()
+    {
+        $this->queryBuilderMock->expects($this->once())
+            ->method('update')
+            ->with(MAUTIC_TABLE_PREFIX.'emails');
+
+        $this->queryBuilderMock->expects($this->once())
+            ->method('set')
+            ->with('sent_count', 'sent_count + 1');
+
+        $this->queryBuilderMock->expects($this->once())
+            ->method('where')
+            ->with('id = 45');
+
+        $this->queryBuilderMock->expects($this->once())
+            ->method('execute');
+
+        $this->repo->upCount(45);
+    }
+
+    public function testUpCountWithVariant()
+    {
+        $this->queryBuilderMock->expects($this->once())
+            ->method('update')
+            ->with(MAUTIC_TABLE_PREFIX.'emails');
+
+        $this->queryBuilderMock->expects($this->at(1))
+            ->method('set')
+            ->with('read_count', 'read_count + 2');
+
+        $this->queryBuilderMock->expects($this->once())
+            ->method('where')
+            ->with('id = 45');
+
+        $this->queryBuilderMock->expects($this->at(3))
+            ->method('set')
+            ->with('variant_read_count', 'variant_read_count + 2');
+
+        $this->queryBuilderMock->expects($this->once())
+            ->method('execute');
+
+        $this->repo->upCount(45, 'read', 2, true);
+    }
+
+    public function testUpCountWithTwoErrors()
+    {
+        $this->queryBuilderMock->expects($this->exactly(3))
+            ->method('execute');
+
+        $this->queryBuilderMock->expects($this->at(3))
+            ->method('execute')
+            ->will($this->throwException(new DBALException()));
+
+        $this->queryBuilderMock->expects($this->at(4))
+            ->method('execute')
+            ->will($this->throwException(new DBALException()));
+
+        $this->queryBuilderMock->expects($this->at(5))
+            ->method('execute');
+
+        $this->repo->upCount(45);
+    }
+
+    public function testUpCountWithFourErrors()
+    {
+        $this->queryBuilderMock->expects($this->exactly(3))
+            ->method('execute')
+            ->will($this->throwException(new DBALException()));
+
+        $this->expectException(DBALException::class);
+        $this->repo->upCount(45);
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
It sometimes happen that the sent count in the `emails` table is not equal to actually sent emails in the `emails_sent` table when there are a lot of emails being sent. This happens because some `UPDATE` queries times out because there are many of those to one row field.

This PR will try to execute the `UPDATE` query up to 3 times before giving up. It should increase the chance of the query to finish.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
This will be hard to reproduce, but the thrown exceptions are covered by unit tests. Make code review.

#### Steps to test this PR:
Just try to send a segment email and ensure the count in the emails table is correct.