### PR TITLE
Update Maxmind test with a new IP

### DIFF
--- a/app/bundles/CoreBundle/Tests/unit/IpLookup/MaxmindDownloadLookupTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/IpLookup/MaxmindDownloadLookupTest.php
@@ -33,14 +33,14 @@ class MaxmindDownloadLookupTest extends \PHPUnit_Framework_TestCase
         // Keep the file contained to cache/test
         $ipService = new MaxmindDownloadLookup(null, null, __DIR__.'/../../../../../cache/test');
 
-        $details = $ipService->setIpAddress('192.30.252.131')->getDetails();
+        $details = $ipService->setIpAddress('52.52.118.192')->getDetails();
 
-        $this->assertEquals('San Francisco', $details['city']);
+        $this->assertEquals('San Jose', $details['city']);
         $this->assertEquals('California', $details['region']);
         $this->assertEquals('United States', $details['country']);
         $this->assertEquals('', $details['zipcode']);
-        $this->assertEquals('37.7697', $details['latitude']);
-        $this->assertEquals('-122.3933', $details['longitude']);
+        $this->assertEquals('37.3388', $details['latitude']);
+        $this->assertEquals('-121.8914', $details['longitude']);
         $this->assertEquals('America/Los_Angeles', $details['timezone']);
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
As of today our travis test are all failing because Github's IP is no longer resolving as San Francisco via the Maxmind Lite DB.

Switch from 192.30.252.131 to a new IP used by Amazon that should be
permanent, and is still included at City level in the Maxmind DB
download. This allows our Travis tests to succeed.
