### PR TITLE
Fix form generate

### DIFF
--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -827,20 +827,23 @@ class FormModel extends CommonFormModel
      */
     public function populateValuesWithLead(Form $form, &$formHtml)
     {
-        $formName = $form->generateFormName();
-        $fields   = $form->getFields();
+        $formName       = $form->generateFormName();
+        $fields         = $form->getFields();
+        $autoFillFields = [];
+
         /** @var \Mautic\FormBundle\Entity\Field $field */
         foreach ($fields as $key => $field) {
             $leadField  = $field->getLeadField();
             $isAutoFill = $field->getIsAutoFill();
 
             // we want work just with matched autofill fields
-            if (!isset($leadField) || !$isAutoFill) {
-                unset($fields[$key]);
+            if (isset($leadField) && $isAutoFill) {
+                $autoFillFields[$key] = $field;
             }
         }
+
         // no fields for populate
-        if (!count($fields)) {
+        if (!count($autoFillFields)) {
             return;
         }
 
@@ -849,7 +852,7 @@ class FormModel extends CommonFormModel
             return;
         }
 
-        foreach ($fields as $field) {
+        foreach ($autoFillFields as $field) {
             $value = $lead->getFieldValue($field->getLeadField());
 
             if (!empty($value)) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Sometimes form integration/preview is incomplete.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

Hard to reproduce, see code and tell me what you think.

I don't know how to reproduce bug, we have found some broken form at our customers instance and bug appear to be random because it's not on all forms.

I've identified that when `app/bundles/FormBundle/Model/FormModel.php populateValuesWithLead()` is called twice to render form (one for HTML and one for JS), during the first time the form is modified by unset() (to check if it's an auto fill fields). But I don't no why, during second time the form is not the original but the form in memory modified by first time.

I have remove unset and add new autoFillFields array() to not have modified form the second time.