### PR TITLE
Support graceful timeout option on ConsumeQueueCommand

### DIFF
--- a/app/bundles/QueueBundle/Command/ConsumeQueueCommand.php
+++ b/app/bundles/QueueBundle/Command/ConsumeQueueCommand.php
@@ -42,7 +42,15 @@ class ConsumeQueueCommand extends ContainerAwareCommand
                 InputOption::VALUE_OPTIONAL,
                 'Number of messages from the queue to process. Default is infinite',
                 null
+            )
+            ->addOption(
+                '--timeout',
+                '-t',
+                InputOption::VALUE_REQUIRED,
+                'Set a graceful execution time at this many seconds in the future.',
+                null
             );
+
         parent::configure();
     }
 
@@ -74,7 +82,14 @@ class ConsumeQueueCommand extends ContainerAwareCommand
             return 0;
         }
 
-        $queueService->consumeFromQueue($queueName, $messages);
+        $timeout = $input->getOption('timeout');
+        if (0 > $timeout) {
+            $output->writeLn('You did not provide a valid number of seconds. It should be null or greater than 0');
+
+            return 0;
+        }
+
+        $queueService->consumeFromQueue($queueName, $messages, $timeout);
 
         return 0;
     }

--- a/app/bundles/QueueBundle/Event/QueueEvent.php
+++ b/app/bundles/QueueBundle/Event/QueueEvent.php
@@ -39,19 +39,26 @@ class QueueEvent extends CommonEvent
     private $queueName;
 
     /**
+     * @var int|null
+     */
+    private $timeout;
+
+    /**
      * QueueEvent constructor.
      *
      * @param string   $protocol
      * @param string   $queueName
      * @param array    $payload
      * @param int|null $messages
+     * @param int|null $timeout
      */
-    public function __construct($protocol, $queueName, array $payload = [], $messages = null)
+    public function __construct($protocol, $queueName, array $payload = [], $messages = null, $timeout = null)
     {
         $this->messages  = $messages;
         $this->payload   = $payload;
         $this->protocol  = $protocol;
         $this->queueName = $queueName;
+        $this->timeout   = $timeout;
     }
 
     /**
@@ -84,6 +91,14 @@ class QueueEvent extends CommonEvent
     public function getQueueName()
     {
         return $this->queueName;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getTimeout()
+    {
+        return $this->timeout;
     }
 
     /**

--- a/app/bundles/QueueBundle/EventListener/RabbitMqSubscriber.php
+++ b/app/bundles/QueueBundle/EventListener/RabbitMqSubscriber.php
@@ -72,6 +72,12 @@ class RabbitMqSubscriber extends AbstractQueueSubscriber
             'durable'     => true,
         ]);
         $consumer->setRoutingKey($event->getQueueName());
+
+        // Check event for positive execution time and set on Consumer
+        if (0 < ($timeout = $event->getTimeout())) {
+            $consumer->setGracefulMaxExecutionDateTimeFromSecondsInTheFuture($timeout);
+        }
+
         $consumer->consume($event->getMessages());
     }
 

--- a/app/bundles/QueueBundle/Queue/QueueService.php
+++ b/app/bundles/QueueBundle/Queue/QueueService.php
@@ -76,11 +76,12 @@ class QueueService
     /**
      * @param string   $queueName
      * @param int|null $messages
+     * @param int|null $timeout
      */
-    public function consumeFromQueue($queueName, $messages = null)
+    public function consumeFromQueue($queueName, $messages = null, $timeout = null)
     {
         $protocol = $this->coreParametersHelper->getParameter('queue_protocol');
-        $event    = new QueueEvent($protocol, $queueName, [], $messages);
+        $event    = new QueueEvent($protocol, $queueName, [], $messages, $timeout);
         $this->eventDispatcher->dispatch(QueueEvents::CONSUME_MESSAGE, $event);
     }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Y
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Added an option (`--timeout=TIMEOUT`, `-t TIMEOUT`) which takes a number of seconds to be used as the graceful execution time on the Queue Consumer.

The value is then passed as an argument to the Queue Service's _consumeFromQueue_ method, where it is passed as a constructor argument for the QueueEvent to be dispatched. Then, the RabbitMqSubscriber uses the event's timeout property to maybe call the consumer's _setGracefulMaxExecutionDateTimeFromSecondsInTheFuture_ method before calling `$consumer->consume(...)`.

This will limit the execution time of the ConsumeQueueCommand by allowing it to exit gracefully after `TIMEOUT` seconds have elapsed.

#### Steps to test this PR:
1. Having an empty queue, run the queue process command with either _queue name_:
    * `app/console mautic:queue:process --queue-name=page_hit`
    * `app/console mautic:queue:process -i email_hit`
2. Wait. Keep waiting. Kill the process.
3. Run again with the new `--timeout` (`-t`) option:
    * `app/console mautic:queue:process --queue-name=page_hit --timeout=10`
    * `app/console mautic:queue:process -i email_hit -t 10`
4. Wait 10 seconds. The process should have exited gracefully.
