### PR TITLE
Notification: Inject new custom content hooks below graphs

### DIFF
--- a/app/bundles/NotificationBundle/Views/Notification/details.html.php
+++ b/app/bundles/NotificationBundle/Views/Notification/details.html.php
@@ -87,6 +87,8 @@ $view['slots']->set(
             </div>
             <!--/ stats -->
 
+            <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); ?>
+
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">
                 <li class="active">


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/pull/6016| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Just the forgotten hook to notification from this merged PR https://github.com/mautic/mautic/pull/6016

#### Steps to test this PR:
Same like in already merged PR https://github.com/mautic/mautic/pull/6016 
1.  Create listener based on https://github.com/mautic/mautic/pull/5288#issuecomment-380266254
2. Test If content from context are displayed on the related place, below the email stats in details for example
