### PR TITLE
Fix permission when cloning object

### DIFF
--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -402,7 +402,8 @@ abstract class AbstractStandardFormController extends AbstractFormController
                     'edit'
                 )
             );
-        } elseif (!$this->checkActionPermission('edit', $entity)) {
+        } elseif ((!$isClone && !$this->checkActionPermission('edit', $entity)) || ($isClone && !$this->checkActionPermission('create'))) {
+            //deny access if the entity is not a clone and don't have permission to edit or is a clone and don't have permission to create
             return $this->accessDenied();
         } elseif (!$isClone && $model->isLocked($entity)) {
             //deny access if the entity is locked

--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -180,7 +180,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
      * @param      $action
      * @param      $isPost
      * @param $objectId
-     * @param   $isClone
+     * @param $isClone
      */
     protected function beforeFormProcessed($entity, Form $form, $action, $isPost, $objectId = null, $isClone = false)
     {
@@ -258,7 +258,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
     /**
      * Clone an entity.
      *
-     * @param   $objectId
+     * @param $objectId
      *
      * @return array|\Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
      */


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When cloning an object extended class `AbstractStandardFormController` there is a permission error on saving because object doesn't exist so we can't check edit permission on it.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a role with permission en Focus View Own, Edit Own, Create, Delete Own and Publish Own
2. Create a user with this role
3. With the created user add a Focus object
4. When object is added, clone it
5. Edit some field in the cloned object and click "Save"
6. Error because you haven't the permission

#### Steps to test this PR:
1. Apply this PR
2. Follow steps above
3. Object cloned succesfully