### PR TITLE
Suggest using mautibox to test the PR.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@
 2. 
 
 #### Steps to test this PR:
-1. 
+1. Load up [this PR](https://mautibox.com)
 2. 
 
 #### List deprecations along with the new alternative:


### PR DESCRIPTION
Mautibox now detects if the referring URL is from a pull request and immediately redirects/builds the PR, so directly linking to mautibox from a PR (in most cases) is a good way to start testing a PR.