### PR TITLE
Fixed contact identification in clickthroughs generated in dynamic content and fixed fatal error for direct-to-contact sends

### DIFF
--- a/app/bundles/CoreBundle/Event/TokenReplacementEvent.php
+++ b/app/bundles/CoreBundle/Event/TokenReplacementEvent.php
@@ -45,12 +45,21 @@ class TokenReplacementEvent extends CommonEvent
     protected $tokens = [];
 
     /**
+     * Whatever the calling code wants to make available to the consumers.
+     *
+     * @var mixed
+     */
+    protected $passthrough;
+
+    /**
      * TokenReplacementEvent constructor.
      *
-     * @param string|CommonEntity $content
-     * @param Lead|array          $lead
+     * @param       $content
+     * @param null  $lead
+     * @param array $clickthrough
+     * @param mixed $passthrough
      */
-    public function __construct($content, $lead = null, array $clickthrough = [])
+    public function __construct($content, $lead = null, array $clickthrough = [], $passthrough = null)
     {
         if ($content instanceof CommonEntity) {
             $this->entity = $content;
@@ -59,6 +68,7 @@ class TokenReplacementEvent extends CommonEvent
         $this->content      = $content;
         $this->lead         = $lead;
         $this->clickthrough = $clickthrough;
+        $this->passthrough  = $passthrough;
     }
 
     /**
@@ -132,5 +142,13 @@ class TokenReplacementEvent extends CommonEvent
     public function getTokens()
     {
         return $this->tokens;
+    }
+
+    /**
+     * @return mixed|null
+     */
+    public function getPassthrough()
+    {
+        return $this->passthrough;
     }
 }

--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -77,10 +77,18 @@ class EmailSendEvent extends CommonEvent
     private $textHeaders = [];
 
     /**
-     * @param MailHelper $helper
-     * @param array      $args
+     * @var bool
      */
-    public function __construct(MailHelper $helper = null, $args = [])
+    private $isDynamicContentParsing;
+
+    /**
+     * EmailSendEvent constructor.
+     *
+     * @param MailHelper|null $helper
+     * @param array           $args
+     * @param bool            $isDynamicContentParsing
+     */
+    public function __construct(MailHelper $helper = null, $args = [], $isDynamicContentParsing = false)
     {
         $this->helper = $helper;
 
@@ -129,6 +137,8 @@ class EmailSendEvent extends CommonEvent
         if (isset($args['textHeaders'])) {
             $this->textHeaders = $args['textHeaders'];
         }
+
+        $this->isDynamicContentParsing = $isDynamicContentParsing;
     }
 
     /**
@@ -379,5 +389,13 @@ class EmailSendEvent extends CommonEvent
         } else {
             return md5($this->getContent().$this->getPlainText());
         }
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDynamicContentParsing()
+    {
+        return $this->isDynamicContentParsing;
     }
 }

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -202,7 +202,7 @@ class ContactRequestHelper
             throw new ContactNotFoundException();
         }
 
-        if ((int) $stat->getEmail()->getId() !== (int) $clickthrough['channel']['email']) {
+        if ($stat->getEmail() && (int) $stat->getEmail()->getId() !== (int) $clickthrough['channel']['email']) {
             // Email ID mismatch - fishy so use tracked lead
             throw new ContactNotFoundException();
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #6008
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This fixes two issues with tracking URLs in emails:
1. If a link is in the dynamic content block, the link would not include the email or stat hash ID in the clickthrough. So unless the contact was already tracked in the browser, the click would not be attributed to them. 
2. Fixed fatal error getId() on null when sending an email directly to a contact

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create an email with a dynamic content block that includes a link (either in the default content or in a variation but make sure the filters match a contact the email is sent to)
2. Go to Configuration -> Tracking settings and make sure "Identify contact by tracking URL" is disabled (disabled by default on new installations).
3. Send the email to a contact
4. Open the link in a guest session
5. Check the contact's profile and notice that the page hit is not associated with them

For the second bug:
1. View the profile of a contact and click Send Email. 
2. Compose an email with a link
3. Send the email and click the link
4. It'll throw the error page

#### Steps to test this PR:
1. Repeat and the link should be associated with the contact
2. Repeat and the link should redirect without a fatal error
