### PR TITLE
Improve redirects/trackable URLs by not executing methods that are not applicable

### DIFF
--- a/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
+++ b/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
@@ -595,5 +595,25 @@ namespace {
                 }
             }
         }
+
+        // Call this at each point of interest, passing a descriptive string
+        function prof_flag($str)
+        {
+            global $prof_timing, $prof_names;
+            $prof_timing[] = microtime(true);
+            $prof_names[]  = $str;
+        }
+
+        // Call this when you're done and want to see the results
+        function prof_print()
+        {
+            global $prof_timing, $prof_names;
+            $size = count($prof_timing);
+            for ($i=0; $i < $size - 1; ++$i) {
+                echo "<b>{$prof_names[$i]}</b><br>";
+                echo sprintf('&nbsp;&nbsp;&nbsp;%f<br>', $prof_timing[$i + 1] - $prof_timing[$i]);
+            }
+            echo "<b>{$prof_names[$size - 1]}</b><br>";
+        }
     }
 }

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -123,7 +123,6 @@ class ContactRequestHelper
     {
         $this->trackedContact = $this->contactTracker->getContact();
         $this->queryFields    = $queryFields;
-
         try {
             $foundContact         = $this->getContactFromUrl();
             $this->trackedContact = $foundContact;
@@ -163,16 +162,18 @@ class ContactRequestHelper
 
         $this->setEmailFromClickthroughIdentification($clickthrough);
 
-        /** @var Lead $foundContact */
-        list($foundContact, $this->publiclyUpdatableFieldValues) = $this->leadModel->checkForDuplicateContact(
-            $this->queryFields,
-            $this->trackedContact,
-            true,
-            true
-        );
-        if ($foundContact->getId() !== $this->trackedContact->getId()) {
-            // A contact was found by a publicly updatable field
-            return $foundContact;
+        /* @var Lead $foundContact */
+        if (!empty($this->queryFields)) {
+            list($foundContact, $this->publiclyUpdatableFieldValues) = $this->leadModel->checkForDuplicateContact(
+                $this->queryFields,
+                $this->trackedContact,
+                true,
+                true
+            );
+            if ($foundContact->getId() !== $this->trackedContact->getId()) {
+                // A contact was found by a publicly updatable field
+                return $foundContact;
+            }
         }
 
         return $this->getContactByFingerprint();
@@ -274,13 +275,15 @@ class ContactRequestHelper
             $this->trackedContact->addIpAddress($ipAddress);
         }
 
-        $this->leadModel->setFieldValues(
-            $this->trackedContact,
-            $this->publiclyUpdatableFieldValues,
-            false,
-            true,
-            true
-        );
+        if (!empty($this->publiclyUpdatableFieldValues)) {
+            $this->leadModel->setFieldValues(
+                $this->trackedContact,
+                $this->publiclyUpdatableFieldValues,
+                false,
+                true,
+                true
+            );
+        }
 
         // Assume a web request as this is likely a tracking request from DWC or tracking code
         $this->trackedContact->setManipulator(


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

**Contributed by the engineering team of Mautic, Inc.**

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This prevents making unnecessary calls to a few methods that save some milliseconds during the redirect. Namely https://github.com/mautic/mautic/compare/staging...mautic-inc:enhancement.redirect-speed-improvements?expand=1#diff-5202b885787b63440de498ce9e92c041R278 which avoids binding to Symfony forms unnecessarily knowing they are a bit expensive. 

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Test redirects and tracking still function as expected