### PR TITLE
Fix critical error when user hit email but lead is deleted

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -502,15 +502,21 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             $this->em->persist($email);
         }
 
-        $emailOpenStat = new StatDevice();
-        $emailOpenStat->setIpAddress($ipAddress);
-        $trackedDevice = $this->deviceTracker->createDeviceFromUserAgent($lead, $request->server->get('HTTP_USER_AGENT'));
-        $emailOpenStat->setDevice($trackedDevice);
-        $emailOpenStat->setDateOpened($readDateTime->toUtcString());
-        $emailOpenStat->setStat($stat);
+        if ($lead) {
+            $emailOpenStat = new StatDevice();
+            $emailOpenStat->setIpAddress($ipAddress);
+            $trackedDevice = $this->deviceTracker->createDeviceFromUserAgent($lead, $request->server->get('HTTP_USER_AGENT'));
+            $emailOpenStat->setDevice($trackedDevice);
+            $emailOpenStat->setDateOpened($readDateTime->toUtcString());
+            $emailOpenStat->setStat($stat);
+        }
 
         $this->em->persist($stat);
-        $this->em->persist($emailOpenStat);
+
+        if ($lead) {
+            $this->em->persist($emailOpenStat);
+        }
+
         try {
             $this->em->flush();
         } catch (\Exception $ex) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When user click on links from received email, if the lead is no more in Mautic theire was errors.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a contact
2. Create a segment and attach the contact
3. Create an email and send this to the segment
4. Delete the contact
5. Open the mail and click on "Having trouble reading this email? Click here." link
6. Error 500

#### Steps to test this PR:
1. Apply PR
2. Click on the same link, no more 500