### PR TITLE
Set auto_delete=false on RabbitMqSubscriber consumer

### DIFF
--- a/app/bundles/QueueBundle/EventListener/RabbitMqSubscriber.php
+++ b/app/bundles/QueueBundle/EventListener/RabbitMqSubscriber.php
@@ -68,7 +68,7 @@ class RabbitMqSubscriber extends AbstractQueueSubscriber
         $consumer = $this->container->get('old_sound_rabbit_mq.mautic_consumer');
         $consumer->setQueueOptions([
             'name'        => $event->getQueueName(),
-            'auto_delete' => true,
+            'auto_delete' => false,
             'durable'     => true,
         ]);
         $consumer->setRoutingKey($event->getQueueName());


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

#### Description:

RabbitMQ will throw an error when there is a discrepancy between the `auto_delete` arguments for producers and consumers operating on the same queue. It appears that whichever creates the queue first, a _producer_ or _consumer_, will have its `auto_delete` option set on that queue. When the inverse operation is performed with a different `auto_delete` setting, an error will occur. For example:

##### _Consumer_ First

If a _consumer_ connects to RabbitMQ first, setting `auto_delete=true`, then a _producer_ will encounter the following:

```
[2018-09-12 14:24:32] mautic.CRITICAL: Uncaught PHP Exception PhpAmqpLib\Exception\AMQPProtocolChannelException:
  "PRECONDITION_FAILED - inequivalent arg 'auto_delete' for queue 'page_hit' in vhost '/':
    received 'false' but current is 'true'"
  at /var/www/html/vendor/php-amqplib/php-amqplib/PhpAmqpLib/Channel/AMQPChannel.php line 188
  {
    "exception":"[object] (
        PhpAmqpLib\\Exception\\AMQPProtocolChannelException(code: 406):
          PRECONDITION_FAILED - inequivalent arg 'auto_delete' for queue 'page_hit' in vhost '/':
            received 'false' but current is 'true'
        at /var/www/html/vendor/php-amqplib/php-amqplib/PhpAmqpLib/Channel/AMQPChannel.php:188
    )"
  } []
```

##### _Producer_ First

When a message is published to a queue by a _producer_ having `auto_delete=false`, the _consumer_ will get the following error:

```
$ app/console mautic:queue:process -i page_hit -m 1


  [PhpAmqpLib\Exception\AMQPProtocolChannelException]
  PRECONDITION_FAILED - inequivalent arg 'auto_delete' for queue 'page_hit' in vhost '/':
    received 'true' but current is 'false'
```

This PR sets the consumer 'auto_delete' queue option in the **RabbitMqSubscriber** to match the options set in the **QueueBundle** service definitions.

* `old_sound_rabbit_mq.mautic_producer`: https://github.com/mautic/mautic/blob/staging/app/bundles/QueueBundle/Config/rabbitmq.php#L39
* `old_sound_rabbit_mq.mautic_consumer`: https://github.com/mautic/mautic/blob/staging/app/bundles/QueueBundle/Config/rabbitmq.php#L54


#### Steps to reproduce the bug:
1. Set up queue processing of *Page hits* with RabbitMQ.
2. Start processing the *page_hit* queue:
    `$ app/console mautic:queue:process -i page_hit`
3. Visit a landing page. Get *500* error. Check logs.
4. Kill the `mautic:queue:process` console command.
5. Visit a landing page. It should work now.
6. Process that *page_hit* from the queue:
    `$ app/console mautic:queue:process -i page_hit -m 1`
7. Receive error message on console.

#### Steps to test this PR:
1. Start processing the *page_hit* queue:
    `$ app/console mautic:queue:process -i page_hit -m 1`
2. Visit a landing page. Get *200* response.
3. The process should have exited cleanly after processing the incoming queue message.
