### PR TITLE
Fix custom text for buttons in prefs center

### DIFF
--- a/app/bundles/PageBundle/Assets/js/prefcenter.js
+++ b/app/bundles/PageBundle/Assets/js/prefcenter.js
@@ -21,6 +21,12 @@ if (typeof MauticPrefCenterLoaded === 'undefined') {
                 setLabelText(slot, 'label.label' + i, text);
             }
         }
+        // button value replace
+        text = slot.dataset['paramLinkText'];
+        if (typeof text !== "undefined") {
+            var labels = slot.querySelectorAll('.button');
+            labels[0].innerHTML = text;
+        }
     }
 
     function setLabelText(slot, querySelector, text) {
@@ -33,7 +39,7 @@ if (typeof MauticPrefCenterLoaded === 'undefined') {
 
     // Handler when the DOM is fully loaded
     var callback = function(){
-        var slots = document.querySelectorAll('div[data-slot="segmentlist"], div[data-slot="categorylist"], div[data-slot="preferredchannel"], div[data-slot="channelfrequency"]');
+        var slots = document.querySelectorAll('div[data-slot="segmentlist"], div[data-slot="categorylist"], div[data-slot="preferredchannel"], div[data-slot="channelfrequency"],div[data-slot="saveprefsbutton"]');
         for (var i = 0; i < slots.length; i++) {
             replaceSlotParams(slots[i]);
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6429
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR added support for custom text from builder for landing page prefs center.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a preference center
2. Add the saveprefbutton bloc and customize the text button
![image](https://user-images.githubusercontent.com/31535432/43763362-e16ed6e8-9a2a-11e8-9cbe-2e8b87429370.png)
3. Create an email, assign this pref center and shoot the email.
4. Click on the unsubscribe link to land to the pref center. 
5. Check the text of the save pref button.
![image](https://user-images.githubusercontent.com/31535432/43763514-33ad7c2a-9a2b-11e8-919d-4e547459c62f.png)
This is a default text.

#### Steps to test this PR:
1.  Apply PR and `run php app/console m:a:g`. Mautibox is in developement mode, not require this step.
2. Check If your custom button text was applied