### PR TITLE
Fix pagination for integration fields

### DIFF
--- a/app/bundles/PluginBundle/Controller/AjaxController.php
+++ b/app/bundles/PluginBundle/Controller/AjaxController.php
@@ -80,6 +80,7 @@ class AjaxController extends CommonAjaxController
                     $featureSettings    = $integrationObject->getIntegrationSettings()->getFeatureSettings();
                     $enableDataPriority = $integrationObject->getDataPriority();
                     $formType           = $isLead ? 'integration_fields' : 'integration_company_fields';
+                    $integrationFields  = (isset($integrationFields[0])) ? $integrationFields[0] : $integrationFields;
                     $form               = $this->createForm(
                         $formType,
                         isset($featureSettings[$object.'Fields']) ? $featureSettings[$object.'Fields'] : [],


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Noticed pagination doesn't work in integration. This PR fixed it 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Install NetSuite plugin via command line by `composer require kuzmany/mautic-netsuite-bundle` from Mautic root 
2.  Go to Mautic - Plugins and click to the button Install/Upgrade plugins
3. Setup custom  credits and enable contact object
4. See contact matching tab and try paginate 
5. Should return error

#### Steps to test this PR:
1.  Repeat all steps and see If pagination work
