### PR TITLE
Cast expire time to int

### DIFF
--- a/app/bundles/CoreBundle/Helper/CookieHelper.php
+++ b/app/bundles/CoreBundle/Helper/CookieHelper.php
@@ -79,7 +79,7 @@ class CookieHelper
         setcookie(
             $name,
             $value,
-            ($expire) ? (int)(time() + $expire) : null,
+            ($expire) ? (int) (time() + $expire) : null,
             ($path == null) ? $this->path : $path,
             ($domain == null) ? $this->domain : $domain,
             ($secure == null) ? $this->secure : $secure,

--- a/app/bundles/CoreBundle/Helper/CookieHelper.php
+++ b/app/bundles/CoreBundle/Helper/CookieHelper.php
@@ -79,7 +79,7 @@ class CookieHelper
         setcookie(
             $name,
             $value,
-            ($expire) ? time() + $expire : null,
+            ($expire) ? (int)(time() + $expire) : null,
             ($path == null) ? $this->path : $path,
             ($domain == null) ? $this->domain : $domain,
             ($secure == null) ? $this->secure : $secure,


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If you go on a page with private navigation and index_dev.php call of setCookie fail because time() + $expire return float instead of int.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form
2. Open a private navigation
3. Go to form URL : http://my-mautic.local/index_dev.php/form/1
4.
![screenshot_2018-07-26 500 internal server error - php warning - setcookie expects parameter 3 to be integer float given](https://user-images.githubusercontent.com/27768270/43254713-4376cb0a-90c8-11e8-8c71-7cc075cced0f.png)


#### Steps to test this PR:
1. Apply PR
2. Clear session or open new private navigation
3. Go to form URL