### PR TITLE
Fix loading default dashboard when default.json is not writable

### DIFF
--- a/app/bundles/CoreBundle/Helper/PathsHelper.php
+++ b/app/bundles/CoreBundle/Helper/PathsHelper.php
@@ -71,8 +71,8 @@ class PathsHelper
     /**
      * PathsHelper constructor.
      *
-     * @param CoreParametersHelper
-     * @param UserHelper $userHelper
+     * @param UserHelper           $userHelper
+     * @param CoreParametersHelper $coreParametersHelper
      */
     public function __construct(UserHelper $userHelper, CoreParametersHelper $coreParametersHelper)
     {
@@ -82,7 +82,7 @@ class PathsHelper
         $this->imagePath              = $this->removeTrailingSlash($coreParametersHelper->getParameter('image_path'));
         $this->dashboardImportDir     = $this->removeTrailingSlash($coreParametersHelper->getParameter('dashboard_import_dir'));
         $this->temporaryDir           = $this->removeTrailingSlash($coreParametersHelper->getParameter('tmp_path'));
-        $this->dashboardImportUserDir = $this->removeTrailingSlash($coreParametersHelper->getParameter('dashboard_import_user_dir'));
+        $this->dashboardUserImportDir = $this->removeTrailingSlash($coreParametersHelper->getParameter('dashboard_import_user_dir'));
         $this->kernelCacheDir         = $this->removeTrailingSlash($coreParametersHelper->getParameter('kernel.cache_dir'));
         $this->kernelLogsDir          = $this->removeTrailingSlash($coreParametersHelper->getParameter('kernel.logs_dir'));
     }

--- a/app/bundles/CoreBundle/Helper/PathsHelper.php
+++ b/app/bundles/CoreBundle/Helper/PathsHelper.php
@@ -116,8 +116,8 @@ class PathsHelper
                 } elseif ('logs' === $name) {
                     return $this->kernelLogsDir;
                 } else {
-                    if (!is_dir($this->temporaryDir) && !file_exists($this->temporaryDir)) {
-                        mkdir($this->temporaryDir, 0755);
+                    if (!is_dir($this->temporaryDir) && !file_exists($this->temporaryDir) && is_writable($this->temporaryDir)) {
+                        mkdir($this->temporaryDir, 0755, true);
                     }
 
                     return $this->temporaryDir;
@@ -142,8 +142,7 @@ class PathsHelper
 
                 $userPath .= '/'.$this->user->getId();
 
-                // @todo check is_writable
-                if (!is_dir($userPath) && !file_exists($userPath)) {
+                if (!is_dir($userPath) && !file_exists($userPath) && is_writable($userPath)) {
                     mkdir($userPath, 0755);
                 }
 

--- a/app/bundles/DashboardBundle/Controller/DashboardController.php
+++ b/app/bundles/DashboardBundle/Controller/DashboardController.php
@@ -321,7 +321,7 @@ class DashboardController extends FormController
     public function exportAction()
     {
         $filename = InputHelper::filename($this->getNameFromRequest(), 'json');
-        $response = new JsonResponse($this->getModel('dashboard')->toArray($name));
+        $response = new JsonResponse($this->getModel('dashboard')->toArray($filename));
         $response->setEncodingOptions($response->getEncodingOptions() | JSON_PRETTY_PRINT);
         $response->headers->set('Content-Type', 'application/force-download');
         $response->headers->set('Content-Type', 'application/octet-stream');
@@ -376,37 +376,39 @@ class DashboardController extends FormController
         $dir  = $this->container->get('mautic.helper.paths')->getSystemPath("dashboard.$type");
         $path = $dir.'/'.$name.'.json';
 
-        if (file_exists($path) && is_writable($path)) {
-            $widgets = json_decode(file_get_contents($path), true);
-            if (isset($widgets['widgets'])) {
-                $widgets = $widgets['widgets'];
+        if (!file_exists($path) || !is_readable($path)) {
+            $this->addFlash('mautic.dashboard.upload.filenotfound', [], 'error', 'validators');
+
+            return $this->redirect($this->generateUrl('mautic_dashboard_action', ['objectAction' => 'import']));
+        }
+
+        $widgets = json_decode(file_get_contents($path), true);
+        if (isset($widgets['widgets'])) {
+            $widgets = $widgets['widgets'];
+        }
+
+        if ($widgets) {
+            /** @var \Mautic\DashboardBundle\Model\DashboardModel $model */
+            $model = $this->getModel('dashboard');
+
+            $model->clearDashboardCache();
+
+            $currentWidgets = $model->getWidgets();
+
+            if (count($currentWidgets)) {
+                foreach ($currentWidgets as $widget) {
+                    $model->deleteEntity($widget);
+                }
             }
 
-            if ($widgets) {
-                /** @var \Mautic\DashboardBundle\Model\DashboardModel $model */
-                $model = $this->getModel('dashboard');
-
-                $model->clearDashboardCache();
-
-                $currentWidgets = $model->getWidgets();
-
-                if (count($currentWidgets)) {
-                    foreach ($currentWidgets as $widget) {
-                        $model->deleteEntity($widget);
-                    }
-                }
-
-                $filter = $model->getDefaultFilter();
-                foreach ($widgets as $widget) {
-                    $widget = $model->populateWidgetEntity($widget, $filter);
-                    $model->saveEntity($widget);
-                }
-
-                return $this->redirect($this->get('router')->generate('mautic_dashboard_index'));
+            $filter = $model->getDefaultFilter();
+            foreach ($widgets as $widget) {
+                $widget = $model->populateWidgetEntity($widget, $filter);
+                $model->saveEntity($widget);
             }
         }
 
-        return $this->redirect($this->generateUrl('mautic_dashboard_action', ['objectAction' => 'import']));
+        return $this->redirect($this->get('router')->generate('mautic_dashboard_index'));
     }
 
     /**
@@ -453,16 +455,20 @@ class DashboardController extends FormController
             }
         }
 
-        $dashboardFiles = [];
+        $dashboardFiles = ['user' => [], 'gobal' => []];
         $dashboards     = [];
 
-        // User specific layouts
-        chdir($directories['user']);
-        $dashboardFiles['user'] = glob('*.json');
+        if (is_readable($directories['user'])) {
+            // User specific layouts
+            chdir($directories['user']);
+            $dashboardFiles['user'] = glob('*.json');
+        }
 
-        // Global dashboards
-        chdir($directories['global']);
-        $dashboardFiles['global'] = glob('*.json');
+        if (is_readable($directories['global'])) {
+            // Global dashboards
+            chdir($directories['global']);
+            $dashboardFiles['global'] = glob('*.json');
+        }
 
         foreach ($dashboardFiles as $type => $dirDashboardFiles) {
             $tempDashboard = [];


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fix loading default dashboard when default.json is not writable

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make media/dashboards unwritable (`chmod -w media/dashboards`)
2. Go to your database and delete all widgets in the mautic_widgets table
3. Go to /s/dashboard and it'll redirect to /s/dashboard/imports

#### Steps to test this PR:
1. Repeat and you should get the default dashboard loaded instead of being redirected to imports. 
2. Add back write permission and repeat and it should still work
3. Edit your config file (local.php) and add `"dashboard_import_user_dir" => '%kernel.root_dir%/cache/files', save and delete `app/cache/prod` (or dev)
4. Try to save, export, and import a custom dashboard; all should work
