### PR TITLE
Fixed fetching messages for campaign replies

### DIFF
--- a/app/bundles/EmailBundle/EventListener/ProcessReplySubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ProcessReplySubscriber.php
@@ -71,10 +71,16 @@ class ProcessReplySubscriber implements EventSubscriberInterface
      */
     public function onEmailPreFetch(ParseEmailEvent $event)
     {
-        $lastFetch = $this->cache->get(self::CACHE_KEY);
-        if ($lastFetch) {
-            $event->setCriteriaRequest(self::BUNDLE, self::FOLDER_KEY, Mailbox::CRITERIA_UID.' '.$lastFetch.':*');
+        if (!$lastFetchedUID = $this->cache->get(self::CACHE_KEY)) {
+            return;
         }
+
+        $startingUID = $lastFetchedUID + 1;
+
+        // Using * will return the last UID even if the starting UID doesn't exist so let's just use a highball number
+        $endingUID = $startingUID + 1000000000;
+
+        $event->setCriteriaRequest(self::BUNDLE, self::FOLDER_KEY, Mailbox::CRITERIA_UID." $startingUID:$endingUID");
     }
 
     /**

--- a/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -556,9 +556,19 @@ class Mailbox
      */
     public function searchMailbox($criteria = self::CRITERIA_ALL)
     {
-        $mailsIds = imap_search($this->getImapStream(), $criteria, SE_UID);
+        if (preg_match('/'.self::CRITERIA_UID.' ((\d+):(\d+|\*))/', $criteria, $matches)) {
+            // PHP imap_search does not support UID n:* so use imap_fetch_overview instead
+            $messages = imap_fetch_overview($this->getImapStream(), $matches[1], FT_UID);
 
-        return $mailsIds ? $mailsIds : [];
+            $mailIds = [];
+            foreach ($messages as $message) {
+                $mailIds[] = $message->uid;
+            }
+        } else {
+            $mailIds = imap_search($this->getImapStream(), $criteria, SE_UID);
+        }
+
+        return $mailIds ? $mailIds : [];
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5793
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The first time messages were fetched for campaign replies, the imap search "UNSEEN" was used. But subsequent calls used "UID n:*" where n is the UID of the last message processed. Turns out, PHP's implementation of imap_search does not support that criteria. This PR fixes this by using imap_fetch_overview for the UID criteria. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to Mautic's Configuration -> Email Settings and setup an IMAP account for Campaign Replies under Monitored Inboxes
2. Create a campaign that sends an email with a replies to email decision attached. Add some action to the green anchor (tag, points, whatever).
3. Add a contact to the campaign
4. Reply to the email received from the campaign; be sure to send it to the email address configured as the monitored inbox and leave the body intact
5. If testing against a self hosted install, run the command `php app/console mautic:emails:fetch`. If testing in the cloud, jobs are ran every 2 minutes
5. The campaign decision is never acknowledged

#### Steps to test this PR:
1. Repeat and the campaign decision will be acknowledged 