### PR TITLE
Extract URL before cleaning query to prevent encoding URL that affects comparisons.

### DIFF
--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -604,10 +604,12 @@ class PageModel extends FormModel
         }
 
         // Set info from request
-        $query = InputHelper::cleanArray($query);
+        $hitUrl = InputHelper::url((isset($query['page_url'])) ? $query['page_url'] : $request->getRequestUri());
+        $query  = InputHelper::cleanArray($query);
 
         $hit->setQuery($query);
-        $hit->setUrl((isset($query['page_url'])) ? $query['page_url'] : $request->getRequestUri());
+        $hit->setUrl($hitUrl);
+
         if (isset($query['page_referrer'])) {
             $hit->setReferer($query['page_referrer']);
         }

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -605,14 +605,16 @@ class PageModel extends FormModel
 
         // Set info from request
         $hitUrl = InputHelper::url((isset($query['page_url'])) ? $query['page_url'] : $request->getRequestUri());
+        $hitReferrer = InputHelper::url((isset($query['page_referrer'])) ? $query['page_referrer'] : '');
+       
         $query  = InputHelper::cleanArray($query);
 
         $hit->setQuery($query);
         $hit->setUrl($hitUrl);
 
-        if (isset($query['page_referrer'])) {
-            $hit->setReferer($query['page_referrer']);
-        }
+        if ($hitReferrer) {
+            $hit->setReferer($hitReferrer);
+        }      
         if (isset($query['page_language'])) {
             $hit->setPageLanguage($query['page_language']);
         }

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -605,7 +605,7 @@ class PageModel extends FormModel
 
         // Set info from request
         $hitUrl = InputHelper::url((isset($query['page_url'])) ? $query['page_url'] : $request->getRequestUri());
-        $hitReferrer = InputHelper::url((isset($query['page_referrer'])) ? $query['page_referrer'] : '');
+        $hitReferrer = isset($query['page_referrer']) ? InputHelper::url($query['page_referrer']) : '';
        
         $query  = InputHelper::cleanArray($query);
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If the URL has ampersands, they will not match campaign page hit decisions because the URL is encoded prior to storing making comparisons not match. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a template email or SMS with a link that has at least one ampersand &
2. Create a campaign to send the message with a page hits decision that matches the full URL
3. Execute the campaign then click on the link
4. The campaign decision is not logged

#### Steps to test this PR:
1. Repeat and the campaign decision will be logged
