### PR TITLE
Fix rendering of timeline details being off by one when device os empty

### DIFF
--- a/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -44,9 +44,8 @@ $query = $event['extra']['hit']['query'];
         </dd>
     <?php endif; ?>
 
-    <dt><?php echo $view['translator']->trans('mautic.core.timeline.device.os'); ?></dt>
-
     <?php if (!empty($event['extra']['hit']['deviceOsName'])): ?>
+        <dt><?php echo $view['translator']->trans('mautic.core.timeline.device.os'); ?></dt>
         <dd class="ellipsis">
             <?php echo InputHelper::clean($event['extra']['hit']['deviceOsName']); ?>
         </dd>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N/A
| Related user documentation PR URL |  N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Currently, if a timeline event does not have a device os it will force
the rendering of all other properties to be off by one and mis-matched.
This patch corrects the issue by putting the `<dt/>` in the conditional
with the `<dd/>`

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Have a contact visit a page who is blocking or is unable to determine the "Device OS", or delete that property from database
2. Go to Contact > Timeline > Expand details for that page hit
3. Notice all details after Device OS off by one and mis-matched from their labels.

#### Steps to test this PR:

Same as above, but notice not off by one