### PR TITLE
Emails in time api fixes

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1900,7 +1900,14 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
 
         if ($flag == 'all' || $flag == 'clicked' || in_array('clicked', $datasets)) {
             $q = $query->prepareTimeDataQuery('page_hits', 'date_hit', []);
-            $q->leftJoin('t', MAUTIC_TABLE_PREFIX.'email_stats', 'es', 't.source_id = es.email_id AND es.source = "email"');
+
+            if ($segmentId !== null) {
+                $q->innerJoin('t', '(SELECT DISTINCT email_id, lead_id FROM '.MAUTIC_TABLE_PREFIX.'email_stats WHERE list_id = :segmentId)', 'es', 't.source_id = es.email_id');
+                $q->setParameter('segmentId', $segmentId);
+            }
+
+            $q->andWhere('t.source = :source');
+            $q->setParameter('source', 'email');
 
             if (isset($filter['email_id'])) {
                 if (is_array($filter['email_id'])) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? |N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR is fixing error:
```
Uncaught PHP Exception Doctrine\DBAL\Exception\InvalidFieldNameException: "An exception occurred while executing 'SELECT DATE_FORMAT(t.date_hit, '%Y-%m-%d') AS date, COUNT(*) AS count FROM mautic_page_hits t INNER JOIN (SELECT DISTINCT email_id FROM mautic_email_stats WHERE list_id = ?) es ON t.source_id = es.email_id INNER JOIN (SELECT DISTINCT event_id, lead_id FROM mautic_campaign_lead_event_log WHERE campaign_id = ?) clel ON t.source_id = clel.event_id AND t.source = "campaign.event" AND t.lead_id = clel.lead_id WHERE (t.date_hit BETWEEN ? AND ?) AND (t.source = ?) AND (EXISTS (SELECT null FROM mautic_companies_leads cl WHERE (cl.company_id = ?) AND (cl.lead_id = t.lead_id))) AND (EXISTS (SELECT null FROM mautic_lead_lists_leads lll WHERE (lll.leadlist_id = ?) AND (lll.lead_id = es.lead_id) AND (lll.manually_removed = 0))) GROUP BY DATE_FORMAT(t.date_hit, '%Y-%m-%d') ORDER BY DATE_FORMAT(t.date_hit, '%Y-%m-%d') ASC LIMIT 19' with params ["1539", "17", "2018-07-01 00:00:00", "2018-07-19 23:59:59", "email", "5405", "1539"]: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'es.lead_id' in 'where clause'" at vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php line 71
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to load this API request:
```
GET /api/data/emails.in.time?dateFrom=2018-07-01&dateTo=2018-09-10&timeUnit=d&filter[campaignId]=17&filter[companyId]=1115&filter[segmentId]=7164&withCounts&dataset[]=sent&dataset[]=opened&dataset[]=unsubscribed&dataset[]=clicked
```
2. The SQL query is logged or returned instead of expected response

#### Steps to test this PR:
1. Refresh the API request