### PR TITLE
Allow the same form to be included multiple times

### DIFF
--- a/app/bundles/FormBundle/Views/Builder/form.html.php
+++ b/app/bundles/FormBundle/Views/Builder/form.html.php
@@ -8,7 +8,7 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
-$formName = '_'.$form->generateFormName().(isset($suffix) ? $suffix : '');
+$formName = '_'.$form->generateFormName().(isset($suffix) ? $suffix : '').'_'.uniqid();
 if (!isset($fields)) {
     $fields = $form->getFields();
 }

--- a/app/bundles/FormBundle/Views/Field/group.html.php
+++ b/app/bundles/FormBundle/Views/Field/group.html.php
@@ -52,7 +52,7 @@ $checkboxBrackets = ($type == 'checkbox') ? '[]' : '';
 
 $option = <<<HTML
 
-                    <label id="mauticform_{$containerType}_label_{$id}" for="mauticform_{$containerType}_{$type}_{$id}" {$optionLabelAttr}>
+                    <label id="mauticform_{$containerType}_label_{$id}" {$optionLabelAttr}>
                         <input {$inputAttr}{$checked} name="mauticform[{$field['alias']}]{$checkboxBrackets}" id="mauticform_{$containerType}_{$type}_{$id}" type="{$type}" value="{$view->escape($listValue)}" />
                         $listLabel
                     </label>


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | v
| New feature? |v 

[//]: # ( Required: )
#### Description:
Forms can't be included multiple times on one page. This PR makes them unique and fixes the radio and checkbox groups to also target the right inputs.

todo: Additional forms don't get a proper submit message on a post request, that still needs a fix for this to fully work.

Let me know what you think.
