### PR TITLE
Decouple Twilio from enabling campaign and channel subscribers

### DIFF
--- a/app/bundles/SmsBundle/Config/config.php
+++ b/app/bundles/SmsBundle/Config/config.php
@@ -15,8 +15,8 @@ return [
             'mautic.sms.campaignbundle.subscriber' => [
                 'class'     => 'Mautic\SmsBundle\EventListener\CampaignSubscriber',
                 'arguments' => [
-                    'mautic.helper.integration',
                     'mautic.sms.model.sms',
+                    'mautic.sms.transport_chain',
                 ],
             ],
             'mautic.sms.smsbundle.subscriber' => [
@@ -31,7 +31,7 @@ return [
             'mautic.sms.channel.subscriber' => [
                 'class'     => \Mautic\SmsBundle\EventListener\ChannelSubscriber::class,
                 'arguments' => [
-                    'mautic.helper.integration',
+                    'mautic.sms.transport_chain',
                 ],
             ],
             'mautic.sms.message_queue.subscriber' => [

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -114,8 +114,6 @@ class SmsController extends FormController
         }
         $session->set('mautic.sms.page', $page);
 
-        $integration = $this->get('mautic.helper.integration')->getIntegrationObject('Twilio');
-
         return $this->delegateView([
             'viewParameters' => [
                 'searchValue' => $search,
@@ -127,7 +125,7 @@ class SmsController extends FormController
                 'permissions' => $permissions,
                 'model'       => $model,
                 'security'    => $this->get('mautic.security'),
-                'configured'  => ($integration && $integration->getIntegrationSettings()->getIsPublished()),
+                'configured'  => count($this->get('mautic.sms.transport_chain')->getEnabledTransports()) > 0,
             ],
             'contentTemplate' => 'MauticSmsBundle:Sms:list.html.php',
             'passthroughVars' => [

--- a/app/bundles/SmsBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/CampaignSubscriber.php
@@ -15,8 +15,8 @@ use Mautic\CampaignBundle\CampaignEvents;
 use Mautic\CampaignBundle\Event\CampaignBuilderEvent;
 use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
 use Mautic\CoreBundle\EventListener\CommonSubscriber;
-use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\SmsBundle\Model\SmsModel;
+use Mautic\SmsBundle\Sms\TransportChain;
 use Mautic\SmsBundle\SmsEvents;
 
 /**
@@ -25,27 +25,27 @@ use Mautic\SmsBundle\SmsEvents;
 class CampaignSubscriber extends CommonSubscriber
 {
     /**
-     * @var IntegrationHelper
-     */
-    protected $integrationHelper;
-
-    /**
      * @var SmsModel
      */
     protected $smsModel;
 
     /**
+     * @var TransportChain
+     */
+    protected $transportChain;
+
+    /**
      * CampaignSubscriber constructor.
      *
-     * @param IntegrationHelper $integrationHelper
-     * @param SmsModel          $smsModel
+     * @param SmsModel       $smsModel
+     * @param TransportChain $transportChain
      */
     public function __construct(
-        IntegrationHelper $integrationHelper,
-        SmsModel $smsModel
+        SmsModel $smsModel,
+        TransportChain $transportChain
     ) {
-        $this->integrationHelper = $integrationHelper;
         $this->smsModel          = $smsModel;
+        $this->transportChain    = $transportChain;
     }
 
     /**
@@ -64,9 +64,7 @@ class CampaignSubscriber extends CommonSubscriber
      */
     public function onCampaignBuild(CampaignBuilderEvent $event)
     {
-        $integration = $this->integrationHelper->getIntegrationObject('Twilio');
-
-        if ($integration && $integration->getIntegrationSettings()->getIsPublished()) {
+        if (count($this->transportChain->getEnabledTransports()) > 0) {
             $event->addAction(
                 'sms.send_text_sms',
                 [
@@ -86,6 +84,8 @@ class CampaignSubscriber extends CommonSubscriber
 
     /**
      * @param CampaignExecutionEvent $event
+     *
+     * @return $this
      */
     public function onCampaignTriggerAction(CampaignExecutionEvent $event)
     {

--- a/app/bundles/SmsBundle/EventListener/ChannelSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/ChannelSubscriber.php
@@ -16,8 +16,8 @@ use Mautic\ChannelBundle\Event\ChannelEvent;
 use Mautic\ChannelBundle\Model\MessageModel;
 use Mautic\CoreBundle\EventListener\CommonSubscriber;
 use Mautic\LeadBundle\Model\LeadModel;
-use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\ReportBundle\Model\ReportModel;
+use Mautic\SmsBundle\Sms\TransportChain;
 
 /**
  * Class ChannelSubscriber.
@@ -25,18 +25,18 @@ use Mautic\ReportBundle\Model\ReportModel;
 class ChannelSubscriber extends CommonSubscriber
 {
     /**
-     * @var IntegrationHelper
+     * @var TransportChain
      */
-    protected $integrationHelper;
+    protected $transportChain;
 
     /**
      * ChannelSubscriber constructor.
      *
-     * @param IntegrationHelper $integrationHelper
+     * @param TransportChain $transportChain
      */
-    public function __construct(IntegrationHelper $integrationHelper)
+    public function __construct(TransportChain $transportChain)
     {
-        $this->integrationHelper = $integrationHelper;
+        $this->transportChain = $transportChain;
     }
 
     /**
@@ -54,9 +54,7 @@ class ChannelSubscriber extends CommonSubscriber
      */
     public function onAddChannel(ChannelEvent $event)
     {
-        $integration = $this->integrationHelper->getIntegrationObject('Twilio');
-
-        if ($integration && $integration->getIntegrationSettings()->getIsPublished()) {
+        if (count($this->transportChain->getEnabledTransports()) > 0) {
             $event->addChannel(
                 'sms',
                 [


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The campaign and channel (frequency rules) actions were hard coded to Twilio being enabled. So they would not show for other SMS transports. This PR fixes it. 

