### PR TITLE
Show publish icons only when having proper permissions.

### DIFF
--- a/app/bundles/AssetBundle/Views/Asset/list.html.php
+++ b/app/bundles/AssetBundle/Views/Asset/list.html.php
@@ -119,13 +119,23 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php echo $view->render(
-                                'MauticCoreBundle:Helper:publishstatus_icon.html.php',
-                                [
-                                    'item'  => $item,
-                                    'model' => 'asset.asset',
-                                ]
-                            ); ?>
+                            <?php
+                            if ($security->hasEntityAccess(
+                                    $permissions['asset:assets:publishown'],
+                                    $permissions['asset:assets:publishother'],
+                                    $item->getCreatedBy()
+                                )
+                            ) {
+                                echo $view->render(
+                                    'MauticCoreBundle:Helper:publishstatus_icon.html.php',
+                                    [
+                                        'item'  => $item,
+                                        'model' => 'asset.asset',
+                                    ]
+                                );
+                            }
+
+                            ?>
                             <a href="<?php echo $view['router']->path(
                                 'mautic_asset_action',
                                 ['objectAction' => 'view', 'objectId' => $item->getId()]

--- a/app/bundles/AssetBundle/Views/Asset/list.html.php
+++ b/app/bundles/AssetBundle/Views/Asset/list.html.php
@@ -119,23 +119,20 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php
-                            if ($security->hasEntityAccess(
+                            <?php if ($security->hasEntityAccess(
                                     $permissions['asset:assets:publishown'],
                                     $permissions['asset:assets:publishother'],
                                     $item->getCreatedBy()
                                 )
-                            ) {
-                                echo $view->render(
+                            ): ?>
+                                <?php echo $view->render(
                                     'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                     [
                                         'item'  => $item,
                                         'model' => 'asset.asset',
                                     ]
-                                );
-                            }
-
-                            ?>
+                                ); ?>
+                            <?php endif; ?>
                             <a href="<?php echo $view['router']->path(
                                 'mautic_asset_action',
                                 ['objectAction' => 'view', 'objectId' => $item->getId()]

--- a/app/bundles/CampaignBundle/Views/Campaign/list.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/list.html.php
@@ -88,13 +88,16 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php echo $view->render(
-                                'MauticCoreBundle:Helper:publishstatus_icon.html.php',
-                                [
-                                    'item'  => $item,
-                                    'model' => 'campaign',
-                                ]
-                            ); ?>
+                            <?php
+                            if ($permissions['campaign:campaigns:publish']) {
+                                echo $view->render(
+                                    'MauticCoreBundle:Helper:publishstatus_icon.html.php',
+                                    [
+                                        'item'  => $item,
+                                        'model' => 'campaign',
+                                    ]
+                                );
+                            } ?>
                             <a href="<?php echo $view['router']->path(
                                 'mautic_campaign_action',
                                 ['objectAction' => 'view', 'objectId' => $item->getId()]

--- a/app/bundles/CampaignBundle/Views/Campaign/list.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/list.html.php
@@ -88,16 +88,15 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php
-                            if ($permissions['campaign:campaigns:publish']) {
-                                echo $view->render(
+                            <?php if ($permissions['campaign:campaigns:publish']): ?>
+                                <?php echo $view->render(
                                     'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                     [
                                         'item'  => $item,
                                         'model' => 'campaign',
                                     ]
-                                );
-                            } ?>
+                                ); ?>
+                             <?php endif; ?>
                             <a href="<?php echo $view['router']->path(
                                 'mautic_campaign_action',
                                 ['objectAction' => 'view', 'objectId' => $item->getId()]

--- a/app/bundles/CategoryBundle/Controller/CategoryController.php
+++ b/app/bundles/CategoryBundle/Controller/CategoryController.php
@@ -68,6 +68,7 @@ class CategoryController extends FormController
                 $permissionBase.':create',
                 $permissionBase.':edit',
                 $permissionBase.':delete',
+                $permissionBase.':publish',
             ],
             'RETURN_ARRAY'
         );

