### PR TITLE
Add isPublished verification on mautic:segments:update

### DIFF
--- a/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
+++ b/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
@@ -56,18 +56,21 @@ class UpdateLeadListsCommand extends ModeratedCommand
 
         if ($id) {
             $list = $listModel->getEntity($id);
-            if ($list !== null) {
-                $output->writeln('<info>'.$translator->trans('mautic.lead.list.rebuild.rebuilding', ['%id%' => $id]).'</info>');
-                $processed = 0;
-                try {
-                    $processed = $listModel->rebuildListLeads($list, $batch, $max, $output);
-                } catch (QueryException $e) {
-                    $this->getContainer()->get('monolog.logger.mautic')->error('Query Builder Exception: '.$e->getMessage());
-                }
 
-                $output->writeln(
-                    '<comment>'.$translator->trans('mautic.lead.list.rebuild.leads_affected', ['%leads%' => $processed]).'</comment>'
-                );
+            if ($list !== null) {
+                if ($list->isPublished()) {
+                    $output->writeln('<info>'.$translator->trans('mautic.lead.list.rebuild.rebuilding', ['%id%' => $id]).'</info>');
+                    $processed = 0;
+                    try {
+                        $processed = $listModel->rebuildListLeads($list, $batch, $max, $output);
+                    } catch (QueryException $e) {
+                        $this->getContainer()->get('monolog.logger.mautic')->error('Query Builder Exception: '.$e->getMessage());
+                    }
+
+                    $output->writeln(
+                        '<comment>'.$translator->trans('mautic.lead.list.rebuild.leads_affected', ['%leads%' => $processed]).'</comment>'
+                    );
+                }
             } else {
                 $output->writeln('<error>'.$translator->trans('mautic.lead.list.rebuild.not_found', ['%id%' => $id]).'</error>');
             }
@@ -82,12 +85,14 @@ class UpdateLeadListsCommand extends ModeratedCommand
                 // Get first item; using reset as the key will be the ID and not 0
                 $l = reset($l);
 
-                $output->writeln('<info>'.$translator->trans('mautic.lead.list.rebuild.rebuilding', ['%id%' => $l->getId()]).'</info>');
+                if ($l->isPublished()) {
+                    $output->writeln('<info>'.$translator->trans('mautic.lead.list.rebuild.rebuilding', ['%id%' => $l->getId()]).'</info>');
 
-                $processed = $listModel->rebuildListLeads($l, $batch, $max, $output);
-                $output->writeln(
-                    '<comment>'.$translator->trans('mautic.lead.list.rebuild.leads_affected', ['%leads%' => $processed]).'</comment>'."\n"
-                );
+                    $processed = $listModel->rebuildListLeads($l, $batch, $max, $output);
+                    $output->writeln(
+                        '<comment>'.$translator->trans('mautic.lead.list.rebuild.leads_affected', ['%leads%' => $processed]).'</comment>'."\n"
+                    );
+                }
 
                 unset($l);
             }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6698
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
It appears that the command `php app/console mautic:segments:update` work on unpublished segments.
Is there a good reason or it's a bug?

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create two segments, one published and an other unpublished.
2. Launch command `php app/console mautic:segments:update`
3. See in console that all segments are rebuild

#### Steps to test this PR:
1. Apply PR
2. Launch command `php app/console mautic:segments:update`
3. See in console that only published segments are rebuild
