### PR TITLE
Add placeholder to phone field type

### DIFF
--- a/app/bundles/FormBundle/Form/Type/FieldType.php
+++ b/app/bundles/FormBundle/Form/Type/FieldType.php
@@ -533,6 +533,14 @@ class FieldType extends AbstractType
                             'data'  => $propertiesData,
                         ]
                     );
+                    $builder->add(
+                        'properties',
+                        'formfield_placeholder',
+                        [
+                            'label' => false,
+                            'data'  => $propertiesData,
+                        ]
+                    );
                     break;
             }
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Just added forgotten placeholder to phone field type.

![image](https://user-images.githubusercontent.com/462477/46527641-1fda9800-c892-11e8-8c43-b4aa94735fab.png)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Add to form phone field type
2.  Placeholder missing

#### Steps to test this PR:
1.  Add to form phone field type
2.  Placeholder is back