### PR TITLE
Import CSV list of contacts via Mautic API

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -292,6 +292,11 @@ return [
                     'channel' => 'email',
                 ],
             ],
+            'bc_mautic_api_importcsv' => [
+                'path'       => '/contacts/importCsv',
+                'controller' => 'MauticLeadBundle:Api\LeadApi:importCsv',
+                'method'     => 'POST',
+            ],
             'bc_mautic_api_dncremovecontact' => [
                 'path'       => '/contacts/{id}/dnc/remove/{channel}',
                 'controller' => 'MauticLeadBundle:Api\LeadApi:removeDnc',

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -14,6 +14,7 @@ namespace Mautic\LeadBundle\Controller\Api;
 use FOS\RestBundle\Util\Codes;
 use JMS\Serializer\SerializationContext;
 use Mautic\ApiBundle\Controller\CommonApiController;
+use Mautic\CoreBundle\Helper\CsvHelper;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\LeadBundle\Controller\FrequencyRuleTrait;
@@ -21,6 +22,7 @@ use Mautic\LeadBundle\Controller\LeadDetailsTrait;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
@@ -401,6 +403,114 @@ class LeadApiController extends CommonApiController
         $view    = $this->view($events);
         $context = SerializationContext::create()->setGroups($serializerGroups);
         $view->setSerializationContext($context);
+
+        return $this->handleView($view);
+    }
+
+    /**
+     * Imports a CSV file with contacts
+     * Accepts multipart form-data requests. Accepted request params:.
+     *
+     *  mapping: JSON mapping of CSV columns in format: {"csv_column": "mautic_field", ...}
+     *   config: Import configuration object, see below for details
+     *     file: multipart-encoded CSV file
+     *
+     * Example usage from cURL:
+     * curl -X POST -H 'Authorization: Basic ...' -F 'file=@path/to/contacts.csv' \
+     *      -F 'mapping={"email":"email","firstname":"first_name"}' http://mautic.local/api/contacts/importCsv
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function importCsvAction()
+    {
+        $files       = $this->request->files;
+        $mapping     = $this->request->request->get('mapping');
+        $user_config = $this->request->request->get('config');
+
+        if (!$this->get('mautic.security')->isGranted('lead:leads:create')) {
+            return $this->accessDenied();
+        }
+
+        if (!$files || count($files) !== 1) {
+            return $this->badRequest('You must upload exactly one CSV file.');
+        }
+        $file      = $files->get('file');
+        $extension = $file->getClientOriginalExtension();
+        if (strtolower($extension) !== 'csv') {
+            return $this->badRequest('Only CSV files are supported. Uploaded file: type'.$extension);
+        }
+
+        if (!$mapping || !json_decode($mapping)) {
+            return $this->badRequest('CSV column mapping is missing or not in JSON format.');
+        }
+
+        $mapping = json_decode($mapping, true);
+
+        // Default configuration
+        $config = [
+            'delimiter'  => ',',
+            'enclosure'  => '"',
+            'escape'     => '\\',
+            'batchlimit' => 200,
+        ];
+
+        // Apply user configuration
+        if ($user_config) {
+            $user_config = json_decode($user_config, true);
+            $config      = array_merge($config, $user_config);
+        }
+
+        /** @var \Mautic\LeadBundle\Model\ImportModel $importModel */
+        $importModel = $this->getModel('lead.import');
+
+        $fs        = new Filesystem();
+        $import    = $importModel->getEntity();
+        $importDir = $importModel->getImportDir();
+        $fileName  = $importModel->getUniqueFileName();
+        $fullPath  = $importDir.'/'.$fileName;
+
+        /** @var \Mautic\LeadBundle\Model\FieldModel $fieldModel */
+        $fieldModel = $this->getModel('lead.field');
+        $leadFields = $fieldModel->getFieldList(false, false);
+
+        foreach ($mapping as $csvField => $leadField) {
+            if (!isset($leadFields[$leadField])) {
+                return $this->badRequest('Unrecognized column mapping field: '.$leadField);
+            }
+        }
+
+        // Create the import dir recursively
+        $fs->mkdir($importDir, 0755);
+
+        if (file_exists($fullPath)) {
+            unlink($fullPath);
+        }
+
+        // Move the file to final location
+        $file->move($importDir, $fullPath);
+
+        // Get file headers and line count
+        $fileData = new \SplFileObject($fullPath);
+        $headers  = $fileData->fgetcsv($config['delimiter'], $config['enclosure'], $config['escape']);
+        $headers  = CsvHelper::sanitizeHeaders($headers);
+
+        $fileData->seek(PHP_INT_MAX);
+        $linecount = $fileData->key();
+
+        // Create an import object
+        $import->setMatchedFields($mapping)
+            ->setDir($importDir)
+            ->setLineCount($linecount)
+            ->setFile($fileName)
+            ->setOriginalFile($file->getClientOriginalName())
+            ->setDefault('owner', null)
+            ->setHeaders($headers)
+            ->setParserConfig($config)
+            ->setStatus($import::QUEUED);
+
+        $importModel->saveEntity($import);
+
+        $view = $this->view(['import' => $import]);
 
         return $this->handleView($view);
     }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/120
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Required: )
#### Description:

This pull request implements a new API call: `POST /api/contacts/importCsv`. It takes a CSV file, a field mapping object and an optional config object which overrides default parser configuration. With this API call one can automate contact imports, e.g. synchronize Mautic contacts with a custom CRM / website user database.

Note: This will require adding a section to developer documentation, and possibly in the API Library. Should you decide that this PR is worthwhile I will create PRs in those repos and post a links here.

#### Steps to test this PR:
1. Create a CSV with some test contacts to import.
2. Call the API uploading the CSV file as a multipart-encoded form data field. Curl example:
```bash
    curl -X POST -H 'Authorization: Basic ...' -F 'file=@path/to/contacts.csv' \
         -F 'mapping={"email":"email","firstname":"first_name"}' 
```