### PR TITLE
Fix format date for integration fetch companies

### DIFF
--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -318,8 +318,20 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
 
         $companyFieldTypes = $this->fieldModel->getFieldListWithProperties('company');
         foreach ($matchedFields as $companyField => $value) {
-            if (isset($companyFieldTypes[$companyField]['type']) && $companyFieldTypes[$companyField]['type'] == 'text') {
-                $matchedFields[$companyField] = substr($value, 0, 255);
+            if (isset($companyFieldTypes[$companyField]['type'])) {
+                switch ($companyFieldTypes[$companyField]['type']) {
+                    case 'text':
+                        $matchedFields[$companyField] = substr($value, 0, 255);
+                        break;
+                    case 'date':
+                        $date = new \DateTime($value);
+                        $matchedFields[$companyField] = $date->format("Y-m-d");
+                        break;
+                    case 'datetime':
+                        $date = new \DateTime($value);
+                        $matchedFields[$companyField] = $date->format("Y-m-d H:i:s");
+                        break;
+                }
             }
         }
 

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -17,7 +17,6 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Helper\IdentifyCompanyHelper;
 use Mautic\PluginBundle\Entity\Integration;
 use Mautic\PluginBundle\Integration\AbstractIntegration;
-use Mautic\UserBundle\Entity\User;
 use MauticPlugin\MauticCrmBundle\Api\CrmApi;
 
 /**
@@ -324,12 +323,12 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
                         $matchedFields[$companyField] = substr($value, 0, 255);
                         break;
                     case 'date':
-                        $date = new \DateTime($value);
-                        $matchedFields[$companyField] = $date->format("Y-m-d");
+                        $date                         = new \DateTime($value);
+                        $matchedFields[$companyField] = $date->format('Y-m-d');
                         break;
                     case 'datetime':
-                        $date = new \DateTime($value);
-                        $matchedFields[$companyField] = $date->format("Y-m-d H:i:s");
+                        $date                         = new \DateTime($value);
+                        $matchedFields[$companyField] = $date->format('Y-m-d H:i:s');
                         break;
                 }
             }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fetch of companies in integration failed, because sometimes the date from the CRM was not formatted for SQL.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a custom field with `Date/Time` type
2. Configure Salesforce integration
3. Map the custom field with a date field from Saleforce
4. Launch `mautic:integration:fetchleads --time-interval=20minutes --integration=Salesforce`
5. Error `mautic.ERROR: INTEGRATION ERROR: Salesforce - An exception occurred while executing 'UPDATE companies SET date_de_creation = ? WHERE id = ?' with params ["2007-04-16T00:00:00.000+0000", 4]: SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value: '2007-04-16T00:00:00.000+0000'`

#### Steps to test this PR:
1. Apply PR
2. Launch `mautic:integration:fetchleads --time-interval=20minutes --integration=Salesforce`
3. Import successful