### PR TITLE
Fixed bug that prevented push to campaign from working if we did not update the SF person

### DIFF
--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -725,8 +725,8 @@ class SalesforceIntegration extends CrmAbstractIntegration
                         $fieldsToUpdate = $mappedData[$object]['update'];
                         $fieldsToUpdate = $this->getBlankFieldsToUpdate($fieldsToUpdate, $existingPersons[$object], $mappedData, $config);
                         $personFound    = true;
-                        if (!empty($fieldsToUpdate)) {
-                            foreach ($existingPersons[$object] as $person) {
+                        foreach ($existingPersons[$object] as $person) {
+                            if (!empty($fieldsToUpdate)) {
                                 if (isset($fieldsToUpdate['AccountId'])) {
                                     $accountId = $this->getCompanyName($fieldsToUpdate['AccountId'], 'Id', 'Name');
                                     if (!$accountId) {
@@ -744,9 +744,10 @@ class SalesforceIntegration extends CrmAbstractIntegration
                                     }
                                 }
 
-                                $personData                     = $this->getApiHelper()->updateObject($fieldsToUpdate, $object, $person['Id']);
-                                $people[$object][$person['Id']] = $person['Id'];
+                                $personData = $this->getApiHelper()->updateObject($fieldsToUpdate, $object, $person['Id']);
                             }
+
+                            $people[$object][$person['Id']] = $person['Id'];
                         }
                     }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If the SF person was not updated during the push to integration campaign action, the Mautic contact would not be added to the SF campaign. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. setup salesforce integration and ensure all fields are mapped to update Mautic
2. run the integration sync `php app/console m:i:s -i Salesforce -a "10 min"` so that contacts are tracked in Mautic against a SF Lead or Contact (will see the association under a contact's Integration tab)
3. Create a campaign to push to integration and select a SF campaign
4. Add a contact that we already have an association with SF
5. Run the campaign
6. Find the contact in SF and they will not be in the selected campaign

#### Steps to test this PR:
1. Apply the PR, repeat and this time the contact should be added to the campaign
