### PR TITLE
Remove global_only from campaign segments condition

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadSegmentsType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadSegmentsType.php
@@ -28,7 +28,6 @@ class CampaignEventLeadSegmentsType extends AbstractType
             'segments',
             'leadlist_choices',
             [
-                'global_only' => true,
                 'label'       => 'mautic.lead.lead.lists',
                 'label_attr'  => ['class' => 'control-label'],
                 'multiple'    => true,


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Contact segments condition show only globa segmetns. This PR fixed it

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create two segments  - with global only option  enabled/disabled
2. Create campaign with Contact segments condition - see just global only segment in condition

#### Steps to test this PR:
1.  Repeat all steps
2.  See all segments in condition. Now works properly
