### PR TITLE
Fix compatibility between tokens and redirect links 

### DIFF
--- a/app/bundles/CoreBundle/Tests/unit/Helper/UrlHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Helper/UrlHelperTest.php
@@ -90,8 +90,9 @@ class UrlHelperTest extends \PHPUnit_Framework_TestCase
     public function testGetUrlsFromPlaintextSkipDefaultTokenValues()
     {
         $this->assertEquals(
-            ['https://find.this'],
-            UrlHelper::getUrlsFromPlaintext('Find this url: https://find.this, but ignore this one: {contactfield=website|http://skip.this}! ')
+            // 1 is skipped because it's set as the token default
+            [0 => 'https://find.this', 2 => '{contactfield=website|http://skip.this}'],
+            UrlHelper::getUrlsFromPlaintext('Find this url: https://find.this, but allow this token because we know its a url: {contactfield=website|http://skip.this}! ')
         );
     }
 

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -141,7 +141,11 @@ return [
                 ],
             ],
             'mautic.emailtoken.subscriber' => [
-                'class' => 'Mautic\EmailBundle\EventListener\TokenSubscriber',
+                'class'     => 'Mautic\EmailBundle\EventListener\TokenSubscriber',
+                'arguments' => [
+                    'event_dispatcher',
+                    'mautic.lead.helper.primary_company',
+                ],
             ],
             'mautic.email.campaignbundle.subscriber' => [
                 'class'     => \Mautic\EmailBundle\EventListener\CampaignSubscriber::class,

--- a/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
@@ -12,18 +12,42 @@
 namespace Mautic\EmailBundle\EventListener;
 
 use Mautic\CoreBundle\Event\TokenReplacementEvent;
-use Mautic\CoreBundle\EventListener\CommonSubscriber;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Helper\PrimaryCompanyHelper;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Class TokenSubscriber.
  */
-class TokenSubscriber extends CommonSubscriber
+class TokenSubscriber implements EventSubscriberInterface
 {
     use MatchFilterForLeadTrait;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var PrimaryCompanyHelper
+     */
+    private $primaryCompanyHelper;
+
+    /**
+     * TokenSubscriber constructor.
+     *
+     * @param EventDispatcherInterface $dispatcher
+     * @param PrimaryCompanyHelper     $primaryCompanyHelper
+     */
+    public function __construct(EventDispatcherInterface $dispatcher, PrimaryCompanyHelper $primaryCompanyHelper)
+    {
+        $this->dispatcher           = $dispatcher;
+        $this->primaryCompanyHelper = $primaryCompanyHelper;
+    }
 
     /**
      * {@inheritdoc}
@@ -93,7 +117,9 @@ class TokenSubscriber extends CommonSubscriber
         $tokenData = $clickthrough['dynamicContent'];
 
         if ($lead instanceof Lead) {
-            $lead = $lead->getProfileFields();
+            $lead = $this->primaryCompanyHelper->getProfileFieldsWithPrimaryCompany($lead);
+        } else {
+            $lead = $this->primaryCompanyHelper->mergePrimaryCompanyWithProfileFields($lead['id'], $lead);
         }
 
         foreach ($tokenData as $data) {

--- a/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
@@ -17,6 +17,7 @@ use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\EmailBundle\EventListener\TokenSubscriber;
 use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Helper\PrimaryCompanyHelper;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class TokenSubscriberTest extends \PHPUnit_Framework_TestCase
@@ -92,15 +93,18 @@ CONTENT
         $lead->setEmail('hello@someone.com');
         $mailHelper->setLead($lead);
 
+        $dispatcher           = new EventDispatcher();
+        $primaryCompanyHelper = $this->createMock(PrimaryCompanyHelper::class);
+        $primaryCompanyHelper->method('getProfileFieldsWithPrimaryCompany')
+            ->willReturn(['email' => 'hello@someone.com']);
+
         /** @var TokenSubscriber $subscriber */
         $subscriber = $this->getMockBuilder(TokenSubscriber::class)
-            ->disableOriginalConstructor()
+            ->setConstructorArgs([$dispatcher, $primaryCompanyHelper])
             ->setMethods(null)
             ->getMock();
 
-        $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber($subscriber);
-        $subscriber->setDispatcher($dispatcher);
 
         $event = new EmailSendEvent($mailHelper);
 

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -818,6 +818,13 @@ return [
                     \Mautic\LeadBundle\Entity\MergeRecord::class,
                 ],
             ],
+            'mautic.lead.repository.field' => [
+                'class'     => Doctrine\ORM\EntityRepository::class,
+                'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
+                'arguments' => [
+                    \Mautic\LeadBundle\Entity\LeadField::class,
+                ],
+            ],
         ],
         'helpers' => [
             'mautic.helper.template.avatar' => [

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -754,6 +754,12 @@ return [
                     'mautic.lead.repository.lead',
                 ],
             ],
+            'mautic.lead.helper.primary_company' => [
+                'class'     => \Mautic\LeadBundle\Helper\PrimaryCompanyHelper::class,
+                'arguments' => [
+                    'mautic.lead.repository.company_lead',
+                ],
+            ],
         ],
         'repositories' => [
             'mautic.lead.repository.company' => [
@@ -761,6 +767,13 @@ return [
                 'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
                 'arguments' => [
                     \Mautic\LeadBundle\Entity\Company::class,
+                ],
+            ],
+            'mautic.lead.repository.company_lead' => [
+                'class'     => Doctrine\ORM\EntityRepository::class,
+                'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
+                'arguments' => [
+                    \Mautic\LeadBundle\Entity\CompanyLead::class,
                 ],
             ],
             'mautic.lead.repository.dnc' => [

--- a/app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
@@ -57,7 +57,7 @@ class CompanyLeadRepository extends CommonRepository
     {
         $q = $this->_em->getConnection()->createQueryBuilder();
 
-        $q->select('cl.company_id, cl.date_added as date_associated, cl.is_primary, comp.companyname, comp.companyemail, comp.companyphone, comp.companycity, comp.companycountry, comp.companywebsite, comp.score, comp.date_added')
+        $q->select('cl.company_id, cl.date_added as date_associated, cl.is_primary, comp.*')
             ->from(MAUTIC_TABLE_PREFIX.'companies_leads', 'cl')
             ->join('cl', MAUTIC_TABLE_PREFIX.'companies', 'comp', 'comp.id = cl.company_id')
         ->where('cl.lead_id = :leadId')

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -329,4 +329,14 @@ class LeadFieldRepository extends CommonRepository
 
         return !empty($result['id']);
     }
+
+    /**
+     * @param $type
+     *
+     * @return LeadField[]
+     */
+    public function getFieldsByType($type)
+    {
+        return $this->findBy(['type' => $type]);
+    }
 }

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -145,7 +145,7 @@ class ContactRequestHelper
     {
         // Check for a lead requested through clickthrough query parameter
         if (isset($this->queryFields['ct'])) {
-            $clickthrough = $this->queryFields['ct'];
+            $clickthrough = (is_array($this->queryFields['ct'])) ? $this->queryFields['ct'] : ClickthroughHelper::decodeArrayFromUrl($this->queryFields['ct']);
         } elseif ($clickthrough = $this->request->get('ct', [])) {
             $clickthrough = ClickthroughHelper::decodeArrayFromUrl($clickthrough);
         }

--- a/app/bundles/LeadBundle/Helper/PrimaryCompanyHelper.php
+++ b/app/bundles/LeadBundle/Helper/PrimaryCompanyHelper.php
@@ -69,7 +69,7 @@ class PrimaryCompanyHelper
                 continue;
             }
 
-            unset($company['score'], $company['date_added'], $company['date_associated'], $company['is_primary']);
+            unset($company['id'], $company['score'], $company['date_added'], $company['date_associated'], $company['is_primary']);
 
             return array_merge($profileFields, $company);
         }

--- a/app/bundles/LeadBundle/Helper/PrimaryCompanyHelper.php
+++ b/app/bundles/LeadBundle/Helper/PrimaryCompanyHelper.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Helper;
+
+use Mautic\LeadBundle\Entity\CompanyLeadRepository;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
+
+class PrimaryCompanyHelper
+{
+    private $companyLeadRepository;
+
+    /**
+     * PrimaryCompanyHelper constructor.
+     *
+     * @param LeadRepository $companyLeadRepository
+     */
+    public function __construct(CompanyLeadRepository $companyLeadRepository)
+    {
+        $this->companyLeadRepository = $companyLeadRepository;
+    }
+
+    /**
+     * @param Lead $lead
+     *
+     * @return array
+     */
+    public function getProfileFieldsWithPrimaryCompany(Lead $lead)
+    {
+        return $this->mergeInPrimaryCompany(
+            $this->companyLeadRepository->getCompaniesByLeadId($lead->getId()),
+            $lead->getProfileFields()
+        );
+    }
+
+    /**
+     * @param       $contactId
+     * @param array $profileFields
+     *
+     * @return array
+     */
+    public function mergePrimaryCompanyWithProfileFields($contactId, array $profileFields)
+    {
+        return $this->mergeInPrimaryCompany(
+            $this->companyLeadRepository->getCompaniesByLeadId($contactId),
+            $profileFields
+        );
+    }
+
+    /**
+     * @param array $companies
+     * @param array $profileFields
+     *
+     * @return array
+     */
+    private function mergeInPrimaryCompany(array $companies, array $profileFields)
+    {
+        foreach ($companies as $company) {
+            if (empty($company['is_primary'])) {
+                continue;
+            }
+
+            unset($company['score'], $company['date_added'], $company['date_associated'], $company['is_primary']);
+
+            return array_merge($profileFields, $company);
+        }
+
+        return $profileFields;
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Helper/PrimaryCompanyHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/PrimaryCompanyHelperTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Helper;
+
+use Mautic\LeadBundle\Entity\CompanyLeadRepository;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Helper\PrimaryCompanyHelper;
+
+class PrimaryCompanyHelperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CompanyLeadRepository|\PHPUnit_Framework_Exception
+     */
+    private $leadRepository;
+
+    protected function setUp()
+    {
+        $this->leadRepository = $this->createMock(CompanyLeadRepository::class);
+
+        $this->leadRepository->expects($this->once())
+            ->method('getCompaniesByLeadId')
+            ->willReturn(
+                [
+                    [
+                        'score'           => 0,
+                        'date_added'      => '2018-06-02 00:00:00',
+                        'date_associated' => '2018-06-02 00:00:00',
+                        'is_primary'      => 1,
+                        'companywebsite'  => 'https://foo.com',
+                    ],
+                    [
+                        'score'           => 0,
+                        'date_added'      => '2018-06-02 00:00:00',
+                        'date_associated' => '2018-06-02 00:00:00',
+                        'is_primary'      => 0,
+                        'companywebsite'  => 'https://bar.com',
+                    ],
+                ]
+            );
+    }
+
+    public function testProfileFieldsReturnedWithPrimaryCompany()
+    {
+        $lead = $this->createMock(Lead::class);
+        $lead->expects($this->once())
+            ->method('getProfileFields')
+            ->willReturn(
+                [
+                    'email' => 'test@test.com',
+                ]
+            );
+
+        $profileFields = $this->getPrimaryCompanyHelper()->getProfileFieldsWithPrimaryCompany($lead);
+
+        $this->assertEquals(['email' => 'test@test.com', 'companywebsite' => 'https://foo.com'], $profileFields);
+    }
+
+    public function testPrimaryCompanyMergedIntoProfileFields()
+    {
+        $leadFields = [
+            'email' => 'test@test.com',
+        ];
+
+        $profileFields = $this->getPrimaryCompanyHelper()->mergePrimaryCompanyWithProfileFields(1, $leadFields);
+
+        $this->assertEquals(['email' => 'test@test.com', 'companywebsite' => 'https://foo.com'], $profileFields);
+    }
+
+    /**
+     * @return PrimaryCompanyHelper
+     */
+    private function getPrimaryCompanyHelper()
+    {
+        return new PrimaryCompanyHelper($this->leadRepository);
+    }
+}

--- a/app/bundles/PageBundle/Config/config.php
+++ b/app/bundles/PageBundle/Config/config.php
@@ -289,9 +289,10 @@ return [
                 ],
             ],
             'mautic.page.model.trackable' => [
-                'class'     => 'Mautic\PageBundle\Model\TrackableModel',
+                'class'     => \Mautic\PageBundle\Model\TrackableModel::class,
                 'arguments' => [
                     'mautic.page.model.redirect',
+                    'mautic.lead.repository.field',
                 ],
             ],
             'mautic.page.model.video' => [

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -640,4 +640,25 @@ class PublicController extends CommonFormController
 
         return new JsonResponse($data);
     }
+
+    /**
+     * @param array $companies
+     * @param array $profileFields
+     *
+     * @return array
+     */
+    private function mergePrimaryCompany(array $companies, array $profileFields)
+    {
+        foreach ($companies as $company) {
+            if (empty($company['is_primary'])) {
+                continue;
+            }
+
+            unset($company['score'], $company['date_added'], $company['date_associated'], $company['is_primary']);
+
+            return array_merge($profileFields, $company);
+        }
+
+        return $profileFields;
+    }
 }

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -453,7 +453,7 @@ class PublicController extends CommonFormController
         // Search replace lead fields in the URL
         /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
         $leadModel = $this->getModel('lead');
