### PR TITLE
Add support for extreme-ip-lookup

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -916,6 +916,10 @@ return [
     ],
 
     'ip_lookup_services' => [
+        'extreme-ip' => [
+            'display_name' => 'Extreme-IP',
+            'class'        => 'Mautic\CoreBundle\IpLookup\ExtremeIpLookup',
+        ],
         'freegeoip' => [
             'display_name' => 'Ipstack.com',
             'class'        => 'Mautic\CoreBundle\IpLookup\IpstackLookup',

--- a/app/bundles/CoreBundle/IpLookup/ExtremeIpLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/ExtremeIpLookup.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * @copyright   2015 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\IpLookup;
+
+class ExtremeIpLookup extends AbstractRemoteDataLookup
+{
+    /**
+     * Return attribution HTML displayed in the configuration UI.
+     *
+     * @return string
+     */
+    public function getAttribution()
+    {
+        return '<a href="https://extreme-ip-lookup.com/" target="_blank">extreme-ip-lookup.com</a> is a free lookup service that does not require an api key.';
+    }
+
+    /**
+     * Get the URL to fetch data from.
+     *
+     * @return string
+     */
+    protected function getUrl()
+    {
+        return 'https://extreme-ip-lookup.com/json/'.$this->ip;
+    }
+
+    /**
+     * @param $response
+     */
+    protected function parseResponse($response)
+    {
+        $data = json_decode($response, true);
+
+        if ($data) {
+            foreach ($data as $key => $value) {
+                switch ($key) {
+                    case 'region':
+                        $key = 'region';
+                        break;
+                    case 'country':
+                        $key = 'country';
+                        break;
+                    case 'city':
+                        $key = 'city';
+                        break;
+                }
+
+                $this->$key = $value;
+            }
+        }
+    }
+}

--- a/app/bundles/CoreBundle/Tests/unit/IpLookup/ExtemeIpLookupTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/IpLookup/ExtemeIpLookupTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * @copyright   2015 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Tests\unit\IpLookup;
+
+use Mautic\CoreBundle\IpLookup\ExtremeIpLookup;
+
+/**
+ * Class ExtremeIpLookupTest.
+ */
+class ExtemeIpLookupTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIpLookupSuccessful()
+    {
+        // Mock http connector
+        $mockHttp = $this->getMockBuilder('Joomla\Http\Http')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // Mock a successful response
+        $mockResponse = $this->getMockBuilder('Joomla\Http\Response')
+            ->getMock();
+        $mockResponse->code = 200;
+        $mockResponse->body = '{"businessName" : "Sandhills Publishing Company","businessWebsite" : "www.sandhills.com","city" : "Lincoln","continent" : "North America","country" : "United States","countryCode" : "US","ipName" : "proxy.sandhills.com","ipType" : "Business","isp" : "Sandhills Publishing Company","lat" : "40.8615","lon" : "-96.7119","org" : "Sandhills Publishing Company","query" : "63.70.164.200","region" : "Nebraska","status" : "success"}';
+
+        $mockHttp->expects($this->once())
+            ->method('get')
+            ->willReturn($mockResponse);
+
+        $ipService = new ExtremeIpLookup(null, null, __DIR__.'/../../../../cache/test', null, $mockHttp);
+
+        $details = $ipService->setIpAddress('63.70.164.200')->getDetails();
+
+        $this->assertEquals('Lincoln', $details['city']);
+        $this->assertEquals('Nebraska', $details['region']);
+        $this->assertEquals('United States', $details['country']);
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | X
| Automated tests included? | X
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This adds extreme-ip-lookup. It is a very lightweight json ip lookup that returns city, country and region (state/province). It requires no api key and thus is very easy to set up. Simply click and go. Easy for people trying out Mautic and for developers (no dealing with api keys, even if free).

Previously FreeGeoIp was serving the job of being the easy one to use, but since it changed to IPStack, you need an api key, which defeats the whole purpose of being easy to setup.

#### Steps to test this PR:
1. Set extreme-ip as ip lookup service
2. Hit some pages
3. See the data being added