### PR TITLE
SMS transport use Lead instead of hardcoded phone

### DIFF
--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -1751,12 +1751,12 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
         return $this;
     }
 
-	/**
-	 * @return string|null
-	 */
-	public function getLeadPhoneNumber()
-	{
-		return $this->getMobile() ?: $this->getPhone();
+    /**
+     * @return string|null
+     */
+    public function getLeadPhoneNumber()
+    {
+        return $this->getMobile() ?: $this->getPhone();
     }
 
     /**

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -1751,6 +1751,14 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
         return $this;
     }
 
+	/**
+	 * @return string|null
+	 */
+	public function getLeadPhoneNumber()
+	{
+		return $this->getMobile() ?: $this->getPhone();
+    }
+
     /**
      * @return mixed
      */

--- a/app/bundles/SmsBundle/Api/AbstractSmsApi.php
+++ b/app/bundles/SmsBundle/Api/AbstractSmsApi.php
@@ -33,12 +33,12 @@ abstract class AbstractSmsApi
         $this->pageTrackableModel = $pageTrackableModel;
     }
 
-	/**
-	 * @param Lead   $lead
-	 * @param string $content
-	 *
-	 * @return mixed
-	 */
+    /**
+     * @param Lead   $lead
+     * @param string $content
+     *
+     * @return mixed
+     */
     abstract public function sendSms(Lead $lead, $content);
 
     /**

--- a/app/bundles/SmsBundle/Api/AbstractSmsApi.php
+++ b/app/bundles/SmsBundle/Api/AbstractSmsApi.php
@@ -13,6 +13,7 @@ namespace Mautic\SmsBundle\Api;
 
 use Joomla\Http\Http;
 use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Model\TrackableModel;
 
 abstract class AbstractSmsApi
@@ -32,13 +33,13 @@ abstract class AbstractSmsApi
         $this->pageTrackableModel = $pageTrackableModel;
     }
 
-    /**
-     * @param string $number
-     * @param string $content
-     *
-     * @return mixed
-     */
-    abstract public function sendSms($number, $content);
+	/**
+	 * @param Lead   $lead
+	 * @param string $content
+	 *
+	 * @return mixed
+	 */
+    abstract public function sendSms(Lead $lead, $content);
 
     /**
      * Convert a non-tracked url to a tracked url.

--- a/app/bundles/SmsBundle/Api/TwilioApi.php
+++ b/app/bundles/SmsBundle/Api/TwilioApi.php
@@ -15,6 +15,7 @@ use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberUtil;
 use Mautic\CoreBundle\Helper\PhoneNumberHelper;
+use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Model\TrackableModel;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Monolog\Logger;
@@ -78,14 +79,16 @@ class TwilioApi extends AbstractSmsApi
         return $util->format($parsed, PhoneNumberFormat::E164);
     }
 
-    /**
-     * @param string $number
-     * @param string $content
-     *
-     * @return bool|string
-     */
-    public function sendSms($number, $content)
+	/**
+	 * @param Lead   $lead
+	 * @param string $content
+	 *
+	 * @return bool|string
+	 */
+    public function sendSms(Lead $lead, $content)
     {
+		$number = $lead->getLeadPhoneNumber();
+
         if ($number === null) {
             return false;
         }

--- a/app/bundles/SmsBundle/Api/TwilioApi.php
+++ b/app/bundles/SmsBundle/Api/TwilioApi.php
@@ -79,15 +79,15 @@ class TwilioApi extends AbstractSmsApi
         return $util->format($parsed, PhoneNumberFormat::E164);
     }
 