-        $lead      = $leadModel->getContactFromRequest([$ct]);
+        $lead      = $leadModel->getContactFromRequest(['ct' => $ct]);
 
         /** @var PrimaryCompanyHelper $primaryCompanyHelper */
         $primaryCompanyHelper = $this->get('mautic.lead.helper.primary_company');

--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -13,6 +13,7 @@ namespace Mautic\PageBundle\Model;
 
 use Mautic\CoreBundle\Helper\UrlHelper;
 use Mautic\CoreBundle\Model\AbstractCommonModel;
+use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\LeadBundle\Helper\TokenHelper;
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\Trackable;
@@ -58,13 +59,24 @@ class TrackableModel extends AbstractCommonModel
     protected $redirectModel;
 
     /**
+     * @var LeadFieldRepository
+     */
+    private $leadFieldRepository;
+
+    /**
+     * @var array|null
+     */
+    private $contactFieldUrlTokens;
+
+    /**
      * TrackableModel constructor.
      *
      * @param RedirectModel $redirectModel
      */
-    public function __construct(RedirectModel $redirectModel)
+    public function __construct(RedirectModel $redirectModel, LeadFieldRepository $leadFieldRepository)
     {
-        $this->redirectModel = $redirectModel;
+        $this->redirectModel       = $redirectModel;
+        $this->leadFieldRepository = $leadFieldRepository;
     }
 
     /**
@@ -243,70 +255,21 @@ class TrackableModel extends AbstractCommonModel
     {
         $this->usingClickthrough = $usingClickthrough;
 
-        // Reset content replacement arrays
-        $this->contentReplacements = [
-            'first_pass' => [
-                // Remove internal attributes
-                // Editor may convert to HTML4
-                'mautic:disable-tracking=""' => '',
-                // HTML5
-                'mautic:disable-tracking' => '',
-            ],
-            'first_pass'  => [],
-            'second_pass' => [],
-        ];
-
         // Set do not track list for validateUrlIsTrackable()
         $this->doNotTrack = $this->getDoNotTrackList($content);
 
         // Set content tokens used by validateUrlIsTrackable()
         $this->contentTokens = $contentTokens;
 
-        $trackableUrls    = [];
-        $trackableTokens  = [];
         $contentWasString = false;
         if (!is_array($content)) {
             $contentWasString = true;
             $content          = [$content];
         }
 
-        foreach ($content as &$text) {
-            if (preg_match('/<[^<]+>/', $text) !== 0) {
-                // Parse as HTML
-                $trackableUrls = array_merge(
-                    $trackableUrls,
-                    $this->extractTrackablesFromHtml($text)
-                );
-            } else {
-                // Parse as plain text
-                $trackableUrls = array_merge(
-                    $trackableUrls,
-                    $this->extractTrackablesFromText($text)
-                );
-            }
-        }
-
-        if (count($trackableUrls)) {
-            // Create Trackable/Redirect entities for the URLs
-            $entities = $this->getEntitiesFromUrls($trackableUrls, $channel, $channelId);
-            unset($trackableUrls);
-
-            // Get a list of url => token to return to calling method and also to be used to
-            // replace the urls in the content with tokens
-            $trackableTokens = $this->createTrackingTokens($entities);
-            unset($entities);
-
-            // Replace URLs in content with tokens
-            foreach ($content as &$text) {
-                $type = (preg_match('/<(.*?) href/i', $text)) ? 'html' : 'text';
-                $text = $this->prepareContentWithTrackableTokens($text, $type);
-            }
-        } elseif (!empty($this->contentReplacements['first_pass'])) {
-            // Replace URLs in content with tokens
-            foreach ($content as &$text) {
-                $type = (preg_match('/<(.*?) href/i', $text)) ? 'html' : 'text';
-                $text = $this->prepareContentWithTrackableTokens($text, $type);
-            }
+        $trackableTokens = [];
+        foreach ($content as $key => $text) {
+            $content[$key] = $this->parseContent($text, $channel, $channelId, $trackableTokens);
         }
 
         return [
@@ -381,6 +344,24 @@ class TrackableModel extends AbstractCommonModel
     }
 
     /**
+     * @param $content
+     *
+     * @return array
+     */
+    protected function extractTrackablesFromContent($content)
+    {
+        if (preg_match('/<[^<]+>/', $content) !== 0) {
+            // Parse as HTML
+            $trackableUrls = $this->extractTrackablesFromHtml($content);
+        } else {
+            // Parse as plain text
+            $trackableUrls = $this->extractTrackablesFromText($content);
+        }
+
+        return $trackableUrls;
+    }
+
+    /**
      * Find URLs in HTML and parse into trackables.
      *
      * @param string $html HTML content
@@ -430,27 +411,16 @@ class TrackableModel extends AbstractCommonModel
     protected function extractTrackablesFromText($text)
     {
         // Remove any HTML tags (such as img) that could contain href or src attributes prior to parsing for links
-        $text          = strip_tags($text);
-        $allUrls       = UrlHelper::getUrlsFromPlaintext($text);
+        $text = strip_tags($text);
+
+        // Get a list of URL type contact fields
+        $allUrls       = UrlHelper::getUrlsFromPlaintext($text, $this->getContactFieldUrlTokens());
         $trackableUrls = [];
 
-        if ($allUrls) {
-            foreach ($allUrls as $url) {
-                if ($preparedUrl = $this->prepareUrlForTracking($url)) {
-                    list($urlKey, $urlValue) = $preparedUrl;
-                    $trackableUrls[$urlKey]  = $urlValue;
-                }
-            }
-        }
-
-        // Any tokens could potentially be a URL so extract and send through prepareUrlForTracking() which will determine
-        // if it's a valid URL or not
-        if (preg_match_all('/{.*?}/i', $text, $matches)) {
-            foreach ($matches[0] as $url) {
-                if ($preparedUrl = $this->prepareUrlForTracking($url)) {
-                    list($urlKey, $urlValue) = $preparedUrl;
-                    $trackableUrls[$urlKey]  = $urlValue;
-                }
+        foreach ($allUrls as $url) {
+            if ($preparedUrl = $this->prepareUrlForTracking($url)) {
+                list($urlKey, $urlValue) = $preparedUrl;
+                $trackableUrls[$urlKey]  = $urlValue;
             }
         }
 
@@ -626,7 +596,12 @@ class TrackableModel extends AbstractCommonModel
         }
 
         // Ensure a valid scheme
-        if (($forceScheme && !isset($urlParts['scheme'])) || (isset($urlParts['scheme']) && !in_array($urlParts['scheme'], ['http', 'https', 'ftp', 'ftps']))) {
+        if (($forceScheme && !isset($urlParts['scheme']))
+            || (isset($urlParts['scheme'])
+                && !in_array(
+                    $urlParts['scheme'],
+                    ['http', 'https', 'ftp', 'ftps']
+                ))) {
             return false;
         }
 
@@ -893,5 +868,75 @@ class TrackableModel extends AbstractCommonModel
     private function isContactFieldToken($token)
     {
         return strpos($token, '{contactfield') !== false || strpos($token, '{leadfield') !== false;
+    }
+
+    /**
+     * @param       $content
+     * @param       $channel
+     * @param       $channelId
+     * @param array $trackableTokens
+     *
+     * @return string
+     */
+    private function parseContent($content, $channel, $channelId, array &$trackableTokens)
+    {
+        // Reset content replacement arrays
+        $this->contentReplacements = [
+            'first_pass'  => [
+                // Remove internal attributes
+                // Editor may convert to HTML4
+                'mautic:disable-tracking=""' => '',
+                // HTML5
+                'mautic:disable-tracking'    => '',
+            ],
+            'first_pass'  => [],
+            'second_pass' => [],
+        ];
+
+        $trackableUrls = $this->extractTrackablesFromContent($content);
+        $contentType   = (preg_match('/<(.*?) href/i', $content)) ? 'html' : 'text';
+        if (count($trackableUrls)) {
+            // Create Trackable/Redirect entities for the URLs
+            $entities = $this->getEntitiesFromUrls($trackableUrls, $channel, $channelId);
+            unset($trackableUrls);
+
+            // Get a list of url => token to return to calling method and also to be used to
+            // replace the urls in the content with tokens
+            $trackableTokens = array_merge(
+                $trackableTokens,
+                $this->createTrackingTokens($entities)
+            );
+
+            unset($entities);
+
+            // Replace URLs in content with tokens
+            $content = $this->prepareContentWithTrackableTokens($content, $contentType);
+        } elseif (!empty($this->contentReplacements['first_pass'])) {
+            // Replace URLs in content with tokens
+            $content = $this->prepareContentWithTrackableTokens($content, $contentType);
+        }
+
+        return $content;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getContactFieldUrlTokens()
+    {
+        if (null !== $this->contactFieldUrlTokens) {
+            return $this->contactFieldUrlTokens;
+        }
+
+        $this->contactFieldUrlTokens = [];
+
+        $fieldEntities = $this->leadFieldRepository->getFieldsByType('url');
+        foreach ($fieldEntities as $field) {
+            $this->contactFieldUrlTokens[] = $field->getAlias();
+        }
+
+        $this->leadFieldRepository->detachEntities($fieldEntities);
+
+        return $this->contactFieldUrlTokens;
     }
 }

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
@@ -462,7 +462,10 @@ class TrackableModelTest extends WebTestCase
             1
         );
 
