### PR TITLE
Other solution to fix special chars in custom multi select field

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
@@ -24,8 +24,9 @@ trait EntityFieldsBuildFormTrait
 {
     private function getFormFields(FormBuilderInterface $builder, array $options, $object = 'lead')
     {
-        $fieldValues = [];
-        $isObject    = false;
+        $cleaningRules = [];
+        $fieldValues   = [];
+        $isObject      = false;
         if (!empty($options['data'])) {
             $isObject    = is_object($options['data']);
             $fieldValues = ($isObject) ? $options['data']->getFields() : $options['data'];
@@ -181,9 +182,10 @@ trait EntityFieldsBuildFormTrait
                     $choiceType = 'choice';
                     $emptyValue = '';
                     if (in_array($type, ['select', 'multiselect']) && !empty($properties['list'])) {
-                        $typeProperties['choices']  = FormFieldHelper::parseList($properties['list']);
-                        $typeProperties['expanded'] = false;
-                        $typeProperties['multiple'] = ('multiselect' === $type);
+                        $typeProperties['choices']      = FormFieldHelper::parseList($properties['list']);
+                        $typeProperties['expanded']     = false;
+                        $typeProperties['multiple']     = ('multiselect' === $type);
+                        $cleaningRules[$field['alias']] = 'raw';
                     }
                     if ($type == 'boolean' && !empty($properties['yes']) && !empty($properties['no'])) {
                         $choiceType                  = 'yesno_button_group';
@@ -285,5 +287,7 @@ trait EntityFieldsBuildFormTrait
                     break;
             }
         }
+
+        return $cleaningRules;
     }
 }

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -13,8 +13,8 @@ namespace Mautic\LeadBundle\Form\Type;
 
 use Doctrine\ORM\EntityRepository;
 use Mautic\CoreBundle\Factory\MauticFactory;
-use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
+use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\LeadBundle\Form\DataTransformer\FieldToOrderTransformer;
 use Mautic\LeadBundle\Helper\FormFieldHelper;
 use Symfony\Component\Form\AbstractType;
@@ -48,7 +48,6 @@ class FieldType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->addEventSubscriber(new CleanFormSubscriber());
         $builder->addEventSubscriber(new FormExitSubscriber('lead.field', $options));
 
         $builder->add(
@@ -217,15 +216,18 @@ class FieldType extends AbstractType
             ]
         );
 
-        $formModifier = function (FormEvent $event) use ($listChoices) {
-            $form = $event->getForm();
-            $data = $event->getData();
-            $type = (is_array($data)) ? (isset($data['type']) ? $data['type'] : null) : $data->getType();
+        $formModifier = function (FormEvent $event) use ($listChoices, $type) {
+            $cleaningRules = [];
+            $form          = $event->getForm();
+            $data          = $event->getData();
+            $type          = (is_array($data)) ? (isset($data['type']) ? $data['type'] : $type) : $data->getType();
 
             switch ($type) {
                 case 'multiselect':
                 case 'select':
                 case 'lookup':
+                    $cleaningRules['defaultValue'] = 'raw';
+
                     if (is_array($data)) {
                         $properties = isset($data['properties']) ? $data['properties'] : [];
                     } else {
@@ -392,6 +394,8 @@ class FieldType extends AbstractType
 
                 break;
             }
+
+            return $cleaningRules;
         };
 
         $builder->addEventListener(
@@ -404,7 +408,13 @@ class FieldType extends AbstractType
         $builder->addEventListener(
             FormEvents::PRE_SUBMIT,
             function (FormEvent $event) use ($formModifier) {
-                $formModifier($event);
+                $data          = $event->getData();
+                $cleaningRules = $formModifier($event);
+                $masks         = !empty($cleaningRules) ? $cleaningRules : 'clean';
+                // clean the data
+                $data = InputHelper::_($data, $masks);
+
+                $event->setData($data);
             }
         );
 

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -240,16 +240,7 @@ class FieldType extends AbstractType
                             'label'             => 'mautic.lead.field.form.properties.select',
                             'data'              => $properties,
                             'with_labels'       => ('lookup' !== $type),
-                            'option_constraint' => [
-                                new Assert\Collection([
-                                    'fields' => [
-                                        'value' => [
-                                            new Assert\Regex(['pattern' => '/(^[\w-]+$)/i', 'message' => 'mautic.lead.field.value.invalid']),
-                                        ],
-                                    ],
-                                    'allowExtraFields' => true,
-                                ]),
-                            ],
+                            'option_constraint' => [],
                         ]
                     );
 

--- a/app/bundles/LeadBundle/Form/Type/LeadType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadType.php
@@ -15,7 +15,6 @@ use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
-use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -106,7 +105,8 @@ class LeadType extends AbstractType
             );
         }
 
-        $this->getFormFields($builder, $options);
+        $cleaningRules          = $this->getFormFields($builder, $options);
+        $cleaningRules['email'] = 'email';
 
         $builder->add(
             'tags',
@@ -199,7 +199,7 @@ class LeadType extends AbstractType
             );
         }
 
-        $builder->addEventSubscriber(new CleanFormSubscriber(['clean', 'raw', 'email' => 'email']));
+        $builder->addEventSubscriber(new CleanFormSubscriber($cleaningRules));
 
         if (!empty($options['action'])) {
             $builder->setAction($options['action']);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6356
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Following the discussion in slack, it's an other solution to the PR https://github.com/mautic/mautic/pull/6418

It is possible to insert special chars in the Value field of multi select.
But special chars cause problems when used.

Is it safe to use RAW? Because tags appear in Mautic Audit Log when values is applied to a contact
![screenshot_2018-09-18 view lol webmeca fr - mautic 1](https://user-images.githubusercontent.com/27768270/45671481-cf3f0d00-bb25-11e8-8581-e25f92a5438e.png)



[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a custom field with `Select - Multiple` type
2. Add one value `it doesn't <3`
3. Try to put this value inside a contact
4. Error

#### Steps to test this PR:
1. Apply PR
2. Try to put this value inside a contact
3. It's work!