### PR TITLE
Fixed progressive profiling for first time site visitors

### DIFF
--- a/app/bundles/FormBundle/Entity/Field.php
+++ b/app/bundles/FormBundle/Entity/Field.php
@@ -836,7 +836,7 @@ class Field
             return true;
         }
 
-        // Hide the field if there is the submission count limit and hide it untill the limit is overcame
+        // Hide the field if there is the submission count limit and hide it until the limit is overcame
         if ($this->showAfterXSubmissions > 0 && $this->showAfterXSubmissions > count($submissions)) {
             return false;
         }

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -500,7 +500,7 @@ class FormModel extends CommonFormModel
             $theme .= '|';
         }
 
-        if ($lead && $entity->usesProgressiveProfiling()) {
+        if ($lead instanceof Lead && $lead->getId() && $entity->usesProgressiveProfiling()) {
             $submissions = $this->getLeadSubmissions($entity, $lead->getId());
         }
 
@@ -578,6 +578,7 @@ class FormModel extends CommonFormModel
                 'inBuilder'     => false,
             ]
         );
+
         if (!$entity->usesProgressiveProfiling()) {
             $entity->setCachedHtml($html);
 

--- a/app/bundles/FormBundle/Views/Builder/field.html.php
+++ b/app/bundles/FormBundle/Views/Builder/field.html.php
@@ -56,9 +56,7 @@ $propertiesTabError = (isset($form['properties']) && ($view['form']->containsErr
     <div role="tabpanel">
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="active">
-                <a<?php if ($generalTabError) {
-    echo ' class="text-danger" ';
-} ?> href="#general" aria-controls="general" role="tab" data-toggle="tab">
+                <a<?php if ($generalTabError): echo ' class="text-danger" '; endif; ?> href="#general" aria-controls="general" role="tab" data-toggle="tab">
                     <?php echo $view['translator']->trans('mautic.form.field.section.general'); ?>
                     <?php if ($generalTabError): ?>
                         <i class="fa fa-warning"></i>
@@ -84,9 +82,7 @@ $propertiesTabError = (isset($form['properties']) && ($view['form']->containsErr
 
             <?php if ($showProperties): ?>
             <li role="presentation">
-                <a<?php if ($propertiesTabError) {
-    echo ' class="text-danger" ';
-} ?> href="#properties" aria-controls="properties" role="tab" data-toggle="tab">
+                <a<?php if ($propertiesTabError): echo ' class="text-danger" '; endif; ?> href="#properties" aria-controls="properties" role="tab" data-toggle="tab">
                     <?php echo $view['translator']->trans('mautic.form.field.section.properties'); ?>
                     <?php if ($propertiesTabError): ?>
                         <i class="fa fa-warning"></i>

--- a/app/bundles/FormBundle/Views/Builder/form.html.php
+++ b/app/bundles/FormBundle/Views/Builder/form.html.php
@@ -56,7 +56,7 @@ if (!isset($isAjax)) {
                     echo "\n          <div class=\"mauticform-page-wrapper mauticform-page-$pageCount\" data-mautic-form-page=\"$pageCount\"$lastFieldAttribute>\n";
                 endif;
 
-                if (!isset($submissions) || $f->showForContact($submissions, $lead, $form)):
+                if ($f->showForContact($submissions, $lead, $form)):
                     if ($f->isCustom()):
                         if (!isset($fieldSettings[$f->getType()])):
                             continue;


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

In the case of a first time visitor (no tracking cookies have been generated), form behavior settings did not behave as expected in two scenarios. 

1. If no tracked contact was found, an empty $lead object was returned by getCurrentLead which then found $submissions where lead ID is null. If the form had submissions from a contact that had since been deleted, $submissions would be hydrated changing the behavior of the form. 
2. If no tracked contact was found, fields that had fields configured to only show after X number 
 of submissions would still show because of a condition that showed the field if there were no submissions :-) 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form with a field that shows no matter what, a field that shows only if a value exists, and a field that shows after 2 submissions (include an email field)
2. Submit the form for contact 1
3. Delete the contact
4. Delete all cookies and values from localStorage using the developer console (in Chrome, both are under Application)
5. Refresh and notice that the field that should only show when a value exists will be hidden and the field that should show after X submissions will show. 

#### Steps to test this PR:
1.  Repeat and the fields should behave as expected
