### PR TITLE
Add login log

### DIFF
--- a/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
@@ -170,8 +170,8 @@ class CoreSubscriber extends CommonSubscriber
 
             //dispatch on login events
             if ($this->dispatcher->hasListeners(UserEvents::USER_LOGIN)) {
-                $event = new LoginEvent($this->userHelper->getUser());
-                $this->dispatcher->dispatch(UserEvents::USER_LOGIN, $event);
+                $loginEvent = new LoginEvent($this->userHelper->getUser());
+                $this->dispatcher->dispatch(UserEvents::USER_LOGIN, $loginEvent);
             }
         } else {
             $session->remove('mautic.user');

--- a/app/bundles/UserBundle/Config/config.php
+++ b/app/bundles/UserBundle/Config/config.php
@@ -144,6 +144,13 @@ return [
             'mautic.user.route.subscriber' => [
                 'class' => 'Mautic\UserBundle\EventListener\RouteSubscriber',
             ],
+            'mautic.user.security_subscriber' => [
+                'class'     => 'Mautic\UserBundle\EventListener\SecuritySubscriber',
+                'arguments' => [
+                    'mautic.helper.ip_lookup',
+                    'mautic.core.model.auditlog',
+                ],
+            ],
         ],
         'forms' => [
             'mautic.form.type.user' => [

--- a/app/bundles/UserBundle/Event/LoginEvent.php
+++ b/app/bundles/UserBundle/Event/LoginEvent.php
@@ -11,8 +11,8 @@
 
 namespace Mautic\UserBundle\Event;
 
-use Mautic\CampaignBundle\Entity\Event;
 use Mautic\UserBundle\Entity\User;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Class LoginEvent.
@@ -20,7 +20,7 @@ use Mautic\UserBundle\Entity\User;
 class LoginEvent extends Event
 {
     /**
-     * @var \Mautic\UserBundle\Entity\User|null
+     * @var User
      */
     private $user;
 

--- a/app/bundles/UserBundle/EventListener/SecuritySubscriber.php
+++ b/app/bundles/UserBundle/EventListener/SecuritySubscriber.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\UserBundle\EventListener;
+
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\UserBundle\Event\LoginEvent;
+use Mautic\UserBundle\UserEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class SecuritySubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var IpLookupHelper
+     */
+    private $ipLookupHelper;
+
+    /**
+     * @var AuditLogModel
+     */
+    private $auditLogModel;
+
+    /**
+     * @param IpLookupHelper $ipLookupHelper
+     * @param AuditLogModel  $auditLogModel
+     */
+    public function __construct(IpLookupHelper $ipLookupHelper, AuditLogModel $auditLogModel)
+    {
+        $this->ipLookupHelper = $ipLookupHelper;
+        $this->auditLogModel  = $auditLogModel;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            UserEvents::USER_LOGIN => ['onSecurityInteractiveLogin', 0],
+        ];
+    }
+
+    /**
+     * @param LoginEvent $event
+     */
+    public function onSecurityInteractiveLogin(LoginEvent $event)
+    {
+        $userId   = (int) $event->getUser()->getId();
+        $useName  = $event->getUser()->getUserName();
+
+        $log     = [
+            'bundle'    => 'user',
+            'object'    => 'security',
+            'objectId'  => $userId,
+            'action'    => 'login',
+            'details'   => ['username' => $useName],
+            'ipAddress' => $this->ipLookupHelper->getIpAddressFromRequest(),
+        ];
+
+        $this->auditLogModel->writeToLog($log);
+    }
+}

--- a/app/bundles/UserBundle/Tests/Event/LoginEventTest.php
+++ b/app/bundles/UserBundle/Tests/Event/LoginEventTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\UserBundle\Tests\Event;
+
+use Mautic\UserBundle\Entity\User;
+use Mautic\UserBundle\Event\LoginEvent;
+
+class LoginEventTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetUser()
+    {
+        $user  = $this->createMock(User::class);
+        $event = new LoginEvent($user);
+
+        $this->assertEquals($user, $event->getUser());
+    }
+}

--- a/app/bundles/UserBundle/Tests/EventListener/SecuritySubscriberTest.php
+++ b/app/bundles/UserBundle/Tests/EventListener/SecuritySubscriberTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\UserBundle\Tests\EventListener;
+
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\UserBundle\Entity\User;
+use Mautic\UserBundle\Event\LoginEvent;
+use Mautic\UserBundle\EventListener\SecuritySubscriber;
+use Mautic\UserBundle\UserEvents;
+
+class SecuritySubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetSubscribedEvents()
+    {
+        $ipLookupHelper = $this->createMock(IpLookupHelper::class);
+        $auditLogModel  = $this->createMock(AuditLogModel::class);
+        $subscriber     = new SecuritySubscriber($ipLookupHelper, $auditLogModel);
+
+        $this->assertEquals(
+            [
+                UserEvents::USER_LOGIN => ['onSecurityInteractiveLogin', 0],
+            ],
+            $subscriber->getSubscribedEvents()
+        );
+    }
+
+    public function testOnSecurityInteractiveLogin()
+    {
+        $userId   = 132564;
+        $userName = 'John Doe';
+        $ip       = '125.55.45.21';
+        $log      = [
+            'bundle'    => 'user',
+            'object'    => 'security',
+            'objectId'  => $userId,
+            'action'    => 'login',
+            'details'   => ['username' => $userName],
+            'ipAddress' => $ip,
+        ];
+
+        $ipLookupHelper = $this->createMock(IpLookupHelper::class);
+        $ipLookupHelper->expects($this->once())
+            ->method('getIpAddressFromRequest')
+            ->willReturn($ip);
+        $auditLogModel = $this->createMock(AuditLogModel::class);
+        $auditLogModel->expects($this->once())
+            ->method('writeToLog')
+            ->with($log);
+        $user = $this->createMock(User::class);
+        $user->expects($this->once())
+            ->method('getId')
+            ->willReturn($userId);
+        $user->expects($this->once())
+            ->method('getUserName')
+            ->willReturn($userName);
+        $event = $this->createMock(LoginEvent::class);
+        $event->expects($this->exactly(2))
+            ->method('getUser')
+            ->willReturn($user);
+        $subscriber = new SecuritySubscriber($ipLookupHelper, $auditLogModel);
+
+        $subscriber->onSecurityInteractiveLogin($event);
+    }
+}


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | Y
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | Possible
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Adds login log.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Just check audit_log table after login.

#### Steps to test this PR:
1.  Same as how to reproduce step.

#### List deprecations along with the new alternative:
None.
#### List backwards compatibility breaks:
1.  LoginEvent now extends Symfony\Component\EventDispatcher\Event instead of Mautic\CampaignBundle\Entity\Event
