### PR TITLE
Pass in a cache expire value for Dashboard Widgets in WidgetDetailEvent

### DIFF
--- a/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
@@ -166,8 +166,8 @@ class WidgetDetailEvent extends CommonEvent
         // Store the template data to the cache
         if (!$skipCache && $this->cacheDir && $this->widget->getCacheTimeout() > 0) {
             $cache = new CacheStorageHelper($this->cacheDir, $this->uniqueCacheDir);
-            // must pass a DateTime object or a int of unixtime to expire as 3rd attribute to set().
-            $expireTime = strtotime('now + '.$this->widget->getCacheTimeout().' minutes');
+            // must pass a DateTime object or a int of seconds to expire as 3rd attribute to set().
+            $expireTime = $this->widget->getCacheTimeout() * 60;
             $cache->set($this->getUniqueWidgetId(), $templateData, (int) $expireTime);
         }
     }

--- a/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
@@ -166,7 +166,7 @@ class WidgetDetailEvent extends CommonEvent
         // Store the template data to the cache
         if (!$skipCache && $this->cacheDir && $this->widget->getCacheTimeout() > 0) {
             $cache = new CacheStorageHelper($this->cacheDir, $this->uniqueCacheDir);
-            $cache->set($this->getUniqueWidgetId(), $templateData);
+            $cache->set($this->getUniqueWidgetId(), $templateData, $this->widget->getCacheTimeout());
         }
     }
 

--- a/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
@@ -166,7 +166,9 @@ class WidgetDetailEvent extends CommonEvent
         // Store the template data to the cache
         if (!$skipCache && $this->cacheDir && $this->widget->getCacheTimeout() > 0) {
             $cache = new CacheStorageHelper($this->cacheDir, $this->uniqueCacheDir);
-            $cache->set($this->getUniqueWidgetId(), $templateData, $this->widget->getCacheTimeout());
+            // must pass a DateTime object or a int of unixtime to expire as 3rd attribute to set().
+            $expireTime = strtotime('now + '.$this->widget->getCacheTimeout().' minutes');
+            $cache->set($this->getUniqueWidgetId(), $templateData, (int) $expireTime);
         }
     }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The Mautic Cache Storage Helper contains a 3rd parameter as input for a cache Expiration, which would get forwarded to the Symfony Cache set method expiresAfter() (as either a DateTime object or integer representing seconds. However, the Dashboard Widget setTemplateData, which checks for a widget cacheTimout doesnt pass that value through when its greater than 0. This PR will pass in the value (as set in miutes) and convert it to seconds.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. set system default cache value
       alternatively, set a cache value to a widget (manually in the DB or programatically in the widget definition.
2. clear all app cache
3. load dashboard -> widget should load from database; 
4. Navigate to the cache directory on the system and find the cache file and examine the expirary timestamp in the file (first line of file). translate the timsestamp to a DateTime and see if it matches your default cache TTL (it will likely be One year out in the future and NOT the TTL)

#### Steps to test this PR:
1. set system default cache value
       alternatively, set a cache value to a widget (manually in the DB or programatically in the widget definition.
2. clear all app cache
3. load dashboard -> widget should load from database; 
4. reload dashboard -> widget should load from cache
5. Wait until expiration occurs
6. reload dashboard -> widget should load from database 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 