### PR TITLE
Fix hit count on trackable object other than email

### DIFF
--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -662,8 +662,13 @@ class PageModel extends FormModel
 
                     // If this is a trackable, up the trackable counts as well
                     if (!empty($clickthrough['channel'])) {
-                        $channelId = reset($clickthrough['channel']);
-                        $channel   = key($clickthrough['channel']);
+                        if (count($clickthrough['channel']) === 1) {
+                            $channelId = reset($clickthrough['channel']);
+                            $channel   = key($clickthrough['channel']);
+                        } else {
+                            $channel   = $clickthrough['channel'][0];
+                            $channelId = (int) $clickthrough['channel'][1];
+                        }
 
                         $this->pageTrackableModel->getRepository()->upHitCount($page->getId(), $channel, $channelId, 1, $isUnique);
                     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When user click on a SMS tracked link, history of contact is updated but `Click counts` on SMS object is not updated.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create SMS with a link
2. In Mautic configuration activate `Identify visitor by tracking url` in `Tracking settings`
3. Send SMS with a campaign
4. Click on the link inside the SMS
5. Go to this SMS view
6. `Click counts` is not updated

#### Steps to test this PR:
1. Apply the PR
2. Repeat step above
3. `Click counts` is good updated