+        reset($trackables);
+        $token = key($trackables);
         $this->assertNotEmpty($trackables, $content);
+        $this->assertContains($token, $content);
     }
 
     /**

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\CoreBundle\Test;
 
+use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\Trackable;
 use Mautic\PageBundle\Model\RedirectModel;
@@ -30,12 +31,11 @@ class TrackableModelTest extends WebTestCase
      */
     public function testHtmlIsDetectedInContent()
     {
-        $mockRedirectModel = $this->getMockBuilder('Mautic\PageBundle\Model\RedirectModel')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockRedirectModel       = $this->createMock(RedirectModel::class);
+        $mockLeadFieldRepository = $this->createMock(LeadFieldRepository::class);
 
-        $mockModel = $this->getMockBuilder('Mautic\PageBundle\Model\TrackableModel')
-            ->setConstructorArgs([$mockRedirectModel])
+        $mockModel = $this->getMockBuilder(TrackableModel::class)
+            ->setConstructorArgs([$mockRedirectModel, $mockLeadFieldRepository])
             ->setMethods(['getDoNotTrackList', 'getEntitiesFromUrls', 'createTrackingTokens',  'extractTrackablesFromHtml'])
             ->getMock();
 
@@ -79,12 +79,11 @@ class TrackableModelTest extends WebTestCase
      */
     public function testPlainTextIsDetectedInContent()
     {
-        $mockRedirectModel = $this->getMockBuilder(RedirectModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockRedirectModel       = $this->createMock(RedirectModel::class);
+        $mockLeadFieldRepository = $this->createMock(LeadFieldRepository::class);
 
         $mockModel = $this->getMockBuilder(TrackableModel::class)
-            ->setConstructorArgs([$mockRedirectModel])
+            ->setConstructorArgs([$mockRedirectModel, $mockLeadFieldRepository])
             ->setMethods(['getDoNotTrackList', 'getEntitiesFromUrls', 'createTrackingTokens',  'extractTrackablesFromText'])
             ->getMock();
 
@@ -129,7 +128,7 @@ class TrackableModelTest extends WebTestCase
     public function testStandardLinkWithStandardQuery()
     {
         $url   = 'https://foo-bar.com?foo=bar';
-        $model = $this->getModel($url);
+        $model = $this->getModel();
 
         list($content, $trackables) = $model->parseContentForTrackables(
             $this->generateContent($url, 'html'),
@@ -163,7 +162,7 @@ class TrackableModelTest extends WebTestCase
     public function testStandardLinkWithoutQuery()
     {
         $url   = 'https://foo-bar.com';
-        $model = $this->getModel($url);
+        $model = $this->getModel();
 
         list($content, $trackables) = $model->parseContentForTrackables(
             $this->generateContent($url, 'html'),
@@ -197,7 +196,7 @@ class TrackableModelTest extends WebTestCase
     public function testStandardLinkWithTokenizedQuery()
     {
         $url   = 'https://foo-bar.com?foo={contactfield=bar}&bar=foo';
-        $model = $this->getModel($url, 'https://foo-bar.com?foo={contactfield=bar}&bar=foo');
+        $model = $this->getModel();
 
         list($content, $trackables) = $model->parseContentForTrackables(
             $this->generateContent($url, 'html'),
@@ -227,7 +226,7 @@ class TrackableModelTest extends WebTestCase
     public function testTokenizedDomain()
     {
         $url   = 'http://{contactfield=foo}.org';
-        $model = $this->getModel($url, 'http://{contactfield=foo}.org');
+        $model = $this->getModel();
 
         list($content, $trackables) = $model->parseContentForTrackables(
             $this->generateContent($url, 'html'),
@@ -255,7 +254,7 @@ class TrackableModelTest extends WebTestCase
     public function testTokenizedHostWithScheme()
     {
         $url   = '{contactfield=foo}';
-        $model = $this->getModel($url, '{contactfield=foo}');
+        $model = $this->getModel();
 
         list($content, $trackables) = $model->parseContentForTrackables(
             $this->generateContent($url, 'html'),
@@ -285,7 +284,7 @@ class TrackableModelTest extends WebTestCase
     public function testTokenizedHostWithQuery()
     {
         $url   = 'http://{contactfield=foo}.com?foo=bar';
-        $model = $this->getModel($url, 'http://{contactfield=foo}.com?foo=bar');
+        $model = $this->getModel();
 
         list($content, $trackables) = $model->parseContentForTrackables(
             $this->generateContent($url, 'html'),
@@ -313,7 +312,7 @@ class TrackableModelTest extends WebTestCase
     public function testTokenizedHostWithTokenizedQuery()
     {
         $url   = 'http://{contactfield=foo}.com?foo={contactfield=bar}';
-        $model = $this->getModel($url, 'http://{contactfield=foo}.com?foo={contactfield=bar}');
+        $model = $this->getModel();
 
         list($content, $trackables) = $model->parseContentForTrackables(
             $this->generateContent($url, 'html'),
@@ -344,7 +343,7 @@ class TrackableModelTest extends WebTestCase
     public function testIgnoredTokensAreNotConverted()
     {
         $url   = 'https://{unsubscribe_url}';
-        $model = $this->getModel($url, null, ['{unsubscribe_url}']);
+        $model = $this->getModel(['{unsubscribe_url}']);
 
         list($content, $trackables) = $model->parseContentForTrackables(
             $this->generateContent($url, 'html'),
@@ -369,7 +368,7 @@ class TrackableModelTest extends WebTestCase
     public function testUnsupportedTokensAreNotConverted()
     {
         $url   = '{random_token}';
-        $model = $this->getModel($url);
+        $model = $this->getModel();
 
         list($content, $trackables) = $model->parseContentForTrackables(
             $this->generateContent($url, 'text'),
@@ -391,7 +390,7 @@ class TrackableModelTest extends WebTestCase
     public function testTokenWithDefaultValueInPlaintextWillCountAsOne()
     {
         $url          = '{contactfield=website|https://mautic.org}';
-        $model        = $this->getModel($url);
+        $model        = $this->getModel();
         $inputContent = $this->generateContent($url, 'text');
 
         list($content, $trackables) = $model->parseContentForTrackables(
@@ -426,7 +425,7 @@ class TrackableModelTest extends WebTestCase
     public function testIgnoredUrlDoesNotCrash()
     {
         $url   = 'https://domain.com';
-        $model = $this->getModel($url, null, [$url]);
+        $model = $this->getModel([$url]);
 
         list($content, $trackables) = $model->parseContentForTrackables(
             $this->generateContent($url, 'html'),
@@ -451,7 +450,7 @@ class TrackableModelTest extends WebTestCase
     public function testTokenAsHostIsConvertedToTrackableToken()
     {
         $url   = 'http://{pagelink=1}';
-        $model = $this->getModel($url, 'http://foo-bar.com');
+        $model = $this->getModel();
 
         list($content, $trackables) = $model->parseContentForTrackables(
             $this->generateContent($url, 'html'),
@@ -484,7 +483,7 @@ class TrackableModelTest extends WebTestCase
             'https://foo-bar.com?foo=bar',
         ];
 
-        $model = $this->getModel($urls);
+        $model = $this->getModel();
 
         list($content, $trackables) = $model->parseContentForTrackables(
             $this->generateContent($urls, 'html'),
@@ -504,8 +503,7 @@ class TrackableModelTest extends WebTestCase
      */
     public function testCssUrlsAreNotConvertedIfThereAreNoLinks()
     {
-        $url   = 'https://foo-bar.com?foo=bar';
-        $model = $this->getModel($url);
+        $model = $this->getModel();
 
         list($content, $trackables) = $model->parseContentForTrackables(
             '<style> .mf-modal { background-image: url(\'https://www.mautic.org/wp-content/uploads/2014/08/iTunesArtwork.png\'); } </style>',
@@ -518,23 +516,91 @@ class TrackableModelTest extends WebTestCase
     }
 
     /**
-     * @param       $urls
-     * @param null  $tokenUrls
-     * @param array $doNotTrack
-     *
-     * @return TrackableModel
+     * @testdox Tests that URLs in the plaintext does not contaminate HTML
      */
-    protected function getModel($urls, $tokenUrls = null, $doNotTrack = [])
+    public function testPlainTextDoesNotContaminateHtml()
     {
-        if (!is_array($urls)) {
-            $urls = [$urls];
-        }
-        if (null === $tokenUrls) {
-            $tokenUrls = $urls;
-        } elseif (!is_array($tokenUrls)) {
-            $tokenUrls = [$tokenUrls];
-        }
+        $model = $this->getModel();
 
+        $html = <<<TEXT
+Hi {contactfield=firstname},
+<br />
+Come to our office in {contactfield=city}! 
+<br />
+John Smith<br />
+VP of Sales<br />
+https://plaintexttest.io
+TEXT;
+
+        $plainText = strip_tags($html);
+
+        $combined                   = [$html, $plainText];
+        list($content, $trackables) = $model->parseContentForTrackables(
+            $combined,
+            [],
+            'email',
+            1
+        );
+
+        $this->assertCount(1, $trackables);
+
+        // No links so no trackables
+        $this->assertEquals($html, $content[0]);
+
+        // Has a URL so has one trackable
+        reset($trackables);
+        $token = key($trackables);
+
+        $this->assertEquals(str_replace('https://plaintexttest.io', $token, $plainText), $content[1]);
+    }
+
+    /**
+     * @testdox Tests that URL based contact fields are found in plain text
+     */
+    public function testPlainTextFindsUrlContactFields()
+    {
+        $model = $this->getModel([], ['website']);
+
+        $html = <<<TEXT
+Hi {contactfield=firstname},
+<br />
+Come to our office in {contactfield=city}! 
+<br />
+John Smith<br />
+VP of Sales<br />
+{contactfield=website}
+TEXT;
+
+        $plainText = strip_tags($html);
+
+        $combined                   = [$html, $plainText];
+        list($content, $trackables) = $model->parseContentForTrackables(
+            $combined,
+            [],
+            'email',
+            1
+        );
+
+        $this->assertCount(1, $trackables);
+
+        // No links so no trackables
+        $this->assertEquals($html, $content[0]);
+
+        // Has a URL so has one trackable
+        reset($trackables);
+        $token = key($trackables);
+
+        $this->assertEquals(str_replace('{contactfield=website}', $token, $plainText), $content[1]);
+    }
+
+    /**
+     * @param array $doNotTrack
+     * @param array $urlFieldsForPlaintext
+     *
+     * @return TrackableModel|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getModel($doNotTrack = [], $urlFieldsForPlaintext = [])
+    {
         // Add default DoNotTrack
         $doNotTrack = array_merge(
             $doNotTrack,
@@ -545,29 +611,34 @@ class TrackableModelTest extends WebTestCase
             ]
         );
 
-        $mockRedirectModel = $this->getMockBuilder(RedirectModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockRedirectModel       = $this->createMock(RedirectModel::class);
+        $mockLeadFieldRepository = $this->createMock(LeadFieldRepository::class);
 
         $mockModel = $this->getMockBuilder(TrackableModel::class)
-            ->setConstructorArgs([$mockRedirectModel])
-            ->setMethods(['getDoNotTrackList', 'getEntitiesFromUrls'])
+            ->setConstructorArgs([$mockRedirectModel, $mockLeadFieldRepository])
+            ->setMethods(['getDoNotTrackList', 'getEntitiesFromUrls', 'getContactFieldUrlTokens'])
             ->getMock();
 
         $mockModel->expects($this->once())
             ->method('getDoNotTrackList')
             ->willReturn($doNotTrack);
 
-        $entities = [];
-        foreach ($urls as $k => $url) {
-            $entities[$url] = $this->getTrackableEntity($tokenUrls[$k]);
-        }
-
         $mockModel->expects($this->any())
             ->method('getEntitiesFromUrls')
-            ->willReturn(
-                $entities
+            ->willReturnCallback(
+                function ($trackableUrls, $channel, $channelId) {
+                    $entities = [];
+                    foreach ($trackableUrls as $url) {
+                        $entities[$url] = $this->getTrackableEntity($url);
+                    }
+
+                    return $entities;
+                }
             );
+
+        $mockModel->expects($this->any())
+            ->method('getContactFieldUrlTokens')
+            ->willReturn($urlFieldsForPlaintext);
 
         return $mockModel;
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6272 & https://github.com/mautic/mautic/issues/6268
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This fixes issue introduced with the merging of #6043. 

1. URL based tokens resulted in a 404 (i.e. `{pagelink=X}` and `{assetlink=X}`
2. Tokens in plaintext caused the same tokens in HTML to be replaced with trackable tokens/redirects
3. Company contactfield tokens did not work in redirects nor in dynamic email content


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. From staging, create an email with a {pagelink=X} token and send the email. It will not be converted. 
2. Use a {contactfield=companywebsite} token in an email and even if the primary company of the contact has a value, it would not populate. 
3. Use a company custom field in a contactfield token in a dynamic email content variation and note that it does not get replaced with the contact's primary company's value. 
4. Add {contactfield=firstname} to the plain text of an email and use the same token in the HTML. Send the email and notice that the first name is replaced with a link. 

#### Steps to test this PR:
Repeat the above steps and the following should work:
1. pagelink and assetlink tokens should now work
2. Company field values should be hydrated in redirects/trackables
3. Company field values should be hydrated in dynamic email content
4. Tokens in plain text should not pollute or HTML and visa versa. Contact field tokens in plain text should not be converted to trackables unless they are URL types. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 