### PR TITLE
Check that the options exist before using their value

### DIFF
--- a/app/bundles/PageBundle/Form/Type/ConfigTrackingPageType.php
+++ b/app/bundles/PageBundle/Form/Type/ConfigTrackingPageType.php
@@ -30,7 +30,7 @@ class ConfigTrackingPageType extends AbstractType
             'yesno_button_group',
             [
                 'label' => 'mautic.page.config.form.track_contact_by_ip',
-                'data'  => (bool) $options['data']['track_contact_by_ip'],
+                'data'  => (bool) isset($options['data']['track_contact_by_ip']) ? $options['data']['track_contact_by_ip'] : false,
                 'attr'  => [
                     'tooltip' => 'mautic.page.config.form.track_contact_by_ip.tooltip',
                 ],
@@ -39,7 +39,7 @@ class ConfigTrackingPageType extends AbstractType
 
         $builder->add('track_by_tracking_url', 'yesno_button_group', [
             'label' => 'mautic.page.config.form.track.by.tracking.url',
-            'data'  => (bool) $options['data']['track_by_tracking_url'],
+            'data'  => (bool) isset($options['data']['track_by_tracking_url']) ? $options['data']['track_by_tracking_url'] : true,
             'attr'  => [
                 'tooltip' => 'mautic.page.config.form.track.by.tracking.url.tooltip',
             ],
@@ -47,7 +47,7 @@ class ConfigTrackingPageType extends AbstractType
 
         $builder->add('track_by_fingerprint', 'yesno_button_group', [
             'label' => 'mautic.page.config.form.track.by.fingerprint',
-            'data'  => (bool) $options['data']['track_by_fingerprint'],
+            'data'  => (bool) isset($options['data']['track_by_fingerprint']) ? $options['data']['track_by_fingerprint'] : false,
             'attr'  => [
                 'tooltip' => 'mautic.page.config.form.track.by.fingerprint.tooltip',
             ],

--- a/app/bundles/PageBundle/Form/Type/ConfigTrackingPageType.php
+++ b/app/bundles/PageBundle/Form/Type/ConfigTrackingPageType.php
@@ -30,7 +30,7 @@ class ConfigTrackingPageType extends AbstractType
             'yesno_button_group',
             [
                 'label' => 'mautic.page.config.form.track_contact_by_ip',
-                'data'  => (bool) isset($options['data']['track_contact_by_ip']) ? $options['data']['track_contact_by_ip'] : false,
+                'data'  => isset($options['data']['track_contact_by_ip']) ? (bool) $options['data']['track_contact_by_ip'] : false,
                 'attr'  => [
                     'tooltip' => 'mautic.page.config.form.track_contact_by_ip.tooltip',
                 ],
@@ -39,7 +39,7 @@ class ConfigTrackingPageType extends AbstractType
 
         $builder->add('track_by_tracking_url', 'yesno_button_group', [
             'label' => 'mautic.page.config.form.track.by.tracking.url',
-            'data'  => (bool) isset($options['data']['track_by_tracking_url']) ? $options['data']['track_by_tracking_url'] : true,
+            'data'  => isset($options['data']['track_by_tracking_url']) ? (bool) $options['data']['track_by_tracking_url'] : true,
             'attr'  => [
                 'tooltip' => 'mautic.page.config.form.track.by.tracking.url.tooltip',
             ],
@@ -47,7 +47,7 @@ class ConfigTrackingPageType extends AbstractType
 
         $builder->add('track_by_fingerprint', 'yesno_button_group', [
             'label' => 'mautic.page.config.form.track.by.fingerprint',
-            'data'  => (bool) isset($options['data']['track_by_fingerprint']) ? $options['data']['track_by_fingerprint'] : false,
+            'data'  => isset($options['data']['track_by_fingerprint']) ? (bool) $options['data']['track_by_fingerprint'] : false,
             'attr'  => [
                 'tooltip' => 'mautic.page.config.form.track.by.fingerprint.tooltip',
             ],


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
We've removed the tracking by IP and tracking by Fingerprint options from the Mautic config form since our customers had many troubles when they turned those options ON. We cannot do this for the community since it would be a BC break. 

With our custom solution we got stuck on PHP error that the array options did not exist and had to do this simple change. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Not worth the time

#### Steps to test this PR:
1. Code review should suffice.
2. But if you wish to test, try to load and safe the Mautic config form.