### PR TITLE
Allow downloading themes when having View permissions.

### DIFF
--- a/app/bundles/CoreBundle/Controller/ThemeController.php
+++ b/app/bundles/CoreBundle/Controller/ThemeController.php
@@ -122,7 +122,7 @@ class ThemeController extends FormController
         $flashes     = [];
         $error       = false;
 
-        if (!$this->get('mautic.security')->isGranted('core:themes:edit')) {
+        if (!$this->get('mautic.security')->isGranted('core:themes:view')) {
             return $this->accessDenied();
         }
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Required: )
#### Description: 
When having theme permissions set to View only, attempting to download a theme ends in 403.

This PR allows downloading the theme with permissions set to `View`.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new user with Theme permissions set to View only.
2. Log in with the new user account.
3. Attempt to download a theme.
4. 403 happens.

#### Steps to test this PR:
1. Apply this PR.
2. Repeat reproduce steps.
3. Theme should be downloaded instead of 403.