### PR TITLE
Add support to process Momentum webhooks in the backend via supported queue protocols

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -111,6 +111,20 @@ return [
                     'mautic.helper.message',
                 ],
             ],
+            'mautic.email.queue.subscriber' => [
+                'class'     => \Mautic\EmailBundle\EventListener\QueueSubscriber::class,
+                'arguments' => [
+                    'mautic.email.model.email',
+                ],
+            ],
+            'mautic.email.momentum.subscriber' => [
+                'class'     => \Mautic\EmailBundle\EventListener\MomentumSubscriber::class,
+                'arguments' => [
+                    'mautic.transport.momentum.callback',
+                    'mautic.queue.service',
+                    'mautic.email.helper.request.storage',
+                ],
+            ],
             'mautic.email.monitored.bounce.subscriber' => [
                 'class'     => \Mautic\EmailBundle\EventListener\ProcessBounceSubscriber::class,
                 'arguments' => [
@@ -654,6 +668,12 @@ return [
                 'class'     => \Mautic\EmailBundle\Stat\StatHelper::class,
                 'arguments' => [
                     'mautic.email.repository.stat',
+                ],
+            ],
+            'mautic.email.helper.request.storage' => [
+                'class'     => \Mautic\EmailBundle\Helper\RequestStorageHelper::class,
+                'arguments' => [
+                    'mautic.helper.cache_storage',
                 ],
             ],
         ],

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -17,6 +17,7 @@ use Mautic\CoreBundle\Helper\TrackingPixelHelper;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Event\EmailSendEvent;
+use Mautic\EmailBundle\Event\TransportWebhookEvent;
 use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\EmailBundle\Swiftmailer\Transport\CallbackTransportInterface;
@@ -413,7 +414,8 @@ class PublicController extends CommonFormController
                     $model->processMailerCallback($response);
                 }
             } elseif ($currentTransport instanceof CallbackTransportInterface) {
-                $currentTransport->processCallbackRequest($this->request);
+                $event = new TransportWebhookEvent($currentTransport, $this->request);
+                $this->dispatcher->dispatch(EmailEvents::ON_TRANSPORT_WEBHOOK, $event);
             }
 
             return new Response('success');

--- a/app/bundles/EmailBundle/EmailEvents.php
+++ b/app/bundles/EmailBundle/EmailEvents.php
@@ -224,4 +224,14 @@ final class EmailEvents
      * @var string
      */
     const ON_CAMPAIGN_TRIGGER_ACTION = 'mautic.email.on_campaign_trigger_action';
+
+    /**
+     * The mautic.email.on_transport_webhook event is fired when an email transport service sends Mautic a webhook request.
+     *
+     * The event listener receives a
+     * Mautic\EmailBundle\Event\TransportWebhookEvent
+     *
+     * @var string
+     */
+    const ON_TRANSPORT_WEBHOOK = 'mautic.email.on_transport_webhook';
 }

--- a/app/bundles/EmailBundle/Event/TransportWebhookEvent.php
+++ b/app/bundles/EmailBundle/Event/TransportWebhookEvent.php
@@ -55,4 +55,16 @@ class TransportWebhookEvent extends Event
     {
         $this->request = $request;
     }
+
+    /**
+     * Checks if the event is for specific transport.
+     *
+     * @param string $transportClassName
+     *
+     * @return bool
+     */
+    public function transportIsInstanceOf($transportClassName)
+    {
+        return $this->transport instanceof $transportClassName;
+    }
 }

--- a/app/bundles/EmailBundle/Event/TransportWebhookEvent.php
+++ b/app/bundles/EmailBundle/Event/TransportWebhookEvent.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Event;
+
+use Mautic\EmailBundle\Swiftmailer\Transport\CallbackTransportInterface;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Event triggered when a transport service send Mautic a webhook request.
+ */
+class TransportWebhookEvent extends Event
+{
+    /**
+     * @var CallbackTransportInterface
+     */
+    private $transport;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @param CallbackTransportInterface $transport
+     * @param Request                    $request
+     */
+    public function __construct(CallbackTransportInterface $transport, Request $request)
+    {
+        $this->transport = $transport;
+        $this->request   = $request;
+    }
+
+    /**
+     * @return CallbackTransportInterface
+     */
+    public function getTransport()
+    {
+        return $this->transport;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        $this->request = $request;
+    }
+}

