### PR TITLE
Disable resubscription by user

### DIFF
--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -934,7 +934,7 @@ Mautic.togglePreferredChannel = function(channel) {
 
        // "select all" checked status
         mQuery('#channels input:checkbox').each(function(){ //iterate all listed checkbox items
-            if (this.checked != status) {
+            if (this.disabled === false && this.checked != status) {
                 this.checked = status;
                 Mautic.setPreferredChannel(this.value);
             }

--- a/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
+++ b/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
@@ -179,7 +179,7 @@ trait FrequencyRuleTrait
         foreach ($formData['subscribed_channels'] as $contactChannel) {
             if (!isset($leadChannels[$contactChannel])) {
                 $contactable = $model->isContactable($lead, $contactChannel);
-                if ($contactable == DoNotContact::UNSUBSCRIBED) {
+                if ($contactable == DoNotContact::UNSUBSCRIBED && $this->isPublicView) {
                     // Only resubscribe if the contact did not opt out themselves
                     $model->removeDncForLead($lead, $contactChannel);
                 }

--- a/app/bundles/LeadBundle/Views/Lead/frequency.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/frequency.html.php
@@ -51,7 +51,9 @@ $leadName = $lead->getPrimaryIdentifier();
                         <input type="checkbox" id="<?php echo $channel->value ?>"
                                name="lead_contact_frequency_rules[subscribed_channels][]" class="control-label"
                                onclick="Mautic.togglePreferredChannel(this.value);"
-                               value="<?php echo $view->escape($channel->value) ?>" <?php echo $checked; ?>>
+                               value="<?php echo $view->escape($channel->value) ?>" <?php echo $checked; ?>
+                               <?php echo ($contactMe === false) ? 'disabled' : '' ?>
+                        >
                     </th>
                     <td class="col-md-1" style="vertical-align: top">
                         <div id="is-contactable-<?php echo $channel->value ?>" class="<?php echo $isContactable; ?> fw-sb">


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Mautic user could manually resubscribe user in `Contact Preference Center` to any channel.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Contacts -> click some email with `DoNotContact` tag -> preferences (right top menu) -> click e-mail checkbox. This can not happen.



#### Steps to test this PR:
1. Same as step to reproduce bug, but it is not possible now. Checkbox is disabled for unsubscribed channel.

#### List deprecations along with the new alternative:
None

#### List backwards compatibility breaks:
None
