### PR TITLE
Stop progress bar on ajax complete to account for timeouts

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -16,8 +16,7 @@ MauticVars.activeRequests = 0;
 mQuery.ajaxSetup({
     beforeSend: function (request, settings) {
         if (settings.showLoadingBar) {
-            mQuery('.loading-bar').addClass('active');
-            MauticVars.activeRequests++;
+            Mautic.startPageLoadingBar();
         }
 
         if (typeof IdleTimer != 'undefined') {
@@ -47,6 +46,7 @@ mQuery.ajaxSetup({
 });
 
 mQuery( document ).ajaxComplete(function(event, xhr, settings) {
+    Mautic.stopPageLoadingBar();
     xhr.always(function(response) {
         if (response.flashes) Mautic.setFlashes(response.flashes);
     });


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | /
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The progress bar was still shown if a ajax request timed out. User must be notified about the ajax complete.

Plus I noticed that `startPageLoadingBar` was not used anywhere and instead its content was used in the `beforeSend` function. I removed that duplication and call the `startPageLoadingBar` instead.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Very hard to replicate. Some users noticed this when saving custom fields.

#### Steps to test this PR:
1. Code review and [read the docs](http://api.jquery.com/jquery.ajax/) about the `complete` method that it works for timeouts too.
2. Click through the UI in the dev mode and check that the progress bar will stop after each ajax call.
