### PR TITLE
Feature ip address in campaign webhook

### DIFF
--- a/app/bundles/WebhookBundle/Config/config.php
+++ b/app/bundles/WebhookBundle/Config/config.php
@@ -87,7 +87,7 @@ return [
             'mautic.webhook.campaign.subscriber' => [
                 'class'     => \Mautic\WebhookBundle\EventListener\CampaignSubscriber::class,
                 'arguments' => [
-                    'mautic.http.connector',
+                    'mautic.webhook.campaign.helper',
                 ],
             ],
         ],
@@ -98,6 +98,14 @@ return [
                     'mautic.helper.core_parameters',
                     'jms_serializer',
                     'mautic.core.model.notification',
+                ],
+            ],
+        ],
+        'others' => [
+            'mautic.webhook.campaign.helper' => [
+                'class'     => \Mautic\WebhookBundle\Helper\CampaignHelper::class,
+                'arguments' => [
+                    'mautic.http.connector',
                 ],
             ],
         ],

--- a/app/bundles/WebhookBundle/Helper/CampaignHelper.php
+++ b/app/bundles/WebhookBundle/Helper/CampaignHelper.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\WebhookBundle\Helper;
+
+use Doctrine\Common\Collections\Collection;
+use Joomla\Http\Http;
+use Mautic\CoreBundle\Helper\AbstractFormFieldHelper;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Helper\TokenHelper;
+
+class CampaignHelper
+{
+    /**
+     * @var Http
+     */
+    protected $connector;
+
+    /**
+     * Cached contact values in format [contact_id => [key1 => val1, key2 => val1]].
+     *
+     * @var array
+     */
+    private $contactsValues = [];
+
+    /**
+     * @param Http $connector
+     */
+    public function __construct(Http $connector)
+    {
+        $this->connector = $connector;
+    }
+
+    /**
+     * Prepares the neccessary data transformations and then makes the HTTP request.
+     *
+     * @param array $config
+     * @param Lead  $contact
+     */
+    public function fireWebhook(array $config, Lead $contact)
+    {
+        // dump($config);die;
+        $payload = $this->getPayload($config, $contact);
+        $headers = $this->getHeaders($config, $contact);
+        $this->makeRequest($config['url'], $config['method'], $config['timeout'], $headers, $payload);
+    }
+
+    /**
+     * Gets the payload fields from the config and if there are tokens it translates them to contact values.
+     *
+     * @param array $config
+     * @param Lead  $contact
+     *
+     * @return array
+     */
+    private function getPayload(array $config, Lead $contact)
+    {
+        $payload = !empty($config['additional_data']['list']) ? $config['additional_data']['list'] : '';
+        $payload = array_flip(AbstractFormFieldHelper::parseList($payload));
+
+        return $this->getTokenValues($payload, $contact);
+    }
+
+    /**
+     * Gets the payload fields from the config and if there are tokens it translates them to contact values.
+     *
+     * @param array $config
+     * @param Lead  $contact
+     *
+     * @return array
+     */
+    private function getHeaders(array $config, Lead $contact)
+    {
+        $headers = !empty($config['headers']['list']) ? $config['headers']['list'] : '';
+        $headers = array_flip(AbstractFormFieldHelper::parseList($headers));
+
+        return $this->getTokenValues($headers, $contact);
+    }
+
+    /**
+     * @param string $url
+     * @param string $method
+     * @param int    $timeout
+     * @param array  $headers
+     * @param array  $payload
+     *
+     * @throws \InvalidArgumentException
+     * @throws \OutOfRangeException
+     */
+    private function makeRequest($url, $method, $timeout, array $headers, array $payload)
+    {
+        switch ($method) {
+            case 'get':
+                $payload  = $url.(parse_url($url, PHP_URL_QUERY) ? '&' : '?').http_build_query($payload);
+                $response = $this->connector->get($payload, $headers, $timeout);
+                break;
+            case 'post':
+            case 'put':
+            case 'patch':
+                $response = $this->connector->$method($url, $payload, $headers, $timeout);
+                break;
+            case 'delete':
+                $response = $this->connector->delete($url, $headers, $timeout, $payload);
+                break;
+            default:
+                throw new \InvalidArgumentException('HTTP method "'.$method.' is not supported."');
+        }
+
+        if (!in_array($response->code, [200, 201])) {
+            throw new \OutOfRangeException('Campaign webhook response returned error code: '.$response->code);
+        }
+    }
+
+    /**
+     * Translates tokens to values.
+     *
+     * @param array $rawTokens
+     * @param Lead  $contact
+     *
+     * @return array
+     */
+    private function getTokenValues(array $rawTokens, Lead $contact)
+    {
+        $values        = [];
+        $contactValues = $this->getContactValues($contact);
+
+        foreach ($rawTokens as $key => $value) {
+            $values[$key] = urldecode(TokenHelper::findLeadTokens($value, $contactValues, true));
+        }
+
+        return $values;
+    }
+
+    /**
+     * Gets array of contact values.
+     *
+     * @param Lead $contact
+     *
+     * @return array
+     */
+    private function getContactValues(Lead $contact)
+    {
+        if (empty($this->contactsValues[$contact->getId()])) {
+            $this->contactsValues[$contact->getId()]              = $contact->getProfileFields();
+            $this->contactsValues[$contact->getId()]['ipAddress'] = $this->ipAddressesToCsv($contact->getIpAddresses());
+        }
+
+        return $this->contactsValues[$contact->getId()];
+    }
+
+    /**
+     * @param Collection $ipAddresses
+     *
+     * @return string
+     */
+    private function ipAddressesToCsv(Collection $ipAddresses)
+    {
+        $addresses = [];
+        foreach ($ipAddresses as $ipAddress) {
+            $addresses[] = $ipAddress->getIpAddress();
+        }
+
+        return implode(',', $addresses);
+    }
+}

