### PR TITLE
Api plugin view settings

### DIFF
--- a/app/bundles/PluginBundle/Config/config.php
+++ b/app/bundles/PluginBundle/Config/config.php
@@ -36,6 +36,10 @@ return [
                 'path'       => '/plugins/reload',
                 'controller' => 'MauticPluginBundle:Plugin:reload',
             ],
+            'mautic_plugin_view_settings' => [
+                'path'       => '/plugins/settings/{name}',
+                'controller' => 'MauticPluginBundle:Plugin:viewSettings',
+            ],
         ],
         'public' => [
             'mautic_integration_auth_user' => [

--- a/app/bundles/PluginBundle/Config/config.php
+++ b/app/bundles/PluginBundle/Config/config.php
@@ -36,7 +36,9 @@ return [
                 'path'       => '/plugins/reload',
                 'controller' => 'MauticPluginBundle:Plugin:reload',
             ],
-            'mautic_plugin_view_settings' => [
+        ],
+        'api' => [
+            'mautic_api_plugin_view_settings' => [
                 'path'       => '/plugins/settings/{name}',
                 'controller' => 'MauticPluginBundle:Plugin:viewSettings',
             ],

--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -64,7 +64,7 @@ class PluginController extends FormController
         $session->set('mautic.integrations.filter', $pluginFilter);
 
         /** @var \Mautic\PluginBundle\Helper\IntegrationHelper $integrationHelper */
-        $integrationHelper  = $this->factory->getHelper('integration');
+        $integrationHelper  = $this->get('mautic.helper.integration');
         $integrationObjects = $integrationHelper->getIntegrationObjects(null, null, true);
         $integrations       = $foundPlugins       = [];
 

--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -443,7 +443,7 @@ class PluginController extends FormController
     {
         $integrationHelper = $this->get('mautic.helper.integration');
         $integrationObject = $integrationHelper->getIntegrationObject($name);
-        $featureSettings = $integrationObject->getIntegrationSettings()->getFeatureSettings();
+        $featureSettings   = $integrationObject->getIntegrationSettings()->getFeatureSettings();
         
         return new JsonResponse($featureSettings);
     }

--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -438,4 +438,12 @@ class PluginController extends FormController
             ]
         );
     }
+
+    public function viewSettingsAction($name)
+    {
+        $integrationHelper = $this->factory->getHelper('integration');
+        $integrationObject = $integrationHelper->getIntegrationObject($name);
+        $featureSettings = $integrationObject->getIntegrationSettings()->getFeatureSettings();
+        return new JsonResponse($featureSettings);
+    }
 }

--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -155,7 +155,7 @@ class PluginController extends FormController
         $authorize = $this->request->request->get('integration_details[in_auth]', false, true);
 
         /** @var \Mautic\PluginBundle\Helper\IntegrationHelper $integrationHelper */
-        $integrationHelper = $this->factory->getHelper('integration');
+        $integrationHelper = $this->get('mautic.helper.integration');
         /** @var AbstractIntegration $integrationObject */
         $integrationObject = $integrationHelper->getIntegrationObject($name);
 
@@ -386,7 +386,7 @@ class PluginController extends FormController
         }
 
         /** @var \Mautic\PluginBundle\Helper\IntegrationHelper $integrationHelper */
-        $integrationHelper = $this->factory->getHelper('integration');
+        $integrationHelper = $this->get('mautic.helper.integration');
 
         $bundle->splitDescriptions();
 
@@ -441,9 +441,10 @@ class PluginController extends FormController
 
     public function viewSettingsAction($name)
     {
-        $integrationHelper = $this->factory->getHelper('integration');
+        $integrationHelper = $this->get('mautic.helper.integration');
         $integrationObject = $integrationHelper->getIntegrationObject($name);
         $featureSettings = $integrationObject->getIntegrationSettings()->getFeatureSettings();
+        
         return new JsonResponse($featureSettings);
     }
 }

--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -439,12 +439,19 @@ class PluginController extends FormController
         );
     }
 
+     /**
+     * @param $name
+     *
+     * @return JsonResponse|Response
+     */
     public function viewSettingsAction($name)
     {
         $integrationHelper = $this->get('mautic.helper.integration');
         $integrationObject = $integrationHelper->getIntegrationObject($name);
-        $featureSettings   = $integrationObject->getIntegrationSettings()->getFeatureSettings();
+        if ($integrationObject && $integrationObject->getIntegrationSettings()->getIsPublished()) {
+            return new JsonResponse($integrationObject->getIntegrationSettings()->getFeatureSettings());
+        }
 
-        return new JsonResponse($featureSettings);
+        return $this->notFound();
     }
 }

--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -444,7 +444,7 @@ class PluginController extends FormController
         $integrationHelper = $this->get('mautic.helper.integration');
         $integrationObject = $integrationHelper->getIntegrationObject($name);
         $featureSettings   = $integrationObject->getIntegrationSettings()->getFeatureSettings();
-        
+
         return new JsonResponse($featureSettings);
     }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | x 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/89 
| Issues addressed (#s or URLs) | 
| BC breaks? | none 
| Deprecations? | none 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR create a new endpoint that allows to get the plugin mapping settings via API. It is very useful for a third application to know how plugins are set. 

The API answer looks like as follow:
```json
{ 
   "objects": [
        "lead",
        "company"
    ],
    "update_mautic": {
        "alias_from_integration": "1",
        "alias_from_integration": "1",
        "FirstName": "1"
    },
    "leadFields": {
        "alias_from_integration": "alias_mapped_from_mautic",
        "alias_from_integration": "alias_mapped_from_mautic",
        "FirstName": "firstname"
    },
    "update_mautic_company": {
        "CompanyName": "1"
    },
    "companyFields": {
        "CompanyName": "companyname"
    }
}
```

#### Steps to test this PR:
1. Configure any integration like Salesforce for instance
2. Enable and set field mapping (contact and/or companies)
3. Request `/api/plugins/settings/{integration_name}`
4. Get your answer