### PR TITLE
Focus View dispatch event

### DIFF
--- a/plugins/MauticFocusBundle/Controller/PublicController.php
+++ b/plugins/MauticFocusBundle/Controller/PublicController.php
@@ -14,6 +14,8 @@ namespace MauticPlugin\MauticFocusBundle\Controller;
 use Mautic\CoreBundle\Controller\CommonController;
 use Mautic\CoreBundle\Helper\TrackingPixelHelper;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
+use MauticPlugin\MauticFocusBundle\Event\FocusViewEvent;
+use MauticPlugin\MauticFocusBundle\FocusEvents;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -62,7 +64,12 @@ class PublicController extends CommonController
             $lead  = $this->getModel('lead')->getCurrentLead();
 
             if ($focus && $focus->isPublished() && $lead) {
-                $model->addStat($focus, Stat::TYPE_NOTIFICATION, $this->request, $lead);
+                $stat = $model->addStat($focus, Stat::TYPE_NOTIFICATION, $this->request, $lead);
+                if ($stat && $this->dispatcher->hasListeners(FocusEvents::FOCUS_ON_VIEW)) {
+                    $event = new FocusViewEvent($stat);
+                    $this->dispatcher->dispatch(FocusEvents::FOCUS_ON_VIEW, $event);
+                    unset($event);
+                }
             }
         }
 

--- a/plugins/MauticFocusBundle/Event/FocusViewEvent.php
+++ b/plugins/MauticFocusBundle/Event/FocusViewEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticFocusBundle\Event;
+
+use MauticPlugin\MauticFocusBundle\Entity\Focus;
+use MauticPlugin\MauticFocusBundle\Entity\Stat;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class FocusViewEvent.
+ */
+class FocusViewEvent extends Event
+{
+    /**
+     * @var Focus
+     */
+    private $focus;
+
+    /**
+     * @var Stat
+     */
+    private $stat;
+
+    /**
+     * @param Stat $stat
+     */
+    public function __construct(Stat $stat)
+    {
+        $this->stat  = $stat;
+        $this->focus = $stat->getFocus();
+    }
+
+    /**
+     * Returns the Focus entity.
+     *
+     * @return Focus
+     */
+    public function getFocus()
+    {
+        return $this->focus;
+    }
+
+    /**
+     * @return Stat
+     */
+    public function getStat()
+    {
+        return $this->stat;
+    }
+}

--- a/plugins/MauticFocusBundle/Event/FocusViewEvent.php
+++ b/plugins/MauticFocusBundle/Event/FocusViewEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * @copyright   2017 Mautic Contributors. All rights reserved
+ * @copyright   2018 Mautic Contributors. All rights reserved
  * @author      Mautic
  *
  * @link        http://mautic.org
@@ -11,7 +11,6 @@
 
 namespace MauticPlugin\MauticFocusBundle\Event;
 
-use MauticPlugin\MauticFocusBundle\Entity\Focus;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
 use Symfony\Component\EventDispatcher\Event;
 
@@ -20,11 +19,6 @@ use Symfony\Component\EventDispatcher\Event;
  */
 class FocusViewEvent extends Event
 {
-    /**
-     * @var Focus
-     */
-    private $focus;
-
     /**
      * @var Stat
      */
@@ -36,17 +30,6 @@ class FocusViewEvent extends Event
     public function __construct(Stat $stat)
     {
         $this->stat  = $stat;
-        $this->focus = $stat->getFocus();
-    }
-
-    /**
-     * Returns the Focus entity.
-     *
-     * @return Focus
-     */
-    public function getFocus()
-    {
-        return $this->focus;
     }
 
     /**

--- a/plugins/MauticFocusBundle/FocusEvents.php
+++ b/plugins/MauticFocusBundle/FocusEvents.php
@@ -72,4 +72,14 @@ final class FocusEvents
      * @var string
      */
     const ON_CAMPAIGN_TRIGGER_ACTION = 'mautic.focus.on_campaign_trigger_action';
+
+    /**
+     * The mautic.focus.on_open event is dispatched when an focus is opened.
+     *
+     * The event listener receives a
+     * MauticPlugin\MauticFocusBundle\Event\FocusOpenEvent instance.
+     *
+     * @var string
+     */
+    const FOCUS_ON_VIEW = 'mautic.focus.on_view';
 }

--- a/plugins/MauticFocusBundle/Model/FocusModel.php
+++ b/plugins/MauticFocusBundle/Model/FocusModel.php
@@ -319,6 +319,8 @@ class FocusModel extends FormModel
     }
 
     /**
+     * Add a stat entry.
+     *
      * @param Focus $focus
      * @param       $type
      * @param null  $data

--- a/plugins/MauticFocusBundle/Model/FocusModel.php
+++ b/plugins/MauticFocusBundle/Model/FocusModel.php
@@ -319,12 +319,12 @@ class FocusModel extends FormModel
     }
 
     /**
-     * Add a stat entry.
-     *
      * @param Focus $focus
      * @param       $type
      * @param null  $data
      * @param null  $lead
+     *
+     * @return Stat
      */
     public function addStat(Focus $focus, $type, $data = null, $lead = null)
     {
@@ -351,6 +351,8 @@ class FocusModel extends FormModel
             ->setLead($lead);
 
         $this->getStatRepository()->saveEntity($stat);
+
+        return $stat;
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR add dispatch event If Focus pixel is viewed.  Useful for developers they can store/trigger or something after focus pixel is viewed. 

#### Steps to test this PR:
1.  Add tracking code and focus to page
2.  Install 
[MauticFocusViewTestBundle.zip](https://github.com/mautic/mautic/files/2423966/MauticFocusViewTestBundle.zip)
 (copy to plugins, clear cache and go to Plugins and click to Install/Upgrade button)
3. Then reload page with tracking code and focus. 
4. Focus should be viewed
5: Then go to logs and see debug line  

> Focus #1 viewed. Works  

![image](https://user-images.githubusercontent.com/462477/45873441-cacb5c00-bd92-11e8-95c0-ca9036cd60fa.png)

Should works properly
 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 