### PR TITLE
Fix translation message after focus item removal.

### DIFF
--- a/plugins/MauticFocusBundle/Views/Focus/details.html.php
+++ b/plugins/MauticFocusBundle/Views/Focus/details.html.php
@@ -35,7 +35,7 @@ $view['slots']->set(
                 'close' => $view['security']->isGranted('plugin:focus:items:view'),
             ],
             'routeBase' => 'focus',
-            'langVar'   => 'mautic.focus',
+            'langVar'   => 'focus',
         ]
     )
 );


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Required: )
#### Description:
When attempting to delete a Focus Item entry, untranslated message shows up.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create new Focus Item entry, named "aaa".
2. Attempt to delete the newly created entry.
3. A modal dialog with "mautic.mautic.focus.form.confirmdelete" shows.

#### Steps to test this PR:
1. Apply PR.
2. Clear browser cache.
3. Repeat reproduction steps above.
4. When deleting the Focus Item entry, the dialog should now be "Delete the Focus item, aaa (1)?"
