### PR TITLE
Fix campaign realtime events

### DIFF
--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -456,6 +456,7 @@ return [
                     'mautic.campaign.event_collector',
                     'mautic.campaign.scheduler',
                     'mautic.tracker.contact',
+                    'mautic.campaign.repository.lead',
                 ],
             ],
             'mautic.campaign.executioner.inactive'     => [

--- a/app/bundles/CampaignBundle/Entity/Event.php
+++ b/app/bundles/CampaignBundle/Entity/Event.php
@@ -636,13 +636,13 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Get path taken from log.
+     * Get log for a contact and a rotation.
      *
      * @param Contact $contact
      * @param $rotation
-     * @return int|null
+     * @return LeadEventLog|null
      */
-    public function getPathTaken(Contact $contact, $rotation)
+    public function getLogByContactAndRotation(Contact $contact, $rotation)
     {
         $criteria = Criteria::create()
             ->where(Criteria::expr()->eq('lead', $contact))
@@ -654,7 +654,7 @@ class Event implements ChannelInterface
         $log = $this->getLog()->matching($criteria);
 
         if (count($log)) {
-            return (int)$log->first()->getNonActionPathTaken();
+            return $log->first();
         }
 
         return null;

--- a/app/bundles/CampaignBundle/Entity/Event.php
+++ b/app/bundles/CampaignBundle/Entity/Event.php
@@ -636,6 +636,31 @@ class Event implements ChannelInterface
     }
 
     /**
+     * Get path taken from log.
+     *
+     * @param Contact $contact
+     * @param $rotation
+     * @return int|null
+     */
+    public function getPathTaken(Contact $contact, $rotation)
+    {
+        $criteria = Criteria::create()
+            ->where(Criteria::expr()->eq('lead', $contact))
+            ->andWhere(Criteria::expr()->eq('rotation', $rotation))
+            ->orderBy(['id' => 'DESC'])
+            ->setMaxResults(1);
+        ;
+
+        $log = $this->getLog()->matching($criteria);
+
+        if (count($log)) {
+            return (int)$log->first()->getNonActionPathTaken();
+        }
+
+        return null;
+    }
+
+    /**
      * Add children.
      *
      * @param \Mautic\CampaignBundle\Entity\Event $children

--- a/app/bundles/CampaignBundle/Entity/Event.php
+++ b/app/bundles/CampaignBundle/Entity/Event.php
@@ -647,9 +647,7 @@ class Event implements ChannelInterface
         $criteria = Criteria::create()
             ->where(Criteria::expr()->eq('lead', $contact))
             ->andWhere(Criteria::expr()->eq('rotation', $rotation))
-            ->orderBy(['id' => 'DESC'])
             ->setMaxResults(1);
-        ;
 
         $log = $this->getLog()->matching($criteria);
 

--- a/app/bundles/CampaignBundle/Entity/Event.php
+++ b/app/bundles/CampaignBundle/Entity/Event.php
@@ -640,6 +640,7 @@ class Event implements ChannelInterface
      *
      * @param Contact $contact
      * @param $rotation
+     *
      * @return LeadEventLog|null
      */
     public function getLogByContactAndRotation(Contact $contact, $rotation)

--- a/app/bundles/CampaignBundle/Entity/EventRepository.php
+++ b/app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -75,7 +75,8 @@ class EventRepository extends LegacyEventRepository
             ->where(
                 $parentQb->expr()->eq('parent_log_event.event', 'e.parent'),
                 $parentQb->expr()->eq('parent_log_event.lead', 'l.lead'),
-                $parentQb->expr()->eq('parent_log_event.rotation', 'l.rotation')
+                $parentQb->expr()->eq('parent_log_event.rotation', 'l.rotation'),
+                $parentQb->expr()->eq('parent_log_event.isScheduled', 0)
             );
 
         $q = $this->createQueryBuilder('e', 'e.id');

--- a/app/bundles/CampaignBundle/Executioner/RealTimeExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/RealTimeExecutioner.php
@@ -14,6 +14,7 @@ namespace Mautic\CampaignBundle\Executioner;
 use Doctrine\Common\Collections\ArrayCollection;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\EventRepository;
+use Mautic\CampaignBundle\Entity\LeadRepository;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\DecisionAccessor;
 use Mautic\CampaignBundle\EventCollector\EventCollector;
 use Mautic\CampaignBundle\Executioner\Event\DecisionExecutioner as Executioner;
@@ -26,7 +27,6 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Psr\Log\LoggerInterface;
-use Mautic\CampaignBundle\Entity\LeadRepository;
 
 class RealTimeExecutioner
 {
@@ -261,13 +261,13 @@ class RealTimeExecutioner
         $parentEvent = $event->getParent();
         if ($parentEvent !== null && $event->getDecisionPath() !== null) {
             $rotation    = $this->leadRepository->getContactRotations([$this->contact->getId()], $event->getCampaign()->getId());
-            $log = $parentEvent->getLogByContactAndRotation($this->contact, $rotation);
+            $log         = $parentEvent->getLogByContactAndRotation($this->contact, $rotation);
 
             if ($log === null) {
                 throw new DecisionNotApplicableException("Parent {$parentEvent->getId()} has not been fired, event {$event->getId()} should not be fired.");
             }
 
-            $pathTaken   = (int)$log->getNonActionPathTaken();
+            $pathTaken   = (int) $log->getNonActionPathTaken();
 
             if ($pathTaken === 1 && !$parentEvent->getNegativeChildren()->contains($event)) {
                 throw new DecisionNotApplicableException("Parent {$parentEvent->getId()} take negative path, event {$event->getId()} is on positive path.");

--- a/app/bundles/CampaignBundle/Executioner/RealTimeExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/RealTimeExecutioner.php
@@ -26,6 +26,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Psr\Log\LoggerInterface;
+use Mautic\CampaignBundle\Entity\LeadRepository;
 
 class RealTimeExecutioner
 {
@@ -85,6 +86,11 @@ class RealTimeExecutioner
     private $responses;
 
     /**
+     * @var LeadRepository
+     */
+    private $leadRepository;
+
+    /**
      * RealTimeExecutioner constructor.
      *
      * @param LoggerInterface  $logger
@@ -95,6 +101,7 @@ class RealTimeExecutioner
      * @param EventCollector   $collector
      * @param EventScheduler   $scheduler
      * @param ContactTracker   $contactTracker
+     * @param LeadRepository   $leadRepository
      */
     public function __construct(
         LoggerInterface $logger,
@@ -104,7 +111,8 @@ class RealTimeExecutioner
         Executioner $decisionExecutioner,
         EventCollector $collector,
         EventScheduler $scheduler,
-        ContactTracker $contactTracker
+        ContactTracker $contactTracker,
+        LeadRepository $leadRepository
     ) {
         $this->logger              = $logger;
         $this->leadModel           = $leadModel;
@@ -114,6 +122,7 @@ class RealTimeExecutioner
         $this->collector           = $collector;
         $this->scheduler           = $scheduler;
         $this->contactTracker      = $contactTracker;
+        $this->leadRepository      = $leadRepository;
     }
 
     /**
@@ -240,12 +249,27 @@ class RealTimeExecutioner
         }
 
         // If channels do not match up at all (not even fuzzy logic i.e. page vs page.redirect), there's no need to go further
-        if ($channel && $event->getChannel() && $channel && strpos($channel, $event->getChannel()) === false) {
+        if ($channel && $event->getChannel() && strpos($channel, $event->getChannel()) === false) {
             throw new DecisionNotApplicableException("Channels, $channel and {$event->getChannel()}, do not match.");
         }
 
         if ($channel && $channelId && $event->getChannelId() && $channelId !== $event->getChannelId()) {
             throw new DecisionNotApplicableException("Channel IDs, $channelId and {$event->getChannelId()}, do not match for $channel.");
+        }
+
+        // Check if parent taken path is the path of this event, otherwise exit
+        $parentEvent = $event->getParent();
+        if ($parentEvent && $event->getDecisionPath() !== null) {
+            $rotation  = $this->leadRepository->getContactRotations([$this->contact->getId()], $event->getCampaign()->getId());
+            $pathTaken = $parentEvent->getPathTaken($this->contact, $rotation);
+
+            if ($pathTaken === null) {
+                throw new DecisionNotApplicableException("Parent {$parentEvent->getId()} has not been fired, event {$event->getId()} should not be fired.");
+            } elseif ($pathTaken === 1 && !$parentEvent->getNegativeChildren()->contains($event)) {
+                throw new DecisionNotApplicableException("Parent {$parentEvent->getId()} take negative path, event {$event->getId()} is on positive path.");
+            } elseif ($pathTaken === 0 && !$parentEvent->getPositiveChildren()->contains($event)) {
+                throw new DecisionNotApplicableException("Parent {$parentEvent->getId()} take positive path, event {$event->getId()} is on negative path.");
+            }
         }
 
         /** @var DecisionAccessor $config */

--- a/app/bundles/CampaignBundle/Executioner/RealTimeExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/RealTimeExecutioner.php
@@ -268,11 +268,8 @@ class RealTimeExecutioner
             }
 
             $pathTaken   = (int)$log->getNonActionPathTaken();
-            $isScheduled = (int)$log->getIsScheduled();
 
-            if ($isScheduled === 1) {
-                throw new DecisionNotApplicableException("Parent {$parentEvent->getId()} has not been fired, event {$event->getId()} should not be fired.");
-            } elseif ($pathTaken === 1 && !$parentEvent->getNegativeChildren()->contains($event)) {
+            if ($pathTaken === 1 && !$parentEvent->getNegativeChildren()->contains($event)) {
                 throw new DecisionNotApplicableException("Parent {$parentEvent->getId()} take negative path, event {$event->getId()} is on positive path.");
             } elseif ($pathTaken === 0 && !$parentEvent->getPositiveChildren()->contains($event)) {
                 throw new DecisionNotApplicableException("Parent {$parentEvent->getId()} take positive path, event {$event->getId()} is on negative path.");

--- a/app/bundles/CampaignBundle/Tests/Executioner/RealTimeExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/RealTimeExecutionerTest.php
@@ -24,6 +24,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Psr\Log\NullLogger;
+use Mautic\CampaignBundle\Entity\LeadRepository;
 
 class RealTimeExecutionerTest extends \PHPUnit_Framework_TestCase
 {
@@ -62,6 +63,11 @@ class RealTimeExecutionerTest extends \PHPUnit_Framework_TestCase
      */
     private $contactTracker;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|LeadRepository
+     */
+    private $leadRepository;
+
     protected function setUp()
     {
         $this->leadModel = $this->getMockBuilder(LeadModel::class)
@@ -89,6 +95,10 @@ class RealTimeExecutionerTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $this->contactTracker = $this->getMockBuilder(ContactTracker::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->leadRepository = $this->getMockBuilder(LeadRepository::class)
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -415,7 +425,8 @@ class RealTimeExecutionerTest extends \PHPUnit_Framework_TestCase
             $this->decisionExecutioner,
             $this->eventCollector,
             $this->eventScheduler,
-            $this->contactTracker
+            $this->contactTracker,
+            $this->leadRepository
         );
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Executioner/RealTimeExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/RealTimeExecutionerTest.php
@@ -14,6 +14,7 @@ namespace Mautic\CampaignBundle\Tests\Executioner;
 use Doctrine\Common\Collections\ArrayCollection;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\EventRepository;
+use Mautic\CampaignBundle\Entity\LeadRepository;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\DecisionAccessor;
 use Mautic\CampaignBundle\EventCollector\EventCollector;
 use Mautic\CampaignBundle\Executioner\Event\DecisionExecutioner;
@@ -24,7 +25,6 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Psr\Log\NullLogger;
-use Mautic\CampaignBundle\Entity\LeadRepository;
 
 class RealTimeExecutionerTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
On campaign, realtime events is launched no matter if previous action has been executed and no matter if the taken path is positive or negative.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a contact without tag
2. Create a segment with this contact
3. Create a campaign like this
![screenshot_2018-11-29 edit campaign mautic](https://user-images.githubusercontent.com/27768270/49229648-44647380-f3ee-11e8-8c75-e188c71363e0.png)

4. Launch command
php app/console m:s:u
php app/console m:c:u
php app/console m:c:t
5. Visit the page that you choose in the campaign event
6. Events `Visits a page` and `Adjust contact points` is triggered

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/6940)
2. Repeat step above
3. Events are not fired
