### PR TITLE
Ajaxify email detail graphs

### DIFF
--- a/app/bundles/EmailBundle/Assets/css/email.css
+++ b/app/bundles/EmailBundle/Assets/css/email.css
@@ -28,3 +28,12 @@
 
 .clickable-stat a { color: #fff; }
 .clickable-stat a:hover { color: #fff; }
+
+#emailGraphStats {
+    height: 437px;
+    text-align: center;
+}
+
+#emailGraphStats .spinner {
+    padding-top: 50px;
+}

--- a/app/bundles/EmailBundle/Assets/css/email.css
+++ b/app/bundles/EmailBundle/Assets/css/email.css
@@ -31,9 +31,9 @@
 
 #emailGraphStats {
     height: 437px;
-    text-align: center;
 }
 
 #emailGraphStats .spinner {
     padding-top: 50px;
+    text-align: center;
 }

--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -57,6 +57,15 @@ Mautic.emailOnLoad = function (container, response) {
 
         });
     }
+
+    if (mQuery('#emailGraphStats').length) {
+        // Email detail graph - loaded via AJAX not to block loading a whole page
+        var graphUrl = mQuery('#emailGraphStats').attr('data-graph-url');
+        mQuery("#emailGraphStats").load(graphUrl, function () {
+            Mautic.renderCharts();
+            Mautic.initDateRangePicker('#emailGraphStats #daterange_date_from', '#emailGraphStats #daterange_date_to');
+        });
+    }
 };
 
 Mautic.emailOnUnload = function(id) {

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -17,7 +17,7 @@ return [
                 'controller' => 'MauticEmailBundle:Email:index',
             ],
             'mautic_email_graph_stats' => [
-                'path'       => '/emails-graph-stats/{objectId}/{isVariant}',
+                'path'       => '/emails-graph-stats/{objectId}/{isVariant}/{dateFrom}/{dateTo}',
                 'controller' => 'MauticEmailBundle:EmailGraphStats:view',
             ],
             'mautic_email_action' => [

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -16,6 +16,10 @@ return [
                 'path'       => '/emails/{page}',
                 'controller' => 'MauticEmailBundle:Email:index',
             ],
+            'mautic_email_graph_stats' => [
+                'path'       => '/emails-graph-stats/{objectId}/{isVariant}',
+                'controller' => 'MauticEmailBundle:EmailGraphStats:view',
+            ],
             'mautic_email_action' => [
                 'path'       => '/emails/{objectAction}/{objectId}',
                 'controller' => 'MauticEmailBundle:Email:execute',

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -372,6 +372,7 @@ class EmailController extends FormController
         //get related translations
         list($translationParent, $translationChildren) = $email->getTranslations();
 
+        /*
         // Prepare stats for bargraph
         if ($chartStatsSource = $this->request->query->get('stats', false)) {
             $includeVariants = ('all' == $chartStatsSource);
@@ -402,6 +403,7 @@ class EmailController extends FormController
             new \DateTime($dateRangeForm->get('date_from')->getData()),
             new \DateTime($dateRangeForm->get('date_to')->getData())
         );
+        */
 
         // Audit Log
         $logs = $this->getModel('core.auditLog')->getLogForObject('email', $email->getId(), $email->getDateAdded());
@@ -420,9 +422,9 @@ class EmailController extends FormController
                 ),
                 'viewParameters' => [
                     'email'        => $email,
-                    'stats'        => $stats,
-                    'statsDevices' => $statsDevices,
-                    'showAllStats' => $includeVariants,
+                    //'stats'        => $stats,
+                    //'statsDevices' => $statsDevices,
+                    //'showAllStats' => $includeVariants,
                     'trackables'   => $trackableLinks,
                     'pending'      => $model->getPendingLeads($email, null, true),
                     'logs'         => $logs,

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -372,39 +372,6 @@ class EmailController extends FormController
         //get related translations
         list($translationParent, $translationChildren) = $email->getTranslations();
 
-        /*
-        // Prepare stats for bargraph
-        if ($chartStatsSource = $this->request->query->get('stats', false)) {
-            $includeVariants = ('all' == $chartStatsSource);
-        } else {
-            $includeVariants = (($email->isVariant() && $parent === $email) || ($email->isTranslation() && $translationParent === $email));
-        }
-
-        if ($email->getEmailType() == 'template') {
-            $stats = $model->getEmailGeneralStats(
-                $email,
-                $includeVariants,
-                null,
-                new \DateTime($dateRangeForm->get('date_from')->getData()),
-                new \DateTime($dateRangeForm->get('date_to')->getData())
-            );
-        } else {
-            $stats = $model->getEmailListStats(
-                $email,
-                $includeVariants,
-                new \DateTime($dateRangeForm->get('date_from')->getData()),
-                new \DateTime($dateRangeForm->get('date_to')->getData())
-            );
-        }
-
-        $statsDevices = $model->getEmailDeviceStats(
-            $email,
-            $includeVariants,
-            new \DateTime($dateRangeForm->get('date_from')->getData()),
-            new \DateTime($dateRangeForm->get('date_to')->getData())
-        );
-        */
-
         // Audit Log
         $logs = $this->getModel('core.auditLog')->getLogForObject('email', $email->getId(), $email->getDateAdded());
 
@@ -422,9 +389,6 @@ class EmailController extends FormController
                 ),
                 'viewParameters' => [
                     'email'        => $email,
-                    //'stats'        => $stats,
-                    //'statsDevices' => $statsDevices,
-                    //'showAllStats' => $includeVariants,
                     'trackables'   => $trackableLinks,
                     'pending'      => $model->getPendingLeads($email, null, true),
                     'logs'         => $logs,

--- a/app/bundles/EmailBundle/Controller/EmailGraphStatsController.php
+++ b/app/bundles/EmailBundle/Controller/EmailGraphStatsController.php
@@ -17,7 +17,6 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class EmailGraphStatsController extends Controller
 {
-
     /**
      * Loads a specific form into the detailed panel.
      *
@@ -93,10 +92,10 @@ class EmailGraphStatsController extends Controller
         return $this->render(
             'MauticEmailBundle:Email:graph.html.php',
             [
-                'email'        => $email,
-                'stats'        => $stats,
-                'statsDevices' => $statsDevices,
-                'showAllStats' => $includeVariants,
+                'email'         => $email,
+                'stats'         => $stats,
+                'statsDevices'  => $statsDevices,
+                'showAllStats'  => $includeVariants,
                 'dateRangeForm' => $dateRangeForm->createView(),
                 'isVariant'     => $isVariant,
             ]

--- a/app/bundles/EmailBundle/Controller/EmailGraphStatsController.php
+++ b/app/bundles/EmailBundle/Controller/EmailGraphStatsController.php
@@ -11,85 +11,50 @@
 
 namespace Mautic\EmailBundle\Controller;
 
-use Mautic\CoreBundle\Controller\AbstractFormController;
-use Mautic\CoreBundle\Controller\BuilderControllerTrait;
-use Mautic\CoreBundle\Controller\FormErrorMessagesTrait;
-use Mautic\LeadBundle\Controller\EntityContactsTrait;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class EmailGraphStatsController extends Controller
 {
-    use BuilderControllerTrait;
-    use FormErrorMessagesTrait;
-    use EntityContactsTrait;
 
     /**
      * Loads a specific form into the detailed panel.
      *
-     * @param int  $objectId
-     * @param bool isVariant
+     * @param Request $request
+     * @param int     $objectId
+     * @param bool    $isVariant
+     * @param string  $dateFrom
+     * @param string  $dateTo
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\Response
      */
-    public function viewAction(Request $request, $objectId, $isVariant = false)
+    public function viewAction(Request $request, $objectId, $isVariant, $dateFrom = null, $dateTo = null)
     {
         /** @var \Mautic\EmailBundle\Model\EmailModel $model */
         $model    = $this->get('mautic.email.model.email');
-        $security = $this->get('mautic.security');
 
         /** @var \Mautic\EmailBundle\Entity\Email $email */
         $email = $model->getEntity($objectId);
 
         // Init the date range filter form
-        $dateRangeValues = $request->get('daterange', []);
+        $dateRangeValues = ['date_from' => $dateFrom, 'date_to' => $dateTo];
         $action          = $this->generateUrl('mautic_email_action', ['objectAction' => 'view', 'objectId' => $objectId]);
         $dateRangeForm   = $this->get('form.factory')->create('daterange', $dateRangeValues, ['action' => $action]);
 
         if ($email === null) {
-            return $this->accessDenied();
+            throw new AccessDeniedHttpException();
         } elseif (!$this->get('mautic.security')->hasEntityAccess(
             'email:emails:viewown',
             'email:emails:viewother',
             $email->getCreatedBy()
         )
         ) {
-            return $this->accessDenied();
+            throw new AccessDeniedHttpException();
         }
 
         //get A/B test information
         list($parent, $children) = $email->getVariants();
-        $properties              = [];
-        $variantError            = false;
-        $weight                  = 0;
-        if (count($children)) {
-            foreach ($children as $c) {
-                $variantSettings = $c->getVariantSettings();
-
-                if (is_array($variantSettings) && isset($variantSettings['winnerCriteria'])) {
-                    if ($c->isPublished()) {
-                        if (!isset($lastCriteria)) {
-                            $lastCriteria = $variantSettings['winnerCriteria'];
-                        }
-
-                        //make sure all the variants are configured with the same criteria
-                        if ($lastCriteria != $variantSettings['winnerCriteria']) {
-                            $variantError = true;
-                        }
-
-                        $weight += $variantSettings['weight'];
-                    }
-                } else {
-                    $variantSettings['winnerCriteria'] = '';
-                    $variantSettings['weight']         = 0;
-                }
-
-                $properties[$c->getId()] = $variantSettings;
-            }
-
-            $properties[$parent->getId()]['weight']         = 100 - $weight;
-            $properties[$parent->getId()]['winnerCriteria'] = '';
-        }
 
         //get related translations
         list($translationParent, $translationChildren) = $email->getTranslations();
@@ -101,28 +66,31 @@ class EmailGraphStatsController extends Controller
             $includeVariants = (($email->isVariant() && $parent === $email) || ($email->isTranslation() && $translationParent === $email));
         }
 
+        $dateFromObject = new \DateTime($dateFrom);
+        $dateToObject   = new \DateTime($dateTo);
+
         if ($email->getEmailType() === 'template') {
             $stats = $model->getEmailGeneralStats(
                 $email,
                 $includeVariants,
                 null,
-                new \DateTime($dateRangeForm->get('date_from')->getData()),
-                new \DateTime($dateRangeForm->get('date_to')->getData())
+                $dateFromObject,
+                $dateToObject
             );
         } else {
             $stats = $model->getEmailListStats(
                 $email,
                 $includeVariants,
-                new \DateTime($dateRangeForm->get('date_from')->getData()),
-                new \DateTime($dateRangeForm->get('date_to')->getData())
+                $dateFromObject,
+                $dateToObject
             );
         }
 
         $statsDevices = $model->getEmailDeviceStats(
             $email,
             $includeVariants,
-            new \DateTime($dateRangeForm->get('date_from')->getData()),
-            new \DateTime($dateRangeForm->get('date_to')->getData())
+            $dateFromObject,
+            $dateToObject
         );
 
         return $this->render(
@@ -136,31 +104,5 @@ class EmailGraphStatsController extends Controller
                 'isVariant'     => $isVariant,
             ]
         );
-        /*
-        return $this->delegateView(
-            [
-                'returnUrl' => $this->generateUrl(
-                    'mautic_email_action',
-                    [
-                        'objectAction' => 'view',
-                        'objectId'     => $email->getId(),
-                    ]
-                ),
-                'viewParameters' => [
-                    'email'        => $email,
-                    'stats'        => $stats,
-                    'statsDevices' => $statsDevices,
-                    'showAllStats' => $includeVariants,
-                    'dateRangeForm' => $dateRangeForm->createView(),
-                    'isVariant'     => $isVariant,
-                ],
-                'contentTemplate' => 'MauticEmailBundle:Email:graph.html.php',
-                'passthroughVars' => [
-                    'activeLink'    => '#mautic_email_index',
-                    'mauticContent' => 'email',
-                ],
-            ]
-        );
-        */
     }
 }

--- a/app/bundles/EmailBundle/Controller/EmailGraphStatsController.php
+++ b/app/bundles/EmailBundle/Controller/EmailGraphStatsController.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Controller;
+
+use Mautic\CoreBundle\Controller\AbstractFormController;
+use Mautic\CoreBundle\Controller\BuilderControllerTrait;
+use Mautic\CoreBundle\Controller\FormErrorMessagesTrait;
+use Mautic\LeadBundle\Controller\EntityContactsTrait;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+
+class EmailGraphStatsController extends Controller
+{
+    use BuilderControllerTrait;
+    use FormErrorMessagesTrait;
+    use EntityContactsTrait;
+
+    /**
+     * Loads a specific form into the detailed panel.
+     *
+     * @param int  $objectId
+     * @param bool isVariant
+     *
+     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\Response
+     */
+    public function viewAction(Request $request, $objectId, $isVariant = false)
+    {
+        /** @var \Mautic\EmailBundle\Model\EmailModel $model */
+        $model    = $this->get('mautic.email.model.email');
+        $security = $this->get('mautic.security');
+
+        /** @var \Mautic\EmailBundle\Entity\Email $email */
+        $email = $model->getEntity($objectId);
+
+        // Init the date range filter form
+        $dateRangeValues = $request->get('daterange', []);
+        $action          = $this->generateUrl('mautic_email_action', ['objectAction' => 'view', 'objectId' => $objectId]);
+        $dateRangeForm   = $this->get('form.factory')->create('daterange', $dateRangeValues, ['action' => $action]);
+
+        if ($email === null) {
+            return $this->accessDenied();
+        } elseif (!$this->get('mautic.security')->hasEntityAccess(
+            'email:emails:viewown',
+            'email:emails:viewother',
+            $email->getCreatedBy()
+        )
+        ) {
+            return $this->accessDenied();
+        }
+
+        //get A/B test information
+        list($parent, $children) = $email->getVariants();
+        $properties              = [];
+        $variantError            = false;
+        $weight                  = 0;
+        if (count($children)) {
+            foreach ($children as $c) {
+                $variantSettings = $c->getVariantSettings();
+
+                if (is_array($variantSettings) && isset($variantSettings['winnerCriteria'])) {
+                    if ($c->isPublished()) {
+                        if (!isset($lastCriteria)) {
+                            $lastCriteria = $variantSettings['winnerCriteria'];
+                        }
+
+                        //make sure all the variants are configured with the same criteria
+                        if ($lastCriteria != $variantSettings['winnerCriteria']) {
+                            $variantError = true;
+                        }
+
+                        $weight += $variantSettings['weight'];
+                    }
+                } else {
+                    $variantSettings['winnerCriteria'] = '';
+                    $variantSettings['weight']         = 0;
+                }
+
+                $properties[$c->getId()] = $variantSettings;
+            }
+
+            $properties[$parent->getId()]['weight']         = 100 - $weight;
+            $properties[$parent->getId()]['winnerCriteria'] = '';
+        }
+
+        //get related translations
+        list($translationParent, $translationChildren) = $email->getTranslations();
+
+        // Prepare stats for bargraph
+        if ($chartStatsSource = $request->query->get('stats', false)) {
+            $includeVariants = ('all' === $chartStatsSource);
+        } else {
+            $includeVariants = (($email->isVariant() && $parent === $email) || ($email->isTranslation() && $translationParent === $email));
+        }
+
+        if ($email->getEmailType() === 'template') {
+            $stats = $model->getEmailGeneralStats(
+                $email,
+                $includeVariants,
+                null,
+                new \DateTime($dateRangeForm->get('date_from')->getData()),
+                new \DateTime($dateRangeForm->get('date_to')->getData())
+            );
+        } else {
+            $stats = $model->getEmailListStats(
+                $email,
+                $includeVariants,
+                new \DateTime($dateRangeForm->get('date_from')->getData()),
+                new \DateTime($dateRangeForm->get('date_to')->getData())
+            );
+        }
+
+        $statsDevices = $model->getEmailDeviceStats(
+            $email,
+            $includeVariants,
+            new \DateTime($dateRangeForm->get('date_from')->getData()),
+            new \DateTime($dateRangeForm->get('date_to')->getData())
+        );
+
+        return $this->render(
+            'MauticEmailBundle:Email:graph.html.php',
+            [
+                'email'        => $email,
+                'stats'        => $stats,
+                'statsDevices' => $statsDevices,
+                'showAllStats' => $includeVariants,
+                'dateRangeForm' => $dateRangeForm->createView(),
+                'isVariant'     => $isVariant,
+            ]
+        );
+        /*
+        return $this->delegateView(
+            [
+                'returnUrl' => $this->generateUrl(
+                    'mautic_email_action',
+                    [
+                        'objectAction' => 'view',
+                        'objectId'     => $email->getId(),
+                    ]
+                ),
+                'viewParameters' => [
+                    'email'        => $email,
+                    'stats'        => $stats,
+                    'statsDevices' => $statsDevices,
+                    'showAllStats' => $includeVariants,
+                    'dateRangeForm' => $dateRangeForm->createView(),
+                    'isVariant'     => $isVariant,
+                ],
+                'contentTemplate' => 'MauticEmailBundle:Email:graph.html.php',
+                'passthroughVars' => [
+                    'activeLink'    => '#mautic_email_index',
+                    'mauticContent' => 'email',
+                ],
+            ]
+        );
+        */
+    }
+}

--- a/app/bundles/EmailBundle/Controller/EmailGraphStatsController.php
+++ b/app/bundles/EmailBundle/Controller/EmailGraphStatsController.php
@@ -32,7 +32,7 @@ class EmailGraphStatsController extends Controller
     public function viewAction(Request $request, $objectId, $isVariant, $dateFrom = null, $dateTo = null)
     {
         /** @var \Mautic\EmailBundle\Model\EmailModel $model */
-        $model    = $this->get('mautic.email.model.email');
+        $model = $this->get('mautic.email.model.email');
 
         /** @var \Mautic\EmailBundle\Entity\Email $email */
         $email = $model->getEntity($objectId);
@@ -42,14 +42,11 @@ class EmailGraphStatsController extends Controller
         $action          = $this->generateUrl('mautic_email_action', ['objectAction' => 'view', 'objectId' => $objectId]);
         $dateRangeForm   = $this->get('form.factory')->create('daterange', $dateRangeValues, ['action' => $action]);
 
-        if ($email === null) {
-            throw new AccessDeniedHttpException();
-        } elseif (!$this->get('mautic.security')->hasEntityAccess(
-            'email:emails:viewown',
-            'email:emails:viewother',
-            $email->getCreatedBy()
-        )
-        ) {
+        if (null === $email || !$this->get('mautic.security')->hasEntityAccess(
+                'email:emails:viewown',
+                'email:emails:viewother',
+                $email->getCreatedBy()
+        )) {
             throw new AccessDeniedHttpException();
         }
 

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -226,7 +226,11 @@ if (!$isEmbedded) {
             $dateFrom = new \DateTime($dateRangeForm->children['date_from']->vars['data']);
             $dateTo   = new \DateTime($dateRangeForm->children['date_to']->vars['data']);
             ?>
-            <div id="emailGraphStats" data-graph-url="<?php echo $view['router']->path('mautic_email_graph_stats', ['objectId' => $email->getId(), 'isVariant' => $isVariant, 'dateFrom' => $dateFrom->format('Y-m-d'), 'dateTo' => $dateTo->format('Y-m-d')]); ?>"></div>
+            <div id="emailGraphStats" data-graph-url="<?php echo $view['router']->path('mautic_email_graph_stats', ['objectId' => $email->getId(), 'isVariant' => $isVariant, 'dateFrom' => $dateFrom->format('Y-m-d'), 'dateTo' => $dateTo->format('Y-m-d')]); ?>">
+                <div class="spinner">
+                    <i class="fa fa-spin fa-spinner"></i>
+                </div>
+            </div>
 
             <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); ?>
 

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -223,8 +223,8 @@ if (!$isEmbedded) {
 
             <?php
             $isVariant = $showTranslations || $showVariants ?: 0;
-            $dateFrom = new \DateTime($dateRangeForm->children['date_from']->vars['data']);
-            $dateTo   = new \DateTime($dateRangeForm->children['date_to']->vars['data']);
+            $dateFrom  = new \DateTime($dateRangeForm->children['date_from']->vars['data']);
+            $dateTo    = new \DateTime($dateRangeForm->children['date_to']->vars['data']);
             ?>
             <div id="emailGraphStats" data-graph-url="<?php echo $view['router']->path('mautic_email_graph_stats', ['objectId' => $email->getId(), 'isVariant' => $isVariant, 'dateFrom' => $dateFrom->format('Y-m-d'), 'dateTo' => $dateTo->format('Y-m-d')]); ?>">
                 <div class="spinner">

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -228,20 +228,7 @@ if (!$isEmbedded) {
             ?>
             <div id="emailGraphStats" data-graph-url="<?php echo $view['router']->path('mautic_email_graph_stats', ['objectId' => $email->getId(), 'isVariant' => $isVariant, 'dateFrom' => $dateFrom->format('Y-m-d'), 'dateTo' => $dateTo->format('Y-m-d')]); ?>"></div>
 
-            <?php /* echo $view->render(
-                'MauticEmailBundle:Email:graph.html.php',
-                [
-                    'stats'         => $stats,
-                    'statsDevices'  => $statsDevices,
-                    'emailType'     => $emailType,
-                    'email'         => $email,
-                    'isVariant'     => ($showTranslations || $showVariants),
-                    'showAllStats'  => $showAllStats,
-                    'dateRangeForm' => $dateRangeForm,
-                ]
-            ); ?>
-
-            <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); */ ?>
+            <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); ?>
 
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -221,13 +221,12 @@ if (!$isEmbedded) {
             </div>
             <!--/ email detail collapseable toggler -->
 
-            <div id="emailGraphStats"></div>
-
-            <script>
-                mQuery( "#emailGraphStats" ).load( "<?php echo $view['router']->path('mautic_email_graph_stats', ['objectId' => $email->getId(), 'isVariant' => $showTranslations || $showVariants ?: 0]); ?>", function() {
-                    alert('Load done');
-                });
-            </script>
+            <?php
+            $isVariant = $showTranslations || $showVariants ?: 0;
+            $dateFrom = new \DateTime($dateRangeForm->children['date_from']->vars['data']);
+            $dateTo   = new \DateTime($dateRangeForm->children['date_to']->vars['data']);
+            ?>
+            <div id="emailGraphStats" data-graph-url="<?php echo $view['router']->path('mautic_email_graph_stats', ['objectId' => $email->getId(), 'isVariant' => $isVariant, 'dateFrom' => $dateFrom->format('Y-m-d'), 'dateTo' => $dateTo->format('Y-m-d')]); ?>"></div>
 
             <?php /* echo $view->render(
                 'MauticEmailBundle:Email:graph.html.php',

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -221,7 +221,15 @@ if (!$isEmbedded) {
             </div>
             <!--/ email detail collapseable toggler -->
 
-            <?php echo $view->render(
+            <div id="emailGraphStats"></div>
+
+            <script>
+                mQuery( "#emailGraphStats" ).load( "<?php echo $view['router']->path('mautic_email_graph_stats', ['objectId' => $email->getId(), 'isVariant' => $showTranslations || $showVariants ?: 0]); ?>", function() {
+                    alert('Load done');
+                });
+            </script>
+
+            <?php /* echo $view->render(
                 'MauticEmailBundle:Email:graph.html.php',
                 [
                     'stats'         => $stats,
@@ -234,7 +242,7 @@ if (!$isEmbedded) {
                 ]
             ); ?>
 
-            <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); ?>
+            <?php echo $view['content']->getCustomContent('details.stats.graph.below', $mauticTemplateVars); */ ?>
 
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/EmailBundle/Views/Email/graph.html.php
+++ b/app/bundles/EmailBundle/Views/Email/graph.html.php
@@ -8,7 +8,7 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
-if ($emailType == 'list') {
+if ($email->getEmailType() == 'list') {
     $label = 'mautic.email.lead.list.comparison';
     $type  = 'bar';
 } else {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | N
| Related user documentation PR URL | -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | -
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Instead of locking up the UI while the graphs data is loaded, we'll update the graphs via ajax.

#### Steps to test this PR:
1. Load a few email's detail pages, find at least 1 with lot of data which takes a long time to load.
2. Checkout this PR
3. Load pages again. Each page should load much faster and graphs will be loaded later via AJAX.
4. Check that page is same like before. There should be no difference after page is fully loaded.
5. Use the filter to select different date range to be sure it works.