### PR TITLE
Give access to plugins to append to clickthrough array on trackable URLs

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -110,6 +110,14 @@ class AppKernel extends Kernel
             $this->boot();
         }
 
+        /*
+         * If we've already sent the response headers, and we have a session
+         * set in the request, set that as the session in the container.
+         */
+        if (headers_sent() && $request->getSession()) {
+            $this->getContainer()->set('session', $request->getSession());
+        }
+
         // Check for an an active db connection and die with error if unable to connect
         if (!defined('MAUTIC_INSTALLER')) {
             $db = $this->getContainer()->get('database_connection');

--- a/app/bundles/PageBundle/Event/RedirectGenerationEvent.php
+++ b/app/bundles/PageBundle/Event/RedirectGenerationEvent.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\PageBundle\Event;
+
+use Mautic\CoreBundle\Event\CommonEvent;
+use Mautic\PageBundle\Entity\Redirect;
+
+class RedirectGenerationEvent extends CommonEvent
+{
+    /**
+     * @var array
+     */
+    private $clickthrough;
+
+    /**
+     * @var Redirect
+     */
+    private $redirect;
+
+    /**
+     * @param Redirect $redirect
+     * @param array    $clickthrough
+     */
+    public function __construct(Redirect $redirect, array $clickthrough)
+    {
+        $this->redirect     = $redirect;
+        $this->clickthrough = $clickthrough;
+    }
+
+    /**
+     * Set or overwrite a value in the clickthrough.
+     *
+     * @param string $key
+     * @param mixed  $value
+     */
+    public function setInClickthrough($key, $value)
+    {
+        $this->clickthrough[$key] = $value;
+    }
+
+    /**
+     * Get the redirect from the event.
+     *
+     * @return Redirect
+     */
+    public function getRedirect()
+    {
+        return $this->redirect;
+    }
+
+    /**
+     * Get the modified clickthrough from the event.
+     *
+     * @return array
+     */
+    public function getClickthrough()
+    {
+        return $this->clickthrough;
+    }
+}

--- a/app/bundles/PageBundle/Model/RedirectModel.php
+++ b/app/bundles/PageBundle/Model/RedirectModel.php
@@ -14,6 +14,8 @@ namespace Mautic\PageBundle\Model;
 use Mautic\CoreBundle\Helper\UrlHelper;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\PageBundle\Entity\Redirect;
+use Mautic\PageBundle\Event\RedirectGenerationEvent;
+use Mautic\PageBundle\PageEvents;
 
 /**
  * Class RedirectModel.
@@ -67,6 +69,13 @@ class RedirectModel extends FormModel
      */
     public function generateRedirectUrl(Redirect $redirect, $clickthrough = [], $shortenUrl = false, $utmTags = [])
     {
+        if ($this->dispatcher->hasListeners(PageEvents::ON_REDIRECT_GENERATE)) {
+            $event = new RedirectGenerationEvent($redirect, $clickthrough);
+            $this->dispatcher->dispatch(PageEvents::ON_REDIRECT_GENERATE, $event);
+
+            $clickthrough = $event->getClickthrough();
+        }
+
         $url = $this->buildUrl(
             'mautic_url_redirect',
             ['redirectId' => $redirect->getRedirectId()],

--- a/app/bundles/PageBundle/PageEvents.php
+++ b/app/bundles/PageBundle/PageEvents.php
@@ -119,4 +119,12 @@ final class PageEvents
      * @var string
      */
     const ON_CAMPAIGN_TRIGGER_ACTION = 'mautic.page.on_campaign_trigger_action';
+
+    /**
+     * The mautic.page.on_redirect_generate event is fired when generating a redirect.
+     *
+     * The event listener receives a
+     * Mautic\PageBundle\Event\RedirectGenerationEvent
+     */
+    const ON_REDIRECT_GENERATE = 'mautic.page.on_redirect_generate';
 }

--- a/app/bundles/PageBundle/Tests/Model/RedirectModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/RedirectModelTest.php
@@ -11,8 +11,14 @@
 
 namespace Mautic\PageBundle\Tests\Model;
 
+use Mautic\CoreBundle\Helper\UrlHelper;
 use Mautic\PageBundle\Entity\Redirect;
+use Mautic\PageBundle\Event\RedirectGenerationEvent;
+use Mautic\PageBundle\Model\RedirectModel;
+use Mautic\PageBundle\PageEvents;
 use Mautic\PageBundle\Tests\PageTestAbstract;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class RedirectModelTest extends PageTestAbstract
 {
@@ -34,5 +40,44 @@ class RedirectModelTest extends PageTestAbstract
         $url           = $redirectModel->generateRedirectUrl($redirect);
 
         $this->assertContains($url, 'http://some-url.com');
+    }
+
+    public function testRedirectGenerationEvent()
+    {
+        $urlHelper = $this
+            ->getMockBuilder(UrlHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $model = new RedirectModel($urlHelper);
+
+        $dispatcher = new EventDispatcher();
+        $model->setDispatcher($dispatcher);
+
+        $url          = 'https://mautic.org';
+        $clickthrough = ['foo' => 'bar'];
+
+        $router = $this->createMock(Router::class);
+        $router->expects($this->exactly(2))
+            ->method('generate')
+            ->willReturn($url);
+        $model->setRouter($router);
+
+        $redirect = new Redirect();
+        $redirect->setUrl($url);
+
+        // URL should just have foo = bar in the CT
+        $url = $model->generateRedirectUrl($redirect, $clickthrough);
+        $this->assertEquals('https://mautic.org?ct=YToxOntzOjM6ImZvbyI7czozOiJiYXIiO30%3D', $url);
+
+        // Add the listener to append something else to the CT
+        $dispatcher->addListener(
+            PageEvents::ON_REDIRECT_GENERATE,
+            function (RedirectGenerationEvent $event) {
+                $event->setInClickthrough('bar', 'foo');
+            }
+        );
+        $url = $model->generateRedirectUrl($redirect, $clickthrough);
+        $this->assertEquals('https://mautic.org?ct=YToyOntzOjM6ImZvbyI7czozOiJiYXIiO3M6MzoiYmFyIjtzOjM6ImZvbyI7fQ%3D%3D', $url);
     }
 }

--- a/index.php
+++ b/index.php
@@ -29,6 +29,9 @@ $loader = require_once __DIR__.'/app/autoload.php';
 \Mautic\CoreBundle\ErrorHandler\ErrorHandler::register('prod');
 
 $kernel = new AppKernel('prod', false);
-$kernel->loadClassCache();
+
+if (version_compare(PHP_VERSION, '7.0.0', '<')) {
+    $kernel->loadClassCache();
+}
 
 Stack\run((new MiddlewareBuilder('prod'))->resolve($kernel));

--- a/index_dev.php
+++ b/index_dev.php
@@ -29,6 +29,5 @@ if (extension_loaded('apc') && in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', 
 \Mautic\CoreBundle\ErrorHandler\ErrorHandler::register('dev');
 
 $kernel = new AppKernel('dev', true);
-$kernel->loadClassCache();
 
 Stack\run((new MiddlewareBuilder('dev'))->resolve($kernel));


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | y
| Automated tests included? | y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

**Contributed by the engineering team of Mautic, Inc.**

[//]: # ( Required: )
#### Description:
This simply gives plugins access through a new event to append custom click through variables to redirects/click tracking URLs.

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Run the new unit test
2. Send an email to a contact with a link and ensure click tracking still works
