### PR TITLE
fix foreign query reference, use exists, realias sub-segment query, a…

### DIFF
--- a/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -204,10 +204,10 @@ class ContactSegmentQueryBuilder
     {
         $tableAlias = $this->generateRandomParameterName();
         $queryBuilder->leftJoin(
-            'l',
+            $queryBuilder->getLeadsTableAlias(),
             MAUTIC_TABLE_PREFIX.'lead_lists_leads',
             $tableAlias,
-            'l.id = '.$tableAlias.'.lead_id and '.$tableAlias.'.leadlist_id = '.intval($leadListId)
+            $queryBuilder->getLeadsTableAlias().'.id = '.$tableAlias.'.lead_id and '.$tableAlias.'.leadlist_id = '.intval($leadListId)
         );
         $queryBuilder->addJoinCondition($tableAlias, $queryBuilder->expr()->eq($tableAlias.'.manually_removed', 1));
         $queryBuilder->andWhere($queryBuilder->expr()->isNull($tableAlias.'.lead_id'));

--- a/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
@@ -1713,4 +1713,12 @@ class QueryBuilder extends \Doctrine\DBAL\Query\QueryBuilder
 
         return $this;
     }
+
+    /**
+     * @return array|bool|string
+     */
+    public function getLeadsTableAlias()
+    {
+        return $this->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
+    }
 }


### PR DESCRIPTION
# Fix segment foreign reference bug

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Issues addressed (#s or URLs) |  none
| BC breaks? | N
| Deprecations? |  N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Segments with reference to another segment were not built correctly if grouped into condition using **in** and **notIn**. This PR fixes it and improves performance by replacing join with exists.

[//]: # ( As applicable: )
#### Steps to reproduce the bug and test this PR:
1. Create a segment that defines reference **in** to multiple other segments that contain different contacts. It should be sufficient that referenced segments contain one contact only.
2. Run and verify that not all contacts that should be there are there.
3. Checkout this PR an rerun
4. Now everything should match.