### PR TITLE
Check DoNotContact by Lead not Email in contact detail

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -350,9 +350,8 @@ class LeadController extends FormController
             }
         }
 
-        // We need the EmailRepository to check if a lead is flagged as do not contact
-        /** @var \Mautic\EmailBundle\Entity\EmailRepository $emailRepo */
-        $emailRepo       = $this->getModel('email')->getRepository();
+        // We need the DoNotContact repository to check if a lead is flagged as do not contact
+        $dnc             = $this->getDoctrine()->getManager()->getRepository('MauticLeadBundle:DoNotContact')->getEntriesByLeadAndChannel($lead, 'email');
         $integrationRepo = $this->get('doctrine.orm.entity_manager')->getRepository('MauticPluginBundle:IntegrationEntity');
 
         return $this->delegateView(
@@ -372,7 +371,7 @@ class LeadController extends FormController
                     'noteCount'         => $this->getModel('lead.note')->getNoteCount($lead, true),
                     'integrations'      => $integrationRepo->getIntegrationEntityByLead($lead->getId()),
                     'auditlog'          => $this->getAuditlogs($lead),
-                    'doNotContact'      => $emailRepo->checkDoNotEmail($fields['core']['email']['value']),
+                    'doNotContact'      => end($dnc),
                     'leadNotes'         => $this->forward(
                         'MauticLeadBundle:Note:index',
                         [
@@ -1311,10 +1310,7 @@ class LeadController extends FormController
         $leadFields['owner_id'] = $this->get('mautic.helper.user')->getUser()->getId();
 
         // Check if lead has a bounce status
-        /** @var \Mautic\EmailBundle\Model\EmailModel $emailModel */
-        $emailModel = $this->getModel('email');
-        $dnc        = $emailModel->getRepository()->checkDoNotEmail($leadEmail);
-
+        $dnc    = $this->getDoctrine()->getManager()->getRepository('MauticLeadBundle:DoNotContact')->getEntriesByLeadAndChannel($lead, 'email');
         $inList = ($this->request->getMethod() == 'GET')
             ? $this->request->get('list', 0)
             : $this->request->request->get(
@@ -1437,7 +1433,7 @@ class LeadController extends FormController
                 'contentTemplate' => 'MauticLeadBundle:Lead:email.html.php',
                 'viewParameters'  => [
                     'form' => $form->createView(),
-                    'dnc'  => $dnc,
+                    'dnc'  => end($dnc),
                 ],
                 'passthroughVars' => [
                     'mauticContent' => 'leadEmail',

--- a/app/bundles/LeadBundle/Views/Lead/email.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/email.html.php
@@ -8,8 +8,8 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
-if ($dnc && $dnc['bounced']) {
-    echo '<div class="alert alert-warning">'.$view['translator']->trans('mautic.lead.do.not.contact_bounced').': '.$dnc['comments'].'</div>';
+if ($dnc && \Mautic\LeadBundle\Entity\DoNotContact::BOUNCED === $dnc->getReason()) {
+    echo '<div class="alert alert-warning">'.$view['translator']->trans('mautic.lead.do.not.contact_bounced').': '.$dnc->getComments().'</div>';
 } else {
     echo $view['form']->start($form);
 

--- a/app/bundles/LeadBundle/Views/Lead/lead.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/lead.html.php
@@ -438,31 +438,31 @@ $view['slots']->set(
                 <?php endif; ?>
             </div>
             <?php if ($doNotContact) : ?>
-                <div id="bounceLabel<?php echo $doNotContact['id']; ?>">
+                <div id="bounceLabel<?php echo $doNotContact->getId(); ?>">
                     <div class="panel-heading text-center">
                         <h4 class="fw-sb">
-                            <?php if ($doNotContact['unsubscribed']): ?>
-                                <span class="label label-danger" data-toggle="tooltip" title="<?php echo $doNotContact['comments']; ?>">
+                            <?php if (\Mautic\LeadBundle\Entity\DoNotContact::UNSUBSCRIBED == $doNotContact->getReason()): ?>
+                                <span class="label label-danger" data-toggle="tooltip" title="<?php echo $doNotContact->getId(); ?>">
                                 <?php echo $view['translator']->trans('mautic.lead.do.not.contact'); ?>
                             </span>
 
-                            <?php elseif ($doNotContact['manual']): ?>
-                                <span class="label label-danger" data-toggle="tooltip" title="<?php echo $doNotContact['comments']; ?>">
+                            <?php elseif (\Mautic\LeadBundle\Entity\DoNotContact::MANUAL == $doNotContact->getReason()): ?>
+                                <span class="label label-danger" data-toggle="tooltip" title="<?php echo $doNotContact->getId(); ?>">
                                 <?php echo $view['translator']->trans('mautic.lead.do.not.contact'); ?>
                                     <span data-toggle="tooltip" data-placement="bottom" title="<?php echo $view['translator']->trans(
                                         'mautic.lead.remove_dnc_status'
                                     ); ?>">
-                                    <i class="fa fa-times has-click-event" onclick="Mautic.removeBounceStatus(this, <?php echo $doNotContact['id']; ?>);"></i>
+                                    <i class="fa fa-times has-click-event" onclick="Mautic.removeBounceStatus(this, <?php echo $doNotContact->getId(); ?>);"></i>
                                 </span>
                             </span>
 
-                            <?php elseif ($doNotContact['bounced']): ?>
-                                <span class="label label-warning" data-toggle="tooltip" title="<?php echo $doNotContact['comments']; ?>">
+                            <?php elseif (\Mautic\LeadBundle\Entity\DoNotContact::BOUNCED == $doNotContact->getReason()): ?>
+                                <span class="label label-warning" data-toggle="tooltip" title="<?php echo $doNotContact->getComments(); ?>">
                                 <?php echo $view['translator']->trans('mautic.lead.do.not.contact_bounced'); ?>
                                     <span data-toggle="tooltip" data-placement="bottom" title="<?php echo $view['translator']->trans(
                                         'mautic.lead.remove_dnc_status'
                                     ); ?>">
-                                    <i class="fa fa-times has-click-event" onclick="Mautic.removeBounceStatus(this, <?php echo $doNotContact['id']; ?>);"></i>
+                                    <i class="fa fa-times has-click-event" onclick="Mautic.removeBounceStatus(this, <?php echo $doNotContact->getId(); ?>);"></i>
                                 </span>
                             </span>
                             <?php endif; ?>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5949
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
LeadController use check DoNotContact flag based on email address. But Mautic usually use DoNotContact flag assign to Lead entity/ID. This PR rewrite  this logic  in Lead details

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a contact
2. Send email to this contact and unsubscribe from email
3. Create a new contact with same email address (a duplicate)
4. See in the contact list that first contact is set DNC with logo but duplicate one is not
![image](https://user-images.githubusercontent.com/31535432/38725380-7a0cd8b6-3f07-11e8-86a7-1b3e80ca9caa.png)
5. Go on the duplicate contact and see that tag DNC is displayed
![image](https://user-images.githubusercontent.com/31535432/38725416-8ef795cc-3f07-11e8-9b1e-6d0cfc7835cf.png)
6. Display contact preferences and see that email is checked
![image](https://user-images.githubusercontent.com/31535432/38725446-a3d9e01c-3f07-11e8-9ee3-98a5d5afcac0.png)


#### Steps to test this PR:
1. Repeat all steps
2.  See flag  just for contact with DoNotContact result