### PR TITLE
Prevent same SQL select aliases in report using numeric suffixes

### DIFF
--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -282,7 +282,41 @@ class ReportModel extends FormModel
     {
         $data = $this->buildAvailableReports($context);
 
-        return (!isset($data['tables'])) ? [] : $data['tables'];
+        $data = (!isset($data['tables'])) ? [] : $data['tables'];
+
+        if (array_key_exists('columns', $data)) {
+            $data['columns'] = $this->preventSameAliases($data['columns']);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Prevent same aliases using numeric suffixes for each alias.
+     *
+     * @param array $columns
+     *
+     * @return array
+     */
+    private function preventSameAliases(array $columns)
+    {
+        $existingAliases = [];
+
+        foreach ($columns as $key => $column) {
+            $alias = $column['alias'];
+
+            // Count suffixes
+            if (!array_key_exists($alias, $existingAliases)) {
+                $existingAliases[$alias] = 1;
+            } else {
+                ++$existingAliases[$alias];
+            }
+
+            // Add numeric suffix
+            $columns[$key]['alias'] = $alias.$existingAliases[$alias];
+        }
+
+        return $columns;
     }
 
     /**


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When generating reports is possible collision of same aliases in SQL select query.

//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Use same aliases for custom fields and use them in report

#### Steps to test this PR:
1. Same as reproduction steps

#### List deprecations along with the new alternative:
None.

#### List backwards compatibility breaks:
None.