### PR TITLE
Add SSL recommendation during install

### DIFF
--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -265,6 +265,10 @@ class CheckStep implements StepInterface
             $messages[] = 'mautic.install.extension.imap';
         }
 
+        if (substr($this->site_url, 0, 5) !== 'https') {
+            $messages[] = 'mautic.install.ssl.certificate';
+        }
+
         if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
             if (!function_exists('posix_isatty')) {
                 $messages[] = 'mautic.install.function.posix';

--- a/app/bundles/InstallBundle/Translations/en_US/messages.ini
+++ b/app/bundles/InstallBundle/Translations/en_US/messages.ini
@@ -97,6 +97,7 @@ mautic.install.sentence.major.problems="We have detected <strong>%majors%</stron
 mautic.install.sentence.minor.problems="We have detected some minor things that we <em>recommend</em> changing in order to have a better Mautic experience:"
 mautic.install.sentence.proceed.to.mautic="Proceed to Mautic"
 mautic.install.sentence.ready="Great! Your environment is ready for Mautic."
+mautic.install.ssl.certificate="It is recommended to secure your installation with an SSL certificate (https)."
 mautic.install.step.1="1"
 mautic.install.step.2="2"
 mautic.install.step.3="3"


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

Reasoning behind this is very simple. Having an SSL certificate should be standard these days with Let's Encrypt around. However, since Mautic handles sensitive user data, it is even more important that the installation is secured with a certificate.

Lets make the internet more secure by notifying our users on install with a recommendation.

Testing this is easy, just open the installer on a non-ssl secured environment and see that the first step in the install has a notice. Do the same on an ssl environment and see that there is no notice. 

This notice is not blocking, it's just a recommendation.