### PR TITLE
Fixed an error with regex used in the segment filter "URL visited"

### DIFF
--- a/app/bundles/LeadBundle/Segment/Query/Filter/ForeignValueFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ForeignValueFilterQueryBuilder.php
@@ -95,6 +95,15 @@ class ForeignValueFilterQueryBuilder extends BaseFilterQueryBuilder
 
                 $queryBuilder->addLogic($queryBuilder->expr()->notExists($subQueryBuilder->getSQL()), $filter->getGlue());
                 break;
+            case 'regexp':
+            case 'notRegexp':
+                $not        = ($filterOperator === 'notRegexp') ? ' NOT' : '';
+                $expression = $tableAlias.'.'.$filter->getField().$not.' REGEXP '.$filterParametersHolder;
+
+                $subQueryBuilder->andWhere($expression);
+
+                $queryBuilder->addLogic($queryBuilder->expr()->exists($subQueryBuilder->getSQL()), $filter->getGlue());
+                break;
             default:
                 $expression = $subQueryBuilder->expr()->$filterOperator(
                     $tableAlias.'.'.$filter->getField(),


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When "Visited url" filter is used with regexp type in segment, update fail.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a segment
2. Inside filter tab add "Visited URL", choose `regexp` type and put some value
3. Lauch `php app/console m:s:u`
4. Error : ```[Symfony\Component\Debug\Exception\UndefinedMethodException]
  Attempted to call an undefined method named "regexp" of class "Doctrine\DBAL\Query\Expression\ExpressionBuilder".```

#### Steps to test this PR:
1. Apply PR
2. No error and segment is updated
