### PR TITLE
Clean old data to be GDPR compliant

### DIFF
--- a/app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php
+++ b/app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php
@@ -42,6 +42,7 @@ class CleanupMaintenanceCommand extends ContainerAwareCommand
                         365
                     ),
                     new InputOption('dry-run', 'r', InputOption::VALUE_NONE, 'Do a dry run without actually deleting anything.'),
+                    new InputOption('gdpr', 'g', InputOption::VALUE_NONE, 'Delete data to fullfil GDPR requiement.'),
                 ]
             )
             ->setHelp(
@@ -73,11 +74,15 @@ EOT
         $daysOld       = $input->getOption('days-old');
         $dryRun        = $input->getOption('dry-run');
         $noInteraction = $input->getOption('no-interaction');
-
-        if (empty($daysOld)) {
+        $gdpr          = $input->getOption('gdpr');
+        if (empty($daysOld) && empty($gdpr)) {
             // Safety catch; bail
-
             return 1;
+        }
+
+        if (!empty($gdpr)) {
+            // to fullfil GDPR, you must delete inactive user data older than 3years
+            $daysOld = 365 * 3;
         }
 
         if (empty($dryRun) && empty($noInteraction)) {
@@ -94,7 +99,7 @@ EOT
 
         $dispatcher = $this->getContainer()->get('event_dispatcher');
 
-        $event = $dispatcher->dispatch(CoreEvents::MAINTENANCE_CLEANUP_DATA, new MaintenanceEvent($daysOld, !empty($dryRun)));
+        $event = $dispatcher->dispatch(CoreEvents::MAINTENANCE_CLEANUP_DATA, new MaintenanceEvent($daysOld, !empty($dryRun), !empty($gdpr)));
         $stats = $event->getStats();
 
         $rows = [];

--- a/app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php
+++ b/app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php
@@ -42,7 +42,7 @@ class CleanupMaintenanceCommand extends ContainerAwareCommand
                         365
                     ),
                     new InputOption('dry-run', 'r', InputOption::VALUE_NONE, 'Do a dry run without actually deleting anything.'),
-                    new InputOption('gdpr', 'g', InputOption::VALUE_NONE, 'Delete data to fullfil GDPR requiement.'),
+                    new InputOption('gdpr', 'g', InputOption::VALUE_NONE, 'Delete data to fullfil GDPR requirement.'),
                 ]
             )
             ->setHelp(

--- a/app/bundles/CoreBundle/Event/MaintenanceEvent.php
+++ b/app/bundles/CoreBundle/Event/MaintenanceEvent.php
@@ -39,6 +39,11 @@ class MaintenanceEvent extends Event
     protected $dryRun = false;
 
     /**
+     * @var bool
+     */
+    protected $gdpr = false;
+
+    /**
      * @var array
      */
     protected $debug = [];
@@ -49,11 +54,12 @@ class MaintenanceEvent extends Event
      * @param int  $daysOld
      * @param bool $dryRun
      */
-    public function __construct($daysOld, $dryRun)
+    public function __construct($daysOld, $dryRun, $gdpr)
     {
         $this->daysOld = (int) $daysOld;
         $this->dryRun  = (bool) $dryRun;
         $this->date    = new \DateTime("$daysOld days ago", new \DateTimeZone('UTC'));
+        $this->gdpr    = (bool) $gdpr;
     }
 
     /**
@@ -120,5 +126,13 @@ class MaintenanceEvent extends Event
     public function getDebug()
     {
         return $this->debug;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isGdpr()
+    {
+        return $this->gdpr;
     }
 }

--- a/app/bundles/LeadBundle/EventListener/MaintenanceSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/MaintenanceSubscriber.php
@@ -55,25 +55,37 @@ class MaintenanceSubscriber extends CommonSubscriber
             ->setParameter('date', $event->getDate()->format('Y-m-d H:i:s'));
 
         if ($event->isDryRun()) {
-            $rows = $qb->select('count(*) as records')
-                ->from(MAUTIC_TABLE_PREFIX.'leads', 'l')
-                ->where(
-                    $qb->expr()->andX(
-                        $qb->expr()->lte('l.last_active', ':date'),
-                        $qb->expr()->isNull('l.date_identified')
-                    )
-                )
-                ->execute()
-                ->fetchColumn();
+            $qb->select('count(*) as records')
+              ->from(MAUTIC_TABLE_PREFIX.'leads', 'l')
+              ->where($qb->expr()->lte('l.last_active', ':date'));
+
+            if ($event->isGdpr() === false) {
+                $qb->andWhere($qb->expr()->isNull('l.date_identified'));
+            } else {
+                $qb->orWhere(
+                  $qb->expr()->andX(
+                    $qb->expr()->lte('l.date_added', ':date2'),
+                    $qb->expr()->isNull('l.last_active')
+                  ));
+                $qb->setParameter('date2', $event->getDate()->format('Y-m-d H:i:s'));
+            }
+            $rows = $qb->execute()->fetchColumn();
         } else {
-            $rows = $qb->delete(MAUTIC_TABLE_PREFIX.'leads')
-                ->where(
-                    $qb->expr()->andX(
-                        $qb->expr()->lte('last_active', ':date'),
-                        $qb->expr()->isNull('date_identified')
-                    )
-                )
-                ->execute();
+            $qb->delete(MAUTIC_TABLE_PREFIX.'leads')
+              ->where($qb->expr()->lte('last_active', ':date'));
+
+            if ($event->isGdpr() === false) {
+                $qb->andWhere($qb->expr()->isNull('date_identified'));
+            } else {
+                $qb->orWhere(
+                  $qb->expr()->andX(
+                    $qb->expr()->lte('date_added', ':date2'),
+                    $qb->expr()->isNull('last_active')
+                  ));
+                $qb->setParameter('date2', $event->getDate()->format('Y-m-d H:i:s'));
+            }
+
+            $rows = $qb->execute();
         }
 
         $event->setStat($this->translator->trans('mautic.maintenance.visitors'), $rows, $qb->getSQL(), $qb->getParameters());

--- a/app/bundles/PageBundle/EventListener/MaintenanceSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/MaintenanceSubscriber.php
@@ -61,28 +61,38 @@ class MaintenanceSubscriber extends CommonSubscriber
             ->setParameter('date', $event->getDate()->format('Y-m-d H:i:s'));
 
         if ($event->isDryRun()) {
-            $rows = $qb->select('count(*) as records')
-                ->from(MAUTIC_TABLE_PREFIX.$table, 'h')
-                ->join('h', MAUTIC_TABLE_PREFIX.'leads', 'l', 'h.lead_id = l.id')
-                ->where(
-                    $qb->expr()->andX(
-                        $qb->expr()->lte('l.last_active', ':date'),
-                        $qb->expr()->isNull('l.date_identified')
-                    )
-                )
-                ->execute()
-                ->fetchColumn();
+            $qb->select('count(*) as records')
+              ->from(MAUTIC_TABLE_PREFIX.$table, 'h')
+              ->join('h', MAUTIC_TABLE_PREFIX.'leads', 'l', 'h.lead_id = l.id')
+              ->where($qb->expr()->lte('l.last_active', ':date'));
+
+            if ($event->isGdpr() === false) {
+                $qb->andWhere($qb->expr()->isNull('l.date_identified'));
+            } else {
+                $qb->orWhere(
+                  $qb->expr()->andX(
+                    $qb->expr()->lte('l.date_added', ':date2'),
+                    $qb->expr()->isNull('l.last_active')
+                  ));
+                $qb->setParameter('date2', $event->getDate()->format('Y-m-d H:i:s'));
+            }
+
+            $rows = $qb->execute()->fetchColumn();
         } else {
             $subQb = $this->db->createQueryBuilder();
-            $subQb->select('id')
-                ->from(MAUTIC_TABLE_PREFIX.'leads', 'l')
-                ->where(
-                    $qb->expr()->andX(
-                        $qb->expr()->lte('l.last_active', ':date'),
-                        $qb->expr()->isNull('l.date_identified')
-                    )
-                );
+            $subQb->select('id')->from(MAUTIC_TABLE_PREFIX.'leads', 'l')
+              ->where($qb->expr()->lte('l.last_active', ':date'));
 
+            if ($event->isGdpr() === false) {
+                $subQb->andWhere($qb->expr()->isNull('l.date_identified'));
+            } else {
+                $subQb->orWhere(
+                  $subQb->expr()->andX(
+                    $subQb->expr()->lte('l.date_added', ':date2'),
+                    $subQb->expr()->isNull('l.last_active')
+                  ));
+                $qb->setParameter('date2', $event->getDate()->format('Y-m-d H:i:s'));
+            }
             $rows = $qb->delete(MAUTIC_TABLE_PREFIX.$table)
                 ->where(
                     $qb->expr()->in(


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N 
| New feature? | Y
| Automated tests included? |
| Related user documentation PR URL | https://github.com/mautic/documentation/pull/287
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5878
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )



[//]: # ( Required: )
#### Description:
Clean data in the database according to European GDPR regulation.

#### Steps to test this PR:
1. Take 4 leads, with pages_hit history
2. In database, for lead 1, modify `last_active` to 2014 and set `date_identified` to 2014 _(identifed lead)_
3. In database, for lead 2, modify `last_active` to 2014 and set `date_identified` to `null` _(anonymous lead)_
4. In database, for lead 3, modify `last_active` to 2018 and set `date_identified` to `null` _(anonymous lead)_
5. In database, for lead 5, modify `last_active` to `null`, set `date_identified` to `null` and `date_added` to 2014 (_simulate imported lead_)
5. In database, for lead 5, modify `last_active` to `null`, set `date_identified` to `null` and `date_added` to 2018 (_simulate imported lead_)

6. run `mautic:maintenance:cleanup --gdpr`
7. lead 1, 2, 5 must be deleted for database with associed pageHits