### PR TITLE
Custom field clone fix

### DIFF
--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -365,6 +365,7 @@ class FieldController extends FormController
             $clone = clone $entity;
             $clone->setIsPublished(false);
             $clone->setIsFixed(false);
+            $this->get('mautic.helper.field.alias')->makeAliasUnique($clone);
             $model->saveEntity($clone);
             $objectId = $clone->getId();
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N 
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The field cloning did not populate the values from the cloned field into the edit form. There are 2 problems:

1. The cloning process is creating new field. The rest of Mautic's entities creates the new entity on save which is more sophisticated.
2. When we consider 1. then the alias had to be unique. The save method in the model checks if the DB table column exists and if so the entity is not saved.

So the easy solution is to make the alias unique and keep the old way of cloning. That's how the current fix works. If we want to change it to the more sophisticated cloning than it would require more time.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to clone a custom field.
2. It opens the edit form which is empty.

#### Steps to test this PR:
1. Try to clone a custom field.
2. It opens the edit form which has new ID and the form is populated.