### PR TITLE
[BLOCKED] Change Oauth server bundle from dev-master to proper version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
         "knplabs/knp-menu-bundle":"^2.0",
         "friendsofsymfony/rest-bundle": "1.8.*",
         "friendsofsymfony/oauth-server-bundle": "1.5.2",
-        "willdurand/oauth-server-bundle": "dev-master",
+        "willdurand/oauth-server-bundle": "0.0.2",
         "jms/serializer-bundle": "~1.1",
         "oneup/uploader-bundle": "~1.3",
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  X
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
This pr is meant to be applied after https://github.com/mautic/BazingaOAuthServerBundle/pull/2 has been merged into https://github.com/mautic/BazingaOAuthServerBundle and it has had a proper new release.

Currently this dependency is listed with dev-master, which is not a good practice. Since Mautic now has control over the code it should be properly versioned with a github release. I propose 0.0.2 as 0.0.1 has already been taken.

I will update the composer.lock file after the aforementioned PR is merged and the proper release has been created on the oauth bundle repository.