### PR TITLE
Add segment activity log + fix Company log

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -468,6 +468,13 @@ return [
                     'mautic.lead.repository.lead_event_log',
                 ],
             ],
+            'mautic.lead.subscriber.segment' => [
+                'class'     => 'Mautic\LeadBundle\EventListener\SegmentSubscriber',
+                'arguments' => [
+                    'mautic.helper.ip_lookup',
+                    'mautic.core.model.auditlog',
+                ],
+            ],
         ],
         'forms' => [
             'mautic.form.type.lead' => [

--- a/app/bundles/LeadBundle/Event/LeadListEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListEvent.php
@@ -42,7 +42,7 @@ class LeadListEvent extends CommonEvent
     /**
      * Sets the List entity.
      *
-     * @param List $list
+     * @param LeadList $list
      */
     public function setList(LeadList $list)
     {

--- a/app/bundles/LeadBundle/EventListener/CompanySubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CompanySubscriber.php
@@ -86,7 +86,7 @@ class CompanySubscriber extends CommonSubscriber
         $company = $event->getCompany();
         $log     = [
             'bundle'    => 'lead',
-            'object'    => 'field',
+            'object'    => 'company',
             'objectId'  => $company->deletedId,
             'action'    => 'delete',
             'details'   => ['name', $company->getPrimaryIdentifier()],

--- a/app/bundles/LeadBundle/EventListener/SegmentSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SegmentSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * @copyright   2016 Mautic Contributors. All rights reserved
+ * @copyright   2018 Mautic Contributors. All rights reserved
  * @author      Mautic
  *
  * @link        http://mautic.org

--- a/app/bundles/LeadBundle/EventListener/SegmentSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SegmentSubscriber.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\EventListener;
+
+use Mautic\CoreBundle\EventListener\CommonSubscriber;
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\LeadBundle\Event\LeadListEvent as SegmentEvent;
+use Mautic\LeadBundle\LeadEvents;
+
+class SegmentSubscriber extends CommonSubscriber
+{
+    /**
+     * @var IpLookupHelper
+     */
+    private $ipLookupHelper;
+
+    /**
+     * @var AuditLogModel
+     */
+    private $auditLogModel;
+
+    /**
+     * SegmentSubscriber constructor.
+     *
+     * @param IpLookupHelper $ipLookupHelper
+     * @param AuditLogModel  $auditLogModel
+     */
+    public function __construct(IpLookupHelper $ipLookupHelper, AuditLogModel $auditLogModel)
+    {
+        $this->ipLookupHelper = $ipLookupHelper;
+        $this->auditLogModel  = $auditLogModel;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            LeadEvents::LIST_POST_SAVE   => ['onSegmentPostSave', 0],
+            LeadEvents::LIST_POST_DELETE => ['onSegmentDelete', 0],
+        ];
+    }
+
+    /**
+     * Add a segment entry to the audit log.
+     *
+     * @param SegmentEvent $event
+     */
+    public function onSegmentPostSave(SegmentEvent $event)
+    {
+        $segment = $event->getList();
+        if ($details = $event->getChanges()) {
+            $log = [
+                'bundle'    => 'lead',
+                'object'    => 'segment',
+                'objectId'  => $segment->getId(),
+                'action'    => ($event->isNew()) ? 'create' : 'update',
+                'details'   => $details,
+                'ipAddress' => $this->ipLookupHelper->getIpAddressFromRequest(),
+            ];
+            $this->auditLogModel->writeToLog($log);
+        }
+    }
+
+    /**
+     * Add a segment delete entry to the audit log.
+     *
+     * @param SegmentEvent $event
+     */
+    public function onSegmentDelete(SegmentEvent $event)
+    {
+        $segment = $event->getList();
+        $log     = [
+            'bundle'    => 'lead',
+            'object'    => 'segment',
+            'objectId'  => $segment->deletedId,
+            'action'    => 'delete',
+            'details'   => ['name', $segment->getName()],
+            'ipAddress' => $this->ipLookupHelper->getIpAddressFromRequest(),
+        ];
+        $this->auditLogModel->writeToLog($log);
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Event/CompanyEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/CompanyEventTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
 namespace Mautic\LeadBundle\Tests\Event;
 
 use Mautic\LeadBundle\Entity\Company;

--- a/app/bundles/LeadBundle/Tests/Event/CompanyEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/CompanyEventTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Mautic\LeadBundle\Tests\Event;
+
+use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Event\CompanyEvent;
+
+class CompanyEventTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructGettersSetters()
+    {
+        $company = new Company();
+        $isNew   = false;
+        $score   = 1;
+        $event   = new CompanyEvent($company, $isNew, $score);
+
+        $this->assertEquals($company, $event->getCompany());
+        $this->assertEquals($isNew, $event->isNew());
+        $this->assertEquals($score, $event->getScore());
+
+        $isNew = true;
+        $event = new CompanyEvent($company, $isNew, $score);
+        $this->assertEquals($isNew, $event->isNew());
+
+        $company2 = new Company();
+        $company2->setName('otherCompany');
+        $event->setCompany($company2);
+        $this->assertEquals($company2, $event->getCompany());
+
+        $secondScore = 2;
+        $event->changeScore($secondScore);
+        $this->assertEquals($secondScore, $event->getScore());
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Event/LeadListEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/LeadListEventTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Mautic\LeadBundle\Tests\Event;
+
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Event\LeadListEvent;
+
+class LeadListEventTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructGettersSetters()
+    {
+        $segment = new LeadList();
+        $event   = new LeadListEvent($segment);
+
+        $this->assertEquals($segment, $event->getList());
+        $this->assertEquals(false, $event->isNew());
+
+        $isNew = false;
+        $event = new LeadListEvent($segment, $isNew);
+        $this->assertEquals($isNew, $event->isNew());
+
+        $isNew = true;
+        $event = new LeadListEvent($segment, $isNew);
+        $this->assertEquals($isNew, $event->isNew());
+
+        $segment2 = new LeadList();
+        $segment2->setName('otherSegmentName');
+        $event->setList($segment2);
+        $this->assertEquals($segment2, $event->getList());
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Event/LeadListEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/LeadListEventTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
 namespace Mautic\LeadBundle\Tests\Event;
 
 use Mautic\LeadBundle\Entity\LeadList;

--- a/app/bundles/LeadBundle/Tests/EventListener/CompanySubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CompanySubscriberTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
 namespace Mautic\LeadBundle\Tests\EventListener;
 
 use Mautic\CoreBundle\Helper\IpLookupHelper;

--- a/app/bundles/LeadBundle/Tests/EventListener/CompanySubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CompanySubscriberTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Mautic\LeadBundle\Tests\EventListener;
+
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Event\CompanyEvent;
+use Mautic\LeadBundle\EventListener\CompanySubscriber;
+use Mautic\LeadBundle\LeadEvents;
+
+class CompanySubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetSubscribedEvents()
+    {
+        $ipLookupHelper = $this->getMockBuilder(IpLookupHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $auditLogModel = $this->getMockBuilder(AuditLogModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $subscriber = new CompanySubscriber($ipLookupHelper, $auditLogModel);
+
+        $this->assertEquals(
+            [
+                LeadEvents::COMPANY_POST_SAVE   => ['onCompanyPostSave', 0],
+                LeadEvents::COMPANY_POST_DELETE => ['onCompanyDelete', 0],
+            ],
+            $subscriber->getSubscribedEvents()
+        );
+    }
+
+    public function testOnCompanyPostSave()
+    {
+        $this->onCompanyPostSaveMethodCall(false); // update company log
+        $this->onCompanyPostSaveMethodCall(true); // create company log
+    }
+
+    public function testOnCompanyDelete()
+    {
+        $companyId        = 1;
+        $companyName      = 'name';
+        $ip               = '127.0.0.2';
+
+        $log = [
+            'bundle'    => 'lead',
+            'object'    => 'company',
+            'objectId'  => $companyId,
+            'action'    => 'delete',
+            'details'   => ['name', $companyName],
+            'ipAddress' => $ip,
+        ];
+
+        $ipLookupHelper = $this->getMockBuilder(IpLookupHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $ipLookupHelper->expects($this->once())
+            ->method('getIpAddressFromRequest')
+            ->will($this->returnValue($ip));
+
+        $auditLogModel = $this->getMockBuilder(AuditLogModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $auditLogModel->expects($this->once())
+            ->method('writeToLog')
+            ->with($log);
+
+        $subscriber = new CompanySubscriber($ipLookupHelper, $auditLogModel);
+
+        $company = $this->getMockBuilder(Company::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $company->deletedId = $companyId;
+
+        $company->expects($this->once())
+            ->method('getPrimaryIdentifier')
+            ->will($this->returnValue($companyName));
+
+        $event = $this->getMockBuilder(CompanyEvent::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $event->expects($this->once())
+            ->method('getCompany')
+            ->will($this->returnValue($company));
+
+        $subscriber->onCompanyDelete($event);
+    }
+
+    /**
+     * Test create or update company logging.
+     *
+     * @param bool $isNew
+     */
+    private function onCompanyPostSaveMethodCall($isNew)
+    {
+        $companyId = 1;
+        $changes   = ['changes'];
+        $ip        = '127.0.0.2';
+
+        $log = [
+            'bundle'    => 'lead',
+            'object'    => 'company',
+            'objectId'  => $companyId,
+            'action'    => ($isNew) ? 'create' : 'update',
+            'details'   => $changes,
+            'ipAddress' => $ip,
+        ];
+
+        $ipLookupHelper = $this->getMockBuilder(IpLookupHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $ipLookupHelper->expects($this->once())
+            ->method('getIpAddressFromRequest')
+            ->will($this->returnValue($ip));
+
+        $auditLogModel = $this->getMockBuilder(AuditLogModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $auditLogModel->expects($this->once())
+            ->method('writeToLog')
+            ->with($log);
+
+        $subscriber = new CompanySubscriber($ipLookupHelper, $auditLogModel);
+
+        $company = $this->getMockBuilder(Company::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $company->expects($this->once())
+            ->method('getId')
+            ->will($this->returnValue($companyId));
+
+        $event = $this->getMockBuilder(CompanyEvent::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $event->expects($this->once())
+            ->method('getCompany')
+            ->will($this->returnValue($company));
+
+        $event->expects($this->once())
+            ->method('getChanges')
+            ->will($this->returnValue($changes));
+
+        $event->expects($this->once())
+            ->method('isNew')
+            ->will($this->returnValue($isNew));
+
+        $subscriber->onCompanyPostSave($event);
+    }
+}

--- a/app/bundles/LeadBundle/Tests/EventListener/CompanySubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CompanySubscriberTest.php
@@ -22,15 +22,9 @@ class CompanySubscriberTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetSubscribedEvents()
     {
-        $ipLookupHelper = $this->getMockBuilder(IpLookupHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $auditLogModel = $this->getMockBuilder(AuditLogModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $subscriber = new CompanySubscriber($ipLookupHelper, $auditLogModel);
+        $ipLookupHelper = $this->createMock(IpLookupHelper::class);
+        $auditLogModel  = $this->createMock(AuditLogModel::class);
+        $subscriber     = new CompanySubscriber($ipLookupHelper, $auditLogModel);
 
         $this->assertEquals(
             [
@@ -62,38 +56,25 @@ class CompanySubscriberTest extends \PHPUnit_Framework_TestCase
             'ipAddress' => $ip,
         ];
 
-        $ipLookupHelper = $this->getMockBuilder(IpLookupHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $ipLookupHelper = $this->createMock(IpLookupHelper::class);
         $ipLookupHelper->expects($this->once())
             ->method('getIpAddressFromRequest')
             ->will($this->returnValue($ip));
 
-        $auditLogModel = $this->getMockBuilder(AuditLogModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $auditLogModel = $this->createMock(AuditLogModel::class);
         $auditLogModel->expects($this->once())
             ->method('writeToLog')
             ->with($log);
 
         $subscriber = new CompanySubscriber($ipLookupHelper, $auditLogModel);
 
-        $company = $this->getMockBuilder(Company::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $company            = $this->createMock(Company::class);
         $company->deletedId = $companyId;
-
         $company->expects($this->once())
             ->method('getPrimaryIdentifier')
             ->will($this->returnValue($companyName));
 
-        $event = $this->getMockBuilder(CompanyEvent::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $event = $this->createMock(CompanyEvent::class);
         $event->expects($this->once())
             ->method('getCompany')
             ->will($this->returnValue($company));
@@ -121,44 +102,30 @@ class CompanySubscriberTest extends \PHPUnit_Framework_TestCase
             'ipAddress' => $ip,
         ];
 
-        $ipLookupHelper = $this->getMockBuilder(IpLookupHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $ipLookupHelper = $this->createMock(IpLookupHelper::class);
         $ipLookupHelper->expects($this->once())
             ->method('getIpAddressFromRequest')
             ->will($this->returnValue($ip));
 
-        $auditLogModel = $this->getMockBuilder(AuditLogModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $auditLogModel = $this->createMock(AuditLogModel::class);
         $auditLogModel->expects($this->once())
             ->method('writeToLog')
             ->with($log);
 
         $subscriber = new CompanySubscriber($ipLookupHelper, $auditLogModel);
 
-        $company = $this->getMockBuilder(Company::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $company = $this->createMock(Company::class);
         $company->expects($this->once())
             ->method('getId')
             ->will($this->returnValue($companyId));
 
-        $event = $this->getMockBuilder(CompanyEvent::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $event = $this->createMock(CompanyEvent::class);
         $event->expects($this->once())
             ->method('getCompany')
             ->will($this->returnValue($company));
-
         $event->expects($this->once())
             ->method('getChanges')
             ->will($this->returnValue($changes));
-
         $event->expects($this->once())
             ->method('isNew')
             ->will($this->returnValue($isNew));

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentSubscriberTest.php
@@ -22,15 +22,9 @@ class SegmentSubscriberTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetSubscribedEvents()
     {
-        $ipLookupHelper = $this->getMockBuilder(IpLookupHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $auditLogModel = $this->getMockBuilder(AuditLogModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $subscriber = new SegmentSubscriber($ipLookupHelper, $auditLogModel);
+        $ipLookupHelper = $this->createMock(IpLookupHelper::class);
+        $auditLogModel  = $this->createMock(AuditLogModel::class);
+        $subscriber     = new SegmentSubscriber($ipLookupHelper, $auditLogModel);
 
         $this->assertEquals(
             [
@@ -52,8 +46,7 @@ class SegmentSubscriberTest extends \PHPUnit_Framework_TestCase
         $segmentId        = 1;
         $segmentName      = 'name';
         $ip               = '127.0.0.2';
-
-        $log = [
+        $log              = [
             'bundle'    => 'lead',
             'object'    => 'segment',
             'objectId'  => $segmentId,
@@ -62,38 +55,25 @@ class SegmentSubscriberTest extends \PHPUnit_Framework_TestCase
             'ipAddress' => $ip,
         ];
 
-        $ipLookupHelper = $this->getMockBuilder(IpLookupHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $ipLookupHelper = $this->createMock(IpLookupHelper::class);
         $ipLookupHelper->expects($this->once())
             ->method('getIpAddressFromRequest')
             ->will($this->returnValue($ip));
 
-        $auditLogModel = $this->getMockBuilder(AuditLogModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $auditLogModel = $this->createMock(AuditLogModel::class);
         $auditLogModel->expects($this->once())
             ->method('writeToLog')
             ->with($log);
 
         $subscriber = new SegmentSubscriber($ipLookupHelper, $auditLogModel);
 
-        $segment = $this->getMockBuilder(LeadList::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $segment            = $this->createMock(LeadList::class);
         $segment->deletedId = $segmentId;
-
         $segment->expects($this->once())
             ->method('getName')
             ->will($this->returnValue($segmentName));
 
-        $event = $this->getMockBuilder(SegmentEvent::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $event = $this->createMock(SegmentEvent::class);
         $event->expects($this->once())
             ->method('getList')
             ->will($this->returnValue($segment));
@@ -121,44 +101,30 @@ class SegmentSubscriberTest extends \PHPUnit_Framework_TestCase
             'ipAddress' => $ip,
         ];
 
-        $ipLookupHelper = $this->getMockBuilder(IpLookupHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $ipLookupHelper = $this->createMock(IpLookupHelper::class);
         $ipLookupHelper->expects($this->once())
             ->method('getIpAddressFromRequest')
             ->will($this->returnValue($ip));
 
-        $auditLogModel = $this->getMockBuilder(AuditLogModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $auditLogModel = $this->createMock(AuditLogModel::class);
         $auditLogModel->expects($this->once())
             ->method('writeToLog')
             ->with($log);
 
         $subscriber = new SegmentSubscriber($ipLookupHelper, $auditLogModel);
 
-        $segment = $this->getMockBuilder(LeadList::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $segment = $this->createMock(LeadList::class);
         $segment->expects($this->once())
             ->method('getId')
             ->will($this->returnValue($segmentId));
 
-        $event = $this->getMockBuilder(SegmentEvent::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $event = $this->createMock(SegmentEvent::class);
         $event->expects($this->once())
             ->method('getList')
             ->will($this->returnValue($segment));
-
         $event->expects($this->once())
             ->method('getChanges')
             ->will($this->returnValue($changes));
-
         $event->expects($this->once())
             ->method('isNew')
             ->will($this->returnValue($isNew));

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentSubscriberTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Mautic\LeadBundle\Tests\EventListener;
+
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Event\LeadListEvent as SegmentEvent;
+use Mautic\LeadBundle\EventListener\SegmentSubscriber;
+use Mautic\LeadBundle\LeadEvents;
+
+class SegmentSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetSubscribedEvents()
+    {
+        $ipLookupHelper = $this->getMockBuilder(IpLookupHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $auditLogModel = $this->getMockBuilder(AuditLogModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $subscriber = new SegmentSubscriber($ipLookupHelper, $auditLogModel);
+
+        $this->assertEquals(
+            [
+                LeadEvents::LIST_POST_SAVE   => ['onSegmentPostSave', 0],
+                LeadEvents::LIST_POST_DELETE => ['onSegmentDelete', 0],
+            ],
+            $subscriber->getSubscribedEvents()
+        );
+    }
+
+    public function testOnSegmentPostSave()
+    {
+        $this->onSegmentPostSaveMethodCall(false); // update segment log
+        $this->onSegmentPostSaveMethodCall(true); // create segment log
+    }
+
+    public function testOnSegmentDelete()
+    {
+        $segmentId        = 1;
+        $segmentName      = 'name';
+        $ip               = '127.0.0.2';
+
+        $log = [
+            'bundle'    => 'lead',
+            'object'    => 'segment',
+            'objectId'  => $segmentId,
+            'action'    => 'delete',
+            'details'   => ['name', $segmentName],
+            'ipAddress' => $ip,
+        ];
+
+        $ipLookupHelper = $this->getMockBuilder(IpLookupHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $ipLookupHelper->expects($this->once())
+            ->method('getIpAddressFromRequest')
+            ->will($this->returnValue($ip));
+
+        $auditLogModel = $this->getMockBuilder(AuditLogModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $auditLogModel->expects($this->once())
+            ->method('writeToLog')
+            ->with($log);
+
+        $subscriber = new SegmentSubscriber($ipLookupHelper, $auditLogModel);
+
+        $segment = $this->getMockBuilder(LeadList::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $segment->deletedId = $segmentId;
+
+        $segment->expects($this->once())
+            ->method('getName')
+            ->will($this->returnValue($segmentName));
+
+        $event = $this->getMockBuilder(SegmentEvent::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $event->expects($this->once())
+            ->method('getList')
+            ->will($this->returnValue($segment));
+
+        $subscriber->onSegmentDelete($event);
+    }
+
+    /**
+     * Test create or update segment logging.
+     *
+     * @param bool $isNew
+     */
+    private function onSegmentPostSaveMethodCall($isNew)
+    {
+        $segmentId = 1;
+        $changes   = ['changes'];
+        $ip        = '127.0.0.2';
+
+        $log = [
+            'bundle'    => 'lead',
+            'object'    => 'segment',
+            'objectId'  => $segmentId,
+            'action'    => ($isNew) ? 'create' : 'update',
+            'details'   => $changes,
+            'ipAddress' => $ip,
+        ];
+
+        $ipLookupHelper = $this->getMockBuilder(IpLookupHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $ipLookupHelper->expects($this->once())
+            ->method('getIpAddressFromRequest')
+            ->will($this->returnValue($ip));
+
+        $auditLogModel = $this->getMockBuilder(AuditLogModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $auditLogModel->expects($this->once())
+            ->method('writeToLog')
+            ->with($log);
+
+        $subscriber = new SegmentSubscriber($ipLookupHelper, $auditLogModel);
+
+        $segment = $this->getMockBuilder(LeadList::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $segment->expects($this->once())
+            ->method('getId')
+            ->will($this->returnValue($segmentId));
+
+        $event = $this->getMockBuilder(SegmentEvent::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $event->expects($this->once())
+            ->method('getList')
+            ->will($this->returnValue($segment));
+
+        $event->expects($this->once())
+            ->method('getChanges')
+            ->will($this->returnValue($changes));
+
+        $event->expects($this->once())
+            ->method('isNew')
+            ->will($this->returnValue($isNew));
+
+        $subscriber->onSegmentPostSave($event);
+    }
+}

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentSubscriberTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
 namespace Mautic\LeadBundle\Tests\EventListener;
 
 use Mautic\CoreBundle\Helper\IpLookupHelper;


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | Y
| Automated tests included? | Y
| Related user documentation PR URL | n
| Related developer documentation PR URL | n
| Issues addressed (#s or URLs) | n
| BC breaks? | n
| Deprecations? | n

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Added segment activity log. I've found bug in company logging. That is fixed in this PR.
Added unit tests for company and segment logging.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. On company delete action it was producing log entry with type "field". Fixed to type "company".
2. Actions such as add/edit/delete segment was not logged.

#### Steps to test this PR:
1. Delete some company and check last record in audit_log table.
2. Add/edit/delete segment and check latest audit_log table rows.

#### List deprecations along with the new alternative:
None.

#### List backwards compatibility breaks:
None.