### PR TITLE
Not contains support for form value condition expression with notLike

### DIFF
--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -459,7 +459,7 @@ class SubmissionRepository extends CommonRepository
         switch ($operatorExpr) {
             case 'like':
             case 'notLike':
-                $value = strpos($value, '%') === false ? '%'.$value.'%' : $value;
+                $value = false === strpos($value, '%') ? '%'.$value.'%' : $value;
                 break;
             case 'startsWith':
                 $operatorExpr    = 'like';

--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -469,6 +469,10 @@ class SubmissionRepository extends CommonRepository
                 $operatorExpr   = 'like';
                 $value          = '%'.$value.'%';
                 break;
+            case 'like':
+            case 'notLike':
+                $value = strpos($value, '%') === false ? '%'.$value.'%' : $value;
+                break;
         }
 
         // use DBAL to get entity fields

--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -457,6 +457,10 @@ class SubmissionRepository extends CommonRepository
     {
         // Modify operator
         switch ($operatorExpr) {
+            case 'like':
+            case 'notLike':
+                $value = strpos($value, '%') === false ? '%'.$value.'%' : $value;
+                break;
             case 'startsWith':
                 $operatorExpr    = 'like';
                 $value           = $value.'%';
@@ -468,10 +472,6 @@ class SubmissionRepository extends CommonRepository
             case 'contains':
                 $operatorExpr   = 'like';
                 $value          = '%'.$value.'%';
-                break;
-            case 'like':
-            case 'notLike':
-                $value = strpos($value, '%') === false ? '%'.$value.'%' : $value;
                 break;
         }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Added same logic to form field value condition like segments fitler do for like/notLike  https://github.com/kuzmany/mautic/blob/f5fd2cf553eec037f7b6211c193f8675d2331b40/app/bundles/LeadBundle/Segment/Decorator/BaseDecorator.php#L131-L131

That means, If search value doesn't contain `%` symbol, we add it `%value%`

#### Steps to test this PR:
1. Create form with multiselect value  with options  `first, second, third`
2. Submit it with first and third option selected
3.  Create campaign with  form field value condition with not like for multi select for notLike first
4. You should be a true in the campaign 
