### PR TITLE
Bugfix - endless loop on segments and segment permissions

### DIFF
--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -728,9 +728,8 @@ class ListController extends FormController
                 ],
             ]);
         } elseif (!$this->get('mautic.security')->hasEntityAccess(
+            'lead:leads:viewown',
             'lead:lists:viewother',
-            'lead:lists:editother',
-            'lead:lists:deleteother',
             $list->getCreatedBy()
         )
         ) {

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -80,7 +80,7 @@ class ListController extends FormController
             $translator      = $this->get('translator');
             $mine            = $translator->trans('mautic.core.searchcommand.ismine');
             $global          = $translator->trans('mautic.lead.list.searchcommand.isglobal');
-            $filter['force'] = " ($mine or $global)";
+            $filter['force'] = "($mine or $global)";
         }
 
         $items = $model->getEntities(


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? |  N
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #6688 #6687 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Required: )
#### Description:
1. Empty space before permissions cause endless loop during parse.
2. Wrong method call with wrong permissions. `hasEntityAccess` taking 3 arguments.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
#6688 #6687 

#### Steps to test this PR:
Same as to reproduce but there shouldn't be errors :) 
