### PR TITLE
Use IN instead of EXISTS for including manually added contacts which …

### DIFF
--- a/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -186,7 +186,6 @@ class ContactSegmentQueryBuilder
         $existsQueryBuilder
             ->select($tableAlias.'.lead_id')
             ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', $tableAlias)
-            ->where($tableAlias.'.lead_id = l.id')
             ->andWhere($queryBuilder->expr()->eq($tableAlias.'.leadlist_id', intval($leadListId)))
             ->andWhere(
                 $queryBuilder->expr()->orX(
@@ -196,7 +195,7 @@ class ContactSegmentQueryBuilder
             );
 
         $queryBuilder->orWhere(
-            $queryBuilder->expr()->exists($existsQueryBuilder->getSQL())
+            $queryBuilder->expr()->in('l.id', $existsQueryBuilder->getSQL())
         );
 
         return $queryBuilder;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The subquery that includes contacts that were manually added to the included segment used exists which had a huge CPU performance hit on the database server. This changes that query to be an IN instead which resulted in significant speed and performance. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Difficult to reproduce unless you are using a heavy database server.

#### Steps to test this PR:
1. Ensure that manually added contacts to included segments are also included in the parent segment.
2. Create Segment A that has a filter that will add several contacts
3. Create Segment B that includes Segment A
4. All of Segment A should have been added to Segment B
5. Now go to a contact that is NOT in Segment A and manually add them to it.
6. The contact should have been added to Segment B
7. Remove the contact from Segment A and they should be removed from Segment B
