### PR TITLE
SMS click tracking and contact identification

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -252,6 +252,12 @@ return [
                     'doctrine.orm.entity_manager',
                 ],
             ],
+            'mautic.email.subscriber.contact_tracker' => [
+                'class'     => \Mautic\EmailBundle\EventListener\TrackingSubscriber::class,
+                'arguments' => [
+                    'mautic.email.repository.stat',
+                ],
+            ],
         ],
         'forms' => [
             'mautic.form.type.email' => [
@@ -555,20 +561,6 @@ return [
                     'mautic.helper.paths',
                 ],
             ],
-            'mautic.email.repository.emailReply' => [
-                'class'     => \Doctrine\ORM\EntityRepository::class,
-                'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
-                'arguments' => [
-                    \Mautic\EmailBundle\Entity\EmailReply::class,
-                ],
-            ],
-            'mautic.email.repository.stat' => [
-                'class'     => Doctrine\ORM\EntityRepository::class,
-                'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
-                'arguments' => [
-                    \Mautic\EmailBundle\Entity\Stat::class,
-                ],
-            ],
             'mautic.message.search.contact' => [
                 'class'     => \Mautic\EmailBundle\MonitoredEmail\Search\ContactFinder::class,
                 'arguments' => [
@@ -721,6 +713,22 @@ return [
                     'mautic.validator.email',
                 ],
                 'tag' => 'validator.constraint_validator',
+            ],
+        ],
+        'repositories' => [
+            'mautic.email.repository.emailReply' => [
+                'class'     => \Doctrine\ORM\EntityRepository::class,
+                'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
+                'arguments' => [
+                    \Mautic\EmailBundle\Entity\EmailReply::class,
+                ],
+            ],
+            'mautic.email.repository.stat' => [
+                'class'     => Doctrine\ORM\EntityRepository::class,
+                'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
+                'arguments' => [
+                    \Mautic\EmailBundle\Entity\Stat::class,
+                ],
             ],
         ],
     ],

--- a/app/bundles/EmailBundle/EventListener/TrackingSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/TrackingSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\EventListener;
+
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\LeadBundle\Event\ContactIdentificationEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class TrackingSubscriber implements EventSubscriberInterface
+{
+    public function onIdentifyContact(ContactIdentificationEvent $event)
+    {
+        $clickthrough = $event->getClickthrough();
+
+        // Nothing left to identify by so stick to the tracked lead
+        if (empty($clickthrough['channel']['email']) && empty($clickthrough['stat'])) {
+            return;
+        }
+
+        /** @var Stat $stat */
+        $stat = $this->statRepository->findOneBy(['trackingHash' => $clickthrough['stat']]);
+
+        if (!$stat) {
+            // Stat doesn't exist so use the tracked lead
+            return;
+        }
+
+        if ($stat->getEmail() && (int) $stat->getEmail()->getId() !== (int) $clickthrough['channel']['email']) {
+            // ID mismatch - fishy so use tracked lead
+            return;
+        }
+
+        if (!$contact = $stat->getLead()) {
+            return;
+        }
+
+        $event->setIdentifiedContact($contact);
+    }
+}

--- a/app/bundles/EmailBundle/EventListener/TrackingSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/TrackingSubscriber.php
@@ -12,11 +12,41 @@
 namespace Mautic\EmailBundle\EventListener;
 
 use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\LeadBundle\Event\ContactIdentificationEvent;
+use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class TrackingSubscriber implements EventSubscriberInterface
 {
+    /**
+     * @var StatRepository
+     */
+    private $statRepository;
+
+    /**
+     * TrackingSubscriber constructor.
+     *
+     * @param StatRepository $statRepository
+     */
+    public function __construct(StatRepository $statRepository)
+    {
+        $this->statRepository = $statRepository;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            LeadEvents::ON_CLICKTHROUGH_IDENTIFICATION => ['onIdentifyContact', 0],
+        ];
+    }
+
+    /**
+     * @param ContactIdentificationEvent $event
+     */
     public function onIdentifyContact(ContactIdentificationEvent $event)
     {
         $clickthrough = $event->getClickthrough();
@@ -43,6 +73,6 @@ class TrackingSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $event->setIdentifiedContact($contact);
+        $event->setIdentifiedContact($contact, 'email');
     }
 }

