### PR TITLE
Fixed data API endpoints

### DIFF
--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -524,6 +524,27 @@ class CampaignRepository extends CommonRepository
     }
 
     /**
+     * @param $contactId
+     * @param $campaignId
+     *
+     * @return mixed
+     */
+    public function getContactSingleSegmentByCampaign($contactId, $campaignId)
+    {
+        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
+
+        return $q->select('ll.id, ll.name')
+            ->from(MAUTIC_TABLE_PREFIX.'lead_lists', 'll')
+            ->join('ll', MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'lll', 'lll.leadlist_id = ll.id and lll.lead_id = :contactId and lll.manually_removed = 0')
+            ->join('ll', MAUTIC_TABLE_PREFIX.'campaign_leadlist_xref', 'clx', 'clx.leadlist_id = ll.id and clx.campaign_id = :campaignId')
+            ->setParameter('contactId', (int) $contactId)
+            ->setParameter('campaignId', (int) $campaignId)
+            ->setMaxResults(1)
+            ->execute()
+            ->fetch();
+    }
+
+    /**
      * Get lead IDs of a campaign.
      *
      * @deprecated 2.13.0 to be removed in 3.0

--- a/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
+++ b/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
@@ -102,7 +102,7 @@ class WidgetApiController extends CommonApiController
         $widget->setType($type);
         $widget->setHeight($widgetHeight);
 
-        if ($cacheTimeout === null) {
+        if ($cacheTimeout !== null) {
             $widget->setCacheTimeout($cacheTimeout);
         }
 

--- a/app/bundles/EmailBundle/Entity/StatRepository.php
+++ b/app/bundles/EmailBundle/Entity/StatRepository.php
@@ -133,7 +133,7 @@ class StatRepository extends CommonRepository
                 ->setParameter('companyId', $companyId);
         }
 
-        $q->leftJoin('s', MAUTIC_TABLE_PREFIX.'campaign_events', 'ce', 's.source_id = ce.id AND s.source = "campaign.event"')
+        $q->leftJoin('s', MAUTIC_TABLE_PREFIX.'campaign_events', 'ce', 's.source = "campaign.event" and s.source_id = ce.id')
             ->leftJoin('ce', MAUTIC_TABLE_PREFIX.'campaigns', 'campaign', 'ce.campaign_id = campaign.id')
             ->addSelect('campaign.id AS campaign_id')
             ->addSelect('campaign.name AS campaign_name');

--- a/app/bundles/EmailBundle/Form/Type/DashboardEmailsInTimeWidgetType.php
+++ b/app/bundles/EmailBundle/Form/Type/DashboardEmailsInTimeWidgetType.php
@@ -65,6 +65,7 @@ class DashboardEmailsInTimeWidgetType extends AbstractType
                 'label'       => 'mautic.email.campaignId.filter',
                 'label_attr'  => ['class' => 'control-label'],
                 'attr'        => ['class' => 'form-control'],
+                'empty_data'  => '',
                 'empty_value' => '',
                 'required'    => false,
                 'multiple'    => false,

--- a/app/bundles/EmailBundle/Form/Type/DashboardMostHitEmailRedirectsWidgetType.php
+++ b/app/bundles/EmailBundle/Form/Type/DashboardMostHitEmailRedirectsWidgetType.php
@@ -34,12 +34,13 @@ class DashboardMostHitEmailRedirectsWidgetType extends AbstractType
             'campaignId',
             'campaign_list',
             [
-                'label'      => 'mautic.email.campaignId.filter',
-                'label_attr' => ['class' => 'control-label'],
-                'attr'       => ['class' => 'form-control'],
-                'empty_data' => '',
-                'required'   => false,
-                'multiple'   => false,
+                'label'       => 'mautic.email.campaignId.filter',
+                'label_attr'  => ['class' => 'control-label'],
+                'attr'        => ['class' => 'form-control'],
+                'empty_data'  => '',
+                'empty_value' => '',
+                'required'    => false,
+                'multiple'    => false,
             ]
         );
 

--- a/app/bundles/EmailBundle/Form/Type/DashboardSentEmailToContactsWidgetType.php
+++ b/app/bundles/EmailBundle/Form/Type/DashboardSentEmailToContactsWidgetType.php
@@ -34,12 +34,13 @@ class DashboardSentEmailToContactsWidgetType extends AbstractType
             'campaignId',
             'campaign_list',
             [
-                'label'      => 'mautic.email.campaignId.filter',
-                'label_attr' => ['class' => 'control-label'],
-                'attr'       => ['class' => 'form-control'],
-                'empty_data' => '',
-                'required'   => false,
-                'multiple'   => false,
+                'label'       => 'mautic.email.campaignId.filter',
+                'label_attr'  => ['class' => 'control-label'],
+                'attr'        => ['class' => 'form-control'],
+                'empty_data'  => '',
+                'empty_value' => '',
+                'required'    => false,
+                'multiple'    => false,
             ]
         );
 

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -571,36 +571,39 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
 
         foreach ($stats as $stat) {
             $statId = $stat['id'];
-            if (!array_key_exists($statId, $data)) {
-                $item = [
-                    'contact_id'    => $stat['lead_id'],
-                    'contact_email' => $stat['email_address'],
-                    'open'          => $stat['is_read'],
-                    'click'         => ($stat['link_hits'] !== null) ? $stat['link_hits'] : 0,
-                    'links_clicked' => [],
-                    'email_id'      => (string) $stat['email_id'],
-                    'email_name'    => (string) $stat['email_name'],
-                    'segment_id'    => (string) $stat['segment_id'],
-                    'segment_name'  => (string) $stat['segment_name'],
-                    'company_id'    => (string) $stat['company_id'],
-                    'company_name'  => (string) $stat['company_name'],
-                    'campaign_id'   => (string) $stat['campaign_id'],
-                    'campaign_name' => (string) $stat['campaign_name'],
-                ];
 
-                if ($item['click'] && $item['email_id'] && $item['contact_id']) {
-                    $item['links_clicked'] = $this->getStatRepository()->getUniqueClickedLinksPerContactAndEmail($item['contact_id'], $item['email_id']);
-                }
+            if (empty($stat['segment_id']) && !empty($stat['campaign_id'])) {
+                // Let's fetch the segment based on current campaign/segment membership
+                $segmentMembership = $this->em->getRepository('MauticCampaignBundle:Campaign')
+                    ->getContactSingleSegmentByCampaign($stat['lead_id'], $stat['campaign_id']);
 
-                $data[$statId] = $item;
-            } else {
-                if ($stat['link_hits'] !== null) {
-                    $data[$statId]['click'] += $stat['link_hits'];
-                }
-                if ($stat['link_url'] !== null && !in_array($stat['link_url'], $data[$statId]['links_clicked'])) {
-                    $data[$statId]['links_clicked'][] = $stat['link_url'];
+                if ($segmentMembership) {
+                    $stat['segment_id']   = $segmentMembership['id'];
+                    $stat['segment_name'] = $segmentMembership['name'];
                 }
             }
+
+            $item = [
+                'contact_id'    => $stat['lead_id'],
+                'contact_email' => $stat['email_address'],
+                'open'          => $stat['is_read'],
+                'click'         => ($stat['link_hits'] !== null) ? $stat['link_hits'] : 0,
+                'links_clicked' => [],
+                'email_id'      => (string) $stat['email_id'],
+                'email_name'    => (string) $stat['email_name'],
+                'segment_id'    => (string) $stat['segment_id'],
+                'segment_name'  => (string) $stat['segment_name'],
+                'company_id'    => (string) $stat['company_id'],
+                'company_name'  => (string) $stat['company_name'],
+                'campaign_id'   => (string) $stat['campaign_id'],
+                'campaign_name' => (string) $stat['campaign_name'],
+            ];
+
+            if ($item['click'] && $item['email_id'] && $item['contact_id']) {
+                $item['links_clicked'] = $this->getStatRepository()->getUniqueClickedLinksPerContactAndEmail($item['contact_id'], $item['email_id']);
+            }
+
+            $data[$statId] = $item;
         }
 
         return $data;

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -428,11 +428,7 @@ class PublicController extends CommonFormController
         $redirectModel = $this->getModel('page.redirect');
         $redirect      = $redirectModel->getRedirectById($redirectId);
 
-        $logger->debug('Redirect hit');
-
-        /** @var \Mautic\PageBundle\Model\PageModel $pageModel */
-        $pageModel = $this->getModel('page');
-        $pageModel->hitPage($redirect, $this->request);
+        $logger->debug('Executing Redirect: '.(string) $redirect);
 
         $url = $redirect->getUrl();
 
