### PR TITLE
Fixed comparison of URLs containing parameters in a campaign

### DIFF
--- a/app/bundles/PageBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/CampaignSubscriber.php
@@ -228,11 +228,11 @@ class CampaignSubscriber extends CommonSubscriber
 
         // Check Landing Pages URL or Tracing Pixel URL
         if (isset($config['url']) && $config['url']) {
-            $pageUrl     = $eventDetails->getUrl();
+            $pageUrl     = html_entity_decode($eventDetails->getUrl());
             $limitToUrls = explode(',', $config['url']);
 
             foreach ($limitToUrls as $url) {
-                $url              = trim($url);
+                $url              = html_entity_decode(trim($url));
                 $urlMatches[$url] = fnmatch($url, $pageUrl);
             }
         }
@@ -241,11 +241,11 @@ class CampaignSubscriber extends CommonSubscriber
 
         // Check Landing Pages URL or Tracing Pixel URL
         if (isset($config['referer']) && $config['referer']) {
-            $refererUrl      = $eventDetails->getReferer();
+            $refererUrl      = html_entity_decode($eventDetails->getReferer());
             $limitToReferers = explode(',', $config['referer']);
 
             foreach ($limitToReferers as $referer) {
-                $referer                  = trim($referer);
+                $referer                  = html_entity_decode(trim($referer));
                 $refererMatches[$referer] = fnmatch($referer, $refererUrl);
             }
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
In a campaign, the action "Visits a page" dosn't work with URL containing params like www.foo.com?foo=1&foo2=2 because `&`  is received like that `&#38;` and then comparison fail.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create segment `test`
2. Create segment `test2`
3. Create a contact and add him to segment `test`
4. Create a template type email with a link like this : `http://www.foo.com?foo=1&foo2=2`
5. Create a campaign with segment `test`
6. In campaign builder add action `Send email` and choose email created before
7. In campaign builder add decision `Visits a page` and put url `*foo=1&foo2=2*`
8. On the positive side, add action `Modify contact's segments` and select segment `test2`
9. Save and launch campaing
10. Click on the link inside the mail
11. Go to contact and look at his segment, you aren't in `test2` segment.

#### Steps to test this PR:
1. Apply PR
2. Click on the link from the mail receive previously
3. Go to contact and look at his segment, you are in `test2` segment.