### PR TITLE
Additional statistics on Form chart

### DIFF
--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -666,6 +666,7 @@ class SubmissionModel extends CommonFormModel
         $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);
 
         $this->setChartDataSubmissionsCount($chart, $query, $filter, $canViewOthers);
+        $this->setChartDataUniqueSubmissionsCount($chart, $query, $filter, $canViewOthers);
 
         return $chart->render();
     }
@@ -775,6 +776,30 @@ class SubmissionModel extends CommonFormModel
 
         $data = $query->loadAndBuildTimeData($q);
         $chart->setDataset($this->translator->trans('mautic.form.submission.count'), $data);
+    }
+
+    /**
+     * Get unique submissions count chart data.
+     *
+     * @param LineChart  $chart
+     * @param ChartQuery $query
+     * @param array      $filter
+     * @param array      $canViewOthers
+     */
+    protected function setChartDataUniqueSubmissionsCount(
+        LineChart $chart,
+        ChartQuery $query,
+        $filter = [],
+        $canViewOthers = true
+    ) {
+        $q = $query->prepareTimeDataQuery('form_submissions', 'date_submitted', $filter, 'distinct(t.lead_id)');
+
+        if (!$canViewOthers) {
+            $this->limitQueryToCreator($q);
+        }
+
+        $data = $query->loadAndBuildTimeData($q);
+        $chart->setDataset($this->translator->trans('mautic.form.submission.unique_count'), $data);
     }
 
     /**

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\FormBundle\Model;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CoreBundle\Exception\FileUploadException;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
@@ -746,6 +747,18 @@ class SubmissionModel extends CommonFormModel
         $results = $q->execute()->fetchAll();
 
         return $results;
+    }
+
+    /**
+     * Restrict results to those created by the current user.
+     *
+     * @param QueryBuilder $q
+     */
+    protected function limitQueryToCreator(QueryBuilder &$q)
+    {
+        $q->join('t', MAUTIC_TABLE_PREFIX.'forms', 'f', 'f.id = t.form_id')
+            ->andWhere('f.created_by = :userId')
+            ->setParameter('userId', $this->userHelper->getUser()->getId());
     }
 
     /**

--- a/app/bundles/FormBundle/Translations/en_US/messages.ini
+++ b/app/bundles/FormBundle/Translations/en_US/messages.ini
@@ -197,6 +197,7 @@ mautic.form.campaign.event.field_value_descr="Trigger actions when a submitted f
 mautic.form.dashboard.widgets="Form Widgets"
 mautic.form.lead="Lead"
 mautic.form.submission.count="Submission Count"
+mautic.form.submission.unique_count="Unique Submission Count"
 mautic.widget.submissions.in.time="Submissions in time"
 mautic.widget.top.submission.referrers="Top submission referrers"
 mautic.widget.top.submitters="Top submitters"


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

#### Description:

Adds additional data lines to the **Form Submissions** chart:

- [x] Unique submission count
- [ ] Display count
- [ ] Unique display count
- [ ] Conversion rate
- [ ] Unique conversion rate

#### Steps to test this PR:

1. Create a form.
2. Access the form several times.
3. Send a few submissions to the form, using a combination of unique and non-unique lead values.
4. View the overview page for that form in the backend, like `<your-domain>/s/forms/view/<form-id>`. Check the chart, located below the "DETAILS" tab. The statistics depicted on the line graph should match the input generated in step (3).

