### PR TITLE
Added support for contact tokens for url in Send a webhook campaign action 

### DIFF
--- a/app/bundles/WebhookBundle/Form/Type/CampaignEventSendWebhookType.php
+++ b/app/bundles/WebhookBundle/Form/Type/CampaignEventSendWebhookType.php
@@ -19,7 +19,6 @@ use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Url;
 
 /**
  * Class CampaignEventRemoteUrlType.
@@ -50,11 +49,6 @@ class CampaignEventSendWebhookType extends AbstractType
                 'attr'        => ['class' => 'form-control'],
                 'required'    => true,
                 'constraints' => [
-                    new Url(
-                        [
-                            'message' => 'mautic.form.submission.url.invalid',
-                        ]
-                    ),
                     new NotBlank(
                         [
                             'message' => 'mautic.core.value.required',

--- a/app/bundles/WebhookBundle/Helper/CampaignHelper.php
+++ b/app/bundles/WebhookBundle/Helper/CampaignHelper.php
@@ -44,7 +44,7 @@ class CampaignHelper
         // dump($config);die;
         $payload = $this->getPayload($config, $contact);
         $headers = $this->getHeaders($config, $contact);
-        $url = rawurldecode(TokenHelper::findLeadTokens($config['url'], $this->getContactValues($contact), true));
+        $url     = rawurldecode(TokenHelper::findLeadTokens($config['url'], $this->getContactValues($contact), true));
         $this->makeRequest($url, $config['method'], $config['timeout'], $headers, $payload);
     }
 

--- a/app/bundles/WebhookBundle/Helper/CampaignHelper.php
+++ b/app/bundles/WebhookBundle/Helper/CampaignHelper.php
@@ -44,7 +44,8 @@ class CampaignHelper
         // dump($config);die;
         $payload = $this->getPayload($config, $contact);
         $headers = $this->getHeaders($config, $contact);
-        $this->makeRequest($config['url'], $config['method'], $config['timeout'], $headers, $payload);
+        $url = rawurldecode(TokenHelper::findLeadTokens($config['url'], $this->getContactValues($contact), true));
+        $this->makeRequest($url, $config['method'], $config['timeout'], $headers, $payload);
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR added to Send a webhook campaign action (https://github.com/mautic/mautic/pull/4357) support for contact token in url. 

PR use case based on slack conversation
https://mautic.slack.com/archives/C02HU8BUT/p1533624667000200

#### Steps to test this PR:
1. Well. Try setup Send a webhook campaign action.
2. Add contact token to url  (see example)

![image](https://user-images.githubusercontent.com/462477/44669663-c2e0fc00-aa20-11e8-9abe-3ff84a48bf31.png)

3. Check If url was replace with token data (need dev skills) 