### PR TITLE
Do first pass of search/replace of tokens before setting the subject into the content DTO

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Momentum/Service/SwiftMessageService.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Momentum/Service/SwiftMessageService.php
@@ -62,10 +62,11 @@ final class SwiftMessageService implements SwiftMessageServiceInterface
         if (!empty($messageFrom[$messageFromEmail])) {
             $from->setName($messageFrom[$messageFromEmail]);
         }
-        $content = new TransmissionDTO\ContentDTO($message->getSubject(), $from);
 
+        // Process metadata before consuming subject, body, etc
         $metadataProcessor = new MetadataProcessor($message);
 
+        $content = new TransmissionDTO\ContentDTO($message->getSubject(), $from);
         if ($body = $message->getBody()) {
             $content->setHtml($body);
         }
@@ -112,6 +113,7 @@ final class SwiftMessageService implements SwiftMessageServiceInterface
                 }
             }
         }
+
         $cssHeader = $message->getHeaders()->get('X-MC-InlineCSS');
         if ($cssHeader !== null) {
             $content->setInlineCss($cssHeader);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The MetadataProcessor is the class responsible for switching Mautic's tokens with Momentum tokens. But the subject was set into the transmission before this happened and so tokens in the subject were never found. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Add a token to the subject such as `{contactfield=firstname}`
2. Send the email to a contact through momentum and note that the token remains intact as is

#### Steps to test this PR:
1. Repeat and this time the token will be replaced with the contact's first name
