### PR TITLE
Decode special characters before setting from name

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -265,7 +265,12 @@ class MailHelper
             $this->logError($e);
         }
 
-        $this->from       = $this->systemFrom       = (!empty($from)) ? $from : [$factory->getParameter('mailer_from_email') => $factory->getParameter('mailer_from_name')];
+        $systemFromEmail  = $factory->getParameter('mailer_from_email');
+        $systemFromName   = $this->cleanName(
+            $factory->getParameter('mailer_from_name')
+        );
+        $this->setDefaultFrom($from, [$systemFromEmail => $systemFromName]);
+
         $this->returnPath = $factory->getParameter('mailer_return_path');
 
         // Check if batching is supported by the transport
@@ -1232,6 +1237,8 @@ class MailHelper
      */
     public function setFrom($fromEmail, $fromName = null, $isGlobal = true)
     {
+        $fromName = $this->cleanName($fromName);
+
         if (null !== $isGlobal) {
             if ($isGlobal) {
                 if (is_array($fromEmail)) {
@@ -1248,7 +1255,6 @@ class MailHelper
         }
 
         try {
-            $fromName = $this->cleanName($fromName);
             $this->message->setFrom($fromEmail, $fromName);
         } catch (\Exception $e) {
             $this->logError($e, 'from');
@@ -2007,13 +2013,15 @@ class MailHelper
      */
     protected function cleanName($name)
     {
-        if (null !== $name) {
-            $name = trim($name);
+        if (null === $name) {
+            return $name;
+        }
 
-            // If empty, replace with null so that email clients do not show empty name because of To: '' <email@domain.com>
-            if (empty($name)) {
-                $name = null;
-            }
+        $name = trim(html_entity_decode($name, ENT_QUOTES));
+
+        // If empty, replace with null so that email clients do not show empty name because of To: '' <email@domain.com>
+        if (empty($name)) {
+            $name = null;
         }
 
         return $name;
@@ -2082,5 +2090,23 @@ class MailHelper
                 'Email address ['.$address.'] is invalid'
             );
         }
+    }
+
+    /**
+     * @param       $overrideFrom
+     * @param array $systemFrom
+     */
+    private function setDefaultFrom($overrideFrom, array $systemFrom)
+    {
+        if (is_array($overrideFrom)) {
+            $fromEmail         = key($overrideFrom);
+            $fromName          = $this->cleanName($overrideFrom[$fromEmail]);
+            $overrideFrom      = [$fromEmail => $fromName];
+        } elseif (!empty($overrideFrom)) {
+            $overrideFrom = [$overrideFrom => null];
+        }
+
+        $this->systemFrom = $overrideFrom ?: $systemFrom;
+        $this->from       = $this->systemFrom;
     }
 }

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -253,6 +253,38 @@ class MailHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['contact3@somewhere.com' => null], $mailer->message->getTo());
     }
 
+    public function testMailAsOwnerWithEncodedCharactersInName()
+    {
+        $mockFactory = $this->getMockFactory();
+
+        $transport   = new BatchTransport();
+        $swiftMailer = new \Swift_Mailer($transport);
+
+        $mailer = new MailHelper($mockFactory, $swiftMailer, ['nobody@nowhere.com' => 'No Body&#39;s Business']);
+        $mailer->enableQueue();
+
+        $mailer->setSubject('Hello');
+
+        $contacts                = $this->contacts;
+        $contacts[3]['owner_id'] = 3;
+
+        foreach ($contacts as $contact) {
+            $mailer->addTo($contact['email']);
+            $mailer->setLead($contact);
+            $mailer->queue();
+        }
+
+        $mailer->flushQueue([]);
+
+        $fromAddresses = $transport->getFromAddresses();
+        $fromNames     = $transport->getFromNames();
+
+        $this->assertEquals(4, count($fromAddresses));
+        $this->assertEquals(4, count($fromNames));
+        $this->assertEquals(['owner1@owner.com', 'nobody@nowhere.com', 'owner2@owner.com', 'owner3@owner.com'], $fromAddresses);
+        $this->assertEquals([null, "No Body's Business", null, "John S'mith"], $fromNames);
+    }
+
     public function testBatchIsEnabledWithBcTokenInterface()
     {
         $mockFactory = $this->getMockFactory();
@@ -488,6 +520,7 @@ class MailHelperTest extends \PHPUnit_Framework_TestCase
                     [
                         [1, ['id' => 1, 'email' => 'owner1@owner.com', 'first_name' => '', 'last_name' => '', 'signature' => 'owner 1']],
                         [2, ['id' => 2, 'email' => 'owner2@owner.com', 'first_name' => '', 'last_name' => '', 'signature' => 'owner 2']],
+                        [3, ['id' => 3, 'email' => 'owner3@owner.com', 'first_name' => 'John', 'last_name' => 'S&#39;mith', 'signature' => 'owner 2']],
                     ]
                 )
             );

--- a/app/bundles/EmailBundle/Tests/Helper/Transport/BatchTransport.php
+++ b/app/bundles/EmailBundle/Tests/Helper/Transport/BatchTransport.php
@@ -16,6 +16,7 @@ use Mautic\EmailBundle\Swiftmailer\Transport\AbstractTokenArrayTransport;
 class BatchTransport extends AbstractTokenArrayTransport implements \Swift_Transport
 {
     private $fromAddresses = [];
+    private $fromNames     = [];
     private $metadatas     = [];
     private $validate      = false;
     private $maxRecipients;
@@ -40,7 +41,10 @@ class BatchTransport extends AbstractTokenArrayTransport implements \Swift_Trans
     public function send(\Swift_Mime_Message $message, &$failedRecipients = null)
     {
         $this->message         = $message;
-        $this->fromAddresses[] = key($message->getFrom());
+        $from                  = $message->getFrom();
+        $fromEmail             = key($from);
+        $this->fromAddresses[] = $fromEmail;
+        $this->fromNames[]     = $from[$fromEmail];
         $this->metadatas[]     = $this->getMetadata();
 
         $messageArray = $this->messageToArray();
@@ -88,6 +92,14 @@ class BatchTransport extends AbstractTokenArrayTransport implements \Swift_Trans
     public function getFromAddresses()
     {
         return $this->fromAddresses;
+    }
+
+    /**
+     * return array.
+     */
+    public function getFromNames()
+    {
+        return $this->fromNames;
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? | y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When the from name in an email has an apostrophe, it is sent to the contact with the encoded version. This is apparent in mail as owner with users that have apostrophes in their name. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a user with `O'Brian` as the last name
2. Edit Mautic's Configuration to enable Mail as Owner
3. Create a contact and assign it to the user in step one
4. Create a segment email, add the contact to the segment, and send
5. Notice that the from name in the received email will be `O&#39;sBrian`

#### Steps to test this PR:
1. Repeat and the name will now be `O'Brian`
