### PR TITLE
Set start date for import entity only when started for the first time

### DIFF
--- a/app/bundles/LeadBundle/Entity/Import.php
+++ b/app/bundles/LeadBundle/Entity/Import.php
@@ -623,8 +623,11 @@ class Import extends FormEntity
      */
     public function start()
     {
-        $this->setDateStarted(new \DateTime())
-            ->setStatus(self::IN_PROGRESS);
+        if (empty($this->getDateStarted())) {
+            $this->setDateStarted(new \DateTime());
+        }
+
+        $this->setStatus(self::IN_PROGRESS);
 
         return $this;
     }

--- a/app/bundles/LeadBundle/Tests/Entity/ImportTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/ImportTest.php
@@ -123,10 +123,19 @@ class ImportTest extends StandardImportTestHelper
         $this->assertSame(Import::QUEUED, $import->getStatus());
         $this->assertNull($import->getDateStarted());
 
+        // Date started will be set when the start is called for the first time.
         $import->start();
 
+        $startDate = $import->getDateStarted();
+
         $this->assertSame(Import::IN_PROGRESS, $import->getStatus());
-        $this->assertTrue($import->getDateStarted() instanceof \DateTime);
+        $this->assertTrue($startDate instanceof \DateTime);
+
+        // But the date started will not change when started for the second time.
+        $import->end(false);
+        $import->start();
+
+        $this->assertSame($startDate, $import->getDateStarted());
     }
 
     public function testEnd()


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) |
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The start date is being reset every time the `mautic:import` command starts to import. But there is option to import only part of the CSV file by providing `--limit` value to this command. It's set to `--limit=10000` for our workers.

After this fix the import can even have empty spaces based on how often the command is run:
![screen shot 2018-09-04 at 14 10 59](https://user-images.githubusercontent.com/1235442/45030660-e4f40300-b04c-11e8-8502-485128ed0c2d.png)

So the runtime is not only time when the import was being actively processed but also time waiting between command executions until the CSV is processed fully. But I guess that make sense.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. It is better reproducible on local since you can set lower limit.
2. Import a CSV with 100+ rows.
3. Run `$ app/console mautic:import --limit=10` - it will import first 10 rows. Notice the start date.
4. Run `$ app/console mautic:import --limit=10` - it will import another 10 rows. Notice the start date has changed and run time is therefore wrong.
5. Cancel or unpublish the import.

#### Steps to test this PR:
1. Repeat the test steps.
2. Start date sticks the same and run time is correct.