### PR TITLE
Fix frequency rule

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1318,7 +1318,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         }
 
         // Process frequency rules for email
-        if ($isMarketing && count($sendTo)) {
+        if (!$isMarketing && count($sendTo)) {
             $campaignEventId = (is_array($channel) && !empty($channel) && 'campaign.event' === $channel[0] && !empty($channel[1])) ? $channel[1]
                 : null;
             $this->messageQueueModel->processFrequencyRules(

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -1083,7 +1083,7 @@ class EmailModelTest extends \PHPUnit_Framework_TestCase
                     'lastname'  => 'someone',
                 ],
             ],
-            ['email_type' => 'marketing']
+            ['email_type' => 'transactional']
         );
         $this->assertTrue(count($result) === 0, print_r($result, true));
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6729
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Based on this issue https://github.com/mautic/mautic/issues/6729 I notice bad condition If frequency rules should applied.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Go to configurations, Emails and set Default Frequency Rule to 1 each week
![image](https://user-images.githubusercontent.com/462477/47166592-d9a71f00-d2fc-11e8-969a-b57e4ec107e3.png)
2.  Create two campaign width send email action
3. Run both campaign
4. See contact profile page, both email send, even we set frequency rule 

#### Steps to test this PR:
1.  Repeat all steps and see If second email is pending
2.  
