### PR TITLE
Fix form actions are not updated through REST API using PUT

### DIFF
--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -246,10 +246,16 @@ class FormApiController extends CommonApiController
 
         // Remove actions which weren't in the PUT request
         if (!$isNew && $method === 'PUT') {
+            $actionsToDelete = [];
+
             foreach ($currentActions as $currentAction) {
                 if (!in_array($currentAction->getId(), $requestActionIds)) {
-                    $entity->removeAction($currentAction);
+                    $actionsToDelete[] = $currentAction->getId();
                 }
+            }
+
+            if ($actionsToDelete) {
+                $this->model->deleteActions($entity, $actionsToDelete);
             }
         }
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | #6884 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Form actions are not updated through REST API endpoint `/forms/{id}/edit` using `PUT` method. Related issue #6884  

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create new form using `POST` `/api/forms/new` endpoint with data:
```
{
    "name": "Test",
    "formType": "standalone",
    "description": "API test",
    "fields": [
        {
            "label": "field name",
            "type": "text"
        }
    ],
    "actions": [
        {
            "name": "action name 1",
            "description": "action desc",
            "type": "lead.pointschange",
            "properties": {
                "operator": "plus",
                "points": 2
            }
        }
    ]
}
```
2. New form with action is successfully created
3. Update created post using `PUT` `/forms/{id}/edit` with data:
 ```
{
    "name": "Test",
    "formType": "standalone",
    "description": "API test",
    "fields": [
        {
            "label": "field name",
            "type": "text"
        }
    ],
    "actions": []
}
```
4. Form is successfully edited, no form actions are present in response data
5. Get form using `GET` `/forms/{id}`. Form still has initially created action: "action name 1"

#### Steps to test this PR:
1. Repeat steps to reproduce