### PR TITLE
Add support for libxml < 2.7.8 in form integration

### DIFF
--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -959,7 +959,7 @@ class FormModel extends CommonFormModel
     }
 
     /**
-     * Load HTML consider Libxml < 2.7.8
+     * Load HTML consider Libxml < 2.7.8.
      *
      * @param $html
      */
@@ -973,7 +973,7 @@ class FormModel extends CommonFormModel
     }
 
     /**
-     * Save HTML consider Libxml < 2.7.8
+     * Save HTML consider Libxml < 2.7.8.
      *
      * @param $html
      *
@@ -985,7 +985,7 @@ class FormModel extends CommonFormModel
             return $dom->saveHTML($html);
         } else {
             // remove DOCTYPE, <html>, and <body> tags for old libxml
-            return preg_replace('/^<!DOCTYPE.+?>/', '', str_replace( array('<html>', '</html>', '<body>', '</body>'), array('', '', '', ''), $dom->saveHTML($html)));
+            return preg_replace('/^<!DOCTYPE.+?>/', '', str_replace(['<html>', '</html>', '<body>', '</body>'], ['', '', '', ''], $dom->saveHTML($html)));
         }
     }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | #6783
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Add support for old libxml version < 2.7.8 in form integration function.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Have a server with Libxml version < 2.7.8
2. Create a form in Mautic
3. Get the form with automatic method
4. See it's broken
5. Go inside log: notice constants not defined: LIBXML_HTML_NODEFDTD and LIBXML_HTML_NOIMPLIED

#### Steps to test this PR:
1. Apply PR
2. Refresh the form, it's good and there is no more notice inside log
