### PR TITLE
Add alias for company ID to avoid Ids mismatch

### DIFF
--- a/app/bundles/LeadBundle/Model/CompanyReportData.php
+++ b/app/bundles/LeadBundle/Model/CompanyReportData.php
@@ -86,6 +86,7 @@ class CompanyReportData
     {
         return [
             'comp.id' => [
+                'alias' => 'comp_id',
                 'label' => 'mautic.lead.report.company.company_id',
                 'type'  => 'int',
                 'link'  => 'mautic_company_action',

--- a/app/bundles/LeadBundle/Tests/Model/CompanyReportDataTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/CompanyReportDataTest.php
@@ -73,6 +73,7 @@ class CompanyReportDataTest extends \PHPUnit_Framework_TestCase
 
         $expected = [
             'comp.id' => [
+                'alias' => 'comp_id',
                 'label' => 'mautic.lead.report.company.company_id',
                 'type'  => 'int',
                 'link'  => 'mautic_company_action',


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6517
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Based on this issue report: https://github.com/mautic/mautic/issues/6517
If you choose in report Contact ID and Company ID, both has alias ID in SQL query.

`SELECT l.email AS email, l.id AS id, comp.id AS id FROM leads  `

This PR added alias for comp.id

Test with Mautibox: https://mautibox.com/6585

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Create contact report with Contact ID, Company ID and Contact Email
2.  See table, with  same Ids

![image](https://user-images.githubusercontent.com/462477/45558094-5860f600-b83f-11e8-951a-c7b4a189b875.png)


#### Steps to test this PR:
1.  Repeat all steps
2.  See correct IDs
3. Query should be
`SELECT l.email AS email, l.id AS id, comp.id AS comp_id FROM leads `