### PR TITLE
Always use the site_url for generating urls in emails

### DIFF
--- a/app/bundles/CoreBundle/Model/AbstractCommonModel.php
+++ b/app/bundles/CoreBundle/Model/AbstractCommonModel.php
@@ -286,9 +286,9 @@ abstract class AbstractCommonModel
      */
     public function buildUrl($route, $routeParams = [], $absolute = true, $clickthrough = [], $utmTags = [])
     {
-        $referenceType = ($absolute) ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH;
-        $url           = $this->router->generate($route, $routeParams, $referenceType);
-
+        $siteBaseUrl = rtrim($this->coreParametersHelper->getParameter('site_url'), '/');
+        $url         = $absolute ? $siteBaseUrl : '';
+        $url .= $this->router->generate($route, $routeParams, UrlGeneratorInterface::ABSOLUTE_PATH);
         $url .= (!empty($clickthrough)) ? '?ct='.$this->encodeArrayForUrl($clickthrough) : '';
 
         return $url;

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -23,7 +23,6 @@ use Mautic\EmailBundle\Swiftmailer\Exception\BatchQueueMaxException;
 use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
 use Mautic\EmailBundle\Swiftmailer\Transport\TokenTransportInterface;
 use Mautic\LeadBundle\Entity\Lead;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Class MailHelper.
@@ -1500,7 +1499,9 @@ class MailHelper
     private function getUnsubscribeHeader()
     {
         if ($this->idHash) {
-            $url = $this->factory->getRouter()->generate('mautic_email_unsubscribe', ['idHash' => $this->idHash], UrlGeneratorInterface::ABSOLUTE_URL);
+            /** @var \Mautic\EmailBundle\Model\EmailModel $emailModel */
+            $emailModel = $this->factory->getModel('email');
+            $url        = $emailModel->buildUrl('mautic_email_unsubscribe', ['idHash' => $this->idHash], true);
 
             return "<$url>";
         }
@@ -1543,12 +1544,14 @@ class MailHelper
 
         // Include the tracking pixel token as it's auto appended to the body
         if ($this->appendTrackingPixel) {
-            $tokens['{tracking_pixel}'] = $this->factory->getRouter()->generate(
+            /** @var \Mautic\EmailBundle\Model\EmailModel $emailModel */
+            $emailModel                 = $this->factory->getModel('email');
+            $tokens['{tracking_pixel}'] = $emailModel->buildUrl(
                 'mautic_email_tracker',
                 [
                     'idHash' => $this->idHash,
                 ],
-                UrlGeneratorInterface::ABSOLUTE_URL
+                true
             );
         } else {
             $tokens['{tracking_pixel}'] = self::getBlankPixel();

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
@@ -255,6 +255,12 @@ class SendEmailToContactTest extends \PHPUnit_Framework_TestCase
         $factoryMock->method('getRouter')
             ->willReturn($routerMock);
 
+        $emailModelMock = $this->getMockBuilder(EmailModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $factoryMock->method('getModel')
+            ->willReturn($emailModelMock);
+
         $mailHelper = $this->getMockBuilder(MailHelper::class)
             ->setConstructorArgs([$factoryMock, $mailer])
             ->setMethods(['createEmailStat'])
@@ -517,6 +523,12 @@ class SendEmailToContactTest extends \PHPUnit_Framework_TestCase
         $factoryMock->method('getRouter')
             ->willReturn($routerMock);
 
+        $emailModelMock = $this->getMockBuilder(EmailModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $factoryMock->method('getModel')
+            ->willReturn($emailModelMock);
+
         $mailHelper = $this->getMockBuilder(MailHelper::class)
             ->setConstructorArgs([$factoryMock, $mailer])
             ->setMethods(['createEmailStat'])
@@ -653,6 +665,12 @@ class SendEmailToContactTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $factoryMock->method('getRouter')
             ->willReturn($routerMock);
+
+        $emailModelMock = $this->getMockBuilder(EmailModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $factoryMock->method('getModel')
+            ->willReturn($emailModelMock);
 
         $mailHelper = $this->getMockBuilder(MailHelper::class)
             ->setConstructorArgs([$factoryMock, $mailer])

--- a/app/bundles/PageBundle/Tests/PageTestAbstract.php
+++ b/app/bundles/PageBundle/Tests/PageTestAbstract.php
@@ -13,6 +13,7 @@ namespace Mautic\PageBundle\Tests;
 
 use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\Helper\CookieHelper;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Helper\UrlHelper;
 use Mautic\CoreBundle\Translation\Translator;
@@ -57,6 +58,11 @@ class PageTestAbstract extends WebTestCase
 
         $ipLookupHelper = $this
             ->getMockBuilder(IpLookupHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $coreParametersHelper = $this
+            ->getMockBuilder(CoreParametersHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -149,6 +155,7 @@ class PageTestAbstract extends WebTestCase
         $pageModel->setTranslator($translator);
         $pageModel->setEntityManager($entityManager);
         $pageModel->setRouter($router);
+        $pageModel->setCoreParametersHelper($coreParametersHelper);
 
         return $pageModel;
     }


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | -
| BC breaks? | ?
| Deprecations? | ?

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This change makes sure that all absolute url's put in emails (unsubscribe/webview links, themes, etc.) are based in the site_url. With the old version of the code this is based on the hostname of the user visiting the Mautic interface, but that breaks when there are different hostnames pointing to the same instance (for example one on a local network)..

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Add a local hostname to access Mautic
2. Use that hostname to send an e-mail
3. See the local hostname appear in the email source, not the public one set in the settings

#### Steps to test this PR:
see above, the url's are then fine 

#### List deprecations along with the new alternative:

#### List backwards compatibility breaks: