### PR TITLE
Cache email stats

### DIFF
--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -44,7 +44,7 @@ Mautic.emailOnLoad = function (container, response) {
                     if (response.success && response.stats) {
                         for (var i = 0; i < response.stats.length; i++) {
                             var stat = response.stats[i];
-                            if (mQuery('#sent-count-' + stat.id + ' div').length) {
+                            if (mQuery('#sent-count-' + stat.id).length) {
                                 if (stat.pending) {
                                     mQuery('#pending-' + stat.id + ' > a').html(stat.pending);
                                     mQuery('#pending-' + stat.id).removeClass('hide');

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -673,6 +673,7 @@ return [
                     'mautic.email.model.send_email_to_contacts',
                     'mautic.tracker.device',
                     'mautic.page.repository.redirect',
+                    'mautic.helper.cache_storage',
                 ],
             ],
             'mautic.email.model.send_email_to_user' => [

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -196,6 +196,16 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
      */
     private $headers = [];
 
+    /**
+     * @var int
+     */
+    private $pendingCount = 0;
+
+    /**
+     * @var int
+     */
+    private $queuedCount = 0;
+
     public function __clone()
     {
         $this->id               = null;
@@ -1149,5 +1159,37 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
         $this->publicPreview = $publicPreview;
 
         return $this;
+    }
+
+    /**
+     * @param int $count
+     */
+    public function setQueuedCount($count)
+    {
+        $this->queuedCount = $count;
+    }
+
+    /**
+     * @return int
+     */
+    public function getQueuedCount()
+    {
+        return $this->queuedCount;
+    }
+
+    /**
+     * @param int $count
+     */
+    public function setPendingCount($count)
+    {
+        $this->pendingCount = $count;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPendingCount()
+    {
+        return $this->pendingCount;
     }
 }

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -1163,10 +1163,14 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
 
     /**
      * @param int $count
+     *
+     * @return $this
      */
     public function setQueuedCount($count)
     {
         $this->queuedCount = $count;
+
+        return $this;
     }
 
     /**
@@ -1179,10 +1183,14 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
 
     /**
      * @param int $count
+     *
+     * @return $this
      */
     public function setPendingCount($count)
     {
         $this->pendingCount = $count;
+
+        return $this;
     }
 
     /**

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -969,7 +969,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         $countWithMaxMin = false
     ) {
         $variantIds = ($includeVariants) ? $email->getRelatedEntityIds() : null;
-        $total      = (int) $this->getRepository()->getEmailPendingLeads(
+        $total      = $this->getRepository()->getEmailPendingLeads(
             $email->getId(),
             $variantIds,
             $listId,
@@ -980,8 +980,16 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             $countWithMaxMin
         );
 
-        if ($total) {
-            $this->cacheStorageHelper->set(sprintf('%s|%s|%s', 'email', $email->getId(), 'pending'), $total);
+        if (!empty($total)) {
+            if ($countOnly && $countWithMaxMin) {
+                $toStore = $total['count'];
+            } elseif ($countOnly) {
+                $toStore = $total;
+            } else {
+                $toStore = count($total);
+            }
+
+            $this->cacheStorageHelper->set(sprintf('%s|%s|%s', 'email', $email->getId(), 'pending'), $toStore);
         }
 
         return $total;

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -247,7 +247,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $sendToContactModel,
             $deviceTrackerMock,
             $redirectRepositoryMock,
-            $cacheStorageHelperMock,
+            $cacheStorageHelperMock
         );
 
         $emailModel->setTranslator($translator);

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -476,6 +476,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
 
         $deviceTrackerMock      = $this->createMock(DeviceTracker::class);
         $redirectRepositoryMock = $this->createMock(RedirectRepository::class);
+        $cacheStorageHelperMock = $this->createMock(CacheStorageHelper::class);
 
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,
@@ -489,7 +490,8 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $messageModel,
             $sendToContactModel,
             $deviceTrackerMock,
-            $redirectRepositoryMock
+            $redirectRepositoryMock,
+            $cacheStorageHelperMock
         );
 
         $emailModel->setTranslator($translator);
@@ -641,6 +643,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
 
         $deviceTrackerMock      = $this->createMock(DeviceTracker::class);
         $redirectRepositoryMock = $this->createMock(RedirectRepository::class);
+        $cacheStorageHelperMock = $this->createMock(CacheStorageHelper::class);
 
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,
@@ -654,7 +657,8 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $messageModel,
             $sendToContactModel,
             $deviceTrackerMock,
-            $redirectRepositoryMock
+            $redirectRepositoryMock,
+            $cacheStorageHelperMock
         );
 
         $emailModel->setTranslator($translator);
@@ -786,6 +790,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
 
         $deviceTrackerMock      = $this->createMock(DeviceTracker::class);
         $redirectRepositoryMock = $this->createMock(RedirectRepository::class);
+        $cacheStorageHelperMock = $this->createMock(CacheStorageHelper::class);
 
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,
@@ -799,7 +804,8 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $messageModel,
             $sendToContactModel,
             $deviceTrackerMock,
-            $redirectRepositoryMock
+            $redirectRepositoryMock,
+            $cacheStorageHelperMock
         );
 
         $emailModel->setTranslator($translator);
@@ -910,6 +916,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
         $deviceTrackerMock  = $this->createMock(DeviceTracker::class);
 
         $redirectRepositoryMock = $this->createMock(RedirectRepository::class);
+        $cacheStorageHelperMock = $this->createMock(CacheStorageHelper::class);
 
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,
@@ -923,7 +930,8 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $messageModel,
             $sendToContactModel,
             $deviceTrackerMock,
-            $redirectRepositoryMock
+            $redirectRepositoryMock,
+            $cacheStorageHelperMock
         );
 
         $emailModel->setTranslator($translator);
@@ -1051,6 +1059,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
 
         $deviceTrackerMock      = $this->createMock(DeviceTracker::class);
         $redirectRepositoryMock = $this->createMock(RedirectRepository::class);
+        $cacheStorageHelperMock = $this->createMock(CacheStorageHelper::class);
 
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,
@@ -1064,7 +1073,8 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $messageModel,
             $sendToContactModel,
             $deviceTrackerMock,
-            $redirectRepositoryMock
+            $redirectRepositoryMock,
+            $cacheStorageHelperMock
         );
 
         $emailModel->setTranslator($translator);

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -14,6 +14,7 @@ namespace Mautic\EmailBundle\Tests;
 use Doctrine\ORM\EntityManager;
 use Mautic\ChannelBundle\Entity\MessageRepository;
 use Mautic\ChannelBundle\Model\MessageQueueModel;
+use Mautic\CoreBundle\Helper\CacheStorageHelper;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Helper\ThemeHelper;
@@ -231,6 +232,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
 
         $deviceTrackerMock      = $this->createMock(DeviceTracker::class);
         $redirectRepositoryMock = $this->createMock(RedirectRepository::class);
+        $cacheStorageHelperMock = $this->createMock(CacheStorageHelper::class);
 
         $emailModel = new \Mautic\EmailBundle\Model\EmailModel(
             $ipLookupHelper,
@@ -244,7 +246,8 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
             $messageModel,
             $sendToContactModel,
             $deviceTrackerMock,
-            $redirectRepositoryMock
+            $redirectRepositoryMock,
+            $cacheStorageHelperMock,
         );
 
         $emailModel->setTranslator($translator);

--- a/app/bundles/EmailBundle/Views/Email/list.html.php
+++ b/app/bundles/EmailBundle/Views/Email/list.html.php
@@ -211,7 +211,7 @@ if ($tmpl == 'index') {
                                 ['search' => $view['translator']->trans('mautic.lead.lead.searchcommand.email_read').':'.$item->getId()]
                             ); ?>" data-toggle="tooltip"
                                title="<?php echo $view['translator']->trans('mautic.email.stat.tooltip'); ?>">
-                                <?php echo $view['translator']->trans('mautic.email.stat.readpercent', ['%count%' => $item->getReadCount(true)]); ?>
+                                <?php echo $view['translator']->trans('mautic.email.stat.readpercent', ['%count%' => $item->getReadPercentage(true)]); ?>
                             </a>
                         </span>
                         <?php echo $view['content']->getCustomContent('email.stats', $mauticTemplateVars); ?>

--- a/app/bundles/EmailBundle/Views/Email/list.html.php
+++ b/app/bundles/EmailBundle/Views/Email/list.html.php
@@ -162,23 +162,27 @@ if ($tmpl == 'index') {
                     </td>
                     <td class="visible-sm visible-md visible-lg col-stats" data-stats="<?php echo $item->getId(); ?>">
                         <?php echo $view['content']->getCustomContent('email.stats.above', $mauticTemplateVars); ?>
-                        <span class="mt-xs label label-default hide has-click-event clickable-stat"
+                        <span class="mt-xs label label-default has-click-event clickable-stat<?php echo $item->getPendingCount() > 0 && $item->getEmailType() === 'list' ? '' : ' hide'; ?>"
                               id="pending-<?php echo $item->getId(); ?>"
                               data-toggle="tooltip"
                               title="<?php echo $view['translator']->trans('mautic.email.stat.leadcount.tooltip'); ?>">
                             <a href="<?php echo $view['router']->path(
                                 'mautic_contact_index',
                                 ['search' => $view['translator']->trans('mautic.lead.lead.searchcommand.email_pending').':'.$item->getId()]
-                            ); ?>"></a>
+                            ); ?>">
+                                <?php echo $view['translator']->trans('mautic.email.stat.leadcount', ['%count%' => $item->getPendingCount()]); ?>
+                            </a>
                         </span>
-                        <span class="mt-xs label label-default hide has-click-event clickable-stat"
+                        <span class="mt-xs label label-default has-click-event clickable-stat<?php echo $item->getQueuedCount() > 0 ? '' : ' hide'; ?>"
                               id="queued-<?php echo $item->getId(); ?>"
                               data-toggle="tooltip"
                               title="<?php echo $view['translator']->trans('mautic.email.stat.queued.tooltip'); ?>">
                             <a href="<?php echo $view['router']->path(
                                 'mautic_contact_index',
                                 ['search' => $view['translator']->trans('mautic.lead.lead.searchcommand.email_queued').':'.$item->getId()]
-                            ); ?>"></a>
+                            ); ?>">
+                                <?php echo $view['translator']->trans('mautic.email.stat.queued', ['%count%' => $item->getQueuedCount()]); ?>
+                            </a>
                         </span>
                         <span class="mt-xs label label-warning has-click-event clickable-stat"
                               id="sent-count-<?php echo $item->getId(); ?>">
@@ -187,9 +191,7 @@ if ($tmpl == 'index') {
                                 ['search' => $view['translator']->trans('mautic.lead.lead.searchcommand.email_sent').':'.$item->getId()]
                             ); ?>" data-toggle="tooltip"
                                title="<?php echo $view['translator']->trans('mautic.email.stat.tooltip'); ?>">
-                                <div style="width: 50px;">
-                                    <i class="fa fa-spin fa-spinner"></i>
-                                </div>
+                                <?php echo $view['translator']->trans('mautic.email.stat.sentcount', ['%count%' => $item->getSentCount(true)]); ?>
                             </a>
                         </span>
                         <span class="mt-xs label label-success has-click-event clickable-stat"
@@ -199,9 +201,7 @@ if ($tmpl == 'index') {
                                 ['search' => $view['translator']->trans('mautic.lead.lead.searchcommand.email_read').':'.$item->getId()]
                             ); ?>" data-toggle="tooltip"
                                title="<?php echo $view['translator']->trans('mautic.email.stat.tooltip'); ?>">
-                                <div style="width: 50px;">
-                                    <i class="fa fa-spin fa-spinner"></i>
-                                </div>
+                                <?php echo $view['translator']->trans('mautic.email.stat.readcount', ['%count%' => $item->getReadCount(true)]); ?>
                             </a>
                         </span>
                         <span class="mt-xs label label-primary has-click-event clickable-stat"
@@ -211,9 +211,7 @@ if ($tmpl == 'index') {
                                 ['search' => $view['translator']->trans('mautic.lead.lead.searchcommand.email_read').':'.$item->getId()]
                             ); ?>" data-toggle="tooltip"
                                title="<?php echo $view['translator']->trans('mautic.email.stat.tooltip'); ?>">
-                                <div style="width: 50px;">
-                                    <i class="fa fa-spin fa-spinner"></i>
-                                </div>
+                                <?php echo $view['translator']->trans('mautic.email.stat.readpercent', ['%count%' => $item->getReadCount(true)]); ?>
                             </a>
                         </span>
                         <?php echo $view['content']->getCustomContent('email.stats', $mauticTemplateVars); ?>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The email list view takes a while to load with the email stats "pending" and "queued" counts. This PR displays the stats that it can right off the bat (on initial page load) and still makes AJAX requests for the pending and queued. The difference now is that the pending and queued results are cached for later use if navigating back to the page, so that the user will see the cached stats immediately on load and not have to wait for the AJAX request to fetch the latest data. This provides a better UX

[//]: # ( As applicable: )

#### Steps to test this PR:
1. Create a campaign email and schedule it to send.
2. Load the list view page and see that it takes a while to load the stats depending on how many contacts you have.
3. See the initial stats (sent, read, read %) load immediately when loading the list view, and the pending and queued come in via AJAX.
4. Nav to the next page of your email list view, then back, you'll see that pending and queued are populated immediately.