### PR TITLE
Restore segment filter empty !empty for multiselect

### DIFF
--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -448,7 +448,7 @@ Mautic.convertLeadFilterInput = function(el) {
             mQuery(filterId).removeAttr('multiple');
 
             // Update the name
-            newName = filterEl.attr('name');
+            newName = mQuery(filterId).attr('name');
             lastPos = newName.lastIndexOf('[]');
             newName = newName.substring(0, lastPos);
 

--- a/app/bundles/LeadBundle/Entity/OperatorListTrait.php
+++ b/app/bundles/LeadBundle/Entity/OperatorListTrait.php
@@ -60,6 +60,8 @@ trait OperatorListTrait
             'include' => [
                 'in',
                 '!in',
+                'empty',
+                '!empty',
             ],
         ],
         'date' => [

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
@@ -194,7 +194,7 @@ class ContactSegmentFilterCrate
     {
         $operator = isset($filter['operator']) ? $filter['operator'] : null;
 
-        if ('multiselect' === $this->getType()) {
+        if ('multiselect' === $this->getType() && in_array($operator, ['in', '!in'])) {
             $neg            = strpos($operator, '!') === false ? '' : '!';
             $this->operator = $neg.$this->getType();
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | Fixing a BC introduced

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
With segment refactoring, a BC break has been introduced that makes some existing segments throwing an error (due to ` WHERE (())`):
```php
An exception occurred while executing 'SELECT count(leadIdPrimary) count, max(leadIdPrimary) maxId, min(leadIdPrimary) minId FROM (SELECT DISTINCT l.id as leadIdPrimary, ZLeqTECa.lead_id AS ZLeqTECa_lead_id FROM leads l LEFT JOIN lead_lists_leads ZLeqTECa ON ZLeqTECa.lead_id = l.id and (ZLeqTECa.leadlist_id = 14) WHERE (()) AND (ZLeqTECa.lead_id IS NULL)) sss':
```

@Maxell92 we'd very appreciate your feedback and test on it :)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a segment with a filter "empty" multiselect field in mautic 2.13
2. Update to 2.14
3. Run segment update command
4. See that the segment crashes

Or simply create a segment in 2.14 and notice that this feature disappeared.

#### Steps to test this PR:
1. Repeat previous steps

________

_Please note that we noticed a JS issue when moving a filter on the interface but this issue is not introduced by this PR. So we reported it here #6683 . This BC break fix should not be slowed down by an already existing bug._