### PR TITLE
Changing order by condition in query for notifications order.

### DIFF
--- a/app/bundles/CoreBundle/Entity/NotificationRepository.php
+++ b/app/bundles/CoreBundle/Entity/NotificationRepository.php
@@ -145,7 +145,7 @@ class NotificationRepository extends CommonRepository
         }
 
         $qb->where($expr)
-            ->orderBy('n.id');
+            ->orderBy('n.dateAdded', 'DESC');
 
         if ($limit) {
             $qb->setMaxResults($limit);


### PR DESCRIPTION
[//]: # ( Required: )
#### Description:
Notifications for each user is shown as the oldest one first. 

#### Steps to reproduce the bug:
1. Check an account which has notifications or replicate the notifications.
2. Open the notifications and the older ones will be on the top of the list. 

#### Steps to test this PR:
1. Checkout to branch in the PR. 
2. Perform the same steps as to reproduce the scenario and now newer notifications will be on the top of the list. 