### PR TITLE
Add page_hits url index and covering email_stats index

### DIFF
--- a/app/bundles/EmailBundle/Entity/Stat.php
+++ b/app/bundles/EmailBundle/Entity/Stat.php
@@ -149,7 +149,7 @@ class Stat
             ->addIndex(['tracking_hash'], 'stat_email_hash_search')
             ->addIndex(['source', 'source_id'], 'stat_email_source_search')
             ->addIndex(['date_sent'], 'email_date_sent')
-            ->addIndex(['date_read'], 'email_date_read');
+            ->addIndex(['date_read', 'lead_id'], 'email_date_read_lead');
 
         $builder->addId();
 

--- a/app/bundles/InstallBundle/InstallFixtures/ORM/PageHitIndex.php
+++ b/app/bundles/InstallBundle/InstallFixtures/ORM/PageHitIndex.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Mautic\InstallBundle\InstallFixtures\ORM;
+
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/*
+ * creates pagehit url prefix index. Cannot be done in the entity itself because doctrine
+ * doesn't support prefix indexes :(
+ */
+class PageHitIndex extends AbstractFixture implements OrderedFixtureInterface, ContainerAwareInterface
+{
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    public function load(ObjectManager $manager)
+    {
+        $prefix = $this->container->getParameter('mautic.db_table_prefix');
+        $manager->getConnection()->exec("CREATE INDEX {$prefix}page_hit_url ON {$prefix}page_hits (url(128))");
+        $manager->flush();
+    }
+
+    public function getOrder()
+    {
+        return 99;
+    }
+}

--- a/app/bundles/PageBundle/Entity/Hit.php
+++ b/app/bundles/PageBundle/Entity/Hit.php
@@ -164,8 +164,9 @@ class Hit
             ->addIndex(['tracking_id'], 'page_hit_tracking_search')
             ->addIndex(['code'], 'page_hit_code_search')
             ->addIndex(['source', 'source_id'], 'page_hit_source_search')
-            ->addIndex(['date_hit'], 'page_date_hit')
-            ->addIndex(['date_hit', 'date_left'], 'date_hit_left_index');
+            ->addIndex(['date_hit', 'date_left'], 'date_hit_left_index')
+            // This should be a 128 char prefix index. How do I do that here?
+            ->addIndex(['url'], 'page_hit_url');
 
         $builder->addId();
 

--- a/app/bundles/PageBundle/Entity/Hit.php
+++ b/app/bundles/PageBundle/Entity/Hit.php
@@ -164,9 +164,10 @@ class Hit
             ->addIndex(['tracking_id'], 'page_hit_tracking_search')
             ->addIndex(['code'], 'page_hit_code_search')
             ->addIndex(['source', 'source_id'], 'page_hit_source_search')
-            ->addIndex(['date_hit', 'date_left'], 'date_hit_left_index')
-            // This should be a 128 char prefix index. How do I do that here?
-            ->addIndex(['url'], 'page_hit_url');
+            ->addIndex(['date_hit', 'date_left'], 'date_hit_left_index');
+        // There should be a 128 char prefix index but it cannot be created here
+        // created in fixtures instead
+        //->addIndex(['url'], 'page_hit_url');
 
         $builder->addId();
 

--- a/app/migrations/Version20180924120832.php
+++ b/app/migrations/Version20180924120832.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * @package     Mautic
+ * @copyright   2018 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+class Version20180924120832 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        $table = $schema->getTable("{$this->prefix}page_hits");
+        if (!$table->hasIndex("{$this->prefix}page_date_hit")) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql("DROP INDEX {$this->prefix}page_date_hit ON {$this->prefix}page_hits");
+    }
+}

--- a/app/migrations/Version20180924120833.php
+++ b/app/migrations/Version20180924120833.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * @package     Mautic
+ * @copyright   2018 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+class Version20180924120833 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        $table = $schema->getTable("{$this->prefix}page_hits");
+        if ($table->hasIndex("{$this->prefix}page_hit_url")) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql("CREATE INDEX {$this->prefix}page_hit_url ON {$this->prefix}page_hits (url(128))");
+    }
+}

--- a/app/migrations/Version20180924120834.php
+++ b/app/migrations/Version20180924120834.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * @package     Mautic
+ * @copyright   2018 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+class Version20180924120834 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        $table = $schema->getTable("{$this->prefix}email_stats");
+        if ($table->hasIndex("{$this->prefix}email_date_read_lead")) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql("alter table {$this->prefix}email_stats add key {$this->prefix}email_date_read_lead (date_read, lead_id)");
+        $table = $schema->getTable("{$this->prefix}email_stats");
+        if ($table->hasIndex("{$this->prefix}email_date_read")) {
+            $this->addSql("alter table {$this->prefix}email_stats drop key {$this->prefix}email_date_read");
+        }
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | n
| New feature? | n
| Automated tests included? |n
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR improves performance in two scenarios:
1. Segmenting on page_hit url prefix
2. Segmenting on email_stats date_read

Unfortunatelly one of the indexes cannot be cleanly created by doctrine and so is "hacked" in by using a fixture instead.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
Try and create a segment based on email read date in mautic instance with several million email_stats. Compare time it took before/after this PR is applied.

Try and create a segment based on page hit url prefix in mautic instance with several million page_hits. Compare time it took before/after this PR is applied.

#### List deprecations along with the new alternative:
No incompatible changes

#### List backwards compatibility breaks:
No incompatible changes