### PR TITLE
Campaign Condition: Form Field Value

### DIFF
--- a/app/bundles/FormBundle/Controller/AjaxController.php
+++ b/app/bundles/FormBundle/Controller/AjaxController.php
@@ -103,6 +103,9 @@ class AjaxController extends CommonAjaxController
                     'type'    => $field->getType(),
                     'options' => $options,
                 ];
+
+                // Be sure to not pollute the symbol table.
+                unset($optionList);
             }
         }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When building the select lists for the Form Field Value campaign condition, select options from fields defined previously in the form would be set as the options for later fields IF those later fields didn't define options of their own. This made putting a value for the `equals` operator on those later fields impossible.  

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new form with a select list field that has multiple values.
2. Create a second field that is a text type then save the form.
3. Create a new campaign, then add a Condition with Form Field Value as the type.
4. Select the form you created from the dropdown in the modal. This will load the available fields.
5. Notice that the Select field you created is first selected and will have the appropriate values selectable in the Value column.
6. Change the selected field to the text field you created. The options from the Select field are still present in the Value column.

#### Steps to test this PR:
1. Apply Pr
2. Delete the old campaign action and add a new one and follow the same steps.
3. The Value column will correctly clear out when changing the selected field.