--- a/app/bundles/CategoryBundle/Views/Category/list.html.php
+++ b/app/bundles/CategoryBundle/Views/Category/list.html.php
@@ -113,10 +113,13 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php echo $view->render(
-                                'MauticCoreBundle:Helper:publishstatus_icon.html.php',
-                                ['item' => $item, 'model' => 'category', 'query' => 'bundle='.$bundle]
-                            ); ?>
+                            <?php
+                            if ($permissions[$permissionBase.'publish']) {
+                                echo $view->render(
+                                    'MauticCoreBundle:Helper:publishstatus_icon.html.php',
+                                    ['item' => $item, 'model' => 'category', 'query' => 'bundle='.$bundle]
+                                );
+                            } ?>
                             <?php if ($permissions[$permissionBase.':edit']): ?>
                                 <a href="<?php echo $view['router']->path(
                                     'mautic_category_action',

--- a/app/bundles/CategoryBundle/Views/Category/list.html.php
+++ b/app/bundles/CategoryBundle/Views/Category/list.html.php
@@ -113,13 +113,12 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php
-                            if ($permissions[$permissionBase.'publish']) {
-                                echo $view->render(
+                            <?php if ($permissions[$permissionBase.'publish']): ?>
+                                <?php echo $view->render(
                                     'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                     ['item' => $item, 'model' => 'category', 'query' => 'bundle='.$bundle]
-                                );
-                            } ?>
+                                ); ?>
+                            <?php endif; ?>
                             <?php if ($permissions[$permissionBase.':edit']): ?>
                                 <a href="<?php echo $view['router']->path(
                                     'mautic_category_action',

--- a/app/bundles/CoreBundle/Views/Standard/list.html.php
+++ b/app/bundles/CoreBundle/Views/Standard/list.html.php
@@ -140,7 +140,7 @@ if (count($items)):
                         </td>
                         <td>
                             <div>