--- a/app/bundles/EmailBundle/Tests/EventListener/TrackingSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/TrackingSubscriberTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\SmsBundle\Tests\EventListener;
+
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Event\ContactIdentificationEvent;
+use Mautic\SmsBundle\Entity\Sms;
+use Mautic\SmsBundle\Entity\Stat;
+use Mautic\SmsBundle\Entity\StatRepository;
+use Mautic\SmsBundle\EventListener\TrackingSubscriber;
+
+class TrackingSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|StatRepository
+     */
+    private $statRepository;
+
+    protected function setUp()
+    {
+        $this->statRepository = $this->createMock(StatRepository::class);
+    }
+
+    public function testIdentifyContactByStat()
+    {
+        $ct = [
+                'lead'    => 2,
+                'channel' => [
+                    'sms' => 1,
+                ],
+                'stat'    => 'abc123',
+        ];
+
+        $sms = $this->createMock(Sms::class);
+        $sms->method('getId')
+            ->willReturn(1);
+
+        $lead = $this->createMock(Lead::class);
+        $lead->method('getId')
+            ->willReturn(2);
+
+        $stat = new Stat();
+        $stat->setSms($sms);
+        $stat->setLead($lead);
+
+        $this->statRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['trackingHash' => 'abc123'])
+            ->willReturn($stat);
+
+        $event = new ContactIdentificationEvent($ct);
+
+        $this->getSubscriber()->onIdentifyContact($event);
+
+        $this->assertEquals($lead->getId(), $event->getIdentifiedContact()->getId());
+    }
+
+    public function testChannelMismatchDoesNotIdentify()
+    {
+        $ct = [
+            'lead'    => 2,
+            'channel' => [
+                'email' => 1,
+            ],
+            'stat'    => 'abc123',
+        ];
+
+        $event = new ContactIdentificationEvent($ct);
+
+        $this->getSubscriber()->onIdentifyContact($event);
+
+        $this->assertNull($event->getIdentifiedContact());
+    }
+
+    public function testChannelIdMismatchDoesNotIdentify()
+    {
+        $ct = [
+            'lead'    => 2,
+            'channel' => [
+                'sms' => 2,
+            ],
+            'stat'    => 'abc123',
+        ];
+
+        $sms = $this->createMock(Sms::class);
+        $sms->method('getId')
+            ->willReturn(1);
+
+        $lead = $this->createMock(Lead::class);
+        $lead->method('getId')
+            ->willReturn(2);
+
+        $stat = new Stat();
+        $stat->setSms($sms);
+        $stat->setLead($lead);
+
+        $this->statRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['trackingHash' => 'abc123'])
+            ->willReturn($stat);
+
+        $event = new ContactIdentificationEvent($ct);
+
+        $this->getSubscriber()->onIdentifyContact($event);
+
+        $this->assertNull($event->getIdentifiedContact());
+    }
+
+    public function testStatEmptyLeadDoesNotIdentify()
+    {
+        $ct = [
+            'lead'    => 2,
+            'channel' => [
+                'sms' => 2,
+            ],
+            'stat'    => 'abc123',
+        ];
+
+        $sms = $this->createMock(Sms::class);
+        $sms->method('getId')
+            ->willReturn(1);
+
+        $stat = new Stat();
+        $stat->setSms($sms);
+
+        $this->statRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['trackingHash' => 'abc123'])
+            ->willReturn($stat);
+
+        $event = new ContactIdentificationEvent($ct);
+
+        $this->getSubscriber()->onIdentifyContact($event);
+
+        $this->assertNull($event->getIdentifiedContact());
+    }
+
+    /**
+     * @return TrackingSubscriber
+     */
+    private function getSubscriber()
+    {
+        return new TrackingSubscriber($this->statRepository);
+    }
+}

