### PR TITLE
Fix alias reset after form name change via api

### DIFF
--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -121,10 +121,13 @@ class FormApiController extends CommonApiController
         $fieldModel  = $this->getModel('form.field');
         $actionModel = $this->getModel('form.action');
         $isNew       = false;
+        $alias       = $entity->getAlias();
 
-        // Set clean alias to prevent SQL errors
-        $alias = $this->model->cleanAlias($entity->getName(), '', 10);
-        $entity->setAlias($alias);
+        if (empty($alias)) {
+            // Set clean alias to prevent SQL errors
+            $alias = $this->model->cleanAlias($entity->getName(), '', 10);
+            $entity->setAlias($alias);
+        }
 
         // Set timestamps
         $this->model->setTimestamps($entity, true, false);

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -572,7 +572,9 @@ class FormController extends CommonFormController
                         $model->setFields($entity, $fields);
                         $model->deleteFields($entity, $deletedFields);
 
-                        if (!$alias = $entity->getAlias()) {
+                        $alias = $entity->getAlias();
+
+                        if (empty($alias)) {
                             $alias = $model->cleanAlias($entity->getName(), '', 10);
                             $entity->setAlias($alias);
                         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6890
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When changing a form name via the api it also changes the alias. This will make the form incompatible with its results table. The form alias has no real use besides matching with the results table, thus this parameter should not be updatable. This pr fixes the issue by redoing a bad condition.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Create a form
2. Submit a result
3. Update form name via api
4. See correct result counter, but results page is empty

#### Steps to test this PR:
1. Same as above, but this time the results are still there