### PR TITLE
Fixed bug introduced in campaign refactoring that prevented some decisions from being evaluated

### DIFF
--- a/app/bundles/CampaignBundle/Executioner/RealTimeExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/RealTimeExecutioner.php
@@ -21,6 +21,7 @@ use Mautic\CampaignBundle\Executioner\Exception\CampaignNotExecutableException;
 use Mautic\CampaignBundle\Executioner\Exception\DecisionNotApplicableException;
 use Mautic\CampaignBundle\Executioner\Result\Responses;
 use Mautic\CampaignBundle\Executioner\Scheduler\EventScheduler;
+use Mautic\CampaignBundle\Helper\ChannelExtractor;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
@@ -271,6 +272,18 @@ class RealTimeExecutioner
             throw new CampaignNotExecutableException('Contact does not have any applicable '.$type.' associations.');
         }
 
-        $this->logger->debug('CAMPAIGN: Found '.count($this->events).' events to analyize for contact ID '.$this->contact->getId());
+        // 2.14 BC break workaround - pre 2.14 had a bug that recorded channelId for decisions as 1 regardless of actually ID
+        // if channelIdField was an array and only one item was selected. That caused the channel ID check in evaluateDecisionForContact
+        // to fail resulting in the decision never being evaluated. Therefore we are going to self heal these decisions.
+        /** @var Event $event */
+        foreach ($this->events as $event) {
+            if (1 === $event->getChannelId()) {
+                ChannelExtractor::setChannel($event, $event, $this->collector->getEventConfig($event));
+
+                $this->eventRepository->saveEntity($event);
+            }
+        }
+
+        $this->logger->debug('CAMPAIGN: Found '.count($this->events).' events to analyze for contact ID '.$this->contact->getId());
     }
 }

--- a/app/bundles/CampaignBundle/Helper/ChannelExtractor.php
+++ b/app/bundles/CampaignBundle/Helper/ChannelExtractor.php
@@ -24,7 +24,10 @@ class ChannelExtractor
      */
     public static function setChannel(ChannelInterface $entity, Event $event, AbstractEventAccessor $eventConfig)
     {
-        if ($entity->getChannel()) {
+        // Allow event to update itself
+        $isSelf = $entity === $event;
+
+        if (!$isSelf && $entity->getChannel()) {
             return;
         }
 

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -20,6 +20,7 @@ use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
 use Mautic\CampaignBundle\Event as Events;
 use Mautic\CampaignBundle\EventCollector\EventCollector;
 use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
+use Mautic\CampaignBundle\Helper\ChannelExtractor;
 use Mautic\CampaignBundle\Helper\RemovedContactTracker;
 use Mautic\CampaignBundle\Membership\MembershipBuilder;
 use Mautic\CampaignBundle\Membership\MembershipManager;
@@ -849,26 +850,9 @@ class CampaignModel extends CommonFormModel
     {
         @trigger_error('Deprecated 2.14 to be removed in 3.0; use \Mautic\CampaignBundle\Helper\ChannelExtractor instead', E_USER_DEPRECATED);
 
-        $channelSet = false;
-        if (!$entity->getChannel() && !empty($eventSettings[$properties['type']]['channel'])) {
-            $entity->setChannel($eventSettings[$properties['type']]['channel']);
-            if (isset($eventSettings[$properties['type']]['channelIdField'])) {
-                $channelIdField = $eventSettings[$properties['type']]['channelIdField'];
-                if (!empty($properties['properties'][$channelIdField])) {
-                    if (is_array($properties['properties'][$channelIdField])) {
-                        if (count($properties['properties'][$channelIdField]) === 1) {
-                            // Only store channel ID if a single item was selected
-                            $entity->setChannelId($properties['properties'][$channelIdField]);
-                        }
-                    } else {
-                        $entity->setChannelId($properties['properties'][$channelIdField]);
-                    }
-                }
-            }
-            $channelSet = true;
-        }
+        ChannelExtractor::setChannel($entity, $entity, $this->eventCollector->getEventConfig($entity));
 
-        return $channelSet;
+        return true;
     }
 
     /**

--- a/app/bundles/CampaignBundle/Tests/Executioner/RealTimeExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/RealTimeExecutionerTest.php
@@ -180,7 +180,7 @@ class RealTimeExecutionerTest extends \PHPUnit_Framework_TestCase
         $event->expects($this->exactly(2))
             ->method('getChannel')
             ->willReturn('email');
-        $event->expects($this->exactly(3))
+        $event->expects($this->exactly(4))
             ->method('getChannelId')
             ->willReturn(3);
         $event->method('getEventType')
@@ -215,7 +215,7 @@ class RealTimeExecutionerTest extends \PHPUnit_Framework_TestCase
         $event->expects($this->exactly(2))
             ->method('getChannel')
             ->willReturn('email');
-        $event->expects($this->exactly(2))
+        $event->expects($this->exactly(3))
             ->method('getChannelId')
             ->willReturn(3);
         $event->expects($this->once())
@@ -268,7 +268,7 @@ class RealTimeExecutionerTest extends \PHPUnit_Framework_TestCase
         $event->expects($this->exactly(2))
             ->method('getChannel')
             ->willReturn('email');
-        $event->expects($this->exactly(2))
+        $event->expects($this->exactly(3))
             ->method('getChannelId')
             ->willReturn(3);
         $event->method('getEventType')


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Pre 2.14 had a bug that recorded channelId for decisions as 1 regardless of actually ID if channelIdField was an array and only one item was selected. That caused the channel ID check in evaluateDecisionForContact to fail resulting in the decision never being evaluated. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a landing page
2. Create an email with the link to the landing page
3. Create a campaign that sends the email then has a visits page decision with the landing page selected as "limited to landing page." Add something to the green/action path (tag, etc)
4. Put a contact through the campaign
5. Open the landing page link from the email in a non-user browser
6. Check the campaign and notice the contact did not have the decision evaluated

#### Steps to test this PR:
1. Apply the PR, send another contact through the campaign and note that it'll evaluate the decision