--- a/app/bundles/LeadBundle/Event/ContactIdentificationEvent.php
+++ b/app/bundles/LeadBundle/Event/ContactIdentificationEvent.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Event;
+
+use Mautic\LeadBundle\Entity\Lead;
+use Symfony\Component\EventDispatcher\Event;
+
+class ContactIdentificationEvent extends Event
+{
+    /**
+     * @var array
+     */
+    private $clickthrough;
+
+    /**
+     * @var Lead
+     */
+    private $identifiedContact;
+
+    /**
+     * ContactIdentificationEvent constructor.
+     *
+     * @param array $clickthrough
+     */
+    public function __construct(array $clickthrough)
+    {
+        $this->clickthrough = $clickthrough;
+    }
+
+    /**
+     * @return array
+     */
+    public function getClickthrough()
+    {
+        return $this->clickthrough;
+    }
+
+    /**
+     * @param Lead $contact
+     */
+    public function setIdentifiedContact(Lead $contact)
+    {
+        $this->identifiedContact = $contact;
+
+        $this->stopPropagation();
+    }
+
+    /**
+     * @return Lead
+     */
+    public function getIdentifiedContact()
+    {
+        return $this->identifiedContact;
+    }
+}

--- a/app/bundles/LeadBundle/Event/ContactIdentificationEvent.php
+++ b/app/bundles/LeadBundle/Event/ContactIdentificationEvent.php
@@ -27,6 +27,11 @@ class ContactIdentificationEvent extends Event
     private $identifiedContact;
 
     /**
+     * @var string
+     */
+    private $identifiedByChannel;
+
+    /**
      * ContactIdentificationEvent constructor.
      *
      * @param array $clickthrough
@@ -45,13 +50,23 @@ class ContactIdentificationEvent extends Event
     }
 
     /**
-     * @param Lead $contact
+     * @param Lead   $contact
+     * @param string $channel
      */
-    public function setIdentifiedContact(Lead $contact)
+    public function setIdentifiedContact(Lead $contact, $channel)
     {
-        $this->identifiedContact = $contact;
+        $this->identifiedContact   = $contact;
+        $this->identifiedByChannel = $channel;
 
         $this->stopPropagation();
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->identifiedByChannel;
     }
 
     /**

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -14,15 +14,16 @@ namespace Mautic\LeadBundle\Helper;
 use Mautic\CoreBundle\Helper\ClickthroughHelper;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
-use Mautic\EmailBundle\Entity\Stat;
-use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadDeviceRepository;
+use Mautic\LeadBundle\Event\ContactIdentificationEvent;
 use Mautic\LeadBundle\Exception\ContactNotFoundException;
+use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Monolog\Logger;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class ContactRequestHelper
@@ -38,9 +39,9 @@ class ContactRequestHelper
     private $coreParametersHelper;
 
     /**
-     * @var StatRepository
+     * @var EventDispatcherInterface
      */
-    private $emailStatRepository;
+    private $eventDispatcher;
 
     /**
      * @var LeadDeviceRepository
@@ -85,36 +86,36 @@ class ContactRequestHelper
     /**
      * ContactRequestHelper constructor.
      *
-     * @param LeadModel            $leadModel
-     * @param ContactTracker       $contactTracker
-     * @param CoreParametersHelper $coreParametersHelper
-     * @param StatRepository       $emailStatRepository
-     * @param LeadDeviceRepository $leadDeviceRepository
-     * @param RequestStack         $requestStack
-     * @param Logger               $logger
+     * @param LeadModel                $leadModel
+     * @param ContactTracker           $contactTracker
+     * @param CoreParametersHelper     $coreParametersHelper
+     * @param IpLookupHelper           $ipLookupHelper
+     * @param LeadDeviceRepository     $leadDeviceRepository
+     * @param RequestStack             $requestStack
+     * @param Logger                   $logger
+     * @param EventDispatcherInterface $eventDispatcher
      */
     public function __construct(
         LeadModel $leadModel,
         ContactTracker $contactTracker,
         CoreParametersHelper $coreParametersHelper,
         IpLookupHelper $ipLookupHelper,
-        StatRepository $emailStatRepository,
         LeadDeviceRepository $leadDeviceRepository,
         RequestStack $requestStack,
-        Logger $logger
+        Logger $logger,
+        EventDispatcherInterface $eventDispatcher
     ) {
         $this->leadModel            = $leadModel;
         $this->contactTracker       = $contactTracker;
         $this->coreParametersHelper = $coreParametersHelper;
         $this->ipLookupHelper       = $ipLookupHelper;
-        $this->emailStatRepository  = $emailStatRepository;
         $this->leadDeviceRepository = $leadDeviceRepository;
         $this->request              = $requestStack->getCurrentRequest();
         $this->logger               = $logger;
+        $this->eventDispatcher      = $eventDispatcher;
     }
 
     /**
-     * @param Lead  $trackedContact
      * @param array $queryFields
      *
      * @return Lead
@@ -155,7 +156,7 @@ class ContactRequestHelper
         }
 
         try {
-            $contact = $this->getContactFromEmailClickthrough($clickthrough);
+            $contact = $this->getContactFromClickthrough($clickthrough);
 
             return $contact;
         } catch (ContactNotFoundException $exception) {
@@ -179,7 +180,7 @@ class ContactRequestHelper
     }
 
     /**
-     * Identify a contact through a clickthrough URL in an email.
+     * Identify a contact through a clickthrough URL.
      *
      * @param array $clickthrough
      *
@@ -187,36 +188,24 @@ class ContactRequestHelper
      *
      * @throws ContactNotFoundException
      */
