### PR TITLE
Bugfix: queued redirect

### DIFF
--- a/app/bundles/PageBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PageSubscriber.php
@@ -188,12 +188,19 @@ class PageSubscriber extends CommonSubscriber
         $trackingNewlyGenerated = $payload['isNew'];
         $pageId                 = $payload['pageId'];
         $leadId                 = $payload['leadId'];
+        $isRedirect             = $payload['isRedirect'];
         $hitRepo                = $this->em->getRepository('MauticPageBundle:Hit');
         $pageRepo               = $this->em->getRepository('MauticPageBundle:Page');
+        $redirectRepo           = $this->em->getRepository('MauticPageBundle:Redirect');
         $leadRepo               = $this->em->getRepository('MauticLeadBundle:Lead');
         $hit                    = $hitRepo->find((int) $payload['hitId']);
-        $page                   = $pageId ? $pageRepo->find((int) $pageId) : null;
         $lead                   = $leadId ? $leadRepo->find((int) $leadId) : null;
+
+        if ($isRedirect) {
+            $page = $pageId ? $redirectRepo->find((int) $pageId) : null;
+        } else {
+            $page = $pageId ? $pageRepo->find((int) $pageId) : null;
+        }
 
         $this->pageModel->processPageHit($hit, $page, $request, $lead, $trackingNewlyGenerated, false);
         $event->setResult(QueueConsumerResults::ACKNOWLEDGE);

--- a/app/bundles/PageBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PageSubscriber.php
@@ -188,7 +188,7 @@ class PageSubscriber extends CommonSubscriber
         $trackingNewlyGenerated = $payload['isNew'];
         $pageId                 = $payload['pageId'];
         $leadId                 = $payload['leadId'];
-        $isRedirect             = $payload['isRedirect'];
+        $isRedirect             = !empty($payload['isRedirect']);
         $hitRepo                = $this->em->getRepository('MauticPageBundle:Hit');
         $pageRepo               = $this->em->getRepository('MauticPageBundle:Page');
         $redirectRepo           = $this->em->getRepository('MauticPageBundle:Redirect');

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -538,7 +538,7 @@ class PageModel extends FormModel
                 'request'       => $request,
                 'leadId'        => $lead ? $lead->getId() : null,
                 'isNew'         => $this->deviceTracker->wasDeviceChanged(),
-                'isRedirect'    => $page instanceof Redirect ? true : false,
+                'isRedirect'    => ($page instanceof Redirect),
             ];
             $this->queueService->publishToQueue(QueueName::PAGE_HIT, $msg);
         } else {

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -533,11 +533,12 @@ class PageModel extends FormModel
 
         if ($this->queueService->isQueueEnabled()) {
             $msg = [
-                'hitId'   => $hit->getId(),
-                'pageId'  => $page ? $page->getId() : null,
-                'request' => $request,
-                'leadId'  => $lead ? $lead->getId() : null,
-                'isNew'   => $this->deviceTracker->wasDeviceChanged(),
+                'hitId'         => $hit->getId(),
+                'pageId'        => $page ? $page->getId() : null,
+                'request'       => $request,
+                'leadId'        => $lead ? $lead->getId() : null,
+                'isNew'         => $this->deviceTracker->wasDeviceChanged(),
+                'isRedirect'    => $page instanceof Redirect ? true : false,
             ];
             $this->queueService->publishToQueue(QueueName::PAGE_HIT, $msg);
         } else {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL |
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Adds an identifier `isRedirect` when pushing to the queue for Redirect vs Page
Consumer expects identifier `isRedirect` and looks up the correct entity accordingly.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Enable queued page_hit processing
2. Create an email with a link to an off-site url
3. Send the email and click the link in the received email.
4. Run the queue processing command to consume the queued page_hit
5. The click counter for the email will not increase

#### Steps to test this PR:
1. Enable queued page_hit processing
2. Create an email with a link to an off-site url
3. Send the email and click the link in the received email.
4. Run the queue processing command to consume the queued page_hit
5. See the click counter for the email increase

#### List deprecations along with the new alternative:
none

#### List backwards compatibility breaks:
1. Existing page_hit entries in the queue may not be processable with the new consumer
 