### PR TITLE
Filtering out sensitive information from SQL error message

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
@@ -37,23 +37,6 @@ class LeadEventLogRepository extends CommonRepository
         return $this->getSpecificRows($importId, 'failed', $args, $bundle, $object);
     }
 
-    public function getEntities(array $args = [])
-    {
-        $entities = parent::getEntities($args);
-        $entities = iterator_to_array($entities);
-
-        foreach ($entities as $key => $row) {
-            if (
-                isset($row['properties']['error'])
-                && preg_match('/SQLSTATE\[\w+\]: (.*)/', $row['properties']['error'], $matches)
-            ) {
-                $entities[$key]['properties']['error'] = $matches[1];
-            }
-        }
-
-        return $entities;
-    }
-
     /**
      * Returns paginator with specific type of rows.
      *

--- a/app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
@@ -37,6 +37,23 @@ class LeadEventLogRepository extends CommonRepository
         return $this->getSpecificRows($importId, 'failed', $args, $bundle, $object);
     }
 
+    public function getEntities(array $args = [])
+    {
+        $entities = parent::getEntities($args);
+        $entities = iterator_to_array($entities);
+
+        foreach ($entities as $key => $row) {
+            if (
+                isset($row['properties']['error'])
+                && preg_match('/SQLSTATE\[\w+\]: (.*)/', $row['properties']['error'], $matches)
+            ) {
+                $entities[$key]['properties']['error'] = $matches[1];
+            }
+        }
+
+        return $entities;
+    }
+
     /**
      * Returns paginator with specific type of rows.
      *

--- a/app/bundles/LeadBundle/Views/Import/details.html.php
+++ b/app/bundles/LeadBundle/Views/Import/details.html.php
@@ -202,7 +202,16 @@ $detailRowTmpl = 'MauticCoreBundle:Helper:detail_row.html.php';
                                     <?php echo $row['properties']['line']; ?>
                                 </td>
                                 <td>
-                                    <?php echo isset($row['properties']['error']) ? $row['properties']['error'] : 'N/A'; ?>
+                                    <?php
+                                    $error = 'N/A';
+                                    if (isset($row['properties']['error'])):
+                                        $error = $row['properties']['error'];
+                                        if (preg_match('/SQLSTATE\[\w+\]: (.*)/', $error, $matches)):
+                                            $error = $matches[1];
+                                        endif;
+                                    endif;
+                                    echo $error;
+                                    ?>
                                 </td>
                             </tr>
                         <?php endif; ?>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N 
| Automated tests included? | N
| Related user documentation PR URL |  N/A
| Related developer documentation PR URL | N/A 
| BC breaks? | N/A
| Deprecations? | N/A

[//]: # ( Required: )
#### Description:
SQL errors are recorded in import details page which looks terrible and reveals table structure.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a date field.
2. Create a CSV with a bad date column
3. Import CSV and it will throw an error which reveals the table structure.

#### Steps to test this PR:
1. Checkout to  the branch in the PR.
2. Repeat the same steps as to reproduce the bug and it will display the message without the table structure information. 
