### PR TITLE
Fix pipedrive push when company have custom field

### DIFF
--- a/plugins/MauticCrmBundle/Integration/Pipedrive/Export/CompanyExport.php
+++ b/plugins/MauticCrmBundle/Integration/Pipedrive/Export/CompanyExport.php
@@ -113,7 +113,13 @@ class CompanyExport extends AbstractPipedrive
         $accessor = PropertyAccess::createPropertyAccessor();
 
         foreach ($companyFields as $externalField => $internalField) {
-            $fieldName                  = substr($internalField, strlen($company::FIELD_ALIAS));
+            if (strpos($internalField, $company::FIELD_ALIAS, 0) !== false && method_exists('get'.ucfirst(substr($internalField, strlen($company::FIELD_ALIAS))))) {
+                //for core company field
+                $fieldName = substr($internalField, strlen($company::FIELD_ALIAS));
+            } else {
+                //for custom company field
+                $fieldName = $internalField;
+            }
             $mappedData[$externalField] = $accessor->getValue($company, $fieldName);
         }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fix Pipedrive company push, it was working only for core company field

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Configure PipeDrive connexion
2. Create a company custom field with less than 6 characters 
3. Create this field into Pipedrive
4. In Pipedrive plugin, map both fields
5. Create a new company --> Fatal


#### Steps to test this PR:
1. Apply this PR
2. Create a new company and check into Pipedrive
