### PR TITLE
Circular dependency validation

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -873,6 +873,14 @@ return [
                     'mautic.schema.helper.column',
                 ],
             ],
+            'mautic.form.list.validator.circular' => [
+                'class'     => Mautic\CoreBundle\Form\Validator\Constraints\CircularDependencyValidator::class,
+                'arguments' => [
+                    'mautic.lead.model.list',
+                    'request_stack',
+                ],
+                'tag' => 'validator.constraint_validator',
+            ],
         ],
         'models' => [
             'mautic.core.model.auditlog' => [

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependency.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependency.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Form\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+class CircularDependency extends Constraint
+{
+    public $message;
+
+    public function validatedBy()
+    {
+        return CircularDependencyValidator::class;
+    }
+}

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependencyValidator.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependencyValidator.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Form\Validator\Constraints;
+
+use Mautic\LeadBundle\Model\ListModel;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Throws an exception if the field alias is equal some segment filter keyword.
+ * It would cause odd behavior with segment filters otherwise.
+ */
+class CircularDependencyValidator extends ConstraintValidator
+{
+    /**
+     * @var ListModel
+     */
+    protected $model;
+    protected $currentSegmentId;
+
+    public function __construct(ListModel $model, $request)
+    {
+        $this->model            = $model;
+        $this->currentSegmentId = (int) $request->getCurrentRequest()->get('_route_params')['objectId'];
+    }
+
+    /**
+     * @param LeadField  $field
+     * @param Constraint $constraint
+     */
+    public function validate($filters, Constraint $constraint)
+    {
+        $dependentSegmentIds = $this->flatten(array_map(function ($id) {
+            return $this->reduceToSegmentIds($this->model->getEntity($id)->getFilters());
+        }, $this->reduceToSegmentIds($filters)));
+
+        if (in_array($this->currentSegmentId, $dependentSegmentIds)) {
+            $this->context->addViolation($constraint->message);
+        }
+    }
+
+    public function reduceToSegmentIds($filters)
+    {
+        $segmentFilters = array_filter($filters, function ($v, $k) {
+            return $v['type'] == 'leadlist';
+        }, ARRAY_FILTER_USE_BOTH);
+
+        $segentIdsInFilter = array_column($segmentFilters, 'filter');
+
+        return $this->flatten($segentIdsInFilter);
+    }
+
+    private function flatten($array)
+    {
+        return array_unique(array_reduce($array, 'array_merge', []));
+    }
+}

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependencyValidator.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependencyValidator.php
@@ -47,11 +47,11 @@ class CircularDependencyValidator extends ConstraintValidator
         }
     }
 
