### PR TITLE
Campaign stats improvement

### DIFF
--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -683,7 +683,7 @@ class CampaignController extends AbstractStandardFormController
                         if ($leadCount) {
                             $event['percent']    = round(($event['logCount'] / $total) * 100, 1);
                             $event['yesPercent'] = round(($campaignLogCounts[$event['id']][1] / $total) * 100, 1);
-                            $event['noPercent']  = $total ? round(($campaignLogCounts[$event['id']][0] / $total) * 100, 1) : 0;
+                            $event['noPercent']  = round(($campaignLogCounts[$event['id']][0] / $total) * 100, 1);
                         }
                     }
                 }
@@ -713,6 +713,7 @@ class CampaignController extends AbstractStandardFormController
                     null,
                     ['campaign_id' => $objectId]
                 );
+
                 $session = $this->get('session');
 
                 $campaignSources = $this->getCampaignModel()->getSourceLists();

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -683,6 +683,7 @@ class CampaignController extends AbstractStandardFormController
 
                     $sortedEvents[$event['eventType']][] = $event;
                 }
+
                 $stats = $this->getCampaignModel()->getCampaignMetricsLineChartData(
                     null,
                     new \DateTime($dateRangeForm->get('date_from')->getData()),
@@ -690,6 +691,7 @@ class CampaignController extends AbstractStandardFormController
                     null,
                     ['campaign_id' => $objectId]
                 );
+
                 $session = $this->get('session');
 
                 $campaignSources = $this->getCampaignModel()->getSourceLists();

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -665,12 +665,12 @@ class CampaignController extends AbstractStandardFormController
                     'condition' => [],
                 ];
                 foreach ($events as &$event) {
-                    $event['logCount']             =
-                    $event['logCountForPending']   =
-                    $event['percent']              =
-                    $event['yesPercent']           =
-                    $event['noPercent']            = 0;
-                    $event['leadCount']            = $leadCount;
+                    $event['logCount']           =
+                    $event['logCountForPending'] =
+                    $event['percent']            =
+                    $event['yesPercent']         =
+                    $event['noPercent']          = 0;
+                    $event['leadCount']          = $leadCount;
 
                     if (isset($campaignLogCounts[$event['id']])) {
                         $event['logCount']           = array_sum($campaignLogCounts[$event['id']]);

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -678,19 +678,14 @@ class CampaignController extends AbstractStandardFormController
                         $event['logCountForPending'] = array_sum($pendingCampaignLogCounts[$event['id']]);
 
                         $pending  = $event['leadCount'] - $event['logCountForPending'];
-                        $total    = $event['logCount'] + $pending;
-                        $totalYes = $campaignLogCounts[$event['id']][1] + round($pending / 2);
-                        $totalNo  = $campaignLogCounts[$event['id']][0] + round($pending / 2);
-                        echo $total;
-                        echo '-';
-                        echo $totalYes;
-                        echo '-';
-                        echo $totalNo;
-                        echo '----';
+                        $totalYes = $campaignLogCounts[$event['id']][1];
+                        $totalNo  = $campaignLogCounts[$event['id']][0];
+                        $total    = $totalYes + $totalNo + $pending;
+
                         if ($leadCount) {
                             $event['percent']    = round(($event['logCount'] / $total) * 100, 1);
-                            $event['yesPercent'] = round(($campaignLogCounts[$event['id']][1] / ($totalYes + $totalNo)) * 100, 1);
-                            $event['noPercent']  = $totalNo ? round(($campaignLogCounts[$event['id']][0] / ($totalYes + $totalNo)) * 100, 1) : 0;
+                            $event['yesPercent'] = round(($campaignLogCounts[$event['id']][1] / $total) * 100, 1);
+                            $event['noPercent']  = $totalNo ? round(($campaignLogCounts[$event['id']][0] / $total) * 100, 1) : 0;
                         }
                     }
 
@@ -703,7 +698,6 @@ class CampaignController extends AbstractStandardFormController
                     null,
                     ['campaign_id' => $objectId]
                 );
-
                 $session = $this->get('session');
 
                 $campaignSources = $this->getCampaignModel()->getSourceLists();

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -683,7 +683,6 @@ class CampaignController extends AbstractStandardFormController
 
                     $sortedEvents[$event['eventType']][] = $event;
                 }
