### PR TITLE
Change deprecated freegeoip api to new ipstack api

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -917,7 +917,7 @@ return [
 
     'ip_lookup_services' => [
         'freegeoip' => [
-            'display_name' => 'Freegeoip.net',
+            'display_name' => 'Ipstack.com',
             'class'        => 'Mautic\CoreBundle\IpLookup\FreegeoipLookup',
         ],
         'geobytes' => [

--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -918,7 +918,7 @@ return [
     'ip_lookup_services' => [
         'freegeoip' => [
             'display_name' => 'Ipstack.com',
-            'class'        => 'Mautic\CoreBundle\IpLookup\FreegeoipLookup',
+            'class'        => 'Mautic\CoreBundle\IpLookup\IpstackLookup',
         ],
         'geobytes' => [
             'display_name' => 'Geobytes',

--- a/app/bundles/CoreBundle/IpLookup/FreegeoipLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/FreegeoipLookup.php
@@ -13,7 +13,6 @@ namespace Mautic\CoreBundle\IpLookup;
 
 class FreegeoipLookup extends AbstractRemoteDataLookup
 {
-
     /**
      * @return string
      */

--- a/app/bundles/CoreBundle/IpLookup/FreegeoipLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/FreegeoipLookup.php
@@ -13,12 +13,13 @@ namespace Mautic\CoreBundle\IpLookup;
 
 class FreegeoipLookup extends AbstractRemoteDataLookup
 {
+
     /**
      * @return string
      */
     public function getAttribution()
     {
-        return '<a href="https://freegeoip.net/" target="_blank">freegeoip.net</a> is a free lookup service that leverages GeoLite2 data created by MaxMind.';
+        return '<a href="https://ipstack.com/" target="_blank">ipstack.com</a> is a free lookup service that leverages GeoLite2 data created by MaxMind.';
     }
 
     /**
@@ -26,7 +27,7 @@ class FreegeoipLookup extends AbstractRemoteDataLookup
      */
     protected function getUrl()
     {
-        return "http://freegeoip.net/json/{$this->ip}";
+        return 'http://api.ipstack.com/'.$this->ip.'?access_key='.$this->auth.'&output=json&legacy=1';
     }
 
     /**

--- a/app/bundles/CoreBundle/IpLookup/IpstackLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/IpstackLookup.php
@@ -26,6 +26,10 @@ class IpstackLookup extends AbstractRemoteDataLookup
      */
     protected function getUrl()
     {
+        if (empty($this->auth)) {
+            $this->logger->error('FreeGeoIP has become IPStack and now requires an API key.');
+        }
+
         return 'http://api.ipstack.com/'.$this->ip.'?access_key='.$this->auth.'&output=json&legacy=1';
     }
 

--- a/app/bundles/CoreBundle/IpLookup/IpstackLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/IpstackLookup.php
@@ -27,7 +27,7 @@ class IpstackLookup extends AbstractRemoteDataLookup
     protected function getUrl()
     {
         if (empty($this->auth)) {
-            $this->logger->error('FreeGeoIP has become IPStack and now requires an API key.');
+            $this->logger->notice('FreeGeoIP has become IPStack and now requires an API key.');
         }
 
         return 'http://api.ipstack.com/'.$this->ip.'?access_key='.$this->auth.'&output=json&legacy=1';

--- a/app/bundles/CoreBundle/IpLookup/IpstackLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/IpstackLookup.php
@@ -27,7 +27,7 @@ class IpstackLookup extends AbstractRemoteDataLookup
     protected function getUrl()
     {
         if (empty($this->auth)) {
-            $this->logger->notice('FreeGeoIP has become IPStack and now requires an API key.');
+            $this->logger->warning('FreeGeoIP has become IPStack and now requires an API key.');
         }
 
         return 'http://api.ipstack.com/'.$this->ip.'?access_key='.$this->auth.'&output=json&legacy=1';

--- a/app/bundles/CoreBundle/IpLookup/IpstackLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/IpstackLookup.php
@@ -11,7 +11,7 @@
 
 namespace Mautic\CoreBundle\IpLookup;
 
-class FreegeoipLookup extends AbstractRemoteDataLookup
+class IpstackLookup extends AbstractRemoteDataLookup
 {
     /**
      * @return string

--- a/app/bundles/CoreBundle/Tests/unit/IpLookup/IpstackLookupTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/IpLookup/IpstackLookupTest.php
@@ -35,7 +35,7 @@ class IpstackLookupTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->willReturn($mockResponse);
 
-        $ipService = new IpstackLookup(null, null, __DIR__.'/../../../../cache/test', null, $mockHttp);
+        $ipService = new IpstackLookup('mockApiToken', null, __DIR__.'/../../../../cache/test', null, $mockHttp);
 
         $details = $ipService->setIpAddress('192.30.252.131')->getDetails();
 

--- a/app/bundles/CoreBundle/Tests/unit/IpLookup/IpstackLookupTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/IpLookup/IpstackLookupTest.php
@@ -11,12 +11,12 @@
 
 namespace Mautic\CoreBundle\Tests\IpLookup;
 
-use Mautic\CoreBundle\IpLookup\FreegeoipLookup;
+use Mautic\CoreBundle\IpLookup\IpstackLookup;
 
 /**
  * Class FreegeoipLookupTest.
  */
-class FreegeoipLookupTest extends \PHPUnit_Framework_TestCase
+class IpstackLookupTest extends \PHPUnit_Framework_TestCase
 {
     public function testIpLookupSuccessful()
     {
@@ -35,7 +35,7 @@ class FreegeoipLookupTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->willReturn($mockResponse);
 
-        $ipService = new FreegeoipLookup(null, null, __DIR__.'/../../../../cache/test', null, $mockHttp);
+        $ipService = new IpstackLookup(null, null, __DIR__.'/../../../../cache/test', null, $mockHttp);
 
         $details = $ipService->setIpAddress('192.30.252.131')->getDetails();
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Automated tests included? | X
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6278
| BC breaks? | 
| Deprecations? | X

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The FreeGeoIp api has been deprecated and replaced with the IpStack api. This pr changes FreeGeoIp to IpStack. See https://github.com/apilayer/freegeoip#readme

#### Steps to test this PR:
1. Get a free access key from ipstack.com
2. Set Ipstack.com as your IP lookup
3. Set your access key
4. Use Ipstack as IP lookup

#### Note:
IpStack requires a (free) access key, so without a key it will not work. FreeGeoIp did not require a key, but since FreeGeoIp is deprecated now it won't work anymore at some point anyway.

Also, since July 1st 2018 FreeGeoIp is not working anymore.