### PR TITLE
Set with and height HTML params to images in emails for Outlook

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -1390,12 +1390,6 @@ Mautic.initSlotListeners = function() {
 
                 var builderEl = parent.mQuery('.builder');
 
-                if (builderEl.length && builderEl.hasClass('email-builder')) {
-                    buttons = parent.mQuery.grep(buttons, function (value) {
-                        return value != 'insertGatedVideo';
-                    });
-                }
-
                 var froalaOptions = {
                     toolbarButtons: buttons,
                     toolbarButtonsMD: buttons,
@@ -1405,6 +1399,13 @@ Mautic.initSlotListeners = function() {
                     linkList: [], // TODO push here the list of tokens from Mautic.getPredefinedLinks
                     imageEditButtons: ['imageReplace', 'imageAlign', 'imageRemove', 'imageAlt', 'imageSize', '|', 'imageLink', 'linkOpen', 'linkEdit', 'linkRemove']
                 };
+
+                if (builderEl.length && builderEl.hasClass('email-builder')) {
+                    buttons = parent.mQuery.grep(buttons, function (value) {
+                        return value != 'insertGatedVideo';
+                    });
+                    froalaOptions.imageOutputSize = true;
+                }
 
                 // prevent overriding variant content in editor
                 if (focusType !== 'dynamicContent') {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/2791
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

https://github.com/mautic/mautic/pull/2459 removed the `imageOutputSize` Froala option as it was buggy at the time. This PR is adding it back to the Email Builder as Outlook and other ancient email clients does not read CSS styles.

This is how images looks like now:
```
<img src="[...]/media/images/mautic_logo_lb200.png" class="fr-fic fr-dib">
```

This is how they looks like after the change:
```
<img src="[...]/media/images/mautic_logo_lb200.png" class="fr-fic fr-dib fr-fil" width="200" height="200">
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create an email.
2. Click on a text and add a new image to it in the right hand column.
3. Save the email.
4. Preview the email.
5. Inspect the HTML source that the image doesn't have the `width` and `height` params.

#### Steps to test this PR:
1. Add a new image to the email.
2. Save the email.
3. Preview the email
4. Inspect the HTML source that the image does have the `width` and `height` params.