### PR TITLE
Add campaign ID to the Momentum payload

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -2124,7 +2124,7 @@ class MailHelper
             'name'        => $name,
             'leadId'      => (!empty($this->lead)) ? $this->lead['id'] : null,
             'emailId'     => (!empty($this->email)) ? $this->email->getId() : null,
-            'emailName'   => $this->email->getName(),
+            'emailName'   => (!empty($this->email)) ? $this->email->getName() : null,
             'hashId'      => $this->idHash,
             'hashIdState' => $this->idHashState,
             'source'      => $this->source,

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -401,17 +401,7 @@ class MailHelper
                 // Set metadata if applicable
                 if (method_exists($this->message, 'addMetadata')) {
                     foreach ($this->queuedRecipients as $email => $name) {
-                        $this->message->addMetadata(
-                            $email,
-                            [
-                                'leadId'      => (!empty($this->lead)) ? $this->lead['id'] : null,
-                                'emailId'     => (!empty($this->email)) ? $this->email->getId() : null,
-                                'hashId'      => $this->idHash,
-                                'hashIdState' => $this->idHashState,
-                                'source'      => $this->source,
-                                'tokens'      => $tokens,
-                            ]
-                        );
+                        $this->message->addMetadata($email, $this->buildMetadata($name, $tokens));
                     }
                 } elseif (!empty($tokens)) {
                     // Replace tokens
@@ -524,16 +514,7 @@ class MailHelper
                     ];
                 }
 
-                $this->metadata[$fromKey]['contacts'][$email] =
-                    [
-                        'name'        => $name,
-                        'leadId'      => (!empty($this->lead)) ? $this->lead['id'] : null,
-                        'emailId'     => (!empty($this->email)) ? $this->email->getId() : null,
-                        'hashId'      => $this->idHash,
-                        'hashIdState' => $this->idHashState,
-                        'source'      => $this->source,
-                        'tokens'      => $tokens,
-                    ];
+                $this->metadata[$fromKey]['contacts'][$email] = $this->buildMetadata($name, $tokens);
             }
 
             // Reset recipients
@@ -2129,6 +2110,27 @@ class MailHelper
                 }
             }
         }
+    }
+
+    /**
+     * @param       $name
+     * @param array $tokens
+     *
+     * @return array
+     */
+    private function buildMetadata($name, array $tokens)
+    {
+        return [
+            'name'        => $name,
+            'leadId'      => (!empty($this->lead)) ? $this->lead['id'] : null,
+            'emailId'     => (!empty($this->email)) ? $this->email->getId() : null,
+            'emailName'   => $this->email->getName(),
+            'hashId'      => $this->idHash,
+            'hashIdState' => $this->idHashState,
+            'source'      => $this->source,
+            'tokens'      => $tokens,
+            'utmTags'     => (!empty($this->email)) ? $this->email->getUtmTags() : [],
+        ];
     }
 
     /**

--- a/app/bundles/EmailBundle/Swiftmailer/Momentum/DTO/TransmissionDTO.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Momentum/DTO/TransmissionDTO.php
@@ -77,6 +77,14 @@ class TransmissionDTO implements \JsonSerializable
     }
 
     /**
+     * @param $campaignId
+     */
+    public function setCampaignId($campaignId)
+    {
+        $this->campaignId = $campaignId;
+    }
+
+    /**
      * @return mixed
      */
     public function jsonSerialize()
@@ -89,10 +97,10 @@ class TransmissionDTO implements \JsonSerializable
         if ($this->options !== null) {
             $json['options'] = $this->options;
         }
