### PR TITLE
create new sessions filter builder. make it backwards compatible.

### DIFF
--- a/app/bundles/LeadBundle/Segment/Query/Filter/SessionsFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/SessionsFilterQueryBuilder.php
@@ -25,51 +25,50 @@ class SessionsFilterQueryBuilder extends BaseFilterQueryBuilder
     }
 
     /** {@inheritdoc} */
-    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter) {
-        $pageHitsAlias = $this->generateRandomParameterName();
-        $exclusionAlias = $this->generateRandomParameterName();
+    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter)
+    {
+        $pageHitsAlias        = $this->generateRandomParameterName();
+        $exclusionAlias       = $this->generateRandomParameterName();
         $expressionValueAlias = $this->generateRandomParameterName();
 
-
         $expressionOperator = $filter->getOperator();
-        $expression = $queryBuilder->expr()->$expressionOperator('count(id)',
+        $expression         = $queryBuilder->expr()->$expressionOperator('count(id)',
             $filter->getParameterHolder($expressionValueAlias));
 
         $queryBuilder->setParameter($expressionValueAlias, (int) $filter->getParameterValue());
 
         $exclusionQueryBuilder = $queryBuilder->getConnection()->createQueryBuilder();
         $exclusionQueryBuilder
-            ->select($exclusionAlias.".id")
-            ->from(MAUTIC_TABLE_PREFIX . 'page_hits', $exclusionAlias)
+            ->select($exclusionAlias.'.id')
+            ->from(MAUTIC_TABLE_PREFIX.'page_hits', $exclusionAlias)
             ->where(
                 $queryBuilder->expr()->andX(
-                    $queryBuilder->expr()->eq('l.id',$exclusionAlias.".lead_id"),
+                    $queryBuilder->expr()->eq('l.id', $exclusionAlias.'.lead_id'),
                     $queryBuilder->expr()->gt(
-                        $exclusionAlias.".date_hit",
-                        $pageHitsAlias.".date_hit - INTERVAL 30 MINUTE"
-                        ),
-                    $queryBuilder->expr()->lt($exclusionAlias.".date_hit", $pageHitsAlias.".date_hit")
+                        $exclusionAlias.'.date_hit',
+                        $pageHitsAlias.'.date_hit - INTERVAL 30 MINUTE'
+                    ),
+                    $queryBuilder->expr()->lt($exclusionAlias.'.date_hit', $pageHitsAlias.'.date_hit')
                 )
             );
 
         $sessionQueryBuilder = $queryBuilder->getConnection()->createQueryBuilder();
         $sessionQueryBuilder
             ->select('count(id)')
-            ->from(MAUTIC_TABLE_PREFIX . 'page_hits', $pageHitsAlias)
+            ->from(MAUTIC_TABLE_PREFIX.'page_hits', $pageHitsAlias)
             ->where(
                 $queryBuilder->expr()->andX(
-                    $queryBuilder->expr()->eq('l.id',$pageHitsAlias.".lead_id"),
-                    $queryBuilder->expr()->isNull($pageHitsAlias.".email_id"),
-                    $queryBuilder->expr()->isNull($pageHitsAlias.".redirect_id"),
+                    $queryBuilder->expr()->eq('l.id', $pageHitsAlias.'.lead_id'),
+                    $queryBuilder->expr()->isNull($pageHitsAlias.'.email_id'),
+                    $queryBuilder->expr()->isNull($pageHitsAlias.'.redirect_id'),
                     $queryBuilder->expr()->notExists(
                         $exclusionQueryBuilder->getSQL()
                     )
                 )
             )
             ->having($expression);
-        ;
 
-        $glue = $filter->getGlue() . 'Where';
+        $glue = $filter->getGlue().'Where';
         $queryBuilder->$glue($queryBuilder->expr()->exists($sessionQueryBuilder->getSQL()));
 
         return $queryBuilder;

--- a/app/bundles/LeadBundle/Segment/Query/Filter/SessionsFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/SessionsFilterQueryBuilder.php
@@ -25,44 +25,52 @@ class SessionsFilterQueryBuilder extends BaseFilterQueryBuilder
     }
 
     /** {@inheritdoc} */
