### PR TITLE
Drastically improve speed times for installations with millions of records

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -306,8 +306,6 @@ class EmailRepository extends CommonRepository
             $q->setFirstResult(0)
                 ->setMaxResults($limit);
         }
-        var_dump($q->getParameters());
-        die(var_export($q->getSQL(), true));
 
         return $q;
     }

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -199,43 +199,45 @@ class EmailRepository extends CommonRepository
     ) {
         // Do not include leads in the do not contact table
         $dncQb = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $dncQb->select('dnc.lead_id')
+        $dncQb->select('null')
             ->from(MAUTIC_TABLE_PREFIX.'lead_donotcontact', 'dnc')
             ->where(
-                $dncQb->expr()->eq('dnc.channel', $dncQb->expr()->literal('email'))
+                $dncQb->expr()->andX(
+                    $dncQb->expr()->eq('dnc.lead_id', 'l.id'),
+                    $dncQb->expr()->eq('dnc.channel', $dncQb->expr()->literal('email'))
+                )
             );
 
         // Do not include contacts where the message is pending in the message queue
         $mqQb = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $mqQb->select('mq.lead_id')
-            ->from(MAUTIC_TABLE_PREFIX.'message_queue', 'mq');
-
-        $messageExpr = $mqQb->expr()->andX(
-            $mqQb->expr()->eq('mq.channel', $mqQb->expr()->literal('email')),
-            $mqQb->expr()->neq('mq.status', $mqQb->expr()->literal(MessageQueue::STATUS_SENT))
-        );
+        $mqQb->select('null')
+            ->from(MAUTIC_TABLE_PREFIX.'message_queue', 'mq')
+            ->where(
+                $mqQb->expr()->andX(
+                    $mqQb->expr()->eq('mq.lead_id', 'l.id'),
+                    $mqQb->expr()->neq('mq.status', $mqQb->expr()->literal(MessageQueue::STATUS_SENT)),
+                    $mqQb->expr()->eq('mq.channel', $mqQb->expr()->literal('email'))
+                )
+            );
 
         // Do not include leads that have already been emailed
-        $statQb = $this->getEntityManager()->getConnection()->createQueryBuilder()
-            ->select('stat.lead_id')
-            ->from(MAUTIC_TABLE_PREFIX.'email_stats', 'stat');
+        $statQb = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        $statQb->select('null')
+            ->from(MAUTIC_TABLE_PREFIX.'email_stats', 'stat')
+            ->where(
+                $statQb->expr()->eq('stat.lead_id', 'l.id')
+            );
 
         if ($variantIds) {
             if (!in_array($emailId, $variantIds)) {
                 $variantIds[] = (int) $emailId;
             }
-            $statQb->where($statQb->expr()->in('stat.email_id', $variantIds));
-            $messageExpr->add(
-                $mqQb->expr()->in('mq.channel_id', $variantIds)
-            );
+            $statQb->andWhere($statQb->expr()->in('stat.email_id', $variantIds));
+            $mqQb->andWhere($mqQb->expr()->in('mq.channel_id', $variantIds));
         } else {
-            $statQb->where($statQb->expr()->eq('stat.email_id', (int) $emailId));
-            $messageExpr->add(
-                $mqQb->expr()->eq('mq.channel_id', (int) $emailId)
-            );
+            $statQb->andWhere($statQb->expr()->eq('stat.email_id', (int) $emailId));
+            $mqQb->andWhere($mqQb->expr()->eq('mq.channel_id', (int) $emailId));
         }
-        $statQb->andWhere($statQb->expr()->isNotNull('stat.lead_id'));
-        $mqQb->where($messageExpr);
 
         // Only include those who belong to the associated lead lists
         if (is_null($listIds)) {
@@ -260,51 +262,34 @@ class EmailRepository extends CommonRepository
             $listIds = [$listIds];
         }
 
-        // Main query
-        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        if ($countOnly) {
-            // distinct with an inner join seems faster
-            $q->select('count(distinct(l.id)) as count');
-            $q->innerJoin('l', MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'll',
-                $q->expr()->andX(
-                    $q->expr()->in('ll.leadlist_id', $listIds),
-                    $q->expr()->eq('ll.lead_id', 'l.id'),
-                    $q->expr()->eq('ll.manually_removed', ':false')
+        // Only include those in associated segments
+        $segmentQb = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        $segmentQb->select('null')
+            ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'll')
+            ->where(
+                $segmentQb->expr()->andX(
+                    $segmentQb->expr()->eq('ll.lead_id', 'l.id'),
+                    $segmentQb->expr()->in('ll.leadlist_id', $listIds),
+                    $segmentQb->expr()->eq('ll.manually_removed', ':false')
                 )
             );
 
+        // Main query
+        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        if ($countOnly) {
+            $q->select('count(*) as count');
             if ($countWithMaxMin) {
-                $q->addSelect('MIN(l.id) as min_id');
-                $q->addSelect('MAX(l.id) as max_id');
+                $q->addSelect('MIN(l.id) as min_id, MAX(l.id) as max_id');
             }
         } else {
             $q->select('l.*');
-
-            // use a derived table in order to retrieve distinct leads in case they belong to multiple
-            // lead lists associated with this email
-            $listQb = $this->getEntityManager()->getConnection()->createQueryBuilder();
-            $listQb->select('distinct(ll.lead_id) lead_id')
-                ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'll')
-                ->where(
-                    $listQb->expr()->andX(
-                        $listQb->expr()->in('ll.leadlist_id', $listIds),
-                        $listQb->expr()->eq('ll.manually_removed', ':false')
-                    )
-                );
-
-            $listQb = $this->setMinMaxIds($listQb, 'll.lead_id', $minContactId, $maxContactId);
-
-            $q->innerJoin('l', sprintf('(%s)', $listQb->getSQL()), 'in_list', 'l.id = in_list.lead_id');
         }
 
-        $dncQb  = $this->setMinMaxIds($dncQb, 'dnc.lead_id', $minContactId, $maxContactId);
-        $mqQb   = $this->setMinMaxIds($mqQb, 'mq.lead_id', $minContactId, $maxContactId);
-        $statQb = $this->setMinMaxIds($statQb, 'stat.lead_id', $minContactId, $maxContactId);
-
         $q->from(MAUTIC_TABLE_PREFIX.'leads', 'l')
-            ->andWhere(sprintf('l.id NOT IN (%s)', $dncQb->getSQL()))
-            ->andWhere(sprintf('l.id NOT IN (%s)', $statQb->getSQL()))
-            ->andWhere(sprintf('l.id NOT IN (%s)', $mqQb->getSQL()))
+            ->andWhere(sprintf('EXISTS (%s)', $segmentQb->getSQL()))
+            ->andWhere(sprintf('NOT EXISTS (%s)', $dncQb->getSQL()))
+            ->andWhere(sprintf('NOT EXISTS (%s)', $statQb->getSQL()))
+            ->andWhere(sprintf('NOT EXISTS (%s)', $mqQb->getSQL()))
             ->setParameter('false', false, 'boolean');
 
         $q = $this->setMinMaxIds($q, 'l.id', $minContactId, $maxContactId);
@@ -321,6 +306,8 @@ class EmailRepository extends CommonRepository
             $q->setFirstResult(0)
                 ->setMaxResults($limit);
         }
+        var_dump($q->getParameters());
+        die(var_export($q->getSQL(), true));
 
         return $q;
     }

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryTest.php
@@ -87,7 +87,7 @@ class EmailRepositoryTest extends \PHPUnit_Framework_TestCase
             $countWithMaxMin
         );
 
