### PR TITLE
Fix: Remove tags in campaign action

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1768,7 +1768,7 @@ class LeadModel extends FormModel
             $tags = explode(',', $tags);
         }
 
-        if (empty($tags)) {
+        if (empty($tags) && empty($removeTags)) {
             return false;
         }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6144
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Remove tags campaign action  doesn't remove tags. This PR fixed it

[//]: # ( As applicable: )

### Steps to reproduce:
1. Create a contact and manually add it a tag.
![image](https://user-images.githubusercontent.com/31535432/40724269-f9844140-6420-11e8-904b-c1127c3677ef.png)
2. Add this contact to a segment
3. Create a campaign, start from this segment and add action "modify contact's tag"
4. In the field, remove tag, choose the tag you added to the contact
![image](https://user-images.githubusercontent.com/31535432/40724566-9fee7816-6421-11e8-9ad7-a0f6f8c10119.png)
5. Lauch campaign.
6. Check contact and see that he still has the tag. 
My contact after going through this campaign
![image](https://user-images.githubusercontent.com/31535432/40724659-d54f4b70-6421-11e8-9254-61d74b269bb4.png)

#### Steps to test this PR:
1. Repeat all steps
2. Tags  are remove  correctly