### PR TITLE
Fixed extracting channel from event properties 

### DIFF
--- a/app/bundles/CampaignBundle/Helper/ChannelExtractor.php
+++ b/app/bundles/CampaignBundle/Helper/ChannelExtractor.php
@@ -38,8 +38,12 @@ class ChannelExtractor
             return;
         }
 
+        if (!$event->getProperties()) {
+            return;
+        }
+
         $entity->setChannelId(
-            self::getChannelId($event->getProperties()['properties'], $channelIdField)
+            self::getChannelId($event->getProperties(), $channelIdField)
         );
     }
 

--- a/app/bundles/CampaignBundle/Tests/Helper/ChannelExtractorTest.php
+++ b/app/bundles/CampaignBundle/Tests/Helper/ChannelExtractorTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CampaignBundle\Tests\Helper;
+
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CampaignBundle\EventCollector\Accessor\Event\AbstractEventAccessor;
+use Mautic\CampaignBundle\Helper\ChannelExtractor;
+
+class ChannelExtractorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testChannelIsSet()
+    {
+        $event  = new Event();
+        $config = $this->createMock(AbstractEventAccessor::class);
+        $config->expects($this->once())
+            ->method('getChannel')
+            ->willReturn('email');
+
+        $log = new LeadEventLog();
+        ChannelExtractor::setChannel($log, $event, $config);
+
+        $this->assertEquals('email', $log->getChannel());
+    }
+
+    public function testChannelIsIgnoredIfSet()
+    {
+        $event  = new Event();
+        $config = $this->createMock(AbstractEventAccessor::class);
+        $config->expects($this->never())
+            ->method('getChannel');
+
+        $log = new LeadEventLog();
+        $log->setChannel('page');
+        ChannelExtractor::setChannel($log, $event, $config);
+
+        $this->assertEquals('page', $log->getChannel());
+    }
+
+    public function testChannelIdIsSet()
+    {
+        $event = new Event();
+        $event->setProperties(['email' => 1]);
+        $config = $this->createMock(AbstractEventAccessor::class);
+        $config->expects($this->once())
+            ->method('getChannel')
+            ->willReturn('email');
+
+        $config->expects($this->once())
+            ->method('getChannelIdField')
+            ->willReturn('email');
+
+        $log = new LeadEventLog();
+        ChannelExtractor::setChannel($log, $event, $config);
+
+        $this->assertEquals('email', $log->getChannel());
+        $this->assertEquals(1, $log->getChannelId());
+    }
+
+    public function testChannelIdIsIgnoredIfPropertiesAreEmpty()
+    {
+        $event = new Event();
+        $event->setProperties(null);
+        $config = $this->createMock(AbstractEventAccessor::class);
+        $config->expects($this->once())
+            ->method('getChannel')
+            ->willReturn('email');
+
+        $config->expects($this->once())
+            ->method('getChannelIdField')
+            ->willReturn('email');
+
+        $log = new LeadEventLog();
+        ChannelExtractor::setChannel($log, $event, $config);
+
+        $this->assertEquals('email', $log->getChannel());
+        $this->assertEquals(null, $log->getChannelId());
+    }
+
+    public function testChannelIdIsIgnoredIfChannelIdFieldIsNotSet()
+    {
+        $event = new Event();
+        $event->setProperties(['email' => 1]);
+        $config = $this->createMock(AbstractEventAccessor::class);
+        $config->expects($this->once())
+            ->method('getChannel')
+            ->willReturn('email');
+
+        $config->expects($this->once())
+            ->method('getChannelIdField')
+            ->willReturn(null);
+
+        $log = new LeadEventLog();
+        ChannelExtractor::setChannel($log, $event, $config);
+
+        $this->assertEquals('email', $log->getChannel());
+        $this->assertEquals(null, $log->getChannelId());
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Seems that a long time ago, we started to save the entire event form data into the properties array https://github.com/mautic/mautic/commit/44ad72a35f0be6ad57dd7b0b3350d5a3e6387db2. But older campaigns do not have this leading to the following error: 

```
Symfony\Component\Debug\Exception\FatalThrowableError]                                                                                                                                                                                                                          
  Type error: Argument 1 passed to Mautic\CampaignBundle\Helper\ChannelExtractor::getChannelId() must be of the type array, null given, called in app/bundles/CampaignBundle/Helper/ChannelExtractor.php on line 42  
```

This PR removes the use of `['properties']` as they are included in the root of the array and is compatible with pre and post 2.8 campaigns. 

Pre 2.8, properties were stored as 
```
a:1:{s:5:"email";i:6;}
```

Since then it's stored like:
```
a:18:{s:14:"canvasSettings";a:2:{s:8:"droppedX";s:2:"10";s:8:"droppedY";s:3:"365";}s:4:"name";s:0:"";s:11:"triggerMode";s:9:"immediate";s:11:"triggerDate";N;s:15:"triggerInterval";s:1:"1";s:19:"triggerIntervalUnit";s:1:"d";s:6:"anchor";s:10:"leadsource";s:10:"properties";a:4:{s:5:"email";s:1:"6";s:10:"email_type";s:13:"transactional";s:8:"priority";s:1:"2";s:8:"attempts";s:1:"3";}s:4:"type";s:10:"email.send";s:9:"eventType";s:6:"action";s:15:"anchorEventType";s:6:"source";s:10:"campaignId";s:1:"1";s:6:"_token";s:43:"ZPX7vzLttHNS9EPwtlGnSMA_sKWEJKtrKbJiZARdQfA";s:7:"buttons";a:1:{s:4:"save";s:0:"";}s:5:"email";s:1:"6";s:10:"email_type";s:13:"transactional";s:8:"priority";i:2;s:8:"attempts";d:3;}
```

You can see that in both, `"email";s:1:"6"` is in the root of the array. 

[//]: # ( As applicable: )

#### Steps to test this PR:
1.  run the new tests