### PR TITLE
Focus items cannot be cloned

### DIFF
--- a/plugins/MauticFocusBundle/Entity/Focus.php
+++ b/plugins/MauticFocusBundle/Entity/Focus.php
@@ -133,6 +133,13 @@ class Focus extends FormEntity
         );
     }
 
+    public function __clone()
+    {
+        $this->id = null;
+
+        parent::__clone();
+    }
+
     /**
      * @param ORM\ClassMetadata $metadata
      */


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
As of 2.14.0 focus items cannot be cloned. 
It's a simple fix of nullifying the ID so that the edit route works as designed.
At some point after 2.13.2-dev this bug was introduced affecting all third-party plugins that follow the Focus model. However, I think it should be on the plugins to solve by a simple entity change.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to clone a test focus: https://mautibox.com/4441/s/focus/1
2. It sends you to https://mautibox.com/4441/s/focus/edit/1 (the edit screen for the original focus)

#### Steps to test this PR:
1. Go to https://mautibox.com/6446
2. Create a focus item.
3. Attempt to clone the focus item, then save.
4. You should now have 2 focus items :)
