### PR TITLE
Prevent bots from logging clicks on contact's behalf

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -167,8 +167,7 @@ class PublicController extends CommonFormController
         $contentTemplate = $this->factory->getHelper('theme')->checkForTwigTemplate(':'.$template.':message.html.php');
 
         if (!empty($stat)) {
-            $lead = $stat->getLead();
-            if ($lead) {
+            if ($lead = $stat->getLead()) {
                 // Set the lead as current lead
                 $leadModel->setCurrentLead($lead);
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/pull/6591
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When using short URLs with SMS links, Bitly is "clicking" the link to analyze it causing false positive clicks on the contact's behalf. This PR simply ignores contact tracking for IPs or bots that are set to not be tracked which is already configurable through the Configuration. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Note that your Mautic must be world accessible. So if testing locally, use ngrok and be sure to update the site_url in local.php to match. 
2. Test SMS link tracking.
3. View the contact's profile after receiving the SMS and notice that there is a click registered even though you hadn't clicked on the link yet. If you show the details of the click, you'll see that it was the bitlybot that did the clicking.

#### Steps to test this PR:
1. Go to Configuration and add the following two entries to the `List of Bots to not track with (one per line)` setting: `bitlybot` and `TweetmemeBot`
2. Send another text through the campaign. After receiving the text, verify there was no click recorded. 
3. Now you open the link and then see that the click is recorded. 