### PR TITLE
Prefer a slave connection for segment counts.

### DIFF
--- a/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -109,8 +109,15 @@ class ContactSegmentQueryBuilder
      */
     public function wrapInCount(QueryBuilder $qb)
     {
+        /** @var Connection $connection */
+        $connection = $this->entityManager->getConnection();
+        if ($connection instanceof MasterSlaveConnection) {
+            // Prefer a slave connection if available.
+            $connection->connect('slave');
+        }
+
         // Add count functions to the query
-        $queryBuilder = new QueryBuilder($this->entityManager->getConnection());
+        $queryBuilder = new QueryBuilder($connection);
 
         //  If there is any right join in the query we need to select its it
         $primary = $qb->guessPrimaryLeadContactIdColumn();


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
#5970 fixed 99% of the performance issues one would have when scaling up to a read/write database cluster. This is one last query modifier we've found that can hit the master, when it should always be hitting a slave. This will move the bottleneck to the slave DB connection (if available) where it can be scaled to meet demands.

#### Steps to test this PR:
1. Set up a master/slave database pair.
2. Fill with at least a million leads.
3. Run console mautic:segments:update
4. Watch your live MySQL connections and you should not see queries involving segment *selects* against the master. Selects should hit the slave, inserts/updates on the master.

Anyone *not* running a master/slave cluster will find this PR does nothing... as it should be :)