-	/**
-	 * @param Lead   $lead
-	 * @param string $content
-	 *
-	 * @return bool|string
-	 */
+    /**
+     * @param Lead   $lead
+     * @param string $content
+     *
+     * @return bool|string
+     */
     public function sendSms(Lead $lead, $content)
     {
-		$number = $lead->getLeadPhoneNumber();
+        $number = $lead->getLeadPhoneNumber();
 
         if ($number === null) {
             return false;

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -270,10 +270,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface
                 foreach ($contacts as $lead) {
                     $leadId = $lead->getId();
 
-                    $leadPhoneNumber = $lead->getMobile();
-                    if (empty($leadPhoneNumber)) {
-                        $leadPhoneNumber = $lead->getPhone();
-                    }
+                    $leadPhoneNumber = $lead->getLeadPhoneNumber();
 
                     if (empty($leadPhoneNumber)) {
                         $results[$leadId] = [
@@ -306,7 +303,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface
                         'content' => $tokenEvent->getContent(),
                     ];
 
-                    $metadata = $this->transport->sendSms($leadPhoneNumber, $tokenEvent->getContent());
+                    $metadata = $this->transport->sendSms($lead, $tokenEvent->getContent());
 
                     if (true !== $metadata) {
                         $sendResult['status'] = $metadata;

--- a/app/bundles/SmsBundle/Sms/TransportChain.php
+++ b/app/bundles/SmsBundle/Sms/TransportChain.php
@@ -87,17 +87,17 @@ class TransportChain
         return $enabled[$this->primaryTransport];
     }
 
-	/**
-	 * @param Lead 	 $lead
-	 * @param string $content
-	 *
-	 * @return mixed
-	 *
-	 * @throws \Exception
-	 */
+    /**
+     * @param Lead   $lead
+     * @param string $content
+     *
+     * @return mixed
+     *
+     * @throws \Exception
+     */
     public function sendSms(Lead $lead, $content)
     {
-    	$number = $lead->getLeadPhoneNumber();
+        $number = $lead->getLeadPhoneNumber();
 
         $this->logger->addInfo('Sending an SMS message using '
                             .$this->transports[$this->primaryTransport]['integrationAlias'].' to '

--- a/app/bundles/SmsBundle/Sms/TransportChain.php
+++ b/app/bundles/SmsBundle/Sms/TransportChain.php
@@ -10,6 +10,7 @@
 
 namespace Mautic\SmsBundle\Sms;
 
+use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\SmsBundle\Api\AbstractSmsApi;
 use Monolog\Logger;
@@ -86,16 +87,18 @@ class TransportChain
         return $enabled[$this->primaryTransport];
     }
 
-    /**
-     * @param $number
-     * @param $content
-     *
-     * @return mixed
-     *
-     * @throws \Exception
-     */
-    public function sendSms($number, $content)
+	/**
+	 * @param Lead 	 $lead
+	 * @param string $content
+	 *
+	 * @return mixed
+	 *
+	 * @throws \Exception
+	 */
+    public function sendSms(Lead $lead, $content)
     {
+    	$number = $lead->getLeadPhoneNumber();
+
         $this->logger->addInfo('Sending an SMS message using '
                             .$this->transports[$this->primaryTransport]['integrationAlias'].' to '
                             .(is_array($number) ? join(',', $number) : $number));

--- a/app/bundles/SmsBundle/Tests/Sms/TransportChainTest.php
+++ b/app/bundles/SmsBundle/Tests/Sms/TransportChainTest.php
@@ -11,6 +11,7 @@
 namespace Mautic\SmsBundle\Tests\Sms;
 
 use Mautic\CoreBundle\Test\AbstractMauticTestCase;
+use Mautic\LeadBundle\Entity\Lead;
 use Mautic\SmsBundle\Api\TwilioApi;
 use Mautic\SmsBundle\Sms\TransportChain;
 
@@ -74,8 +75,11 @@ class TransportChainTest extends AbstractMauticTestCase
 
         $this->transportChain->addTransport('mautic.test.twilio.mock', $this->twilioTransport, 'mautic.test.twilio.mock', 'Twilio');
 
+        $lead = new Lead();
+        $lead->setMobile('+123456789');
+
         try {
-            $this->transportChain->sendSms('+123456789', 'Yeah');
+            $this->transportChain->sendSms($lead, 'Yeah');
         } catch (\Exception $e) {
             $message = $e->getMessage();
             $this->assertEquals('Primary SMS transport is not enabled. mautic.test.twilio.mock', $message);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Y
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | Y
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Change SMS transport to accept Lead instead of just phone number for SMS transports that need data other than the Lead's phone number

[//]: # ( As applicable: )

#### Steps to test this PR:
1. Test Twilio integration

#### List backwards compatibility breaks:
1. Transport accepts Lead instead of just a phone number