-    private function getContactFromEmailClickthrough(array $clickthrough)
+    private function getContactFromClickthrough(array $clickthrough)
     {
-        // Nothing left to identify by so stick to the tracked lead
-        if (empty($clickthrough['channel']['email']) && empty($clickthrough['stat'])) {
-            throw new ContactNotFoundException();
-        }
+        $event = new ContactIdentificationEvent($clickthrough);
+        $this->eventDispatcher->dispatch(LeadEvents::ON_CLICKTHROUGH_IDENTIFICATION, $event);
 
-        /** @var Stat $stat */
-        $stat = $this->emailStatRepository->findOneBy(['trackingHash' => $clickthrough['stat']]);
-
-        if (!$stat) {
-            // Stat doesn't exist so use the tracked lead
-            throw new ContactNotFoundException();
-        }
-
-        if ($stat->getEmail() && (int) $stat->getEmail()->getId() !== (int) $clickthrough['channel']['email']) {
-            // Email ID mismatch - fishy so use tracked lead
-            throw new ContactNotFoundException();
-        }
-
-        if ($statLead = $stat->getLead()) {
-            $this->logger->addDebug("LEAD: Contact ID# {$statLead->getId()} tracked through clickthrough query from email.");
+        if ($contact = $event->getIdentifiedContact()) {
+            $this->logger->addDebug("LEAD: Contact ID# {$contact->getId()} tracked through clickthrough query from email.");
 
             // Merge tracked visitor into the clickthrough contact
-            return $this->mergeWithTrackedContact($statLead);
+            return $this->mergeWithTrackedContact($contact);
         }
 
         throw new ContactNotFoundException();
     }
 
+    /**
+     * @param array $clickthrough
+     */
     private function setEmailFromClickthroughIdentification(array $clickthrough)
     {
         if (!$this->coreParametersHelper->getParameter('track_by_tracking_url') || !empty($queryFields['email'])) {

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -194,7 +194,7 @@ class ContactRequestHelper
         $this->eventDispatcher->dispatch(LeadEvents::ON_CLICKTHROUGH_IDENTIFICATION, $event);
 
         if ($contact = $event->getIdentifiedContact()) {
-            $this->logger->addDebug("LEAD: Contact ID# {$contact->getId()} tracked through clickthrough query from email.");
+            $this->logger->addDebug("LEAD: Contact ID# {$contact->getId()} tracked through clickthrough query by the ".$event->getIdentifier().' channel');
 
             // Merge tracked visitor into the clickthrough contact
             return $this->mergeWithTrackedContact($contact);

--- a/app/bundles/LeadBundle/LeadEvents.php
+++ b/app/bundles/LeadBundle/LeadEvents.php
@@ -573,6 +573,16 @@ final class LeadEvents
     const FORM_SUBMIT_REMOVE_DO_NO_CONTACT = 'mautic.form_submit_remove_do_no_contact';
 
     /**
+     * The mautic.clickthrough_contact_identification event is dispatched when a clickthrough array is parsed from a tracking
+     * URL.
+     *
+     * The event listener receives a Mautic\LeadBundle\Event\ContactIdentificationEvent instance.
+     *
+     * @var string
+     */
+    const ON_CLICKTHROUGH_IDENTIFICATION = 'mautic.clickthrough_contact_identification';
+
+    /**
      * @deprecated - 2.4 to be removed in 3.0; use Mautic\ChannelBundle\ChannelEvents::ADD_CHANNEL
      *
      * The mautic.add_channel event registers communication channels.

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -28,7 +28,6 @@ use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Model\FormModel;
-use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\Helper\EmailValidator;
 use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\Company;
@@ -935,8 +934,6 @@ class LeadModel extends FormModel
     public function getContactFromRequest($queryFields = [])
     {
         // @todo Instantiate here until we can remove circular dependency on LeadModel in order to make it a service
-        /** @var StatRepository $emailStatRepository */
-        $emailStatRepository = $this->em->getRepository('MauticEmailBundle:Stat');
         $requestStack        = new RequestStack();
         $requestStack->push($this->request);
         $contactRequestHelper = new ContactRequestHelper(
@@ -944,10 +941,10 @@ class LeadModel extends FormModel
             $this->contactTracker,
             $this->coreParametersHelper,
             $this->ipLookupHelper,
-            $emailStatRepository,
             $this->getDeviceRepository(),
             $requestStack,
-            $this->logger
+            $this->logger,
+            $this->dispatcher
         );
 
         return $contactRequestHelper->getContactFromQuery($queryFields);

--- a/app/bundles/LeadBundle/Tests/Helper/ContactRequestHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/ContactRequestHelperTest.php
@@ -17,13 +17,14 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
-use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadDeviceRepository;
+use Mautic\LeadBundle\Event\ContactIdentificationEvent;
 use Mautic\LeadBundle\Helper\ContactRequestHelper;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Monolog\Logger;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class ContactRequestHelperTest extends \PHPUnit_Framework_TestCase
@@ -49,9 +50,9 @@ class ContactRequestHelperTest extends \PHPUnit_Framework_TestCase
     private $ipLookupHelper;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|StatRepository
+     * @var \PHPUnit_Framework_MockObject_MockObject|EventDispatcher
      */
-    private $emailStatRepository;
+    private $dispatcher;
 
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|LeadDeviceRepository
@@ -79,10 +80,10 @@ class ContactRequestHelperTest extends \PHPUnit_Framework_TestCase
         $this->contactTracker       = $this->createMock(ContactTracker::class);
         $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
         $this->ipLookupHelper       = $this->createMock(IpLookupHelper::class);
-        $this->emailStatRepository  = $this->createMock(StatRepository::class);
         $this->leadDeviceRepository = $this->createMock(LeadDeviceRepository::class);
         $this->requestStack         = $this->createMock(RequestStack::class);
         $this->logger               = $this->createMock(Logger::class);
+        $this->dispatcher           = $this->createMock(EventDispatcher::class);
 
         $this->trackedContact = $this->createMock(Lead::class);
         $this->trackedContact->method('getId')
@@ -98,49 +99,7 @@ class ContactRequestHelperTest extends \PHPUnit_Framework_TestCase
             ->willReturn(new IpAddress());
     }
 
-    public function testIdentifyContactByEmailStat()
-    {
-        $query = [
-            'ct' => [
-                'lead'    => 2,
-                'channel' => [
-                    'email' => 1,
-                ],
-                'stat'    => 'abc123',
-            ],
-        ];
-
-        $email = $this->createMock(Email::class);
-        $email->method('getId')
-            ->willReturn(1);
-
-        $lead = $this->createMock(Lead::class);
-        $lead->method('getId')
-            ->willReturn(2);
-        $lead->method('getIpAddresses')
-            ->willReturn(new ArrayCollection());
-
-        $stat = new Stat();
-        $stat->setEmail($email);
-        $stat->setLead($lead);
-
-        $this->emailStatRepository->expects($this->once())
-            ->method('findOneBy')
-            ->with(['trackingHash' => 'abc123'])
-            ->willReturn($stat);
-
-        $this->leadModel->expects($this->once())
-            ->method('mergeLeads')
-            ->willReturn($lead);
-
-        $this->trackedContact->method('isAnonymous')
-            ->willReturn(true);
-
-        $helper = $this->getContactRequestHelper();
-        $this->assertEquals($lead->getId(), $helper->getContactFromQuery($query)->getId());
-    }
-
-    public function testEmailStatWithMisMatchingEmailIdDoesNotIdentifyContact()
+    public function testEventDoesNotIdentifyContact()
     {
         $query = [
             'ct' => [
@@ -158,11 +117,6 @@ class ContactRequestHelperTest extends \PHPUnit_Framework_TestCase
 
         $stat = new Stat();
         $stat->setEmail($email);
-
-        $this->emailStatRepository->expects($this->once())
-            ->method('findOneBy')
-            ->with(['trackingHash' => 'abc123'])
-            ->willReturn($stat);
 
         $this->leadModel->expects($this->never())
             ->method('mergeLeads');
@@ -175,7 +129,7 @@ class ContactRequestHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->trackedContact->getId(), $helper->getContactFromQuery($query)->getId());
     }
 
-    public function testTrackedIdentifiedContactIsNotMergedIntoIdentifiedByEmailStat()
+    public function testEventIdentifiesContact()
     {
         $query = [
             'ct' => [
@@ -187,34 +141,22 @@ class ContactRequestHelperTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $email = $this->createMock(Email::class);
-        $email->method('getId')
-            ->willReturn(2);
+        $contact = new Lead();
 
-        $lead = $this->createMock(Lead::class);
-        $lead->method('getId')
-            ->willReturn(2);
-        $lead->method('getIpAddresses')
-            ->willReturn(new ArrayCollection());
-
-        $stat = new Stat();
-        $stat->setEmail($email);
-        $stat->setLead($lead);
-
-        $this->emailStatRepository->expects($this->once())
-            ->method('findOneBy')
-            ->with(['trackingHash' => 'abc123'])
-            ->willReturn($stat);
+        $this->dispatcher->method('dispatch')
+            ->willReturnCallback(
+                function ($eventName, ContactIdentificationEvent $event) use ($contact) {
+                    $event->setIdentifiedContact($contact, 'email');
+                }
+            );
 
         $this->leadModel->expects($this->never())
             ->method('mergeLeads');
 
-        $this->leadModel->expects($this->once())
-            ->method('checkForDuplicateContact')
-            ->willReturn([$lead, []]);
+        $helper       = $this->getContactRequestHelper();
+        $foundContact = $helper->getContactFromQuery($query);
 
-        $helper = $this->getContactRequestHelper();
-        $this->assertEquals($lead->getId(), $helper->getContactFromQuery($query)->getId());
+        $this->assertTrue($contact === $foundContact);
     }
 
     public function testLandingPageClickthroughIdentifiesLeadIfEnabled()
@@ -430,10 +372,10 @@ class ContactRequestHelperTest extends \PHPUnit_Framework_TestCase
             $this->contactTracker,
             $this->coreParametersHelper,
             $this->ipLookupHelper,
-            $this->emailStatRepository,
             $this->leadDeviceRepository,
             $this->requestStack,
-            $this->logger
+            $this->logger,
+            $this->dispatcher
         );
     }
 }

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -640,8 +640,6 @@ class PageModel extends FormModel
         // Check if this is a unique page hit
         $isUnique = $this->getHitRepository()->isUniquePageHit($page, $trackingId, $lead);
 
-        $clickthrough = $this->generateClickThrough($hit);
-
         if (!empty($page)) {
             if ($page instanceof Page) {
                 $hit->setPageLanguage($page->getLanguage());
@@ -661,16 +659,14 @@ class PageModel extends FormModel
                     $this->pageRedirectModel->getRepository()->upHitCount($page->getId(), 1, $isUnique);
 
                     // If this is a trackable, up the trackable counts as well
-                    if (!empty($clickthrough['channel'])) {
-                        if (count($clickthrough['channel']) === 1) {
-                            $channelId = reset($clickthrough['channel']);
-                            $channel   = key($clickthrough['channel']);
-                        } else {
-                            $channel   = $clickthrough['channel'][0];
-                            $channelId = (int) $clickthrough['channel'][1];
-                        }
-
-                        $this->pageTrackableModel->getRepository()->upHitCount($page->getId(), $channel, $channelId, 1, $isUnique);
+                    if ($hit->getSource() && $hit->getSourceId()) {
+                        $this->pageTrackableModel->getRepository()->upHitCount(
+                            $page->getId(),
+                            $hit->getSource(),
+                            $hit->getSourceId(),
+                            1,
+                            $isUnique
+                        );
                     }
                 } catch (\Exception $exception) {
                     if (MAUTIC_ENV === 'dev') {

--- a/app/bundles/SmsBundle/Config/config.php
+++ b/app/bundles/SmsBundle/Config/config.php
@@ -50,6 +50,12 @@ return [
             'mautic.sms.configbundle.subscriber' => [
                 'class' => Mautic\SmsBundle\EventListener\ConfigSubscriber::class,
             ],
+            'mautic.sms.subscriber.contact_tracker' => [
+                'class'     => \Mautic\SmsBundle\EventListener\TrackingSubscriber::class,
+                'arguments' => [
+                    'mautic.sms.repository.stat',
+                ],
+            ],
         ],
         'forms' => [
             'mautic.form.type.sms' => [
@@ -136,6 +142,15 @@ return [
         'integrations' => [
             'mautic.integration.twilio' => [
                 'class' => \Mautic\SmsBundle\Integration\TwilioIntegration::class,
+            ],
+        ],
+        'repositories' => [
+            'mautic.sms.repository.stat' => [
+                'class'     => Doctrine\ORM\EntityRepository::class,
+                'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
+                'arguments' => [
+                    \Mautic\SmsBundle\Entity\Stat::class,
+                ],
             ],
         ],
     ],

--- a/app/bundles/SmsBundle/EventListener/SmsSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/SmsSubscriber.php
@@ -152,6 +152,7 @@ class SmsSubscriber extends CommonSubscriber
                     'sms',
                     $clickthrough['channel'][1]
                 );
+
                 /**
                  * @var string
                  * @var Trackable $trackable

--- a/app/bundles/SmsBundle/EventListener/TrackingSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/TrackingSubscriber.php
@@ -12,11 +12,41 @@
 namespace Mautic\SmsBundle\EventListener;
 
 use Mautic\LeadBundle\Event\ContactIdentificationEvent;
+use Mautic\LeadBundle\LeadEvents;
 use Mautic\SmsBundle\Entity\Stat;
+use Mautic\SmsBundle\Entity\StatRepository;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class TrackingSubscriber implements EventSubscriberInterface
 {
+    /**
+     * @var StatRepository
+     */
+    private $statRepository;
+
+    /**
+     * TrackingSubscriber constructor.
+     *
+     * @param StatRepository $statRepository
+     */
+    public function __construct(StatRepository $statRepository)
+    {
+        $this->statRepository = $statRepository;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            LeadEvents::ON_CLICKTHROUGH_IDENTIFICATION => ['onIdentifyContact', 0],
+        ];
+    }
+
+    /**
+     * @param ContactIdentificationEvent $event
+     */
     public function onIdentifyContact(ContactIdentificationEvent $event)
     {
         $clickthrough = $event->getClickthrough();
@@ -43,6 +73,6 @@ class TrackingSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $event->setIdentifiedContact($contact);
+        $event->setIdentifiedContact($contact, 'sms');
     }
 }

--- a/app/bundles/SmsBundle/EventListener/TrackingSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/TrackingSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\SmsBundle\EventListener;
+
+use Mautic\LeadBundle\Event\ContactIdentificationEvent;
+use Mautic\SmsBundle\Entity\Stat;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class TrackingSubscriber implements EventSubscriberInterface
+{
+    public function onIdentifyContact(ContactIdentificationEvent $event)
+    {
+        $clickthrough = $event->getClickthrough();
+
+        // Nothing left to identify by so stick to the tracked lead
+        if (empty($clickthrough['channel']['sms']) && empty($clickthrough['stat'])) {
+            return;
+        }
+
+        /** @var Stat $stat */
+        $stat = $this->statRepository->findOneBy(['trackingHash' => $clickthrough['stat']]);
+
+        if (!$stat) {
+            // Stat doesn't exist so use the tracked lead
+            return;
+        }
+
+        if ($stat->getSms() && (int) $stat->getSms()->getId() !== (int) $clickthrough['channel']['sms']) {
+            // ID mismatch - fishy so use tracked lead
+            return;
+        }
+
+        if (!$contact = $stat->getLead()) {
+            return;
+        }
+
+        $event->setIdentifiedContact($contact);
+    }
+}

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -292,7 +292,11 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface
                             $smsEvent->getContent(),
                             $lead,
                             [
-                                'channel' => ['sms' => $sms->getId()],
+                                'channel' => [
+                                    'sms',          // Keep BC pre 2.14.1
+                                    $sms->getId(),  // Keep BC pre 2.14.1
+                                    'sms' => $sms->getId(),
+                                ],
                                 'stat'    => $stat->getTrackingHash(),
                             ]
                         )

--- a/app/bundles/SmsBundle/Tests/EventListener/TrackingSubscriberTest.php
+++ b/app/bundles/SmsBundle/Tests/EventListener/TrackingSubscriberTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\EventListener;
+
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\EmailBundle\EventListener\TrackingSubscriber;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Event\ContactIdentificationEvent;
+
+class TrackingSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|StatRepository
+     */
+    private $statRepository;
+
+    protected function setUp()
+    {
+        $this->statRepository = $this->createMock(StatRepository::class);
+    }
+
+    public function testIdentifyContactByStat()
+    {
+        $ct = [
+                'lead'    => 2,
+                'channel' => [
+                    'email' => 1,
+                ],
+                'stat'    => 'abc123',
+        ];
+
+        $email = $this->createMock(Email::class);
+        $email->method('getId')
+            ->willReturn(1);
+
+        $lead = $this->createMock(Lead::class);
+        $lead->method('getId')
+            ->willReturn(2);
+
+        $stat = new Stat();
+        $stat->setEmail($email);
+        $stat->setLead($lead);
+
+        $this->statRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['trackingHash' => 'abc123'])
+            ->willReturn($stat);
+
+        $event = new ContactIdentificationEvent($ct);
+
+        $this->getSubscriber()->onIdentifyContact($event);
+
+        $this->assertEquals($lead->getId(), $event->getIdentifiedContact()->getId());
+    }
+
+    public function testChannelMismatchDoesNotIdentify()
+    {
+        $ct = [
+            'lead'    => 2,
+            'channel' => [
+                'sms' => 1,
+            ],
+            'stat'    => 'abc123',
+        ];
+
+        $event = new ContactIdentificationEvent($ct);
+
+        $this->getSubscriber()->onIdentifyContact($event);
+
+        $this->assertNull($event->getIdentifiedContact());
+    }
+
+    public function testChannelIdMismatchDoesNotIdentify()
+    {
+        $ct = [
+            'lead'    => 2,
+            'channel' => [
+                'email' => 2,
+            ],
+            'stat'    => 'abc123',
+        ];
+
+        $email = $this->createMock(Email::class);
+        $email->method('getId')
+            ->willReturn(1);
+
+        $lead = $this->createMock(Lead::class);
+        $lead->method('getId')
+            ->willReturn(2);
+
+        $stat = new Stat();
+        $stat->setEmail($email);
+        $stat->setLead($lead);
+
+        $this->statRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['trackingHash' => 'abc123'])
+            ->willReturn($stat);
+
+        $event = new ContactIdentificationEvent($ct);
+
+        $this->getSubscriber()->onIdentifyContact($event);
+
+        $this->assertNull($event->getIdentifiedContact());
+    }
+
+    public function testStatEmptyLeadDoesNotIdentify()
+    {
+        $ct = [
+            'lead'    => 2,
+            'channel' => [
+                'email' => 2,
+            ],
+            'stat'    => 'abc123',
+        ];
+
+        $email = $this->createMock(Email::class);
+        $email->method('getId')
+            ->willReturn(1);
+
+        $stat = new Stat();
+        $stat->setEmail($email);
+
+        $this->statRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['trackingHash' => 'abc123'])
+            ->willReturn($stat);
+
+        $event = new ContactIdentificationEvent($ct);
+
+        $this->getSubscriber()->onIdentifyContact($event);
+
+        $this->assertNull($event->getIdentifiedContact());
+    }
+
+    /**
+     * @return TrackingSubscriber
+     */
+    private function getSubscriber()
+    {
+        return new TrackingSubscriber($this->statRepository);
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |
| New feature? | Y
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6747 https://github.com/mautic/mautic/issues/6855
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This adds support to identify contacts from tracking links in text messages.

#### Steps to test this PR:
1. Configure Twilio
2. (You will likely need to us bit.ly for the url shortening service as the URL itself can be too long for a single SMS)
3. Create a text message with a link
4. Create a campaign to send the text message and add a contact with a mobile number
5. You should receive the text message with a redirect link
6. Open the URL
7. The click should be recorded in the  contact timeline
8. Test links in emails are still tracked against the contact since tracking was moved into an event subscriber
