### PR TITLE
Add a "Created By" column to the Imports list.

### DIFF
--- a/app/bundles/LeadBundle/Views/Import/list.html.php
+++ b/app/bundles/LeadBundle/Views/Import/list.html.php
@@ -73,6 +73,13 @@ endif;
 
                 echo $view->render('MauticCoreBundle:Helper:tableheader.html.php', [
                     'sessionVar' => $sessionVar,
+                    'orderBy'    => $tablePrefix.'.createdByUser',
+                    'text'       => 'mautic.core.create.by.past.tense',
+                    'class'      => 'col-created visible-md visible-lg',
+                ]);
+
+                echo $view->render('MauticCoreBundle:Helper:tableheader.html.php', [
+                    'sessionVar' => $sessionVar,
                     'orderBy'    => $tablePrefix.'.dateAdded',
                     'text'       => 'mautic.core.date.added',
                     'class'      => 'col-date-added visible-md visible-lg',

--- a/app/bundles/LeadBundle/Views/Import/list_rows.html.php
+++ b/app/bundles/LeadBundle/Views/Import/list_rows.html.php
@@ -44,6 +44,7 @@
         <td class="visible-md visible-lg"><?php echo $item->getInsertedCount(); ?></td>
         <td class="visible-md visible-lg"><?php echo $item->getUpdatedCount(); ?></td>
         <td class="visible-md visible-lg"><?php echo $item->getIgnoredCount(); ?></td>
+        <td class="visible-md visible-lg"><?php echo $item->getCreatedByUser(); ?></td>
         <td class="visible-md visible-lg">
             <abbr title="<?php echo $view['date']->toFull($item->getDateAdded()); ?>">
                 <?php echo $view['date']->toText($item->getDateAdded()); ?>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Y
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Required: )
#### Description:
We've had several requests to add a "Created By" column to the imports list to make it easier to maintain Mautic when you have several people doing imports simultaneously. This PR adds the feature  for medium/large screens like so.

![](https://i.imgur.com/ai48HXX.png)

#### Steps to test this PR:
1. Open the imports screen at https://mautibox.com
2. See the "Created By" column appear on medium/large screens (hidden on mobile).
