### PR TITLE
Fix checkbox bool overwrite

### DIFF
--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -37,6 +37,11 @@ trait RequestTrait
                             if (is_array($params[$name]) && count($params[$name]) == 1) {
                                 $params[$name] = end($params[$name]);
                             }
+
+                            if ('' === $params[$name]) {
+                                continue;
+                            }
+
                             $data = filter_var($params[$name], FILTER_VALIDATE_BOOLEAN);
                             $data = (bool) $data;
                             try {

--- a/app/bundles/FormBundle/Views/Field/checkboxgrp.html.php
+++ b/app/bundles/FormBundle/Views/Field/checkboxgrp.html.php
@@ -8,6 +8,25 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
+
+if (isset($field['defaultValue']) && '' !== $field['defaultValue']) {
+    $hiddenDefault = $view->render(
+        'MauticFormBundle:Field:hidden.html.php',
+        [
+            'field'         => $field,
+            'inForm'        => (isset($inForm)) ? $inForm : false,
+            'id'            => $id,
+            'formId'        => (isset($formId)) ? $formId : 0,
+            'type'          => 'checkbox',
+            'formName'      => (isset($formName)) ? $formName : '',
+            'contactFields' => (isset($contactFields)) ? $contactFields : [],
+            'companyFields' => (isset($companyFields)) ? $companyFields : [],
+        ]
+    );
+
+    echo str_replace('<input', '<input value="'.$field['defaultValue'].'"', $hiddenDefault);
+}
+
 echo $view->render(
     'MauticFormBundle:Field:group.html.php',
     [


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6087
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixed form bool lead mapping witch checkbox based on this issue https://github.com/mautic/mautic/issues/6087
The form request handle empty result and then filter it https://github.com/mautic/mautic/compare/staging...kuzmany:fix-form-bool-type-null-result?expand=1#diff-21d987361e23066733f8c6d958fa2016R45 
But filter_var return false.If value is empty.  Every form field contain empty result (https://github.com/kuzmany/mautic/blob/5c0aa9bf7cd2ad2d79c9f557f5578418d11fb06e/app/bundles/FormBundle/Model/SubmissionModel.php#L233)

This PR added 
- IF defaultValue exist then added hidden field before checkbox with defaultValue 
- During request process skip if value of checkbox is empty (https://github.com/mautic/mautic/pull/6282/files#diff-21d987361e23066733f8c6d958fa2016R42)


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create form witch checkbox and lead matching bool custom field
2. Create contact with true to custom bool field
3. Send form with unchecked checkbox 
4. See contact. Even checkbox is not checked, contact custom bool field was set to false

#### Steps to test this PR:
1.  Repeat all steps and see If custom contact bool field is still true
2.  Then update form and default value of checkbox to 0 and enable in contact profile the custom field bool to true
3. Send form with unchecked checkbox and see If custom contact bool field are set to false
