### PR TITLE
Fix international phone number form validation

### DIFF
--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -167,7 +167,7 @@ class FormFieldHelper extends AbstractFormFieldHelper
                     continue;
                 }
 
-                if ($f !== null && $f->getType() === 'tel' && !empty($f->getProperties()['international']) && !empty($value)) {
+                if ($f !== null && $f->getType() === 'tel' && empty($f->getProperties()['international'])) {
                     continue;
                 }
                 if ($type == 'captcha') {

--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -167,7 +167,7 @@ class FormFieldHelper extends AbstractFormFieldHelper
                     continue;
                 }
 
-                if ($f !== null && $f->getType() === 'tel' && empty($f->getProperties()['international'])) {
+                if ($f !== null && $f->getType() === 'tel' && empty($f->getProperties()['international']) && !empty($value)) {
                     continue;
                 }
                 if ($type == 'captcha') {

--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -167,7 +167,7 @@ class FormFieldHelper extends AbstractFormFieldHelper
                     continue;
                 }
 
-                if ($f !== null && $f->getType() === 'tel' && empty($f->getProperties()['international']) && !empty($value)) {
+                if ($f !== null && $f->getType() === 'tel' && empty($f->getProperties()['international'])) {
                     continue;
                 }
                 if ($type == 'captcha') {

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -1077,7 +1077,7 @@ class SubmissionModel extends CommonFormModel
      */
     protected function validateFieldValue(Field $field, $value)
     {
-        $standardValidation = $this->fieldHelper->validateFieldValue($field->getType(), $value);
+        $standardValidation = $this->fieldHelper->validateFieldValue($field->getType(), $value, $field);
         if (!empty($standardValidation)) {
             return $standardValidation;
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6633
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Enhancement validation for phone number form field in Mautic 2.14.1 didn't work properly.
https://github.com/mautic/mautic/pull/5400
This PR fixed the condition When validation is skipped (everytime If validaton is disabled from properties tab).

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Create from and phone field type with disable required and validation from properties tab
2.  Go to to form (mauticurl.com/form/idForm) and try send it.
3. Form should return validation error event the option for validation is disabled

#### Steps to test this PR:
1.  Repeat all steps
2.  See If validation is use just when is enabled
