### PR TITLE
Prevent CSV import of non-UTF8 file

### DIFF
--- a/app/bundles/CoreBundle/Form/Validator/Constraints/FileEncoding.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/FileEncoding.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Form\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+class FileEncoding extends Constraint
+{
+    public $encodingFormatMessage = 'mautic.core.invalid_file_encoding';
+    public $encodingFormat        = '[UTF-8]';
+
+    public function validatedBy()
+    {
+        return FileEncodingValidator::class;
+    }
+}

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/FileEncodingValidator.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/FileEncodingValidator.php
@@ -26,10 +26,20 @@ class FileEncodingValidator extends ConstraintValidator
      */
     public function validate($field, Constraint $constraint)
     {
-        if ($field->getPathname() != null) {
-            if (!mb_check_encoding(file_get_contents($field->getPathname()), 'UTF-8')) {
-                $this->context->addViolation($constraint->encodingFormatMessage, ['%keyword%' => $field->getClientOriginalName()]);
-            }
+        /*
+            If the file uploaded exceeds the max size, it will not be considered,
+            and the file path will be an empty string "". If that is the case
+            no further checks are required. Just return.
+        */
+        if ($field->getPathname() === '' || $field->getPathname() === null) {
+            return;
+        }
+
+        /*
+            If file is below the max size then only check for UTF-8 encoding.
+        */
+        if (!mb_check_encoding(file_get_contents($field->getPathname()), 'UTF-8')) {
+            $this->context->addViolation($constraint->encodingFormatMessage, ['%keyword%' => $field->getClientOriginalName()]);
         }
     }
 }

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/FileEncodingValidator.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/FileEncodingValidator.php
@@ -26,8 +26,10 @@ class FileEncodingValidator extends ConstraintValidator
      */
     public function validate($field, Constraint $constraint)
     {
-        if (!mb_check_encoding(file_get_contents($field->getPathname()), 'UTF-8')) {
-            $this->context->addViolation($constraint->encodingFormatMessage, ['%keyword%' => $field->getClientOriginalName()]);
+        if ($field->getPathname() != null) {
+            if (!mb_check_encoding(file_get_contents($field->getPathname()), 'UTF-8')) {
+                $this->context->addViolation($constraint->encodingFormatMessage, ['%keyword%' => $field->getClientOriginalName()]);
+            }
         }
     }
 }

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/FileEncodingValidator.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/FileEncodingValidator.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Form\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Throws an exception if the field alias is equal some segment filter keyword.
+ * It would cause odd behavior with segment filters otherwise.
+ */
+class FileEncodingValidator extends ConstraintValidator
+{
+    /**
+     * @param LeadField  $field
+     * @param Constraint $constraint
+     */
+    public function validate($field, Constraint $constraint)
+    {
+        if (!mb_check_encoding(file_get_contents($field->getPathname()), 'UTF-8')) {
+            $this->context->addViolation($constraint->encodingFormatMessage, ['%keyword%' => $field->getClientOriginalName()]);
+        }
+    }
+}

--- a/app/bundles/CoreBundle/Translations/en_US/validators.ini
+++ b/app/bundles/CoreBundle/Translations/en_US/validators.ini
@@ -13,5 +13,6 @@ mautic.core.theme.default.cannot.overwrite="%name% is the default theme and ther
 mautic.core.valid_url_required="A valid URL is required."
 mautic.core.theme.upload.empty="The file was not selected. Select a ZIP file to upload."
 mautic.core.invalid_file_type="Invalid file type {{ type }}. Use a file that matches one of the following mime types: {{ types }}."
+mautic.core.invalid_file_encoding="The file is not encoded correctly into UTF-8."
 mautic.core.not.allowed.file.extension="%extension% is not an allowed file extension"
 mautic.core.regex.invalid="The regex syntax is invalid."

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -725,6 +725,14 @@ return [
                     'mautic.helper.field.alias',
                 ],
             ],
+            \Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class => [
+                'class'     => \Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class,
+                'tag'       => 'validator.constraint_validator',
+                'arguments' => [
+                    'mautic.lead.model.list',
+                    'mautic.helper.field.alias',
+                ],
+            ],
             'mautic.lead.constraint.alias' => [
                 'class'     => 'Mautic\LeadBundle\Form\Validator\Constraints\UniqueUserAliasValidator',
                 'arguments' => ['mautic.factory'],

--- a/app/bundles/LeadBundle/Form/Type/LeadImportType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadImportType.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\LeadBundle\Form\Type;
 
+use Mautic\CoreBundle\Form\Validator\Constraints\FileEncoding as EncodingValidation;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\File;
@@ -40,6 +41,12 @@ class LeadImportType extends AbstractType
                         [
                             'mimeTypes'        => ['text/csv', 'text/plain'],
                             'mimeTypesMessage' => 'mautic.core.invalid_file_type',
+                        ]
+                    ),
+                    new EncodingValidation(
+                        [
+                            'encodingFormat'        => ['UTF-8'],
+                            'encodingFormatMessage' => 'mautic.core.invalid_file_encoding',
                         ]
                     ),
                 ],


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A 
| Issues addressed (#s or URLs) | https://github.com/mautic-inc/mautic-internal/issues/26
| BC breaks? | N/A
| Deprecations? | N/A

**Contributed by the engineering team of Mautic, Inc.**

[//]: # ( Required: )
#### Description:

When a CSV that is not UTF8 is imported, the import may just fail without a reason making it hard to determine why and assuming something is wrong with the importer. This PR simply validates if the file is UTF8 and if not, prevents the import.  

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Attempt to upload the attached CSV named non_utf.csv. 
2. After matching the fields with Mautic, when pressed import in browser button and attempt to upload the CSV, it doesn't work and in network it provides internal server error.
3. Import the utf8.csv file and try to import. This time it will work. 

#### Steps to test this PR:
1. Repeat the same steps as to reproduce the bug and it should throw an error and preventing the import of CSV.

[csvs.zip](https://github.com/mautic/mautic/files/2237239/csvs.zip)
