### PR TITLE
Fix export scheduler report attached file 

### DIFF
--- a/app/bundles/ReportBundle/Model/ReportExporter.php
+++ b/app/bundles/ReportBundle/Model/ReportExporter.php
@@ -102,8 +102,6 @@ class ReportExporter
         $event = new ReportScheduleSendEvent($scheduler, $file);
         $this->eventDispatcher->dispatch(ReportEvents::REPORT_SCHEDULE_SEND, $event);
 
-        $this->reportFileWriter->clear($scheduler);
-
         $this->schedulerModel->reportWasScheduled($report);
     }
 }

--- a/app/bundles/ReportBundle/Scheduler/Model/SendSchedule.php
+++ b/app/bundles/ReportBundle/Scheduler/Model/SendSchedule.php
@@ -39,6 +39,8 @@ class SendSchedule
      */
     public function send(Scheduler $scheduler, $filePath)
     {
+        $this->mailer->reset(true);
+
         $transformer = new ArrayStringTransformer();
         $report      = $scheduler->getReport();
         $emails      = $transformer->reverseTransform($report->getToAddress());

--- a/app/bundles/ReportBundle/Tests/Model/ReportExporterTest.php
+++ b/app/bundles/ReportBundle/Tests/Model/ReportExporterTest.php
@@ -93,9 +93,6 @@ class ReportExporterTest extends \PHPUnit_Framework_TestCase
         $eventDispatcher->expects($this->exactly(2))
             ->method('dispatch');
 
-        $reportFileWriter->expects($this->exactly(2))
-            ->method('clear');
-
         $schedulerModel->expects($this->exactly(2))
             ->method('reportWasScheduled');
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? |N
| Related user documentation PR URL |  
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
**Please install https://github.com/mautic/mautic/pull/6220 first**.

This PR correct 2 bugs:  
- In email queue mode, attached report file were missing
- If you have 2 scheduled reports, the second mail had both files attached

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
##### Bug 1
1. Configure email "send immediately" mode
2. Create 2 reports
3. Modify date in the database to schedule report in the past
4. Run `mautic:reports:scheduler`
5. 2d message have 2 file attached

##### Bug 2
1. Configure email "send by queue" mode
2. Modify date in the database to schedule report in the past
3. Run `mautic:reports:scheduler`
4. email avec no file attached

#### Steps to test this PR:
1. Apply PR
2. Redo process to reproduce bug