### PR TITLE
Fix cleaning function on segment multi-select filters

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -1736,7 +1736,7 @@ class LeadListRepository extends CommonRepository
                         case 'notIn':
                             foreach ($details['filter'] as &$value) {
                                 $value = $q->expr()->literal(
-                                    InputHelper::clean($value)
+                                    InputHelper::string($value)
                                 );
                             }
                             if ($details['type'] == 'multiselect') {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
String's sanitization used for regexp inside segment filters is wrong.
Regex fail because special chars like quote are ASCII encoded.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a custom field with `Select - Multiple` type and `Contact` object
2. Add one value `it does` and second value `it doesn't`
3. Create two contact, on first apply `it does` and on second `it doesn't`
4. Create a segment and go to filters tab choose the `Select - Multiple` custom field
5. Select `including` and add the value `it doesn't`
6. Launch command `php app/console mautic:segments:update`
7. Nothing appear (if you select `it does` one contact is added)

#### Steps to test this PR:
1. Apply PR
2. Launch command `php app/console mautic:segments:update`
3. Rebuilding contacts is good