### PR TITLE
List sync for campaign conditions

### DIFF
--- a/app/bundles/FormBundle/Form/Type/CampaignEventFormFieldValueType.php
+++ b/app/bundles/FormBundle/Form/Type/CampaignEventFormFieldValueType.php
@@ -110,6 +110,10 @@ class CampaignEventFormFieldValueType extends AbstractType
                                 if (is_array($option) && isset($option['value']) && isset($option['label'])) {
                                     //The select box needs values to be [value] => label format so make sure we have that style then put it in
                                     $options[$field->getAlias()][$option['value']] = $option['label'];
+                                } elseif (is_array($option)) {
+                                    foreach ($option as $optgroup => $option) {
+                                        $options[$field->getAlias()][$option] = $option;
+                                    }
                                 } elseif (!is_array($option)) {
                                     //Kept here for BC
                                     $options[$field->getAlias()][$option] = $option;

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -178,7 +178,13 @@ class FormModel extends CommonFormModel
             return new Form();
         }
 
-        return parent::getEntity($id);
+        $entity = parent::getEntity($id);
+
+        foreach ($entity->getFields() as $field) {
+            $this->addLeadFieldOptions($field);
+        }
+
+        return $entity;
     }
 
     /**
@@ -1046,5 +1052,26 @@ class FormModel extends CommonFormModel
         }
 
         return $javascript;
+    }
+
+    /**
+     * Finds out whether the.
+     *
+     * @param Field $field
+     */
+    private function addLeadFieldOptions(Field $field)
+    {
+        $properties = $field->getProperties();
+
+        if (empty($properties['syncList']) || empty($field->getLeadField())) {
+            return;
+        }
+
+        $leadField = $this->leadFieldModel->getEntityByAlias($field->getLeadField());
+
+        if ($leadField && !empty($leadField->getProperties()['list'])) {
+            $properties['list'] = ['list' => $leadField->getProperties()['list']];
+            $field->setProperties($properties);
+        }
     }
 }

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -181,8 +181,10 @@ class FormModel extends CommonFormModel
 
         $entity = parent::getEntity($id);
 