-    public function reduceToSegmentIds($filters)
+    private function reduceToSegmentIds($filters)
     {
-        $segmentFilters = array_filter($filters, function ($v, $k) {
+        $segmentFilters = array_filter($filters, function ($v) {
             return $v['type'] == 'leadlist';
-        }, ARRAY_FILTER_USE_BOTH);
+        });
 
         $segentIdsInFilter = array_column($segmentFilters, 'filter');
 

--- a/app/bundles/CoreBundle/Tests/unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Mautic\CoreBundle\Tests\Form\Validator\Constraints;
+
+use Mautic\CoreBundle\Form\Validator\Constraints\CircularDependency;
+use Mautic\CoreBundle\Form\Validator\Constraints\CircularDependencyValidator;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Model\ListModel;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Exercises CircularDependencyValidator.
+ */
+class CircularDependencyValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Configure a CircularDependencyValidator.
+     *
+     * @param string $expectedMessage the expected message on a validation violation, if any
+     *
+     * @return Mautic\CoreBundle\Form\Validator\Constraints\CircularDependencyValidator
+     */
+    public function configureValidator($expectedMessage = null)
+    {
+        $filters  = 'a:1:{i:0;a:7:{s:4:"glue";s:3:"and";s:5:"field";s:8:"leadlist";s:6:"object";s:4:"lead";s:4:"type";s:8:"leadlist";s:6:"filter";a:1:{i:0;i:2;}s:7:"display";N;s:8:"operator";s:2:"in";}}';
+        $filters2 = 'a:1:{i:0;a:7:{s:4:"glue";s:3:"and";s:5:"field";s:8:"leadlist";s:6:"object";s:4:"lead";s:4:"type";s:8:"leadlist";s:6:"filter";a:1:{i:0;i:1;}s:7:"display";N;s:8:"operator";s:2:"in";}}';
+
+        $mockListModel = $this->getMockBuilder(ListModel::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getEntity'])
+            ->getMock();
+
+        $mockEntity = $this->getMockBuilder(LeadList::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockEntity1 = clone $mockEntity;
+        $mockEntity1->expects($this->any())
+            ->method('getId')
+            ->willReturn(1);
+        $mockEntity2 = clone $mockEntity;
+        $mockEntity2->expects($this->any())
+            ->method('getId')
+            ->willReturn(2);
+
+        // $mockListModel->expects($this->any())
+        //     ->method('getEntity')
+        //     ->willReturnCallback(function ($id) {
+        //         $mockEntity = $this->getMockBuilder(LeadList::class)
+        //             ->disableOriginalConstructor()
+        //             ->setMethods(['getFilters'])
+        //             ->getMock();
+        //          $mockEntity->expects($this->once())
+        //             ->method('getFilters')
+        //             ->willReturn(unserialize($filters));
+        //          return $mockEntity;
+        // });
+
+        // mock the violation builder
+        $builder = $this->getMockBuilder('Symfony\Component\Validator\Violation\ConstraintViolationBuilder')
+            ->disableOriginalConstructor()
+            ->setMethods(['addViolation'])
+            ->getMock()
+        ;
+
+        // mock the validator context
+        $context = $this->getMockBuilder('Symfony\Component\Validator\Context\ExecutionContext')
+            ->disableOriginalConstructor()
+            ->setMethods(['buildViolation'])
+            ->getMock()
+        ;
+
+        if ($expectedMessage) {
+            $builder->expects($this->once())
+                ->method('addViolation')
+            ;
+
+            $context->expects($this->once())
+                ->method('buildViolation')
+                ->with($this->equalTo($expectedMessage))
+                ->willReturn($this->returnValue($builder))
+            ;
+        } else {
+            $context->expects($this->never())
+                ->method('buildViolation')
+            ;
+        }
+
+        $request = $this
+            ->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $requestStack = $this->getMockBuilder(RequestStack::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCurrentRequest', '_route_params'])
+            ->getMock();
+
+        $requestStack
+            ->expects($this->once())
+            ->method('getCurrentRequest')
+            ->willReturn($request);
+
+        $requestStack
+            ->expects($this->once())
+            ->method('_route_params')
+            ->willReturn([
+                'objectId' => 1,
+            ]);
+
+        // initialize the validator with the mocked context
+        $validator = new CircularDependencyValidator($mockListModel, $requestStack);
+        $validator->initialize($context);
+
+        // return the CircularDependencyValidator
+        return $validator;
+    }
+
+    /**
+     * Verify a constraint message is triggered when value is invalid.
+     */
+    public function testValidateOnInvalid()
+    {
+        $filters    = 'a:1:{i:0;a:7:{s:4:"glue";s:3:"and";s:5:"field";s:8:"leadlist";s:6:"object";s:4:"lead";s:4:"type";s:8:"leadlist";s:6:"filter";a:1:{i:0;i:2;}s:7:"display";N;s:8:"operator";s:2:"in";}}';
+        $filters    = unserialize($filters);
+        $constraint = new CircularDependency();
+        $validator  = $this->configureValidator($constraint->message);
+
+        $validator->validate($filters, $constraint);
+    }
+}

--- a/app/bundles/CoreBundle/Translations/en_US/validators.ini
+++ b/app/bundles/CoreBundle/Translations/en_US/validators.ini
@@ -1,5 +1,6 @@
 mautic.core.ab_test.winner_criteria.not_blank="Select a winning criteria."
 mautic.core.email.required="A valid email is required."
+mautic.core.segment.circular_dependency_exists="The current operation can cause circular dependency among the segments, hence cannot finish the operation."
 mautic.core.name.required="A name is required."
 mautic.core.title.required="A title is required."
 mautic.core.type.required="A type is required"

--- a/app/bundles/CoreBundle/Translations/en_US/validators.ini
+++ b/app/bundles/CoreBundle/Translations/en_US/validators.ini
@@ -1,6 +1,6 @@
 mautic.core.ab_test.winner_criteria.not_blank="Select a winning criteria."
 mautic.core.email.required="A valid email is required."
-mautic.core.segment.circular_dependency_exists="Update cannot be completed as there are one or more circular dependencies in this segment. Please remove the dependency for the segment to function."
+mautic.core.segment.circular_dependency_exists="Update cannot be completed as the current filters are conflicting with the filters of another segment. Make sure your segment filters are not creating impossible or contradictory conditions (e.g. Segment A must be a member of Segment B while Segment B must be a member of Segment A)."
 mautic.core.name.required="A name is required."
 mautic.core.title.required="A title is required."
 mautic.core.type.required="A type is required"

--- a/app/bundles/CoreBundle/Translations/en_US/validators.ini
+++ b/app/bundles/CoreBundle/Translations/en_US/validators.ini
@@ -1,6 +1,6 @@
 mautic.core.ab_test.winner_criteria.not_blank="Select a winning criteria."
 mautic.core.email.required="A valid email is required."
-mautic.core.segment.circular_dependency_exists="The current operation can cause circular dependency among the segments, hence cannot finish the operation."
+mautic.core.segment.circular_dependency_exists="Update cannot be completed as there are one or more circular dependencies in this segment. Please remove the dependency for the segment to function."
 mautic.core.name.required="A name is required."
 mautic.core.title.required="A title is required."
 mautic.core.type.required="A type is required"

--- a/app/bundles/LeadBundle/Form/Type/ListType.php
+++ b/app/bundles/LeadBundle/Form/Type/ListType.php
@@ -16,6 +16,7 @@ use DeviceDetector\Parser\OperatingSystem;
 use Mautic\CategoryBundle\Model\CategoryModel;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
+use Mautic\CoreBundle\Form\Validator\Constraints\CircularDependency;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\EmailBundle\Model\EmailModel;
@@ -197,6 +198,11 @@ class ListType extends AbstractType
                     'allow_add'      => true,
                     'allow_delete'   => true,
                     'label'          => false,
+                    'constraints'    => [
+                        new CircularDependency([
+                            'message' => 'mautic.core.segment.circular_dependency_exists',
+                        ]),
+                    ],
                 ]
             )->addModelTransformer($filterModalTransformer)
         );

