### PR TITLE
LIBXML_HTML_NOIMPLIED and LIBXML_HTML_NODEFDTD don't exist when libxml < 2.7.8

### DIFF
--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -959,6 +959,31 @@ class FormModel extends CommonFormModel
     }
 
     /**
+     * Consider Libxml < 2.7.8
+     *
+     * @param $html
+     *
+     * @return array
+     */
+    private function cleanHTML($html)
+    {
+      $dom = new DOMDocument();
+      if (defined('LIBXML_HTML_NOIMPLIED') && defined('LIBXML_HTML_NODEFDTD')){
+          $dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+          $html = $dom->saveHTML();
+        } else {
+          $dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+          // remove DOCTYPE, <html>, and <body> tags.
+          // use preg_replace to clean up DOCTYPE.
+          $html = $dom->saveHTML();
+          $html_start = strpos($html, '<html><body>') + 12;
+          $html_length = strpos($html, '</body></html>') - $html_start;
+          $html = substr($html, $html_start, $html_length);
+
+        }
+        return $html;
+    }
+    /**
      * Extract script from html.
      *
      * @param $html
@@ -968,8 +993,9 @@ class FormModel extends CommonFormModel
     private function extractScriptTag($html)
     {
         libxml_use_internal_errors(true);
+        $html = $this->cleanHTML($html);
         $dom = new DOMDocument();
-        $dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
         $items = $dom->getElementsByTagName('script');
 
         $scripts = [];
@@ -990,8 +1016,9 @@ class FormModel extends CommonFormModel
     private function removeScriptTag($html)
     {
         libxml_use_internal_errors(true);
+        $html = $this->cleanHTML($html);
         $dom = new DOMDocument();
-        $dom->loadHTML('<div>'.mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8').'</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $dom->loadHTML('<div>'.mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8').'</div>');
         $items = $dom->getElementsByTagName('script');
 
         $remove = [];
@@ -1022,8 +1049,9 @@ class FormModel extends CommonFormModel
     private function generateJsScript($html)
     {
         libxml_use_internal_errors(true);
+        $html = $this->cleanHTML($html);
         $dom = new DOMDocument();
-        $dom->loadHTML('<div>'.mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8').'</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $dom->loadHTML('<div>'.mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8').'</div>');
         $items = $dom->getElementsByTagName('script');
 
         $javascript = '';


### PR DESCRIPTION
[//]: # ( Invisible comment: 
IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
Before you create the issue:
IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
Search for similar report among other reported issues.
Learn how to troubleshoot at https://www.mautic.org/docs/en/tips/troubleshooting.html
Use drag&drop to attach images or other files )

## Bug Description
LIBXML_HTML_NOIMPLIED and LIBXML_HTML_NODEFDTD don't exist when liibxml is older than 2.7.8

This causes the forms to not render.

| Q   | A
| --- | ---
| Mautic version |  2.14.2
| PHP version |  7.1
| Browser | 

### Steps to reproduce
1.  Have Libxml < 2.7.8
2.  Preview form
3. Notice how form is not rendering. 
4. Check Logs
5. notice constants not defined: LIBXML_HTML_NODEFDTD and LIBXML_HTML_NOIMPLIED
 
### Log errors
```
[2018-10-25 16:41:20] mautic.NOTICE: PHP Notice - Use of undefined constant LIBXML_HTML_NODEFDTD - assumed 'LIBXML_HTML_NODEFDTD' - in file /home/sites/5a/2/20933a36e2/public_html/mautic/app/bundles/FormBundle/Model/FormModel.php - at line 972 [] []
[2018-10-25 16:41:20] mautic.WARNING: PHP Warning - DOMDocument::loadHTML() expects parameter 2 to be integer, string given - in file /home/sites/5a/2/20933a36e2/public_html/mautic/app/bundles/FormBundle/Model/FormModel.php - at line 972 [] []
[2018-10-25 16:41:20] mautic.NOTICE: PHP Notice - Use of undefined constant LIBXML_HTML_NOIMPLIED - assumed 'LIBXML_HTML_NOIMPLIED' - in file /home/sites/5a/2/20933a36e2/public_html/mautic/app/bundles/FormBundle/Model/FormModel.php - at line 1026 [] []
[2018-10-25 16:41:20] mautic.NOTICE: PHP Notice - Use of undefined constant LIBXML_HTML_NODEFDTD - assumed 'LIBXML_HTML_NODEFDTD' - in file /home/sites/5a/2/20933a36e2/public_html/mautic/app/bundles/FormBundle/Model/FormModel.php - at line 1026 [] []
[2018-10-25 16:41:20] mautic.WARNING: PHP Warning - DOMDocument::loadHTML() expects parameter 2 to be integer, string given - in file /home/sites/5a/2/20933a36e2/public_html/mautic/app/bundles/FormBundle/Model/FormModel.php - at line 1026 [] []
```
[//]: # ( Invisible comment:
Please check for related errors in the latest log file in [mautic root]/app/log/ and/or the web server's logs and post them here. Be sure to remove sensitive information if applicable. )