### PR TITLE
Forward HTTP status codes as they are provided to ApiSubscriber

### DIFF
--- a/app/bundles/ApiBundle/EventListener/ApiSubscriber.php
+++ b/app/bundles/ApiBundle/EventListener/ApiSubscriber.php
@@ -96,8 +96,9 @@ class ApiSubscriber extends CommonSubscriber
      */
     public function onKernelResponse(FilterResponseEvent $event)
     {
-        $response = $event->getResponse();
-        $content  = $response->getContent();
+        $response   = $event->getResponse();
+        $content    = $response->getContent();
+        $statusCode = $response->getStatusCode();
 
         if ($this->isApiRequest($event) && strpos($content, 'error') !== false) {
             // Override api messages with something useful
@@ -140,22 +141,23 @@ class ApiSubscriber extends CommonSubscriber
                     }
 
                     if ($message) {
-                        $event->setResponse(
-                            new JsonResponse(
-                                [
-                                    'errors' => [
-                                        [
-                                            'message' => $message,
-                                            'code'    => $response->getStatusCode(),
-                                            'type'    => $type,
-                                        ],
+                        $response = new JsonResponse(
+                            [
+                                'errors' => [
+                                    [
+                                        'message' => $message,
+                                        'code'    => $response->getStatusCode(),
+                                        'type'    => $type,
                                     ],
-                                    // @deprecated 2.6.0 to be removed in 3.0
-                                    'error'             => $data['error'],
-                                    'error_description' => $message.' (`error` and `error_description` are deprecated as of 2.6.0 and will be removed in 3.0. Use the `errors` array instead.)',
-                                ]
-                            )
+                                ],
+                                // @deprecated 2.6.0 to be removed in 3.0
+                                'error'             => $data['error'],
+                                'error_description' => $message.' (`error` and `error_description` are deprecated as of 2.6.0 and will be removed in 3.0. Use the `errors` array instead.)',
+                            ],
+                            $statusCode
                         );
+
+                        $event->setResponse($response);
                     }
                 }
             }


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
ApiSubscriber overwrites response codes to 200 OK when authentication fails

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Send basic auth request with incorrect credentials

#### Steps to test this PR:
1.  Send basic auth request with incorrect credentials

#### List backwards compatibility breaks:
1. May on APIs
