### PR TITLE
Report field system compatibility issue in MySQL8

### DIFF
--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -133,7 +133,7 @@ class Report extends FormEntity implements SchedulerInterface
 
         $builder->addIdColumns();
 
-        $builder->addField('system', Type::BOOLEAN);
+        $builder->addField('system', Type::BOOLEAN, array("columnName"=>"`system`"));
 
         $builder->addField('source', Type::STRING);
 

--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -133,7 +133,7 @@ class Report extends FormEntity implements SchedulerInterface
 
         $builder->addIdColumns();
 
-        $builder->addField('system', Type::BOOLEAN, ["columnName"=>"`system`"]);
+        $builder->addField('system', Type::BOOLEAN, ['columnName'=>'`system`']);
 
         $builder->addField('source', Type::STRING);
 

--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -133,7 +133,7 @@ class Report extends FormEntity implements SchedulerInterface
 
         $builder->addIdColumns();
 
-        $builder->addField('system', Type::BOOLEAN, array("columnName"=>"`system`"));
+        $builder->addField('system', Type::BOOLEAN, ["columnName"=>"`system`"]);
 
         $builder->addField('source', Type::STRING);
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No 
| Automated tests included? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs)  | #6933 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Address compatibility issue with Mysql 8 . since this release 'system' is a reserved keyword thus conflicting with the field in the "Report" entity.
By adding "columnName" to $builder->addField is possible to specify an arbitrary column name not taken from the PHP field. In order to use reserved word as column name Mysql requires to surround the field with backticks ( hence `system` )

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 