### PR TITLE
Fix interface bug when adding Order, Filter or Function elements in report

### DIFF
--- a/app/bundles/ReportBundle/Assets/css/report.css
+++ b/app/bundles/ReportBundle/Assets/css/report.css
@@ -42,11 +42,11 @@
 	margin:0;
 }
 
-#report_filters > .in-group > .panel-heading {
+#report_filters > .in-group:first-child > .panel-heading {
 	display:none;
 }
 
-#report_filters > .in-group ~ .in-group {
+#report_filters > .in-group:not(:first-child) {
 	margin-top:0;
 	border-top:0;
 	border-top-left-radius: 0;
@@ -54,12 +54,12 @@
 	margin-left:20px;
 }
 
-#report_filters > .in-group ~ .in-group > .panel-heading {
+#report_filters > .in-group:not(:first-child) > .panel-heading {
 	display:block;
 	padding-left:10px;
 }
 
-#report_filters > .in-group ~ .in-group > .panel-body > .row > div {
+#report_filters > .in-group:not(:first-child) > .panel-body > .row > div {
 	padding-left:10px;
 	padding-right:10px;
 }

--- a/app/bundles/ReportBundle/Assets/js/report.js
+++ b/app/bundles/ReportBundle/Assets/js/report.js
@@ -7,9 +7,9 @@ Mautic.reportOnLoad = function (container) {
 
     // Append an index of the number of filters on the edit form
     if (mQuery('div[id=report_filters]').length) {
-        mQuery('div[id=report_filters]').attr('data-index', mQuery('#report_filters > div').length + 1);
-        mQuery('div[id=report_tableOrder]').attr('data-index', mQuery('#report_tableOrder > div').length + 1);
-        mQuery('div[id=report_aggregators]').attr('data-index', mQuery('#report_aggregators > div').length + 1);
+        mQuery('div[id=report_filters]').attr('data-index', Mautic.getHighestIndex('report_filters'));
+        mQuery('div[id=report_tableOrder]').attr('data-index', Mautic.getHighestIndex('report_tableOrder'));
+        mQuery('div[id=report_aggregators]').attr('data-index', Mautic.getHighestIndex('report_aggregators'));
 
         if (mQuery('.filter-columns').length) {
             mQuery('.filter-columns').each(function () {
@@ -361,4 +361,16 @@ Mautic.checkSelectedGroupBy = function () {
         });
         mQuery('#aggregators-button').prop('disabled', true);
     }
+};
+
+Mautic.getHighestIndex = function (selector) {
+    var highestIndex = 1;
+    var selectorChildren = mQuery('#' + selector + ' > div');
+
+    selectorChildren.each(function() {
+        var index = mQuery(this).attr('id').split('_')[2];
+        highestIndex = (index > highestIndex) ? index : highestIndex;
+    });
+
+    return parseInt(highestIndex);
 };


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
In Report > Data interface when you add an Order, Filter or Function elements javascript it's appaear that sometime new element has the same id than an old element due to the way in which the id is calculate. When this appaear the element is not saved and the interface bug.

2nd commit fix an interface bug due to css selector used.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a report
2. Go to data tab
3. Add 3 filter with OR
4. Click on apply
5. Delete first filter
6. Click on apply
7. Add a filter
8. At this time interface bug and if you click on apply the last filter is not saved

#### Steps to test this PR:
1. Apply this PR
2. Delete media/css/app.css and media/js/app.js, they will be regenerated by Mautic
2. Repeat step above
3. It's work as expected