### PR TITLE
Fixed correctly determining blank CSV row for contact import

### DIFF
--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -518,7 +518,7 @@ class ImportModel extends FormModel
             return true;
         }
 
-        return false;
+        return !array_filter($row);
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N 
| Automated tests included? | N
| Related user documentation PR URL |  N/A
| Related developer documentation PR URL | N/A 
| Issues addressed (#s or URLs) | 

| BC breaks? | N/A
| Deprecations? | N/A

**Contributed by the engineering team of Mautic, Inc.**

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Importing contacts by a CSV file containing blank rows would result in successful import, but the percentage of that import process would be incorrect as it was not considering blank rows correctly. 

For example, for the attached CSV file it would show 66.67% completed after the import as there are 4 rows that needs to be ignored (3 empty, 1 header) but it just ignores the header row and not the blank rows. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Attempt to import the attached CSV file in contacts. 
2. After the completion it would show the incorrect results as stated in the description. 

#### Steps to test this PR:
1. Follow the same steps as to reproduce the bugs and it should work without the bug. 

[test.csv.zip](https://github.com/mautic/mautic/files/2237202/test.csv.zip)

