### PR TITLE
Fix sugarcrm pushleadactivity error

### DIFF
--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -277,7 +277,13 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
                 ++$page;
 
                 // Lots of entities will be loaded into memory while compiling these events so let's prevent memory overload by clearing the EM
-                $this->em->clear();
+                $entityToNotDetach = ['Mautic\PluginBundle\Entity\Integration', 'Mautic\PluginBundle\Entity\Plugin'];
+                $loadedEntities    = $this->em->getUnitOfWork()->getIdentityMap();
+                foreach ($loadedEntities as $name => $loadedEntity) {
+                    if (!in_array($name, $entityToNotDetach)) {
+                        $this->em->clear($name);
+                    }
+                }
             }
 
             $leadActivity[$leadId] = [

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -520,7 +520,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                             $leadIds
                         );
 
-                        $saugarLeadData = [];
+                        $sugarLeadData = [];
                         foreach ($sugarIds as $ids) {
                             $leadId = $ids['internal_entity_id'];
                             if (isset($leadActivity[$leadId])) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
With command
```
php app/console mautic:integration:pushleadactivity --time -interval=180minutes --integration=Sugarcrm
```
error appear in console and plugin configuration line is duplicated in database due to "$this->em->clear()" that clear all entity.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Configure SugarCrm plugin with events
![screenshot_2018-10-16 manage plugins mautic](https://user-images.githubusercontent.com/27768270/47002897-65b71c00-d12e-11e8-9968-4b5ccdcf775c.png)

2. Create a contact synced to SugarCrm
3. Create a form with mail field in Mautic and fill it with the synced contact to have history
4. Launch `php app/console mautic:integration:pushleadactivity --time -interval=180minutes --integration=Sugarcrm`
5. Error: 
`PHP Notice:  Undefined index: 000000003a358473000000006fa6c0dc in vendor\doctrine\orm\lib\Doctrine\ORM\UnitOfWork.php on line 2917`
6. Duplicated lines in plugin_integration_settings
![screenshot_2018-10-16 127 0 0 1 127 0 0 1 mautic-wmk plugin_integration_settings phpmyadmin 4 7 0](https://user-images.githubusercontent.com/27768270/47004127-2807c280-d131-11e8-9d15-3b209b5337c7.png)

#### Steps to test this PR:
1. Apply PR
2. Launch `php app/console mautic:integration:pushleadactivity --time -interval=180minutes --integration=Sugarcrm`
3. No error, no duplication
