### PR TITLE
Fix form actions are not removed through REST API using DELETE

### DIFF
--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -97,15 +97,7 @@ class FormApiController extends CommonApiController
             return $this->badRequest('The actions attribute must be array.');
         }
 
-        $currentActions = $entity->getActions();
-
-        foreach ($currentActions as $currentAction) {
-            if (in_array($currentAction->getId(), $actionsToDelete)) {
-                $entity->removeAction($currentAction);
-            }
-        }
-
-        $this->model->saveEntity($entity);
+        $this->model->deleteActions($entity, $actionsToDelete);
 
         $view = $this->view([$this->entityNameOne => $entity]);
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | #6885 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Form actions are not removed through REST API endpoint /forms/{form_id}/actions/delete?actions[]={action_id} using DELETE method. Related issue #6885 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create new form using `POST` `/api/forms/new` endpoint with data:
```
{
    "name": "Test",
    "formType": "standalone",
    "description": "API test",
    "fields": [
        {
            "label": "field name",
            "type": "text"
        }
    ],
    "actions": [
        {
            "name": "action name 1",
            "description": "action desc",
            "type": "lead.pointschange",
            "properties": {
                "operator": "plus",
                "points": 2
            }
        }
    ]
}
```
2. New form with action is successfully created
3. Delete created action with `DELETE` `/forms/{form_id}/actions/delete?actions[]={action_id}`
4. Action is successfully removed (action is not present in response data)
5. Get form using `GET` `/forms/{id}`. Form still has initially created action: "action name 1"

#### Steps to test this PR:
1. Repeat steps to reproduce