### PR TITLE
Hide "Send example email" button in email detail and "Send email" button

### DIFF
--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1128,6 +1128,10 @@ class EmailController extends FormController
         $session = $this->container->get('session');
         $page    = $session->get('mautic.email.page', 1);
 
+        if (!$this->get('mautic.security')->isGranted('email:emails:create')) {
+            return $this->accessDenied();
+        }
+
         //set the return URL
         $returnUrl = $this->generateUrl('mautic_email_index', ['page' => $page]);
 

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -44,34 +44,36 @@ if (empty($emailType)) {
 }
 
 $customButtons = [];
-if (!$isEmbedded) {
-    if ($emailType == 'list') {
+if ($permissions['email:emails:create']) {
+    if (!$isEmbedded) {
+        if ($emailType == 'list') {
+            $customButtons[] = [
+                'attr' => [
+                    'data-toggle' => 'ajax',
+                    'href'        => $view['router']->path(
+                        'mautic_email_action',
+                        ['objectAction' => 'send', 'objectId' => $email->getId()]
+                    ),
+                ],
+                'iconClass' => 'fa fa-send-o',
+                'btnText'   => 'mautic.email.send',
+                'primary'   => true,
+            ];
+        }
+
         $customButtons[] = [
             'attr' => [
-                'data-toggle' => 'ajax',
-                'href'        => $view['router']->path(
-                    'mautic_email_action',
-                    ['objectAction' => 'send', 'objectId' => $email->getId()]
-                ),
+                'class'       => 'btn btn-default btn-nospin',
+                'data-toggle' => 'ajaxmodal',
+                'data-target' => '#MauticSharedModal',
+                'href'        => $view['router']->path('mautic_email_action', ['objectAction' => 'sendExample', 'objectId' => $email->getId()]),
+                'data-header' => $view['translator']->trans('mautic.email.send.example'),
             ],
-            'iconClass' => 'fa fa-send-o',
-            'btnText'   => 'mautic.email.send',
+            'iconClass' => 'fa fa-send',
+            'btnText'   => 'mautic.email.send.example',
             'primary'   => true,
         ];
     }
-
-    $customButtons[] = [
-        'attr' => [
-            'class'       => 'btn btn-default btn-nospin',
-            'data-toggle' => 'ajaxmodal',
-            'data-target' => '#MauticSharedModal',
-            'href'        => $view['router']->path('mautic_email_action', ['objectAction' => 'sendExample', 'objectId' => $email->getId()]),
-            'data-header' => $view['translator']->trans('mautic.email.send.example'),
-        ],
-        'iconClass' => 'fa fa-send',
-        'btnText'   => 'mautic.email.send.example',
-        'primary'   => true,
-    ];
 }
 // Only show A/B test button if not already a translation of an a/b test
 $allowAbTest = $email->isTranslation(true) && $translations['parent']->isVariant(true) ? false : true;

--- a/app/bundles/EmailBundle/Views/Email/list.html.php
+++ b/app/bundles/EmailBundle/Views/Email/list.html.php
@@ -83,19 +83,22 @@ if ($tmpl == 'index') {
                             $permissions['email:emails:editother'],
                             $item->getCreatedBy()
                         );
-                        $customButtons = ($type == 'list') ? [
-                            [
-                                'attr' => [
-                                    'data-toggle' => 'ajax',
-                                    'href'        => $view['router']->path(
-                                        'mautic_email_action',
-                                        ['objectAction' => 'send', 'objectId' => $item->getId()]
-                                    ),
+                        $customButtons = [];
+                        if ($permissions['email:emails:create']) {
+                            $customButtons = ($type == 'list') ? [
+                                [
+                                    'attr' => [
+                                        'data-toggle' => 'ajax',
+                                        'href'        => $view['router']->path(
+                                            'mautic_email_action',
+                                            ['objectAction' => 'send', 'objectId' => $item->getId()]
+                                        ),
+                                    ],
+                                    'iconClass' => 'fa fa-send-o',
+                                    'btnText'   => 'mautic.email.send',
                                 ],
-                                'iconClass' => 'fa fa-send-o',
-                                'btnText'   => 'mautic.email.send',
-                            ],
-                        ] : [];
+                            ] : [];
+                        }
                         echo $view->render(
                             'MauticCoreBundle:Helper:list_actions.html.php',
                             [

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -48,6 +48,7 @@ class LeadController extends FormController
                 'lead:leads:deleteother',
                 'lead:imports:view',
                 'lead:imports:create',
+                'email:emails:create',
             ],
             'RETURN_ARRAY'
         );
@@ -281,6 +282,7 @@ class LeadController extends FormController
                 'lead:leads:editother',
                 'lead:leads:deleteown',
                 'lead:leads:deleteother',
+                'email:emails:create',
             ],
             'RETURN_ARRAY'
         );

--- a/app/bundles/LeadBundle/Views/Lead/lead.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/lead.html.php
@@ -44,7 +44,7 @@ $edit   = $view['security']->hasEntityAccess(
 
 $buttons = [];
 //Send email button
-if (!empty($fields['core']['email']['value'])) {
+if (!empty($fields['core']['email']['value']) && $permissions['email:emails:create']) {
     $buttons[] = [
         'attr' => [
             'id'          => 'sendEmailButton',

--- a/app/bundles/LeadBundle/Views/Lead/list_rows.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/list_rows.html.php
@@ -39,12 +39,11 @@
                         ];
                     }
 
-                    if (!empty($fields['core']['email']['value'])) {
+                    if (!empty($fields['core']['email']['value']) && $permissions['email:emails:create']) {
                         $custom[] = [
                             'attr' => [
                                 'data-toggle' => 'ajaxmodal',
                                 'data-target' => '#MauticSharedModal',
-                                'data-header' => $view['translator']->trans('mautic.lead.email.send_email.header', ['%email%' => $fields['core']['email']['value']]),
                                 'href'        => $view['router']->path('mautic_contact_action', ['objectId' => $item->getId(), 'objectAction' => 'email', 'list' => 1]),
                             ],
                             'btnText'   => 'mautic.lead.email.send_email',


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #6915 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
When having permissions to View Others/View Own/Edit, user can still send emails to contact via dropdown menu on index page and dedicated button in the detail. User can also send an example mail in mail index page.

This PR shows the email buttons only when the user has `email:emails:create` permission. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new user account with Contact permissions for View own/others and Edit own/others and Email permissions for View own/others.
2. Check the Contacts index page - "Send email" is offered in the dropdown menu.
3. Check a Contact Detail page - "Send email" is present.
4. Check the Emails index page - "Send example email" is offered in the dropdown menu.

#### Steps to test this PR:
1. Apply this PR.
2. Repeat reproduce steps above.
3. The "Send email" buttons should no longer be visible.
