### PR TITLE
Populate tag list in contact webhooks (#6861)

### DIFF
--- a/app/bundles/LeadBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/WebhookSubscriber.php
@@ -118,6 +118,7 @@ class WebhookSubscriber extends CommonSubscriber
                 'userList',
                 'publishDetails',
                 'ipAddress',
+                'tagList',
             ]
         );
     }

--- a/app/bundles/LeadBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/WebhookSubscriber.php
@@ -143,6 +143,7 @@ class WebhookSubscriber extends CommonSubscriber
                 'userList',
                 'publishDetails',
                 'ipAddress',
+                'tagList',
             ]
         );
     }
@@ -187,6 +188,7 @@ class WebhookSubscriber extends CommonSubscriber
                 'userList',
                 'publishDetails',
                 'ipAddress',
+                'tagList',
             ]
         );
     }

--- a/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberTest.php
@@ -154,6 +154,7 @@ class WebhookSubscriberTest extends \PHPUnit_Framework_TestCase
                     'userList',
                     'publishDetails',
                     'ipAddress',
+                    'tagList',
                 ]
             );
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes | 
| New feature? | No |
| Automated tests included? | No |
| Related user documentation PR URL | No |
| Related developer documentation PR URL | No |
| Issues addressed (#s or URLs) | #6861 |
| BC breaks? | No |
| Deprecations? | No |

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: 
At the moment, tag list in the contact webhooks contains only empty objects. This PR, populate tag list with tag's data.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create webhook for "Contact Updated Event", "Contact subscription change" and "Contact point change"
2. Trigger each webhooks for a tagged contact
3. Check webhook's payload (with empty tag array)

#### Steps to test this PR:
1. Create webhook for "Contact Updated Event", "Contact subscription change" and "Contact point change"
2. Trigger each webhooks for a tagged contact
3. Check webhook's payload, tags array should be populated with tag's data

#### List deprecations along with the new alternative:
No deprecations

#### List backwards compatibility breaks:
No backwards compatibility breaks