### PR TITLE
Make item entry rows unclickable when not having permissions to view them.

### DIFF
--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -35,6 +35,7 @@ class CompanyController extends FormController
                 'lead:leads:viewother',
                 'lead:leads:create',
                 'lead:leads:editother',
+                'lead:leads:editown',
                 'lead:leads:deleteother',
             ],
             'RETURN_ARRAY'

--- a/app/bundles/LeadBundle/Views/Company/list.html.php
+++ b/app/bundles/LeadBundle/Views/Company/list.html.php
@@ -108,6 +108,12 @@ if ($tmpl == 'index') {
                     </td>
                     <td>
                         <div>
+                            <?php if ($view['security']->hasEntityAccess(
+                                       $permissions['lead:leads:editown'],
+                                       $permissions['lead:leads:editother'],
+                                       $item->getCreatedBy()
+                                       )
+                                   ): ?>
 
                             <a href="<?php echo $view['router']->generate(
                                 'mautic_company_action',
@@ -117,6 +123,11 @@ if ($tmpl == 'index') {
                                     <?php echo $view->escape($fields['core']['companyname']['value']); ?>
                                 <?php endif; ?>
                             </a>
+                        <?php else: ?>
+                            <?php if (isset($fields['core']['companyname'])) : ?>
+                                <?php echo $view->escape($fields['core']['companyname']['value']); ?>
+                            <?php endif; ?>
+                        <?php endif; ?>
                         </div>
                     </td>
                     <td>

--- a/app/bundles/PointBundle/Views/Point/list.html.php
+++ b/app/bundles/PointBundle/Views/Point/list.html.php
@@ -102,12 +102,16 @@ if ($tmpl == 'index') {
                                 'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                 ['item' => $item, 'model' => 'point']
                             ); ?>
-                            <a href="<?php echo $view['router']->path(
-                                'mautic_point_action',
-                                ['objectAction' => 'edit', 'objectId' => $item->getId()]
-                            ); ?>" data-toggle="ajax">
+                            <?php if ($permissions['point:points:edit']): ?>
+                                <a href="<?php echo $view['router']->path(
+                                    'mautic_point_action',
+                                    ['objectAction' => 'edit', 'objectId' => $item->getId()]
+                                ); ?>" data-toggle="ajax">
+                                    <?php echo $item->getName(); ?>
+                                </a>
+                            <?php else: ?>
                                 <?php echo $item->getName(); ?>
-                            </a>
+                            <?php endif; ?>
                         </div>
                         <?php if ($description = $item->getDescription()): ?>
                             <div class="text-muted mt-4">

--- a/app/bundles/StageBundle/Views/Stage/list.html.php
+++ b/app/bundles/StageBundle/Views/Stage/list.html.php
@@ -90,12 +90,16 @@ if ($tmpl == 'index') {
                                 'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                 ['item' => $item, 'model' => 'stage']
                             ); ?>
+                            <?php if ($permissions['stage:stages:edit']): ?>
                             <a href="<?php echo $view['router']->generate(
                                 'mautic_stage_action',
                                 ['objectAction' => 'edit', 'objectId' => $item->getId()]
                             ); ?>" data-toggle="ajax">
                                 <?php echo $item->getName(); ?>
                             </a>
+                            <?php else: ?>
+                                <?php echo $item->getName(); ?>
+                            <?php endif; ?>
                         </div>
                         <?php if ($description = $item->getDescription()): ?>
                             <div class="text-muted mt-4">


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
When having permissions for viewing only, items from Company, Stage and Point lists are still clickable. These links lead to the edit pages, but because of missing permissions, the application won't do anything (On dev a modal dialog with exception is shown).

This PR fixes the issue by generating plaintext only when having insufficient permissions.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new user account with View permissions for Company/Stage/Point only.
2. Try to click on any item in these categories. Application shouldn't do anything.

#### Steps to test this PR:
1. Apply this PR.
2. Repeat reproduce steps.
3. The item names should be now plaintext instead of a link to edit page. 