@@ -461,6 +457,10 @@ class PublicController extends CommonFormController
         $leadModel = $this->getModel('lead');
         $lead      = $leadModel->getContactFromRequest(['ct' => $ct]);
 
+        /** @var \Mautic\PageBundle\Model\PageModel $pageModel */
+        $pageModel = $this->getModel('page');
+        $pageModel->hitPage($redirect, $this->request, 200, $lead);
+
         /** @var PrimaryCompanyHelper $primaryCompanyHelper */
         $primaryCompanyHelper = $this->get('mautic.lead.helper.primary_company');
         $leadArray            = ($lead) ? $primaryCompanyHelper->getProfileFieldsWithPrimaryCompany($lead) : [];
@@ -471,13 +471,6 @@ class PublicController extends CommonFormController
         if (false === filter_var($url, FILTER_VALIDATE_URL)) {
             throw $this->createNotFoundException($this->translator->trans('mautic.core.url.error.404', ['%url%' => $url]));
         }
-
-        // Set the URL after tokens have been replaced so that page_hits has recorded the actual URL and not the token
-        $this->request->attributes->set('page_url', $url);
-
-        /** @var \Mautic\PageBundle\Model\PageModel $pageModel */
-        $pageModel = $this->getModel('page');
-        $pageModel->hitPage($redirect, $this->request);
 
         return $this->redirect($url);
     }

