### PR TITLE
Fix: Create new contact with default values

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -1109,6 +1109,7 @@ return [
                     'request_stack',
                     'mautic.helper.core_parameters',
                     'event_dispatcher',
+                    'mautic.lead.model.field',
                 ],
             ],
             'mautic.tracker.device' => [

--- a/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerTest.php
@@ -19,6 +19,8 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadDevice;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\LeadEvents;
+use Mautic\LeadBundle\Model\DefaultValueTrait;
+use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Mautic\LeadBundle\Tracker\DeviceTracker;
 use Mautic\LeadBundle\Tracker\Service\ContactTrackingService\ContactTrackingServiceInterface;
@@ -29,6 +31,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class ContactTrackerTest extends \PHPUnit_Framework_TestCase
 {
+    use DefaultValueTrait;
     /**
      * @var LeadRepository
      */
@@ -74,6 +77,11 @@ class ContactTrackerTest extends \PHPUnit_Framework_TestCase
      */
     private $dispatcherMock;
 
+    /**
+     * @var FieldModel
+     */
+    private $leadFieldModelMock;
+
     public function setUp()
     {
         $this->leadRepositoryMock = $this->getMockBuilder(LeadRepository::class)
@@ -113,6 +121,8 @@ class ContactTrackerTest extends \PHPUnit_Framework_TestCase
         $this->dispatcherMock = $this->getMockBuilder(EventDispatcher::class)
             ->disableOriginalConstructor()
             ->getMock();
+
+        $this->leadFieldModelMock = $this->createMock(FieldModel::class);
     }
 
     public function testSystemContactIsUsedOverTrackedContact()
@@ -231,9 +241,9 @@ class ContactTrackerTest extends \PHPUnit_Framework_TestCase
 
         $this->leadRepositoryMock->expects($this->never())
             ->method('getLeadsByIp');
+        $this->leadFieldModelMock->expects($this->any())->method('getFieldListWithProperties')->willReturn([]);
 
         $contact = $contactTracker->getContact();
-
         $this->assertEquals(true, $contact->isNewlyCreated());
     }
 
@@ -294,7 +304,8 @@ class ContactTrackerTest extends \PHPUnit_Framework_TestCase
             $this->ipLookupHelperMock,
             $this->requestStack,
             $this->coreParametersHelperMock,
-            $this->dispatcherMock
+            $this->dispatcherMock,
+            $this->leadFieldModelMock
         );
     }
 }

--- a/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerTest.php
@@ -19,7 +19,6 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadDevice;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\LeadEvents;
-use Mautic\LeadBundle\Model\DefaultValueTrait;
 use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Mautic\LeadBundle\Tracker\DeviceTracker;
@@ -31,7 +30,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class ContactTrackerTest extends \PHPUnit_Framework_TestCase
 {
-    use DefaultValueTrait;
     /**
      * @var LeadRepository
      */


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6302 & https://github.com/mautic/mautic/issues/6435
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Issue with default values If contact is created by contactTracker->createNewContact method.
This PR fixed it.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Create custom field with defaultValue 
2. Create form
3. Open private browser window  and open form page http://yourmautiurl.tld/form/idForm
4. See new created ID in anonymous contacts and see profile. No set default  custom value

#### Steps to test this PR:
1.  Repeat all steps to reprodue
2.  Anonymous  contact created with default values