--- a/app/bundles/LeadBundle/Views/List/form.html.php
+++ b/app/bundles/LeadBundle/Views/List/form.html.php
@@ -119,6 +119,11 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
                             <div class="clearfix"></div>
                         </div>
                         <div class="selected-filters" id="leadlist_filters">
+                            <?php if ($filterErrors): ?>
+                                <div class="alert alert-danger">
+                                    <?php echo $view['form']->errors($form['filters']); ?>
+                                </div>
+                            <?php endif ?>
                             <?php echo $view['form']->widget($form['filters']); ?>
                         </div>
                     </div>

--- a/app/bundles/LeadBundle/Views/List/form.html.php
+++ b/app/bundles/LeadBundle/Views/List/form.html.php
@@ -120,7 +120,7 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
                         </div>
                         <div class="selected-filters" id="leadlist_filters">
                             <?php if ($filterErrors): ?>
-                                <div class="alert alert-danger">
+                                <div class="alert alert-danger has-error">
                                     <?php echo $view['form']->errors($form['filters']); ?>
                                 </div>
                             <?php endif ?>


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | N/A
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

[//]: # ( Required: )
#### Description:
Segment A can exclude Segment B and Segment B exclude Segment A. We need a validation for when the form is saved to check any segments included in a filter to see if those segment refer back to the one being saved. If so, throw a validation error.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Add Segment A as a member in filters of Segment B and do the same with Segment B in filters of Segment A.
2. The operation will be completed without any validation errors.

#### Steps to test this PR:
1. Apply PR.
2. Perform the same steps as to reproduce the issue and this time it will prevent the operation from getting completed and show the validation error message. 
