### PR TITLE
Add support to dispatch CampaignEvents::ON_EVENT_SCHEDULED_BATCH for the batch of failed rescheduled jobs

### DIFF
--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -247,6 +247,7 @@ return [
                     'mautic.campaign.dispatcher.action',
                     'mautic.campaign.dispatcher.condition',
                     'mautic.campaign.dispatcher.decision',
+                    'mautic.campaign.repository.lead_event_log',
                 ],
             ],
             'mautic.campaign.model.event_log' => [

--- a/app/bundles/CampaignBundle/Event/ScheduledBatchEvent.php
+++ b/app/bundles/CampaignBundle/Event/ScheduledBatchEvent.php
@@ -12,14 +12,44 @@
 namespace Mautic\CampaignBundle\Event;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\EventCollector\Accessor\Event\AbstractEventAccessor;
 
 class ScheduledBatchEvent extends AbstractLogCollectionEvent
 {
+    /**
+     * @var bool
+     */
+    private $isReschedule;
+
+    /**
+     * ScheduledBatchEvent constructor.
+     *
+     * @param AbstractEventAccessor $config
+     * @param Event                 $event
+     * @param ArrayCollection       $logs
+     * @param bool                  $isReschedule
+     */
+    public function __construct(AbstractEventAccessor $config, Event $event, ArrayCollection $logs, $isReschedule = false)
+    {
+        parent::__construct($config, $event, $logs);
+
+        $this->isReschedule = $isReschedule;
+    }
+
     /**
      * @return ArrayCollection
      */
     public function getScheduled()
     {
         return $this->logs;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isReschedule()
+    {
+        return $this->isReschedule;
     }
 }

--- a/app/bundles/CampaignBundle/Executioner/Dispatcher/ActionDispatcher.php
+++ b/app/bundles/CampaignBundle/Executioner/Dispatcher/ActionDispatcher.php
@@ -131,6 +131,10 @@ class ActionDispatcher
      */
     private function dispatchExecutedEvent(AbstractEventAccessor $config, Event $event, ArrayCollection $logs)
     {
+        if (!$logs->count()) {
+            return;
+        }
+
         foreach ($logs as $log) {
             $this->dispatcher->dispatch(
                 CampaignEvents::ON_EVENT_EXECUTED,
@@ -150,13 +154,15 @@ class ActionDispatcher
      */
     private function dispatchedFailedEvent(AbstractEventAccessor $config, ArrayCollection $logs)
     {
+        if (!$logs->count()) {
+            return;
+        }
+
         /** @var LeadEventLog $log */
         foreach ($logs as $log) {
             $this->logger->debug(
                 'CAMPAIGN: '.ucfirst($log->getEvent()->getEventType()).' ID# '.$log->getEvent()->getId().' for contact ID# '.$log->getLead()->getId()
             );
-
-            $this->scheduler->rescheduleFailure($log);
 
             $this->dispatcher->dispatch(
                 CampaignEvents::ON_EVENT_FAILED,
@@ -165,6 +171,8 @@ class ActionDispatcher
 
             $this->notificationHelper->notifyOfFailure($log->getLead(), $log->getEvent());
         }
+
+        $this->scheduler->rescheduleFailures($logs);
     }
 
     /**

--- a/app/bundles/CampaignBundle/Executioner/Dispatcher/DecisionDispatcher.php
+++ b/app/bundles/CampaignBundle/Executioner/Dispatcher/DecisionDispatcher.php
@@ -84,6 +84,10 @@ class DecisionDispatcher
      */
     public function dispatchDecisionResultsEvent(DecisionAccessor $config, ArrayCollection $logs, EvaluatedContacts $evaluatedContacts)
     {
+        if (!$logs->count()) {
+            return;
+        }
+
         $this->dispatcher->dispatch(
             CampaignEvents::ON_EVENT_DECISION_EVALUATION_RESULTS,
             new DecisionResultsEvent($config, $logs, $evaluatedContacts)

--- a/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
@@ -345,7 +345,6 @@ class ScheduledExecutioner implements ExecutionerInterface
             if ($this->scheduler->shouldSchedule($executionDate, $now)) {
                 // The schedule has changed for this event since first scheduled
                 $this->counter->advanceTotalScheduled();
-
                 if ($scheduleTogether) {
                     $toBeRescheduled->set($key, $log);
 

--- a/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
@@ -13,6 +13,7 @@ namespace Mautic\CampaignBundle\Executioner;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
@@ -201,28 +202,28 @@ class ScheduledExecutioner implements ExecutionerInterface
         $this->progressBar = ProgressBarHelper::init($this->output, $totalLogsFound);
         $this->progressBar->start();
 
-        // Validate that the schedule is still appropriate
-        $now = new \DateTime();
-        $this->validateSchedule($logs, $now);
         $scheduledLogCount = $totalLogsFound - $logs->count();
         $this->progressBar->advance($scheduledLogCount);
 
-        try {
-            // Hydrate contacts with custom field data
-            $this->scheduledContactFinder->hydrateContacts($logs);
-        } catch (NoContactsFoundException $e) {
-            $this->progressBar->clear();
-
-            return $this->counter;
-        }
-
         // Organize the logs by event ID
         $organized = $this->organizeByEvent($logs);
+        $now       = new \DateTime();
         foreach ($organized as $organizedLogs) {
-            $this->progressBar->advance($organizedLogs->count());
-
             $event = $organizedLogs->first()->getEvent();
-            $this->executioner->executeLogs($event, $organizedLogs, $this->counter);
+
+            // Validate that the schedule is still appropriate
+            $this->validateSchedule($event, $organizedLogs, $now);
+
+            try {
+                // Hydrate contacts with custom field data
+                $this->scheduledContactFinder->hydrateContacts($organizedLogs);
+
+                $this->executioner->executeLogs($event, $organizedLogs, $this->counter);
+            } catch (NoContactsFoundException $e) {
+                // All of the events were rescheduled
+            }
+
+            $this->progressBar->advance($organizedLogs->count());
         }
 
         $this->progressBar->finish();
@@ -307,7 +308,7 @@ class ScheduledExecutioner implements ExecutionerInterface
             $this->counter->advanceEvaluated($logs->count());
 
             // Validate that the schedule is still appropriate
-            $this->validateSchedule($logs, $now);
+            $this->validateSchedule($event, $logs, $now);
 
             // Execute if there are any that did not get rescheduled
             $this->executioner->executeLogs($event, $logs, $this->counter);
@@ -319,37 +320,39 @@ class ScheduledExecutioner implements ExecutionerInterface
     }
 
     /**
+     * @param Event           $event
      * @param ArrayCollection $logs
      * @param \DateTime       $now
      *
      * @throws Scheduler\Exception\NotSchedulableException
      */
-    private function validateSchedule(ArrayCollection $logs, \DateTime $now)
+    private function validateSchedule(Event $event, ArrayCollection $logs, \DateTime $now)
     {
+        $executionDate = $this->scheduler->getExecutionDateTime($event, $now);
+        $this->logger->debug(
+            'CAMPAIGN: Batch of scheduled logs'.
+            ' to be executed on '.$executionDate->format('Y-m-d H:i:s').
+            ' compared to '.$now->format('Y-m-d H:i:s')
+        );
+
+        $toBeRescheduled = new ArrayCollection();
+
         // Check if the event should be scheduled (let the schedulers do the debug logging)
         /** @var LeadEventLog $log */
         foreach ($logs as $key => $log) {
-            if ($createdDate = $log->getDateTriggered()) {
-                $event = $log->getEvent();
+            if ($this->scheduler->shouldSchedule($executionDate, $now)) {
+                // The schedule has changed for this event since first scheduled
+                $this->counter->advanceTotalScheduled();
 
-                // Date Triggered will be when the log entry was first created so use it to compare to ensure that the event's schedule
-                // hasn't been changed since this event was first scheduled
-                $executionDate = $this->scheduler->getExecutionDateTime($event, $now, $createdDate);
-                $this->logger->debug(
-                    'CAMPAIGN: Log ID# '.$log->getId().
-                    ' to be executed on '.$executionDate->format('Y-m-d H:i:s').
-                    ' compared to '.$now->format('Y-m-d H:i:s')
-                );
+                $toBeRescheduled->set($key, $log);
+                $logs->remove($key);
 
-                if ($this->scheduler->shouldSchedule($executionDate, $now)) {
-                    // The schedule has changed for this event since first scheduled
-                    $this->counter->advanceTotalScheduled();
-                    $this->scheduler->reschedule($log, $executionDate);
-                    $logs->remove($key);
-
-                    continue;
-                }
+                continue;
             }
+        }
+
+        if ($toBeRescheduled->count()) {
+            $this->scheduler->rescheduleLogs($toBeRescheduled, $executionDate);
         }
     }
 

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
@@ -329,6 +329,10 @@ class EventScheduler
      */
     public function shouldSchedule(\DateTime $executionDate, \DateTime $now)
     {
+        // Purposively ignore seconds to prevent rescheduling based on a variance of a few seconds
+        $executionDate = new \DateTime($executionDate->format('Y-m-d H:i'), $executionDate->getTimezone());
+        $now           = new \DateTime($now->format('Y-m-d H:i'), $now->getTimezone());
+
         return $executionDate > $now;
     }
 

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
@@ -329,9 +329,13 @@ class EventScheduler
      */
     public function shouldSchedule(\DateTime $executionDate, \DateTime $now)
     {
-        // Purposively ignore seconds to prevent rescheduling based on a variance of a few seconds
-        $executionDate = new \DateTime($executionDate->format('Y-m-d H:i'), $executionDate->getTimezone());
-        $now           = new \DateTime($now->format('Y-m-d H:i'), $now->getTimezone());
+        // Mainly for functional tests so we don't have to wait minutes but technically can be used in an environment as well if this behavior
+        // is desired by system admin
+        if (false === (bool) getenv('CAMPAIGN_EXECUTIONER_SCHEDULER_ACKNOWLEDGE_SECONDS')) {
+            // Purposively ignore seconds to prevent rescheduling based on a variance of a few seconds
+            $executionDate = new \DateTime($executionDate->format('Y-m-d H:i'), $executionDate->getTimezone());
+            $now           = new \DateTime($now->format('Y-m-d H:i'), $now->getTimezone());
+        }
 
         return $executionDate > $now;
     }

--- a/app/bundles/CampaignBundle/Model/LegacyEventModel.php
+++ b/app/bundles/CampaignBundle/Model/LegacyEventModel.php
@@ -496,7 +496,7 @@ class LegacyEventModel extends CommonFormModel
         $executedEventCount += $counter->getTotalExecuted();
         $totalEventCount += $counter->getEventCount();
 
-        return (bool) $executedEventCount;
+        return (bool) $counter->getTotalExecuted();
     }
 
     /**

--- a/app/bundles/CampaignBundle/Tests/Command/ExecuteEventCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/ExecuteEventCommandTest.php
@@ -15,6 +15,8 @@ class ExecuteEventCommandTest extends AbstractCampaignCommand
 {
     public function testEventsAreExecutedForInactiveEventWithSingleContact()
     {
+        putenv('CAMPAIGN_EXECUTIONER_SCHEDULER_ACKNOWLEDGE_SECONDS=1');
+
         $this->runCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-ids' => '1,2,3']);
 
         // There should be two events scheduled
@@ -68,5 +70,7 @@ class ExecuteEventCommandTest extends AbstractCampaignCommand
                 $this->fail('Event is still scheduled for lead ID '.$log['lead_id']);
             }
         }
+
+        putenv('CAMPAIGN_EXECUTIONER_SCHEDULER_ACKNOWLEDGE_SECONDS=0');
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -13,6 +13,20 @@ namespace Mautic\CampaignBundle\Tests\Command;
 
 class TriggerCampaignCommandTest extends AbstractCampaignCommand
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        putenv('CAMPAIGN_EXECUTIONER_SCHEDULER_ACKNOWLEDGE_SECONDS=1');
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        putenv('CAMPAIGN_EXECUTIONER_SCHEDULER_ACKNOWLEDGE_SECONDS=0');
+    }
+
     /**
      * @throws \Exception
      */

--- a/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/ActionDispatcherTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/ActionDispatcherTest.php
@@ -143,8 +143,16 @@ class ActionDispatcherTest extends \PHPUnit_Framework_TestCase
             ->with(CampaignEvents::ON_EVENT_FAILED, $this->isInstanceOf(FailedEvent::class));
 
         $this->scheduler->expects($this->once())
-            ->method('rescheduleFailure')
-            ->with($logs->get(2));
+            ->method('rescheduleFailures')
+            ->willReturnCallback(
+                function (ArrayCollection $logs) use ($log2) {
+                    if ($logs->count() > 1) {
+                        $this->fail('Only one log was supposed to fail');
+                    }
+
+                    $this->assertEquals($log2, $logs->first());
+                }
+            );
 
         $this->notificationHelper->expects($this->once())
             ->method('notifyOfFailure')

--- a/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/DecisionDispatcherTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/DecisionDispatcherTest.php
@@ -94,7 +94,7 @@ class DecisionDispatcherTest extends \PHPUnit_Framework_TestCase
             ->method('dispatch')
             ->with(CampaignEvents::ON_EVENT_DECISION_EVALUATION_RESULTS, $this->isInstanceOf(DecisionResultsEvent::class));
 
-        $this->getEventDispatcher()->dispatchDecisionResultsEvent($config, new ArrayCollection(), new EvaluatedContacts());
+        $this->getEventDispatcher()->dispatchDecisionResultsEvent($config, new ArrayCollection([new LeadEventLog()]), new EvaluatedContacts());
     }
 
     /**

--- a/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/LegacyEventDispatcherTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/LegacyEventDispatcherTest.php
@@ -271,7 +271,7 @@ class LegacyEventDispatcherTest extends \PHPUnit_Framework_TestCase
             ->with(CampaignEvents::ON_EVENT_FAILED, $this->isInstanceOf(FailedEvent::class));
 
         $this->scheduler->expects($this->once())
-            ->method('rescheduleFailure');
+            ->method('rescheduleFailures');
 
         $this->notificationHelper->expects($this->once())
             ->method('notifyOfFailure')
@@ -323,7 +323,7 @@ class LegacyEventDispatcherTest extends \PHPUnit_Framework_TestCase
             ->with(CampaignEvents::ON_EVENT_FAILED, $this->isInstanceOf(FailedEvent::class));
 
         $this->scheduler->expects($this->once())
-            ->method('rescheduleFailure');
+            ->method('rescheduleFailures');
 
         $this->getLegacyEventDispatcher()->dispatchCustomEvent($config, $logs, false, $pendingEvent);
     }

--- a/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerTest.php
@@ -339,7 +339,7 @@ class ScheduledExecutionerTest extends \PHPUnit_Framework_TestCase
 
         $this->scheduler->expects($this->once())
             ->method('rescheduleLogs')
-            ->with($this->isInstanceOf(ArrayCollection::class, $threeMinuteDateTime));
+            ->with($this->isInstanceOf(ArrayCollection::class), $threeMinuteDateTime);
 
         $counter = $this->getExecutioner()->executeByIds([1, 2]);
 

--- a/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerTest.php
@@ -146,7 +146,7 @@ class ScheduledExecutionerTest extends \PHPUnit_Framework_TestCase
         $this->executioner->expects($this->exactly(2))
             ->method('executeLogs');
 
-        $this->scheduler->expects($this->exactly(2))
+        $this->scheduler->expects($this->exactly(4))
             ->method('getExecutionDateTime')
             ->willReturn(new \DateTime());
 

--- a/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerTest.php
@@ -213,6 +213,140 @@ class ScheduledExecutionerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, $counter->getTotalEvaluated());
     }
 
+    public function testEventsAreScheduled()
+    {
+        $this->repository->expects($this->once())
+            ->method('getScheduledCounts')
+            ->willReturn([1 => 2]);
+
+        $campaign = $this->getMockBuilder(Campaign::class)
+            ->getMock();
+
+        $event = new Event();
+        $event->setCampaign($campaign);
+
+        $oneMinuteDateTime = new \DateTime('+1 minutes');
+        $twoMinuteDateTime = new \DateTime('+2 minutes');
+
+        $log1 = new LeadEventLog();
+        $log1->setEvent($event);
+        $log1->setCampaign($campaign);
+
+        $log2 = new LeadEventLog();
+        $log2->setEvent($event);
+        $log2->setCampaign($campaign);
+        $log2->setDateTriggered();
+
+        $this->repository->expects($this->exactly(2))
+            ->method('getScheduled')
+            ->willReturnOnConsecutiveCalls(
+                new ArrayCollection(
+                    [
+                        $log1,
+                        $log2,
+                    ]
+                ),
+                new ArrayCollection()
+            );
+
+        $this->executioner->expects($this->exactly(1))
+            ->method('executeLogs');
+
+        $this->scheduler->expects($this->exactly(2))
+            ->method('getExecutionDateTime')
+            ->willReturnOnConsecutiveCalls(
+                $oneMinuteDateTime,
+                $twoMinuteDateTime
+            );
+
+        $this->scheduler->expects($this->exactly(2))
+            ->method('shouldSchedule')
+            ->willReturn(true);
+
+        $this->scheduler->expects($this->exactly(2))
+            ->method('reschedule')
+            ->withConsecutive(
+                [$log1, $oneMinuteDateTime],
+                [$log2, $twoMinuteDateTime]
+            );
+
+        $limiter = new ContactLimiter(0, 0, 0, 0);
+
+        $counter = $this->getExecutioner()->execute($campaign, $limiter);
+
+        $this->assertEquals(2, $counter->getTotalScheduled());
+    }
+
+    public function testSpecificEventsAreScheduled()
+    {
+        $campaign = $this->getMockBuilder(Campaign::class)
+            ->getMock();
+
+        $event = $this->getMockBuilder(Event::class)
+            ->getMock();
+        $event->method('getId')
+            ->willReturn(1);
+        $event->method('getCampaign')
+            ->willReturn($campaign);
+
+        $log1 = $this->createMock(LeadEventLog::class);
+        $log1->method('getId')
+            ->willReturn(1);
+        $log1->method('getEvent')
+            ->willReturn($event);
+        $log1->method('getCampaign')
+            ->willReturn($campaign);
+        $log1->method('getDateTriggered')
+            ->willReturn(new \DateTime());
+
+        $log2 = $this->createMock(LeadEventLog::class);
+        $log2->method('getId')
+            ->willReturn(2);
+        $log2->method('getEvent')
+            ->willReturn($event);
+        $log2->method('getCampaign')
+            ->willReturn($campaign);
+        $log2->method('getDateTriggered')
+            ->willReturn(new \DateTime());
+
+        $logs = new ArrayCollection([1 => $log1, 2 => $log2]);
+
+        $this->repository->expects($this->once())
+            ->method('getScheduledByIds')
+            ->with([1, 2])
+            ->willReturn($logs);
+
+        $twoMinuteDateTime   = new \DateTime('+2 minutes');
+        $threeMinuteDateTime = new \DateTime('+3 minutes');
+
+        $this->scheduler->expects($this->exactly(2))
+            ->method('getExecutionDateTime')
+            ->willReturnOnConsecutiveCalls(
+                $twoMinuteDateTime,
+                $threeMinuteDateTime
+            );
+
+        $this->scheduler->expects($this->exactly(2))
+            ->method('shouldSchedule')
+            ->willReturn(true);
+
+        // Should only be executed once because the two logs were grouped by event ID
+        $this->executioner->expects($this->exactly(1))
+            ->method('executeLogs');
+
+        $this->contactFinder->expects($this->once())
+            ->method('hydrateContacts');
+
+        $this->scheduler->expects($this->once())
+            ->method('rescheduleLogs')
+            ->with($this->isInstanceOf(ArrayCollection::class, $threeMinuteDateTime));
+
+        $counter = $this->getExecutioner()->executeByIds([1, 2]);
+
+        // Two events were evaluated
+        $this->assertEquals(2, $counter->getTotalScheduled());
+    }
+
     /**
      * @return ScheduledExecutioner
      */

--- a/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerTest.php
@@ -146,6 +146,10 @@ class ScheduledExecutionerTest extends \PHPUnit_Framework_TestCase
         $this->executioner->expects($this->exactly(2))
             ->method('executeLogs');
 
+        $this->scheduler->expects($this->exactly(2))
+            ->method('getExecutionDateTime')
+            ->willReturn(new \DateTime());
+
         $limiter = new ContactLimiter(0, 0, 0, 0);
 
         $counter = $this->getExecutioner()->execute($campaign, $limiter);
@@ -165,17 +169,27 @@ class ScheduledExecutionerTest extends \PHPUnit_Framework_TestCase
         $event->method('getCampaign')
             ->willReturn($campaign);
 
-        $log1 = new LeadEventLog();
-        $log1->setEvent($event);
-        $log1->setCampaign($campaign);
-        $log1->setDateTriggered(new \DateTime());
+        $log1 = $this->createMock(LeadEventLog::class);
+        $log1->method('getId')
+            ->willReturn(1);
+        $log1->method('getEvent')
+            ->willReturn($event);
+        $log1->method('getCampaign')
+            ->willReturn($campaign);
+        $log1->method('getDateTriggered')
+            ->willReturn(new \DateTime());
 
-        $log2 = new LeadEventLog();
-        $log2->setEvent($event);
-        $log2->setCampaign($campaign);
-        $log2->setDateTriggered(new \DateTime());
+        $log2 = $this->createMock(LeadEventLog::class);
+        $log2->method('getId')
+            ->willReturn(2);
+        $log2->method('getEvent')
+            ->willReturn($event);
+        $log2->method('getCampaign')
+            ->willReturn($campaign);
+        $log2->method('getDateTriggered')
+            ->willReturn(new \DateTime());
 
-        $logs = new ArrayCollection([$log1, $log2]);
+        $logs = new ArrayCollection([1 => $log1, 2 => $log2]);
 
         $this->repository->expects($this->once())
             ->method('getScheduledByIds')
@@ -189,7 +203,7 @@ class ScheduledExecutionerTest extends \PHPUnit_Framework_TestCase
         $this->executioner->expects($this->exactly(1))
             ->method('executeLogs');
 
-        $this->contactFinder->expects($this->once())
+        $this->contactFinder->expects($this->exactly(1))
             ->method('hydrateContacts')
             ->with($logs);
 

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -9,7 +9,7 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-namespace Mautic\CampaignBundle\Executioner\Scheduler;
+namespace Mautic\CampaignBundle\Tests\Executioner\Scheduler;
 
 use Mautic\CampaignBundle\EventCollector\EventCollector;
 use Mautic\CampaignBundle\Executioner\Logger\EventLogger;

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -13,9 +13,11 @@ namespace Mautic\CampaignBundle\Tests\Executioner\Scheduler;
 
 use Mautic\CampaignBundle\EventCollector\EventCollector;
 use Mautic\CampaignBundle\Executioner\Logger\EventLogger;
+use Mautic\CampaignBundle\Executioner\Scheduler\EventScheduler;
 use Mautic\CampaignBundle\Executioner\Scheduler\Mode\DateTime;
 use Mautic\CampaignBundle\Executioner\Scheduler\Mode\Interval;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CampaignBundle\Executioner\Scheduler;
+
+use Mautic\CampaignBundle\EventCollector\EventCollector;
+use Mautic\CampaignBundle\Executioner\Logger\EventLogger;
+use Mautic\CampaignBundle\Executioner\Scheduler\Mode\DateTime;
+use Mautic\CampaignBundle\Executioner\Scheduler\Mode\Interval;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Psr\Log\NullLogger;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class EventSchedulerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $logger;
+
+    /**
+     * @var EventLogger|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $eventLogger;
+
+    /**
+     * @var Interval|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $intervalScheduler;
+
+    /**
+     * @var DateTime|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $dateTimeScheduler;
+
+    /**
+     * @var EventCollector|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $eventCollector;
+
+    /**
+     * @var EventDispatcherInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $dispatcher;
+
+    /**
+     * @var CoreParametersHelper|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $coreParamtersHelper;
+
+    protected function setUp()
+    {
+        $this->logger              = new NullLogger();
+        $this->eventLogger         = $this->createMock(EventLogger::class);
+        $this->intervalScheduler   = $this->createMock(Interval::class);
+        $this->dateTimeScheduler   = $this->createMock(DateTime::class);
+        $this->eventCollector      = $this->createMock(EventCollector::class);
+        $this->dispatcher          = $this->createMock(EventDispatcherInterface::class);
+        $this->coreParamtersHelper = $this->createMock(CoreParametersHelper::class);
+    }
+
+    public function testShouldScheduleIgnoresSeconds()
+    {
+        $this->assertFalse(
+            $this->getScheduler()->shouldSchedule(
+                new \DateTime('2018-07-03 09:20:45'),
+                new \DateTime('2018-07-03 09:20:30')
+            )
+        );
+    }
+
+    public function testShouldSchedule()
+    {
+        $this->assertTrue(
+            $this->getScheduler()->shouldSchedule(
+                new \DateTime('2018-07-03 09:21:45'),
+                new \DateTime('2018-07-03 09:20:30')
+            )
+        );
+    }
+
+    private function getScheduler()
+    {
+        return new EventScheduler(
+            $this->logger,
+            $this->eventLogger,
+            $this->intervalScheduler,
+            $this->dateTimeScheduler,
+            $this->eventCollector,
+            $this->dispatcher,
+            $this->coreParamtersHelper
+        );
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | enhancement
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This simply dispatches the CampaignEvents::ON_EVENT_SCHEDULED_BATCH event for the batch of failed logs for listeners that want to process the reschedules in batch rather than one by one. 

It includes #6207

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Mainly make sure that failed events get rescheduled
2. Create a campaign to send an email
3. Unpublish the email
4. Execute the campaign
5. The send email job should be rescheduled for an hour later for each contact (or whatever you have set as your failed campaign event interval in Configuration -> Campaign Settings
