### PR TITLE
add Campaign Event object to config array

### DIFF
--- a/app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
@@ -56,10 +56,11 @@ class CampaignSubscriber extends CommonSubscriber
      */
     public function onCampaignTriggerAction(CampaignExecutionEvent $event)
     {
-        $config  = $event->getConfig();
-        $lead    = $event->getLead();
-        $errors  = [];
-        $success = $this->pushToIntegration($config, $lead, $errors);
+        $config                  = $event->getConfig();
+        $config['campaignEvent'] = $event->getEvent();
+        $lead                    = $event->getLead();
+        $errors                  = [];
+        $success                 = $this->pushToIntegration($config, $lead, $errors);
 
         if (count($errors)) {
             $log = $event->getLogEntry();


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Y
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If a campaign is cloned, its events may contain out of date or stale config data in the serialized blob. Adding the Event object into the entire Config array allows integrations to have access to the most current instance of the event object and provides backwards compatibility.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Clone a campaign with several action events
2. Edit cloned Events or add new ones.
3. Note how the parameters preserves the older data as a serialized blob

#### Steps to test this PR:
1. run campaign triggers
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 