--- a/app/bundles/PageBundle/Entity/RedirectRepository.php
+++ b/app/bundles/PageBundle/Entity/RedirectRepository.php
@@ -111,15 +111,18 @@ class RedirectRepository extends CommonRepository
         $campaignId = null,
         $segmentId = null
     ) {
-        $q = $this->_em->getConnection()->createQueryBuilder();
+        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
         $q->addSelect('ph.url')
             ->addSelect('count(ph.id) as hits')
             ->addSelect('count(distinct ph.tracking_id) as unique_hits')
-            ->from(MAUTIC_TABLE_PREFIX.'page_redirects', 'pr')
-            ->leftJoin('pr', MAUTIC_TABLE_PREFIX.'page_hits', 'ph', 'pr.redirect_id = ph.redirect_id')
-            ->leftJoin('ph', MAUTIC_TABLE_PREFIX.'emails', 'e', 'ph.email_id = e.id')
+            ->from(MAUTIC_TABLE_PREFIX.'page_hits', 'ph')
+            ->join('ph', MAUTIC_TABLE_PREFIX.'email_stats', 'es', 'ph.source = "email" and ph.source_id = es.email_id and ph.lead_id = es.lead_id')
+            ->join('es', MAUTIC_TABLE_PREFIX.'emails', 'e', 'es.email_id = e.id')
             ->addSelect('e.id AS email_id')
             ->addSelect('e.name AS email_name');
+
+        // Group by the page hit URL instead of redirect ID because the redirect could be a token
+        $q->groupBy('ph.url, e.id, e.name, campaign.id, campaign.name');
 
         if ($createdByUserId !== null) {
             $q->andWhere('e.created_by = :userId')
@@ -131,12 +134,24 @@ class RedirectRepository extends CommonRepository
             ->setParameter('dateTo', $dateTo->format('Y-m-d H:i:s'));
 
         if ($companyId !== null) {
-            $q->leftJoin('ph', MAUTIC_TABLE_PREFIX.'companies_leads', 'cl', 'ph.lead_id = cl.lead_id')
-                ->andWhere('cl.company_id = :companyId')
+            $sb = $this->getEntityManager()->getConnection()->createQueryBuilder();
+
+            $sb->select('null')
+                ->from(MAUTIC_TABLE_PREFIX.'companies_leads', 'cl')
+                ->where(
+                    $sb->expr()->andX(
+                        $sb->expr()->eq('cl.company_id', ':companyId'),
+                        $sb->expr()->eq('cl.lead_id', 'ph.lead_id')
+                    )
+                );
+
+            $q->andWhere(
+                sprintf('EXISTS (%s)', $sb->getSQL())
+            )
                 ->setParameter('companyId', $companyId);
         }
 
-        $q->leftJoin('ph', MAUTIC_TABLE_PREFIX.'campaign_events', 'ce', 'ph.source_id = ce.id AND ph.source = "campaign.event"')
+        $q->leftJoin('es', MAUTIC_TABLE_PREFIX.'campaign_events', 'ce', 'es.source = "campaign.event" and es.source_id = ce.id')
             ->leftJoin('ce', MAUTIC_TABLE_PREFIX.'campaigns', 'campaign', 'ce.campaign_id = campaign.id')
             ->addSelect('campaign.id AS campaign_id')
             ->addSelect('campaign.name AS campaign_name');
@@ -146,20 +161,28 @@ class RedirectRepository extends CommonRepository
                 ->setParameter('campaignId', $campaignId);
         }
 
-        $q->leftJoin('ph', MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'lll', 'ph.lead_id = lll.lead_id')
-            ->leftJoin('lll', MAUTIC_TABLE_PREFIX.'lead_lists', 'll', 'lll.leadlist_id = ll.id')
-            ->addSelect('ll.id AS segment_id')
-            ->addSelect('ll.name AS segment_name');
-
         if ($segmentId !== null) {
+            $q->leftJoin('ph', MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'lll', 'ph.lead_id = lll.lead_id')
+                ->leftJoin('lll', MAUTIC_TABLE_PREFIX.'lead_lists', 'll', 'lll.leadlist_id = ll.id')
+                ->addSelect('ll.id AS segment_id')
+                ->addSelect('ll.name AS segment_name');
+
+            // Prevent strict errors in MySQL 5.7
+            $q->addGroupBy('ll.id, ll.name');
+
             $q->andWhere('lll.leadlist_id = :segmentId')
                 ->setParameter('segmentId', $segmentId);
+        } else {
+            // Due to many-to-many relationship between contact and segment, we cannot include segments unless filtering by segment or else
+            // each segment a contact is in will result in a click leading to confusing results. Imagine there is a click from a contact that is in
+            // one segment and a click from a contact that is in the same plus another. The results will show 1 click for the one segment and
+            // 2 clicks for the second. But there were only two clicks total and so there's no way to determine actual number of clicks.
+            // Since these results are not time aware (and thus not usable in a line graph), we should not include duplicate click counts.
+            $q->addSelect('null as segment_id, null as segment_name');
         }
 
         $q->setMaxResults($limit);
 
-        // Group by the page hit URL instead of redirect ID because the redirect could be a token
-        $q->groupBy('ph.url');
         $q->orderBy('hits', 'DESC');
 
         return $q->execute()->fetchAll();

--- a/app/bundles/PageBundle/Entity/RedirectRepository.php
+++ b/app/bundles/PageBundle/Entity/RedirectRepository.php
@@ -112,7 +112,7 @@ class RedirectRepository extends CommonRepository
         $segmentId = null
     ) {
         $q = $this->_em->getConnection()->createQueryBuilder();
-        $q->addSelect('pr.url')
+        $q->addSelect('ph.url')
             ->addSelect('pr.hits')
             ->addSelect('pr.unique_hits')
             ->from(MAUTIC_TABLE_PREFIX.'page_redirects', 'pr')
@@ -126,7 +126,7 @@ class RedirectRepository extends CommonRepository
                 ->setParameter('userId', $createdByUserId);
         }
 
