### PR TITLE
Fix selected value for focus in campaign action

### DIFF
--- a/plugins/MauticFocusBundle/Form/Type/FocusShowType.php
+++ b/plugins/MauticFocusBundle/Form/Type/FocusShowType.php
@@ -59,7 +59,7 @@ class FocusShowType extends AbstractType
                         ['message' => 'mautic.focus.choosefocus.notblank']
                     ),
                 ],
-                'data' => $options['data']['properties']['focus'],
+                'data' => isset($options['data']['focus']) ? $options['data']['focus'] : null,
             ]
         );
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Select value for focus in campaign action

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Create campaign   with visits a page and then add Show focus Item
2.  Open action Show focus Item and see not selected focus show as you choose before

#### Steps to test this PR:
1.  Repeat all steps
2.  See  selected value what you choose before 
