### PR TITLE
Fixes relative campaign hour for scheduling events more than 1 day in the future

### DIFF
--- a/app/bundles/CampaignBundle/Executioner/KickoffExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/KickoffExecutioner.php
@@ -213,7 +213,16 @@ class KickoffExecutioner implements ExecutionerInterface
                 $this->counter->advanceEvaluated($contacts->count());
 
                 try {
-                    $this->scheduler->validateAndScheduleEventForContacts($event, $now, $contacts);
+                    // Get the date the event would be executed on as if it was based on days only
+                    $executionDate = $this->scheduler->getExecutionDateTime($event, $now);
+                    $this->logger->debug(
+                        'CAMPAIGN: Event ID# '.$event->getId().
+                        ' to be executed on '.$executionDate->format('Y-m-d H:i:s').
+                        ' compared to '.$now->format('Y-m-d H:i:s')
+                    );
+
+                    // Adjust the hour based on contact timezone if applicable
+                    $this->scheduler->validateAndScheduleEventForContacts($event, $executionDate, $contacts, $now);
 
                     $this->counter->advanceTotalScheduled($contacts->count());
                     $rootEvents->remove($key);

--- a/app/bundles/CampaignBundle/Tests/Executioner/KickoffExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/KickoffExecutionerTest.php
@@ -109,20 +109,36 @@ class KickoffExecutionerTest extends \PHPUnit_Framework_TestCase
         $limiter = new ContactLimiter(0, 0, 0, 0);
 
         $this->scheduler->expects($this->at(0))
-            ->method('validateAndScheduleEventForContacts')
-            ->willReturn(null);
+            ->method('getExecutionDateTime')
+            ->willReturn(new \DateTime());
 
         $this->scheduler->expects($this->at(1))
             ->method('validateAndScheduleEventForContacts')
             ->willReturn(null);
 
         $this->scheduler->expects($this->at(2))
+            ->method('getExecutionDateTime')
+            ->willReturn(new \DateTime());
+
+        $this->scheduler->expects($this->at(3))
+            ->method('validateAndScheduleEventForContacts')
+            ->willReturn(null);
+
+        $this->scheduler->expects($this->at(4))
+            ->method('getExecutionDateTime')
+            ->willReturn(new \DateTime());
+
+        $this->scheduler->expects($this->at(5))
             ->method('validateAndScheduleEventForContacts')
             ->willReturnCallback(function () {
                 throw new NotSchedulableException();
             });
 
-        $this->scheduler->expects($this->at(3))
+        $this->scheduler->expects($this->at(6))
+            ->method('getExecutionDateTime')
+            ->willReturn(new \DateTime());
+
+        $this->scheduler->expects($this->at(7))
             ->method('validateAndScheduleEventForContacts')
             ->willReturnCallback(function () {
                 throw new NotSchedulableException();


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Apparently relative hour code worked well for 0 and 1 day but not for more than that :-) This is needed before beta is released.

Introduced with https://github.com/mautic/mautic/pull/6520.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create Campaign using relative time period
2. Schedule actions at 0 days, 1 day, and 5 days at different relative hours
3. Execute/publish the campaign
4. All will be scheduled today at the hour selected

#### Steps to test this PR:
1. Repeat and all will go out relative to the number of days configured and the time configured. Check the contact's timeline to confirm this
