### PR TITLE
Enable the integrations to integrate by disabling injection

### DIFF
--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/IntegrationPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/IntegrationPass.php
@@ -28,33 +28,35 @@ class IntegrationPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds('mautic.integration') as $id => $tags) {
             $definition = $container->findDefinition($id);
 
-            /*
-             * @deprecated: To be removed in 3.0. Set dependencies on Integration constructor instead,
-             *              using the service container config.php to pass those dependencies in.
-             */
-            $definition->addMethodCall('setFactory', [new Reference('mautic.factory')]);
+            if (!$definition->hasTag('mautic.basic_integration')) {
+                /*
+                 * @deprecated: To be removed in 3.0. Set dependencies on Integration constructor instead,
+                 *              using the service container config.php to pass those dependencies in.
+                 */
+                $definition->addMethodCall('setFactory', [new Reference('mautic.factory')]);
 
-            $definition->addMethodCall('setDispatcher', [new Reference('event_dispatcher')]);
-            $definition->addMethodCall('setCache', [new Reference('mautic.helper.cache_storage')]);
-            $definition->addMethodCall('setEntityManager', [new Reference('doctrine.orm.entity_manager')]);
-            $definition->addMethodCall('setSession', [new Reference('session')]);
-            $definition->addMethodCall('setRequest', [new Reference('request_stack')]);
-            $definition->addMethodCall('setRouter', [new Reference('router')]);
-            $definition->addMethodCall('setTranslator', [new Reference('translator')]);
-            $definition->addMethodCall('setLogger', [new Reference('monolog.logger.mautic')]);
-            $definition->addMethodCall('setEncryptionHelper', [new Reference('mautic.helper.encryption')]);
-            $definition->addMethodCall('setLeadModel', [new Reference('mautic.lead.model.lead')]);
-            $definition->addMethodCall('setCompanyModel', [new Reference('mautic.lead.model.company')]);
-            $definition->addMethodCall('setPathsHelper', [new Reference('mautic.helper.paths')]);
-            $definition->addMethodCall('setNotificationModel', [new Reference('mautic.core.model.notification')]);
-            $definition->addMethodCall('setFieldModel', [new Reference('mautic.lead.model.field')]);
-            $definition->addMethodCall('setIntegrationEntityModel', [new Reference('mautic.plugin.model.integration_entity')]);
+                $definition->addMethodCall('setDispatcher', [new Reference('event_dispatcher')]);
+                $definition->addMethodCall('setCache', [new Reference('mautic.helper.cache_storage')]);
+                $definition->addMethodCall('setEntityManager', [new Reference('doctrine.orm.entity_manager')]);
+                $definition->addMethodCall('setSession', [new Reference('session')]);
+                $definition->addMethodCall('setRequest', [new Reference('request_stack')]);
+                $definition->addMethodCall('setRouter', [new Reference('router')]);
+                $definition->addMethodCall('setTranslator', [new Reference('translator')]);
+                $definition->addMethodCall('setLogger', [new Reference('monolog.logger.mautic')]);
+                $definition->addMethodCall('setEncryptionHelper', [new Reference('mautic.helper.encryption')]);
+                $definition->addMethodCall('setLeadModel', [new Reference('mautic.lead.model.lead')]);
+                $definition->addMethodCall('setCompanyModel', [new Reference('mautic.lead.model.company')]);
+                $definition->addMethodCall('setPathsHelper', [new Reference('mautic.helper.paths')]);
+                $definition->addMethodCall('setNotificationModel', [new Reference('mautic.core.model.notification')]);
+                $definition->addMethodCall('setFieldModel', [new Reference('mautic.lead.model.field')]);
+                $definition->addMethodCall('setIntegrationEntityModel', [new Reference('mautic.plugin.model.integration_entity')]);
 
-            $class     = $definition->getClass();
-            $reflected = new \ReflectionClass($class);
+                $class     = $definition->getClass();
+                $reflected = new \ReflectionClass($class);
 
-            if ($reflected->hasMethod('setIntegrationHelper')) {
-                $definition->addMethodCall('setIntegrationHelper', [new Reference('mautic.helper.integration')]);
+                if ($reflected->hasMethod('setIntegrationHelper')) {
+                    $definition->addMethodCall('setIntegrationHelper', [new Reference('mautic.helper.integration')]);
+                }
             }
         }
     }


### PR DESCRIPTION
# Enable integrations services

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Automated tests included? | N
| Issues addressed (#s or URLs) | Slooce Epic
| BC breaks? |  N
| Deprecations? |  N

#### Description:

New integrations do not use all the injections currently used. We need to disable this injection for services tagged as **mautic.basic_integration**.

This PR only disables the injection for services marked like that.