-        foreach ($entity->getFields() as $field) {
-            $this->addLeadFieldOptions($field);
+        if ($entity && $entity->getFields()) {
+            foreach ($entity->getFields() as $field) {
+                $this->addLeadFieldOptions($field);
+            }
         }
 
         return $entity;

--- a/app/bundles/FormBundle/Tests/FormTestAbstract.php
+++ b/app/bundles/FormBundle/Tests/FormTestAbstract.php
@@ -50,6 +50,8 @@ class FormTestAbstract extends WebTestCase
     protected static $mockName = 'Mock test name';
     protected $mockTrackingId;
     protected $container;
+    protected $formRepository;
+    protected $leadFieldModel;
 
     protected function setUp()
     {
@@ -63,60 +65,20 @@ class FormTestAbstract extends WebTestCase
      */
     protected function getFormModel()
     {
-        $requestStack = $this
-            ->getMockBuilder(RequestStack::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $templatingHelperMock = $this
-            ->getMockBuilder(TemplatingHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $themeHelper = $this
-            ->getMockBuilder(ThemeHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $schemaHelperFactory = $this
-            ->getMockBuilder(SchemaHelperFactory::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $formActionModel = $this
-            ->getMockBuilder(ActionModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $formFieldModel = $this
-            ->getMockBuilder(FieldModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $leadModel = $this
-            ->getMockBuilder(LeadModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $fieldHelper = $this
-            ->getMockBuilder(FormFieldHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $leadFieldModel = $this
-            ->getMockBuilder(LeadFieldModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $dispatcher = $this
-            ->getMockBuilder(EventDispatcher::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $translator = $this
-            ->getMockBuilder(Translator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $requestStack         = $this->createMock(RequestStack::class);
+        $templatingHelperMock = $this->createMock(TemplatingHelper::class);
+        $themeHelper          = $this->createMock(ThemeHelper::class);
+        $schemaHelperFactory  = $this->createMock(SchemaHelperFactory::class);
+        $formActionModel      = $this->createMock(ActionModel::class);
+        $formFieldModel       = $this->createMock(FieldModel::class);
+        $leadModel            = $this->createMock(LeadModel::class);
+        $fieldHelper          = $this->createMock(FormFieldHelper::class);
+        $dispatcher           = $this->createMock(EventDispatcher::class);
+        $translator           = $this->createMock(Translator::class);
+        $entityManager        = $this->createMock(EntityManager::class);
+        $formUploaderMock     = $this->createMock(FormUploader::class);
+        $this->leadFieldModel = $this->createMock(LeadFieldModel::class);
+        $this->formRepository = $this->createMock(FormRepository::class);
 
         $leadModel->expects($this
             ->any())
@@ -129,31 +91,16 @@ class FormTestAbstract extends WebTestCase
             ->method('getTemplating')
             ->willReturn($this->container->get('templating'));
 
-        $entityManager = $this
-            ->getMockBuilder(EntityManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $formRepository = $this
-            ->getMockBuilder(FormRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $entityManager->expects($this
             ->any())
             ->method('getRepository')
             ->will(
                 $this->returnValueMap(
                     [
-                        ['MauticFormBundle:Form', $formRepository],
+                        ['MauticFormBundle:Form', $this->formRepository],
                     ]
                 )
             );
-
-        $formUploaderMock = $this
-            ->getMockBuilder(FormUploader::class)
-            ->disableOriginalConstructor()
-            ->getMock();
 
         $formModel = new FormModel(
             $requestStack,
@@ -164,7 +111,7 @@ class FormTestAbstract extends WebTestCase
             $formFieldModel,
             $leadModel,
             $fieldHelper,
-            $leadFieldModel,
+            $this->leadFieldModel,
             $formUploaderMock
         );
 
@@ -180,82 +127,38 @@ class FormTestAbstract extends WebTestCase
      */
     protected function getSubmissionModel()
     {
-        $ipLookupHelper = $this
-            ->getMockBuilder(IpLookupHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $ipLookupHelper           = $this->createMock(IpLookupHelper::class);
+        $templatingHelperMock     = $this->createMock(TemplatingHelper::class);
+        $formModel                = $this->createMock(FormModel::class);
+        $pageModel                = $this->createMock(PageModel::class);
+        $leadModel                = $this->createMock(LeadModel::class);
+        $campaignModel            = $this->createMock(CampaignModel::class);
+        $leadFieldModel           = $this->createMock(LeadFieldModel::class);
+        $companyModel             = $this->createMock(CompanyModel::class);
+        $fieldHelper              = $this->createMock(FormFieldHelper::class);
+        $dispatcher               = $this->createMock(EventDispatcher::class);
+        $translator               = $this->createMock(Translator::class);
+        $dateHelper               = $this->createMock(DateHelper::class);
+        $userHelper               = $this->createMock(UserHelper::class);
+        $entityManager            = $this->createMock(EntityManager::class);
+        $formRepository           = $this->createMock(FormRepository::class);
+        $leadRepository           = $this->createMock(LeadRepository::class);
+        $mockLogger               = $this->createMock(Logger::class);
+        $uploadFieldValidatorMock = $this->createMock(UploadFieldValidator::class);
+        $formUploaderMock         = $this->createMock(FormUploader::class);
+        $deviceTrackingService    = $this->createMock(DeviceTrackingServiceInterface::class);
+        $file1Mock                = $this->createMock(UploadedFile::class);
 
-        $templatingHelperMock = $this
-            ->getMockBuilder(TemplatingHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $formModel = $this
-            ->getMockBuilder(FormModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $pageModel = $this
-            ->getMockBuilder(PageModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $leadModel = $this
-            ->getMockBuilder(LeadModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $campaignModel = $this
-            ->getMockBuilder(CampaignModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $leadFieldModel = $this
-            ->getMockBuilder(LeadFieldModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $leadFieldModel->expects($this
-            ->any())->method('getUniqueIdentifierFields')
+        $leadFieldModel->expects($this->any())
+            ->method('getUniqueIdentifierFields')
             ->willReturn(['eyJpc1B1Ymxpc2hlZCI6dHJ1ZSwiaXNVbmlxdWVJZGVudGlmZXIiOnRydWUsIm9iamVjdCI6ImxlYWQifQ==' => ['email' => 'Email']]);
 
-        $companyModel = $this
-            ->getMockBuilder(CompanyModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $fieldHelper = $this
-            ->getMockBuilder(FormFieldHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $dispatcher = $this->getMockBuilder(EventDispatcher::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $translator = $this
-            ->getMockBuilder(Translator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $dateHelper = $this->createMock(DateHelper::class);
-
-        $leadModel->expects($this
-            ->any())
+        $leadModel->expects($this->any())
             ->method('getCurrentLead')
-            ->with($this->logicalOr(
-                false,
-                true
-            ))
+            ->with($this->logicalOr(false, true))
             ->will($this->returnCallback([$this, 'getCurrentLead']));
 
-        $userHelper = $this
-            ->getMockBuilder(UserHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $userHelper->expects($this
-            ->any())
+        $userHelper->expects($this->any())
             ->method('getUser')
             ->willReturn(new User());
 
@@ -269,27 +172,13 @@ class FormTestAbstract extends WebTestCase
                 'properties'   => [],
             ];
 
-        $leadFieldModel->expects($this
-            ->any())
+        $leadFieldModel->expects($this->any())
             ->method('getFieldListWithProperties')
             ->willReturn($mockLeadField);
 
-        $leadFieldModel->expects($this
-            ->any())->method('getUniqueIdentiferFields')
+        $leadFieldModel->expects($this->any())
+            ->method('getUniqueIdentiferFields')
             ->willReturn($mockLeadField);
-
-        $entityManager = $this
-            ->getMockBuilder(EntityManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $formRepository = $this->getMockBuilder(FormRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $leadRepository = $this->getMockBuilder(LeadRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
 
         $entityManager->expects($this->any())
             ->method('getRepository')
@@ -305,42 +194,20 @@ class FormTestAbstract extends WebTestCase
         $leadRepository->expects($this->any())
             ->method('getLeadsByUniqueFields')
             ->willReturn(null);
-        $ipAddress = new IpAddress();
-        $ipLookupHelper
-            ->expects($this
-                ->any())
-            ->method('getIpAddress')
-            ->willReturn($ipAddress);
-
-        $mockLogger = $this
-            ->getMockBuilder(Logger::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $file1Mock = $this->getMockBuilder(UploadedFile::class)
-            ->disableOriginalConstructor()
-            ->getMock();
 
         $file1Mock->expects($this->any())
             ->method('getClientOriginalName')
             ->willReturn('test.jpg');
 
-        $uploadFieldValidatorMock = $this
-            ->getMockBuilder(UploadFieldValidator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $uploadFieldValidatorMock->expects($this->any())
             ->method('processFileValidation')
             ->willReturn($file1Mock);
 
-        $formUploaderMock = $this
-            ->getMockBuilder(FormUploader::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $ipLookupHelper->expects($this->any())
+            ->method('getIpAddress')
+            ->willReturn(new IpAddress());
 
-        $deviceTrackingService = $this->createMock(DeviceTrackingServiceInterface::class);
-        $submissionModel       = new SubmissionModel(
+        $submissionModel = new SubmissionModel(
             $ipLookupHelper,
             $templatingHelperMock,
             $formModel,

--- a/app/bundles/FormBundle/Tests/Model/FormModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormModelTest.php
@@ -11,9 +11,11 @@
 
 namespace Mautic\FormBundle\Tests\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Mautic\FormBundle\Entity\Field;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\FormBundle\Tests\FormTestAbstract;
+use Mautic\LeadBundle\Entity\LeadField;
 
 class FormModelTest extends FormTestAbstract
 {
@@ -46,5 +48,232 @@ class FormModelTest extends FormTestAbstract
         $formModel  = $this->getFormModel();
         $components = $formModel->getCustomComponents();
         $this->assertArrayHasKey('validators', $components);
+    }
+
+    public function testGetEntityForNotFoundContactField()
+    {
+        $formModel  = $this->getFormModel();
+        $formEntity = $this->createMock(Form::class);
+        $fields     = new ArrayCollection();
+
+        $formField = new Field();
+        $formField->setLeadField('contactselect');
+        $formField->setProperties(['syncList' => true]);
+
+        $fields->add($formField);
+
+        $formEntity->expects($this->once())
+            ->method('getFields')
+            ->willReturn($fields);
+
+        $this->formRepository->expects($this->once())
+            ->method('getEntity')
+            ->with(5)
+            ->willReturn($formEntity);
+
+        $this->leadFieldModel->expects($this->once())
+            ->method('getEntityByAlias')
+            ->willReturn(null);
+
+        $formModel->getEntity(5);
+
+        $this->assertSame(['syncList' => true], $formField->getProperties());
+    }
+
+    public function testGetEntityForNotLinkedSelectField()
+    {
+        $formModel  = $this->getFormModel();
+        $formEntity = $this->createMock(Form::class);
+        $fields     = new ArrayCollection();
+
+        $formField = new Field();
+        $formField->setProperties(['syncList' => true]);
+
+        $fields->add($formField);
+
+        $formEntity->expects($this->once())
+            ->method('getFields')
+            ->willReturn($fields);
+
+        $this->formRepository->expects($this->once())
+            ->method('getEntity')
+            ->with(5)
+            ->willReturn($formEntity);
+
+        $this->leadFieldModel->expects($this->never())
+            ->method('getEntityByAlias');
+
+        $formModel->getEntity(5);
+    }
+
+    public function testGetEntityForNotSyncedSelectField()
+    {
+        $formModel  = $this->getFormModel();
+        $formEntity = $this->createMock(Form::class);
+        $fields     = new ArrayCollection();
+
+        $formField = new Field();
+        $formField->setLeadField('contactselect');
+        $formField->setProperties(['syncList' => false]);
+
+        $fields->add($formField);
+
+        $formEntity->expects($this->once())
+            ->method('getFields')
+            ->willReturn($fields);
+
+        $this->formRepository->expects($this->once())
+            ->method('getEntity')
+            ->with(5)
+            ->willReturn($formEntity);
+
+        $this->leadFieldModel->expects($this->never())
+            ->method('getEntityByAlias');
+
+        $formModel->getEntity(5);
+    }
+
+    public function testGetEntityForSyncedBooleanField()
+    {
+        $formModel  = $this->getFormModel();
+        $formEntity = $this->createMock(Form::class);
+        $fields     = new ArrayCollection();
+        $options    = ['no' => 'lunch?', 'yes' => 'dinner?'];
+
+        $formField = new Field();
+        $formField->setLeadField('contactbool');
+        $formField->setProperties(['syncList' => true]);
+
+        $fields->add($formField);
+
+        $contactField = new LeadField();
+        $contactField->setType('boolean');
+        $contactField->setProperties($options);
+
+        $formEntity->expects($this->once())
+            ->method('getFields')
+            ->willReturn($fields);
+
+        $this->formRepository->expects($this->once())
+            ->method('getEntity')
+            ->with(5)
+            ->willReturn($formEntity);
+
+        $this->leadFieldModel->expects($this->once())
+            ->method('getEntityByAlias')
+            ->with('contactbool')
+            ->willReturn($contactField);
+
+        $formModel->getEntity(5);
+
+        $this->assertSame(['lunch?', 'dinner?'], $formField->getProperties()['list']['list']);
+    }
+
+    public function testGetEntityForSyncedCountryField()
+    {
+        $formField = $this->standardSyncListStaticFieldTest('country');
+
+        $this->assertArrayHasKey('Czech Republic', $formField->getProperties()['list']['list']);
+    }
+
+    public function testGetEntityForSyncedRegionField()
+    {
+        $formField = $this->standardSyncListStaticFieldTest('region');
+
+        $this->assertArrayHasKey('Canada', $formField->getProperties()['list']['list']);
+    }
+
+    public function testGetEntityForSyncedTimezoneField()
+    {
+        $formField = $this->standardSyncListStaticFieldTest('timezone');
+
+        $this->assertArrayHasKey('Africa', $formField->getProperties()['list']['list']);
+    }
+
+    public function testGetEntityForSyncedLocaleField()
+    {
+        $formField = $this->standardSyncListStaticFieldTest('locale');
+
+        $this->assertArrayHasKey('cs_CZ', $formField->getProperties()['list']['list']);
+    }
+
+    public function testGetEntityForLinkedSyncListFields()
+    {
+        $this->standardSyncListFieldTest('select');
+        $this->standardSyncListFieldTest('multiselect');
+        $this->standardSyncListFieldTest('lookup');
+    }
+
+    private function standardSyncListFieldTest($type)
+    {
+        $formModel  = $this->getFormModel();
+        $formEntity = $this->createMock(Form::class);
+        $fields     = new ArrayCollection();
+        $options    = [
+            ['label' => 'label1', 'value' => 'value1'],
+            ['label' => 'label2', 'value' => 'value2'],
+        ];
+
+        $formField = new Field();
+        $formField->setLeadField('contactfieldalias');
+        $formField->setProperties(['syncList' => true]);
+
+        $contactField = new LeadField();
+        $contactField->setType($type);
+        $contactField->setProperties(['list' => $options]);
+
+        $fields->add($formField);
+
+        $formEntity->expects($this->once())
+            ->method('getFields')
+            ->willReturn($fields);
+
+        $this->formRepository->expects($this->once())
+            ->method('getEntity')
+            ->with(5)
+            ->willReturn($formEntity);
+
+        $this->leadFieldModel->expects($this->once())
+            ->method('getEntityByAlias')
+            ->with('contactfieldalias')
+            ->willReturn($contactField);
+
+        $formModel->getEntity(5);
+
+        $this->assertSame($options, $formField->getProperties()['list']['list']);
+    }
+
+    private function standardSyncListStaticFieldTest($type)
+    {
+        $formModel  = $this->getFormModel();
+        $formEntity = $this->createMock(Form::class);
+        $fields     = new ArrayCollection();
+
+        $formField = new Field();
+        $formField->setLeadField('contactfield');
+        $formField->setProperties(['syncList' => true]);
+
+        $fields->add($formField);
+
+        $contactField = new LeadField();
+        $contactField->setType($type);
+
+        $formEntity->expects($this->once())
+            ->method('getFields')
+            ->willReturn($fields);
+
+        $this->formRepository->expects($this->once())
+            ->method('getEntity')
+            ->with(5)
+            ->willReturn($formEntity);
+
+        $this->leadFieldModel->expects($this->once())
+            ->method('getEntityByAlias')
+            ->with('contactfield')
+            ->willReturn($contactField);
+
+        $formModel->getEntity(5);
+
+        return $formField;
     }
 }

--- a/app/bundles/FormBundle/Tests/Model/FormModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormModelTest.php
@@ -62,7 +62,7 @@ class FormModelTest extends FormTestAbstract
 
         $fields->add($formField);
 
-        $formEntity->expects($this->once())
+        $formEntity->expects($this->exactly(2))
             ->method('getFields')
             ->willReturn($fields);
 
@@ -91,7 +91,7 @@ class FormModelTest extends FormTestAbstract
 
         $fields->add($formField);
 
-        $formEntity->expects($this->once())
+        $formEntity->expects($this->exactly(2))
             ->method('getFields')
             ->willReturn($fields);
 
@@ -118,7 +118,7 @@ class FormModelTest extends FormTestAbstract
 
         $fields->add($formField);
 
-        $formEntity->expects($this->once())
+        $formEntity->expects($this->exactly(2))
             ->method('getFields')
             ->willReturn($fields);
 
@@ -150,7 +150,7 @@ class FormModelTest extends FormTestAbstract
         $contactField->setType('boolean');
         $contactField->setProperties($options);
 
-        $formEntity->expects($this->once())
+        $formEntity->expects($this->exactly(2))
             ->method('getFields')
             ->willReturn($fields);
 
@@ -224,7 +224,7 @@ class FormModelTest extends FormTestAbstract
 
         $fields->add($formField);
 
-        $formEntity->expects($this->once())
+        $formEntity->expects($this->exactly(2))
             ->method('getFields')
             ->willReturn($fields);
 
@@ -258,7 +258,7 @@ class FormModelTest extends FormTestAbstract
         $contactField = new LeadField();
         $contactField->setType($type);
 
-        $formEntity->expects($this->once())
+        $formEntity->expects($this->exactly(2))
             ->method('getFields')
             ->willReturn($fields);
 

--- a/app/bundles/LeadBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/LeadBundle/Helper/FormFieldHelper.php
@@ -122,7 +122,7 @@ class FormFieldHelper extends AbstractFormFieldHelper
      */
     public static function getListTypes()
     {
-        return ['select', 'boolean', 'lookup', 'country', 'region', 'timezone', 'locale'];
+        return ['select', 'multiselect', 'boolean', 'lookup', 'country', 'region', 'timezone', 'locale'];
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -1031,4 +1031,12 @@ class FieldModel extends FormModel
             'options' => ['notnull' => false],
         ];
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEntityByAlias($alias, $categoryAlias = null, $lang = null)
+    {
+        return $this->getRepository()->findOneByAlias($alias);
+    }
 }


### PR DESCRIPTION
 to show them everywhere the field is loaded

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The (multi)select fields that had a contact field linked and that should sync the contact field options with the form field options were not displaying in a campaign form field conditions.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a "Select - Multiple" custom field and add some options to it
![image](https://user-images.githubusercontent.com/30011667/47135604-2bed2f00-d26e-11e8-8c69-bb551d6aa4e6.png)

2. Create a form with email textbox field and "Multiple Choice" field
3. Add in "contact field" tab the custom field you created on step 1
4. on Properties behaviour set to ON : "allow multiple?" and "Use assigned contact/company .... list choices"
![image](https://user-images.githubusercontent.com/30011667/47135657-65be3580-d26e-11e8-98da-0bbbdf1d3f31.png)

5. Create a campaign, add a decision
6. Select "Form field value"
7. Choose in "Limit to forms" the one you created in step 2
8. Choose in "Fields" the multi-select custom field

- There is only a text field. Options cannot be selected.

9. Test that all field types are working for Campaign conditions, normal form preview, JS embed and dynamic content filters.

#### Steps to test this PR:
1. Test again, the options will be selectable.
