### PR TITLE
Fixes campaign interval tests and fixes minor bug with scheduling

### DIFF
--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -331,7 +331,13 @@ class Interval implements ScheduleModeInterface
         $testStopDateTime = clone $groupExecutionDate;
         $testStopDateTime->setTime($endTime->format('H'), $endTime->format('i'));
 
-        if ($groupExecutionDate < $testStartDateTime || $groupExecutionDate > $testStopDateTime) {
+        if ($groupExecutionDate < $testStartDateTime) {
+            // Too early so set it to the start date
+            return $testStartDateTime;
+        }
+
+        if ($groupExecutionDate > $testStopDateTime) {
+            // Too late so try again tomorrow
             $groupExecutionDate->modify('+1 day')->setTime($startTime->format('H'), $startTime->format('i'));
         }
 

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -96,6 +96,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
                     $this->assertCount(4, $groupExecutionDateDAO->getContacts());
                     $this->assertEquals([1, 2, 5, 6], $groupExecutionDateDAO->getContacts()->getKeys());
                     $this->assertEquals('13:00', $executionDate->format('H:i'));
+                    $this->adjustForDST($scheduledExecutionDate, $executionDate);
                     $diff = $scheduledExecutionDate->diff($executionDate);
 
                     // This was within the time range for all contacts so should be 0
@@ -241,8 +242,8 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
                     $this->assertCount(4, $groupExecutionDateDAO->getContacts());
                     $this->assertEquals([1, 2, 5, 6], $groupExecutionDateDAO->getContacts()->getKeys());
                     $this->assertEquals('13:00', $executionDate->format('H:i'));
+                    $this->adjustForDST($scheduledExecutionDate, $executionDate);
                     $diff = $scheduledExecutionDate->diff($executionDate);
-
                     // This was within the time range for all contacts so should be 0
                     $this->assertEquals(0, $diff->h);
                     $this->assertEquals(2, $diff->d);
@@ -329,5 +330,21 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
         ]);
 
         return $contacts;
+    }
+
+    private function adjustForDST(\DateTime $leftDateTime, \DateTime $rightDateTime)
+    {
+        // DST hack
+        $springForward = new \DateTime('Second Sunday March');
+        if ($leftDateTime < $springForward && $rightDateTime >= $springForward) {
+            $rightDateTime->modify('+1 hour');
+
+            return;
+        }
+
+        $fallBack = new \DateTime('First Sunday November');
+        if ($leftDateTime < $fallBack && $rightDateTime >= $fallBack) {
+            $rightDateTime->modify('-1 hour');
+        }
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -332,9 +332,18 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
         return $contacts;
     }
 
