### PR TITLE
Fix form script load when they are include inside html by plugin

### DIFF
--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -969,7 +969,7 @@ class FormModel extends CommonFormModel
     {
         libxml_use_internal_errors(true);
         $dom = new DOMDocument();
-        $dom->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
         $items = $dom->getElementsByTagName('script');
 
         $scripts = [];
@@ -991,7 +991,7 @@ class FormModel extends CommonFormModel
     {
         libxml_use_internal_errors(true);
         $dom = new DOMDocument();
-        $dom->loadHTML('<div>'.$html.'</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $dom->loadHTML('<div>'.mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8').'</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
         $items = $dom->getElementsByTagName('script');
 
         $remove = [];
@@ -1023,7 +1023,7 @@ class FormModel extends CommonFormModel
     {
         libxml_use_internal_errors(true);
         $dom = new DOMDocument();
-        $dom->loadHTML('<div>'.$html.'</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $dom->loadHTML('<div>'.mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8').'</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
         $items = $dom->getElementsByTagName('script');
 
         $javascript = '';

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\FormBundle\Model;
 
+use DOMDocument;
 use Mautic\CoreBundle\Doctrine\Helper\SchemaHelperFactory;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\CoreBundle\Helper\TemplatingHelper;
@@ -413,7 +414,7 @@ class FormModel extends CommonFormModel
     }
 
     /**
-     * Obtains the cached HTML of a form and generates it if missing.
+     * Obtains the content.
      *
      * @param Form      $form
      * @param bool|true $withScript
@@ -422,6 +423,27 @@ class FormModel extends CommonFormModel
      * @return string
      */
     public function getContent(Form $form, $withScript = true, $useCache = true)
+    {
+        $html = $this->getFormHtml($form, $useCache);
+
+        if ($withScript) {
+            $html = $this->getFormScript($form)."\n\n".$this->removeScriptTag($html);
+        } else {
+            $html = $this->removeScriptTag($html);
+        }
+
+        return $html;
+    }
+
+    /**
+     * Obtains the cached HTML of a form and generates it if missing.
+     *
+     * @param Form      $form
+     * @param bool|true $useCache
+     *
+     * @return string
+     */
+    public function getFormHtml(Form $form, $useCache = true)
     {
         if ($useCache && !$form->usesProgressiveProfiling()) {
             $cachedHtml = $form->getCachedHtml();
@@ -433,10 +455,6 @@ class FormModel extends CommonFormModel
 
         if (!$form->getInKioskMode()) {
             $this->populateValuesWithLead($form, $cachedHtml);
-        }
-
-        if ($withScript) {
-            $cachedHtml = $this->getFormScript($form)."\n\n".$cachedHtml;
         }
 
         return $cachedHtml;
@@ -728,28 +746,22 @@ class FormModel extends CommonFormModel
         $formScript = $this->getFormScript($form);
 
         //replace line breaks with literal symbol and escape quotations
-        $search                = ["\r\n", "\n", '"'];
-        $replace               = ['', '', '\"'];
-        $html                  = str_replace($search, $replace, $html);
-        $formScript            = str_replace($search, $replace, $formScript);
-        $formScriptWithoutTag  = str_replace(['<script type=\"text/javascript\">', '</script>'], '', $formScript);
+        $search        = ["\r\n", "\n", '"'];
+        $replace       = ['', '', '\"'];
+        $html          = str_replace($search, $replace, $html);
+        $oldFormScript = str_replace($search, $replace, $formScript);
+        $newFormScript = $this->generateJsScript($formScript);
 
         // Write html for all browser and fallback for IE
         $script = '
-            var scr        = document.currentScript;
-            var formHtml   = "'.$html.'";
-            var formScript = "'.$formScriptWithoutTag.'";
+            var scr  = document.currentScript;
+            var html = "'.$html.'";
             
             if (scr !== undefined) {
-                scr.insertAdjacentHTML("afterend", formHtml);
-                
-                var head         = document.getElementsByTagName("head")[0];
-                var inlineScript = document.createTextNode(formScript);
-                var script       = document.createElement("script");
-                script.appendChild(inlineScript);
-                head.appendChild(script);
+                scr.insertAdjacentHTML("afterend", html);
+                '.$newFormScript.'
             } else {
-                document.write("<script type=\"text/javascript\">"+formScript+"</script>"+formHtml);
+                document.write("'.$oldFormScript.'"+html);
             }
         ';
 
@@ -776,6 +788,13 @@ class FormModel extends CommonFormModel
                 'theme' => $theme,
             ]
         );
+
+        $html    = $this->getFormHtml($form);
+        $scripts = $this->extractScriptTag($html);
+
+        foreach ($scripts as $item) {
+            $script .= $item."\n";
+        }
 
         return $script;
     }
@@ -937,5 +956,95 @@ class FormModel extends CommonFormModel
         $results = $q->execute()->fetchAll();
 
         return $results;
+    }
+
+    /**
+     * Extract script from html.
+     *
+     * @param $html
+     *
+     * @return array
+     */
+    private function extractScriptTag($html)
+    {
+        libxml_use_internal_errors(true);
+        $dom = new DOMDocument();
+        $dom->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $items = $dom->getElementsByTagName('script');
+
+        $scripts = [];
+        foreach ($items as $script) {
+            $scripts[] = $dom->saveHTML($script);
+        }
+
+        return $scripts;
+    }
+
+    /**
+     * Remove script from html.
+     *
+     * @param $html
+     *
+     * @return string
+     */
+    private function removeScriptTag($html)
+    {
+        libxml_use_internal_errors(true);
+        $dom = new DOMDocument();
+        $dom->loadHTML('<div>'.$html.'</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $items = $dom->getElementsByTagName('script');
+
+        $remove = [];
+        foreach ($items as $item) {
+            $remove[] = $item;
+        }
+
+        foreach ($remove as $item) {
+            $item->parentNode->removeChild($item);
+        }
+
+        $root   = $dom->documentElement;
+        $result = '';
+        foreach ($root->childNodes as $childNode) {
+            $result .= $dom->saveHTML($childNode);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Generate dom manipulation javascript to include all script.
+     *
+     * @param $html
+     *
+     * @return string
+     */
+    private function generateJsScript($html)
+    {
+        libxml_use_internal_errors(true);
+        $dom = new DOMDocument();
+        $dom->loadHTML('<div>'.$html.'</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $items = $dom->getElementsByTagName('script');
+
+        $javascript = '';
+        foreach ($items as $key => $script) {
+            if ($script->hasAttribute('src')) {
+                $javascript .= "
+                var script$key = document.createElement('script');
+                script$key.src = '".$script->getAttribute('src')."';
+                document.getElementsByTagName('head')[0].appendChild(script$key);";
+            } else {
+                $scriptContent = $script->nodeValue;
+                $scriptContent = str_replace(["\r\n", "\n", '"'], ['', '', '\"'], $scriptContent);
+
+                $javascript .= "
+                var inlineScript$key = document.createTextNode(\"$scriptContent\");
+                var script$key       = document.createElement('script');
+                script$key.appendChild(inlineScript$key);
+                document.getElementsByTagName('head')[0].appendChild(script$key);";
+            }
+        }
+
+        return $javascript;
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
External plugins such as reCaptcha include their JavaScript code in their HTML component.
With the new insertAdjacentHTML method, javascript tags added in HTML are never interpreted by the browser.

This PR adds methods to extract all the JS added by plugins from HTML in order to inject them correctly into the head tag.
This PR is a complement of https://github.com/mautic/mautic/pull/6665

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Install and configure reCaptcha plugin https://www.mautic.org/mixin/recaptcha/
2. Create a form and put a recaptcha field
3. Get the form with automatic method
4. Recaptcha won't load

#### Steps to test this PR:
1. Apply PR
2. HTML is clean and all JS is in head
3. Manual copy is also cleaned to have all JS in head and html in body
![screenshot_2018-10-05 form recaptcha mautic](https://user-images.githubusercontent.com/27768270/46536080-a2bd1c00-c8ad-11e8-9256-02816ada578d.png)


