### PR TITLE
Bug fix: Email contacts list (in details view)

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -21,7 +21,7 @@ return [
                 'controller' => 'MauticEmailBundle:Email:execute',
             ],
             'mautic_email_contacts' => [
-                'path'       => '/emails/contacts/{objectId}',
+                'path'       => '/emails/view/{objectId}/contact/{page}',
                 'controller' => 'MauticEmailBundle:Email:contacts',
             ],
         ],

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -276,7 +276,7 @@ if (!$isEmbedded) {
                 ]); ?>
             </div>
 
-            <div class="tab-pane bdr-w-0" id="contacts-container">
+            <div class="tab-pane bdr-w-0 page-list" id="contacts-container">
                 <?php echo $contacts; ?>
             </div>
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | -
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The paged list of contacts in the detailed view of an email is broken. We can only see the first page.
In order to correct the problem, I relied on what is done in the detailed display of the segments.
This contact list is located at the bottom of the interface in the detailed view of an email object ( MAUTICURL/s/emails/view/{objectId} ).

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to the detailed view of an email (URL like YOURMAUTICURL/s/emails/view/{objectId} ).
2. Click on a page (other than the active page).
3. The rest of the contact list is not displayed.

#### Steps to test this PR:
1. Reproduce the previous steps.
2. The contacts list is displayed correctly.
