### PR TITLE
Fixed regression in dynamic content filters from #6510

### DIFF
--- a/app/bundles/DynamicContentBundle/Views/DynamicContent/form.html.php
+++ b/app/bundles/DynamicContentBundle/Views/DynamicContent/form.html.php
@@ -121,7 +121,7 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
                                                             ) : '{}';
                                                             ?>
                                                             <option value="<?php echo $view->escape($value); ?>"
-                                                                    id="available_<?php echo $value; ?>"
+                                                                    id="available_<?php echo $object.'_'.$value; ?>"
                                                                     data-field-object="<?php echo $object; ?>"
                                                                     data-field-type="<?php echo $params['properties']['type']; ?>"
                                                                     data-field-list="<?php echo $view->escape($list); ?>"


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6766
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

https://github.com/mautic/mautic/pull/6510 introduced a bug in "not campaign" dynamic content filters.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create new Dynamic Content in Components > Dynamic Content.
2. Type in the Internal Name.
3. Switch off "Is campaign based?"
4. Click on "Filters".
5. Select any field from the drop-down menu.
Result: nothing happens. I do not get the expected row of criteria and logical operators to create a filter.

#### Steps to test this PR:
1. Repeat.

Result: the filters work.