### PR TITLE
Fix js loading with automatic form integration

### DIFF
--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -724,12 +724,15 @@ class FormModel extends CommonFormModel
      */
     public function getAutomaticJavascript(Form $form)
     {
-        $html = $this->getContent($form);
+        $html       = $this->getContent($form, false);
+        $formScript = $this->getFormScript($form);
 
         //replace line breaks with literal symbol and escape quotations
-        $search  = ["\r\n", "\n", '"'];
-        $replace = ['', '', '\"'];
-        $html    = str_replace($search, $replace, $html);
+        $search                = ["\r\n", "\n", '"'];
+        $replace               = ['', '', '\"'];
+        $html                  = str_replace($search, $replace, $html);
+        $formScript            = str_replace($search, $replace, $formScript);
+        $formScriptWithoutTag  = str_replace(['<script type=\"text/javascript\">', '</script>'], '', $formScript);
 
         // Write html for all browser and fallback for IE
         $script = '
@@ -737,8 +740,14 @@ class FormModel extends CommonFormModel
             
             if (scr !== undefined) {
                 scr.insertAdjacentHTML("afterend" , "'.$html.'");
+                
+                var head            = document.getElementsByTagName("head")[0];
+                var inlineScript    = document.createTextNode("'.$formScriptWithoutTag.'");
+                var script          = document.createElement("script");
+                script.appendChild(inlineScript);
+                head.appendChild(script);
             } else {
-                document.write("'.$html.'");
+                document.write("'.$formScript.$html.'");
             }
         ';
 

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -736,18 +736,20 @@ class FormModel extends CommonFormModel
 
         // Write html for all browser and fallback for IE
         $script = '
-            var scr = document.currentScript;
+            var scr        = document.currentScript;
+            var formHtml   = "'.$html.'";
+            var formScript = "'.$formScriptWithoutTag.'";
             
             if (scr !== undefined) {
-                scr.insertAdjacentHTML("afterend" , "'.$html.'");
+                scr.insertAdjacentHTML("afterend", formHtml);
                 
-                var head            = document.getElementsByTagName("head")[0];
-                var inlineScript    = document.createTextNode("'.$formScriptWithoutTag.'");
-                var script          = document.createElement("script");
+                var head         = document.getElementsByTagName("head")[0];
+                var inlineScript = document.createTextNode(formScript);
+                var script       = document.createElement("script");
                 script.appendChild(inlineScript);
                 head.appendChild(script);
             } else {
-                document.write("'.$formScript.$html.'");
+                document.write("<script type=\"text/javascript\">"+formScript+"</script>"+formHtml);
             }
         ';
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6632
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Enhancement to load async form, didn't work properly for automatic integration: https://github.com/mautic/mautic/pull/6432
Errors are no longer mapped to fields.
This PR fix this.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form with required fields
2. Integrate the form with the script tag <script type="text/javascript" src="http://mymautic.com/form/generate.js?id=1"></script>
3. Fill and submit the form
4. Errors are not mapped

#### Steps to test this PR:
1. Apply the PR
2. Errors are now good mapped to fields
