### PR TITLE
Fix mailjet bounce when there a dash "-" in email address

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/MailjetTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/MailjetTransport.php
@@ -129,7 +129,9 @@ class MailjetTransport extends \Swift_SmtpTransport implements CallbackTransport
             }
 
             if (isset($event['CustomID']) && $event['CustomID'] !== '' && strpos($event['CustomID'], '-', 0) !== false) {
-                list($leadIdHash, $leadEmail) = explode('-', $event['CustomID']);
+                $fistDashPos = strpos($event['CustomID'], '-', 0);
+                $leadIdHash  = substr($event['CustomID'], 0, $fistDashPos);
+                $leadEmail   = substr($event['CustomID'], $fistDashPos + 1, strlen($event['CustomID']));
                 if ($event['email'] == $leadEmail) {
                     $this->transportCallback->addFailureByHashId($leadIdHash, $reason, $type);
                 }

--- a/app/bundles/EmailBundle/Tests/Transport/MailjetTransportTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/MailjetTransportTest.php
@@ -24,13 +24,14 @@ class MailjetTransportTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $transportCallback->expects($this->exactly(4))
+        $transportCallback->expects($this->exactly(5))
             ->method('addFailureByHashId')
             ->withConsecutive(
                 [$this->equalTo('1'), 'User unsubscribed', DoNotContact::UNSUBSCRIBED],
                 [$this->equalTo('2'), 'blocked: blocked', DoNotContact::BOUNCED],
                 [$this->equalTo('3'), 'User reported email as spam, source: spam button', DoNotContact::UNSUBSCRIBED],
-                [$this->equalTo('4'), 'bounced: bounced', DoNotContact::BOUNCED]
+                [$this->equalTo('4'), 'bounced: bounced', DoNotContact::BOUNCED],
+                [$this->equalTo('5'), 'bounced: bounced', DoNotContact::BOUNCED]
             );
 
         $transportCallback->expects($this->once())
@@ -102,6 +103,21 @@ class MailjetTransportTest extends \PHPUnit_Framework_TestCase
     "mj_contact_id": 0,
     "customcampaign": "",
     "CustomID": "4-bounce@test.com",
+    "Payload": "",
+    "blocked": "",
+    "hard_bounce": "",
+    "error_related_to": "bounced",
+    "error": "bounced"
+  }, 
+  {
+    "event": "bounce",
+    "time": 1513975372,
+    "MessageID": 0,
+    "email": "bounce3@test-test.com",
+    "mj_campaign_id": 0,
+    "mj_contact_id": 0,
+    "customcampaign": "",
+    "CustomID": "5-bounce3@test-test.com",
     "Payload": "",
     "blocked": "",
     "hard_bounce": "",


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y 
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:

When there is a dash (`-`) in the email address, lead isn't reported as bounce if the case when using Mailjet transport.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Configure Mailjet as email provider
2. create a lead `test@ex-emple.com`
3. add it to a segment, and shoot an segment email.
4. lead isn't reported as bounce as he should be.

#### Steps to test this PR:
1. Apply this PR and redo test process.

Unit test was updated to cover this case
