### PR TITLE
Fix writing html inside DOM with asynchronous javascript

### DIFF
--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -731,7 +731,18 @@ class FormModel extends CommonFormModel
         $replace = ['', '', '\"'];
         $html    = str_replace($search, $replace, $html);
 
-        return 'document.write("'.$html.'");';
+        // Write html for all browser and fallback for IE
+        $script = '
+            var scr = document.currentScript;
+            
+            if (scr !== undefined) {
+                scr.insertAdjacentHTML("afterend" , "'.$html.'");
+            } else {
+                document.write("'.$html.'");
+            }
+        ';
+
+        return $script;
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
document.write JS method is a bad practice and don't work with asynchronous javascript.
Condition was added to support generate.js load asynchronously.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form
2. Integrate the form with the script tag `<script type="text/javascript" src="http://mymautic.com/form/generate.js?id=1" defer></script>`
**defer** must be added to load it asynchronously
3. Nothing appears and the firefox console says : `A call to document.write() from an asynchronously-loaded external script was ignored`

#### Steps to test this PR:
1. Apply PR
2. Reload the page
3. The form appears