### PR TITLE
Campaign email condition all variant check

### DIFF
--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -219,15 +219,6 @@ class CampaignSubscriber implements EventSubscriberInterface
         }
     }
 
-    private function isFromParent(Email $email, $emailId)
-    {
-        if ($email->getVariantParent()) {
-            return in_array($emailId, [$email->getId(), $email->getVariantParent()->getId()]);
-        } else {
-            return in_array($emailId, [$email->getId()]);
-        }
-    }
-
     /**
      * @param CampaignExecutionEvent $event
      */


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3898
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Report here issue https://github.com/mautic/mautic/issues/3898
A/B child email  in campaign cannot continue on condition because we check just parent ID.
This PR fixed it.


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Create email with A/B testing variant with 50% weight rate
2.  Create campaign with send email
3. Add condition open email and add action (points for example)
4.  Add two contacts
5.  Trigger campaign
6. Open both emails
7. Just one email will run action after open email decision

#### Steps to test this PR:
1. Repeat all steps and see If decision is triggered for both contact as we expect