-        $q->andWhere('pr.date_added BETWEEN :dateFrom AND :dateTo')
+        $q->andWhere('ph.date_hit BETWEEN :dateFrom AND :dateTo')
             ->setParameter('dateFrom', $dateFrom->format('Y-m-d H:i:s'))
             ->setParameter('dateTo', $dateTo->format('Y-m-d H:i:s'));
 

--- a/app/bundles/PageBundle/Entity/RedirectRepository.php
+++ b/app/bundles/PageBundle/Entity/RedirectRepository.php
@@ -113,8 +113,8 @@ class RedirectRepository extends CommonRepository
     ) {
         $q = $this->_em->getConnection()->createQueryBuilder();
         $q->addSelect('ph.url')
-            ->addSelect('pr.hits')
-            ->addSelect('pr.unique_hits')
+            ->addSelect('count(ph.id) as hits')
+            ->addSelect('count(distinct ph.tracking_id) as unique_hits')
             ->from(MAUTIC_TABLE_PREFIX.'page_redirects', 'pr')
             ->leftJoin('pr', MAUTIC_TABLE_PREFIX.'page_hits', 'ph', 'pr.redirect_id = ph.redirect_id')
             ->leftJoin('ph', MAUTIC_TABLE_PREFIX.'emails', 'e', 'ph.email_id = e.id')
@@ -157,8 +157,10 @@ class RedirectRepository extends CommonRepository
         }
 
         $q->setMaxResults($limit);
