### PR TITLE
Return explicit response code for all JsonResponses returned by Excep…

### DIFF
--- a/app/bundles/CoreBundle/Controller/ExceptionController.php
+++ b/app/bundles/CoreBundle/Controller/ExceptionController.php
@@ -65,7 +65,9 @@ class ExceptionController extends CommonController
                     $dataArray['trace'] = $exception->getTrace();
                 }
 
-                return new JsonResponse($dataArray, 200);
+                // Normal behavior in Symfony dev mode is to send 200 with error message,
+                // but this is used in prod mode for all "/api" requests too. (#224)
+                return new JsonResponse($dataArray, $code);
             }
 
             if ($request->get('prod')) {


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When something general happens (app error, no route found) on API, no correct response code is returned.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. /api/nonexistingurl (you can do that in browser)
2. you can throw HTTP exception or any other exception

#### Steps to test this PR:
1. Same way as how to reproduce

#### List deprecations along with the new alternative:
None

#### List backwards compatibility breaks:
1. Maybe on customer side.
