### PR TITLE
This adds support for campaign decisions to support both page and pag…

### DIFF
--- a/app/bundles/CampaignBundle/Executioner/RealTimeExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/RealTimeExecutioner.php
@@ -239,8 +239,8 @@ class RealTimeExecutioner
             throw new DecisionNotApplicableException("Event {$event->getId()} is not a decision.");
         }
 
-        // If channels do not match up, there's no need to go further
-        if ($channel && $event->getChannel() && $channel !== $event->getChannel()) {
+        // If channels do not match up at all (not even fuzzy logic i.e. page vs page.redirect), there's no need to go further
+        if ($channel && $event->getChannel() && $channel && strpos($channel, $event->getChannel()) === false) {
             throw new DecisionNotApplicableException("Channels, $channel and {$event->getChannel()}, do not match.");
         }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Campaign visited URL decisions do not honor redirects. This fixes that. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a template email with a link to a URL that's NOT tracked by Mautic
2. Create a campaign that sends the email then has a visits URL decision that matches the URL of that in the email (and then do something as a result)
3. Send a contact through the campaign
4. Click the link in the email using a different browser/guest session
5. Look at the contact's timeline and notice the page hit entry but they did not trigger the campaign 

#### Steps to test this PR:
1. Repeat and this time the contact should finish going through the campaign
