### PR TITLE
Don't use full viewParameters list when building returnUrl

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -967,8 +967,8 @@ class LeadController extends FormController
             return $this->postActionRedirect(
                 [
                     'returnUrl'       => $this->generateUrl('mautic_contact_action', [
-                        'objectId' => $lead->getId(),
-                        'objectAction' => 'view'
+                        'objectId'     => $lead->getId(),
+                        'objectAction' => 'view',
                     ]),
                     'viewParameters'  => $viewParameters,
                     'contentTemplate' => 'MauticLeadBundle:Lead:view',

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -966,7 +966,10 @@ class LeadController extends FormController
         if (true === $form) {
             return $this->postActionRedirect(
                 [
-                    'returnUrl'       => $this->generateUrl('mautic_contact_action', $viewParameters),
+                    'returnUrl'       => $this->generateUrl('mautic_contact_action', [
+                        'objectId' => $lead->getId(),
+                        'objectAction' => 'view'
+                    ]),
                     'viewParameters'  => $viewParameters,
                     'contentTemplate' => 'MauticLeadBundle:Lead:view',
                     'passthroughVars' => [


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? |N/A
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Some contacts have so many segments in the preferences form that the extraneous appended data exceeds the URL size limit causing this bug. Combine that with merging all segment data into the `viewParameters` [here](https://github.com/mautic/mautic/blob/staging/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php#L54), and it results in getting a huge referrer URL that breaks nginx

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
- Have your dev environment running on nginx with standard settings
- Have several (~25) segments created
- open a contact
- click the arrow in the top right and then click preferences
- On the segments tab, add the contact to all the segments
- click apply on the modal form
- notice that a lot of new parameters appeared in the url
- Refresh the page with the long URL and you should get an nginx "Request URI Too Long" error

#### Steps to test this PR:
1. Apply PR
2. Redo test steps
3. You'll see that the parameters are not appended to the URL and refreshing doesn't result in the error