### PR TITLE
Fix conditions to update a lead with tracking pixel

### DIFF
--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -1171,25 +1171,23 @@ class PageModel extends FormModel
     private function setLeadManipulator($page, Hit $hit, Lead $lead)
     {
         // Only save the lead and dispatch events if needed
-        if ($lead->isNewlyCreated() || $lead->wasAnonymous()) {
-            $source   = 'hit';
-            $sourceId = $hit->getId();
-            if ($page) {
-                $source   = $page instanceof Page ? 'page' : 'redirect';
-                $sourceId = $page->getId();
-            }
-
-            $lead->setManipulator(
-                new LeadManipulator(
-                    'page',
-                    $source,
-                    $sourceId,
-                    $hit->getUrl()
-                )
-            );
-
-            $this->leadModel->saveEntity($lead);
+        $source   = 'hit';
+        $sourceId = $hit->getId();
+        if ($page) {
+            $source   = $page instanceof Page ? 'page' : 'redirect';
+            $sourceId = $page->getId();
         }
+
+        $lead->setManipulator(
+            new LeadManipulator(
+                'page',
+                $source,
+                $sourceId,
+                $hit->getUrl()
+            )
+        );
+
+        $this->leadModel->saveEntity($lead);
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Update a lead with tracking pixel fails, unless the contact is new or anonymous. I think lead should be always editable by tracking pixel and editable fields must be managed by option `publicly updatable` in Mautic.

This solution fixes another bug: in the current version of Mautic if you map the company field with MTC tracking script, the lead is always saved, no matter whether the lead is new, anonymous or something else.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a standalone custom form with firstname and email field
2. Map it with MTC tracking script `https://www.mautic.org/docs/en/contacts/contact_monitoring.html`
3. Mautic fields must be publicly updatable
4. Send form, contact is created in Mautic
5. Resend the same form but change the firstname, nothing appear even if field is publicly updatable

#### Steps to test this PR:
1. Apply PR
2. Resend the same form but change the firstname
3. Contact firstname is updated