### PR TITLE
Prevent SF from choking due to unsupported states

### DIFF
--- a/plugins/MauticCrmBundle/Integration/Salesforce/Helper/StateValidationHelper.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/Helper/StateValidationHelper.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://www.mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce\Helper;
+
+class StateValidationHelper
+{
+    private static $supportedCountriesWithStates = [
+        'United States',
+        'Canada',
+        'Australia',
+        'Brazil',
+        'China',
+        'India',
+        'Ireland',
+        'Italy',
+        'Mexico',
+    ];
+
+    /**
+     * Out of the box SF only supports states for the following countries. So in order to prevent SF from rejecting the entire payload, we'll
+     * only send state if it is supported out of the box by SF.
+     *
+     * @param array $mappedData
+     *
+     * @return array
+     */
+    public static function validate(array $mappedData)
+    {
+        if (!isset($mappedData['State'])) {
+            return $mappedData;
+        }
+
+        if (
+            !isset($mappedData['Country']) ||
+            !in_array($mappedData['Country'], self::$supportedCountriesWithStates)
+        ) {
+            unset($mappedData['State']);
+
+            return $mappedData;
+        }
+
+        return $mappedData;
+    }
+}

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -22,6 +22,7 @@ use MauticPlugin\MauticCrmBundle\Api\SalesforceApi;
 use MauticPlugin\MauticCrmBundle\Integration\Salesforce\CampaignMember\Fetcher;
 use MauticPlugin\MauticCrmBundle\Integration\Salesforce\CampaignMember\Organizer;
 use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Exception\NoObjectsToFetchException;
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Helper\StateValidationHelper;
 use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object\CampaignMember;
 use MauticPlugin\MauticCrmBundle\Integration\Salesforce\ResultsPaginator;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -1828,6 +1829,8 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 }
             }
 
+            $this->amendLeadDataBeforePush($body);
+
             if (!empty($body)) {
                 $url = '/services/data/v38.0/sobjects/'.$object;
                 if ($objectId) {
@@ -2557,6 +2560,14 @@ class SalesforceIntegration extends CrmAbstractIntegration
         }
 
         return $mappedData;
+    }
+
+    /**
+     * @param $mappedData
+     */
+    public function amendLeadDataBeforePush(&$mappedData)
+    {
+        $mappedData = StateValidationHelper::validate($mappedData);
     }
 
     /**

--- a/plugins/MauticCrmBundle/Tests/Integration/Salesforce/Helper/StateValidationHelperTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/Salesforce/Helper/StateValidationHelperTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://www.mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticCrmBundle\Tests\Integration\Salesforce\Helper;
+
+use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Helper\StateValidationHelper;
+
+class StateValidationHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testStateIsRemovedWhenCountryIsUnknown()
+    {
+        $payload = [
+            'State' => 'Paris',
+        ];
+
+        $this->assertEquals([], StateValidationHelper::validate($payload));
+    }
+
+    public function testStateIsRemovedWhenCountryIsNotSupported()
+    {
+        $payload = [
+            'Country' => 'France',
+            'State'   => 'Paris',
+        ];
+
+        $this->assertEquals(['Country' => 'France'], StateValidationHelper::validate($payload));
+    }
+
+    public function testStateIsLeftWhenCountryIsSupported()
+    {
+        $payload = [
+            'Country' => 'United States',
+            'State'   => 'Texas',
+        ];
+
+        $this->assertEquals($payload, StateValidationHelper::validate($payload));
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Mautic supports states/provinces for many countries where SF only supports specific ones "out of the box." This PR will unset the State if it is not for a SF supported company to prevent SF from rejecting the entire object when it has country/state picklists enabled.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup Salesforce plugin with push sync enabled
2. Map country and state and set it to push to SF (SF must have picklists enabled)
3. Create a new contact in Mautic and assign the country as France and state as Paris.
4. Run the sync and note the contact is not created in SF
5. Create a form with email, country and state (region) fields mapped
6. Add a push to integration form action and select SF
7. Fill in the form using France as the country and state as Paris
8. Notice the contact is not created in SF

#### Steps to test this PR:
1. Repeat but this time the contact will be created but without the ""state"