+    /**
+     * Because the test is comparing hour differences, there is the chance that a future date is after the US changes time for daylights savings time.
+     * This causes the expected hour to be off by one hour depending on if the date is during the "fall back" or "spring forward" DST change.
+     *
+     * @param \DateTime $leftDateTime
+     * @param \DateTime $rightDateTime
+     */
     private function adjustForDST(\DateTime $leftDateTime, \DateTime $rightDateTime)
     {
         // DST hack
+
+        // DST goes into effect causing there to be an extra hour that must be accounted for
         $springForward = new \DateTime('Second Sunday March');
         if ($leftDateTime < $springForward && $rightDateTime >= $springForward) {
             $rightDateTime->modify('+1 hour');
@@ -342,6 +351,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
             return;
         }
 
+        // DST is reverted causing there to be an less that must be accounted for
         $fallBack = new \DateTime('First Sunday November');
         if ($leftDateTime < $fallBack && $rightDateTime >= $fallBack) {
             $rightDateTime->modify('-1 hour');

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -21,7 +21,7 @@ use Psr\Log\NullLogger;
 
 class IntervalTest extends \PHPUnit_Framework_TestCase
 {
-    public function testRelativeHour()
+    public function testRescheduledToDueBeingBeforeSpecificHourRestriction()
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -40,32 +40,93 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
             ->willReturn($campaign);
 
         $interval = $this->getInterval();
-        $grouped  = $interval->groupContactsByDate($event, $this->getContacts(), new \DateTime('+1 day'));
 
-        foreach ($grouped as $groupExecutionDateDAO) {
-            $executionDate = $groupExecutionDateDAO->getExecutionDate();
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+            ->willReturn(1);
+        $contact1->method('getTimezone')
+            ->willReturn('America/Los_Angeles');
+        $contacts = new ArrayCollection([$contact1]);
 
-            switch ($executionDate->getTimezone()->getName()) {
-                case 'America/Los_Angeles':
-                    $this->assertCount(2, $groupExecutionDateDAO->getContacts());
-                    $this->assertEquals([1, 2], $groupExecutionDateDAO->getContacts()->getKeys());
-                    $this->assertEquals('09:00', $executionDate->format('H:i'));
-                    break;
-                case 'Africa/Johannesburg':
-                    $this->assertCount(2, $groupExecutionDateDAO->getContacts());
-                    $this->assertEquals([3, 4], $groupExecutionDateDAO->getContacts()->getKeys());
-                    $this->assertEquals('09:00', $executionDate->format('H:i'));
-                    break;
-                case 'America/New_York':
-                    $this->assertCount(2, $groupExecutionDateDAO->getContacts());
-                    $this->assertEquals([5, 6], $groupExecutionDateDAO->getContacts()->getKeys());
-                    $this->assertEquals('09:00', $executionDate->format('H:i'));
-                    break;
-            }
-        }
+        $grouped    = $interval->groupContactsByDate($event, $contacts, new \DateTime('2018-10-18 07:00:00', new \DateTimeZone('America/Los_Angeles')));
+        $firstGroup = reset($grouped);
+
+        $executionDate = $firstGroup->getExecutionDate();
+
+        $this->assertEquals('2018-10-18 09:00', $executionDate->format('Y-m-d H:i'));
     }
 
-    public function testRelativeStartEndHours()
+    public function testRescheduledDueToBeingAfterSpecificHourRestriction()
+    {
+        $campaign = $this->createMock(Campaign::class);
+        $campaign->method('getId')
+            ->willReturn(1);
+
+        $event = $this->createMock(Event::class);
+        $event->method('getTriggerMode')
+            ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerHour')
+            ->willReturn(
+                new \DateTime('1970-01-01 09:00:00')
+            );
+        $event->method('getTriggerRestrictedDaysOfWeek')
+            ->willReturn([]);
+        $event->method('getCampaign')
+            ->willReturn($campaign);
+
+        $interval = $this->getInterval();
+
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+            ->willReturn(1);
+        $contact1->method('getTimezone')
+            ->willReturn('America/Los_Angeles');
+        $contacts = new ArrayCollection([$contact1]);
+
+        $grouped    = $interval->groupContactsByDate($event, $contacts, new \DateTime('2018-10-18 10:00:00', new \DateTimeZone('America/Los_Angeles')));
+        $firstGroup = reset($grouped);
+
+        $executionDate = $firstGroup->getExecutionDate();
+
+        $this->assertEquals('2018-10-18 09:00', $executionDate->format('Y-m-d H:i'));
+    }
+
+    public function testNotRescheduledDueToSpecificHourRestriction()
+    {
+        $campaign = $this->createMock(Campaign::class);
+        $campaign->method('getId')
+            ->willReturn(1);
+
+        $event = $this->createMock(Event::class);
+        $event->method('getTriggerMode')
+            ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerHour')
+            ->willReturn(
+                new \DateTime('1970-01-01 09:00:00')
+            );
+        $event->method('getTriggerRestrictedDaysOfWeek')
+            ->willReturn([]);
+        $event->method('getCampaign')
+            ->willReturn($campaign);
+
+        $interval = $this->getInterval();
+
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+            ->willReturn(1);
+        $contact1->method('getTimezone')
+            ->willReturn('America/New_York');
+        $contacts = new ArrayCollection([$contact1]);
+
+        $grouped       = $interval->groupContactsByDate($event, $contacts, new \DateTime('2018-10-18 6:00:00', new \DateTimeZone('America/Los_Angeles')));
+        $firstGroup    = reset($grouped);
+        $executionDate = $firstGroup->getExecutionDate();
+
+        // 6am pacific = 9am eastern so don't reschedule
+        $this->assertEquals('2018-10-18 09:00', $executionDate->format('Y-m-d H:i'));
+    }
+
+    public function testRescheduledToSameDayDueToStartHourRestriction()
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -82,138 +143,29 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
             ->willReturn([]);
         $event->method('getCampaign')
             ->willReturn($campaign);
+
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+            ->willReturn(1);
+        $contact1->method('getTimezone')
+            ->willReturn('America/New_York');
+        $contacts = new ArrayCollection([$contact1]);
 
         $interval               = $this->getInterval();
-        $scheduledExecutionDate = new \DateTime('16:00', new \DateTimeZone('America/New_York'));
-        $grouped                = $interval->groupContactsByDate($event, $this->getContacts(), $scheduledExecutionDate);
+        $scheduledExecutionDate = new \DateTime('2018-10-18 07:00', new \DateTimeZone('America/New_York'));
+        $grouped                = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
 
-        foreach ($grouped as $groupExecutionDateDAO) {
-            $executionDate = $groupExecutionDateDAO->getExecutionDate();
+        $firstGroup    = reset($grouped);
+        $executionDate = $firstGroup->getExecutionDate();
 
-            switch ($executionDate->getTimezone()->getName()) {
-                case 'America/Los_Angeles':
-                    // New York is scheduled at 4pm it's time where Los Angeles at 1pm it's time which is the same time
-                    $this->assertCount(4, $groupExecutionDateDAO->getContacts());
-                    $this->assertEquals([1, 2, 5, 6], $groupExecutionDateDAO->getContacts()->getKeys());
-                    $this->assertEquals('13:00', $executionDate->format('H:i'));
-                    $this->adjustForDST($scheduledExecutionDate, $executionDate);
-                    $diff = $scheduledExecutionDate->diff($executionDate);
-
-                    // This was within the time range for all contacts so should be 0
-                    $this->assertEquals(0, $diff->h);
-                    $this->assertEquals(0, $diff->d);
-                    break;
-                case 'Africa/Johannesburg':
-                    $this->assertCount(2, $groupExecutionDateDAO->getContacts());
-                    $this->assertEquals([3, 4], $groupExecutionDateDAO->getContacts()->getKeys());
-                    $this->assertEquals('10:00', $executionDate->format('H:i'));
-                    // Johannesburg should be 12 hours difference because 4pm ET their time is 10pm which is after hours so it should be sent
-                    // at 10am instead
-                    $diff = $scheduledExecutionDate->diff($executionDate);
-                    $this->assertEquals(12, $diff->h);
-                    $this->assertEquals(0, $diff->d);
-
-                    break;
-            }
-        }
+        $this->assertEquals('2018-10-18 10:00', $executionDate->format('Y-m-d H:i'));
     }
 
-    public function testRelativeDayOfWeek()
+    public function testIsNotRescheduledDueToStartAndStopHourRestrictions()
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
             ->willReturn(1);
-
-        $scheduledExecutionDate = new \DateTime('now');
-        $inTwoDays              = clone $scheduledExecutionDate;
-        $inTwoDays->modify('+2 days');
-
-        $dow = $inTwoDays->format('w');
-
-        $event = $this->createMock(Event::class);
-        $event->method('getTriggerMode')
-            ->willReturn(Event::TRIGGER_MODE_INTERVAL);
-        $event->method('getTriggerRestrictedDaysOfWeek')
-            ->willReturn([$dow]);
-        $event->method('getCampaign')
-            ->willReturn($campaign);
-
-        $interval = $this->getInterval();
-        $grouped  = $interval->groupContactsByDate($event, $this->getContacts(), $scheduledExecutionDate);
-
-        foreach ($grouped as $groupExecutionDateDAO) {
-            // Everyone should be on the same day
-            $this->assertCount(6, $groupExecutionDateDAO->getContacts());
-
-            // The scheduled date should not be the same day of the week we set getTriggerRestrictedDaysOfWeek
-            $this->assertEquals($dow, $groupExecutionDateDAO->getExecutionDate()->format('w'));
-        }
-    }
-
-    public function testHourWithDaysOfWeek()
-    {
-        $campaign = $this->createMock(Campaign::class);
-        $campaign->method('getId')
-            ->willReturn(1);
-
-        $scheduledExecutionDate = new \DateTime('now');
-        $inTwoDays              = clone $scheduledExecutionDate;
-        $inTwoDays->modify('+2 days');
-
-        $dow = $inTwoDays->format('w');
-
-        $event = $this->createMock(Event::class);
-        $event->method('getTriggerMode')
-            ->willReturn(Event::TRIGGER_MODE_INTERVAL);
-        $event->method('getTriggerHour')
-            ->willReturn(
-                new \DateTime('1970-01-01 09:00:00')
-            );
-        $event->method('getTriggerRestrictedDaysOfWeek')
-            ->willReturn([$dow]);
-        $event->method('getCampaign')
-            ->willReturn($campaign);
-
-        $interval = $this->getInterval();
-        $grouped  = $interval->groupContactsByDate($event, $this->getContacts(), $scheduledExecutionDate);
-
-        foreach ($grouped as $groupExecutionDateDAO) {
-            $executionDate = $groupExecutionDateDAO->getExecutionDate();
-
-            // Should be on the allowed DOW
-            $this->assertEquals($dow, $executionDate->format('w'));
-
-            switch ($executionDate->getTimezone()->getName()) {
-                case 'America/Los_Angeles':
-                    $this->assertCount(2, $groupExecutionDateDAO->getContacts());
-                    $this->assertEquals([1, 2], $groupExecutionDateDAO->getContacts()->getKeys());
-                    $this->assertEquals('09:00', $executionDate->format('H:i'));
-                    break;
-                case 'Africa/Johannesburg':
-                    $this->assertCount(2, $groupExecutionDateDAO->getContacts());
-                    $this->assertEquals([3, 4], $groupExecutionDateDAO->getContacts()->getKeys());
-                    $this->assertEquals('09:00', $executionDate->format('H:i'));
-                    break;
-                case 'America/New_York':
-                    $this->assertCount(2, $groupExecutionDateDAO->getContacts());
-                    $this->assertEquals([5, 6], $groupExecutionDateDAO->getContacts()->getKeys());
-                    $this->assertEquals('09:00', $executionDate->format('H:i'));
-                    break;
-            }
-        }
-    }
-
-    public function testRelativeStartEndHoursWithDaysOfWeek()
-    {
-        $campaign = $this->createMock(Campaign::class);
-        $campaign->method('getId')
-            ->willReturn(1);
-
-        $scheduledExecutionDate = new \DateTime('16:00', new \DateTimeZone('America/New_York'));
-        $inTwoDays              = clone $scheduledExecutionDate;
-        $inTwoDays->modify('+2 days');
-
-        $dow = $inTwoDays->format('w');
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
@@ -223,41 +175,488 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
         $event->method('getTriggerRestrictedStopHour')
             ->willReturn(new \DateTime('1970-01-01 20:00:00'));
         $event->method('getTriggerRestrictedDaysOfWeek')
-            ->willReturn([$dow]);
+            ->willReturn([]);
+        $event->method('getCampaign')
+            ->willReturn($campaign);
+
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+            ->willReturn(1);
+        $contact1->method('getTimezone')
+            ->willReturn('America/New_York');
+        $contacts = new ArrayCollection([$contact1]);
+
+        $interval               = $this->getInterval();
+        $scheduledExecutionDate = new \DateTime('2018-10-18 11:00', new \DateTimeZone('America/New_York'));
+        $grouped                = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
+
+        $firstGroup    = reset($grouped);
+        $executionDate = $firstGroup->getExecutionDate();
+
+        $this->assertEquals('2018-10-18 11:00', $executionDate->format('Y-m-d H:i'));
+    }
+
+    public function testRescheduledToNextDayDueToStopHourRestriction()
+    {
+        $campaign = $this->createMock(Campaign::class);
+        $campaign->method('getId')
+            ->willReturn(1);
+
+        $event = $this->createMock(Event::class);
+        $event->method('getTriggerMode')
+            ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerRestrictedStartHour')
+            ->willReturn(new \DateTime('1970-01-01 10:00:00'));
+        $event->method('getTriggerRestrictedStopHour')
+            ->willReturn(new \DateTime('1970-01-01 20:00:00'));
+        $event->method('getTriggerRestrictedDaysOfWeek')
+            ->willReturn([]);
+        $event->method('getCampaign')
+            ->willReturn($campaign);
+
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+            ->willReturn(1);
+        $contact1->method('getTimezone')
+            ->willReturn('America/New_York');
+        $contacts = new ArrayCollection([$contact1]);
+
+        $interval               = $this->getInterval();
+        $scheduledExecutionDate = new \DateTime('2018-10-18 21:00', new \DateTimeZone('America/New_York'));
+        $grouped                = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
+
+        $firstGroup    = reset($grouped);
+        $executionDate = $firstGroup->getExecutionDate();
+
+        $this->assertEquals('2018-10-19 10:00', $executionDate->format('Y-m-d H:i'));
+    }
+
+    public function testRescheduledDueDayOfWeekRestriction()
+    {
+        $campaign = $this->createMock(Campaign::class);
+        $campaign->method('getId')
+            ->willReturn(1);
+
+        // Thursday/4
+        $scheduledExecutionDate = new \DateTime('2018-10-18 10:00:00', new \DateTimeZone('America/New_York'));
+
+        $event = $this->createMock(Event::class);
+        $event->method('getTriggerMode')
+            ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getCampaign')
+            ->willReturn($campaign);
+        // Only send on Saturday
+        $event->method('getTriggerRestrictedDaysOfWeek')
+            ->willReturn([6]);
+
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+            ->willReturn(1);
+        $contact1->method('getTimezone')
+            ->willReturn('America/New_York');
+        $contacts = new ArrayCollection([$contact1]);
+
+        $interval = $this->getInterval();
+        $grouped  = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
+
+        $firstGroup    = reset($grouped);
+        $executionDate = $firstGroup->getExecutionDate();
+
+        $this->assertEquals('2018-10-20 10:00', $executionDate->format('Y-m-d H:i'));
+    }
+
+    public function testNotRescheduledDueDayOfWeekRestriction()
+    {
+        $campaign = $this->createMock(Campaign::class);
+        $campaign->method('getId')
+            ->willReturn(1);
+
+        // Thursday/4
+        $scheduledExecutionDate = new \DateTime('2018-10-18 10:00:00', new \DateTimeZone('America/New_York'));
+
+        $event = $this->createMock(Event::class);
+        $event->method('getTriggerMode')
+            ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getCampaign')
+            ->willReturn($campaign);
+        $event->method('getTriggerRestrictedDaysOfWeek')
+            ->willReturn([4]);
+
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+            ->willReturn(1);
+        $contact1->method('getTimezone')
+            ->willReturn('America/New_York');
+        $contacts = new ArrayCollection([$contact1]);
+
+        $interval = $this->getInterval();
+        $grouped  = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
+
+        $firstGroup    = reset($grouped);
+        $executionDate = $firstGroup->getExecutionDate();
+
+        $this->assertEquals('2018-10-18 10:00', $executionDate->format('Y-m-d H:i'));
+    }
+
+    public function testRescheduledDueToSpecificHourAndDayOfWeekRestrictions()
+    {
+        $campaign = $this->createMock(Campaign::class);
+        $campaign->method('getId')
+            ->willReturn(1);
+
+        // Thursday/4
+        $scheduledExecutionDate = new \DateTime('2018-10-18 10:00:00', new \DateTimeZone('America/New_York'));
+
+        $event = $this->createMock(Event::class);
+        $event->method('getTriggerMode')
+            ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerHour')
+            ->willReturn(
+                new \DateTime('1970-01-01 09:00:00')
+            );
+        $event->method('getTriggerRestrictedDaysOfWeek')
+            ->willReturn([6]);
+        $event->method('getCampaign')
+            ->willReturn($campaign);
+
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+            ->willReturn(1);
+        $contact1->method('getTimezone')
+            ->willReturn('America/New_York');
+        $contacts = new ArrayCollection([$contact1]);
+
+        $interval = $this->getInterval();
+        $grouped  = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
+
+        $firstGroup    = reset($grouped);
+        $executionDate = $firstGroup->getExecutionDate();
+
+        $this->assertEquals('2018-10-20 09:00', $executionDate->format('Y-m-d H:i'));
+    }
+
+    public function testNotRescheduledDueToSpecificHourAndDayOfWeekRestrictions()
+    {
+        $campaign = $this->createMock(Campaign::class);
+        $campaign->method('getId')
+            ->willReturn(1);
+
+        // Thursday/4
+        $scheduledExecutionDate = new \DateTime('2018-10-18 10:00:00', new \DateTimeZone('America/New_York'));
+
+        $event = $this->createMock(Event::class);
+        $event->method('getTriggerMode')
+            ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerHour')
+            ->willReturn(
+                new \DateTime('1970-01-01 10:00:00')
+            );
+        $event->method('getTriggerRestrictedDaysOfWeek')
+            ->willReturn([4]);
+        $event->method('getCampaign')
+            ->willReturn($campaign);
+
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+            ->willReturn(1);
+        $contact1->method('getTimezone')
+            ->willReturn('America/New_York');
+        $contacts = new ArrayCollection([$contact1]);
+
+        $interval = $this->getInterval();
+        $grouped  = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
+
+        $firstGroup    = reset($grouped);
+        $executionDate = $firstGroup->getExecutionDate();
+
+        $this->assertEquals('2018-10-18 10:00', $executionDate->format('Y-m-d H:i'));
+    }
+
+    public function testRescheduledDueToStartEndHoursAndDayOfWeekRestrictions()
+    {
+        $campaign = $this->createMock(Campaign::class);
+        $campaign->method('getId')
+            ->willReturn(1);
+
+        // Thursday/4
+        $scheduledExecutionDate = new \DateTime('2018-10-18 9:00:00', new \DateTimeZone('America/New_York'));
+
+        $event = $this->createMock(Event::class);
+        $event->method('getTriggerMode')
+            ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerRestrictedStartHour')
+            ->willReturn(new \DateTime('1970-01-01 10:00:00'));
+        $event->method('getTriggerRestrictedStopHour')
+            ->willReturn(new \DateTime('1970-01-01 20:00:00'));
+        $event->method('getTriggerRestrictedDaysOfWeek')
+            ->willReturn([6]);
+        $event->method('getCampaign')
+            ->willReturn($campaign);
+
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+            ->willReturn(1);
+        $contact1->method('getTimezone')
+            ->willReturn('America/New_York');
+        $contacts = new ArrayCollection([$contact1]);
+
+        $interval = $this->getInterval();
+        $grouped  = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
+
+        $firstGroup    = reset($grouped);
+        $executionDate = $firstGroup->getExecutionDate();
+
+        $this->assertEquals('2018-10-20 10:00', $executionDate->format('Y-m-d H:i'));
+    }
+
+    public function testNotRescheduledDueToStartEndHoursAndDayOfWeekRestrictions()
+    {
+        $campaign = $this->createMock(Campaign::class);
+        $campaign->method('getId')
+            ->willReturn(1);
+
+        // Thursday/4
+        $scheduledExecutionDate = new \DateTime('2018-10-18 11:00:00', new \DateTimeZone('America/New_York'));
+
+        $event = $this->createMock(Event::class);
+        $event->method('getTriggerMode')
+            ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerRestrictedStartHour')
+            ->willReturn(new \DateTime('1970-01-01 10:00:00'));
+        $event->method('getTriggerRestrictedStopHour')
+            ->willReturn(new \DateTime('1970-01-01 20:00:00'));
+        $event->method('getTriggerRestrictedDaysOfWeek')
+            ->willReturn([4]);
+        $event->method('getCampaign')
+            ->willReturn($campaign);
+
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+            ->willReturn(1);
+        $contact1->method('getTimezone')
+            ->willReturn('America/New_York');
+        $contacts = new ArrayCollection([$contact1]);
+
+        $interval = $this->getInterval();
+        $grouped  = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
+
+        $firstGroup    = reset($grouped);
+        $executionDate = $firstGroup->getExecutionDate();
+
+        $this->assertEquals('2018-10-18 11:00', $executionDate->format('Y-m-d H:i'));
+    }
+
+    public function testRescheduledDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyDowViolation()
+    {
+        $campaign = $this->createMock(Campaign::class);
+        $campaign->method('getId')
+            ->willReturn(1);
+
+        // Thursday/4
+        $scheduledExecutionDate = new \DateTime('2018-10-18 10:00:00', new \DateTimeZone('America/New_York'));
+
+        $event = $this->createMock(Event::class);
+        $event->method('getTriggerMode')
+            ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerRestrictedStartHour')
+            ->willReturn(new \DateTime('1970-01-01 10:00:00'));
+        $event->method('getTriggerRestrictedStopHour')
+            ->willReturn(new \DateTime('1970-01-01 20:00:00'));
+        $event->method('getTriggerRestrictedDaysOfWeek')
+            ->willReturn([6]);
+        $event->method('getCampaign')
+            ->willReturn($campaign);
+
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+            ->willReturn(1);
+        $contact1->method('getTimezone')
+            ->willReturn('America/New_York');
+        $contacts = new ArrayCollection([$contact1]);
+
+        $interval = $this->getInterval();
+        $grouped  = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
+
+        $firstGroup    = reset($grouped);
+        $executionDate = $firstGroup->getExecutionDate();
+
+        $this->assertEquals('2018-10-20 10:00', $executionDate->format('Y-m-d H:i'));
+    }
+
+    public function testRescheduledToSameDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyStartHourViolation()
+    {
+        $campaign = $this->createMock(Campaign::class);
+        $campaign->method('getId')
+            ->willReturn(1);
+
+        // Thursday/4
+        $scheduledExecutionDate = new \DateTime('2018-10-18 08:00:00', new \DateTimeZone('America/New_York'));
+
+        $event = $this->createMock(Event::class);
+        $event->method('getTriggerMode')
+            ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerRestrictedStartHour')
+            ->willReturn(new \DateTime('1970-01-01 10:00:00'));
+        $event->method('getTriggerRestrictedStopHour')
+            ->willReturn(new \DateTime('1970-01-01 20:00:00'));
+        $event->method('getTriggerRestrictedDaysOfWeek')
+            ->willReturn([4]);
+        $event->method('getCampaign')
+            ->willReturn($campaign);
+
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+            ->willReturn(1);
+        $contact1->method('getTimezone')
+            ->willReturn('America/New_York');
+        $contacts = new ArrayCollection([$contact1]);
+
+        $interval = $this->getInterval();
+        $grouped  = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
+
+        $firstGroup    = reset($grouped);
+        $executionDate = $firstGroup->getExecutionDate();
+
+        $this->assertEquals('2018-10-18 10:00', $executionDate->format('Y-m-d H:i'));
+    }
+
+    public function testRescheduledToNextDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyEndHourViolation()
+    {
+        $campaign = $this->createMock(Campaign::class);
+        $campaign->method('getId')
+            ->willReturn(1);
+
+        // Thursday/4
+        $scheduledExecutionDate = new \DateTime('2018-10-18 21:00:00', new \DateTimeZone('America/New_York'));
+
+        $event = $this->createMock(Event::class);
+        $event->method('getTriggerMode')
+            ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerRestrictedStartHour')
+            ->willReturn(new \DateTime('1970-01-01 10:00:00'));
+        $event->method('getTriggerRestrictedStopHour')
+            ->willReturn(new \DateTime('1970-01-01 20:00:00'));
+        $event->method('getTriggerRestrictedDaysOfWeek')
+            ->willReturn([4, 5]);
+        $event->method('getCampaign')
+            ->willReturn($campaign);
+
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+            ->willReturn(1);
+        $contact1->method('getTimezone')
+            ->willReturn('America/New_York');
+        $contacts = new ArrayCollection([$contact1]);
+
+        $interval = $this->getInterval();
+        $grouped  = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
+
+        $firstGroup    = reset($grouped);
+        $executionDate = $firstGroup->getExecutionDate();
+
+        $this->assertEquals('2018-10-18 10:00', $executionDate->format('Y-m-d H:i'));
+    }
+
+    public function testContactsAreGrouped()
+    {
+        $campaign = $this->createMock(Campaign::class);
+        $campaign->method('getId')
+            ->willReturn(1);
+
+        $event = $this->createMock(Event::class);
+        $event->method('getTriggerMode')
+            ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerHour')
+            ->willReturn(
+                new \DateTime('1970-01-01 06:00:00')
+            );
+        $event->method('getTriggerRestrictedDaysOfWeek')
+            ->willReturn([]);
         $event->method('getCampaign')
             ->willReturn($campaign);
 
         $interval = $this->getInterval();
-        $grouped  = $interval->groupContactsByDate($event, $this->getContacts(), $scheduledExecutionDate);
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+            ->willReturn(1);
+        $contact1->method('getTimezone')
+            ->willReturn('America/Los_Angeles');
+
+        $contact2 = $this->createMock(Lead::class);
+        $contact2->method('getId')
+            ->willReturn(2);
+        $contact2->method('getTimezone')
+            ->willReturn('America/Los_Angeles');
+
+        $contact3 = $this->createMock(Lead::class);
+        $contact3->method('getId')
+            ->willReturn(3);
+        $contact3->method('getTimezone')
+            ->willReturn('America/North_Dakota/Center');
+
+        $contact4 = $this->createMock(Lead::class);
+        $contact4->method('getId')
+            ->willReturn(4);
+        $contact4->method('getTimezone')
+            ->willReturn('America/North_Dakota/Center');
+
+        $contact5 = $this->createMock(Lead::class);
+        $contact5->method('getId')
+            ->willReturn(5);
+        $contact5->method('getTimezone')
+            ->willReturn(''); // use default of New_York
+
+        $contact6 = $this->createMock(Lead::class);
+        $contact6->method('getId')
+            ->willReturn(6);
+        $contact6->method('getTimezone')
+            ->willReturn(''); // use default of New_York
+
+        $contact7 = $this->createMock(Lead::class);
+        $contact7->method('getId')
+            ->willReturn(7);
+        $contact7->method('getTimezone')
+            ->willReturn('Bad/Timezone'); // use default of New_York
+
+        $contact8 = $this->createMock(Lead::class);
+        $contact8->method('getId')
+            ->willReturn(8);
+        $contact8->method('getTimezone')
+            ->willReturn('Bad/Timezone'); // use default of New_York
+
+        $contacts = new ArrayCollection([
+            1 => $contact1,
+            2 => $contact2,
+            3 => $contact3,
+            4 => $contact4,
+            5 => $contact5,
+            6 => $contact6,
+            7 => $contact7,
+            8 => $contact8,
+        ]);
+
+        $scheduledExecutionDate = new \DateTime('2018-10-18 6:00:00', new \DateTimeZone('America/Los_Angeles'));
+        $grouped                = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
+        $this->assertCount(3, $grouped);
 
         foreach ($grouped as $groupExecutionDateDAO) {
             $executionDate = $groupExecutionDateDAO->getExecutionDate();
 
-            // Should be on the allowed DOW
-            $this->assertEquals($dow, $executionDate->format('w'));
-
             switch ($executionDate->getTimezone()->getName()) {
                 case 'America/Los_Angeles':
-                    // New York is scheduled at 4pm it's time where Los Angeles at 1pm it's time which is the same time
-                    $this->assertCount(4, $groupExecutionDateDAO->getContacts());
-                    $this->assertEquals([1, 2, 5, 6], $groupExecutionDateDAO->getContacts()->getKeys());
-                    $this->assertEquals('13:00', $executionDate->format('H:i'));
-                    $this->adjustForDST($scheduledExecutionDate, $executionDate);
-                    $diff = $scheduledExecutionDate->diff($executionDate);
-                    // This was within the time range for all contacts so should be 0
-                    $this->assertEquals(0, $diff->h);
-                    $this->assertEquals(2, $diff->d);
+                    $this->assertCount(2, $groupExecutionDateDAO->getContacts());
+                    $this->assertEquals([1, 2], $groupExecutionDateDAO->getContacts()->getKeys());
+                    $this->assertEquals('2018-10-18 06:00', $executionDate->format('Y-m-d H:i'));
                     break;
-                case 'Africa/Johannesburg':
+                case 'America/North_Dakota/Center':
                     $this->assertCount(2, $groupExecutionDateDAO->getContacts());
                     $this->assertEquals([3, 4], $groupExecutionDateDAO->getContacts()->getKeys());
-                    $this->assertEquals('10:00', $executionDate->format('H:i'));
-                    // Johannesburg should be 12 hours difference because 4pm ET their time is 10pm which is after hours so it should be sent
-                    // at 10am instead but also should be the expected weekday
-                    $diff = $scheduledExecutionDate->diff($executionDate);
-                    $this->assertEquals(12, $diff->h);
-                    $this->assertEquals(1, $diff->d);
-
+                    $this->assertEquals('2018-10-18 06:00', $executionDate->format('Y-m-d H:i'));
+                    break;
+                case 'America/New_York':
+                    $this->assertCount(4, $groupExecutionDateDAO->getContacts());
+                    $this->assertEquals([5, 6, 7, 8], $groupExecutionDateDAO->getContacts()->getKeys());
+                    $this->assertEquals('2018-10-18 06:00', $executionDate->format('Y-m-d H:i'));
                     break;
             }
         }
@@ -277,84 +676,5 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
             );
 
         return new Interval(new NullLogger(), $coreParametersHelper);
