### PR TITLE
Fix multiple value api import

### DIFF
--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -53,7 +53,11 @@ trait RequestTrait
                         if ($child->getConfig()->getOption('multiple')) {
                             // Ensure the value is an array
                             if (!is_array($params[$name])) {
-                                $params[$name] = [$params[$name]];
+                                if (strpos($params[$name], '|') !== false) {
+                                    $params[$name] = explode('|', $params[$name]);
+                                } else {
+                                    $params[$name] = [$params[$name]];
+                                }
                             }
                         }
                         break;


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Add a contact with api fail if you send a multiple value custom field.
The API and others Mautic functions support sending multiple values ​​with the `|` separator, but one function had a missing process.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a custom field with `Select - Multiple` type and `Contact` object
2. Add one value `Value 1` and a second value `Value 2`
3. Use API tester to add a contact `endpoint: /api/contacts/new`

![screenshot_2018-07-27 api tester](https://user-images.githubusercontent.com/27768270/43320596-46075100-91a9-11e8-96d7-8eb9eacf9892.png)

4. Error response: `"code": 400, "message": "multi_select: This value is not valid."`

#### Steps to test this PR:
1. Apply PR
2. Resend same information
3. Contact is now added to Mautic