### PR TITLE
Fix error 500 when opening tracked links on email when logged

### DIFF
--- a/app/bundles/CoreBundle/Tests/unit/IpLookup/MaxmindDownloadLookupTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/IpLookup/MaxmindDownloadLookupTest.php
@@ -33,14 +33,14 @@ class MaxmindDownloadLookupTest extends \PHPUnit_Framework_TestCase
         // Keep the file contained to cache/test
         $ipService = new MaxmindDownloadLookup(null, null, __DIR__.'/../../../../../cache/test');
 
-        $details = $ipService->setIpAddress('192.30.252.131')->getDetails();
+        $details = $ipService->setIpAddress('52.52.118.192')->getDetails();
 
-        $this->assertEquals('San Francisco', $details['city']);
+        $this->assertEquals('San Jose', $details['city']);
         $this->assertEquals('California', $details['region']);
         $this->assertEquals('United States', $details['country']);
         $this->assertEquals('', $details['zipcode']);
-        $this->assertEquals('37.7697', $details['latitude']);
-        $this->assertEquals('-122.3933', $details['longitude']);
+        $this->assertEquals('37.3388', $details['latitude']);
+        $this->assertEquals('-121.8914', $details['longitude']);
         $this->assertEquals('America/Los_Angeles', $details['timezone']);
     }
 }

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -304,7 +304,7 @@ class ContactRequestHelper
      */
     private function mergeWithTrackedContact(Lead $foundContact)
     {
-        if ($this->trackedContact->getId() && $this->trackedContact->isAnonymous()) {
+        if ($this->trackedContact && $this->trackedContact->getId() && $this->trackedContact->isAnonymous()) {
             return $this->leadModel->mergeLeads($this->trackedContact, $foundContact, false);
         }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6400
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fix error 500 when opening tracked links on email when logged in to Mautic.
Since the trackedContact can be null it was missing a condition.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create an email for a campaign and add a link with the builder
2. Create a campaign to send the mail
3. Send mail to a contact
4. Open the sent email and click on any link
5. Mautic will raise a 500 error

#### Steps to test this PR:
1. Apply the PR
2. It's now good