### PR TITLE
Handle error in PageSubscriber on page hit

### DIFF
--- a/app/bundles/PageBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PageSubscriber.php
@@ -195,7 +195,12 @@ class PageSubscriber extends CommonSubscriber
         $page                   = $pageId ? $pageRepo->find((int) $pageId) : null;
         $lead                   = $leadId ? $leadRepo->find((int) $leadId) : null;
 
-        $this->pageModel->processPageHit($hit, $page, $request, $lead, $trackingNewlyGenerated, false);
-        $event->setResult(QueueConsumerResults::ACKNOWLEDGE);
+        if ($hit != null && $lead != null) {
+          $this->pageModel->processPageHit($hit, $page, $request, $lead, $trackingNewlyGenerated, false);
+          $event->setResult(QueueConsumerResults::ACKNOWLEDGE);
+        } else {
+          $this->factory->getLogger()->log('error', 'Error processing page hit ' . $pageId . ' for ' . $leadId);
+          $event->setResult(QueueConsumerResults::REJECT);
+        }
     }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| Automated tests included? | no
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: 
When there's a missing hit record, the whole page hit daemon gets stuck. This at least marks this job as rejected, and logs the error.

Related to #5452