--- a/app/bundles/EmailBundle/EventListener/MomentumSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/MomentumSubscriber.php
@@ -92,10 +92,10 @@ class MomentumSubscriber extends CommonSubscriber
      */
     public function onMomentumWebhookRequest(TransportWebhookEvent $event)
     {
-        if ($this->queueService->isQueueEnabled()) {
+        $transport = MomentumTransport::class;
+        if ($this->queueService->isQueueEnabled() && $event->transportIsInstanceOf($transport)) {
             // Beanstalk jobs are limited to 65,535 kB. Momentum can send up to 10.000 items per request.
             // One item has about 1,6 kB. Lets store the request to the cache storage instead of the job itself.
-            $transport = MomentumTransport::class;
             $key       = $this->requestStorageHelper->storeRequest($transport, $event->getRequest());
             $this->queueService->publishToQueue(QueueName::TRANSPORT_WEBHOOK, ['transport' => $transport, 'key' => $key]);
             $event->stopPropagation();

--- a/app/bundles/EmailBundle/EventListener/MomentumSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/MomentumSubscriber.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\EventListener;
+
+use Mautic\CoreBundle\EventListener\CommonSubscriber;
+use Mautic\EmailBundle\EmailEvents;
+use Mautic\EmailBundle\Event\TransportWebhookEvent;
+use Mautic\EmailBundle\Helper\RequestStorageHelper;
+use Mautic\EmailBundle\Swiftmailer\Momentum\Callback\MomentumCallbackInterface;
+use Mautic\EmailBundle\Swiftmailer\Transport\MomentumTransport;
+use Mautic\QueueBundle\Event\QueueConsumerEvent;
+use Mautic\QueueBundle\Queue\QueueConsumerResults;
+use Mautic\QueueBundle\Queue\QueueName;
+use Mautic\QueueBundle\Queue\QueueService;
+use Mautic\QueueBundle\QueueEvents;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Listeners specific for Momentum transport.
+ */
+class MomentumSubscriber extends CommonSubscriber
+{
+    /**
+     * @var MomentumCallbackInterface
+     */
+    protected $momentumCallback;
+
+    /**
+     * @var QueueService
+     */
+    private $queueService;
+
+    /**
+     * @var RequestStorageHelper
+     */
+    private $requestStorageHelper;
+
+    /**
+     * @param MomentumCallbackInterface $momentumCallback
+     * @param QueueService              $queueService
+     * @param RequestStorageHelper      $requestStorageHelper
+     */
+    public function __construct(
+        MomentumCallbackInterface $momentumCallback,
+        QueueService $queueService,
+        RequestStorageHelper $requestStorageHelper
+    ) {
+        $this->momentumCallback     = $momentumCallback;
+        $this->queueService         = $queueService;
+        $this->requestStorageHelper = $requestStorageHelper;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            QueueEvents::TRANSPORT_WEBHOOK    => ['onMomentumWebhookQueueProcessing', 0],
+            EmailEvents::ON_TRANSPORT_WEBHOOK => ['onMomentumWebhookRequest', 0],
+        ];
+    }
+
+    /**
+     * Webhook handling specific to Momentum transport.
+     *
+     * @param QueueConsumerEvent $event
+     */
+    public function onMomentumWebhookQueueProcessing(QueueConsumerEvent $event)
+    {
+        if ($event->checkTransport(MomentumTransport::class)) {
+            $payload = $event->getPayload();
+            $key     = $payload['key'];
+            $request = $this->requestStorageHelper->getRequest($key);
+            $this->momentumCallback->processCallbackRequest($request);
+            $this->requestStorageHelper->deleteCachedRequest($key);
+            $event->setResult(QueueConsumerResults::ACKNOWLEDGE);
+        }
+    }
+
+    /**
+     * @param TransportWebhookEvent $event
+     */
+    public function onMomentumWebhookRequest(TransportWebhookEvent $event)
+    {
+        if ($this->queueService->isQueueEnabled()) {
+            // Beanstalk jobs are limited to 65,535 kB. Momentum can send up to 10.000 items per request.
+            // One item has about 1,6 kB. Lets store the request to the cache storage instead of the job itself.
+            $transport = MomentumTransport::class;
+            $key       = $this->requestStorageHelper->storeRequest($transport, $event->getRequest());
+            $this->queueService->publishToQueue(QueueName::TRANSPORT_WEBHOOK, ['transport' => $transport, 'key' => $key]);
+            $event->stopPropagation();
+        }
+
+        // If the queue processing is disabled do nothing and let the default listener to process immediately
+    }
+}

--- a/app/bundles/EmailBundle/EventListener/QueueSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/QueueSubscriber.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\EventListener;
+
+use Mautic\CoreBundle\EventListener\CommonSubscriber;
+use Mautic\EmailBundle\Model\EmailModel;
+use Mautic\QueueBundle\Event\QueueConsumerEvent;
+use Mautic\QueueBundle\Queue\QueueConsumerResults;
+use Mautic\QueueBundle\QueueEvents;
+
+/**
+ * Proceses queue (Beanstalk, RabitMQ, ...) jobs.
+ */
+class QueueSubscriber extends CommonSubscriber
+{
+    /**
+     * @var EmailModel
+     */
+    protected $emailModel;
+
+    /**
+     * @param EmailModel $emailModel
+     */
+    public function __construct(EmailModel $emailModel)
+    {
+        $this->emailModel = $emailModel;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            QueueEvents::EMAIL_HIT => ['onEmailHit', 0],
+        ];
+    }
+
+    /**
+     * @param QueueConsumerEvent $event
+     */
+    public function onEmailHit(QueueConsumerEvent $event)
+    {
+        $payload = $event->getPayload();
+        $this->emailModel->hitEmail($payload['idHash'], $payload['request'], false, false);
+        $event->setResult(QueueConsumerResults::ACKNOWLEDGE);
+    }
+}

--- a/app/bundles/EmailBundle/Helper/RequestStorageHelper.php
+++ b/app/bundles/EmailBundle/Helper/RequestStorageHelper.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Helper;
+
+use Mautic\CoreBundle\Helper\CacheStorageHelper;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Helper class for storing request payload to a cache location and retrieving it back as a Request.
+ */
+class RequestStorageHelper
+{
+    /**
+     * Separator between the transport class name and random hash.
+     */
+    const KEY_SEPARATOR = ':webhook_request:';
+
+    /**
+     * @var CacheStorageHelper
+     */
+    private $cacheStorage;
+
+    /**
+     * @param CacheStorageHelper $cacheStorage
+     */
+    public function __construct(CacheStorageHelper $cacheStorage)
+    {
+        $this->cacheStorage = $cacheStorage;
+    }
+
+    /**
+     * Stores the request content into cache and returns the unique key under which it's stored.
+     *
+     * @param string  $transportName
+     * @param Request $request
+     *
+     * @return string
+     */
+    public function storeRequest($transportName, Request $request)
+    {
+        $key = $this->getUniqueCacheHash($transportName);
+
+        $this->cacheStorage->set($key, $request->request->all());
+
+        return $key;
+    }
+
+    /**
+     * Creates new Request with the original payload.
+     *
+     * @param string $key
+     *
+     * @return Request
+     */
+    public function getRequest($key)
+    {
+        return new Request([], $this->cacheStorage->get($key));
+    }
+
+    /**
+     * @param string $key
+     */
+    public function deleteCachedRequest($key)
+    {
+        $this->cacheStorage->delete($key);
+    }
+
+    /**
+     * Reads the transport class name path from the key.
+     *
+     * @param string $key
+     *
+     * @return string
+     */
+    public function getTransportNameFromKey($key)
+    {
+        list($transportName) = explode(self::KEY_SEPARATOR, $key);
+
+        return $transportName;
+    }
+
+    /**
+     * Generates unique hash in format $transportName:webhook_request:unique.hash.
+     *
+     * @param string $transportName
+     *
+     * @return string
+     *
+     * @throws \LengthException
+     */
+    private function getUniqueCacheHash($transportName)
+    {
+        $key       = uniqid($transportName.self::KEY_SEPARATOR, true);
+        $keyLength = strlen($key);
+
+        if ($keyLength > 255) {
+            throw new \LengthException(sprintf('Key %s must be shorter than 256 characters. It has %d characters', $key, $keyLength));
+        }
+
+        return $key;
+    }
+}

--- a/app/bundles/EmailBundle/Tests/EventListener/MomentumSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MomentumSubscriberTest.php
@@ -123,6 +123,10 @@ class MomentumSubscriberTest extends \PHPUnit_Framework_TestCase
             ->method('getRequest')
             ->willReturn($request);
 
+        $transportWebhookEvent->expects($this->once())
+            ->method('transportIsInstanceOf')
+            ->willReturn(true);
+
         $this->requestStorageHelperMock->expects($this->once())
             ->method('storeRequest')
             ->with(MomentumTransport::class, $request)

--- a/app/bundles/EmailBundle/Tests/EventListener/MomentumSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MomentumSubscriberTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Test\EventListener;
+
+use Mautic\EmailBundle\Event\TransportWebhookEvent;
+use Mautic\EmailBundle\EventListener\MomentumSubscriber;
+use Mautic\EmailBundle\Helper\RequestStorageHelper;
+use Mautic\EmailBundle\Swiftmailer\Momentum\Callback\MomentumCallbackInterface;
+use Mautic\EmailBundle\Swiftmailer\Transport\MomentumTransport;
+use Mautic\QueueBundle\Event\QueueConsumerEvent;
+use Mautic\QueueBundle\Queue\QueueConsumerResults;
+use Mautic\QueueBundle\Queue\QueueName;
+use Mautic\QueueBundle\Queue\QueueService;
+use Symfony\Component\HttpFoundation\Request;
+
+class MomentumSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    private $queueServiceMock;
+    private $momentumCallbackMock;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->momentumCallbackMock     = $this->createMock(MomentumCallbackInterface::class);
+        $this->queueServiceMock         = $this->createMock(QueueService::class);
+        $this->requestStorageHelperMock = $this->createMock(RequestStorageHelper::class);
+        $this->momentumSubscriber       = new MomentumSubscriber($this->momentumCallbackMock, $this->queueServiceMock, $this->requestStorageHelperMock);
+    }
+
+    public function testOnMomentumWebhookQueueProcessingForNonMomentumTransport()
+    {
+        $queueConsumerEvent = $this->createMock(QueueConsumerEvent::class);
+
+        $queueConsumerEvent->expects($this->once())
+        ->method('checkTransport')
+        ->with(MomentumTransport::class)
+        ->willReturn(false);
+
+        $queueConsumerEvent->expects($this->never())
+            ->method('getPayload');
+
+        $this->momentumCallbackMock->expects($this->never())
+            ->method('processCallbackRequest');
+
+        $queueConsumerEvent->expects($this->never())
+            ->method('setResult');
+
+        $this->momentumSubscriber->onMomentumWebhookQueueProcessing($queueConsumerEvent);
+    }
+
+    public function testOnMomentumWebhookQueueProcessingForMomentumTransport()
+    {
+        $queueConsumerEvent = $this->createMock(QueueConsumerEvent::class);
+
+        $queueConsumerEvent->expects($this->once())
+            ->method('getPayload')
+            ->willReturn([
+                'transport' => MomentumTransport::class,
+                'key'       => 'value',
+            ]);
+
+        $queueConsumerEvent->expects($this->once())
+            ->method('checkTransport')
+            ->with(MomentumTransport::class)
+            ->willReturn(true);
+
+        $this->requestStorageHelperMock->expects($this->once())
+            ->method('getRequest')
+            ->with('value')
+            ->willReturn(new Request([], ['request' => 'value']));
+
+        $this->momentumCallbackMock->expects($this->once())
+            ->method('processCallbackRequest')
+            ->with($this->callback(function ($request) {
+                $requestValues = $request->request->all();
+                $this->assertEquals(['request' => 'value'], $requestValues);
+
+                return true;
+            }));
+
+        $queueConsumerEvent->expects($this->once())
+            ->method('setResult')
+            ->with(QueueConsumerResults::ACKNOWLEDGE);
+
+        $this->momentumSubscriber->onMomentumWebhookQueueProcessing($queueConsumerEvent);
+    }
+
+    public function testOnMomentumWebhookRequestWhenQueueIsDisabled()
+    {
+        $transportWebhookEvent = $this->createMock(TransportWebhookEvent::class);
+
+        $this->queueServiceMock->expects($this->once())
+            ->method('isQueueEnabled')
+            ->willReturn(false);
+
+        $transportWebhookEvent->expects($this->never())
+            ->method('getRequest');
+
+        $this->momentumSubscriber->onMomentumWebhookRequest($transportWebhookEvent);
+    }
+
+    public function testOnMomentumWebhookRequestWhenQueueIsEnabled()
+    {
+        $transportWebhookEvent = $this->createMock(TransportWebhookEvent::class);
+        $request               = new Request([], ['one', 'two', 'three']);
+        $key                   = 'Mautic\EmailBundle\Swiftmailer\Transport\MomentumTransport:webhook_request:5b43832134cfb0.36545510';
+
+        $this->queueServiceMock->expects($this->once())
+            ->method('isQueueEnabled')
+            ->willReturn(true);
+
+        $transportWebhookEvent->expects($this->once())
+            ->method('getRequest')
+            ->willReturn($request);
+
+        $this->requestStorageHelperMock->expects($this->once())
+            ->method('storeRequest')
+            ->with(MomentumTransport::class, $request)
+            ->willReturn($key);
+
+        $this->queueServiceMock->expects($this->once())
+            ->method('publishToQueue')
+            ->with(QueueName::TRANSPORT_WEBHOOK, ['transport' => MomentumTransport::class, 'key' => $key]);
+
+        $transportWebhookEvent->expects($this->once())
+            ->method('stopPropagation');
+
+        $this->momentumSubscriber->onMomentumWebhookRequest($transportWebhookEvent);
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Helper;
+
+use Mautic\CoreBundle\Helper\CacheStorageHelper;
+use Mautic\EmailBundle\Helper\RequestStorageHelper;
+use Mautic\EmailBundle\Swiftmailer\Transport\MomentumTransport;
+use Symfony\Component\HttpFoundation\Request;
+
+class RequestStorageHelperTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->cacheStorageMock = $this->createMock(CacheStorageHelper::class);
+        $this->helper           = new RequestStorageHelper($this->cacheStorageMock);
+    }
+
+    public function testStoreRequest()
+    {
+        $payload = ['some' => 'values'];
+
+        $this->cacheStorageMock->expects($this->once())
+            ->method('set')
+            ->with($this->anything(), $payload);
+
+        $key = $this->helper->storeRequest(MomentumTransport::class, new Request([], $payload));
+
+        $this->assertStringStartsWith(MomentumTransport::class, $key);
+        $this->assertEquals(98, strlen($key));
+    }
+
+    public function testStoreRequestWithLongTansportName()
+    {
+        $payload           = ['some' => 'values'];
+        $longTransportName = '';
+
+        for ($i = 0; $i < 5; ++$i) {
+            $longTransportName .= MomentumTransport::class;
+        }
+
+        $this->cacheStorageMock->expects($this->never())
+            ->method('set');
+
+        $this->expectException(\LengthException::class);
+        $key = $this->helper->storeRequest($longTransportName, new Request([], $payload));
+    }
+
+    public function testGetRequest()
+    {
+        $payload = ['some' => 'values'];
+        $key     = MomentumTransport::class.':webhook_request:5b43832134cfb0.36545510';
+
+        $this->cacheStorageMock->expects($this->once())
+            ->method('get')
+            ->with($key)
+            ->willReturn($payload);
+
+        $request = $this->helper->getRequest($key);
+
+        $this->assertInstanceOf(Request::class, $request);
+        $this->assertEquals($payload, $request->request->all());
+    }
+
+    public function testGetTransportNameFromKey()
+    {
+        $this->assertEquals(MomentumTransport::class, $this->helper->getTransportNameFromKey('Mautic\EmailBundle\Swiftmailer\Transport\MomentumTransport:webhook_request:5b43832134cfb0.36545510'));
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/Momentum/Callback/MomentumCallbackTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/Momentum/Callback/MomentumCallbackTest.php
@@ -20,9 +20,7 @@ class MomentumTransportTest extends \PHPUnit_Framework_TestCase
 {
     public function testWebhookPayloadIsProcessed()
     {
-        $transportCallback = $this->getMockBuilder(TransportCallback::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $transportCallback = $this->createMock(TransportCallback::class);
 
         $transportCallback->expects($this->exactly(6))
             ->method('addFailureByHashId')
@@ -38,11 +36,7 @@ class MomentumTransportTest extends \PHPUnit_Framework_TestCase
 
         $transportCallback->expects($this->once())
             ->method('addFailureByAddress')
-            ->with(
-                'bounce@example.com',
-                'MAIL REFUSED - IP (17.99.99.99) is in black list',
-                DoNotContact::BOUNCED
-            );
+            ->with('bounce@example.com', 'MAIL REFUSED - IP (17.99.99.99) is in black list', DoNotContact::BOUNCED);
 
         $momentumCallback = new MomentumCallback($transportCallback);
 

--- a/app/bundles/QueueBundle/Event/QueueConsumerEvent.php
+++ b/app/bundles/QueueBundle/Event/QueueConsumerEvent.php
@@ -58,4 +58,16 @@ class QueueConsumerEvent extends CommonEvent
     {
         $this->result = $result;
     }
+
+    /**
+     * Checks if the event is for specific transport.
+     *
+     * @param string $transport
+     *
+     * @return bool
+     */
+    public function checkTransport($transport)
+    {
+        return isset($this->payload['transport']) && $this->payload['transport'] === $transport;
+    }
 }

--- a/app/bundles/QueueBundle/Queue/QueueName.php
+++ b/app/bundles/QueueBundle/Queue/QueueName.php
@@ -16,6 +16,7 @@ namespace Mautic\QueueBundle\Queue;
  */
 final class QueueName
 {
-    const EMAIL_HIT = 'email_hit';
-    const PAGE_HIT  = 'page_hit';
+    const EMAIL_HIT         = 'email_hit';
+    const PAGE_HIT          = 'page_hit';
+    const TRANSPORT_WEBHOOK = 'transport_webhook';
 }

--- a/app/bundles/QueueBundle/QueueEvents.php
+++ b/app/bundles/QueueBundle/QueueEvents.php
@@ -26,4 +26,6 @@ final class QueueEvents
     const EMAIL_HIT = 'mautic.queue_email_hit';
 
     const PAGE_HIT = 'mautic.queue_page_hit';
+
+    const TRANSPORT_WEBHOOK = 'mautic.queue_transport_webhook';
 }

--- a/app/bundles/QueueBundle/Tests/Event/QueueConsumerEventTest.php
+++ b/app/bundles/QueueBundle/Tests/Event/QueueConsumerEventTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\QueueBundle\Tests\Event;
+
+use Mautic\QueueBundle\Event\QueueConsumerEvent;
+
+class QueueConsumerEventTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCheckTransportIfNoTransport()
+    {
+        $queueConsumerEvent = new QueueConsumerEvent();
+        $this->assertEquals(false, $queueConsumerEvent->checkTransport('transportName'));
+    }
+
+    public function testCheckTransportIfWrongTransport()
+    {
+        $queueConsumerEvent = new QueueConsumerEvent(['transport' => 'wrongTransportName']);
+        $this->assertEquals(false, $queueConsumerEvent->checkTransport('transportName'));
+    }
+
+    public function testCheckTransportIfCorrectTransport()
+    {
+        $queueConsumerEvent = new QueueConsumerEvent(['transport' => 'transportName']);
+        $this->assertEquals(true, $queueConsumerEvent->checkTransport('transportName'));
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Y
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

**Contributed by the engineering team of Mautic, Inc.**


[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Momentum transport webhooks only allow a certain number of seconds (~6) before it breaks off communication. If there is a large batch of events to process, the web request may terminate before Mautic can finish marking everyone as DNC. The service may attempt to send the webhooks again but they'll still fail as Mautic processes the same number of contacts before again having the request terminated. 

This change takes advantage of Mautic's queue protocol support (RabbitMq or Beanstalkd) to process webhook payloads outside the web request. 

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Setup and enable one of the supported queue protocols. https://www.mautic.org/docs/en/queue/index.html
1. Setup a Momentum webhook

The webhook should be queued to be processed by the protocl service. Once processed, contacts should be marked as DNC. 