### PR TITLE
Fix z-index for gated video

### DIFF
--- a/media/css/mediaelementplayer.css
+++ b/media/css/mediaelementplayer.css
@@ -1001,7 +1001,7 @@ div.mejs-speed-button {
 .mejs-poster {
 	text-align: center;
 	background: rgba(0,0,0,0.75);
-	z-index: 1000;
+	z-index: 100000000;
 	color: white;
 }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6745
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Gated video allow continue video without send from. 
This PR fixed it by increase z-index of  layer

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Add an MP4 video as an asset (must end with mp4)
2. Create a landing page, add a gated video bloc and add the URL of the mp4 you just upload
![image](https://user-images.githubusercontent.com/31535432/47007436-81272480-d138-11e8-8da0-948c5c4a3078.png)
3. Save and close
4. Open the landing page, start the video and wait for the form to display
5. See the play video
![image](https://user-images.githubusercontent.com/31535432/47007492-a1ef7a00-d138-11e8-9f89-9521b3e2dee7.png)
6. Do not submit the form, just click on the play button and see that the video continue to play
 

#### Steps to test this PR:
1. Repeat all steps and see If play button is not clickable
