### PR TITLE
Prevent an indefinite loop when building the membership of a campaign 

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -373,12 +373,13 @@ class LeadRepository extends CommonRepository
     }
 
     /**
-     * @param int            $campaignId
+     * @param                $campaignId
      * @param ContactLimiter $limiter
+     * @param bool           $campaignCanBeRestarted
      *
      * @return CountResult
      */
-    public function getCountsForCampaignContactsBySegment($campaignId, ContactLimiter $limiter)
+    public function getCountsForCampaignContactsBySegment($campaignId, ContactLimiter $limiter, $campaignCanBeRestarted = false)
     {
         if (!$segments = $this->getCampaignSegments($campaignId)) {
             return new CountResult(0, 0, 0);
@@ -397,18 +398,23 @@ class LeadRepository extends CommonRepository
         $this->updateQueryFromContactLimiter('ll', $qb, $limiter, true);
         $this->updateQueryWithExistingMembershipExclusion($campaignId, $qb);
 
+        if (!$campaignCanBeRestarted) {
+            $this->updateQueryWithHistoryExclusion($campaignId, $qb);
+        }
+
         $result = $qb->execute()->fetch();
 
         return new CountResult($result['the_count'], $result['min_id'], $result['max_id']);
     }
 
     /**
-     * @param int            $campaignId
+     * @param                $campaignId
      * @param ContactLimiter $limiter
+     * @param bool           $campaignCanBeRestarted
      *
      * @return array
      */
-    public function getCampaignContactsBySegments($campaignId, ContactLimiter $limiter)
+    public function getCampaignContactsBySegments($campaignId, ContactLimiter $limiter, $campaignCanBeRestarted = false)
     {
         if (!$segments = $this->getCampaignSegments($campaignId)) {
             return [];
@@ -426,6 +432,10 @@ class LeadRepository extends CommonRepository
 
         $this->updateQueryFromContactLimiter('ll', $qb, $limiter, true);
         $this->updateQueryWithExistingMembershipExclusion($campaignId, $qb);
+
+        if (!$campaignCanBeRestarted) {
+            $this->updateQueryWithHistoryExclusion($campaignId, $qb);
+        }
 
         $results = $qb->execute()->fetchAll();
 
@@ -577,7 +587,7 @@ class LeadRepository extends CommonRepository
     }
 
     /**
-     * @param int          $campaignId
+     * @param array        $segments
      * @param QueryBuilder $qb
      */
     private function updateQueryWithSegmentMembershipExclusion(array $segments, QueryBuilder $qb)
@@ -595,6 +605,29 @@ class LeadRepository extends CommonRepository
                     $qb->expr()->eq('ll.lead_id', 'cl.lead_id'),
                     $qb->expr()->eq('ll.manually_removed', 0),
                     $qb->expr()->in('ll.leadlist_id', $segments)
+                )
+            );
+
+        $qb->andWhere(
+            sprintf('NOT EXISTS (%s)', $subq->getSQL())
+        );
+    }
+
+    /**
+     * Exclude contacts with any previous campaign history; this is mainly BC for pre 2.14.0 where the membership entry was deleted.
+     *
+     * @param              $campaignId
+     * @param QueryBuilder $qb
+     */
+    private function updateQueryWithHistoryExclusion($campaignId, QueryBuilder $qb)
+    {
+        $subq = $this->getEntityManager()->getConnection()->createQueryBuilder()
+            ->select('null')
+            ->from(MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'el')
+            ->where(
+                $qb->expr()->andX(
+                    $qb->expr()->eq('el.lead_id', 'll.lead_id'),
+                    $qb->expr()->eq('el.campaign_id', (int) $campaignId)
                 )
             );
 

--- a/app/bundles/CampaignBundle/Membership/Action/Adder.php
+++ b/app/bundles/CampaignBundle/Membership/Action/Adder.php
@@ -50,8 +50,6 @@ class Adder
      * @param          $isManualAction
      *
      * @return CampaignMember
-     *
-     * @throws ContactCannotBeAddedToCampaignException
      */
     public function createNewMembership(Lead $contact, Campaign $campaign, $isManualAction)
     {
@@ -60,11 +58,6 @@ class Adder
         // Start the new rotation at 2
         $rotation = 1;
         if ($this->leadEventLogRepository->hasBeenInCampaignRotation($contact->getId(), $campaign->getId(), 1)) {
-            if (!$campaign->allowRestart()) {
-                // This contact has already been in the campaign at some point
-                throw new ContactCannotBeAddedToCampaignException();
-            }
-
             $rotation = 2;
         }
 

--- a/app/bundles/CampaignBundle/Membership/MembershipBuilder.php
+++ b/app/bundles/CampaignBundle/Membership/MembershipBuilder.php
@@ -144,7 +144,7 @@ class MembershipBuilder
         $contactsProcessed = 0;
 
         if ($this->output) {
-            $countResult = $this->campaignMemberRepository->getCountsForCampaignContactsBySegment($this->campaign->getId(), $this->contactLimiter);
+            $countResult = $this->campaignMemberRepository->getCountsForCampaignContactsBySegment($this->campaign->getId(), $this->contactLimiter, $this->campaign->allowRestart());
 
             $this->output->writeln(
                 $this->translator->trans(
@@ -161,9 +161,15 @@ class MembershipBuilder
             $this->startProgressBar($countResult->getCount());
         }
 
-        $contacts = $this->campaignMemberRepository->getCampaignContactsBySegments($this->campaign->getId(), $this->contactLimiter);
+        $contacts = $this->campaignMemberRepository->getCampaignContactsBySegments($this->campaign->getId(), $this->contactLimiter, $this->campaign->allowRestart());
+
         while (count($contacts)) {
             $contactCollection = $this->leadRepository->getContactCollection($contacts);
+            if (!$contactCollection->count()) {
+                // Prevent endless loop just in case
+                break;
+            }
+
             $contactsProcessed += $contactCollection->count();
 
             // Add the contacts to this segment
@@ -220,6 +226,11 @@ class MembershipBuilder
         $contacts = $this->campaignMemberRepository->getOrphanedContacts($this->campaign->getId(), $this->contactLimiter);
         while (count($contacts)) {
             $contactCollection = $this->leadRepository->getContactCollection($contacts);
+            if (!$contactCollection->count()) {
+                // Prevent endless loop just in case
+                break;
+            }
+
             $contactsProcessed += $contactCollection->count();
 
             // Add the contacts to this segment

--- a/app/bundles/CampaignBundle/Membership/MembershipManager.php
+++ b/app/bundles/CampaignBundle/Membership/MembershipManager.php
@@ -165,17 +165,8 @@ class MembershipManager
                 continue;
             }
 
-            try {
-                // Existing membership does not exist so create a new one
-                $this->adder->createNewMembership($contact, $campaign, $isManualAction);
-            } catch (ContactCannotBeAddedToCampaignException $exception) {
-                $this->logger->debug(
-                    "CAMPAIGN: Contact ID {$contact->getId()} could not be added to campaign ID {$campaign->getId()}."
-                );
-
-                $contacts->remove($contact->getId());
-                continue;
-            }
+            // Existing membership does not exist so create a new one
+            $this->adder->createNewMembership($contact, $campaign, $isManualAction);
 
             $this->logger->debug("CAMPAIGN: Contact ID {$contact->getId()} was added to campaign ID {$campaign->getId()} as a new member.");
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6393
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

An infinite loop would occur when a campaign was build before 2.14.0, the contacts were removed from the campaign by a segment, the campaign is set as not repeatable, and the contacts are now added back by a segment. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Unless you have a pre-2.14 campaign, you have to hack the database to replicate the symptoms.
2. Ensure that a contact has gone through a campaign already so that there is history on the campaign_lead_events_log table for the contact and campaign. 
3. Go to the campaign_leads table and delete the row for a contact and campaign
3. Make sure the campaign is set as not repeatable
4. Run the command `app/console mautic:campaign:update -i ID` and replace ID with the campaign ID. 
5. Note that it will cause an infinite loop. 

#### Steps to test this PR:
1. Repeat with this PR and the loop will never occur while the campaign still updates membership for others that are applicable. 