-                                <?php if (method_exists($item, 'isPublished')): ?>
+                                <?php if (method_exists($item, 'isPublished' && $permissions[$permissionBase.':publish'])): ?>
                                     <?php echo $view->render(
                                         'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                         ['item' => $item, 'model' => $modelName]

--- a/app/bundles/DynamicContentBundle/Views/DynamicContent/list.html.php
+++ b/app/bundles/DynamicContentBundle/Views/DynamicContent/list.html.php
@@ -105,10 +105,18 @@ if ($tmpl == 'index') {
                         ?>
                     </td>
                     <td>
-                        <?php echo $view->render(
+                        <?php
+                        if ($view['security']->hasEntityAccess(
+                            $permissions['dynamiccontent:dynamiccontents:publishown'],
+                            $permissions['dynamiccontent:dynamiccontents:publishother'],
+                            $item->getCreatedBy()
+                            )
+                        ) {
+                            echo $view->render(
                             'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                             ['item' => $item, 'model' => 'dynamicContent']
-                        ); ?>
+                            );
+                        } ?>
                         <a href="<?php echo $view['router']->generate(
                             'mautic_dynamicContent_action',
                             ['objectAction' => 'view', 'objectId' => $item->getId()]

--- a/app/bundles/DynamicContentBundle/Views/DynamicContent/list.html.php
+++ b/app/bundles/DynamicContentBundle/Views/DynamicContent/list.html.php
@@ -105,18 +105,17 @@ if ($tmpl == 'index') {
                         ?>
                     </td>
                     <td>
-                        <?php
-                        if ($view['security']->hasEntityAccess(
+                        <?php if ($view['security']->hasEntityAccess(
                             $permissions['dynamiccontent:dynamiccontents:publishown'],
                             $permissions['dynamiccontent:dynamiccontents:publishother'],
                             $item->getCreatedBy()
                             )
-                        ) {
-                            echo $view->render(
-                            'MauticCoreBundle:Helper:publishstatus_icon.html.php',
-                            ['item' => $item, 'model' => 'dynamicContent']
-                            );
-                        } ?>
+                        ): ?>
+                            <?php echo $view->render(
+                                'MauticCoreBundle:Helper:publishstatus_icon.html.php',
+                                ['item' => $item, 'model' => 'dynamicContent']
+                            ); ?>
+                        <?php endif; ?>
                         <a href="<?php echo $view['router']->generate(
                             'mautic_dynamicContent_action',
                             ['objectAction' => 'view', 'objectId' => $item->getId()]

--- a/app/bundles/EmailBundle/Views/Email/list.html.php
+++ b/app/bundles/EmailBundle/Views/Email/list.html.php
@@ -118,7 +118,15 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php echo $view->render('MauticCoreBundle:Helper:publishstatus_icon.html.php', ['item' => $item, 'model' => 'email']); ?>
+                            <?php
+                            if ($view['security']->hasEntityAccess(
+                                $permissions['email:emails:publishown'],
+                                $permissions['email:emails:publishother'],
+                                $item->getCreatedBy()
+                                )
+                            ) {
+                                echo $view->render('MauticCoreBundle:Helper:publishstatus_icon.html.php', ['item' => $item, 'model' => 'email']);
+                            } ?>
                             <a href="<?php echo $view['router']->path(
                                 'mautic_email_action',
                                 ['objectAction' => 'view', 'objectId' => $item->getId()]

--- a/app/bundles/EmailBundle/Views/Email/list.html.php
+++ b/app/bundles/EmailBundle/Views/Email/list.html.php
@@ -118,15 +118,14 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php
-                            if ($view['security']->hasEntityAccess(
+                            <?php if ($view['security']->hasEntityAccess(
                                 $permissions['email:emails:publishown'],
                                 $permissions['email:emails:publishother'],
                                 $item->getCreatedBy()
                                 )
-                            ) {
-                                echo $view->render('MauticCoreBundle:Helper:publishstatus_icon.html.php', ['item' => $item, 'model' => 'email']);
-                            } ?>
+                            ): ?>
+                                <?php echo $view->render('MauticCoreBundle:Helper:publishstatus_icon.html.php', ['item' => $item, 'model' => 'email']); ?>
+                            <?php endif; ?>
                             <a href="<?php echo $view['router']->path(
                                 'mautic_email_action',
                                 ['objectAction' => 'view', 'objectId' => $item->getId()]

--- a/app/bundles/FormBundle/Views/Form/list.html.php
+++ b/app/bundles/FormBundle/Views/Form/list.html.php
@@ -146,10 +146,18 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php echo $view->render(
+                            <?php
+                            if ($security->hasEntityAccess(
+                                $permissions['form:forms:publishown'],
+                                $permissions['form:forms:publishother'],
+                                $item->getCreatedBy()
+                                )
+                            ) {
+                                echo $view->render(
                                 'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                 ['item' => $item, 'model' => 'form.form']
-                            ); ?>
+                                );
+                            } ?>
                             <a href="<?php echo $view['router']->path(
                                 'mautic_form_action',
                                 ['objectAction' => 'view', 'objectId' => $item->getId()]

--- a/app/bundles/FormBundle/Views/Form/list.html.php
+++ b/app/bundles/FormBundle/Views/Form/list.html.php
@@ -146,18 +146,17 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php
-                            if ($security->hasEntityAccess(
+                            <?php if ($security->hasEntityAccess(
                                 $permissions['form:forms:publishown'],
                                 $permissions['form:forms:publishother'],
                                 $item->getCreatedBy()
                                 )
-                            ) {
-                                echo $view->render(
-                                'MauticCoreBundle:Helper:publishstatus_icon.html.php',
-                                ['item' => $item, 'model' => 'form.form']
-                                );
-                            } ?>
+                            ): ?>
+                                <?php echo $view->render(
+                                    'MauticCoreBundle:Helper:publishstatus_icon.html.php',
+                                    ['item' => $item, 'model' => 'form.form']
+                                ); ?>
+                            <?php endif; ?>
                             <a href="<?php echo $view['router']->path(
                                 'mautic_form_action',
                                 ['objectAction' => 'view', 'objectId' => $item->getId()]

--- a/app/bundles/LeadBundle/Views/List/list.html.php
+++ b/app/bundles/LeadBundle/Views/List/list.html.php
@@ -103,10 +103,18 @@ $listCommand = $view['translator']->trans('mautic.lead.lead.searchcommand.list')
                     </td>
                     <td>
                         <div>
-                            <?php echo $view->render(
-                                'MauticCoreBundle:Helper:publishstatus_icon.html.php',
-                                ['item' => $item, 'model' => 'lead.list']
-                            ); ?>
+                            <?php
+                            if ($view['security']->hasEntityAccess(
+                                true,
+                                $permissions['lead:lists:editother'],
+                                $item->getCreatedBy()
+                                )
+                            ) {
+                                echo $view->render(
+                                    'MauticCoreBundle:Helper:publishstatus_icon.html.php',
+                                    ['item' => $item, 'model' => 'lead.list']
+                                );
+                            } ?>
                             <?php if ($view['security']->hasEntityAccess(true, $permissions['lead:lists:editother'], $item->getCreatedBy())) : ?>
                                 <a href="<?php echo $view['router']->path(
                                     'mautic_segment_action',

--- a/app/bundles/LeadBundle/Views/List/list.html.php
+++ b/app/bundles/LeadBundle/Views/List/list.html.php
@@ -103,18 +103,17 @@ $listCommand = $view['translator']->trans('mautic.lead.lead.searchcommand.list')
                     </td>
                     <td>
                         <div>
-                            <?php
-                            if ($view['security']->hasEntityAccess(
+                            <?php if ($view['security']->hasEntityAccess(
                                 true,
                                 $permissions['lead:lists:editother'],
                                 $item->getCreatedBy()
                                 )
-                            ) {
-                                echo $view->render(
+                            ): ?>
+                                <?php echo $view->render(
                                     'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                     ['item' => $item, 'model' => 'lead.list']
-                                );
-                            } ?>
+                                ); ?>
+                            <?php endif; ?>
                             <?php if ($view['security']->hasEntityAccess(true, $permissions['lead:lists:editother'], $item->getCreatedBy())) : ?>
                                 <a href="<?php echo $view['router']->path(
                                     'mautic_segment_action',

--- a/app/bundles/PageBundle/Views/Page/list.html.php
+++ b/app/bundles/PageBundle/Views/Page/list.html.php
@@ -103,7 +103,15 @@ if ($tmpl == 'index') {
                         ?>
                     </td>
                     <td>
-                        <?php echo $view->render('MauticCoreBundle:Helper:publishstatus_icon.html.php', ['item' => $item, 'model' => 'page.page']); ?>
+                        <?php
+                        if ($view['security']->hasEntityAccess(
+                            $permissions['page:pages:publishown'],
+                            $permissions['page:pages:publishother'],
+                            $item->getCreatedBy()
+                            )
+                        ) {
+                            echo $view->render('MauticCoreBundle:Helper:publishstatus_icon.html.php', ['item' => $item, 'model' => 'page.page']);
+                        } ?>
                         <a href="<?php echo $view['router']->path(
                             'mautic_page_action',
                             ['objectAction' => 'view', 'objectId' => $item->getId()]

--- a/app/bundles/PageBundle/Views/Page/list.html.php
+++ b/app/bundles/PageBundle/Views/Page/list.html.php
@@ -103,15 +103,14 @@ if ($tmpl == 'index') {
                         ?>
                     </td>
                     <td>
-                        <?php
-                        if ($view['security']->hasEntityAccess(
+                        <?php if ($view['security']->hasEntityAccess(
                             $permissions['page:pages:publishown'],
                             $permissions['page:pages:publishother'],
                             $item->getCreatedBy()
                             )
-                        ) {
-                            echo $view->render('MauticCoreBundle:Helper:publishstatus_icon.html.php', ['item' => $item, 'model' => 'page.page']);
-                        } ?>
+                        ): ?>
+                            <?php echo $view->render('MauticCoreBundle:Helper:publishstatus_icon.html.php', ['item' => $item, 'model' => 'page.page']); ?>
+                        <?php endif; ?>
                         <a href="<?php echo $view['router']->path(
                             'mautic_page_action',
                             ['objectAction' => 'view', 'objectId' => $item->getId()]

--- a/app/bundles/PointBundle/Views/Point/list.html.php
+++ b/app/bundles/PointBundle/Views/Point/list.html.php
@@ -98,10 +98,12 @@ if ($tmpl == 'index') {
                     <td>
                         <div>
 
-                            <?php echo $view->render(
-                                'MauticCoreBundle:Helper:publishstatus_icon.html.php',
-                                ['item' => $item, 'model' => 'point']
-                            ); ?>
+                            <?php if ($permissions['point:points:publish']) {
+                            echo $view->render(
+                                    'MauticCoreBundle:Helper:publishstatus_icon.html.php',
+                                    ['item' => $item, 'model' => 'point']
+                                );
+                        } ?>
                             <a href="<?php echo $view['router']->path(
                                 'mautic_point_action',
                                 ['objectAction' => 'edit', 'objectId' => $item->getId()]

--- a/app/bundles/PointBundle/Views/Point/list.html.php
+++ b/app/bundles/PointBundle/Views/Point/list.html.php
@@ -97,13 +97,12 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-
-                            <?php if ($permissions['point:points:publish']) {
-                            echo $view->render(
+                            <?php if ($permissions['point:points:publish']): ?>
+                                <?php echo $view->render(
                                     'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                     ['item' => $item, 'model' => 'point']
-                                );
-                        } ?>
+                                ); ?>
+                            <?php endif; ?>
                             <a href="<?php echo $view['router']->path(
                                 'mautic_point_action',
                                 ['objectAction' => 'edit', 'objectId' => $item->getId()]

--- a/app/bundles/PointBundle/Views/Trigger/list.html.php
+++ b/app/bundles/PointBundle/Views/Trigger/list.html.php
@@ -102,10 +102,12 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php echo $view->render(
-                                'MauticCoreBundle:Helper:publishstatus_icon.html.php',
-                                ['item' => $item, 'model' => 'point.trigger']
-                            ); ?>
+                            <?php if ($permissions['point:triggers:publish']) {
+                            echo $view->render(
+                                        'MauticCoreBundle:Helper:publishstatus_icon.html.php',
+                                        ['item' => $item, 'model' => 'point.trigger']
+                                    );
+                        } ?>
                             <?php if ($permissions['point:triggers:edit']): ?>
                                 <a href="<?php echo $view['router']->path(
                                     'mautic_pointtrigger_action',

--- a/app/bundles/PointBundle/Views/Trigger/list.html.php
+++ b/app/bundles/PointBundle/Views/Trigger/list.html.php
@@ -102,12 +102,12 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php if ($permissions['point:triggers:publish']) {
-                            echo $view->render(
-                                        'MauticCoreBundle:Helper:publishstatus_icon.html.php',
-                                        ['item' => $item, 'model' => 'point.trigger']
-                                    );
-                        } ?>
+                            <?php if ($permissions['point:triggers:publish']): ?>
+                                <?php echo $view->render(
+                                    'MauticCoreBundle:Helper:publishstatus_icon.html.php',
+                                    ['item' => $item, 'model' => 'point.trigger']
+                                ); ?>
+                            <?php endif; ?>
                             <?php if ($permissions['point:triggers:edit']): ?>
                                 <a href="<?php echo $view['router']->path(
                                     'mautic_pointtrigger_action',

--- a/app/bundles/ReportBundle/Views/Report/list.html.php
+++ b/app/bundles/ReportBundle/Views/Report/list.html.php
@@ -84,10 +84,17 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php echo $view->render(
-                                'MauticCoreBundle:Helper:publishstatus_icon.html.php',
-                                ['item' => $item, 'model' => 'report.report']
-                            ); ?>
+                            <?php
+                            if ($security->hasEntityAccess(
+                                $permissions['report:reports:publishown'],
+                                $permissions['report:reports:publishother'],
+                                $item->getCreatedBy())
+                            ) {
+                                echo $view->render(
+                                    'MauticCoreBundle:Helper:publishstatus_icon.html.php',
+                                    ['item' => $item, 'model' => 'report.report']
+                                );
+                            } ?>
                             <a href="<?php echo $view['router']->path('mautic_report_view', ['objectId' => $item->getId()]); ?>" data-toggle="ajax">
                                 <?php echo $item->getName(); ?>
                             </a>

--- a/app/bundles/ReportBundle/Views/Report/list.html.php
+++ b/app/bundles/ReportBundle/Views/Report/list.html.php
@@ -84,17 +84,16 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php
-                            if ($security->hasEntityAccess(
+                            <?php if ($security->hasEntityAccess(
                                 $permissions['report:reports:publishown'],
                                 $permissions['report:reports:publishother'],
                                 $item->getCreatedBy())
-                            ) {
-                                echo $view->render(
+                            ): ?>
+                                <?php echo $view->render(
                                     'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                     ['item' => $item, 'model' => 'report.report']
-                                );
-                            } ?>
+                                ); ?>
+                            <?php endif; ?>
                             <a href="<?php echo $view['router']->path('mautic_report_view', ['objectId' => $item->getId()]); ?>" data-toggle="ajax">
                                 <?php echo $item->getName(); ?>
                             </a>

--- a/app/bundles/SmsBundle/Views/Sms/list.html.php
+++ b/app/bundles/SmsBundle/Views/Sms/list.html.php
@@ -124,10 +124,18 @@ if (count($items)):
                     <td>
                         <div>
                             <?php if ($type == 'template'): ?>
-                                <?php echo $view->render(
-                                    'MauticCoreBundle:Helper:publishstatus_icon.html.php',
-                                    ['item' => $item, 'model' => 'sms']
-                                ); ?>
+                                <?php
+                                if ($security->hasEntityAccess(
+                                    $permissions['sms:smses:publishown'],
+                                    $permissions['sms:smses:publishother'],
+                                    $item->getCreatedBy()
+                                    )
+                                ) {
+                                    echo $view->render(
+                                        'MauticCoreBundle:Helper:publishstatus_icon.html.php',
+                                        ['item' => $item, 'model' => 'sms']
+                                    );
+                                } ?>
                             <?php else: ?>
                                 <i class="fa fa-fw fa-lg fa-toggle-on text-muted disabled"></i>
                             <?php endif; ?>

--- a/app/bundles/SmsBundle/Views/Sms/list.html.php
+++ b/app/bundles/SmsBundle/Views/Sms/list.html.php
@@ -124,18 +124,17 @@ if (count($items)):
                     <td>
                         <div>
                             <?php if ($type == 'template'): ?>
-                                <?php
-                                if ($security->hasEntityAccess(
+                                <?php if ($security->hasEntityAccess(
                                     $permissions['sms:smses:publishown'],
                                     $permissions['sms:smses:publishother'],
                                     $item->getCreatedBy()
                                     )
-                                ) {
-                                    echo $view->render(
+                                ): ?>
+                                    <?php echo $view->render(
                                         'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                         ['item' => $item, 'model' => 'sms']
-                                    );
-                                } ?>
+                                    ); ?>
+                                <?php endif; ?>
                             <?php else: ?>
                                 <i class="fa fa-fw fa-lg fa-toggle-on text-muted disabled"></i>
                             <?php endif; ?>

--- a/app/bundles/StageBundle/Views/Stage/list.html.php
+++ b/app/bundles/StageBundle/Views/Stage/list.html.php
@@ -86,10 +86,12 @@ if ($tmpl == 'index') {
                     <td>
                         <div>
 
-                            <?php echo $view->render(
-                                'MauticCoreBundle:Helper:publishstatus_icon.html.php',
-                                ['item' => $item, 'model' => 'stage']
-                            ); ?>
+                            <?php if ($permissions['stage:stages:publish']) {
+                            echo $view->render(
+                                    'MauticCoreBundle:Helper:publishstatus_icon.html.php',
+                                    ['item' => $item, 'model' => 'stage']
+                                );
+                        } ?>
                             <a href="<?php echo $view['router']->generate(
                                 'mautic_stage_action',
                                 ['objectAction' => 'edit', 'objectId' => $item->getId()]

--- a/app/bundles/StageBundle/Views/Stage/list.html.php
+++ b/app/bundles/StageBundle/Views/Stage/list.html.php
@@ -85,13 +85,12 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-
-                            <?php if ($permissions['stage:stages:publish']) {
-                            echo $view->render(
+                            <?php if ($permissions['stage:stages:publish']): ?>
+                                <?php echo $view->render(
                                     'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                     ['item' => $item, 'model' => 'stage']
-                                );
-                        } ?>
+                                ); ?>
+                            <?php endif; ?>
                             <a href="<?php echo $view['router']->generate(
                                 'mautic_stage_action',
                                 ['objectAction' => 'edit', 'objectId' => $item->getId()]

--- a/app/bundles/WebhookBundle/Views/Webhook/list.html.php
+++ b/app/bundles/WebhookBundle/Views/Webhook/list.html.php
@@ -94,10 +94,12 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php echo $view->render(
-                                'MauticCoreBundle:Helper:publishstatus_icon.html.php',
-                                ['item' => $item, 'model' => 'webhook']
-                            ); ?>
+                            <?php if ($permissions['webhook:webhooks:publish']) {
+                            echo $view->render(
+                                    'MauticCoreBundle:Helper:publishstatus_icon.html.php',
+                                    ['item' => $item, 'model' => 'webhook']
+                                );
+                        } ?>
                             <a data-toggle="ajax" href="<?php echo $view['router']->path(
                                 'mautic_webhook_action',
                                 ['objectId' => $item->getId(), 'objectAction' => 'view']

--- a/app/bundles/WebhookBundle/Views/Webhook/list.html.php
+++ b/app/bundles/WebhookBundle/Views/Webhook/list.html.php
@@ -94,12 +94,12 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php if ($permissions['webhook:webhooks:publish']) {
-                            echo $view->render(
+                            <?php if ($permissions['webhook:webhooks:publish']): ?>
+                                <?php echo $view->render(
                                     'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                     ['item' => $item, 'model' => 'webhook']
-                                );
-                        } ?>
+                                ); ?>
+                            <?php endif; ?>
                             <a data-toggle="ajax" href="<?php echo $view['router']->path(
                                 'mautic_webhook_action',
                                 ['objectId' => $item->getId(), 'objectAction' => 'view']

--- a/plugins/MauticFocusBundle/Views/Focus/list.html.php
+++ b/plugins/MauticFocusBundle/Views/Focus/list.html.php
@@ -113,7 +113,9 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php echo $view->render('MauticCoreBundle:Helper:publishstatus_icon.html.php', ['item' => $item, 'model' => 'focus']); ?>
+                            <?php if ($permissions['plugin:focus:items:publish']) {
+                            echo $view->render('MauticCoreBundle:Helper:publishstatus_icon.html.php', ['item' => $item, 'model' => 'focus']);
+                        } ?>
                             <a data-toggle="ajax" href="<?php echo $view['router']->path(
                                 'mautic_focus_action',
                                 ['objectId' => $item->getId(), 'objectAction' => 'view']

--- a/plugins/MauticFocusBundle/Views/Focus/list.html.php
+++ b/plugins/MauticFocusBundle/Views/Focus/list.html.php
@@ -113,9 +113,9 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php if ($permissions['plugin:focus:items:publish']) {
-                            echo $view->render('MauticCoreBundle:Helper:publishstatus_icon.html.php', ['item' => $item, 'model' => 'focus']);
-                        } ?>
+                            <?php if ($permissions['plugin:focus:items:publish']): ?>
+                                <?php echo $view->render('MauticCoreBundle:Helper:publishstatus_icon.html.php', ['item' => $item, 'model' => 'focus']); ?>
+                            <?php endif; ?>
                             <a data-toggle="ajax" href="<?php echo $view['router']->path(
                                 'mautic_focus_action',
                                 ['objectId' => $item->getId(), 'objectAction' => 'view']

--- a/plugins/MauticSocialBundle/Controller/MonitoringController.php
+++ b/plugins/MauticSocialBundle/Controller/MonitoringController.php
@@ -33,7 +33,11 @@ class MonitoringController extends FormController
         $this->setListFilters();
 
         /** @var \MauticPlugin\MauticSocialBundle\Model\MonitoringModel $model */
-        $model = $this->getModel('social.monitoring');
+        $model       = $this->getModel('social.monitoring');
+        $permissions = $this->get('mautic.security')->isGranted(
+            ['plugin:mauticSocial:monitoring:publish'],
+            'RETURN_ARRAY'
+        );
 
         //set limits
         $limit = $session->get('mautic.social.monitoring.limit', $this->container->getParameter('mautic.default_pagelimit'));
@@ -74,7 +78,7 @@ class MonitoringController extends FormController
             return $this->postActionRedirect(
                 [
                     'returnUrl'       => $returnUrl,
-                    'viewParameters'  => ['page' => $lastPage],
+                    'viewParameters'  => ['page' => $lastPage, 'permissions' => $permissions],
                     'contentTemplate' => 'MauticSocialBundle:Monitoring:index',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_social_index',
@@ -98,6 +102,7 @@ class MonitoringController extends FormController
                     'model'       => $model,
                     'tmpl'        => $tmpl,
                     'page'        => $page,
+                    'permissions' => $permissions,
                 ],
                 'contentTemplate' => 'MauticSocialBundle:Monitoring:list.html.php',
                 'passthroughVars' => [

--- a/plugins/MauticSocialBundle/Views/Monitoring/list.html.php
+++ b/plugins/MauticSocialBundle/Views/Monitoring/list.html.php
@@ -76,13 +76,15 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php echo $view->render(
-                                'MauticCoreBundle:Helper:publishstatus_icon.html.php',
-                                [
-                                    'item'  => $item,
-                                    'model' => 'social.monitoring',
-                                ]
-                            ); ?>
+                            <?php if ($permissions['plugin:mauticSocial:monitoring:publish']) {
+                            echo $view->render(
+                                    'MauticCoreBundle:Helper:publishstatus_icon.html.php',
+                                    [
+                                        'item'  => $item,
+                                        'model' => 'social.monitoring',
+                                    ]
+                                );
+                        } ?>
                             <a href="<?php echo $view['router']->path(
                                 'mautic_social_action',
                                 ['objectAction' => 'view', 'objectId' => $item->getId()]

--- a/plugins/MauticSocialBundle/Views/Monitoring/list.html.php
+++ b/plugins/MauticSocialBundle/Views/Monitoring/list.html.php
@@ -76,15 +76,15 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
-                            <?php if ($permissions['plugin:mauticSocial:monitoring:publish']) {
-                            echo $view->render(
+                            <?php if ($permissions['plugin:mauticSocial:monitoring:publish']): ?>
+                                <?php echo $view->render(
                                     'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                     [
                                         'item'  => $item,
                                         'model' => 'social.monitoring',
                                     ]
-                                );
-                        } ?>
+                                ); ?>
+                            <?php endif; ?>
                             <a href="<?php echo $view['router']->path(
                                 'mautic_social_action',
                                 ['objectAction' => 'view', 'objectId' => $item->getId()]


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #3781 
 BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
The publish button was displayed even in cases user did not have proper permissions. This PR fixes this.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new user without any permissions.
2. For every item in left menu (Assets, Forms, Marketing Messages, etc...) set the new user's permissions to View own/View Other/View.
3. For every item in left menu, the publish button can be still seen, although it does nothing when clicked (a spinning wheel animation pops up indefinitely).

#### Steps to test this PR:
1. Apply this PR
2. Repeat reproduce steps
3. The publish button should not be visible now.

#### Backwards compatibility breaks:
I've modified the `app/bundles/CoreBundle/Views/Standard/list.html.php` file. This is apparently used only for Marketing Messages, but if anyone else uses this "default" template, they might have some problems, since the template now checks for `permissions[$permissionBase.':publish']`.