### PR TITLE
Prevent interval from doubling the expected scheduled time

### DIFF
--- a/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
@@ -364,21 +364,22 @@ class EventScheduler
 
     /**
      * @param Event           $event
-     * @param \DateTime       $comparedFromDateTime
+     * @param \DateTime       $executionDateTime
      * @param ArrayCollection $contacts
+     * @param \DateTime       $comparedFromDateTime
      *
      * @throws NotSchedulableException
      */
-    public function validateAndScheduleEventForContacts(Event $event, \DateTime $comparedFromDateTime, ArrayCollection $contacts)
+    public function validateAndScheduleEventForContacts(Event $event, \DateTime $executionDateTime, ArrayCollection $contacts, \DateTime $comparedFromDateTime)
     {
         if ($this->intervalScheduler->isContactSpecificExecutionDateRequired($event)) {
             $this->logger->debug(
                 'CAMPAIGN: Event ID# '.$event->getId().
                 ' has to be scheduled based on contact specific parameters '.
-                ' compared to '.$comparedFromDateTime->format('Y-m-d H:i:s')
+                ' compared to '.$executionDateTime->format('Y-m-d H:i:s')
             );
 
-            $groupedExecutionDates = $this->intervalScheduler->groupContactsByDate($event, $contacts, $comparedFromDateTime);
+            $groupedExecutionDates = $this->intervalScheduler->groupContactsByDate($event, $contacts, $executionDateTime);
             $config                = $this->collector->getEventConfig($event);
 
             foreach ($groupedExecutionDates as $groupExecutionDateDAO) {
@@ -392,13 +393,6 @@ class EventScheduler
 
             return;
         }
-
-        $executionDateTime = $this->getExecutionDateTime($event, $comparedFromDateTime);
-        $this->logger->debug(
-            'CAMPAIGN: Event ID# '.$event->getId().
-            ' to be executed on '.$executionDateTime->format('Y-m-d H:i:s').
-            ' compared to '.$comparedFromDateTime->format('Y-m-d H:i:s')
-        );
 
         if ($this->shouldSchedule($executionDateTime, $comparedFromDateTime)) {
             $this->schedule($event, $executionDateTime, $contacts);

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -170,8 +170,9 @@ class Interval implements ScheduleModeInterface
         }
 
         if (
-            null === $event->getTriggerHour() && (null === $event->getTriggerRestrictedStartHour() || null === $event->getTriggerRestrictedStopHour())
-            && empty($event->getTriggerRestrictedDaysOfWeek())
+            null === $event->getTriggerHour() &&
+            (null === $event->getTriggerRestrictedStartHour() || null === $event->getTriggerRestrictedStopHour()) &&
+            empty($event->getTriggerRestrictedDaysOfWeek())
         ) {
             return false;
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Scheduling campaign events at the root of a campaign (kickoff) with an interval schedule without hour or day of the week limiters resulted in the action being scheduled double what it was supposed to be. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new campaign
2. Add an action and schedule it to be executed in 1 day ( leave all the hour and dow options blank or unchecked)
3. Execute and note the action is scheduled for 2 days

#### Steps to test this PR:
1. Repeat the above 
2. Also schedule actions at 0 days, 1 day, and 5 days at different relative hours for a total of 4 scheduled actions
3. Each action should be scheduled at the appropriate time
