### PR TITLE
Bug fix : Search company result in autopopulate input (lookupResults)

### DIFF
--- a/app/bundles/LeadBundle/Entity/CompanyRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyRepository.php
@@ -418,7 +418,7 @@ class CompanyRepository extends CommonRepository implements CustomFieldRepositor
         case
         when (comp.companycountry is not null and comp.companycity is not null) then concat(comp.companyname, " <small>", companycity,", ", companycountry, "</small>")
         when (comp.companycountry is not null) then concat(comp.companyname, " <small>", comp.companycountry, "</small>")
-        when (comp.companycity is not null) then concat(comp.companycity, " <small>", comp.companycity, "</small>")
+        when (comp.companycity is not null) then concat(comp.companyname, " <small>", comp.companycity, "</small>")
         else comp.companyname
         end
         as label')


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N 
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | -
| BC breaks? | N
| Deprecations? | N 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The autocomplete search field of a company does not always return the expected company. The response of the Ajax call returning the list contains a bug in the variable to return in case only the city field of company known. The results list contains "CITY, city" whereas it should be "COMPANY, city" in this case.
The fix is to return the correct variable so that the result is "COMPANY, city" in the case of a company with only the city field known.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a company with a name and a city only.
2. Edit a contact
3. Try to add the previously created company by searching for it by name.
4. This one appears like "CITY, city"

#### Steps to test this PR:
1. Create a company with a name and a city only.
2. Edit a contact
3. Try to add the previously created company by searching for it by name.
4. This one appears correctly, "COMPANY, city"

#### List deprecations along with the new alternative:
 
#### List backwards compatibility breaks:
 