### PR TITLE
New campaign condition: Has active notification

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -33,7 +33,7 @@ use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyChangeLog;
 use Mautic\LeadBundle\Entity\CompanyLead;
-use Mautic\LeadBundle\Entity\DoNotContact as DNC;
+use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\FrequencyRule;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadCategory;
@@ -1466,7 +1466,7 @@ class LeadModel extends FormModel
 
                 // The email must be set for successful unsubscribtion
                 $lead->addUpdatedField('email', $data[$fields['email']]);
-                $this->addDncForLead($lead, 'email', $reason, DNC::MANUAL);
+                $this->addDncForLead($lead, 'email', $reason, DoNotContact::MANUAL);
             }
         }
         unset($fieldData['doNotEmail']);
@@ -1661,8 +1661,8 @@ class LeadModel extends FormModel
     public function addUTMTags(Lead $lead, $params)
     {
         // known "synonym" fields expected
-        $synonyms = ['useragent' => 'user_agent',
-                    'remotehost' => 'remote_host', ];
+        $synonyms = ['useragent'  => 'user_agent',
+                     'remotehost' => 'remote_host', ];
 
         // convert 'query' option to an array if necessary
         if (isset($params['query']) && !is_array($params['query'])) {
@@ -2244,7 +2244,7 @@ class LeadModel extends FormModel
 
         $channels = [];
         foreach ($allChannels as $channel) {
-            if ($this->isContactable($lead, $channel) === DNC::IS_CONTACTABLE) {
+            if ($this->isContactable($lead, $channel) === DoNotContact::IS_CONTACTABLE) {
                 $channels[$channel] = $channel;
             }
         }
@@ -2259,13 +2259,13 @@ class LeadModel extends FormModel
      *
      * @return array
      */
-    public function getDNCChannels(Lead $lead)
+    public function getDoNotContactChannels(Lead $lead)
     {
         $allChannels = $this->getPreferenceChannels();
 
         $channels = [];
         foreach ($allChannels as $channel) {
-            if ($this->isContactable($lead, $channel) !== DNC::IS_CONTACTABLE) {
+            if ($this->isContactable($lead, $channel) !== DoNotContact::IS_CONTACTABLE) {
                 $channels[$channel] = $channel;
             }
         }
@@ -2464,16 +2464,16 @@ class LeadModel extends FormModel
     }
 
     /**
-     * @deprecated 2.12.0 to be removed in 3.0; use Mautic\LeadBundle\Model\DNC instead
+     * @deprecated 2.12.0 to be removed in 3.0; use Mautic\LeadBundle\Model\DoNotContact instead
      *
      * @param Lead   $lead
      * @param string $channel
      *
      * @return int
      *
-     * @see \Mautic\LeadBundle\Entity\DNC This method can return boolean false, so be
+     * @see \Mautic\LeadBundle\Entity\DoNotContact This method can return boolean false, so be
      *                                             sure to always compare the return value against
-     *                                             the class constants of DNC
+     *                                             the class constants of DoNotContact
      */
     public function isContactable(Lead $lead, $channel)
     {
@@ -2481,30 +2481,30 @@ class LeadModel extends FormModel
             $channel = key($channel);
         }
 
-        /** @var \Mautic\LeadBundle\Entity\DNCRepository $dncRepo */
-        $dncRepo = $this->em->getRepository('MauticLeadBundle:DNC');
+        /** @var \Mautic\LeadBundle\Entity\DoNotContactRepository $dncRepo */
+        $dncRepo = $this->em->getRepository('MauticLeadBundle:DoNotContact');
 
-        /** @var \Mautic\LeadBundle\Entity\DNC[] $entries */
+        /** @var \Mautic\LeadBundle\Entity\DoNotContact[] $entries */
         $dncEntries = $dncRepo->getEntriesByLeadAndChannel($lead, $channel);
 
         // If the lead has no entries in the DNC table, we're good to go
         if (empty($dncEntries)) {
-            return DNC::IS_CONTACTABLE;
+            return DoNotContact::IS_CONTACTABLE;
         }
 
         foreach ($dncEntries as $dnc) {
-            if ($dnc->getReason() !== DNC::IS_CONTACTABLE) {
+            if ($dnc->getReason() !== DoNotContact::IS_CONTACTABLE) {
                 return $dnc->getReason();
             }
         }
 
-        return DNC::IS_CONTACTABLE;
+        return DoNotContact::IS_CONTACTABLE;
     }
 
     /**
      * Remove a Lead's DNC entry based on channel.
      *
-     * @deprecated 2.12.0 to be removed in 3.0; use Mautic\LeadBundle\Model\DNC instead
+     * @deprecated 2.12.0 to be removed in 3.0; use Mautic\LeadBundle\Model\DoNotContact instead
      *
      * @param Lead      $lead
      * @param string    $channel
@@ -2514,10 +2514,10 @@ class LeadModel extends FormModel
      */
     public function removeDncForLead(Lead $lead, $channel, $persist = true)
     {
-        /** @var DNC $dnc */
-        foreach ($lead->getDNC() as $dnc) {
+        /** @var DoNotContact $dnc */
+        foreach ($lead->getDoNotContact() as $dnc) {
             if ($dnc->getChannel() === $channel) {
-                $lead->removeDNCEntry($dnc);
+                $lead->removeDoNotContactEntry($dnc);
 
                 if ($persist) {
                     $this->saveEntity($lead);
@@ -2533,27 +2533,27 @@ class LeadModel extends FormModel
     /**
      * Create a DNC entry for a lead.
      *
-     * @deprecated 2.12.0 to be removed in 3.0; use Mautic\LeadBundle\Model\DNC instead
+     * @deprecated 2.12.0 to be removed in 3.0; use Mautic\LeadBundle\Model\DoNotContact instead
      *
      * @param Lead         $lead
      * @param string|array $channel            If an array with an ID, use the structure ['email' => 123]
      * @param string       $comments
-     * @param int          $reason             Must be a class constant from the DNC class
+     * @param int          $reason             Must be a class constant from the DoNotContact class
      * @param bool         $persist
      * @param bool         $checkCurrentStatus
      * @param bool         $override
      *
-     * @return bool|DNC If a DNC entry is added or updated, returns the DNC object. If a DNC is already present
-     *                  and has the specified reason, nothing is done and this returns false
+     * @return bool|DoNotContact If a DNC entry is added or updated, returns the DoNotContact object. If a DNC is already present
+     *                           and has the specified reason, nothing is done and this returns false
      */
-    public function addDncForLead(Lead $lead, $channel, $comments = '', $reason = DNC::BOUNCED, $persist = true, $checkCurrentStatus = true, $override = false)
+    public function addDncForLead(Lead $lead, $channel, $comments = '', $reason = DoNotContact::BOUNCED, $persist = true, $checkCurrentStatus = true, $override = false)
     {
         // if !$checkCurrentStatus, assume is contactable due to already being valided
-        $isContactable = ($checkCurrentStatus) ? $this->isContactable($lead, $channel) : DNC::IS_CONTACTABLE;
+        $isContactable = ($checkCurrentStatus) ? $this->isContactable($lead, $channel) : DoNotContact::IS_CONTACTABLE;
 
         // If they don't have a DNC entry yet
-        if ($isContactable === DNC::IS_CONTACTABLE) {
-            $dnc = new DNC();
+        if ($isContactable === DoNotContact::IS_CONTACTABLE) {
+            $dnc = new DoNotContact();
 
             if (is_array($channel)) {
                 $channelId = reset($channel);
@@ -2568,7 +2568,7 @@ class LeadModel extends FormModel
             $dnc->setDateAdded(new \DateTime());
             $dnc->setComments($comments);
 
-            $lead->addDNCEntry($dnc);
+            $lead->addDoNotContactEntry($dnc);
 
             if ($persist) {
                 // Use model saveEntity to trigger events for DNC change
@@ -2579,15 +2579,15 @@ class LeadModel extends FormModel
         }
         // Or if the given reason is different than the stated reason
         elseif ($isContactable !== $reason) {
-            /** @var DNC $dnc */
-            foreach ($lead->getDNC() as $dnc) {
+            /** @var DoNotContact $dnc */
+            foreach ($lead->getDoNotContact() as $dnc) {
                 // Only update if the contact did not unsubscribe themselves
-                if (!$override && $dnc->getReason() !== DNC::UNSUBSCRIBED) {
+                if (!$override && $dnc->getReason() !== DoNotContact::UNSUBSCRIBED) {
                     $override = true;
                 }
                 if ($dnc->getChannel() === $channel && $override) {
                     // Remove the outdated entry
-                    $lead->removeDNCEntry($dnc);
+                    $lead->removeDoNotContactEntry($dnc);
 
                     // Update the DNC entry
                     $dnc->setChannel($channel);
@@ -2597,7 +2597,7 @@ class LeadModel extends FormModel
                     $dnc->setComments($comments);
 
                     // Re-add the entry to the lead
-                    $lead->addDNCEntry($dnc);
+                    $lead->addDoNotContactEntry($dnc);
 
                     if ($persist) {
                         // Use model saveEntity to trigger events for DNC change

--- a/app/bundles/NotificationBundle/Config/config.php
+++ b/app/bundles/NotificationBundle/Config/config.php
@@ -21,6 +21,9 @@ return [
                     'mautic.notification.api',
                 ],
             ],
+            'mautic.notification.campaignbundle.condition_subscriber' => [
+                'class'     => 'Mautic\NotificationBundle\EventListener\CampaignConditionSubscriber',
+            ],
             'mautic.notification.pagebundle.subscriber' => [
                 'class'     => 'Mautic\NotificationBundle\EventListener\PageSubscriber',
                 'arguments' => [

--- a/app/bundles/NotificationBundle/EventListener/CampaignConditionSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/CampaignConditionSubscriber.php
@@ -30,7 +30,7 @@ class CampaignConditionSubscriber implements EventSubscriberInterface
     {
         return [
             CampaignEvents::CAMPAIGN_ON_BUILD                 => ['onCampaignBuild', 0],
-            NotificationEvents::ON_CAMPAIGN_TRIGGER_CONDITION => ['onCampaignTriggerCondition', 0],
+            NotificationEvents::ON_CAMPAIGN_TRIGGER_CONDITION => ['onCampaignTriggerHasActiveCondition', 0],
         ];
     }
 
@@ -52,8 +52,12 @@ class CampaignConditionSubscriber implements EventSubscriberInterface
     /**
      * @param CampaignExecutionEvent $event
      */
-    public function onCampaignTriggerCondition(CampaignExecutionEvent $event)
+    public function onCampaignTriggerHasActiveCondition(CampaignExecutionEvent $event)
     {
+        if (!$event->checkContext('notification.has.active')) {
+            return;
+        }
+
         $pushIds = $event->getLead()->getPushIDs();
         /** @var PushID $pushID */
         foreach ($pushIds as $pushID) {

--- a/app/bundles/NotificationBundle/EventListener/CampaignConditionSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/CampaignConditionSubscriber.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\NotificationBundle\EventListener;
+
+use Mautic\CampaignBundle\CampaignEvents;
+use Mautic\CampaignBundle\Event\CampaignBuilderEvent;
+use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
+use Mautic\NotificationBundle\Entity\PushID;
+use Mautic\NotificationBundle\NotificationEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class CampaignConditionSubscriber.
+ */
+class CampaignConditionSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            CampaignEvents::CAMPAIGN_ON_BUILD                 => ['onCampaignBuild', 0],
+            NotificationEvents::ON_CAMPAIGN_TRIGGER_CONDITION => ['onCampaignTriggerCondition', 0],
+        ];
+    }
+
+    /**
+     * @param CampaignBuilderEvent $event
+     */
+    public function onCampaignBuild(CampaignBuilderEvent $event)
+    {
+        $event->addCondition(
+            'notification.has.active',
+            [
+                'label'       => 'mautic.notification.campaign.event.notification.has.active',
+                'description' => 'mautic.notification.campaign.event.notification.has.active.desc',
+                'eventName'   => NotificationEvents::ON_CAMPAIGN_TRIGGER_CONDITION,
+            ]
+        );
+    }
+
+    /**
+     * @param CampaignExecutionEvent $event
+     */
+    public function onCampaignTriggerCondition(CampaignExecutionEvent $event)
+    {
+        $pushIds = $event->getLead()->getPushIDs();
+        /** @var PushID $pushID */
+        foreach ($pushIds as $pushID) {
+            if ($pushID->isEnabled()) {
+                return $event->setResult(true);
+            }
+        }
+
+        return $event->setResult(false);
+    }
+}

--- a/app/bundles/NotificationBundle/NotificationEvents.php
+++ b/app/bundles/NotificationBundle/NotificationEvents.php
@@ -97,4 +97,14 @@ final class NotificationEvents
      * @var string
      */
     const ON_CAMPAIGN_TRIGGER_ACTION = 'mautic.notification.on_campaign_trigger_action';
+
+    /**
+     * The mautic.notification.on_campaign_trigger_condition event is fired when the campaign condition triggers.
+     *
+     * The event listener receives a
+     * Mautic\CampaignBundle\Event\CampaignExecutionEvent
+     *
+     * @var string
+     */
+    const ON_CAMPAIGN_TRIGGER_CONDITION = 'mautic.notification.on_campaign_trigger_notification';
 }

--- a/app/bundles/NotificationBundle/Translations/en_US/messages.ini
+++ b/app/bundles/NotificationBundle/Translations/en_US/messages.ini
@@ -163,6 +163,10 @@ mautic.notification.campaign.failed.missing_entity="The specified Web Notificati
 mautic.notification.show.total.sent="Total sent"
 mautic.notification.help.searchcommands="<strong>Search commands</strong><br />ids:ID1,ID2 (comma separated IDs, no spaces)"
 
+mautic.notification.campaign.event.notification.has.active="Has active notification"
+mautic.campaign.notification.has.active="Has active notification"
+mautic.notification.campaign.event.notification.has.active.desc=""
+
 mautic.report.group.mobile_notifications="Mobile Notifications"
 mautic.mobile_notification.stats.report.table="Mobile Notifications sent"
 mautic.mobile_notification.report.hits_count="Hits Count"

--- a/app/bundles/NotificationBundle/Translations/en_US/messages.ini
+++ b/app/bundles/NotificationBundle/Translations/en_US/messages.ini
@@ -165,7 +165,7 @@ mautic.notification.help.searchcommands="<strong>Search commands</strong><br />i
 
 mautic.notification.campaign.event.notification.has.active="Has active notification"
 mautic.campaign.notification.has.active="Has active notification"
-mautic.notification.campaign.event.notification.has.active.desc=""
+mautic.notification.campaign.event.notification.has.active.desc="Condition check If contact has active notification."
 
 mautic.report.group.mobile_notifications="Mobile Notifications"
 mautic.mobile_notification.stats.report.table="Mobile Notifications sent"


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Just added new  condition based on active notification from push_ids table.
Prevent too much failed campaign Send notification action.

#### Steps to test this PR:
1.  Setup OneSignal an web push Notification
2. Create campaign with Has active notification. 
3. Go to website with tracking code and active notification. 
4. Go to website with incognito  (another anonymouse contact  was created)
5. Then both contact add to campaign with Has active notification
6. First should go to true, second to false
