### PR TITLE
Alias DoNotContact entity as DNC in LeadModel

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -33,7 +33,7 @@ use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyChangeLog;
 use Mautic\LeadBundle\Entity\CompanyLead;
-use Mautic\LeadBundle\Entity\DoNotContact;
+use Mautic\LeadBundle\Entity\DoNotContact as DNC;
 use Mautic\LeadBundle\Entity\FrequencyRule;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadCategory;
@@ -1467,7 +1467,7 @@ class LeadModel extends FormModel
 
                 // The email must be set for successful unsubscribtion
                 $lead->addUpdatedField('email', $data[$fields['email']]);
-                $this->addDncForLead($lead, 'email', $reason, DoNotContact::MANUAL);
+                $this->addDncForLead($lead, 'email', $reason, DNC::MANUAL);
             }
         }
         unset($fieldData['doNotEmail']);
@@ -2245,7 +2245,7 @@ class LeadModel extends FormModel
 
         $channels = [];
         foreach ($allChannels as $channel) {
-            if ($this->isContactable($lead, $channel) === DoNotContact::IS_CONTACTABLE) {
+            if ($this->isContactable($lead, $channel) === DNC::IS_CONTACTABLE) {
                 $channels[$channel] = $channel;
             }
         }
@@ -2266,7 +2266,7 @@ class LeadModel extends FormModel
 
         $channels = [];
         foreach ($allChannels as $channel) {
-            if ($this->isContactable($lead, $channel) !== DoNotContact::IS_CONTACTABLE) {
+            if ($this->isContactable($lead, $channel) !== DNC::IS_CONTACTABLE) {
                 $channels[$channel] = $channel;
             }
         }
@@ -2490,16 +2490,16 @@ class LeadModel extends FormModel
 
         // If the lead has no entries in the DNC table, we're good to go
         if (empty($dncEntries)) {
-            return DoNotContact::IS_CONTACTABLE;
+            return DNC::IS_CONTACTABLE;
         }
 
         foreach ($dncEntries as $dnc) {
-            if ($dnc->getReason() !== DoNotContact::IS_CONTACTABLE) {
+            if ($dnc->getReason() !== DNC::IS_CONTACTABLE) {
                 return $dnc->getReason();
             }
         }
 
-        return DoNotContact::IS_CONTACTABLE;
+        return DNC::IS_CONTACTABLE;
     }
 
     /**
@@ -2515,7 +2515,7 @@ class LeadModel extends FormModel
      */
     public function removeDncForLead(Lead $lead, $channel, $persist = true)
     {
-        /** @var DoNotContact $dnc */
+        /** @var DNC $dnc */
         foreach ($lead->getDoNotContact() as $dnc) {
             if ($dnc->getChannel() === $channel) {
                 $lead->removeDoNotContactEntry($dnc);
@@ -2544,17 +2544,17 @@ class LeadModel extends FormModel
      * @param bool         $checkCurrentStatus
      * @param bool         $override
      *
-     * @return bool|DoNotContact If a DNC entry is added or updated, returns the DoNotContact object. If a DNC is already present
-     *                           and has the specified reason, nothing is done and this returns false
+     * @return bool|DNC If a DNC entry is added or updated, returns the DNC object. If a DNC is already present
+     *                  and has the specified reason, nothing is done and this returns false
      */
-    public function addDncForLead(Lead $lead, $channel, $comments = '', $reason = DoNotContact::BOUNCED, $persist = true, $checkCurrentStatus = true, $override = false)
+    public function addDncForLead(Lead $lead, $channel, $comments = '', $reason = DNC::BOUNCED, $persist = true, $checkCurrentStatus = true, $override = false)
     {
         // if !$checkCurrentStatus, assume is contactable due to already being valided
-        $isContactable = ($checkCurrentStatus) ? $this->isContactable($lead, $channel) : DoNotContact::IS_CONTACTABLE;
+        $isContactable = ($checkCurrentStatus) ? $this->isContactable($lead, $channel) : DNC::IS_CONTACTABLE;
 
         // If they don't have a DNC entry yet
-        if ($isContactable === DoNotContact::IS_CONTACTABLE) {
-            $dnc = new DoNotContact();
+        if ($isContactable === DNC::IS_CONTACTABLE) {
+            $dnc = new DNC();
 
             if (is_array($channel)) {
                 $channelId = reset($channel);
@@ -2580,10 +2580,10 @@ class LeadModel extends FormModel
         }
         // Or if the given reason is different than the stated reason
         elseif ($isContactable !== $reason) {
-            /** @var DoNotContact $dnc */
+            /** @var DNC $dnc */
             foreach ($lead->getDoNotContact() as $dnc) {
                 // Only update if the contact did not unsubscribe themselves
-                if (!$override && $dnc->getReason() !== DoNotContact::UNSUBSCRIBED) {
+                if (!$override && $dnc->getReason() !== DNC::UNSUBSCRIBED) {
                     $override = true;
                 }
                 if ($dnc->getChannel() === $channel && $override) {


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6386
| BC breaks? | 
| Deprecations? | 


#### Description:

The model counterpart to the DoNotContact Entity is also named
DoNotContact, breaking with the convention of Model classes being
suffixed as such. This can cause a classname collision within the
LeadModel class which imports the DoNotContact entity class. To
prevent collision, the import is aliased as "DNC" and all mentions of
the DoNotContact classname within LeadModel have been replaced with
the alias.


#### Steps to reproduce the bug:
1. Run a console command which utilizes **LeadModel**, e.g.: `mautic:campaigns:trigger`

##### Example:

`$ app/console mautic:campaigns:trigger`

```
Fatal error: Cannot use Mautic\LeadBundle\Entity\DoNotContact as DoNotContact because the name is already in use in /var/www/html/app/bundles/LeadBundle/Model/LeadModel.php on line 36

Call Stack:
    0.0007     237344   1. {main}() /var/www/html/app/console:0
    0.2099    3136184   2. Symfony\Component\Console\Application->run() /var/www/html/app/console:41
    0.2745    4004488   3. Symfony\Bundle\FrameworkBundle\Console\Application->doRun() /var/www/html/vendor/symfony/console/Application.php:117
    2.2705   43774000   4. Symfony\Bundle\FrameworkBundle\Console\Application->all() /var/www/html/vendor/symfony/framework-bundle/Console/Application.php:66
    2.2705   43774288   5. Symfony\Bundle\FrameworkBundle\Console\Application->registerCommands() /var/www/html/vendor/symfony/framework-bundle/Console/Application.php:112
    3.0273   50698024   6. Symfony\Component\DependencyInjection\Container->get() /var/www/html/vendor/symfony/framework-bundle/Console/Application.php:147
    3.0273   50698424   7. appProdProjectContainer->getMautic_Campaign_Command_TriggerService() /var/www/html/vendor/symfony/dependency-injection/Container.php:297
    3.1859   53386144   8. Symfony\Component\DependencyInjection\Container->get() /var/www/html/app/cache/prod/appProdProjectContainer.php:5830
    3.1859   53386496   9. appProdProjectContainer->getMautic_Campaign_Executioner_KickoffService() /var/www/html/vendor/symfony/dependency-injection/Container.php:297
    3.2810   55053768  10. Symfony\Component\DependencyInjection\Container->get() /var/www/html/app/cache/prod/appProdProjectContainer.php:6015
    3.2810   55054184  11. appProdProjectContainer->getMautic_Campaign_EventExecutionerService() /var/www/html/vendor/symfony/dependency-injection/Container.php:297
    3.4374   56881808  12. Symfony\Component\DependencyInjection\Container->get() /var/www/html/app/cache/prod/appProdProjectContainer.php:5955
    3.4375   56882112  13. appProdProjectContainer->getMautic_Campaign_Executioner_ActionService() /var/www/html/vendor/symfony/dependency-injection/Container.php:297
    3.4450   56897928  14. Symfony\Component\DependencyInjection\Container->get() /var/www/html/app/cache/prod/appProdProjectContainer.php:5975
    3.4450   56898280  15. appProdProjectContainer->getMautic_Campaign_Dispatcher_ActionService() /var/www/html/vendor/symfony/dependency-injection/Container.php:297
    3.4632   57038800  16. Symfony\Component\DependencyInjection\Container->get() /var/www/html/app/cache/prod/appProdProjectContainer.php:5915
    3.4632   57039136  17. appProdProjectContainer->getMautic_Campaign_Helper_NotificationService() /var/www/html/vendor/symfony/dependency-injection/Container.php:297
    3.4677   57058352  18. Symfony\Component\DependencyInjection\Container->get() /var/www/html/app/cache/prod/appProdProjectContainer.php:6055
    3.4677   57058968  19. appProdProjectContainer->getMautic_User_Model_UserService() /var/www/html/vendor/symfony/dependency-injection/Container.php:297
    3.4718   57166720  20. Symfony\Component\DependencyInjection\Container->get() /var/www/html/app/cache/prod/appProdProjectContainer.php:16846
    3.4719   57167048  21. appProdProjectContainer->getMautic_Helper_MailerService() /var/www/html/vendor/symfony/dependency-injection/Container.php:297
    3.4779   57621416  22. Symfony\Component\DependencyInjection\Container->get() /var/www/html/app/cache/prod/appProdProjectContainer.php:11263
    3.4779   57621800  23. appProdProjectContainer->getSwiftmailer_Mailer_DefaultService() /var/www/html/vendor/symfony/dependency-injection/Container.php:297
    3.5117   57986952  24. Symfony\Component\DependencyInjection\Container->get() /var/www/html/app/cache/prod/appProdProjectContainer.php:18223
    3.5117   57987256  25. appProdProjectContainer->getMautic_Transport_SendgridApiService() /var/www/html/vendor/symfony/dependency-injection/Container.php:297
    3.5687   58211304  26. Symfony\Component\DependencyInjection\Container->get() /var/www/html/app/cache/prod/appProdProjectContainer.php:16659
    3.5687   58211632  27. appProdProjectContainer->getMautic_Transport_SendgridApi_CalbackService() /var/www/html/vendor/symfony/dependency-injection/Container.php:297
    3.5720   58218416  28. Symfony\Component\DependencyInjection\Container->get() /var/www/html/app/cache/prod/appProdProjectContainer.php:16669
    3.5720   58218736  29. appProdProjectContainer->getMautic_Email_Model_TransportCallbackService() /var/www/html/vendor/symfony/dependency-injection/Container.php:297
    3.5755   58244544  30. Symfony\Component\DependencyInjection\Container->get() /var/www/html/app/cache/prod/appProdProjectContainer.php:7880
    3.5755   58244872  31. appProdProjectContainer->getMautic_Lead_Model_DncService() /var/www/html/vendor/symfony/dependency-injection/Container.php:297
    3.5794   58286536  32. Symfony\Component\DependencyInjection\Container->get() /var/www/html/app/cache/prod/appProdProjectContainer.php:12878
    3.5794   58287376  33. appProdProjectContainer->getMautic_Lead_Model_LeadService() /var/www/html/vendor/symfony/dependency-injection/Container.php:297
    3.5794   58287688  34. spl_autoload_call() /var/www/html/vendor/symfony/dependency-injection/Container.php:12936
    3.5794   58287744  35. Composer\Autoload\ClassLoader->loadClass() /var/www/html/vendor/symfony/dependency-injection/Container.php:12936
    3.5801   58287888  36. Composer\Autoload\includeFile() /var/www/html/vendor/composer/ClassLoader.php:322
```

#### Steps to test this PR:
1. Clear app cache (and probably APC if applicable).
2. Run console command as above.
