### PR TITLE
StatId to sendSms result

### DIFF
--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -323,6 +323,9 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface
         if ($sentCount) {
             $this->getRepository()->upCount($sms->getId(), 'sent', $sentCount);
             $this->getStatRepository()->saveEntities($stats);
+            // send statId to results
+            $stat                                         = reset($stats);
+            $results[$stat->getLead()->getId()]['statId'] = $stat->getId();
             $this->em->clear(Stat::class);
         }
 

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -324,8 +324,10 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface
             $this->getRepository()->upCount($sms->getId(), 'sent', $sentCount);
             $this->getStatRepository()->saveEntities($stats);
             // send statId to results
-            $stat                                         = reset($stats);
-            $results[$stat->getLead()->getId()]['statId'] = $stat->getId();
+            $stat = reset($stats);
+            if ($stat instanceof Stat) {
+                $results[$stat->getLead()->getId()]['statId'] = $stat->getId();
+            }
             $this->em->clear(Stat::class);
         }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If You want to use sendToContact API and store identification for internal use.  
This PR added  statId to response after sendSms

#### Steps to test this PR:
1.  Create Api and call `$smsApi->sendToContact($textMessageId, $contactId)`;
2.  See  response and new statId parameter