### PR TITLE
Enable plugins to show buttons on the position even if there aren't any yet

### DIFF
--- a/app/bundles/CoreBundle/Views/Helper/page_actions.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/page_actions.html.php
@@ -102,15 +102,13 @@ foreach ($templateButtons as $action => $enabled) {
     }
 }
 
-if ($view['buttons']->getButtonCount() > 0) {
-    echo '<div class="std-toolbar btn-group">';
+echo '<div class="std-toolbar btn-group">';
 
-    $dropdownOpenHtml = '<button type="button" class="btn btn-default btn-nospin  dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><i class="fa fa-caret-down"></i></button>'
-        ."\n";
-    $dropdownOpenHtml .= '<ul class="dropdown-menu dropdown-menu-right" role="menu">'."\n";
-    echo $view['buttons']->renderButtons($dropdownOpenHtml, '</ul>');
+$dropdownOpenHtml = '<button type="button" class="btn btn-default btn-nospin dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><i class="fa fa-caret-down"></i></button>'
+    ."\n";
+$dropdownOpenHtml .= '<ul class="dropdown-menu dropdown-menu-right" role="menu">'."\n";
+echo $view['buttons']->renderButtons($dropdownOpenHtml, '</ul>');
 
-    echo '</div>';
-}
+echo '</div>';
 
 echo $extraHtml;


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If a bundle doesn't specify any "page actions" buttons then plugins cannot add them either because the event is being dispatched inside the `renderButtons` method and that's already in the if.

There is no visible harm in the UI if a bundle nor a plugin doesn't specify any buttons for that position.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Not possible without hacking

#### Steps to test this PR:
1. Not possible without a test plugin. But the code change is quite simple. Code review will suffice.
2. Ensure that you can load detail page of for example email or campaign or page.