### PR TITLE
Fix: Notifciation list ordering

### DIFF
--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -52,6 +52,10 @@ class NotificationController extends FormController
             return $this->accessDenied();
         }
 
+        if ($this->request->getMethod() == 'POST') {
+            $this->setListFilters();
+        }
+
         $session = $this->get('session');
 
         //set limits


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Noticed ordering in notification indexAction doesn't work. 
This PR added setListFilters  for store filter information to sesssion.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Go to Web notifications and create 2 notification
2.  Try order by ID
3.  See nothing happend 

#### Steps to test this PR:
1.  Repeat all steps
2.  See  If works like in other controller (Email for example)
