### PR TITLE
Report api pagination

### DIFF
--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -1220,7 +1220,7 @@ class CommonApiController extends FOSRestController implements MauticController
      *
      * @return Response|array
      */
-    protected function returnError($msg, $code = Codes::HTTP_OK, $details = [])
+    protected function returnError($msg, $code = Codes::HTTP_INTERNAL_SERVER_ERROR, $details = [])
     {
         if ($this->get('translator')->hasId($msg, 'flashes')) {
             $msg = $this->get('translator')->trans($msg, [], 'flashes');

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -672,6 +672,7 @@ class ReportModel extends FormModel
             'contentTemplate' => $contentTemplate,
             'columns'         => $tableDetails['columns'],
             'limit'           => ($paginate) ? $limit : 0,
+            'page'            => ($paginate) ? $reportPage : 1,
             'dateFrom'        => $dataOptions['dateFrom'],
             'dateTo'          => $dataOptions['dateTo'],
             'debug'           => $debugData,


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Enhancement
| Automated tests included? | mautic/api-library#178
| Related user documentation PR URL | N
| Related developer documentation PR URL | mautic/developer-documentation#111
| Issues addressed (#s or URLs) | /
| BC breaks? | Y
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Up till now the Reports returned all rows. It obviously killed the requests for reports with many rows. This PR adds pagination and date range filters.

Related API Library PR: mautic/api-library#178

Example query:
```
GET /api/reports/3?dateFrom=2017-01-01&limit=5&page=3
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to load a report with more than 500.000 rows via API.

#### Steps to test this PR:
1. Try now. It will load only 10 rows by default.
2. Test the `dateFrom`, `dateTo`, `limit` and `page` query params.

#### List backwards compatibility breaks:
1. Users may expect different result since it used to load all rows. But this endpoint exists for 3 years it was never documented, so do we care?