### PR TITLE
Bug empty csv header

### DIFF
--- a/app/bundles/CoreBundle/Helper/CsvHelper.php
+++ b/app/bundles/CoreBundle/Helper/CsvHelper.php
@@ -43,4 +43,41 @@ class CsvHelper
 
         return $data;
     }
+
+    /**
+     * @param array $headers
+     *
+     * @return array
+     */
+    public static function sanitizeHeaders(array $headers)
+    {
+        array_walk($headers, function (&$val) {
+            $val = trim($val);
+        });
+
+        return $headers;
+    }
+
+    /**
+     * @param array $headers
+     *
+     * @return array
+     */
+    public static function convertHeadersIntoFields(array $headers)
+    {
+        sort($headers);
+
+        $importedFields = [];
+
+        foreach ($headers as $header) {
+            $fieldName = strtolower(InputHelper::alphanum($header, false, '_'));
+
+            // Skip columns with empty names as they cannot be mapped.
+            if (!empty($fieldName)) {
+                $importedFields[$fieldName] = $header;
+            }
+        }
+
+        return $importedFields;
+    }
 }

--- a/app/bundles/CoreBundle/Helper/CsvHelper.php
+++ b/app/bundles/CoreBundle/Helper/CsvHelper.php
@@ -51,11 +51,7 @@ class CsvHelper
      */
     public static function sanitizeHeaders(array $headers)
     {
-        array_walk($headers, function (&$val) {
-            $val = trim($val);
-        });
-
-        return $headers;
+        return array_map('trim', $headers);
     }
 
     /**

--- a/app/bundles/CoreBundle/Tests/unit/Helper/CsvHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Helper/CsvHelperTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Tests\Helper;
+
+use Mautic\CoreBundle\Helper\CsvHelper;
+
+class CsvHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSanitizeHeaders()
+    {
+        $headers = [
+            'withoutSpaces',
+            ' with spaces ',
+            ' left space',
+            'right space ',
+        ];
+
+        $expected = [
+            'withoutSpaces',
+            'with spaces',
+            'left space',
+            'right space',
+        ];
+
+        $this->assertEquals($expected, CsvHelper::sanitizeHeaders($headers));
+    }
+
+    public function testConvertHeadersIntoFields()
+    {
+        $headers = [
+            'České znáčky',
+            '',
+            'First Name',
+        ];
+
+        $expected = [
+            'first_name' => 'First Name',
+            'esk_znky'   => 'České znáčky',
+        ];
+
+        $this->assertEquals($expected, CsvHelper::convertHeadersIntoFields($headers));
+    }
+}

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -12,7 +12,7 @@
 namespace Mautic\LeadBundle\Controller;
 
 use Mautic\CoreBundle\Controller\FormController;
-use Mautic\CoreBundle\Helper\InputHelper;
+use Mautic\CoreBundle\Helper\CsvHelper;
 use Mautic\LeadBundle\Entity\Import;
 use Mautic\LeadBundle\Helper\Progress;
 use Symfony\Component\Filesystem\Filesystem;
@@ -306,22 +306,11 @@ class ImportController extends FormController
                                         $linecount = $file->key();
 
                                         if (!empty($headers) && is_array($headers)) {
-                                            array_walk($headers, function (&$val) {
-                                                $val = trim($val);
-                                            });
+                                            $headers = CsvHelper::sanitizeHeaders($headers);
 
                                             $session->set('mautic.'.$object.'.import.headers', $headers);
-                                            sort($headers);
-
-                                            $importFields = [];
-
-                                            foreach ($headers as $header) {
-                                                $fieldName                = strtolower(InputHelper::alphanum($header, false, '_'));
-                                                $importFields[$fieldName] = $header;
-                                            }
-
                                             $session->set('mautic.'.$object.'.import.step', self::STEP_MATCH_FIELDS);
-                                            $session->set('mautic.'.$object.'.import.importfields', $importFields);
+                                            $session->set('mautic.'.$object.'.import.importfields', CsvHelper::convertHeadersIntoFields($headers));
                                             $session->set('mautic.'.$object.'.import.progress', [0, $linecount]);
                                             $session->set('mautic.'.$object.'.import.original.file', $fileData->getClientOriginalName());
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/4937
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If a CSV contains an empty column name then the mapping form fails with the error message specified in the linked issue.

Example CSV:
```
email,, last Name, comp
ka@ka.bus, johan, straus, ka
ko@bo.ro,cow,boy,bel
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Use the example CSV and try to import it.
2. The upload will get stuck.
3. Refresh the page - error
4. Update the URL to go to the mautic dashboard (/s/) and log out and back in to get rid of the error.

#### Steps to test this PR:
1. Try to upload the CSV again.
2. Field mapping will show up. Map them.
3. Import
4. View the imported contacts that the correct values are there.
