### PR TITLE
Fix for non Outlook condition in email builder

### DIFF
--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -406,6 +406,7 @@ class InputHelper
             $value = str_replace(['<![CDATA[', ']]>'], ['<mcdata>', '</mcdata>'], $value, $cdataCount);
 
             // Special handling for conditional blocks
+            $value = preg_replace("/<!--\[if(.*?)\]><!-(.*?)->(.*?)<!--<!\[endif\]-->/is", '<mconditionnegative><mif>$1</mif>$3</mconditionnegative>', $value, -1, $conditionsFoundNegative);
             $value = preg_replace("/<!--\[if(.*?)\]>(.*?)<!\[endif\]-->/is", '<mcondition><mif>$1</mif>$2</mcondition>', $value, -1, $conditionsFound);
 
             // Slecial handling for XML tags used in Outlook optimized emails <o:*/> and <w:/>
@@ -426,7 +427,6 @@ class InputHelper
 
             // Special handling for HTML comments
             $value = str_replace(['<!--', '-->'], ['<mcomment>', '</mcomment>'], $value, $commentCount);
-
             $value = self::getFilter(true)->clean($value, 'html');
 
             // Was a doctype found?
@@ -441,6 +441,11 @@ class InputHelper
             if ($conditionsFound) {
                 // Special handling for conditional blocks
                 $value = preg_replace("/<mcondition><mif>(.*?)<\/mif>(.*?)<\/mcondition>/is", '<!--[if$1]>$2<![endif]-->', $value);
+            }
+
+            if ($conditionsFoundNegative) {
+                // Special handling for conditional blocks
+                $value = preg_replace("/<mconditionnegative><mif>(.*?)<\/mif>(.*?)<\/mconditionnegative>/is", '<!--[if$1]><!-->$2<!--<![endif]-->', $value);
             }
 
             if ($commentCount) {

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -406,7 +406,7 @@ class InputHelper
             $value = str_replace(['<![CDATA[', ']]>'], ['<mcdata>', '</mcdata>'], $value, $cdataCount);
 
             // Special handling for conditional blocks
-            $value = preg_replace("/<!--\[if(.*?)\]><!-(.*?)->(.*?)<!--<!\[endif\]-->/is", '<mconditionnegative><mif>$1</mif>$3</mconditionnegative>', $value, -1, $conditionsFoundNegative);
+            $value = preg_replace("/<!--\[if(.*?)\]><!-(.*?)->(.*?)<!--<!\[endif\]-->/is", '<mconditionnonoutlook><mif>$1</mif>$3</mconditionnonoutlook>', $value, -1, $conditionsFoundNonOutlook);
             $value = preg_replace("/<!--\[if(.*?)\]>(.*?)<!\[endif\]-->/is", '<mcondition><mif>$1</mif>$2</mcondition>', $value, -1, $conditionsFound);
 
             // Slecial handling for XML tags used in Outlook optimized emails <o:*/> and <w:/>
@@ -443,9 +443,9 @@ class InputHelper
                 $value = preg_replace("/<mcondition><mif>(.*?)<\/mif>(.*?)<\/mcondition>/is", '<!--[if$1]>$2<![endif]-->', $value);
             }
 
-            if ($conditionsFoundNegative) {
-                // Special handling for conditional blocks
-                $value = preg_replace("/<mconditionnegative><mif>(.*?)<\/mif>(.*?)<\/mconditionnegative>/is", '<!--[if$1]><!-->$2<!--<![endif]-->', $value);
+            if ($conditionsFoundNonOutlook) {
+                // Special handling for non Outlook conditional blocks
+                $value = preg_replace("/<mconditionnonoutlook><mif>(.*?)<\/mif>(.*?)<\/mconditionnonoutlook>/is", '<!--[if$1]><!-- -->$2<!--<![endif]-->', $value);
             }
 
             if ($commentCount) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Non outlook condition are not translated correctly.
More https://stackoverflow.com/questions/5982364/is-there-a-html-conditional-statement-for-everything-not-outlook

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Add test blank test template [blank-test.zip](https://github.com/mautic/mautic/files/2629462/blank-test.zip)
2. Create email with that template and save
3. Check the source code of preview email and `<mcomment />` tag

![image](https://user-images.githubusercontent.com/462477/49228401-8a6c0800-f3eb-11e8-9406-562e42124269.png)


#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps and then check email source doe, you will see the correct condition

![image](https://user-images.githubusercontent.com/462477/49228480-bb4c3d00-f3eb-11e8-9b9e-6d5712db18f3.png)