-    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter)
-    {
-        $filterOperator = $filter->getOperator();
+    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter) {
+        $pageHitsAlias = $this->generateRandomParameterName();
+        $exclusionAlias = $this->generateRandomParameterName();
+        $expressionValueAlias = $this->generateRandomParameterName();
 
-        $filterParameters = $filter->getParameterValue();
 
-        if (is_array($filterParameters)) {
-            $parameters = [];
-            foreach ($filterParameters as $filterParameter) {
-                $parameters[] = $this->generateRandomParameterName();
-            }
-        } else {
-            $parameters = $this->generateRandomParameterName();
-        }
+        $expressionOperator = $filter->getOperator();
+        $expression = $queryBuilder->expr()->$expressionOperator('count(id)',
+            $filter->getParameterHolder($expressionValueAlias));
 
-        $filterParametersHolder = $filter->getParameterHolder($parameters);
+        $queryBuilder->setParameter($expressionValueAlias, (int) $filter->getParameterValue());
 
-        $tableAlias = $queryBuilder->getTableAlias($filter->getTable());
-
-        if (!$tableAlias) {
-            $tableAlias = $this->generateRandomParameterName();
-
-            $queryBuilder = $queryBuilder->leftJoin(
-                $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads'),
-                $filter->getTable(),
-                $tableAlias,
-                $tableAlias.'.lead_id = l.id'
+        $exclusionQueryBuilder = $queryBuilder->getConnection()->createQueryBuilder();
+        $exclusionQueryBuilder
+            ->select($exclusionAlias.".id")
+            ->from(MAUTIC_TABLE_PREFIX . 'page_hits', $exclusionAlias)
+            ->where(
+                $queryBuilder->expr()->andX(
+                    $queryBuilder->expr()->eq('l.id',$exclusionAlias.".lead_id"),
+                    $queryBuilder->expr()->gt(
+                        $exclusionAlias.".date_hit",
+                        $pageHitsAlias.".date_hit - INTERVAL 30 MINUTE"
+                        ),
+                    $queryBuilder->expr()->lt($exclusionAlias.".date_hit", $pageHitsAlias.".date_hit")
+                )
             );
-        }
 
-        $expression = $queryBuilder->expr()->$filterOperator(
-            'count('.$tableAlias.'.id)',
-            $filterParametersHolder
-        );
-        $queryBuilder->addJoinCondition($tableAlias, ' ('.$expression.')');
-        $queryBuilder->setParametersPairs($parameters, $filterParameters);
+        $sessionQueryBuilder = $queryBuilder->getConnection()->createQueryBuilder();
+        $sessionQueryBuilder
+            ->select('count(id)')
+            ->from(MAUTIC_TABLE_PREFIX . 'page_hits', $pageHitsAlias)
+            ->where(
+                $queryBuilder->expr()->andX(
+                    $queryBuilder->expr()->eq('l.id',$pageHitsAlias.".lead_id"),
+                    $queryBuilder->expr()->isNull($pageHitsAlias.".email_id"),
+                    $queryBuilder->expr()->isNull($pageHitsAlias.".redirect_id"),
+                    $queryBuilder->expr()->notExists(
+                        $exclusionQueryBuilder->getSQL()
+                    )
+                )
+            )
+            ->having($expression);
+        ;
 
-        $queryBuilder->andHaving($expression);
+        $glue = $filter->getGlue() . 'Where';
+        $queryBuilder->$glue($queryBuilder->expr()->exists($sessionQueryBuilder->getSQL()));
 
         return $queryBuilder;
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6399
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR adds missing Segment Query Build for sessions. The QB was there but was not doing at all what it should. I have made it to create identical query to the old segment system.

[//]: # ( As applicable: )
#### Steps to reproduce and test the bug/PR:
1. Create a filter with session in it
2. Run the segment from command ```app/console mautic:segments:update -i XXX```
  where XXX is the number of the segment, it should fail
3. Checkout the PR and run the command again.
  it should work right now.