### PR TITLE
Change function renderArray() to use single quotes for key and value strings

### DIFF
--- a/app/bundles/CoreBundle/Configurator/Configurator.php
+++ b/app/bundles/CoreBundle/Configurator/Configurator.php
@@ -257,13 +257,13 @@ class Configurator
                 if ($counter === $count) {
                     $string .= str_repeat("\t", $level + 1);
                 }
-                $string .= "'".$key."' => ";
+                $string .= '\''.$key.'\' => ';
             }
 
             if (is_array($value)) {
                 $string .= $this->renderArray($value, $level + 1);
             } else {
-                $string .= "'".addcslashes($value, '\\\'')."'";
+                $string .= '\''.addcslashes($value, '\\\'').'\'';
             }
 
             --$counter;

--- a/app/bundles/CoreBundle/Configurator/Configurator.php
+++ b/app/bundles/CoreBundle/Configurator/Configurator.php
@@ -257,18 +257,18 @@ class Configurator
                 if ($counter === $count) {
                     $string .= str_repeat("\t", $level + 1);
                 }
-                $string .= '"'.$key.'" => ';
+                $string .= "'".$key."' => ";
             }
 
             if (is_array($value)) {
                 $string .= $this->renderArray($value, $level + 1);
             } else {
-                $string .= '"'.addcslashes($value, '\\"').'"';
+                $string .= "'".addcslashes($value, '\\\'')."'";
             }
 
             --$counter;
             if ($counter > 0) {
-                $string .= ", \n".str_repeat("\t", $level + 1);
+                $string .= ",\n".str_repeat("\t", $level + 1);
             }
         }
         $string .= "\n".str_repeat("\t", $level).')';


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This is the same as #5648 but fixed the issues with the pr as the author is not responding.

Description of 5684
Changes function renderArray() to use single quotes for key and value strings instead of double quotes. This allows to use $ in passwords which otherwise gets parsed as variable. If the password contains {$ – without the closing bracket of the complex syntax for variables like {$foo} – this leads to parsing errors of …/app/config/local.php.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.    Use a password containing {$ in Configuration > Email Settings > Monitored Inbox Settings > Default Mailbox > IMAP password.
2.    'Save & Close' should throw: Parse error: syntax error, unexpected ')', expecting variable (T_VARIABLE) or '{' or '$' - in file /…/app/config/local.php


#### Steps to test this PR:
Same as above