-        if ($this->campaignId !== null) {
+        if (!empty($this->campaignId)) {
             $json['campaign_id'] = $this->campaignId;
         }
-        if ($this->description !== null) {
+        if (!empty($this->description)) {
             $json['description'] = $this->description;
         }
 

--- a/app/bundles/EmailBundle/Swiftmailer/Momentum/Metadata/MetadataProcessor.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Momentum/Metadata/MetadataProcessor.php
@@ -106,11 +106,12 @@ class MetadataProcessor
     }
 
     /**
-     * @return string
+     * @return null|string
      */
     public function getCampaignId()
     {
-        return $this->campaignId;
+        // Sparkpost/Momentum only supports 64 bytes
+        return $this->campaignId ? mb_strcut($this->campaignId, 0, 64) : null;
     }
 
     private function buildSubstitutionData()

--- a/app/bundles/EmailBundle/Swiftmailer/Momentum/Metadata/MetadataProcessor.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Momentum/Metadata/MetadataProcessor.php
@@ -144,6 +144,10 @@ class MetadataProcessor
             return;
         }
 
-        $this->campaignId = $metadataSample['emailName'];
+        if (empty($metadataSample['emailId'])) {
+            return;
+        }
+
+        $this->campaignId = $metadataSample['emailId'].':'.$metadataSample['emailName'];
     }
 }

--- a/app/bundles/EmailBundle/Swiftmailer/Momentum/Service/SwiftMessageService.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Momentum/Service/SwiftMessageService.php
@@ -117,8 +117,10 @@ final class SwiftMessageService implements SwiftMessageServiceInterface
             $content->setInlineCss($cssHeader);
         }
 
-        $returnPath   = $message->getReturnPath() ? $message->getReturnPath() : $messageFromEmail;
+        $returnPath = $message->getReturnPath() ? $message->getReturnPath() : $messageFromEmail;
+
         $transmission = new TransmissionDTO($content, $returnPath);