--- a/app/bundles/WebhookBundle/Tests/Helper/CampaignHelperTest.php
+++ b/app/bundles/WebhookBundle/Tests/Helper/CampaignHelperTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\WebhookBundle\Tests\Helper;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Joomla\Http\Http;
+use Mautic\CoreBundle\Entity\IpAddress;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\WebhookBundle\Helper\CampaignHelper;
+
+class CampaignHelperTest extends \PHPUnit_Framework_TestCase
+{
+    private $contact;
+    private $connector;
+
+    /**
+     * @var ArrayCollection
+     */
+    private $ipCollection;
+
+    /**
+     * @var CampaignHelper
+     */
+    private $campaignHelper;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->contact        = $this->createMock(Lead::class);
+        $this->connector      = $this->createMock(Http::class);
+        $this->ipCollection   = new ArrayCollection();
+        $this->campaignHelper = new CampaignHelper($this->connector);
+
+        $this->ipCollection->add((new IpAddress())->setIpAddress('127.0.0.1'));
+        $this->ipCollection->add((new IpAddress())->setIpAddress('127.0.0.2'));
+
+        $this->contact->expects($this->once())
+            ->method('getProfileFields')
+            ->willReturn(['email' => 'john@doe.email', 'company' => 'Mautic']);
+
+        $this->contact->expects($this->once())
+            ->method('getIpAddresses')
+            ->willReturn($this->ipCollection);
+    }
+
+    public function testFireWebhookWithGet()
+    {
+        $expectedUrl = 'https://mautic.org?test=tee&email=john%40doe.email&IP=127.0.0.1%2C127.0.0.2';
+
+        $this->connector->expects($this->once())
+            ->method('get')
+            ->with($expectedUrl, ['test' => 'tee', 'company' => 'Mautic'], 10)
+            ->willReturn((object) ['code' => 200]);
+
+        $this->campaignHelper->fireWebhook($this->provideSampleConfig(), $this->contact);
+    }
+
+    public function testFireWebhookWithPost()
+    {
+        $config      = $this->provideSampleConfig('post');
+        $expectedUrl = 'https://mautic.org?test=tee&email=john%40doe.email&IP=127.0.0.1%2C127.0.0.2';
+
+        $this->connector->expects($this->once())
+            ->method('post')
+            ->with('https://mautic.org', ['test'  => 'tee', 'email' => 'john@doe.email', 'IP' => '127.0.0.1,127.0.0.2'], ['test' => 'tee', 'company' => 'Mautic'], 10)
+            ->willReturn((object) ['code' => 200]);
+
+        $this->campaignHelper->fireWebhook($config, $this->contact);
+    }
+
+    public function testFireWebhookWhenReturningNotFound()
+    {
+        $this->connector->expects($this->once())
+            ->method('get')
+            ->willReturn((object) ['code' => 404]);
+
+        $this->expectException(\OutOfRangeException::class);
+
+        $this->campaignHelper->fireWebhook($this->provideSampleConfig(), $this->contact);
+    }
+
+    private function provideSampleConfig($method = 'get')
+    {
+        return [
+            'url'             => 'https://mautic.org',
+            'method'          => $method,
+            'timeout'         => 10,
+            'additional_data' => [
+                'list' => [
+                    [
+                        'label' => 'test',
+                        'value' => 'tee',
+                    ],
+                    [
+                        'label' => 'email',
+                        'value' => '{contactfield=email}',
+                    ],
+                    [
+                        'label' => 'IP',
+                        'value' => '{contactfield=ipAddress}',
+                    ],
+                ],
+            ],
+            'headers' => [
+                'list' => [
+                    [
+                        'label' => 'test',
+                        'value' => 'tee',
+                    ],
+                    [
+                        'label' => 'company',
+                        'value' => '{contactfield=company}',
+                    ],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | Y
| Related user documentation PR URL | https://github.com/mautic/documentation/pull/296
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The send webhook campaign action can now work with `{contactfield=ipAddress}` which will return CSV of contact's IP addresses. Example campaign action setup:

![screen shot 2018-08-24 at 17 52 29](https://user-images.githubusercontent.com/1235442/44594445-81edab00-a7c6-11e8-9f40-3a1642e8c9c1.png)

Will return payload like this: `test=tee&email=linhartescope+form2%40gmail.com&IP=127.0.0.1`

#### Steps to test this PR:
1. Create a campaign with the webhook action.
2. Use the new token for IP addresses.
3. Create a Request bin or similar webhook catcher.
4. Run the campaign and check that the IP address token is converted to the correct value.