### PR TITLE
Prevent memory leak in reports and export more than 10K rows

### DIFF
--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -731,7 +731,9 @@ class ReportModel extends FormModel
         $countQb->select('count(*)')
             ->from('('.$qb->getSQL().')', 'c');
 
-        $debugData['count_query'] = $countQb->getSQL();
+        if (MAUTIC_ENV == 'dev') {
+            $debugData['count_query'] = $countQb->getSQL();
+        }
 
         return (int) $countQb->execute()->fetchColumn();
     }

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\ReportBundle\Model;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use Mautic\ChannelBundle\Helper\ChannelListHelper;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
@@ -542,7 +543,7 @@ class ReportModel extends FormModel
             'dynamicFilters' => (isset($options['dynamicFilters'])) ? $options['dynamicFilters'] : [],
         ];
 
-        /** @var \Doctrine\DBAL\Query\QueryBuilder $query */
+        /** @var QueryBuilder $query */
         $query                 = $reportGenerator->getQuery($dataOptions);
         $options['translator'] = $this->translator;
 
@@ -612,7 +613,12 @@ class ReportModel extends FormModel
                     $start = 0;
                 }
 
-                $totalResults = $query->execute()->rowCount();
+                if (empty($options['totalResults'])) {
+                    $options['totalResults'] = $totalResults = $this->getTotalCount($query, $debugData);
+                } else {
+                    $totalResults = $options['totalResults'];
+                }
+
                 if ($limit > 0) {
                     $query->setFirstResult($start)
                         ->setMaxResults($limit);
@@ -709,5 +715,24 @@ class ReportModel extends FormModel
         }
 
         return $options;
+    }
+
+    /**
+     * @param QueryBuilder $qb
+     * @param array        $debugData
+     *
+     * @return int
+     */
+    private function getTotalCount(QueryBuilder $qb, array &$debugData)
+    {
+        $countQb = clone $qb;
+        $countQb->resetQueryParts();
+
+        $countQb->select('count(*)')
+            ->from('('.$qb->getSQL().')', 'c');
+
+        $debugData['count_query'] = $countQb->getSQL();
+
+        return (int) $countQb->execute()->fetchColumn();
     }
 }

--- a/app/bundles/ReportBundle/Views/Report/details.html.php
+++ b/app/bundles/ReportBundle/Views/Report/details.html.php
@@ -172,6 +172,8 @@ if ($tmpl == 'index') {
 <?php if (!empty($debug)): ?>
 <div class="well">
     <h4>Debug: <?php echo $debug['query_time']; ?></h4>
+    <div><?php echo $debug['count_query']; ?></div>
+    <br />
     <div><?php echo $debug['query']; ?></div>
 </div>
 <?php endif; ?>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR uses a wrapping count query to get results rather than loading all results into memory to count via PHP. 

It also fixes the export of the report to ensure it exports more than 10K. 

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Ensure total results are correct for various reports created (include at least one report with a group by)
2. Create a report with more than 1000 results (yes one thousand) and export as a CSV. All results should be included in the CSV. 
