### PR TITLE
Fix applying DNC for not existing contact

### DIFF
--- a/app/bundles/LeadBundle/Model/DoNotContact.php
+++ b/app/bundles/LeadBundle/Model/DoNotContact.php
@@ -100,7 +100,12 @@ class DoNotContact
         $dnc     = false;
         $contact = $this->leadModel->getEntity($contactId);
 
-        // if !$checkCurrentStatus, assume is contactable due to already being valided
+        if ($contact === null) {
+            // Contact not found, nothing to do
+            return false;
+        }
+
+        // if !$checkCurrentStatus, assume is contactable due to already being validated
         $isContactable = ($checkCurrentStatus) ? $this->isContactable($contact, $channel) : DNC::IS_CONTACTABLE;
 
         // If they don't have a DNC entry yet


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When parallel process delete contact and the other is trying to apply DNC, PHP throws exception, because contact not exists.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Described in issue

#### Steps to test this PR:
1. Same as reproduction steps
