### PR TITLE
Fixes campaign bug that prevented some events from executing for all contacts

### DIFF
--- a/app/bundles/CampaignBundle/EventListener/CampaignActionJumpToEventSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignActionJumpToEventSubscriber.php
@@ -98,17 +98,14 @@ class CampaignActionJumpToEventSubscriber implements EventSubscriberInterface
      */
     public function onJumpToEvent(PendingEvent $campaignEvent)
     {
-        foreach ($campaignEvent->getPending() as $log) {
-            $event      = $log->getEvent();
-            $jumpTarget = $this->getJumpTargetForEvent($event, 'e.id');
+        $event      = $campaignEvent->getEvent();
+        $jumpTarget = $this->getJumpTargetForEvent($event, 'e.id');
 
-            if ($jumpTarget === null) {
-                $campaignEvent->passWithError($jumpTarget, $this->translator->trans('mautic.campaign.campaign.jump_to_event.target_not_exist'));
-                continue;
-            }
-
-            $this->eventExecutioner->executeForContacts($jumpTarget, $campaignEvent->getContacts());
+        if ($jumpTarget === null) {
+            $campaignEvent->passWithError($jumpTarget, $this->translator->trans('mautic.campaign.campaign.jump_to_event.target_not_exist'));
         }
+
+        $this->eventExecutioner->executeForContacts($jumpTarget, $campaignEvent->getContacts());
 
         $campaignEvent->passRemaining();
     }

--- a/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
@@ -284,7 +284,6 @@ class EventExecutioner
             foreach ($jumpEvents as $key => $event) {
                 $config         = $this->collector->getEventConfig($event);
                 $jumpLogs[$key] = $this->eventLogger->fetchRotationAndGenerateLogsFromContacts($event, $config, $contacts, $isInactive);
-                $this->eventLogger->persistCollection($jumpLogs[$key]);
             }
 
             // Increment the campaign rotation for the given contacts and current campaign

--- a/app/bundles/CampaignBundle/Executioner/InactiveExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/InactiveExecutioner.php
@@ -248,7 +248,6 @@ class InactiveExecutioner implements ExecutionerInterface
      * @throws Dispatcher\Exception\LogNotProcessedException
      * @throws Dispatcher\Exception\LogPassedAndFailedException
      * @throws Exception\CannotProcessEventException
-     * @throws NoContactsFoundException
      * @throws Scheduler\Exception\NotSchedulableException
      */
     private function executeEvents()
@@ -316,7 +315,7 @@ class InactiveExecutioner implements ExecutionerInterface
     }
 
     /**
-     * @param ArrayCollection $children
+     * @param ArrayCollection $events
      * @param ArrayCollection $contacts
      * @param Counter         $childrenCounter
      * @param \DateTime       $earliestLastActiveDateTime

--- a/app/bundles/CampaignBundle/Executioner/Logger/EventLogger.php
+++ b/app/bundles/CampaignBundle/Executioner/Logger/EventLogger.php
@@ -88,7 +88,6 @@ class EventLogger
     public function queueToPersist(LeadEventLog $log)
     {
         $this->persistQueue->add($log);
-        $this->logs->set($log->getId(), $log);
 
         if ($this->persistQueue->count() >= 20) {
             $this->persistPendingAndInsertIntoLogStack();

--- a/app/bundles/CampaignBundle/Executioner/Logger/EventLogger.php
+++ b/app/bundles/CampaignBundle/Executioner/Logger/EventLogger.php
@@ -144,6 +144,8 @@ class EventLogger
 
     /**
      * Persist the queue, clear the entities from memory, and reset the queue.
+     *
+     * @return ArrayCollection
      */
     public function persistQueuedLogs()
     {
@@ -202,10 +204,10 @@ class EventLogger
     }
 
     /**
-     * @param Event                  $event
-     * @param AbstractEventAccessor  $config
-     * @param ArrayCollection|Lead[] $contacts
-     * @param bool                   $isInactiveEvent
+     * @param Event                 $event
+     * @param AbstractEventAccessor $config
+     * @param ArrayCollection       $contacts
+     * @param bool                  $isInactiveEntry
      *
      * @return ArrayCollection
      */

--- a/app/bundles/CampaignBundle/Tests/Executioner/Logger/EventLoggerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Logger/EventLoggerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CampaignBundle\Tests\Executioner\Logger;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
+use Mautic\CampaignBundle\Entity\LeadRepository;
+use Mautic\CampaignBundle\Executioner\Logger\EventLogger;
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\LeadBundle\Tracker\ContactTracker;
+
+class EventLoggerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var LeadRepository|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $ipLookupHelper;
+
+    /**
+     * @var ContactTracker|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $contactTracker;
+
+    /**
+     * @var LeadEventLogRepository|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $leadEventLogRepository;
+
+    /**
+     * @var LeadRepository|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $leadRepository;
+
+    protected function setUp()
+    {
+        $this->ipLookupHelper         = $this->createMock(IpLookupHelper::class);
+        $this->contactTracker         = $this->createMock(ContactTracker::class);
+        $this->leadEventLogRepository = $this->createMock(LeadEventLogRepository::class);
+        $this->leadRepository         = $this->createMock(LeadRepository::class);
+    }
+
+    public function testAllLogsAreReturnedWithFinalPersist()
+    {
+        $logCollection = new ArrayCollection();
+        while ($logCollection->count() < 60) {
+            $log = $this->createMock(LeadEventLog::class);
+            $log->method('getId')
+                ->willReturn($logCollection->count() + 1);
+
+            $logCollection->add($log);
+        }
+
+        $this->leadEventLogRepository->expects($this->exactly(3))
+            ->method('saveEntities');
+
+        $logger = $this->getLogger();
+        foreach ($logCollection as $log) {
+            $logger->queueToPersist($log);
+        }
+
+        $persistedLogs = $logger->persistQueuedLogs();
+
+        $this->assertEquals($persistedLogs->count(), $logCollection->count());
+        $this->assertEquals($logCollection->getValues(), $persistedLogs->getValues());
+    }
+
+    private function getLogger()
+    {
+        return new EventLogger(
+            $this->ipLookupHelper,
+            $this->contactTracker,
+            $this->leadEventLogRepository,
+            $this->leadRepository
+        );
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If executing more than 20 events in a campaign, some events may not execute. This is confirmed with deleting contacts and adding points.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a campaign that executes for at least 50 contacts to add 100 points
2. Execute the campaign
3. Not all contacts will get the points

#### Steps to test this PR:
1. Repeat and everyone will get the points
