### PR TITLE
[Bugfix] Scheduled Campaign Events without Contacts

### DIFF
--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -290,6 +290,7 @@ return [
                 'class'     => \Mautic\CampaignBundle\Executioner\ContactFinder\ScheduledContactFinder::class,
                 'arguments' => [
                     'mautic.lead.repository.lead',
+                    'monolog.logger.mautic',
                 ],
             ],
             'mautic.campaign.contact_finder.inactive'     => [

--- a/app/bundles/CampaignBundle/Executioner/ContactFinder/ScheduledContactFinder.php
+++ b/app/bundles/CampaignBundle/Executioner/ContactFinder/ScheduledContactFinder.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Executioner\Exception\NoContactsFoundException;
 use Mautic\LeadBundle\Entity\LeadRepository;
+use Psr\Log\LoggerInterface;
 
 class ScheduledContactFinder
 {
@@ -24,13 +25,20 @@ class ScheduledContactFinder
     private $leadRepository;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * ScheduledContactFinder constructor.
      *
-     * @param LeadRepository $leadRepository
+     * @param LeadRepository  $leadRepository
+     * @param LoggerInterface $logger
      */
-    public function __construct(LeadRepository $leadRepository)
+    public function __construct(LeadRepository $leadRepository, LoggerInterface $logger)
     {
         $this->leadRepository = $leadRepository;
+        $this->logger         = $logger;
     }
 
     /**

--- a/app/bundles/CampaignBundle/Executioner/ContactFinder/ScheduledContactFinder.php
+++ b/app/bundles/CampaignBundle/Executioner/ContactFinder/ScheduledContactFinder.php
@@ -54,14 +54,14 @@ class ScheduledContactFinder
             $contactIds[] = $log->getLead()->getId();
         }
 
-        $contacts = $this->leadRepository->getContactCollection($contactIds);
-
-        if (!count($contacts)) {
+        if (!count($contactIds)) {
             // Just a precaution in case non-existent contacts are lingering in the campaign leads table
             $this->logger->debug('CAMPAIGN: No contact entities found.');
 
             throw new NoContactsFoundException();
         }
+
+        $contacts = $this->leadRepository->getContactCollection($contactIds);
 
         foreach ($logs as $log) {
             $contactId = $log->getLead()->getId();

--- a/app/bundles/CampaignBundle/Executioner/ContactFinder/ScheduledContactFinder.php
+++ b/app/bundles/CampaignBundle/Executioner/ContactFinder/ScheduledContactFinder.php
@@ -13,6 +13,7 @@ namespace Mautic\CampaignBundle\Executioner\ContactFinder;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CampaignBundle\Executioner\Exception\NoContactsFoundException;
 use Mautic\LeadBundle\Entity\LeadRepository;
 
 class ScheduledContactFinder
@@ -46,6 +47,13 @@ class ScheduledContactFinder
         }
 
         $contacts = $this->leadRepository->getContactCollection($contactIds);
+
+        if (!count($contacts)) {
+            // Just a precaution in case non-existent contacts are lingering in the campaign leads table
+            $this->logger->debug('CAMPAIGN: No contact entities found.');
+
+            throw new NoContactsFoundException();
+        }
 
         foreach ($logs as $log) {
             $contactId = $log->getLead()->getId();

--- a/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
@@ -213,7 +213,7 @@ class ScheduledExecutioner implements ExecutionerInterface
         } catch (NoContactsFoundException $e) {
             $this->progressBar->clear();
 
-            return;
+            return $this->counter;
         }
 
         // Organize the logs by event ID

--- a/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
@@ -17,6 +17,7 @@ use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
 use Mautic\CampaignBundle\Executioner\ContactFinder\ScheduledContactFinder;
+use Mautic\CampaignBundle\Executioner\Exception\NoContactsFoundException;
 use Mautic\CampaignBundle\Executioner\Exception\NoEventsFoundException;
 use Mautic\CampaignBundle\Executioner\Result\Counter;
 use Mautic\CampaignBundle\Executioner\Scheduler\EventScheduler;
@@ -206,8 +207,14 @@ class ScheduledExecutioner implements ExecutionerInterface
         $scheduledLogCount = $totalLogsFound - $logs->count();
         $this->progressBar->advance($scheduledLogCount);
 
-        // Hydrate contacts with custom field data
-        $this->scheduledContactFinder->hydrateContacts($logs);
+        try {
+            // Hydrate contacts with custom field data
+            $this->scheduledContactFinder->hydrateContacts($logs);
+        } catch (NoContactsFoundException $e) {
+            $this->progressBar->clear();
+
+            return;
+        }
 
         // Organize the logs by event ID
         $organized = $this->organizeByEvent($logs);
@@ -289,7 +296,11 @@ class ScheduledExecutioner implements ExecutionerInterface
     {
         $logs = $this->repo->getScheduled($eventId, $this->now, $this->limiter);
         while ($logs->count()) {
-            $this->scheduledContactFinder->hydrateContacts($logs);
+            try {
+                $this->scheduledContactFinder->hydrateContacts($logs);
+            } catch (NoContactsFoundException $e) {
+                break;
+            }
 
             $event = $logs->first()->getEvent();
             $this->progressBar->advance($logs->count());

--- a/app/bundles/CampaignBundle/Tests/Executioner/ContactFinder/ScheduledContactFinderTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ContactFinder/ScheduledContactFinderTest.php
@@ -96,9 +96,8 @@ class ScheduledContactFinderTest extends \PHPUnit_Framework_TestCase
 
     public function testNoContactsFoundExceptionIsThrownIfEntitiesAreNotFound()
     {
-        $this->leadRepository->expects($this->once())
-            ->method('getContactCollection')
-            ->willReturn([]);
+        $this->leadRepository->expects($this->never())
+            ->method('getContactCollection');
 
         $this->expectException(NoContactsFoundException::class);
 

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -1082,6 +1082,10 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
      */
     public function getContactCollection(array $ids)
     {
+        if (empty($ids)) {
+            return new ArrayCollection();
+        }
+
         $contacts = $this->getEntities(
             [
                 'filter'             => [


### PR DESCRIPTION
#**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Scheduled campaign events without any contacts in them were still being executed. This PR fixes that.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Run Unit Tests `cd app && ../bin/phpunit --filter="ScheduledContactFinder"`