### PR TITLE
SQL error fix; Message seems to be a keyword

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -552,14 +552,14 @@ class LeadEventLogRepository extends CommonRepository
         $prefix = MAUTIC_TABLE_PREFIX;
         $sql    = <<<SQL
 REPLACE INTO {$prefix}campaign_lead_event_failed_log( `log_id`, `date_added`, `reason`)
-SELECT id, :dateAdded as date_added, :message as reason from {$prefix}campaign_lead_event_log
+SELECT id, :dateAdded as date_added, :reason as reason from {$prefix}campaign_lead_event_log
 WHERE is_scheduled = 1 AND lead_id = :contactId AND campaign_id = :campaignId AND rotation = :rotation
 SQL;
 
         $connection = $this->getEntityManager()->getConnection();
         $stmt       = $connection->prepare($sql);
         $stmt->bindParam('dateAdded', $dateAdded, \PDO::PARAM_STR);
-        $stmt->bindParam('message', $message, \PDO::PARAM_STR);
+        $stmt->bindParam('reason', $message, \PDO::PARAM_STR);
         $stmt->bindParam('contactId', $contactId, \PDO::PARAM_INT);
         $stmt->bindParam('campaignId', $campaignId, \PDO::PARAM_INT);
         $stmt->bindParam('rotation', $rotation, \PDO::PARAM_INT);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | [slack message](https://mautic.slack.com/archives/C02HU8BUT/p1536841497000100), https://github.com/mautic/mautic/issues/6509
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

There were this error reported several times:
```
Doctrine\DBAL\Exception\SyntaxErrorException: An exception occurred while executing 'REPLACE INTO mau8g_campaign_lead_event_failed_log( `log_id`, `date_added`, `reason`) SELECT id, :dateAdded as date_added, :message as reason from mau8g_campaign_lead_event_log WHERE is_scheduled = 1 AND lead_id = :contactId AND campaign_id = :campaignId AND rotation = :rotation':  You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ':dateAdded as date_added, :message as reason from mau8g_campaign_lead_event_log ' at line 2 (uncaught exception) at /home/clientsiwanta/public_html/mautic/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php line 90 while running console command `mautic:segments:update` [] []
```
I think it's because the `message` is MySql keyword and therefore I suggest to replace it with `reason`. My IDE is highlighting the `message` word as well:
![screen shot 2018-09-13 at 15 23 26](https://user-images.githubusercontent.com/1235442/45491074-136a9000-b769-11e8-91f2-008a83dadbd4.png)


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Unknown.

#### Steps to test this PR:
1. Code review should suffice.