### PR TITLE
Allow setting of filter parameters without a POST request

### DIFF
--- a/app/bundles/CategoryBundle/Controller/CategoryController.php
+++ b/app/bundles/CategoryBundle/Controller/CategoryController.php
@@ -76,9 +76,7 @@ class CategoryController extends FormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         $viewParams = [
             'page'   => $page,

--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -878,9 +878,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         $session = $this->get('session');
         if (empty($page)) {
@@ -1143,10 +1141,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
             return $this->accessDenied();
         }
 
-        // Set filters
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         // Audit log entries
         $logs = ($logObject) ? $this->getModel('core.auditLog')->getLogForObject($logObject, $objectId, $entity->getDateAdded(), 10, $logBundle) : [];

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -558,40 +558,38 @@ class CommonController extends Controller implements MauticController
         }
         $name = 'mautic.'.$name;
 
-        if (!empty($name)) {
-            if ($this->request->query->has('orderby')) {
-                $orderBy = InputHelper::clean($this->request->query->get('orderby'), true);
-                $dir     = $session->get("$name.orderbydir", 'ASC');
-                $dir     = ($dir == 'ASC') ? 'DESC' : 'ASC';
-                $session->set("$name.orderby", $orderBy);
-                $session->set("$name.orderbydir", $dir);
-            }
+        if ($this->request->query->has('orderby')) {
+            $orderBy = InputHelper::clean($this->request->query->get('orderby'), true);
+            $dir     = $session->get("$name.orderbydir", 'ASC');
+            $dir     = ($dir == 'ASC') ? 'DESC' : 'ASC';
+            $session->set("$name.orderby", $orderBy);
+            $session->set("$name.orderbydir", $dir);
+        }
 
-            if ($this->request->query->has('limit')) {
-                $limit = InputHelper::int($this->request->query->get('limit'));
-                $session->set("$name.limit", $limit);
-            }
+        if ($this->request->query->has('limit')) {
+            $limit = InputHelper::int($this->request->query->get('limit'));
+            $session->set("$name.limit", $limit);
+        }
 
-            if ($this->request->query->has('filterby')) {
-                $filter  = InputHelper::clean($this->request->query->get('filterby'), true);
-                $value   = InputHelper::clean($this->request->query->get('value'), true);
-                $filters = $session->get("$name.filters", []);
+        if ($this->request->query->has('filterby')) {
+            $filter  = InputHelper::clean($this->request->query->get('filterby'), true);
+            $value   = InputHelper::clean($this->request->query->get('value'), true);
+            $filters = $session->get("$name.filters", []);
 
-                if ($value == '') {
-                    if (isset($filters[$filter])) {
-                        unset($filters[$filter]);
-                    }
-                } else {
-                    $filters[$filter] = [
-                        'column' => $filter,
-                        'expr'   => 'like',
-                        'value'  => $value,
-                        'strict' => false,
-                    ];
+            if ($value == '') {
+                if (isset($filters[$filter])) {
+                    unset($filters[$filter]);
                 }
-
-                $session->set("$name.filters", $filters);
+            } else {
+                $filters[$filter] = [
+                    'column' => $filter,
+                    'expr'   => 'like',
+                    'value'  => $value,
+                    'strict' => false,
+                ];
             }
+
+            $session->set("$name.filters", $filters);
         }
     }
 

--- a/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
+++ b/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
@@ -52,9 +52,7 @@ class DynamicContentController extends FormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         //set limits
         $limit = $this->get('session')->get('mautic.dynamicContent.limit', $this->coreParametersHelper->getParameter('default_pagelimit'));

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -61,9 +61,7 @@ class EmailController extends FormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         $session = $this->get('session');
 

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -51,9 +51,7 @@ class FormController extends CommonFormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         $session = $this->get('session');
 

--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -44,9 +44,7 @@ class CompanyController extends FormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         //set limits
         $limit = $this->get('session')->get(

--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -38,9 +38,7 @@ class FieldController extends FormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         $limit  = $session->get('mautic.leadfield.limit', $this->coreParametersHelper->getParameter('default_pagelimit'));
         $search = $this->request->get('search', $session->get('mautic.leadfield.filter', ''));

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -57,9 +57,7 @@ class LeadController extends FormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         /** @var \Mautic\LeadBundle\Model\LeadModel $model */
         $model   = $this->getModel('lead');

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -54,9 +54,7 @@ class ListController extends FormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         //set limits
         $limit = $session->get('mautic.segment.limit', $this->coreParametersHelper->getParameter('default_pagelimit'));

--- a/app/bundles/LeadBundle/Controller/NoteController.php
+++ b/app/bundles/LeadBundle/Controller/NoteController.php
@@ -39,9 +39,7 @@ class NoteController extends FormController
             return $lead;
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         $session = $this->get('session');
 

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -54,9 +54,7 @@ class PageController extends FormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         //set limits
         $limit = $this->get('session')->get('mautic.page.limit', $this->coreParametersHelper->getParameter('default_pagelimit'));

--- a/app/bundles/PointBundle/Controller/PointController.php
+++ b/app/bundles/PointBundle/Controller/PointController.php
@@ -41,9 +41,7 @@ class PointController extends AbstractFormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         //set limits
         $limit = $this->get('session')->get('mautic.point.limit', $this->coreParametersHelper->getParameter('default_pagelimit'));

--- a/app/bundles/PointBundle/Controller/TriggerController.php
+++ b/app/bundles/PointBundle/Controller/TriggerController.php
@@ -42,9 +42,7 @@ class TriggerController extends FormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         //set limits
         $limit = $this->get('session')->get('mautic.point.trigger.limit', $this->coreParametersHelper->getParameter('default_pagelimit'));

--- a/app/bundles/ReportBundle/Controller/ReportController.php
+++ b/app/bundles/ReportBundle/Controller/ReportController.php
@@ -53,9 +53,7 @@ class ReportController extends FormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         //set limits
         $limit = $this->container->get('session')->get('mautic.report.limit', $this->coreParametersHelper->getParameter('default_pagelimit'));
@@ -588,10 +586,7 @@ class ReportController extends FormController
             return $this->accessDenied();
         }
 
-        // Set filters
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         $mysqlFormat = 'Y-m-d';
         $session     = $this->container->get('session');

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -52,9 +52,7 @@ class SmsController extends FormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         $session = $this->get('session');
 

--- a/app/bundles/StageBundle/Controller/StageController.php
+++ b/app/bundles/StageBundle/Controller/StageController.php
@@ -44,9 +44,7 @@ class StageController extends FormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         //set limits
         $limit = $this->get('session')->get(

--- a/app/bundles/UserBundle/Controller/RoleController.php
+++ b/app/bundles/UserBundle/Controller/RoleController.php
@@ -33,9 +33,7 @@ class RoleController extends FormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         //set limits
         $limit = $this->get('session')->get('mautic.role.limit', $this->coreParametersHelper->getParameter('default_pagelimit'));

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -33,9 +33,7 @@ class UserController extends FormController
             return $this->accessDenied();
         }
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         //set limits
         $limit = $this->get('session')->get('mautic.user.limit', $this->coreParametersHelper->getParameter('default_pagelimit'));

--- a/plugins/MauticSocialBundle/Controller/MonitoringController.php
+++ b/plugins/MauticSocialBundle/Controller/MonitoringController.php
@@ -30,9 +30,7 @@ class MonitoringController extends FormController
     {
         $session = $this->get('session');
 
-        if ($this->request->getMethod() == 'POST') {
-            $this->setListFilters();
-        }
+        $this->setListFilters();
 
         /** @var \MauticPlugin\MauticSocialBundle\Model\MonitoringModel $model */
         $model = $this->getModel('social.monitoring');


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Currently the filters are set from query string parameters; through a POST request. However, there is no reason to not set the filters when only receiving a GET request.

One example of this is directly linking to a report.
https://mautic.example.org/s/reports/view/36?tmpl=list&name=report.36&filterby=l.fname&value=JOHN

Linking to this will not work because it will come through as a GET request where mautic "normally" sends it as a POST request.

After looking through the code of the `ReportController` with  @alanhartless it appears that the conditional check is left over from an older time when the code behaved differently. Now, the method `setListFilters()` does the checking and there is no reason to check for a POST request.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Open up a report with some dynamic filters
2. Set the filter value
3. Notice in a debugger the url being called (e.g. https://mautic.example.org/s/reports/view/36?tmpl=list&name=report.36&filterby=l.fname&value=JOHN)
4. Attempt to go to https://mautic.example.org/s/reports/view/36?tmpl=list&name=report.36&filterby=l.fname&value=JOSEPH
5. Notice that the filter value does not actually get updated

#### Steps to test this PR:
1. Checkout PR
2. Follow above steps
3. Note that the filter value does change
