### PR TITLE
Speed up caching+page loads and reduce memory footprint by referencing system parameters instead of copying/duplicating them

### DIFF
--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/EventPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/EventPass.php
@@ -15,8 +15,8 @@ use Mautic\CoreBundle\EventListener\CommonSubscriber;
 use Mautic\WebhookBundle\EventListener\WebhookSubscriberBase;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 /**
  * Class EventPass.
@@ -40,7 +40,7 @@ class EventPass implements CompilerPassInterface
             $definition->addMethodCall('setRequest', [new Reference('request_stack')]);
             $definition->addMethodCall('setSecurity', [new Reference('mautic.security')]);
             $definition->addMethodCall('setSerializer', [new Reference('jms_serializer')]);
-            $definition->addMethodCall('setSystemParameters', [new Parameter('mautic.parameters')]);
+            $definition->addMethodCall('setSystemParameters', [new Expression("parameter('mautic.parameters')")]);
             $definition->addMethodCall('setDispatcher', [new Reference('event_dispatcher')]);
             $definition->addMethodCall('setTranslator', [new Reference('translator')]);
             $definition->addMethodCall('setEntityManager', [new Reference('doctrine.orm.entity_manager')]);


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | No
| New feature? | No
| Automated tests included? | N/A
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

#### Description:
This 2-line tweak to the DI compiler speeds up cache generation and page load time, while shrinking cache file size and memory footprint.  Instead of copying the full array of system parameters into the PHP code once for each event listener (i.e. many dozens of times), the existing parameter array is fetched as needed at runtime, allowing it to be shared between listeners (reducing memory overhead) while avoiding array creation overhead.

(On my development/test install, the size of the service container cache file was reduced by about 1.5M and cache warmup time dropped by about 100ms.)
