### PR TITLE
Add switch to enable attachments saving for monitored mailbox

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -751,12 +751,13 @@ return [
         'resubscribe_message'          => null,
         'monitored_email'              => [
             'general' => [
-                'address'    => null,
-                'host'       => null,
-                'port'       => '993',
-                'encryption' => '/ssl',
-                'user'       => null,
-                'password'   => null,
+                'address'         => null,
+                'host'            => null,
+                'port'            => '993',
+                'encryption'      => '/ssl',
+                'user'            => null,
+                'password'        => null,
+                'use_attachments' => false,
             ],
             'EmailBundle_bounces' => [
                 'address'           => null,

--- a/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -182,20 +182,23 @@ class Mailbox
             $this->settings = $this->mailboxes['general'];
         } else {
             $this->settings = [
-                'host'       => '',
-                'port'       => '',
-                'password'   => '',
-                'user'       => '',
-                'encryption' => '',
+                'host'            => '',
+                'port'            => '',
+                'password'        => '',
+                'user'            => '',
+                'encryption'      => '',
+                'use_attachments' => true,
             ];
         }
 
-        // Check that cache attachments directory exists
-        $cacheDir             = $pathsHelper->getSystemPath('cache', true);
-        $this->attachmentsDir = $cacheDir.'/attachments';
+        if ($this->settings['use_attachments']) {
+            // Check that cache attachments directory exists
+            $cacheDir             = $pathsHelper->getSystemPath('tmp', true);
+            $this->attachmentsDir = $cacheDir.'/attachments';
 
-        if (!file_exists($this->attachmentsDir)) {
-            mkdir($this->attachmentsDir);
+            if (!file_exists($this->attachmentsDir)) {
+                mkdir($this->attachmentsDir);
+            }
         }
 
         if ($this->settings['host'] == 'imap.gmail.com') {
@@ -981,32 +984,34 @@ class Mailbox
             : (isset($params['filename']) || isset($params['name']) ? mt_rand().mt_rand() : null);
 
         if ($attachmentId) {
-            if (empty($params['filename']) && empty($params['name'])) {
-                $fileName = $attachmentId.'.'.strtolower($partStructure->subtype);
-            } else {
-                $fileName = !empty($params['filename']) ? $params['filename'] : $params['name'];
-                $fileName = $this->decodeMimeStr($fileName, $this->serverEncoding);
-                $fileName = $this->decodeRFC2231($fileName, $this->serverEncoding);
+            if ($this->settings['use_attachments']) {
+                if (empty($params['filename']) && empty($params['name'])) {
+                    $fileName = $attachmentId.'.'.strtolower($partStructure->subtype);
+                } else {
+                    $fileName = !empty($params['filename']) ? $params['filename'] : $params['name'];
+                    $fileName = $this->decodeMimeStr($fileName, $this->serverEncoding);
+                    $fileName = $this->decodeRFC2231($fileName, $this->serverEncoding);
+                }
+                $attachment       = new Attachment();
+                $attachment->id   = $attachmentId;
+                $attachment->name = $fileName;
+                if ($this->attachmentsDir) {
+                    $replace = [
+                        '/\s/'                   => '_',
+                        '/[^0-9a-zа-яіїє_\.]/iu' => '',
+                        '/_+/'                   => '_',
+                        '/(^_)|(_$)/'            => '',
+                    ];
+                    $fileSysName = preg_replace(
+                        '~[\\\\/]~',
+                        '',
+                        $mail->id.'_'.$attachmentId.'_'.preg_replace(array_keys($replace), $replace, $fileName)
+                    );
+                    $attachment->filePath = $this->attachmentsDir.DIRECTORY_SEPARATOR.$fileSysName;
+                    file_put_contents($attachment->filePath, $data);
+                }
+                $mail->addAttachment($attachment);
             }
-            $attachment       = new Attachment();
-            $attachment->id   = $attachmentId;
-            $attachment->name = $fileName;
-            if ($this->attachmentsDir) {
-                $replace = [
-                    '/\s/'                   => '_',
-                    '/[^0-9a-zа-яіїє_\.]/iu' => '',
-                    '/_+/'                   => '_',
-                    '/(^_)|(_$)/'            => '',
-                ];
-                $fileSysName = preg_replace(
-                    '~[\\\\/]~',
-                    '',
-                    $mail->id.'_'.$attachmentId.'_'.preg_replace(array_keys($replace), $replace, $fileName)
-                );
-                $attachment->filePath = $this->attachmentsDir.DIRECTORY_SEPARATOR.$fileSysName;
-                file_put_contents($attachment->filePath, $data);
-            }
-            $mail->addAttachment($attachment);
         } else {
             if (!empty($params['charset'])) {
                 $data = $this->convertStringEncoding($data, $params['charset'], $this->serverEncoding);

--- a/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -191,15 +191,7 @@ class Mailbox
             ];
         }
 
-        if (isset($this->settings['use_attachments']) && $this->settings['use_attachments']) {
-            // Check that cache attachments directory exists
-            $cacheDir             = $pathsHelper->getSystemPath('tmp', true);
-            $this->attachmentsDir = $cacheDir.'/attachments';
-
-            if (!file_exists($this->attachmentsDir)) {
-                mkdir($this->attachmentsDir);
-            }
-        }
+        $this->createAttachmentsDir($pathsHelper);
 
         if ($this->settings['host'] == 'imap.gmail.com') {
             $this->isGmail = true;
@@ -1191,6 +1183,27 @@ class Mailbox
             imap_alerts();
 
             @imap_close($this->imapStream, CL_EXPUNGE);
+        }
+    }
+
+    /**
+     * @param PathsHelper $pathsHelper
+     */
+    private function createAttachmentsDir(PathsHelper $pathsHelper)
+    {
+        if (!isset($this->settings['use_attachments']) || !$this->settings['use_attachments']) {
+            return;
+        }
+
+        $this->attachmentsDir = $pathsHelper->getSystemPath('tmp', true);
+
+        if (!file_exists($this->attachmentsDir)) {
+            mkdir($this->attachmentsDir);
+        }
+        $this->attachmentsDir .= '/attachments';
+
+        if (!file_exists($this->attachmentsDir)) {
+            mkdir($this->attachmentsDir);
         }
     }
 

--- a/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -191,7 +191,7 @@ class Mailbox
             ];
         }
 
-        if ($this->settings['use_attachments']) {
+        if (isset($this->settings['use_attachments']) && $this->settings['use_attachments']) {
             // Check that cache attachments directory exists
             $cacheDir             = $pathsHelper->getSystemPath('tmp', true);
             $this->attachmentsDir = $cacheDir.'/attachments';
@@ -984,7 +984,7 @@ class Mailbox
             : (isset($params['filename']) || isset($params['name']) ? mt_rand().mt_rand() : null);
 
         if ($attachmentId) {
-            if ($this->settings['use_attachments']) {
+            if (isset($this->settings['use_attachments']) && $this->settings['use_attachments']) {
                 if (empty($params['filename']) && empty($params['name'])) {
                     $fileName = $attachmentId.'.'.strtolower($partStructure->subtype);
                 } else {

--- a/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -187,7 +187,7 @@ class Mailbox
                 'password'        => '',
                 'user'            => '',
                 'encryption'      => '',
-                'use_attachments' => true,
+                'use_attachments' => false,
             ];
         }
 

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/MailboxTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/MailboxTest.php
@@ -23,12 +23,13 @@ class MailboxTest extends \PHPUnit_Framework_TestCase
     {
         $config = [
             'general' => [
-                'address'    => 'foo@bar.com',
-                'host'       => 'imap.bar.com',
-                'port'       => '993',
-                'encryption' => '/ssl',
-                'user'       => 'foo@bar.com',
-                'password'   => 'topsecret',
+                'address'         => 'foo@bar.com',
+                'host'            => 'imap.bar.com',
+                'port'            => '993',
+                'encryption'      => '/ssl',
+                'user'            => 'foo@bar.com',
+                'password'        => 'topsecret',
+                'use_attachments' => true,
             ],
             'EmailBundle_bounces' => [
                 'address'           => null,
@@ -69,12 +70,13 @@ class MailboxTest extends \PHPUnit_Framework_TestCase
     {
         $config = [
             'general' => [
-                'address'    => 'foo@bar.com',
-                'host'       => 'imap.bar.com',
-                'port'       => '993',
-                'encryption' => '/ssl',
-                'user'       => 'foo@bar.com',
-                'password'   => 'topsecret',
+                'address'         => 'foo@bar.com',
+                'host'            => 'imap.bar.com',
+                'port'            => '993',
+                'encryption'      => '/ssl',
+                'user'            => 'foo@bar.com',
+                'password'        => 'topsecret',
+                'use_attachments' => true,
             ],
             'EmailBundle_bounces' => [
                 'address'           => 'bar@foo.com',


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | Y
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
`cache/attachments` dir is full of cached attachments from mailbox monitoring. This feature is now switchable.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup monitored mailbox.

#### Steps to test this PR:
1. Same as reproduction, but now you can switch it of in configuration. `Email settings -> monitored inbox settings -> Use attachments`

#### List deprecations along with the new alternative:
None.

#### List backwards compatibility breaks:
None.