### PR TITLE
Fix timezone conversion in DateHelper::toText() method

### DIFF
--- a/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
@@ -172,7 +172,8 @@ class DateHelper extends Helper
 
         if ($datetime instanceof \DateTime) {
             // Fix time shift with timezone conversion into string representation
-            $datetime = $this->toFull($datetime, 'UTC');
+            $timezone  = ($datetime->getTimezone()->getName() === 'UTC') ? 'utc' : $timezone;
+            $datetime  = $datetime->format($fromFormat);
         }
 
         $this->helper->setDateTime($datetime, $fromFormat, $timezone);

--- a/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
@@ -170,6 +170,11 @@ class DateHelper extends Helper
             return '';
         }
 
+        if ($datetime instanceof \DateTime) {
+            // Fix time shift with timezone conversion into string representation
+            $datetime = $this->toFull($datetime, 'UTC');
+        }
+
         $this->helper->setDateTime($datetime, $fromFormat, $timezone);
 
         $textDate = $this->helper->getTextDate();


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3478
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
In contact history was sometimes incorrect timestamps shown.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create contact
2. Use manually selected timezone (near the start of the next day) in user account settings and in contact history you will see something like this:

![snimek obrazovky 2018-10-16 v 12 58 01](https://user-images.githubusercontent.com/12815758/47015369-ade13900-d144-11e8-9fa8-942535332e58.png)

#### Steps to test this PR:
1. Same as bug reproduction, but you will see something like this:

![snimek obrazovky 2018-10-16 v 12 58 20](https://user-images.githubusercontent.com/12815758/47015407-d1a47f00-d144-11e8-9ea3-01cf4fc0b6c0.png)