-        $expectedQuery = "SELECT count(distinct(l.id)) as count FROM leads l INNER JOIN lead_lists_leads ll ON (ll.leadlist_id IN (22, 33)) AND (ll.lead_id = l.id) AND (ll.manually_removed = :false) WHERE (l.id NOT IN (SELECT dnc.lead_id FROM lead_donotcontact dnc WHERE dnc.channel = 'email')) AND (l.id NOT IN (SELECT stat.lead_id FROM email_stats stat WHERE (stat.email_id = 5) AND (stat.lead_id IS NOT NULL))) AND (l.id NOT IN (SELECT mq.lead_id FROM message_queue mq WHERE (mq.channel = 'email') AND (mq.status <> 'sent') AND (mq.channel_id = 5))) AND ((l.email IS NOT NULL) AND (l.email <> ''))";
+        $expectedQuery = "SELECT count(*) as count FROM leads l WHERE (EXISTS (SELECT null FROM lead_lists_leads ll WHERE (ll.lead_id = l.id) AND (ll.leadlist_id IN (22, 33)) AND (ll.manually_removed = :false))) AND (NOT EXISTS (SELECT null FROM lead_donotcontact dnc WHERE (dnc.lead_id = l.id) AND (dnc.channel = 'email'))) AND (NOT EXISTS (SELECT null FROM email_stats stat WHERE (stat.lead_id = l.id) AND (stat.email_id = 5))) AND (NOT EXISTS (SELECT null FROM message_queue mq WHERE (mq.lead_id = l.id) AND (mq.status <> 'sent') AND (mq.channel = 'email') AND (mq.channel_id = 5))) AND ((l.email IS NOT NULL) AND (l.email <> ''))";
         $this->assertEquals($expectedQuery, $query->getSql());
         $this->assertEquals(['false' => false], $query->getParameters());
     }
@@ -114,7 +114,7 @@ class EmailRepositoryTest extends \PHPUnit_Framework_TestCase
             $countWithMaxMin
         );
 
