### PR TITLE
Fix for undefined property in segment command in case of an error

### DIFF
--- a/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
+++ b/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
@@ -58,6 +58,7 @@ class UpdateLeadListsCommand extends ModeratedCommand
             $list = $listModel->getEntity($id);
             if ($list !== null) {
                 $output->writeln('<info>'.$translator->trans('mautic.lead.list.rebuild.rebuilding', ['%id%' => $id]).'</info>');
+                $processed = 0;
                 try {
                     $processed = $listModel->rebuildListLeads($list, $batch, $max, $output);
                 } catch (QueryException $e) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

I got an error `undefined property $processed` when I was testing PR for https://github.com/mautic/mautic/issues/6399.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Look at the code and notice that `$processed` property could be undefined if there is an Exception.

#### Steps to test this PR:
1. Code review should be enough.