+        $transmission->setCampaignId($metadataProcessor->getCampaignId());
 
         $recipientsGrouped = [
             'to'  => (array) $message->getTo(),

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/Momentum/Service/SwiftMessageServiceTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/Momentum/Service/SwiftMessageServiceTest.php
@@ -141,6 +141,7 @@ class SwiftMessageServiceTest extends \PHPUnit_Framework_TestCase
         $mauticMessage->addMetadata(
             'to1@test.local',
             [
+                'emailId'   => 1,
                 'emailName' => 'Email Name',
                 'tokens'    => [
                     '{hashId}' => '1234',
@@ -150,6 +151,7 @@ class SwiftMessageServiceTest extends \PHPUnit_Framework_TestCase
         $mauticMessage->addMetadata(
             'to2@test.local',
             [
+                'emailId'   => 1,
                 'emailName' => 'Email Name',
                 'tokens'    => [
                     '{hashId}' => '4321',
@@ -180,6 +182,7 @@ class SwiftMessageServiceTest extends \PHPUnit_Framework_TestCase
                         "header_to":"to1@test.local"
                      },
                      "metadata":{
+                        "emailId":1,
                         "emailName":"Email Name"
                      },
                      "substitution_data":{
@@ -193,6 +196,7 @@ class SwiftMessageServiceTest extends \PHPUnit_Framework_TestCase
                         "header_to":"to2@test.local"
                      },
                      "metadata":{
+                        "emailId":1,
                         "emailName":"Email Name"
                      },
                      "substitution_data":{
@@ -244,7 +248,7 @@ class SwiftMessageServiceTest extends \PHPUnit_Framework_TestCase
                      }
                   ]
                },
-               "campaign_id":"Email Name"
+               "campaign_id":"1:Email Name"
             }
         ';
 

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/Momentum/Service/SwiftMessageServiceTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/Momentum/Service/SwiftMessageServiceTest.php
@@ -39,6 +39,8 @@ class SwiftMessageServiceTest extends \PHPUnit_Framework_TestCase
     {
         return [
             $this->geTransformToTransmissionComplexData(),
+            $this->geTransformToTransmissionComplexDataWithEmailName(),
+            $this->geTransformToTransmissionComplexDataWithUtmTag(),
         ];
     }
 
@@ -47,7 +49,8 @@ class SwiftMessageServiceTest extends \PHPUnit_Framework_TestCase
      */
     private function geTransformToTransmissionComplexData()
     {
-        $mauticMessage   = new MauticMessage();
+        $mauticMessage = new MauticMessage();
+
         $mauticMessage->setSubject('Test subject')
             ->setReturnPath('return-path@test.local')
             ->setSender('sender@test.local', 'Sender test')
@@ -61,68 +64,323 @@ class SwiftMessageServiceTest extends \PHPUnit_Framework_TestCase
             ->addBcc('bcc2@test.local', 'BCC2 test')
             ->addAttachment(__DIR__.'/data/attachments/sample.txt');
         $json = '
-            {
-                "return_path":"return-path@test.local",
-                "recipients": [
-                    {
-                        "address": {
-                            "email": "to1@test.local",
-                            "name": "To1 test",
-                            "header_to": "to1@test.local"
-                        }
-                    },
-                    {
-                        "address": {
-                            "email": "to2@test.local",
-                            "name": "To2 test",
-                            "header_to": "to2@test.local"
-                        }
-                    },
-                    {
-                        "address": {
-                            "email": "cc1@test.local",
-                            "name": "CC1 test",
-                            "header_to": "cc1@test.local"
-                        }
-                    },
-                    {
-                        "address": {
-                            "email": "cc2@test.local",
-                            "name": "CC2 test",
-                            "header_to": "cc2@test.local"
-                        }
-                    },
-                    {
-                        "address": {
-                            "email": "bcc1@test.local",
-                            "name": "BCC1 test"
-                        }
-                    },
-                    {
-                        "address": {
-                            "email": "bcc2@test.local",
-                            "name": "BCC2 test"
-                        }
-                    }
+           {
+               "return_path":"return-path@test.local",
+               "recipients":[
+                  {
+                     "address":{
+                        "email":"to1@test.local",
+                        "name":"To1 test",
+                        "header_to":"to1@test.local"
+                     }
+                  },
+                  {
+                     "address":{
+                        "email":"to2@test.local",
+                        "name":"To2 test",
+                        "header_to":"to2@test.local"
+                     }
+                  },
+                  {
+                     "address":{
+                        "email":"cc1@test.local",
+                        "name":"CC1 test",
+                        "header_to":"cc1@test.local"
+                     }
+                  },
+                  {
+                     "address":{
+                        "email":"cc2@test.local",
+                        "name":"CC2 test",
+                        "header_to":"cc2@test.local"
+                     }
+                  },
+                  {
+                     "address":{
+                        "email":"bcc1@test.local",
+                        "name":"BCC1 test"
+                     }
+                  },
+                  {
+                     "address":{
+                        "email":"bcc2@test.local",
+                        "name":"BCC2 test"
+                     }
+                  }
+               ],
+               "content":{
+                  "subject":"Test subject",
+                  "from":{
+                     "email":"from@test.local",
+                     "name":"From test"
+                  },
+                  "html":"<html><\/html>",
+                  "headers":{
+                     "CC":"cc1@test.local,cc2@test.local"
+                  },
+                  "attachments":[
+                     {
+                        "type":"text\/plain",
+                        "name":"sample.txt",
+                        "data":"VGhpcyBpcyBzYW1wbGUgYXR0YWNobWVudAo="
+                     }
+                  ]
+               }
+            }
+        ';
+
+        return [$mauticMessage, $json];
+    }
+
+    /**
+     * @return array
+     */
+    private function geTransformToTransmissionComplexDataWithEmailName()
+    {
+        $mauticMessage = new MauticMessage();
+        $mauticMessage->addMetadata(
+            'to1@test.local',
+            [
+                'emailName' => 'Email Name',
+                'tokens'    => [
+                    '{hashId}' => '1234',
                 ],
-                "content": {
-                    "subject": "Test subject",
-                    "from": {
-                        "email": "from@test.local",
-                        "name": "From test"
-                    },
-                    "html": "<html><\/html>",
-                    "attachments": [
-                        {
-                            "type": "text\/plain",
-                            "name": "sample.txt",
-                            "data": "VGhpcyBpcyBzYW1wbGUgYXR0YWNobWVudAo="
-                        }
+            ]
+        );
+        $mauticMessage->addMetadata(
+            'to2@test.local',
+            [
+                'emailName' => 'Email Name',
+                'tokens'    => [
+                    '{hashId}' => '4321',
+                ],
+            ]
+        );
+
+        $mauticMessage->setSubject('Test subject')
+            ->setReturnPath('return-path@test.local')
+            ->setSender('sender@test.local', 'Sender test')
+            ->setFrom('from@test.local', 'From test')
+            ->setBody('<html></html>')
+            ->addTo('to1@test.local', 'To1 test')
+            ->addTo('to2@test.local', 'To2 test')
+            ->addCc('cc1@test.local', 'CC1 test')
+            ->addCc('cc2@test.local', 'CC2 test')
+            ->addBcc('bcc1@test.local', 'BCC1 test')
+            ->addBcc('bcc2@test.local', 'BCC2 test')
+            ->addAttachment(__DIR__.'/data/attachments/sample.txt');
+        $json = '
+           {
+               "return_path":"return-path@test.local",
+               "recipients":[
+                  {
+                     "address":{
+                        "email":"to1@test.local",
+                        "name":"To1 test",
+                        "header_to":"to1@test.local"
+                     },
+                     "metadata":{
+                        "emailName":"Email Name"
+                     },
+                     "substitution_data":{
+                        "HASHID":"1234"
+                     }
+                  },
+                  {
+                     "address":{
+                        "email":"to2@test.local",
+                        "name":"To2 test",
+                        "header_to":"to2@test.local"
+                     },
+                     "metadata":{
+                        "emailName":"Email Name"
+                     },
+                     "substitution_data":{
+                        "HASHID":"4321"
+                     }
+                  },
+                  {
+                     "address":{
+                        "email":"cc1@test.local",
+                        "name":"CC1 test",
+                        "header_to":"cc1@test.local"
+                     }
+                  },
+                  {
+                     "address":{
+                        "email":"cc2@test.local",
+                        "name":"CC2 test",
+                        "header_to":"cc2@test.local"
+                     }
+                  },
+                  {
+                     "address":{
+                        "email":"bcc1@test.local",
+                        "name":"BCC1 test"
+                     }
+                  },
+                  {
+                     "address":{
+                        "email":"bcc2@test.local",
+                        "name":"BCC2 test"
+                     }
+                  }
+               ],
+               "content":{
+                  "subject":"Test subject",
+                  "from":{
+                     "email":"from@test.local",
+                     "name":"From test"
+                  },
+                  "html":"<html><\/html>",
+                  "headers":{
+                     "CC":"cc1@test.local,cc2@test.local"
+                  },
+                  "attachments":[
+                     {
+                        "type":"text\/plain",
+                        "name":"sample.txt",
+                        "data":"VGhpcyBpcyBzYW1wbGUgYXR0YWNobWVudAo="
+                     }
+                  ]
+               },
+               "campaign_id":"Email Name"
+            }
+        ';
+
+        return [$mauticMessage, $json];
+    }
+
+    /**
+     * @return array
+     */
+    private function geTransformToTransmissionComplexDataWithUtmTag()
+    {
+        $metadata = [
+            'emailName' => 'Email Name',
+            'utmTags'   => [
+                'utmCampaign' => 'Custom Name',
+            ],
+        ];
+
+        $mauticMessage = new MauticMessage();
+        $mauticMessage->addMetadata(
+            'to1@test.local',
+            array_merge(
+                $metadata,
+                [
+                    'tokens' => [
+                        '{hashId}' => '1234',
                     ],
-                    "headers": {
-                        "CC": "cc1@test.local,cc2@test.local"
-                    }
-                }
+                ]
+            )
+        );
+        $mauticMessage->addMetadata(
+            'to2@test.local',
+            array_merge(
+                $metadata,
+                [
+                    'tokens' => [
+                        '{hashId}' => '4321',
+                    ],
+                ]
+            )
+        );
+
+        $mauticMessage->setSubject('Test subject')
+            ->setReturnPath('return-path@test.local')
+            ->setSender('sender@test.local', 'Sender test')
+            ->setFrom('from@test.local', 'From test')
+            ->setBody('<html></html>')
+            ->addTo('to1@test.local', 'To1 test')
+            ->addTo('to2@test.local', 'To2 test')
+            ->addCc('cc1@test.local', 'CC1 test')
+            ->addCc('cc2@test.local', 'CC2 test')
+            ->addBcc('bcc1@test.local', 'BCC1 test')
+            ->addBcc('bcc2@test.local', 'BCC2 test')
+            ->addAttachment(__DIR__.'/data/attachments/sample.txt');
+        $json = '
+           {
+               "return_path":"return-path@test.local",
+               "recipients":[
+                  {
+                     "address":{
+                        "email":"to1@test.local",
+                        "name":"To1 test",
+                        "header_to":"to1@test.local"
+                     },
+                     "metadata":{
+                        "emailName":"Email Name",
+                        "utmTags":{
+                            "utmCampaign": "Custom Name"
+                        }
+                     },
+                     "substitution_data":{
+                        "HASHID":"1234"
+                     }
+                  },
+                  {
+                     "address":{
+                        "email":"to2@test.local",
+                        "name":"To2 test",
+                        "header_to":"to2@test.local"
+                     },
+                     "metadata":{
+                        "emailName":"Email Name",
+                         "utmTags":{
+                            "utmCampaign": "Custom Name"
+                        }
+                     },
+                     "substitution_data":{
+                        "HASHID":"4321"
+                     }
+                  },
+                  {
+                     "address":{
+                        "email":"cc1@test.local",
+                        "name":"CC1 test",
+                        "header_to":"cc1@test.local"
+                     }
+                  },
+                  {
+                     "address":{
+                        "email":"cc2@test.local",
+                        "name":"CC2 test",
+                        "header_to":"cc2@test.local"
+                     }
+                  },
+                  {
+                     "address":{
+                        "email":"bcc1@test.local",
+                        "name":"BCC1 test"
+                     }
+                  },
+                  {
+                     "address":{
+                        "email":"bcc2@test.local",
+                        "name":"BCC2 test"
+                     }
+                  }
+               ],
+               "content":{
+                  "subject":"Test subject",
+                  "from":{
+                     "email":"from@test.local",
+                     "name":"From test"
+                  },
+                  "html":"<html><\/html>",
+                  "headers":{
+                     "CC":"cc1@test.local,cc2@test.local"
+                  },
+                  "attachments":[
+                     {
+                        "type":"text\/plain",
+                        "name":"sample.txt",
+                        "data":"VGhpcyBpcyBzYW1wbGUgYXR0YWNobWVudAo="
+                     }
+                  ]
+               },
+               "campaign_id":"Custom Name"
             }
         ';
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | y
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This simply hydrates the momentum's campaign_id to either the campaign UTM tag if populated or defaults to ID:Email Name. 

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Configure momentum (if possible)
2. Create a segment with a handful of contacts
3. Create a segment/broadcast email 
4. Send the email
5. Login to the momentum dashboard and click on the Campaigns tab
6. Notice that it'll be populated with the email ID:email Name
7. Delete the stats for this email or clone it
8. This time fill in a UTM Campaign Name and send (use something different than the email internal name)
9. Send and look at momentum's dashboard again. This time they emails should have the utm tag as the campaign. 

If you don't have access to momentum, code review and run the new unit test.