### PR TITLE
Use scheduled date for report time range

### DIFF
--- a/app/bundles/ReportBundle/Adapter/ReportDataAdapter.php
+++ b/app/bundles/ReportBundle/Adapter/ReportDataAdapter.php
@@ -35,6 +35,8 @@ class ReportDataAdapter
         $options['limit']           = $reportExportOptions->getBatchSize();
         $options['ignoreGraphData'] = true;
         $options['page']            = $reportExportOptions->getPage();
+        $options['dateTo']          = $reportExportOptions->getDateTo();
+        $options['dateFrom']        = $reportExportOptions->getDateFrom();
 
         $data = $this->reportModel->getReportData($report, null, $options);
 

--- a/app/bundles/ReportBundle/Model/ReportExportOptions.php
+++ b/app/bundles/ReportBundle/Model/ReportExportOptions.php
@@ -25,6 +25,16 @@ class ReportExportOptions
      */
     private $page;
 
+    /**
+     * @var \DateTime
+     */
+    private $dateFrom;
+
+    /**
+     * @var \DateTime
+     */
+    private $dateTo;
+
     public function __construct(CoreParametersHelper $coreParametersHelper)
     {
         $this->batchSize = $coreParametersHelper->getParameter('report_export_batch_size');
@@ -63,5 +73,37 @@ class ReportExportOptions
     public function getNumberOfProcessedResults()
     {
         return $this->page * $this->getBatchSize();
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDateFrom()
+    {
+        return $this->dateFrom;
+    }
+
+    /**
+     * @param \DateTime $dateFrom
+     */
+    public function setDateFrom($dateFrom)
+    {
+        $this->dateFrom = $dateFrom;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDateTo()
+    {
+        return $this->dateTo;
+    }
+
+    /**
+     * @param \DateTime $dateTo
+     */
+    public function setDateTo($dateTo)
+    {
+        $this->dateTo = $dateTo;
     }
 }

--- a/app/bundles/ReportBundle/Model/ReportExporter.php
+++ b/app/bundles/ReportBundle/Model/ReportExporter.php
@@ -101,7 +101,7 @@ class ReportExporter
             }
 
             $this->reportExportOptions->setDateFrom($dateFrom);
-            $this->reportExportOptions->setDateTo($dateTo);
+            $this->reportExportOptions->setDateTo($dateTo->sub(new \DateInterval('PT1S')));
         }
 
         $this->reportExportOptions->beginExport();

--- a/app/bundles/ReportBundle/Model/ReportExporter.php
+++ b/app/bundles/ReportBundle/Model/ReportExporter.php
@@ -81,6 +81,29 @@ class ReportExporter
     private function processReport(Scheduler $scheduler)
     {
         $report = $scheduler->getReport();
+
+        if (!is_null($scheduler->getScheduleDate())) {
+            /** @var /DateTime $dateTo */
+            $dateTo = clone $scheduler->getScheduleDate();
+            $dateTo->setTime(0, 0, 0);
+
+            $dateFrom = clone $dateTo;
+            switch ($report->getScheduleUnit()) {
+                case 'DAILY':
+                    $dateFrom->sub(new \DateInterval('P1D'));
+                    break;
+                case 'WEEKLY':
+                    $dateFrom->sub(new \DateInterval('P7D'));
+                    break;
+                case 'MONTHLY':
+                    $dateFrom->sub(new \DateInterval('P1M'));
+                    break;
+            }
+
+            $this->reportExportOptions->setDateFrom($dateFrom);
+            $this->reportExportOptions->setDateTo($dateTo);
+        }
+
         $this->reportExportOptions->beginExport();
         while (true) {
             $data = $this->reportDataAdapter->getReportData($report, $this->reportExportOptions);

--- a/app/bundles/ReportBundle/Tests/Adapter/ReportDataAdapterTest.php
+++ b/app/bundles/ReportBundle/Tests/Adapter/ReportDataAdapterTest.php
@@ -45,6 +45,8 @@ class ReportDataAdapterTest extends \PHPUnit_Framework_TestCase
             'limit'           => 11,
             'ignoreGraphData' => true,
             'page'            => 1,
+            'dateTo'          => null,
+            'dateFrom'        => null,
         ];
 
         $reportModelMock->expects($this->once())


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
On scheduled report, limit the size of the report to the time frame chosen.
If you choose a daily report, send you data of yesterday, etc...

#### Steps to test this PR:
1. Apply this PR
2. Create a daily scheduled report
3. run `mautic:report:scheduler` command
4. you get a mail with a last 24h report instead 1 month report

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 