### PR TITLE
Remove contacts from segments in batches to prevent RAM issues

### DIFF
--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -1043,7 +1043,7 @@ class ListModel extends FormModel
                 // Keep CPU down for large lists; sleep per $limit batch
                 $this->batchSleep();
 
-                $removeLeadList = $this->leadSegmentService->getOrphanedLeadListLeads($leadList);
+                $removeLeadList = $this->leadSegmentService->getOrphanedLeadListLeads($leadList, [], $limit);
 
                 if (empty($removeLeadList[$leadList->getId()])) {
                     // Somehow ran out of leads so break out

--- a/app/bundles/LeadBundle/Segment/ContactSegmentService.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentService.php
@@ -64,10 +64,11 @@ class ContactSegmentService
         if (!count($segmentFilters)) {
             $this->logger->debug('Segment QB: Segment has no filters', ['segmentId' => $segment->getId()]);
 
-            return [$segment->getId() => [
-                'count' => '0',
-                'maxId' => '0',
-            ],
+            return [
+                $segment->getId() => [
+                    'count' => '0',
+                    'maxId' => '0',
+                ],
             ];
         }
 
@@ -104,10 +105,11 @@ class ContactSegmentService
         if (!count($segmentFilters)) {
             $this->logger->debug('Segment QB: Segment has no filters', ['segmentId' => $segment->getId()]);
 
-            return [$segment->getId() => [
-                'count' => '0',
-                'maxId' => '0',
-            ],
+            return [
+                $segment->getId() => [
+                    'count' => '0',
+                    'maxId' => '0',
+                ],
             ];
         }
 
@@ -194,7 +196,7 @@ class ContactSegmentService
     /**
      * @param LeadList $segment
      * @param array    $batchLimiters
-     * @param null     $limit
+     * @param null|int $limit
      *
      * @return array
      *
@@ -223,8 +225,10 @@ class ContactSegmentService
      */
     private function getNewSegmentContactsQuery(LeadList $segment, $batchLimiters)
     {
-        $queryBuilder = $this->contactSegmentQueryBuilder->assembleContactsSegmentQueryBuilder($segment->getId(),
-            $this->contactSegmentFilterFactory->getSegmentFilters($segment));
+        $queryBuilder = $this->contactSegmentQueryBuilder->assembleContactsSegmentQueryBuilder(
+            $segment->getId(),
+            $this->contactSegmentFilterFactory->getSegmentFilters($segment)
+        );
 
         $queryBuilder = $this->contactSegmentQueryBuilder->addNewContactsRestrictions($queryBuilder, $segment->getId(), $batchLimiters);
 
@@ -255,7 +259,7 @@ class ContactSegmentService
     /**
      * @param LeadList $segment
      * @param array    $batchLimiters
-     * @param null     $limit
+     * @param null|int $limit
      *
      * @return QueryBuilder
      *
@@ -360,7 +364,7 @@ class ContactSegmentService
     private function timedFetch(QueryBuilder $qb, $segmentId)
     {
         try {
-            $start  = microtime(true);
+            $start = microtime(true);
 
             $result = $qb->execute()->fetch(\PDO::FETCH_ASSOC);
 
@@ -368,9 +372,13 @@ class ContactSegmentService
 
             $this->logger->debug('Segment QB: Query took: '.$this->formatPeriod($end).', Result count: '.count($result), ['segmentId' => $segmentId]);
         } catch (\Exception $e) {
-            $this->logger->error('Segment QB: Query Exception: '.$e->getMessage(), [
-                'query' => $qb->getSQL(), 'parameters' => $qb->getParameters(),
-            ]);
+            $this->logger->error(
+                'Segment QB: Query Exception: '.$e->getMessage(),
+                [
+                    'query'      => $qb->getSQL(),
+                    'parameters' => $qb->getParameters(),
+                ]
+            );
             throw $e;
         }
 
@@ -393,11 +401,18 @@ class ContactSegmentService
 
             $end = microtime(true) - $start;
 
-            $this->logger->debug('Segment QB: Query took: '.$this->formatPeriod($end).'ms. Result count: '.count($result), ['segmentId' => $segmentId]);
+            $this->logger->debug(
+                'Segment QB: Query took: '.$this->formatPeriod($end).'ms. Result count: '.count($result),
+                ['segmentId' => $segmentId]
+            );
         } catch (\Exception $e) {
-            $this->logger->error('Segment QB: Query Exception: '.$e->getMessage(), [
-                'query' => $qb->getSQL(), 'parameters' => $qb->getParameters(),
-            ]);
+            $this->logger->error(
+                'Segment QB: Query Exception: '.$e->getMessage(),
+                [
+                    'query'      => $qb->getSQL(),
+                    'parameters' => $qb->getParameters(),
+                ]
+            );
             throw $e;
         }
 

--- a/app/bundles/LeadBundle/Segment/ContactSegmentService.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentService.php
@@ -194,15 +194,16 @@ class ContactSegmentService
     /**
      * @param LeadList $segment
      * @param array    $batchLimiters
+     * @param null     $limit
      *
      * @return array
      *
      * @throws Exception\SegmentQueryException
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function getOrphanedLeadListLeads(LeadList $segment, array $batchLimiters = [])
+    public function getOrphanedLeadListLeads(LeadList $segment, array $batchLimiters = [], $limit = null)
     {
-        $queryBuilder = $this->getOrphanedLeadListLeadsQueryBuilder($segment, $batchLimiters);
+        $queryBuilder = $this->getOrphanedLeadListLeadsQueryBuilder($segment, $batchLimiters, $limit);
 
         $this->logger->debug('Segment QB: Orphan Leads SQL: '.$queryBuilder->getDebugOutput(), ['segmentId' => $segment->getId()]);
 
@@ -254,13 +255,14 @@ class ContactSegmentService
     /**
      * @param LeadList $segment
      * @param array    $batchLimiters
+     * @param null     $limit
      *
      * @return QueryBuilder
      *
      * @throws Exception\SegmentQueryException
      * @throws \Doctrine\DBAL\DBALException
      */
-    private function getOrphanedLeadListLeadsQueryBuilder(LeadList $segment, array $batchLimiters = [])
+    private function getOrphanedLeadListLeadsQueryBuilder(LeadList $segment, array $batchLimiters = [], $limit = null)
     {
         $segmentFilters = $this->contactSegmentFilterFactory->getSegmentFilters($segment);
 
@@ -279,6 +281,10 @@ class ContactSegmentService
         $qbO->andWhere($qbO->expr()->eq('orp.manually_added', $qbO->expr()->literal(0)));
         $qbO->setParameter(':orpsegid', $segment->getId());
         $this->addLeadLimiter($qbO, $batchLimiters, 'orp.lead_id');
+
+        if ($limit) {
+            $qbO->setMaxResults((int) $limit);
+        }
 
         return $qbO;
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This adds support to remove contacts from segments in batches rather than all at once to prevent RAM issues and long running queries. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Requires large numbers of contacts with complex segments so difficult to reproduce :-)

#### Steps to test this PR:
1. Add a new segment that matches most of your contacts (email not empty) and run `mautic:segments:update` command to add them
2. Adjust the filter to now remove most of the contacts from the segment (email is empty) and run the command again
3. All applicable contacts should be removed