-    }
-
-    /**
-     * @return ArrayCollection
-     */
-    private function getContacts()
-    {
-        $contact1 = $this->createMock(Lead::class);
-        $contact1->method('getId')
-            ->willReturn(1);
-        $contact1->method('getTimezone')
-            ->willReturn('America/Los_Angeles');
-
-        $contact2 = $this->createMock(Lead::class);
-        $contact2->method('getId')
-            ->willReturn(2);
-        $contact2->method('getTimezone')
-            ->willReturn('America/Los_Angeles');
-
-        $contact3 = $this->createMock(Lead::class);
-        $contact3->method('getId')
-            ->willReturn(3);
-        $contact3->method('getTimezone')
-            ->willReturn('Africa/Johannesburg');
-
-        $contact4 = $this->createMock(Lead::class);
-        $contact4->method('getId')
-            ->willReturn(4);
-        $contact4->method('getTimezone')
-            ->willReturn('Africa/Johannesburg');
-
-        $contact5 = $this->createMock(Lead::class);
-        $contact5->method('getId')
-            ->willReturn(5);
-        $contact5->method('getTimezone')
-            ->willReturn('');
-
-        $contact6 = $this->createMock(Lead::class);
-        $contact6->method('getId')
-            ->willReturn(6);
-        $contact6->method('getTimezone')
-            ->willReturn('');
-
-        $contacts = new ArrayCollection([
-            1 => $contact1,
-            2 => $contact2,
-            3 => $contact3,
-            4 => $contact4,
-            5 => $contact5,
-            6 => $contact6,
-        ]);
-
-        return $contacts;
-    }
-
-    /**
-     * Because the test is comparing hour differences, there is the chance that a future date is after the US changes time for daylights savings time.
-     * This causes the expected hour to be off by one hour depending on if the date is during the "fall back" or "spring forward" DST change.
-     *
-     * @param \DateTime $leftDateTime
-     * @param \DateTime $rightDateTime
-     */
-    private function adjustForDST(\DateTime $leftDateTime, \DateTime $rightDateTime)
-    {
-        // DST hack
-
-        // DST goes into effect causing there to be an extra hour that must be accounted for
-        $springForward = new \DateTime('Second Sunday March');
-        if ($leftDateTime < $springForward && $rightDateTime >= $springForward) {
-            $rightDateTime->modify('+1 hour');
-
-            return;
-        }
-
-        // DST is reverted causing there to be an less that must be accounted for
-        $fallBack = new \DateTime('First Sunday November');
-        if ($leftDateTime < $fallBack && $rightDateTime >= $fallBack) {
-            $rightDateTime->modify('-1 hour');
-        }
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -554,7 +554,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
         $firstGroup    = reset($grouped);
         $executionDate = $firstGroup->getExecutionDate();
 
-        $this->assertEquals('2018-10-18 10:00', $executionDate->format('Y-m-d H:i'));
+        $this->assertEquals('2018-10-19 10:00', $executionDate->format('Y-m-d H:i'));
     }
 
     public function testContactsAreGrouped()


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Tests were failing again due to DST differences with Johannesburg which does not recognize DST

It also fixes a bug where if the scheduled time is earlier than the earliest allowed hour, it schedules for the same day at that hour. For example, if the "schedule at 10am" and it's 9am, the action should be scheduled 10am today rather than 10am tomorrow. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run the tests
2. Create a campaign and schedule an action with a start hour of one hour past the time it is currently (use any end hour as long)
3. Execute the campaign and notice it'll be scheduled for tomorrow at that time

#### Steps to test this PR:
1. Run the tests
2. Repeat above and it should schedule for today at the start time