### PR TITLE
Update Symfony security component to fix multiple CVEs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/intl": "~2.8",
         "symfony/options-resolver": "~2.8",
         "symfony/process": "~2.8",
-        "symfony/security": "~2.8",
+        "symfony/security": "^2.8.41",
         "symfony/security-acl": "~2.7",
         "symfony/translation": "2.8.11",
         "symfony/validator": "~2.8",
@@ -51,7 +51,7 @@
 
         "symfony/framework-bundle": "~2.8",
         "symfony/monolog-bundle": "~2.11",
-        "symfony/security-bundle": "~2.8",
+        "symfony/security-bundle": "^2.8.41",
         "symfony/swiftmailer-bundle": "~2.3",
 
         "symfony/doctrine-bridge": "~2.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b22d650f8ba498dd42031ca3ad79b67",
+    "content-hash": "10dadf00307b2db829fa7013b0c4ce73",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -7245,16 +7245,16 @@
         },
         {
             "name": "symfony/security",
-            "version": "v2.8.34",
+            "version": "v2.8.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security.git",
-                "reference": "8f451ddc1c8c0985e130de1ed96a6dc35ae21097"
+                "reference": "2a1c4c71e944cfa94fc0f41d9a99837021060e1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security/zipball/8f451ddc1c8c0985e130de1ed96a6dc35ae21097",
-                "reference": "8f451ddc1c8c0985e130de1ed96a6dc35ae21097",
+                "url": "https://api.github.com/repos/symfony/security/zipball/2a1c4c71e944cfa94fc0f41d9a99837021060e1c",
+                "reference": "2a1c4c71e944cfa94fc0f41d9a99837021060e1c",
                 "shasum": ""
             },
             "require": {
@@ -7270,7 +7270,7 @@
                 "symfony/security-acl": "~2.7|~3.0.0"
             },
             "conflict": {
-                "symfony/http-foundation": "~2.8,<2.8.31|~3.4,<3.4-beta5"
+                "symfony/http-foundation": "~2.8,<2.8.31"
             },
             "replace": {
                 "symfony/security-core": "self.version",
@@ -7324,7 +7324,7 @@
             ],
             "description": "Symfony Security Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-18T13:56:23+00:00"
+            "time": "2018-08-11T11:15:56+00:00"
         },
         {
             "name": "symfony/security-acl",
@@ -7389,16 +7389,16 @@
         },
         {
             "name": "symfony/security-bundle",
-            "version": "v2.8.34",
+            "version": "v2.8.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-bundle.git",
-                "reference": "8bdecbbab35b971363cb7a5093d0f8f0f08211e1"
+                "reference": "a34e30addf491a71bbf3d616626fbb0968d7dfc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/8bdecbbab35b971363cb7a5093d0f8f0f08211e1",
-                "reference": "8bdecbbab35b971363cb7a5093d0f8f0f08211e1",
+                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/a34e30addf491a71bbf3d616626fbb0968d7dfc3",
+                "reference": "a34e30addf491a71bbf3d616626fbb0968d7dfc3",
                 "shasum": ""
             },
             "require": {
@@ -7406,7 +7406,7 @@
                 "php": ">=5.3.9",
                 "symfony/http-kernel": "~2.7|~3.0.0",
                 "symfony/polyfill-php70": "~1.0",
-                "symfony/security": "^2.8.31|~3.3.13",
+                "symfony/security": "^2.8.45|^3.4.15",
                 "symfony/security-acl": "~2.7|~3.0.0"
             },
             "require-dev": {
@@ -7414,6 +7414,7 @@
                 "symfony/browser-kit": "~2.7|~3.0.0",
                 "symfony/console": "~2.7|~3.0.0",
                 "symfony/css-selector": "^2.7|~3.0.0",
+                "symfony/dependency-injection": "~2.8.41",
                 "symfony/dom-crawler": "^2.7|~3.0.0",
                 "symfony/expression-language": "~2.7|~3.0.0",
                 "symfony/form": "^2.8.18",
@@ -7456,7 +7457,7 @@
             ],
             "description": "Symfony SecurityBundle",
             "homepage": "https://symfony.com",
-            "time": "2018-01-23T20:17:18+00:00"
+            "time": "2018-08-01T18:49:49+00:00"
         },
         {
             "name": "symfony/stopwatch",


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This updates the Symfony security component to 2.8.45 (the latest version at the moment) to apply the fix for multiple low risk vulnerabilities. See [CVE-2018-11407](https://symfony.com/blog/cve-2018-11407-unauthorized-access-on-a-misconfigured-ldap-server-when-using-an-empty-password), [CVE-2018-11406](https://symfony.com/blog/cve-2018-11406-csrf-token-fixation), [CVE-2018-11385](https://symfony.com/blog/cve-2018-11385-session-fixation-issue-for-guard-authentication), [CVE-2018-11408](https://symfony.com/blog/cve-2018-11408-open-redirect-vulnerability-on-security-handlers).

#### Steps to test this PR:
1. Run `composer install`
2. Check that the login/logout is working.

#### List backwards compatibility breaks:
None