### PR TITLE
Add  applyDateFilters to CampaignEventLog report

### DIFF
--- a/app/bundles/CampaignBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/ReportSubscriber.php
@@ -205,6 +205,8 @@ class ReportSubscriber extends CommonSubscriber
             $event->addCompanyLeftJoin($qb);
         }
 
+        $event->applyDateFilters($qb, 'date_triggered', 'log');
+
         $event->setQueryBuilder($qb);
     }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Notice with work with Reports with Campaign Events that date range didn't apply to results. 
This PR fixed it

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Create report: Campaigns > Campaign Events
2. Apply date range filter for short period, maybe 1-2 days
3. See report show all data and not apply date range filter

#### Steps to test this PR:
1.  Repeat all steps and see If results are displayed just for date what was selected