### PR TITLE
Fix: Send email by API return not found even If email entity exists

### DIFF
--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -75,7 +75,7 @@ class EmailApiController extends CommonApiController
     {
         $entity = $this->model->getEntity($id);
 
-        if (null !== $entity || !$entity->isPublished()) {
+        if (null === $entity || !$entity->isPublished()) {
             return $this->notFound();
         }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Notice bad condition statement during the send email aciton by API.
Code check should be enought.

Test with Mautibox: https://mautibox.com/6581

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Jus try send published email by API

```
$apiEmails = $api->newApi('emails', $auth, $apiUrl);
$r = $apiEmails->sendToContact($emailId, $contactId);
print_r($r);
```

2.  Response should return not found

#### Steps to test this PR:
1. Repeat all steps
2. See published email is sent correctly