-        $expectedQuery = "SELECT count(distinct(l.id)) as count, MIN(l.id) as min_id, MAX(l.id) as max_id FROM leads l INNER JOIN lead_lists_leads ll ON (ll.leadlist_id IN (22, 33)) AND (ll.lead_id = l.id) AND (ll.manually_removed = :false) WHERE (l.id NOT IN (SELECT dnc.lead_id FROM lead_donotcontact dnc WHERE dnc.channel = 'email')) AND (l.id NOT IN (SELECT stat.lead_id FROM email_stats stat WHERE (stat.email_id = 5) AND (stat.lead_id IS NOT NULL))) AND (l.id NOT IN (SELECT mq.lead_id FROM message_queue mq WHERE (mq.channel = 'email') AND (mq.status <> 'sent') AND (mq.channel_id = 5))) AND ((l.email IS NOT NULL) AND (l.email <> ''))";
+        $expectedQuery = "SELECT count(*) as count, MIN(l.id) as min_id, MAX(l.id) as max_id FROM leads l WHERE (EXISTS (SELECT null FROM lead_lists_leads ll WHERE (ll.lead_id = l.id) AND (ll.leadlist_id IN (22, 33)) AND (ll.manually_removed = :false))) AND (NOT EXISTS (SELECT null FROM lead_donotcontact dnc WHERE (dnc.lead_id = l.id) AND (dnc.channel = 'email'))) AND (NOT EXISTS (SELECT null FROM email_stats stat WHERE (stat.lead_id = l.id) AND (stat.email_id = 5))) AND (NOT EXISTS (SELECT null FROM message_queue mq WHERE (mq.lead_id = l.id) AND (mq.status <> 'sent') AND (mq.channel = 'email') AND (mq.channel_id = 5))) AND ((l.email IS NOT NULL) AND (l.email <> ''))";
         $this->assertEquals($expectedQuery, $query->getSql());
         $this->assertEquals(['false' => false], $query->getParameters());
     }
@@ -141,7 +141,7 @@ class EmailRepositoryTest extends \PHPUnit_Framework_TestCase
             $countWithMaxMin
         );
 
-        $expectedQuery = "SELECT count(distinct(l.id)) as count, MIN(l.id) as min_id, MAX(l.id) as max_id FROM leads l INNER JOIN lead_lists_leads ll ON (ll.leadlist_id IN (22, 33)) AND (ll.lead_id = l.id) AND (ll.manually_removed = :false) WHERE (l.id NOT IN (SELECT dnc.lead_id FROM lead_donotcontact dnc WHERE (dnc.channel = 'email') AND (dnc.lead_id >= :minContactId) AND (dnc.lead_id <= :maxContactId))) AND (l.id NOT IN (SELECT stat.lead_id FROM email_stats stat WHERE (stat.email_id = 5) AND (stat.lead_id IS NOT NULL) AND (stat.lead_id >= :minContactId) AND (stat.lead_id <= :maxContactId))) AND (l.id NOT IN (SELECT mq.lead_id FROM message_queue mq WHERE (mq.channel = 'email') AND (mq.status <> 'sent') AND (mq.channel_id = 5) AND (mq.lead_id >= :minContactId) AND (mq.lead_id <= :maxContactId))) AND (l.id >= :minContactId) AND (l.id <= :maxContactId) AND ((l.email IS NOT NULL) AND (l.email <> ''))";
+        $expectedQuery = "SELECT count(*) as count, MIN(l.id) as min_id, MAX(l.id) as max_id FROM leads l WHERE (EXISTS (SELECT null FROM lead_lists_leads ll WHERE (ll.lead_id = l.id) AND (ll.leadlist_id IN (22, 33)) AND (ll.manually_removed = :false))) AND (NOT EXISTS (SELECT null FROM lead_donotcontact dnc WHERE (dnc.lead_id = l.id) AND (dnc.channel = 'email'))) AND (NOT EXISTS (SELECT null FROM email_stats stat WHERE (stat.lead_id = l.id) AND (stat.email_id = 5))) AND (NOT EXISTS (SELECT null FROM message_queue mq WHERE (mq.lead_id = l.id) AND (mq.status <> 'sent') AND (mq.channel = 'email') AND (mq.channel_id = 5))) AND (l.id >= :minContactId) AND (l.id <= :maxContactId) AND ((l.email IS NOT NULL) AND (l.email <> ''))";
 
         $expectedParams = [
             'false'        => false,


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This changes the query that determines who is to receive an email from NOT INs to EXISTS/NOT EXISTS. For a database of 2 million records with a lot of DNC and stat records, the original query took over 15 minutes. This new query takes 53ms. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Difficult to reproduce without millions of records in the database. 

#### Steps to test this PR:
Test that email pending count/sends are still correct. They should:
1. Include only contacts in the associated segments
2. Exclude contacts that are DNC
3. Exclude contacts that has already received the email
4. Exclude contacts that has the email pending in the message queue (due to contact frequency rules)
