### PR TITLE
media images: autodetect mimetype for uploaded images

### DIFF
--- a/media/images/.htaccess
+++ b/media/images/.htaccess
@@ -14,13 +14,3 @@ RemoveHandler .cgi .pl .py .pyc .pyo .phtml .php .php3 .php4 .php5 .php6 .pcgi .
 RemoveType .cgi .pl .py .pyc .pyo .phtml .php .php3 .php4 .php5 .php6 .pcgi .pcgi3 .pcgi4 .pcgi5 .pchi6 .inc
 SetHandler None
 SetHandler default-handler
-
-ForceType text/plain
-
-<FilesMatch "\.css$">
-    ForceType text/css
-</FilesMatch>
-
-<FilesMatch "\.js$">
-    ForceType text/js
-</FilesMatch>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| Automated tests included? | no, infrastrucutre configuration
| Related user documentation PR URL |  N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A, [realated comment](https://github.com/mautic/mautic/commit/c788459473a56c664c0055530ebb1460c5e1d212#r29483440)
| BC breaks? | no
| Deprecations? | no

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Uploaded image in e-mail builder is served with wrong mime-type.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Install fresh Mautic and create e-mail with image frame
2. upload image into frame
3. evaluate result:
   a. Open sent e-mail in any webmail client that serves images directly from originating server (Kerio Connect in my case)
   b. Or open image URL in any web browser, you will see ton of text instead of image (as it is served as `text/plain`)

#### Steps to test this PR:
a. open image link in browser and see image
b. open e-mail in webmail that loads images directly and see image in e-mail

It would makes sense to see @alanhartless review as he is the author of original code that forces mime-types for uploaded files.

cc @dakur @Nbaru 