### PR TITLE
Fix typo in PlainText Message Helper classname

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -629,7 +629,7 @@ return [
                 ],
             ],
             'mautic.helper.plain_text_message' => [
-                'class'     => \Mautic\EmailBundle\Helper\PlainTextMassageHelper::class,
+                'class'     => \Mautic\EmailBundle\Helper\PlainTextMessageHelper::class,
             ],
             'mautic.validator.email' => [
                 'class'     => \Mautic\EmailBundle\Helper\EmailValidator::class,

--- a/app/bundles/EmailBundle/Helper/PlainTextMessageHelper.php
+++ b/app/bundles/EmailBundle/Helper/PlainTextMessageHelper.php
@@ -12,9 +12,9 @@
 namespace Mautic\EmailBundle\Helper;
 
 /**
- * Class PlainTextMassageHelper.
+ * Class PlainTextMessageHelper.
  */
-class PlainTextMassageHelper
+class PlainTextMessageHelper
 {
     /**
      * Extract plain text from message.

--- a/app/bundles/EmailBundle/Swiftmailer/Momentum/Service/SwiftMessageService.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Momentum/Service/SwiftMessageService.php
@@ -11,7 +11,7 @@
 
 namespace Mautic\EmailBundle\Swiftmailer\Momentum\Service;
 
-use Mautic\EmailBundle\Helper\PlainTextMassageHelper;
+use Mautic\EmailBundle\Helper\PlainTextMessageHelper;
 use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
 use Mautic\EmailBundle\Swiftmailer\Momentum\DTO\TransmissionDTO;
 use Mautic\EmailBundle\Swiftmailer\Momentum\Metadata\MetadataProcessor;
@@ -78,7 +78,7 @@ final class SwiftMessageService implements SwiftMessageServiceInterface
             }
         }
 
-        if ($messageText = PlainTextMassageHelper::getPlainTextFromMessage($message)) {
+        if ($messageText = PlainTextMessageHelper::getPlainTextFromMessage($message)) {
             $content->setText($messageText);
         }
 

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailBase.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailBase.php
@@ -11,7 +11,7 @@
 
 namespace Mautic\EmailBundle\Swiftmailer\SendGrid\Mail;
 
-use Mautic\EmailBundle\Helper\PlainTextMassageHelper;
+use Mautic\EmailBundle\Helper\PlainTextMessageHelper;
 use SendGrid\Content;
 use SendGrid\Email;
 use SendGrid\Mail;
@@ -19,13 +19,13 @@ use SendGrid\Mail;
 class SendGridMailBase
 {
     /**
-     * @var PlainTextMassageHelper
+     * @var PlainTextMessageHelper
      */
-    private $plainTextMassageHelper;
+    private $plainTextMessageHelper;
 
-    public function __construct(PlainTextMassageHelper $plainTextMassageHelper)
+    public function __construct(PlainTextMessageHelper $plainTextMessageHelper)
     {
-        $this->plainTextMassageHelper = $plainTextMassageHelper;
+        $this->plainTextMessageHelper = $plainTextMessageHelper;
     }
 
     /**
@@ -44,7 +44,7 @@ class SendGridMailBase
 
         // Plain text message must be first if present
         if ($contentMain->getType() !== 'text/plain') {
-            $plainText = $this->plainTextMassageHelper->getPlainTextFromMessageNotStatic($message);
+            $plainText = $this->plainTextMessageHelper->getPlainTextFromMessageNotStatic($message);
             if ($plainText) {
                 $contentSecond = $contentMain;
                 $contentMain   = new Content('text/plain', $plainText);

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/AbstractTokenArrayTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/AbstractTokenArrayTransport.php
@@ -13,7 +13,7 @@ namespace Mautic\EmailBundle\Swiftmailer\Transport;
 
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\EmailBundle\Helper\MailHelper;
-use Mautic\EmailBundle\Helper\PlainTextMassageHelper;
+use Mautic\EmailBundle\Helper\PlainTextMessageHelper;
 use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
 
 /**
@@ -157,7 +157,7 @@ abstract class AbstractTokenArrayTransport implements TokenTransportInterface
 
         $message = [
             'html'    => $this->message->getBody(),
-            'text'    => PlainTextMassageHelper::getPlainTextFromMessage($this->message),
+            'text'    => PlainTextMessageHelper::getPlainTextFromMessage($this->message),
             'subject' => $this->message->getSubject(),
             'from'    => [
                 'name'  => $fromName,

--- a/app/bundles/EmailBundle/Tests/Helper/PlainTextMessageHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/PlainTextMessageHelperTest.php
@@ -11,7 +11,7 @@
 
 namespace Mautic\EmailBundle\Tests\Helper;
 
-use Mautic\EmailBundle\Helper\PlainTextMassageHelper;
+use Mautic\EmailBundle\Helper\PlainTextMessageHelper;
 
 /**
  * Class MessageHelperTest.
@@ -23,6 +23,6 @@ class PlainTextMessageHelperTest extends \PHPUnit_Framework_TestCase
         $message = new \Swift_Message('Subject', 'My Content', 'text/html');
         $message->addPart('plain text', 'text/plain');
 
-        $this->assertSame('plain text', PlainTextMassageHelper::getPlainTextFromMessage($message));
+        $this->assertSame('plain text', PlainTextMessageHelper::getPlainTextFromMessage($message));
     }
 }

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailBaseTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailBaseTest.php
@@ -11,7 +11,7 @@
 
 namespace Mautic\EmailBundle\Tests\Swiftmailer\SendGrid\Mail;
 
-use Mautic\EmailBundle\Helper\PlainTextMassageHelper;
+use Mautic\EmailBundle\Helper\PlainTextMessageHelper;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailBase;
 use SendGrid\Content;
 use SendGrid\Email;
@@ -23,11 +23,11 @@ class SendGridMailBaseTest extends \PHPUnit_Framework_TestCase
      */
     public function testHtmlMessage($contentType)
     {
-        $plainTextMassageHelper = $this->getMockBuilder(PlainTextMassageHelper::class)
+        $plainTextMessageHelper = $this->getMockBuilder(PlainTextMessageHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $sendGridMailBase = new SendGridMailBase($plainTextMassageHelper);
+        $sendGridMailBase = new SendGridMailBase($plainTextMessageHelper);
 
         $message = $this->getMockBuilder(\Swift_Mime_Message::class)
             ->getMock();
@@ -52,7 +52,7 @@ class SendGridMailBaseTest extends \PHPUnit_Framework_TestCase
             ->with()
             ->willReturn('HTML body');
 
-        $plainTextMassageHelper->expects($this->once())
+        $plainTextMessageHelper->expects($this->once())
             ->method('getPlainTextFromMessageNotStatic')
             ->with($message)
             ->willReturn('Plain text');
@@ -86,11 +86,11 @@ class SendGridMailBaseTest extends \PHPUnit_Framework_TestCase
 
     public function testPlainTextMessage()
     {
-        $plainTextMassageHelper = $this->getMockBuilder(PlainTextMassageHelper::class)
+        $plainTextMessageHelper = $this->getMockBuilder(PlainTextMessageHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $sendGridMailBase = new SendGridMailBase($plainTextMassageHelper);
+        $sendGridMailBase = new SendGridMailBase($plainTextMessageHelper);
 
         $message = $this->getMockBuilder(\Swift_Mime_Message::class)
             ->getMock();
@@ -115,7 +115,7 @@ class SendGridMailBaseTest extends \PHPUnit_Framework_TestCase
             ->with()
             ->willReturn('Plain text');
 
-        $plainTextMassageHelper->expects($this->never())
+        $plainTextMessageHelper->expects($this->never())
             ->method('getPlainTextFromMessageNotStatic');
 
         $mail = $sendGridMailBase->getSendGridMail($message);
@@ -137,11 +137,11 @@ class SendGridMailBaseTest extends \PHPUnit_Framework_TestCase
 
     public function testEmptyPlainTextMessage()
     {
-        $plainTextMassageHelper = $this->getMockBuilder(PlainTextMassageHelper::class)
+        $plainTextMessageHelper = $this->getMockBuilder(PlainTextMessageHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $sendGridMailBase = new SendGridMailBase($plainTextMassageHelper);
+        $sendGridMailBase = new SendGridMailBase($plainTextMessageHelper);
 
         $message = $this->getMockBuilder(\Swift_Mime_Message::class)
             ->getMock();
@@ -166,7 +166,7 @@ class SendGridMailBaseTest extends \PHPUnit_Framework_TestCase
             ->with()
             ->willReturn('HTML body');
 
-        $plainTextMassageHelper->expects($this->once())
+        $plainTextMessageHelper->expects($this->once())
             ->method('getPlainTextFromMessageNotStatic')
             ->with($message)
             ->willReturn('');


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | Maybe
| Deprecations? | N

[//]: # ( Required: )
#### Description:

An apparent typo had the `mautic.helper.plain_text_message` service's
class named "PlainTextMassageHelper", which sounds luxurious but is a
bit confusing and was probably unintended.

Full find/replace done in app/bundles/EmailBundle/ with [`repren`](https://github.com/jlevy/repren) like so:

```
    $ cd app/bundles/EmailBundle/
    $ repren --preserve-case --full --from=massage --to=message .
```

#### Steps to test this PR:
1. Run the PlainTextMessageHelper unit test: 
    ```sh
    bin/phpunit \
      --bootstrap vendor/autoload.php \
      --configuration app/phpunit.xml.dist \
      Mautic\EmailBundle\Tests\Helper\PlainTextMessageHelperTest \
      app/bundles/EmailBundle/Tests/Helper/PlainTextMessageHelperTest.php
    ```

#### List backwards compatibility breaks:
1. The **PlainTextMassageHelper** class and its filename have been renamed, but the service name under which it is instantiated remains the same.
