### PR TITLE
Fix bug with merging contact timestamps

### DIFF
--- a/app/bundles/LeadBundle/Deduplicate/ContactMerger.php
+++ b/app/bundles/LeadBundle/Deduplicate/ContactMerger.php
@@ -130,8 +130,10 @@ class ContactMerger
         /*
          * The winner should keep the oldest date identified timestamp
          * as long as the loser's date identified is not null.
+         * Alternatively, if the winner's date identified is null,
+         * use the loser's date identified (doesn't matter if it is null).
          */
-        if ($loser->getDateIdentified() !== null && $loser->getDateIdentified() < $winner->getDateIdentified()) {
+        if (($loser->getDateIdentified() !== null && $loser->getDateIdentified() < $winner->getDateIdentified()) || $winner->getDateIdentified() === null) {
             $winner->setDateIdentified($loser->getDateIdentified());
         }
 

--- a/app/bundles/LeadBundle/Deduplicate/ContactMerger.php
+++ b/app/bundles/LeadBundle/Deduplicate/ContactMerger.php
@@ -127,8 +127,11 @@ class ContactMerger
             $winner->setLastActive($loser->getLastActive());
         }
 
-        // The winner should keep the oldest date identified timestamp
-        if ($loser->getDateIdentified() < $winner->getDateIdentified()) {
+        /*
+         * The winner should keep the oldest date identified timestamp
+         * as long as the loser's date identified is not null.
+         */
+        if ($loser->getDateIdentified() !== null && $loser->getDateIdentified() < $winner->getDateIdentified()) {
             $winner->setDateIdentified($loser->getDateIdentified());
         }
 

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -93,6 +93,14 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($latestDateTime, $winner->getLastActive());
         $this->assertEquals($oldestDateTime, $winner->getDateIdentified());
+
+        // Test with null date identified loser
+        $winner->setDateIdentified($latestDateTime);
+        $loser->setDateIdentified(null);
+
+        $this->getMerger()->mergeTimestamps($winner, $loser);
+
+        $this->assertEquals($latestDateTime, $winner->getDateIdentified());
     }
 
     public function testMergeIpAddresses()

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -101,6 +101,14 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
         $this->getMerger()->mergeTimestamps($winner, $loser);
 
         $this->assertEquals($latestDateTime, $winner->getDateIdentified());
+
+        // Test with null date identified winner
+        $winner->setDateIdentified(null);
+        $loser->setDateIdentified($latestDateTime);
+
+        $this->getMerger()->mergeTimestamps($winner, $loser);
+
+        $this->assertEquals($latestDateTime, $winner->getDateIdentified());
     }
 
     public function testMergeIpAddresses()


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When merging two contacts, if the determined loser had an identified date of `null`, it would overwrite the winner's identified date with `null`. This would result in the winner's identified date being set to the current time when the contact was saved to the database.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to your Mautic site and open an anonymous contact record (if there are any, if there aren't, create one by visiting a mautic landing page in an anonymous / icognito browser)
2. Merge that anonymous contact with a known contact that has a date identified in the past
3. See that the identified date is set to the current time.

#### Steps to test this PR:
1. Apply PR and reproduce
2. When following reproduction steps, use a different known contact.
3. See that the date identified remains the same as that of the known contact instead of being set to today
4. Run the unit tests to verify the "loser with null doesn't set winner to null" `bin/phpunit --configuration="app/phpunit.xml" --filter="ContactMergerTest"`