### PR TITLE
Remove dead code from segment QB

### DIFF
--- a/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -145,16 +145,7 @@ class ContactSegmentQueryBuilder
         $queryBuilder->leftJoin('l', MAUTIC_TABLE_PREFIX.'lead_lists_leads', $tableAlias, $tableAlias.'.lead_id = l.id');
         $queryBuilder->addSelect($tableAlias.'.lead_id AS '.$tableAlias.'_lead_id');
 
-        // @todo evaluate if this was supposed to be here; it's causing contacts already in the segment to be added because the join is based on
-        // when the contact is created
-        if (false && isset($batchRestrictions['dateTime'])) {
-            $expression = $queryBuilder->expr()->andX(
-                $queryBuilder->expr()->eq($tableAlias.'.leadlist_id', $segmentId),
-                $queryBuilder->expr()->lte('l.date_added', "'".$batchRestrictions['dateTime']."'")
-            );
-        } else {
-            $expression = $queryBuilder->expr()->eq($tableAlias.'.leadlist_id', $segmentId);
-        }
+        $expression = $queryBuilder->expr()->eq($tableAlias.'.leadlist_id', $segmentId);
 
         $queryBuilder->addJoinCondition($tableAlias, $expression);
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | -
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

There was a dead code which could never run. I removed a condition which starts with `false && ..`

#### Steps to test this PR:
1. Code review should be enough. Notice that there is a condition `if (false && isset($batchRestrictions['dateTime']))` which could never be true. Every time code in an `else` statement was run.
2. You can test several segments, no new problem should occur.