-        $q->groupBy('pr.id');
-        $q->orderBy('pr.hits', 'DESC');
+
+        // Group by the page hit URL instead of redirect ID because the redirect could be a token
+        $q->groupBy('ph.url');
+        $q->orderBy('hits', 'DESC');
 
         return $q->execute()->fetchAll();
     }

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -1192,7 +1192,7 @@ class PageModel extends FormModel
         }
         $pageURL .= '://';
 
-        if ($request->server->get('SERVER_PORT') != '80') {
+        if (!in_array((int) $request->server->get('SERVER_PORT', 80), [80, 8080, 443])) {
             return $pageURL.$request->server->get('SERVER_NAME').':'.$request->server->get('SERVER_PORT').
                 $request->server->get('REQUEST_URI');
         }

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -790,91 +790,12 @@ class PageModel extends FormModel
      */
     public function getHitQuery(Request $request, $page = null)
     {
-        if ($page instanceof Redirect) {
-            //use the configured redirect URL
-            $pageURL = $page->getUrl();
-        } else {
-            //use current URL
-
-            $isPageEvent = false;
-            if (strpos($request->server->get('REQUEST_URI'), $this->router->generate('mautic_page_tracker')) !== false) {
-                // Tracking pixel is used
-                if ($request->server->get('QUERY_STRING')) {
-                    parse_str($request->server->get('QUERY_STRING'), $query);
-                    $isPageEvent = true;
-                }
-            } elseif (strpos($request->server->get('REQUEST_URI'), $this->router->generate('mautic_page_tracker_cors')) !== false) {
-                $query       = $request->request->all();
-                $isPageEvent = true;
-            }
-
-            if ($isPageEvent) {
-                $pageURL = $request->server->get('HTTP_REFERER');
-
-                // if additional data were sent with the tracking pixel
-                if (isset($query)) {
-                    // URL attr 'd' is encoded so let's decode it first.
-                    $decoded = false;
-                    if (isset($query['d'])) {
-                        // parse_str auto urldecodes
-                        $query   = $this->decodeArrayFromUrl($query['d'], false);
-                        $decoded = true;
-                    }
-
-                    if (is_array($query) && !empty($query)) {
-                        if (isset($query['page_url'])) {
-                            $pageURL = $query['page_url'];
-                            if (!$decoded) {
-                                $pageURL = urldecode($pageURL);
-                            }
-                        }
-
-                        if (isset($query['page_referrer'])) {
-                            if (!$decoded) {
-                                $query['page_referrer'] = urldecode($query['page_referrer']);
-                            }
-                        }
-
-                        if (isset($query['page_language'])) {
-                            if (!$decoded) {
-                                $query['page_language'] = urldecode($query['page_language']);
-                            }
-                        }
-
-                        if (isset($query['page_title'])) {
-                            if (!$decoded) {
-                                $query['page_title'] = urldecode($query['page_title']);
-                            }
-                        }
-
-                        if (isset($query['tags'])) {
-                            if (!$decoded) {
-                                $query['tags'] = urldecode($query['tags']);
-                            }
-                        }
-                    }
-                }
-            } else {
-                $pageURL = 'http';
-                if ($request->server->get('HTTPS') == 'on') {
-                    $pageURL .= 's';
-                }
-                $pageURL .= '://';
-                if ($request->server->get('SERVER_PORT') != '80') {
-                    $pageURL .= $request->server->get('SERVER_NAME').':'.$request->server->get('SERVER_PORT').
-                        $request->server->get('REQUEST_URI');
-                } else {
-                    $pageURL .= $request->server->get('SERVER_NAME').$request->server->get('REQUEST_URI');
-                }
-            }
-        }
-
         if (!isset($query)) {
             $query = $request->query->all();
         }
 
         // Set generated page url
-        $query['page_url'] = $pageURL;
+        $query['page_url'] = $this->getPageUrl($request, $page);
 
         // Process clickthrough if applicable
         if (!empty($query['ct'])) {
@@ -1158,20 +1079,9 @@ class PageModel extends FormModel
     }
 
     /**
-     * @deprecated 2.1 - use $entity->getVariants() instead; to be removed in 3.0
-     *
-     * @param Page $entity
-     *
-     * @return array
-     */
-    public function getVariants(Page $entity)
-    {
-        return $entity->getVariants();
-    }
-
-    /**
-     * @param null|Page|Redirect $page
-     * @param Lead               $lead
+     * @param      $page
+     * @param Hit  $hit
+     * @param Lead $lead
      */
     private function setLeadManipulator($page, Hit $hit, Lead $lead)
     {
@@ -1196,11 +1106,118 @@ class PageModel extends FormModel
     }
 
     /**
+     * @param Request $request
+     * @param         $page
+     *
+     * @return mixed|string
+     */
+    private function getPageUrl(Request $request, $page)
+    {
+        // Default to page_url set in the query from tracking pixel and/or contactfield token
+        if ($pageURL = $request->get('page_url')) {
+            return $pageURL;
+        }
+
+        if ($page instanceof Redirect) {
+            //use the configured redirect URL
+            return $page->getUrl();
+        }
+
+        // Use the current URL
+        $isPageEvent = false;
+        if (strpos($request->server->get('REQUEST_URI'), $this->router->generate('mautic_page_tracker')) !== false) {
+            // Tracking pixel is used
+            if ($request->server->get('QUERY_STRING')) {
+                parse_str($request->server->get('QUERY_STRING'), $query);
+                $isPageEvent = true;
+            }
+        } elseif (strpos($request->server->get('REQUEST_URI'), $this->router->generate('mautic_page_tracker_cors')) !== false) {
+            $query       = $request->request->all();
+            $isPageEvent = true;
+        }
+
+        if ($isPageEvent) {
+            $pageURL = $request->server->get('HTTP_REFERER');
+
+            // if additional data were sent with the tracking pixel
+            if (isset($query)) {
+                // URL attr 'd' is encoded so let's decode it first.
+                $decoded = false;
+                if (isset($query['d'])) {
+                    // parse_str auto urldecodes
+                    $query   = $this->decodeArrayFromUrl($query['d'], false);
+                    $decoded = true;
+                }
+
+                if (is_array($query) && !empty($query)) {
+                    if (isset($query['page_url'])) {
+                        $pageURL = $query['page_url'];
+                        if (!$decoded) {
+                            $pageURL = urldecode($pageURL);
+                        }
+                    }
+
+                    if (isset($query['page_referrer'])) {
+                        if (!$decoded) {
+                            $query['page_referrer'] = urldecode($query['page_referrer']);
+                        }
+                    }
+
+                    if (isset($query['page_language'])) {
+                        if (!$decoded) {
+                            $query['page_language'] = urldecode($query['page_language']);
+                        }
+                    }
+
+                    if (isset($query['page_title'])) {
+                        if (!$decoded) {
+                            $query['page_title'] = urldecode($query['page_title']);
+                        }
+                    }
+
+                    if (isset($query['tags'])) {
+                        if (!$decoded) {
+                            $query['tags'] = urldecode($query['tags']);
+                        }
+                    }
+                }
+            }
+
+            return $pageURL;
+        }
+
+        $pageURL = 'http';
+        if ($request->server->get('HTTPS') == 'on') {
+            $pageURL .= 's';
+        }
+        $pageURL .= '://';
+
+        if ($request->server->get('SERVER_PORT') != '80') {
+            return $pageURL.$request->server->get('SERVER_NAME').':'.$request->server->get('SERVER_PORT').
+                $request->server->get('REQUEST_URI');
+        }
+
+        return $pageURL.$request->server->get('SERVER_NAME').$request->server->get('REQUEST_URI');
+    }
+
+    /**
      * @deprecated 2.13.0; no longer used
      *
      * @param $trackByFingerprint
      */
     public function setTrackByFingerprint($trackByFingerprint)
     {
+    }
+
+    /**
+     * @deprecated 2.1 - use $entity->getVariants() instead; to be removed in 3.0
+     *
+     * @param Page $entity
+     *
+     * @return array
+     */
+    public function getVariants(Page $entity)
+    {
+        return $entity->getVariants();
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This fixes the following issues with the newly introduced data API endpoints

1. cacheTimeout was always ignored therefore it used the global config
2. ~~Page redirects that were contact tokens were recorded in the page hits table as tokens making it impossible to know the actual URLs clicked. Redirects now record the decoded URL in the page hits table
3. ~~Because of step 2 above, the results in the API were grouped by token and not by unique URL
4. sent.email.to.contacts filtered segments related to broadcasts but the customer needs it to support campaigns
5. Fixed a bad query that resulted in no results when filtering by company even though results were applicable for the `/api/data/most.hit.email.redirects` endpoint. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Use any of the data endpoints and not that cache is returned as true for subsequent requests
2. ~~Create a contact with a website. Create an email with a link to the {contactfield=website} token. Send the email and click on the link. Look at the page hits table and notice that the URL is the token not the decoded URL
3. ~~Use the `/api/data/most.hit.email.redirects?dateFrom=2018-07-01&dateTo=2018-07-09` endpoint and notice the URLs are grouped by token. Adjust dates.
4. Send an email by campaign and try to use the `/api/data/sent.email.to.contacts?dateFrom=2018-07-01&dateTo=2018-07-09&timeUnit=d&filter[segmentId]=1539`. Replace dates and the segment ID with something appropriate to testing. Notice no results are included even though the contact is in the segment. 
5. Assign the contact to a company `/api/data/most.hit.email.redirects?dateFrom=2018-07-01&dateTo=2018-01-01&timeUnit=d&filter[companyId]=1234`. Replace dates and the company ID with something appropriate to testing. Notice no results are included even though the contact is in the company. 

#### Steps to test this PR:
1. All requests should have cache = false
2. ~~Token should now be the URL in page_hits 
3. ~~Results should be returned grouped by actual URL not token
4. Results should be filterable by segment ID
5. Results should be filterable by company ID
6. Ensure `api/data/emails.in.time` endpoint functions properly