### PR TITLE
Code improved from security perspective for the function `parse_ini_file` 

### DIFF
--- a/app/bundles/CoreBundle/Loader/TranslationLoader.php
+++ b/app/bundles/CoreBundle/Loader/TranslationLoader.php
@@ -103,8 +103,8 @@ class TranslationLoader extends ArrayLoader implements LoaderInterface
      */
     private function loadTranslations($catalogue, $locale, $file)
     {
-        $iniFile = $file->getRealpath();
-        $content = file_get_contents($iniFile);
+        $iniFile  = $file->getRealpath();
+        $content  = file_get_contents($iniFile);
         $messages = parse_ini_string($content, true);
         if (false === $messages) {
             // The translation file is corrupt

--- a/app/bundles/CoreBundle/Loader/TranslationLoader.php
+++ b/app/bundles/CoreBundle/Loader/TranslationLoader.php
@@ -103,8 +103,9 @@ class TranslationLoader extends ArrayLoader implements LoaderInterface
      */
     private function loadTranslations($catalogue, $locale, $file)
     {
-        $iniFile  = $file->getRealpath();
-        $messages = parse_ini_file($iniFile, true);
+        $iniFile = $file->getRealpath();
+        $content = file_get_contents($iniFile);
+        $messages = parse_ini_string($content, true);
         if (false === $messages) {
             // The translation file is corrupt
             if ('dev' === MAUTIC_ENV) {


### PR DESCRIPTION
…_string

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  YES
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Most of the servers nowadays block `parse_ini_file` function as it is dangerous from security perspective.
So replaced it with `file_get_contents` and `parse_ini_string`
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 