### PR TITLE
Prevent deadlock errors due to updating the webhooks table with a modified by/modified by user each time an event is queued

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\CoreBundle\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\ExpressionBuilder;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\ORM\EntityRepository;
@@ -766,7 +767,7 @@ class CommonRepository extends EntityRepository
     /**
      * Persist an array of entities.
      *
-     * @param array $entities
+     * @param array|ArrayCollection $entities
      */
     public function saveEntities($entities)
     {

--- a/app/bundles/WebhookBundle/Entity/Event.php
+++ b/app/bundles/WebhookBundle/Entity/Event.php
@@ -102,7 +102,7 @@ class Event
     }
 
     /**
-     * @return mixed
+     * @return Webhook
      */
     public function getWebhook()
     {
@@ -110,9 +110,11 @@ class Event
     }
 
     /**
-     * @param mixed $webhook
+     * @param Webhook $webhook
+     *
+     * @return $this
      */
-    public function setWebhook($webhook)
+    public function setWebhook(Webhook $webhook)
     {
         $this->webhook = $webhook;
 

--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -246,17 +246,16 @@ class WebhookModel extends FormModel
 
             $webhook->addQueue($this->queueWebhook($webhook, $event, $payload, $serializationGroups));
 
-            // add the queuelist and save everything if command process
-            if ($this->queueMode == self::COMMAND_PROCESS) {
-                $this->saveEntity($webhook);
+            if (self::COMMAND_PROCESS === $this->queueMode) {
+                // Queue to the database to process later
+                $this->getQueueRepository()->saveEntities($webhook->getQueues());
             }
         }
 
-        if ($this->queueMode == self::IMMEDIATE_PROCESS) {
+        if (self::IMMEDIATE_PROCESS === $this->queueMode) {
+            // Immediately process
             $this->processWebhooks($webhookList);
         }
-
-        return;
     }
 
     /**

--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -256,7 +256,7 @@ class WebhookModel extends FormModel
 
             if (self::COMMAND_PROCESS === $this->queueMode) {
                 // Queue to the database to process later
-                $this->getQueueRepository()->saveEntities($this->queuedPayloads[$webhook->getId()]);
+                $this->getQueueRepository()->saveEntity($this->queuedPayloads[$webhook->getId()]);
             }
         }
 

--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -113,6 +113,11 @@ class WebhookModel extends FormModel
     protected $eventsOrderByDir;
 
     /**
+     * @var array
+     */
+    private $queuedPayloads = [];
+
+    /**
      * WebhookModel constructor.
      *
      * @param CoreParametersHelper $coreParametersHelper
@@ -244,17 +249,21 @@ class WebhookModel extends FormModel
             $webhook       = $event->getWebhook();
             $webhookList[] = $webhook;
 
-            $webhook->addQueue($this->queueWebhook($webhook, $event, $payload, $serializationGroups));
+            if (!isset($this->queuedPayloads[$webhook->getId()])) {
+                $this->queuedPayloads[$webhook->getId()] = [];
+            }
+            $this->queuedPayloads[$webhook->getId()] = $this->queueWebhook($webhook, $event, $payload, $serializationGroups);
 
             if (self::COMMAND_PROCESS === $this->queueMode) {
                 // Queue to the database to process later
-                $this->getQueueRepository()->saveEntities($webhook->getQueues());
+                $this->getQueueRepository()->saveEntities($this->queuedPayloads[$webhook->getId()]);
             }
         }
 
         if (self::IMMEDIATE_PROCESS === $this->queueMode) {
             // Immediately process
             $this->processWebhooks($webhookList);
+            $this->queuedPayloads = [];
         }
     }
 
@@ -512,7 +521,7 @@ class WebhookModel extends FormModel
         if ($this->queueMode === self::COMMAND_PROCESS) {
             $queuesArray = $this->getWebhookQueues($webhook);
         } else {
-            $queuesArray = [$webhook->getQueues()];
+            $queuesArray = isset($this->queuedPayloads[$webhook->getId()]) ? $this->queuedPayloads[$webhook->getId()] : $webhook->getQueues();
         }
 
         /* @var WebhookQueue $queue */

--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -521,7 +521,7 @@ class WebhookModel extends FormModel
         if ($this->queueMode === self::COMMAND_PROCESS) {
             $queuesArray = $this->getWebhookQueues($webhook);
         } else {
-            $queuesArray = isset($this->queuedPayloads[$webhook->getId()]) ? $this->queuedPayloads[$webhook->getId()] : $webhook->getQueues();
+            $queuesArray = isset($this->queuedPayloads[$webhook->getId()]) ? $this->queuedPayloads[$webhook->getId()] : [$webhook->getQueues()];
         }
 
         /* @var WebhookQueue $queue */


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Users are seeing a bunch of deadlock errors because they have a webhook that is having the modified by/modified by user fields getting updated every time they update a contact. This is causing deadlock errors that could be leading to holding onto connections and thus cascading implications.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new webhook based on updating a contact
2. Update a contact
3. Look at the database's table for webhooks and notice that the modified_by/modified_by_user fields have been filled in

#### Steps to test this PR:
1. Create a second new webhook and repeat. The event should be queued in database but the modified_by/modified_by_user columns should still be null
