### PR TITLE
Fix pref center error

### DIFF
--- a/app/bundles/CoreBundle/Views/Slots/channelfrequency.html.php
+++ b/app/bundles/CoreBundle/Views/Slots/channelfrequency.html.php
@@ -21,11 +21,11 @@ $channelNumber = 0;
         <tr>
             <td>
                 <div class="text-left">
-                    <input type="checkbox" id="<?php echo $channel->value ?>"
+                    <input type="checkbox" id="<?php echo $channel->value; ?>"
                            name="lead_contact_frequency_rules[subscribed_channels][]"
                            onclick="togglePreferredChannel(this.value);"
-                           value="<?php echo $view->escape($channel->value) ?>" <?php echo $checked; ?>>
-                    <label for="<?php echo $channel->value ?>" id="is-contactable-<?php echo $channel->value ?>" data-channel="<?php echo $channelName; ?>">
+                           value="<?php echo $view->escape($channel->value); ?>" <?php echo $checked; ?>>
+                    <label for="<?php echo $channel->value; ?>" id="is-contactable-<?php echo $channel->value; ?>" data-channel="<?php echo $channelName; ?>">
                         <?php echo $view['translator']->trans('mautic.lead.contact.me.label', ['%channel%' => $channelName]); ?>
                     </label>
                 </div>
@@ -35,7 +35,7 @@ $channelNumber = 0;
             <td>
                 <div id="frequency_<?php echo $channel->value; ?>" class="text-left">
                     <?php
-                    if ($showContactFrequency):?>
+                    if ($showContactFrequency && isset($form['frequency_number_'.$channel->value]) && isset($form['frequency_time_'.$channel->value])):?>
                         <div class="col-md-6">
                             <label class="text-muted label1"><?php echo $view['translator']->trans($form['frequency_number_'.$channel->value]->vars['label']); ?></label>
                             <?php echo $view['form']->widget($form['frequency_number_'.$channel->value]); ?>
@@ -46,7 +46,7 @@ $channelNumber = 0;
                         unset($form['frequency_time_'.$channel->value]);
                         unset($form['frequency_number_'.$channel->value]);
                     endif; ?>
-                    <?php if ($showContactPauseDates):?>
+                    <?php if ($showContactPauseDates && isset($form['contact_pause_start_date_'.$channel->value]) && isset($form['contact_pause_end_date_'.$channel->value])):?>
                         <div class="col-md-6">
                             <label class="text-muted label3"><?php echo $view['translator']->trans('mautic.lead.frequency.dates.label'); ?></label>
                             <?php echo $view['form']->widget($form['contact_pause_start_date_'.$channel->value]); ?>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. In configurations > Email Settings > Unsubscribe Settings > turn off `Show contact frequency preferences`
2. Create a custom landing page and turn his `preference center` to on 
3. Select a template (blank) and open the builder
4. Place Segment List, Channel Frequency and Save Preferences into the builder
5. Close builder and save page
6. Send yourself an email with the created pref. center link, open the page
7. Error

![screenshot_2018-09-18 centre de pref](https://user-images.githubusercontent.com/27768270/45694294-3f1db980-bb5f-11e8-8bbb-f96e25d6afb0.png)


#### Steps to test this PR:
1. Apply PR
2. Clear cache
3. Re-open pref. center link
4. No error