### PR TITLE
Fix JS front bug in segment filter view

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -970,6 +970,21 @@ Mautic.activateChosenSelect = function(el, ignoreGlobal, jQueryVariant) {
 };
 
 /**
+ * Check and destroy chosen select
+ *
+ * @param el
+ */
+Mautic.destroyChosen = function(el) {
+    var eventObject = mQuery._data(el.get(0), 'events');
+
+    // Check if object has chosen event
+    if (eventObject !== undefined && eventObject['chosen:activate'] !== undefined) {
+        el.chosen('destroy');
+        el.off('chosen:activate chosen:close chosen:open chosen:updated'); //Clear chosen events because chosen('destroy') doesn't
+    }
+};
+
+/**
  * Activate a typeahead lookup
  *
  * @param field

--- a/app/bundles/CoreBundle/Assets/js/6.forms.js
+++ b/app/bundles/CoreBundle/Assets/js/6.forms.js
@@ -582,7 +582,7 @@ Mautic.updateFieldOperatorValue = function(field, action, valueOnChange, valueOn
 
             if (mQuery('#'+fieldPrefix+'value_chosen').length) {
                 valueFieldAttrs['value'] = '';
-                valueField.chosen('destroy');
+                Mautic.destroyChosen(valueField);
             }
 
             if (!mQuery.isEmptyObject(response.options) && response.fieldType !== 'number') {
@@ -658,9 +658,7 @@ Mautic.updateFieldOperatorValue = function(field, action, valueOnChange, valueOn
             if (!mQuery.isEmptyObject(response.operators)) {
                 var operatorField = mQuery('#'+fieldPrefix+'operator');
 
-                if (mQuery('#'+fieldPrefix+'operator_chosen').length) {
-                    operatorField.chosen('destroy');
-                }
+                Mautic.destroyChosen(operatorField);
 
                 var operatorFieldAttrs = {
                     'class': operatorField.attr('class'),

--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -725,9 +725,7 @@ Mautic.convertDynamicContentFilterInput = function(el, jQueryVariant) {
         }
 
         // Destroy the chosen and recreate
-        if (mQuery(filterId + '_chosen').length) {
-            filterEl.chosen('destroy');
-        }
+        Mautic.destroyChosen(filterEl);
 
         filterEl.attr('data-placeholder', placeholder);
 

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -380,15 +380,27 @@ Mautic.reorderSegmentFilters = function() {
     mQuery('#' + prefix + '_filters .panel').each(function() {
         Mautic.updateFilterPositioning(mQuery(this).find('select.glue-select').first());
         mQuery(this).find('[id^="' + prefix + '_filters_"]').each(function() {
-            var id = mQuery(this).attr('id');
+            var id     = mQuery(this).attr('id');
+            var name   = mQuery(this).attr('name');
+            var suffix = id.split(/[_]+/).pop();
+
             if (prefix + '_filters___name___filter' === id) {
                 return true;
             }
 
-            var suffix = id.split(/[_]+/).pop();
+            var newName = prefix+'[filters]['+counter+']['+suffix+']';
+            if (name.slice(-2) === '[]') {
+                newName += '[]';
+            }
 
+            mQuery(this).attr('name', newName);
             mQuery(this).attr('id', prefix + '_filters_'+counter+'_'+suffix);
-            mQuery(this).attr('name', prefix + '[filters]['+counter+']['+suffix+']');
+
+            // Destroy the chosen and recreate
+            if (mQuery(this).is('select') && suffix == "filter") {
+                Mautic.destroyChosen(mQuery(this));
+                Mautic.activateChosenSelect(mQuery(this));
+            }
         });
 
         ++counter;
@@ -469,9 +481,7 @@ Mautic.convertLeadFilterInput = function(el) {
         }
 
         // Destroy the chosen and recreate
-        if (mQuery(filterId + '_chosen').length) {
-            mQuery(filterId).chosen('destroy');
-        }
+        Mautic.destroyChosen(mQuery(filterId));
 
         mQuery(filterId).attr('data-placeholder', placeholder);
 
@@ -766,7 +776,7 @@ Mautic.updateLeadFieldProperties = function(selectedVal, onload) {
     if (defaultValueField.hasClass('calendar-activated')) {
         defaultValueField.datetimepicker('destroy').removeClass('calendar-activated');
     } else if (mQuery('#leadfield_defaultValue_chosen').length) {
-        mQuery('#leadfield_defaultValue').chosen('destroy');
+        Mautic.destroyChosen(defaultValueField);
     }
 
     var defaultFieldType = mQuery('input[name="leadfield[defaultValue]"]').attr('type');
@@ -1442,4 +1452,4 @@ Mautic.setAsPrimaryCompany = function (companyId,leadId){
 
         }
     });
-}
+};

--- a/app/bundles/ReportBundle/Assets/js/report.js
+++ b/app/bundles/ReportBundle/Assets/js/report.js
@@ -209,9 +209,7 @@ Mautic.updateReportFilterValueInput = function (filterColumn, setup) {
     }
 
     // Replace the value field appropriately
-    if (mQuery('#' + valueId + '_chosen').length) {
-        mQuery('#' + valueId).chosen('destroy');
-    }
+    Mautic.destroyChosen(mQuery('#' + valueId));
 
     if (filterType == 'bool' || filterType == 'boolean') {
         if (mQuery(valueEl).attr('type') != 'radio') {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5026 & https://github.com/mautic/mautic/issues/6683
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR correct two front bug in segment filter view.

The new function `Mautic.destroyChosen` allows for better performance by removing all the old events from the chosen plugin. Because before on every `activateChosenSelect`, all events were duplicated.

![duplicatedevents](https://user-images.githubusercontent.com/27768270/47287784-b8dc1380-d5f3-11e8-8f7c-c5d72c9c9986.PNG)


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
**1st Bug**
1. Create a custom field with `multiselect type` and `multiple values`
2. Create a segment and add filter with the previous custom field
3. In the filter operator choose `empty`
4. Drag & drop the filter line
5. Change operator to `including`
6. Bug: Value is stuck and you can't use it

**2nd Bug**
1. Create a custom field with `multiselect type` and `multiple values`
2. Create a segment and add filter with the previous custom field
3. In the filter operator choose `including`
4. Select two or more values
4. Drag & drop the filter line
6. Click on `Apply`
7. Bug: Return to filter view and see that only one filter value is saved

#### Steps to test this PR:
1. Apply PR
2. Repeat step above
3. Change operator on field, it's work
4. Save segment and return to filter view and see that all filter values is saved.
