### PR TITLE
Added correct handling of callback events for Momentum

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Momentum/Callback/CallbackEnum.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Momentum/Callback/CallbackEnum.php
@@ -18,21 +18,34 @@ use Mautic\LeadBundle\Entity\DoNotContact;
  */
 class CallbackEnum
 {
-    const BOUNCE            = 'bounce';
-    const DROPPED           = 'dropped';
-    const SPAM_REPORT       = 'spamreport';
-    const UNSUBSCRIBE       = 'unsubscribe';
-    const GROUP_UNSUBSCRIBE = 'group_unsubscribe';
+    const BOUNCE           = 'bounce';
+    const OUT_OF_BAND      = 'out_of_band';
+    const POLICY_REJECTION = 'policy_rejection';
+    const SPAM_COMPLAINT   = 'spam_complaint';
+    const LIST_UNSUBSCRIBE = 'list_unsubscribe';
+    const LINK_UNSUBSCRIBE = 'link_unsubscribe';
+
+    const BOUNCE_CLASS_INVALID_RECIPIENT     = 10;
+    const BOUNCE_CLASS_GENERIC               = 30;
+    const BOUNCE_CLASS_MAIL_BLOCK            = 50;
+    const BOUNCE_CLASS_SPAM_BLOCK            = 51;
+    const BOUNCE_CLASS_SPAM_CONTENT          = 52;
+    const BOUNCE_CLASS_PROHIBITED_ATTACHMENT = 53;
+    const BOUNCE_CLASS_RELAYING_DENIED       = 54;
+    const BOUNCE_CLASS_UNSUBSCRIBE           = 90;
 
     /**
-     * @see https://sendgrid.com/docs/API_Reference/Webhooks/event.html#-Event-Types
-     *
      * @param string $event
+     * @param null   $bounceClass
      *
      * @return bool
      */
-    public static function shouldBeEventProcessed($event)
+    public static function shouldBeEventProcessed($event, $bounceClass = null)
     {
+        if ($bounceClass && self::BOUNCE === $event) {
+            return in_array($bounceClass, self::getHardBounces(), true);
+        }
+
         return in_array($event, self::getSupportedEvents(), true);
     }
 
@@ -53,16 +66,51 @@ class CallbackEnum
     }
 
     /**
+     * @param string $event
+     * @param array  $item
+     *
+     * @return string|null
+     */
+    public static function getDncComments($event, array $item)
+    {
+        if (!self::shouldBeEventProcessed($event)) {
+            return null;
+        }
+
+        $key = self::getCommentsKeyForEvent($event);
+
+        return isset($item[$key]) ? $item[$key] : $key;
+    }
+
+    /**
      * @return array
      */
     private static function getSupportedEvents()
     {
         return [
             self::BOUNCE,
-            self::DROPPED,
-            self::SPAM_REPORT,
-            self::UNSUBSCRIBE,
-            self::GROUP_UNSUBSCRIBE,
+            self::OUT_OF_BAND,
+            self::POLICY_REJECTION,
+            self::SPAM_COMPLAINT,
+            self::LIST_UNSUBSCRIBE,
+            self::LINK_UNSUBSCRIBE,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private static function getHardBounces()
+    {
+        return [
+            self::BOUNCE_CLASS_INVALID_RECIPIENT,
+            self::BOUNCE_CLASS_GENERIC,
+            self::BOUNCE_CLASS_MAIL_BLOCK,
+            self::BOUNCE_CLASS_SPAM_BLOCK,
+            self::BOUNCE_CLASS_SPAM_CONTENT,
+            self::BOUNCE_CLASS_PROHIBITED_ATTACHMENT,
+            self::BOUNCE_CLASS_RELAYING_DENIED,
+            self::BOUNCE_CLASS_UNSUBSCRIBE,
         ];
     }
 
@@ -72,11 +120,31 @@ class CallbackEnum
     private static function eventMappingToDncReason()
     {
         return [
-            self::BOUNCE            => DoNotContact::BOUNCED,
-            self::DROPPED           => DoNotContact::BOUNCED,
-            self::SPAM_REPORT       => DoNotContact::BOUNCED,
-            self::UNSUBSCRIBE       => DoNotContact::UNSUBSCRIBED,
-            self::GROUP_UNSUBSCRIBE => DoNotContact::UNSUBSCRIBED,
+            self::BOUNCE           => DoNotContact::BOUNCED,
+            self::OUT_OF_BAND      => DoNotContact::BOUNCED,
+            self::POLICY_REJECTION => DoNotContact::BOUNCED,
+            self::SPAM_COMPLAINT   => DoNotContact::UNSUBSCRIBED,
+            self::LIST_UNSUBSCRIBE => DoNotContact::UNSUBSCRIBED,
+            self::LINK_UNSUBSCRIBE => DoNotContact::UNSUBSCRIBED,
         ];
+    }
+
+    /**
+     * @param $event
+     *
+     * @return mixed|null
+     */
+    private static function getCommentsKeyForEvent($event)
+    {
+        $mapping = [
+            self::BOUNCE           => 'raw_reason',
+            self::OUT_OF_BAND      => 'raw_reason',
+            self::POLICY_REJECTION => 'raw_reason',
+            self::SPAM_COMPLAINT   => 'fbtype',
+            self::LIST_UNSUBSCRIBE => 'unsubscribed',
+            self::LINK_UNSUBSCRIBE => 'unsubscribed',
+        ];
+
+        return (isset($mapping[$event])) ? $mapping[$event] : null;
     }
 }

--- a/app/bundles/EmailBundle/Swiftmailer/Momentum/Callback/MomentumCallback.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Momentum/Callback/MomentumCallback.php
@@ -39,8 +39,13 @@ final class MomentumCallback implements MomentumCallbackInterface
     public function processCallbackRequest(Request $request)
     {
         $responseItems = new ResponseItems($request);
+
         foreach ($responseItems as $item) {
-            $this->transportCallback->addFailureByAddress($item->getEmail(), $item->getReason(), $item->getDncReason());
+            if ($statHash = $item->getStatHash()) {
+                $this->transportCallback->addFailureByHashId($statHash, $item->getReason(), $item->getDncReason());
+            } else {
+                $this->transportCallback->addFailureByAddress($item->getEmail(), $item->getReason(), $item->getDncReason());
+            }
         }
     }
 

--- a/app/bundles/EmailBundle/Swiftmailer/Momentum/Callback/ResponseItem.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Momentum/Callback/ResponseItem.php
@@ -31,18 +31,24 @@ class ResponseItem
     private $dncReason;
 
     /**
+     * @var string
+     */
+    private $statHash;
+
+    /**
      * @param array $item
      *
      * @throws ResponseItemException
      */
     public function __construct(array $item)
     {
-        if (empty($item['email'])) {
+        if (empty($item['rcpt_to'])) {
             throw new ResponseItemException();
         }
-        $this->email     = $item['email'];
-        $this->reason    = !empty($item['reason']) ? $item['reason'] : null;
-        $this->dncReason = CallbackEnum::convertEventToDncReason($item['event']);
+        $this->email     = $item['rcpt_to'];
+        $this->dncReason = CallbackEnum::convertEventToDncReason($item['type']);
+        $this->reason    = CallbackEnum::getDncComments($item['type'], $item);
+        $this->statHash  = (!empty($item['rcpt_meta']['hashId'])) ? $item['rcpt_meta']['hashId'] : null;
     }
 
     /**
@@ -54,7 +60,7 @@ class ResponseItem
     }
 
     /**
-     * @return string
+     * @return null|string
      */
     public function getReason()
     {
@@ -67,5 +73,13 @@ class ResponseItem
     public function getDncReason()
     {
         return $this->dncReason;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getStatHash()
+    {
+        return $this->statHash;
     }
 }

--- a/app/bundles/EmailBundle/Swiftmailer/Sparkpost/SparkpostFactory.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Sparkpost/SparkpostFactory.php
@@ -42,7 +42,7 @@ final class SparkpostFactory implements SparkpostFactoryInterface
             'host'     => '',
             'protocol' => 'https',
             'port'     => $port,
-            'key'      => $apiKey,
+            'key'      => ($apiKey) ?: 1234, // prevent Exception: You must provide an API key
         ];
 
         $hostInfo = parse_url($host);

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/Momentum/Callback/MomentumCallbackTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/Momentum/Callback/MomentumCallbackTest.php
@@ -1,0 +1,445 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Transport;
+
+use Mautic\EmailBundle\Model\TransportCallback;
+use Mautic\EmailBundle\Swiftmailer\Momentum\Callback\MomentumCallback;
+use Mautic\LeadBundle\Entity\DoNotContact;
+use Symfony\Component\HttpFoundation\Request;
+
+class MomentumTransportTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWebhookPayloadIsProcessed()
+    {
+        $transportCallback = $this->getMockBuilder(TransportCallback::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $transportCallback->expects($this->exactly(6))
+            ->method('addFailureByHashId')
+            ->withConsecutive(
+                [$this->equalTo('1'), 'MAIL REFUSED - IP (17.99.99.99) is in black list', DoNotContact::BOUNCED],
+                [$this->equalTo('2'), 'abuse', DoNotContact::UNSUBSCRIBED],
+                [$this->equalTo('3'), 'MAIL REFUSED - IP (18.99.99.99) is in black list', DoNotContact::BOUNCED],
+                [$this->equalTo('4'), 'MAIL REFUSED - IP (19.99.99.99) is in black list', DoNotContact::BOUNCED],
+                [$this->equalTo('5'), 'unsubscribed', DoNotContact::UNSUBSCRIBED],
+                [$this->equalTo('6'), 'unsubscribed', DoNotContact::UNSUBSCRIBED]
+                // cc recipient type is ignored so addFailureByHashId should not be called
+        );
+
+        $transportCallback->expects($this->once())
+            ->method('addFailureByAddress')
+            ->with(
+                'bounce@example.com',
+                'MAIL REFUSED - IP (17.99.99.99) is in black list',
+                DoNotContact::BOUNCED
+            );
+
+        $momentumCallback = new MomentumCallback($transportCallback);
+
+        $momentumCallback->processCallbackRequest($this->getRequestWithPayload());
+    }
+
+    private function getRequestWithPayload()
+    {
+        $json = <<<JSON
+[
+    {
+      "msys": {
+        "message_event": {
+          "type": "bounce",
+          "bounce_class": "10",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "delv_method": "esmtp",
+          "device_token": "45c19189783f867973f6e6a5cca60061ffe4fa77c547150563a1192fa9847f8a",
+          "error_code": "554",
+          "event_id": "92356927693813856",
+          "friendly_from": "sender@example.com",
+          "ip_address": "127.0.0.1",
+          "ip_pool": "Example-Ip-Pool",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "msg_size": "1337",
+          "num_retries": "2",
+          "rcpt_meta": {
+            "hashId": "1"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "recipient@example.com",
+          "raw_rcpt_to": "recipient@example.com",
+          "rcpt_type": "to",
+          "raw_reason": "MAIL REFUSED - IP (17.99.99.99) is in black list",
+          "reason": "MAIL REFUSED - IP (a.b.c.d) is in black list",
+          "routing_domain": "example.com",
+          "sending_ip": "127.0.0.1",
+          "sms_coding": "ASCII",
+          "sms_dst": "7876712656",
+          "sms_dst_npi": "E164",
+          "sms_dst_ton": "International",
+          "sms_src": "1234",
+          "sms_src_npi": "E164",
+          "sms_src_ton": "Unknown",
+          "subaccount_id": "101",
+          "subject": "Summer deals are here!",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138"
+        }
+      }
+    },
+    {
+      "msys": {
+        "message_event": {
+          "type": "spam_complaint",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "delv_method": "esmtp",
+          "event_id": "92356927693813856",
+          "fbtype": "abuse",
+          "friendly_from": "sender@example.com",
+          "ip_address": "127.0.0.1",
+          "ip_pool": "Example-Ip-Pool",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "msg_size": "1337",
+          "num_retries": "2",
+          "queue_time": "12",
+          "rcpt_meta": {
+            "hashId": "2"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "recipient@example.com",
+          "raw_rcpt_to": "recipient@example.com",
+          "rcpt_type": "to",
+          "report_by": "server.email.com",
+          "report_to": "abuse.example.com",
+          "routing_domain": "example.com",
+          "sending_ip": "127.0.0.1",
+          "subaccount_id": "101",
+          "subject": "Summer deals are here!",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138",
+          "user_str": "Additional Example Information"
+        }
+      }
+    },
+    {
+      "msys": {
+        "message_event": {
+          "type": "out_of_band",
+          "bounce_class": "1",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "delv_method": "esmtp",
+          "device_token": "45c19189783f867973f6e6a5cca60061ffe4fa77c547150563a1192fa9847f8a",
+          "error_code": "554",
+          "event_id": "92356927693813856",
+          "friendly_from": "sender@example.com",
+          "ip_address": "127.0.0.1",
+          "ip_pool": "Example-Ip-Pool",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "msg_size": "1337",
+          "num_retries": "2",
+          "queue_time": "12",
+          "raw_rcpt_to": "recipient@example.com",
+          "raw_reason": "MAIL REFUSED - IP (18.99.99.99) is in black list",
+          "rcpt_meta": {
+            "hashId": "3"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "recipient@example.com",
+          "reason": "MAIL REFUSED - IP (a.b.c.d) is in black list",
+          "routing_domain": "example.com",
+          "sending_ip": "127.0.0.1",
+          "subaccount_id": "101",
+          "subject": "Summer deals are here!",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138"
+        }
+      }
+    },
+    {
+      "msys": {
+        "message_event": {
+          "type": "policy_rejection",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "error_code": "554",
+          "event_id": "92356927693813856",
+          "friendly_from": "sender@example.com",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "rcpt_meta": {
+            "hashId": "4"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "recipient@example.com",
+          "raw_rcpt_to": "recipient@example.com",
+          "rcpt_type": "to",
+          "raw_reason": "MAIL REFUSED - IP (19.99.99.99) is in black list",
+          "reason": "MAIL REFUSED - IP (a.b.c.d) is in black list",
+          "remote_addr": "127.0.0.1",
+          "subaccount_id": "101",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138",
+          "bounce_class": "25"
+        }
+      }
+    },
+    {
+      "msys": {
+        "unsubscribe_event": {
+          "type": "list_unsubscribe",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "delv_method": "esmtp",
+          "event_id": "92356927693813856",
+          "friendly_from": "sender@example.com",
+          "ip_address": "127.0.0.1",
+          "ip_pool": "Example-Ip-Pool",
+          "mailfrom": "recipient@example.com",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "msg_size": "1337",
+          "num_retries": "2",
+          "queue_time": "12",
+          "rcpt_meta": {
+            "hashId": "5"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "recipient@example.com",
+          "raw_rcpt_to": "recipient@example.com",
+          "rcpt_type": "to",
+          "routing_domain": "example.com",
+          "sending_ip": "127.0.0.1",
+          "subaccount_id": "101",
+          "subject": "Summer deals are here!",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138"
+        }
+      }
+    },
+    {
+      "msys": {
+        "unsubscribe_event": {
+          "type": "link_unsubscribe",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "delv_method": "esmtp",
+          "event_id": "92356927693813856",
+          "friendly_from": "sender@example.com",
+          "ip_address": "127.0.0.1",
+          "ip_pool": "Example-Ip-Pool",
+          "mailfrom": "recipient@example.com",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "msg_size": "1337",
+          "num_retries": "2",
+          "queue_time": "12",
+          "rcpt_meta": {
+            "hashId": "6"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "recipient@example.com",
+          "raw_rcpt_to": "recipient@example.com",
+          "rcpt_type": "to",
+          "routing_domain": "example.com",
+          "sending_ip": "127.0.0.1",
+          "subaccount_id": "101",
+          "subject": "Summer deals are here!",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138",
+          "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36"
+        }
+      }
+    },
+    {
+      "msys": {
+        "message_event": {
+          "type": "bounce",
+          "bounce_class": "10",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "delv_method": "esmtp",
+          "device_token": "45c19189783f867973f6e6a5cca60061ffe4fa77c547150563a1192fa9847f8a",
+          "error_code": "554",
+          "event_id": "92356927693813856",
+          "friendly_from": "sender@example.com",
+          "ip_address": "127.0.0.1",
+          "ip_pool": "Example-Ip-Pool",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "msg_size": "1337",
+          "num_retries": "2",
+          "rcpt_meta": {
+            "hashId": "7"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "recipient@example.com",
+          "raw_rcpt_to": "recipient@example.com",
+          "rcpt_type": "cc",
+          "raw_reason": "MAIL REFUSED - IP (17.99.99.99) is in black list",
+          "reason": "MAIL REFUSED - IP (a.b.c.d) is in black list",
+          "routing_domain": "example.com",
+          "sending_ip": "127.0.0.1",
+          "sms_coding": "ASCII",
+          "sms_dst": "7876712656",
+          "sms_dst_npi": "E164",
+          "sms_dst_ton": "International",
+          "sms_src": "1234",
+          "sms_src_npi": "E164",
+          "sms_src_ton": "Unknown",
+          "subaccount_id": "101",
+          "subject": "Summer deals are here!",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138"
+        }
+      }
+    },
+    {
+      "msys": {
+        "message_event": {
+          "type": "bounce",
+          "bounce_class": "10",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "delv_method": "esmtp",
+          "device_token": "45c19189783f867973f6e6a5cca60061ffe4fa77c547150563a1192fa9847f8a",
+          "error_code": "554",
+          "event_id": "92356927693813856",
+          "friendly_from": "sender@example.com",
+          "ip_address": "127.0.0.1",
+          "ip_pool": "Example-Ip-Pool",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "msg_size": "1337",
+          "num_retries": "2",
+          "rcpt_meta": {
+            "customField": "customValue"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "recipient@example.com",
+          "raw_rcpt_to": "recipient@example.com",
+          "rcpt_type": "cc",
+          "raw_reason": "MAIL REFUSED - IP (17.99.99.99) is in black list",
+          "reason": "MAIL REFUSED - IP (a.b.c.d) is in black list",
+          "routing_domain": "example.com",
+          "sending_ip": "127.0.0.1",
+          "sms_coding": "ASCII",
+          "sms_dst": "7876712656",
+          "sms_dst_npi": "E164",
+          "sms_dst_ton": "International",
+          "sms_src": "1234",
+          "sms_src_npi": "E164",
+          "sms_src_ton": "Unknown",
+          "subaccount_id": "101",
+          "subject": "Summer deals are here!",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138"
+        }
+      }
+    },
+    {
+      "msys": {
+        "message_event": {
+          "type": "bounce",
+          "bounce_class": "10",
+          "campaign_id": "Example Campaign Name",
+          "customer_id": "1",
+          "delv_method": "esmtp",
+          "device_token": "45c19189783f867973f6e6a5cca60061ffe4fa77c547150563a1192fa9847f8a",
+          "error_code": "554",
+          "event_id": "92356927693813856",
+          "friendly_from": "sender@example.com",
+          "ip_address": "127.0.0.1",
+          "ip_pool": "Example-Ip-Pool",
+          "message_id": "000443ee14578172be22",
+          "msg_from": "sender@example.com",
+          "msg_size": "1337",
+          "num_retries": "2",
+          "rcpt_meta": {
+            "customField": "customValue"
+          },
+          "rcpt_tags": [
+            "male",
+            "US"
+          ],
+          "rcpt_to": "bounce@example.com",
+          "raw_rcpt_to": "recipient@example.com",
+          "rcpt_type": "to",
+          "raw_reason": "MAIL REFUSED - IP (17.99.99.99) is in black list",
+          "reason": "MAIL REFUSED - IP (a.b.c.d) is in black list",
+          "routing_domain": "example.com",
+          "sending_ip": "127.0.0.1",
+          "sms_coding": "ASCII",
+          "sms_dst": "7876712656",
+          "sms_dst_npi": "E164",
+          "sms_dst_ton": "International",
+          "sms_src": "1234",
+          "sms_src_npi": "E164",
+          "sms_src_ton": "Unknown",
+          "subaccount_id": "101",
+          "subject": "Summer deals are here!",
+          "template_id": "templ-1234",
+          "template_version": "1",
+          "timestamp": "1454442600",
+          "transmission_id": "65832150921904138"
+        }
+      }
+    }
+]
+JSON;
+
+        return new Request([], json_decode($json, true));
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This adds correct handling of Momentum webhooks ported from Sparkpost so that hard and soft bounces are differentiated appropriately. 

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Run the tests for parsing example Sparkpost webhook payloads (assumed to be the same as momentum)
