### PR TITLE
Fix: Campaign  form field value condition options and new operators

### DIFF
--- a/app/bundles/FormBundle/Controller/AjaxController.php
+++ b/app/bundles/FormBundle/Controller/AjaxController.php
@@ -108,7 +108,6 @@ class AjaxController extends CommonAjaxController
                 unset($optionList);
             }
         }
-
         $dataArray['fields']  = $fields;
         $dataArray['success'] = 1;
 

--- a/app/bundles/FormBundle/Controller/AjaxController.php
+++ b/app/bundles/FormBundle/Controller/AjaxController.php
@@ -108,6 +108,7 @@ class AjaxController extends CommonAjaxController
                 unset($optionList);
             }
         }
+
         $dataArray['fields']  = $fields;
         $dataArray['success'] = 1;
 

--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -444,6 +444,22 @@ class SubmissionRepository extends CommonRepository
      */
     public function compareValue($lead, $form, $formAlias, $field, $value, $operatorExpr)
     {
+        // Modify operator
+        switch ($operatorExpr) {
+            case 'startsWith':
+                $operatorExpr    = 'like';
+                $value           = $value.'%';
+                break;
+            case 'endsWith':
+                $operatorExpr   = 'like';
+                $value          = '%'.$value;
+                break;
+            case 'contains':
+                $operatorExpr   = 'like';
+                $value          = '%'.$value.'%';
+                break;
+        }
+
         //use DBAL to get entity fields
         $q = $this->_em->getConnection()->createQueryBuilder();
         $q->select('s.id')

--- a/app/bundles/FormBundle/Form/Type/CampaignEventFormFieldValueType.php
+++ b/app/bundles/FormBundle/Form/Type/CampaignEventFormFieldValueType.php
@@ -97,10 +97,16 @@ class CampaignEventFormFieldValueType extends AbstractType
                         $fields[$field->getAlias()]  = $field->getLabel();
                         $options[$field->getAlias()] = [];
                         $properties                  = $field->getProperties();
-
+                        $list                        = [];
                         if (!empty($properties['list']['list'])) {
+                            $list = $properties['list']['list'];
+                        } elseif (!empty($properties['optionlist']['list'])) {
+                            $list =$properties['optionlist']['list'];
+                        }
+
+                        if (!empty($list)) {
                             $options[$field->getAlias()] = [];
-                            foreach ($properties['list']['list'] as $option) {
+                            foreach ($list as $option) {
                                 if (is_array($option) && isset($option['value']) && isset($option['label'])) {
                                     //The select box needs values to be [value] => label format so make sure we have that style then put it in
                                     $options[$field->getAlias()][$option['value']] = $option['label'];

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -857,6 +857,21 @@ class FormModel extends CommonFormModel
                 'expr'        => 'notLike',
                 'negate_expr' => 'like',
             ],
+            'startsWith' => [
+                'label'       => 'mautic.core.operator.starts.with',
+                'expr'        => 'startsWith',
+                'negate_expr' => 'startsWith',
+            ],
+            'endsWith' => [
+                'label'       => 'mautic.core.operator.ends.with',
+                'expr'        => 'endsWith',
+                'negate_expr' => 'endsWith',
+            ],
+            'contains' => [
+                'label'       => 'mautic.core.operator.contains',
+                'expr'        => 'contains',
+                'negate_expr' => 'contains',
+            ],
         ];
 
         return ($operator === null) ? $operatorOptions : $operatorOptions[$operator];


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6299
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Related to issue https://github.com/mautic/mautic/issues/6299
Added  to CampaignEventFormFieldValueType  support for both type of properties array for options (list and optionlist)
This PR also added starts with, ends with and contains operator.  This update allow use condition with multiple selected choice. If contact select more choices (second,third) at the moment there no operator for control exist one value. 

![image](https://user-images.githubusercontent.com/462477/42626480-bb3382ea-85ca-11e8-8f38-4221f8293a68.png)

Before

Selected second,third equal third  (FALSE)
Selected second,third like third  (FALSE)
etc

AFTER

Selected second,third contains third (TRUE)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Create form with multiple choices (checkboxes) option field
2.  Go to campaigns and create campaign with form value condition and choose multiple choices option
3. See selectbox with options as value
3. Save and then reopen condition
4. Values is not options but text input 

#### Steps to test this PR:
1.  Repeat all steps
2.  See if selectbox is loaded after re-open condition
3. Then test new form value condition operators: starts/ends with, contains

![image](https://user-images.githubusercontent.com/462477/42626899-c1d8dc34-85cb-11e8-91ff-1359cee04fc4.png)