### PR TITLE
Fix #6367 email stats

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1894,7 +1894,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
 
         if ($flag == 'all' || $flag == 'clicked' || in_array('clicked', $datasets)) {
             $q = $query->prepareTimeDataQuery('page_hits', 'date_hit', []);
-            $q->leftJoin('t', MAUTIC_TABLE_PREFIX.'email_stats', 'es', 't.source_id = es.email_id AND t.source = "email"');
+            $q->leftJoin('t', MAUTIC_TABLE_PREFIX.'email_stats', 'es', 't.source_id = es.email_id AND es.source = "email"');
 
             if (isset($filter['email_id'])) {
                 if (is_array($filter['email_id'])) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | #6367 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Fixes a bug where email stats shows way too many clicks because the LEFT JOIN query is matching on many rows.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
See https://github.com/mautic/mautic/issues/6367#issuecomment-416327529 for details