### PR TITLE
Fix Warning: Illegal offset type with m:s:u command

### DIFF
--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -99,7 +99,7 @@ class LeadSubscriber extends CommonSubscriber
 
                     $removeLeads = [];
                     foreach ($leads as $l) {
-                        $lists = (isset($leadLists[$l["id"]])) ? $leadLists[$l["id"]] : [];
+                        $lists = (isset($leadLists[$l['id']])) ? $leadLists[$l['id']] : [];
                         if (array_intersect(array_keys($lists), $campaignLists[$c['id']])) {
                             continue;
                         } else {

--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -99,7 +99,7 @@ class LeadSubscriber extends CommonSubscriber
 
                     $removeLeads = [];
                     foreach ($leads as $l) {
-                        $lists = (isset($leadLists[$l])) ? $leadLists[$l] : [];
+                        $lists = (isset($leadLists[$l["id"]])) ? $leadLists[$l["id"]] : [];
                         if (array_intersect(array_keys($lists), $campaignLists[$c['id']])) {
                             continue;
                         } else {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
With command `php app/console m:s:u` when lead is deleted from segment, warning appear: `Warning: Illegal offset type in isset or empty in app\bundles\CampaignBundle\EventListener\LeadSubscriber.php on line 102`

It's because `$l` is an array, I have modified to pass only the lead id.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a lead with an address
2. Create a segment with filter `Address Line 1` with operator `not empty`
3. Launch in console `php app/console m:s:u`
4. Lead is added to segment
5. Edit segment to change filter `Address Line 1` with operator `empty`
6. Launch in console `php app/console m:s:u`
7. Lead is deleted but warning appear

#### Steps to test this PR:
1. Apply PR
2. Repeat step above
3. No warning
