### PR TITLE
Fixed Twilio sending failure

### DIFF
--- a/app/bundles/SmsBundle/Sms/TransportChain.php
+++ b/app/bundles/SmsBundle/Sms/TransportChain.php
@@ -97,12 +97,7 @@ class TransportChain
      */
     public function sendSms(Lead $lead, $content)
     {
-        $number = $lead->getLeadPhoneNumber();
-
-        $this->logger->addInfo('Sending an SMS message using '
-                            .$this->transports[$this->primaryTransport]['integrationAlias'].' to '
-                            .(is_array($number) ? join(',', $number) : $number));
-        $response = $this->getPrimaryTransport()->sendSms($number, $content);
+        $response = $this->getPrimaryTransport()->sendSms($lead, $content);
 
         return $response;
     }
@@ -125,7 +120,7 @@ class TransportChain
     public function getEnabledTransports()
     {
         $enabled = [];
-        foreach ($this->transports as $alias=>$transport) {
+        foreach ($this->transports as $alias => $transport) {
             if (!isset($transport['published'])) {
                 $integration = $this->integrationHelper->getIntegrationObject($transport['integrationAlias']);
                 if (!$integration) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
2.14.0 included changes to expand support for SMS gateways but a piece of crucial code didn't make it. This fixes that to restore Twilio functionality. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup Twilio
2. Create text message
3. Create campaign to send text message
4. Add contact to campaign and trigger
5. An exception will be thrown with `Type error: Argument 1 passed to Mautic\SmsBundle\Api\TwilioApi::sendSms() must be an instance of Mautic\LeadBundle\Entity\Lead, string given`

#### Steps to test this PR:
1. Repeat and the SMS will send