-
                 $stats = $this->getCampaignModel()->getCampaignMetricsLineChartData(
                     null,
                     new \DateTime($dateRangeForm->get('date_from')->getData()),

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -657,7 +657,7 @@ class CampaignController extends AbstractStandardFormController
                 $eventLogRepo      = $this->getDoctrine()->getManager()->getRepository('MauticCampaignBundle:LeadEventLog');
                 $events            = $this->getCampaignModel()->getEventRepository()->getCampaignEvents($entity->getId());
                 $leadCount         = $this->getCampaignModel()->getRepository()->getCampaignLeadCount($entity->getId());
-                $campaignLogCounts = $eventLogRepo->getCampaignLogCounts($entity->getId(), false, false);
+                $campaignLogCounts = $eventLogRepo->getCampaignLogCounts($entity->getId(), false, false, true);
                 $sortedEvents      = [
                     'decision'  => [],
                     'action'    => [],
@@ -691,7 +691,6 @@ class CampaignController extends AbstractStandardFormController
                     null,
                     ['campaign_id' => $objectId]
                 );
-
                 $session = $this->get('session');
 
                 $campaignSources = $this->getCampaignModel()->getSourceLists();

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -692,7 +692,6 @@ class CampaignController extends AbstractStandardFormController
                 foreach ($events as &$event) {
                     if (!empty($event['decisionPath']) && !empty($event['parent_id']) && isset($events[$event['parent_id']])) {
                         $parentEvent                 = $events[$event['parent_id']];
-                        $event['logCount']           = $parentEvent['logCount'];
                         $event['logCountForPending'] = $parentEvent['logCountForPending'];
                         $event['percent']            = $parentEvent['percent'];
                         $event['yesPercent']         = $parentEvent['yesPercent'];

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -215,19 +215,26 @@ class LeadEventLogRepository extends CommonRepository
     /**
      * @param      $campaignId
      * @param bool $excludeScheduled
+     * @param bool $excludeNegative
+     * @param bool $all
      *
      * @return array
      */
-    public function getCampaignLogCounts($campaignId, $excludeScheduled = false, $excludeNegative = true)
+    public function getCampaignLogCounts($campaignId, $excludeScheduled = false, $excludeNegative = true, $all = false)
     {
         $q = $this->getSlaveConnection()->createQueryBuilder()
-                       ->from(MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'o')
-                       ->innerJoin(
-                           'o',
-                           MAUTIC_TABLE_PREFIX.'campaign_leads',
-                           'l',
-                           'l.campaign_id = '.(int) $campaignId.' and l.manually_removed = 0 and o.lead_id = l.lead_id and l.rotation = o.rotation'
-                       );
+                      ->from(MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'o');
+
+        $join = 'innerJoin';
+        if ($all === true) {
+            $join = 'leftJoin';
+        }
+        $q->$join(
+                    'o',
+                    MAUTIC_TABLE_PREFIX.'campaign_leads',
+                    'l',
+                    'l.campaign_id = '.(int) $campaignId.' and l.manually_removed = 0 and o.lead_id = l.lead_id and l.rotation = o.rotation'
+                );
 
         $expr = $q->expr()->andX(
             $q->expr()->eq('o.campaign_id', (int) $campaignId)

--- a/app/bundles/CampaignBundle/Views/Campaign/events.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/events.html.php
@@ -29,7 +29,7 @@
                         <?php echo $event['noPercent'].'%'; ?>
                     </span>
                     <?php endif; ?>
-                <span class="mt-xs label label-warning" data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.report.campaign.completed.actions'); ?>"><?= $event['logCount']; ?></span> <span class="mt-xs label label-default"  data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.report.campaign.pending.actions'); ?>"><?= $event['leadCount'] - $event['logCount']; ?></span>
+                <span class="mt-xs label label-warning" data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.report.campaign.completed.actions'); ?>"><?= $event['logCount']; ?></span> <span class="mt-xs label label-default"  data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.report.campaign.pending.actions'); ?>"><?= $event['leadCount'] - $event['logCountForPending']; ?></span>
                 </div>
                     <div class="col-md-5 va-m">
                     <h5 class="fw-sb text-primary mb-xs">

--- a/app/bundles/CampaignBundle/Views/Campaign/events.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/events.html.php
@@ -16,7 +16,6 @@
         <?php $typeClass    = ('action' === $event['eventType'] && 'no' === $event['decisionPath']) ? 'danger' : 'success'; ?>
         <?php $percentLabel = ($typeClass === 'danger') ? 'mautic.report.campaign.no.percent' : 'mautic.report.campaign.yes.percent'; ?>
         <?php $percentProp  = ($typeClass === 'danger') ? 'noPercent' : 'yesPercent'; ?>
-        <?php $percentProp  = ('no' === $event['decisionPath']) ? 'percent' : $percentProp; ?>
         <li class="list-group-item bg-auto bg-light-xs">
             <div class="progress-bar progress-bar-<?php echo $typeClass; ?>" style="width:<?php echo $event['yesPercent']; ?>%; left: 0;"></div>
             <div class="progress-bar progress-bar-danger" style="width:<?php echo $event['noPercent']; ?>%; left: <?php echo $event['yesPercent']; ?>%"></div>

--- a/app/bundles/CampaignBundle/Views/Campaign/events.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/events.html.php
@@ -16,6 +16,7 @@
         <?php $typeClass    = ('action' === $event['eventType'] && 'no' === $event['decisionPath']) ? 'danger' : 'success'; ?>
         <?php $percentLabel = ($typeClass === 'danger') ? 'mautic.report.campaign.no.percent' : 'mautic.report.campaign.yes.percent'; ?>
         <?php $percentProp  = ($typeClass === 'danger') ? 'noPercent' : 'yesPercent'; ?>
+        <?php $percentProp  = ('no' === $event['decisionPath']) ? 'percent' : $percentProp; ?>
         <li class="list-group-item bg-auto bg-light-xs">
             <div class="progress-bar progress-bar-<?php echo $typeClass; ?>" style="width:<?php echo $event['yesPercent']; ?>%; left: 0;"></div>
             <div class="progress-bar progress-bar-danger" style="width:<?php echo $event['noPercent']; ?>%; left: <?php echo $event['yesPercent']; ?>%"></div>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6847
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR should resolve inconsintent stats between graph and event data.
This PR take all event logs and making  stats from them.  For actions after condition we take data from parent condition for true/false. 

![image](https://user-images.githubusercontent.com/462477/48774719-48481580-eccb-11e8-99c2-32ace8bd733e.png)


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Stats data are inconsistent in every detail. This data count stats from events execute with acutal contacts and don't count repeat events, manually removed contacts etc.  Look to reported issue https://github.com/mautic/mautic/issues/6847


#### Steps to test this PR:
1. Test random campaign with random stats and check if works properly

For example this campaigh with 3 contacts and few repeat actions and condition display 14 events for graph and 9 events for positive action and 5 events for negative action. That means 14 = 9+5 (correct)

![image](https://user-images.githubusercontent.com/462477/48790443-a1c23b80-ecef-11e8-920c-dfe680369280.png)