### PR TITLE
Prevent date range change by mousewheel or touch

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/libraries/other/datetimepicker.less
+++ b/app/bundles/CoreBundle/Assets/css/libraries/other/datetimepicker.less
@@ -102,7 +102,7 @@
   margin-bottom: 3px
 }
 
-.xdsoft_datetimepicker .xdsoft_mounthpicker {
+.xdsoft_datetimepicker .xdsoft_monthpicker {
   position: relative;
   text-align: center;
 }

--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -1221,6 +1221,7 @@ Mautic.activateDateTimeInputs = function(el, type) {
             lazyInit: true,
             validateOnBlur: false,
             allowBlank: true,
+            scrollMonth: false,
             scrollInput: false
         });
     } else if(type == 'date') {
@@ -1230,6 +1231,7 @@ Mautic.activateDateTimeInputs = function(el, type) {
             lazyInit: true,
             validateOnBlur: false,
             allowBlank: true,
+            scrollMonth: false,
             scrollInput: false,
             closeOnDateSelect: true
         });
@@ -1240,6 +1242,7 @@ Mautic.activateDateTimeInputs = function(el, type) {
             lazyInit: true,
             validateOnBlur: false,
             allowBlank: true,
+            scrollMonth: false,
             scrollInput: false
         });
     }

--- a/app/bundles/CoreBundle/Assets/js/7.charts.js
+++ b/app/bundles/CoreBundle/Assets/js/7.charts.js
@@ -359,7 +359,9 @@ Mautic.initDateRangePicker = function (fromId, toId) {
                     maxDate: dateTo.val() ? new Date(dateTo.val()) : false
                 });
             },
-            timepicker: false
+            timepicker: false,
+            scrollMonth: false,
+            scrollInput: false
         });
 
         dateTo.datetimepicker({
@@ -370,7 +372,9 @@ Mautic.initDateRangePicker = function (fromId, toId) {
                     minDate: dateFrom.val() ? new Date(dateFrom.val()) : false
                 });
             },
-            timepicker: false
+            timepicker: false,
+            scrollMonth: false,
+            scrollInput: false
         });
     }
 };

--- a/app/bundles/CoreBundle/Assets/js/libraries/7.datetimepicker.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/7.datetimepicker.js
@@ -1,184 +1,153 @@
 /**
- * @preserve jQuery DateTimePicker
+ * @preserve jQuery DateTimePicker plugin v2.3.8
  * @homepage http://xdsoft.net/jqplugins/datetimepicker/
- * @author Chupurnov Valeriy (<chupurnov@gmail.com>)
+ * (c) 2014, Chupurnov Valeriy.
  */
-
-/**
- * @param {jQuery} $
- */
-var datetimepickerFactory = function ($) {
+(function ($) {
     'use strict';
-
     var default_options  = {
         i18n: {
             ar: { // Arabic
                 months: [
                     "كانون الثاني", "شباط", "آذار", "نيسان", "مايو", "حزيران", "تموز", "آب", "أيلول", "تشرين الأول", "تشرين الثاني", "كانون الأول"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "ن", "ث", "ع", "خ", "ج", "س", "ح"
-                ],
-                dayOfWeek: ["الأحد", "الاثنين", "الثلاثاء", "الأربعاء", "الخميس", "الجمعة", "السبت", "الأحد"]
+                ]
             },
             ro: { // Romanian
                 months: [
-                    "Ianuarie", "Februarie", "Martie", "Aprilie", "Mai", "Iunie", "Iulie", "August", "Septembrie", "Octombrie", "Noiembrie", "Decembrie"
+                    "ianuarie", "februarie", "martie", "aprilie", "mai", "iunie", "iulie", "august", "septembrie", "octombrie", "noiembrie", "decembrie"
                 ],
-                dayOfWeekShort: [
-                    "Du", "Lu", "Ma", "Mi", "Jo", "Vi", "Sâ"
-                ],
-                dayOfWeek: ["Duminică", "Luni", "Marţi", "Miercuri", "Joi", "Vineri", "Sâmbătă"]
+                dayOfWeek: [
+                    "l", "ma", "mi", "j", "v", "s", "d"
+                ]
             },
             id: { // Indonesian
                 months: [
                     "Januari", "Februari", "Maret", "April", "Mei", "Juni", "Juli", "Agustus", "September", "Oktober", "November", "Desember"
                 ],
-                dayOfWeekShort: [
-                    "Min", "Sen", "Sel", "Rab", "Kam", "Jum", "Sab"
-                ],
-                dayOfWeek: ["Minggu", "Senin", "Selasa", "Rabu", "Kamis", "Jumat", "Sabtu"]
-            },
-            is: { // Icelandic
-                months: [
-                    "Janúar", "Febrúar", "Mars", "Apríl", "Maí", "Júní", "Júlí", "Ágúst", "September", "Október", "Nóvember", "Desember"
-                ],
-                dayOfWeekShort: [
-                    "Sun", "Mán", "Þrið", "Mið", "Fim", "Fös", "Lau"
-                ],
-                dayOfWeek: ["Sunnudagur", "Mánudagur", "Þriðjudagur", "Miðvikudagur", "Fimmtudagur", "Föstudagur", "Laugardagur"]
+                dayOfWeek: [
+                    "Sen", "Sel", "Rab", "Kam", "Jum", "Sab", "Min"
+                ]
             },
             bg: { // Bulgarian
                 months: [
                     "Януари", "Февруари", "Март", "Април", "Май", "Юни", "Юли", "Август", "Септември", "Октомври", "Ноември", "Декември"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"
-                ],
-                dayOfWeek: ["Неделя", "Понеделник", "Вторник", "Сряда", "Четвъртък", "Петък", "Събота"]
+                ]
             },
             fa: { // Persian/Farsi
                 months: [
                     'فروردین', 'اردیبهشت', 'خرداد', 'تیر', 'مرداد', 'شهریور', 'مهر', 'آبان', 'آذر', 'دی', 'بهمن', 'اسفند'
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     'یکشنبه', 'دوشنبه', 'سه شنبه', 'چهارشنبه', 'پنجشنبه', 'جمعه', 'شنبه'
-                ],
-                dayOfWeek: ["یک‌شنبه", "دوشنبه", "سه‌شنبه", "چهارشنبه", "پنج‌شنبه", "جمعه", "شنبه", "یک‌شنبه"]
+                ]
             },
             ru: { // Russian
                 months: [
                     'Январь', 'Февраль', 'Март', 'Апрель', 'Май', 'Июнь', 'Июль', 'Август', 'Сентябрь', 'Октябрь', 'Ноябрь', 'Декабрь'
                 ],
-                dayOfWeekShort: [
-                    "Вс", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"
-                ],
-                dayOfWeek: ["Воскресенье", "Понедельник", "Вторник", "Среда", "Четверг", "Пятница", "Суббота"]
+                dayOfWeek: [
+                    "Вск", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"
+                ]
             },
             uk: { // Ukrainian
                 months: [
                     'Січень', 'Лютий', 'Березень', 'Квітень', 'Травень', 'Червень', 'Липень', 'Серпень', 'Вересень', 'Жовтень', 'Листопад', 'Грудень'
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "Ндл", "Пнд", "Втр", "Срд", "Чтв", "Птн", "Сбт"
-                ],
-                dayOfWeek: ["Неділя", "Понеділок", "Вівторок", "Середа", "Четвер", "П'ятниця", "Субота"]
+                ]
             },
             en: { // English
                 months: [
                     "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
-                ],
-                dayOfWeek: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+                ]
             },
             el: { // Ελληνικά
                 months: [
                     "Ιανουάριος", "Φεβρουάριος", "Μάρτιος", "Απρίλιος", "Μάιος", "Ιούνιος", "Ιούλιος", "Αύγουστος", "Σεπτέμβριος", "Οκτώβριος", "Νοέμβριος", "Δεκέμβριος"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "Κυρ", "Δευ", "Τρι", "Τετ", "Πεμ", "Παρ", "Σαβ"
-                ],
-                dayOfWeek: ["Κυριακή", "Δευτέρα", "Τρίτη", "Τετάρτη", "Πέμπτη", "Παρασκευή", "Σάββατο"]
+                ]
             },
             de: { // German
                 months: [
                     'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"
-                ],
-                dayOfWeek: ["Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"]
+                ]
             },
             nl: { // Dutch
                 months: [
                     "januari", "februari", "maart", "april", "mei", "juni", "juli", "augustus", "september", "oktober", "november", "december"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "zo", "ma", "di", "wo", "do", "vr", "za"
-                ],
-                dayOfWeek: ["zondag", "maandag", "dinsdag", "woensdag", "donderdag", "vrijdag", "zaterdag"]
+                ]
             },
             tr: { // Turkish
                 months: [
                     "Ocak", "Şubat", "Mart", "Nisan", "Mayıs", "Haziran", "Temmuz", "Ağustos", "Eylül", "Ekim", "Kasım", "Aralık"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "Paz", "Pts", "Sal", "Çar", "Per", "Cum", "Cts"
-                ],
-                dayOfWeek: ["Pazar", "Pazartesi", "Salı", "Çarşamba", "Perşembe", "Cuma", "Cumartesi"]
+                ]
             },
             fr: { //French
                 months: [
                     "Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam"
-                ],
-                dayOfWeek: ["dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi"]
+                ]
             },
             es: { // Spanish
                 months: [
                     "Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"
-                ],
-                dayOfWeek: ["Domingo", "Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado"]
+                ]
             },
             th: { // Thai
                 months: [
                     'มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน', 'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม'
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     'อา.', 'จ.', 'อ.', 'พ.', 'พฤ.', 'ศ.', 'ส.'
-                ],
-                dayOfWeek: ["อาทิตย์", "จันทร์", "อังคาร", "พุธ", "พฤหัส", "ศุกร์", "เสาร์", "อาทิตย์"]
+                ]
             },
             pl: { // Polish
                 months: [
                     "styczeń", "luty", "marzec", "kwiecień", "maj", "czerwiec", "lipiec", "sierpień", "wrzesień", "październik", "listopad", "grudzień"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "nd", "pn", "wt", "śr", "cz", "pt", "sb"
-                ],
-                dayOfWeek: ["niedziela", "poniedziałek", "wtorek", "środa", "czwartek", "piątek", "sobota"]
+                ]
             },
             pt: { // Portuguese
                 months: [
                     "Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sab"
-                ],
-                dayOfWeek: ["Domingo", "Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado"]
+                ]
             },
             ch: { // Simplified Chinese
                 months: [
                     "一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "日", "一", "二", "三", "四", "五", "六"
                 ]
             },
@@ -186,85 +155,71 @@ var datetimepickerFactory = function ($) {
                 months: [
                     "Januari", "Februari", "Mars", "April", "Maj", "Juni", "Juli", "Augusti", "September",  "Oktober", "November", "December"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "Sön", "Mån", "Tis", "Ons", "Tor", "Fre", "Lör"
                 ]
-            },
-            km: { // Khmer (ភាសាខ្មែរ)
-                months: [
-                    "មករា​", "កុម្ភៈ", "មិនា​", "មេសា​", "ឧសភា​", "មិថុនា​", "កក្កដា​", "សីហា​", "កញ្ញា​", "តុលា​", "វិច្ឆិកា", "ធ្នូ​"
-                ],
-                dayOfWeekShort: ["អាទិ​", "ច័ន្ទ​", "អង្គារ​", "ពុធ​", "ព្រហ​​", "សុក្រ​", "សៅរ៍"],
-                dayOfWeek: ["អាទិត្យ​", "ច័ន្ទ​", "អង្គារ​", "ពុធ​", "ព្រហស្បតិ៍​", "សុក្រ​", "សៅរ៍"]
             },
             kr: { // Korean
                 months: [
                     "1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "일", "월", "화", "수", "목", "금", "토"
-                ],
-                dayOfWeek: ["일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"]
+                ]
             },
             it: { // Italian
                 months: [
                     "Gennaio", "Febbraio", "Marzo", "Aprile", "Maggio", "Giugno", "Luglio", "Agosto", "Settembre", "Ottobre", "Novembre", "Dicembre"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "Dom", "Lun", "Mar", "Mer", "Gio", "Ven", "Sab"
-                ],
-                dayOfWeek: ["Domenica", "Lunedì", "Martedì", "Mercoledì", "Giovedì", "Venerdì", "Sabato"]
+                ]
             },
             da: { // Dansk
                 months: [
-                    "Januar", "Februar", "Marts", "April", "Maj", "Juni", "Juli", "August", "September", "Oktober", "November", "December"
+                    "January", "Februar", "Marts", "April", "Maj", "Juni", "July", "August", "September", "Oktober", "November", "December"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "Søn", "Man", "Tir", "Ons", "Tor", "Fre", "Lør"
-                ],
-                dayOfWeek: ["søndag", "mandag", "tirsdag", "onsdag", "torsdag", "fredag", "lørdag"]
+                ]
             },
             no: { // Norwegian
                 months: [
                     "Januar", "Februar", "Mars", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Desember"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "Søn", "Man", "Tir", "Ons", "Tor", "Fre", "Lør"
-                ],
-                dayOfWeek: ['Søndag', 'Mandag', 'Tirsdag', 'Onsdag', 'Torsdag', 'Fredag', 'Lørdag']
+                ]
             },
             ja: { // Japanese
                 months: [
                     "1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "日", "月", "火", "水", "木", "金", "土"
-                ],
-                dayOfWeek: ["日曜", "月曜", "火曜", "水曜", "木曜", "金曜", "土曜"]
+                ]
             },
             vi: { // Vietnamese
                 months: [
                     "Tháng 1", "Tháng 2", "Tháng 3", "Tháng 4", "Tháng 5", "Tháng 6", "Tháng 7", "Tháng 8", "Tháng 9", "Tháng 10", "Tháng 11", "Tháng 12"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "CN", "T2", "T3", "T4", "T5", "T6", "T7"
-                ],
-                dayOfWeek: ["Chủ nhật", "Thứ hai", "Thứ ba", "Thứ tư", "Thứ năm", "Thứ sáu", "Thứ bảy"]
+                ]
             },
             sl: { // Slovenščina
                 months: [
                     "Januar", "Februar", "Marec", "April", "Maj", "Junij", "Julij", "Avgust", "September", "Oktober", "November", "December"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "Ned", "Pon", "Tor", "Sre", "Čet", "Pet", "Sob"
-                ],
-                dayOfWeek: ["Nedelja", "Ponedeljek", "Torek", "Sreda", "Četrtek", "Petek", "Sobota"]
+                ]
             },
             cs: { // Čeština
                 months: [
                     "Leden", "Únor", "Březen", "Duben", "Květen", "Červen", "Červenec", "Srpen", "Září", "Říjen", "Listopad", "Prosinec"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "Ne", "Po", "Út", "St", "Čt", "Pá", "So"
                 ]
             },
@@ -272,273 +227,13 @@ var datetimepickerFactory = function ($) {
                 months: [
                     "Január", "Február", "Március", "Április", "Május", "Június", "Július", "Augusztus", "Szeptember", "Október", "November", "December"
                 ],
-                dayOfWeekShort: [
+                dayOfWeek: [
                     "Va", "Hé", "Ke", "Sze", "Cs", "Pé", "Szo"
-                ],
-                dayOfWeek: ["vasárnap", "hétfő", "kedd", "szerda", "csütörtök", "péntek", "szombat"]
-            },
-            az: { //Azerbaijanian (Azeri)
-                months: [
-                    "Yanvar", "Fevral", "Mart", "Aprel", "May", "Iyun", "Iyul", "Avqust", "Sentyabr", "Oktyabr", "Noyabr", "Dekabr"
-                ],
-                dayOfWeekShort: [
-                    "B", "Be", "Ça", "Ç", "Ca", "C", "Ş"
-                ],
-                dayOfWeek: ["Bazar", "Bazar ertəsi", "Çərşənbə axşamı", "Çərşənbə", "Cümə axşamı", "Cümə", "Şənbə"]
-            },
-            bs: { //Bosanski
-                months: [
-                    "Januar", "Februar", "Mart", "April", "Maj", "Jun", "Jul", "Avgust", "Septembar", "Oktobar", "Novembar", "Decembar"
-                ],
-                dayOfWeekShort: [
-                    "Ned", "Pon", "Uto", "Sri", "Čet", "Pet", "Sub"
-                ],
-                dayOfWeek: ["Nedjelja","Ponedjeljak", "Utorak", "Srijeda", "Četvrtak", "Petak", "Subota"]
-            },
-            ca: { //Català
-                months: [
-                    "Gener", "Febrer", "Març", "Abril", "Maig", "Juny", "Juliol", "Agost", "Setembre", "Octubre", "Novembre", "Desembre"
-                ],
-                dayOfWeekShort: [
-                    "Dg", "Dl", "Dt", "Dc", "Dj", "Dv", "Ds"
-                ],
-                dayOfWeek: ["Diumenge", "Dilluns", "Dimarts", "Dimecres", "Dijous", "Divendres", "Dissabte"]
-            },
-            'en-GB': { //English (British)
-                months: [
-                    "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
-                ],
-                dayOfWeekShort: [
-                    "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
-                ],
-                dayOfWeek: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
-            },
-            et: { //"Eesti"
-                months: [
-                    "Jaanuar", "Veebruar", "Märts", "Aprill", "Mai", "Juuni", "Juuli", "August", "September", "Oktoober", "November", "Detsember"
-                ],
-                dayOfWeekShort: [
-                    "P", "E", "T", "K", "N", "R", "L"
-                ],
-                dayOfWeek: ["Pühapäev", "Esmaspäev", "Teisipäev", "Kolmapäev", "Neljapäev", "Reede", "Laupäev"]
-            },
-            eu: { //Euskara
-                months: [
-                    "Urtarrila", "Otsaila", "Martxoa", "Apirila", "Maiatza", "Ekaina", "Uztaila", "Abuztua", "Iraila", "Urria", "Azaroa", "Abendua"
-                ],
-                dayOfWeekShort: [
-                    "Ig.", "Al.", "Ar.", "Az.", "Og.", "Or.", "La."
-                ],
-                dayOfWeek: ['Igandea', 'Astelehena', 'Asteartea', 'Asteazkena', 'Osteguna', 'Ostirala', 'Larunbata']
-            },
-            fi: { //Finnish (Suomi)
-                months: [
-                    "Tammikuu", "Helmikuu", "Maaliskuu", "Huhtikuu", "Toukokuu", "Kesäkuu", "Heinäkuu", "Elokuu", "Syyskuu", "Lokakuu", "Marraskuu", "Joulukuu"
-                ],
-                dayOfWeekShort: [
-                    "Su", "Ma", "Ti", "Ke", "To", "Pe", "La"
-                ],
-                dayOfWeek: ["sunnuntai", "maanantai", "tiistai", "keskiviikko", "torstai", "perjantai", "lauantai"]
-            },
-            gl: { //Galego
-                months: [
-                    "Xan", "Feb", "Maz", "Abr", "Mai", "Xun", "Xul", "Ago", "Set", "Out", "Nov", "Dec"
-                ],
-                dayOfWeekShort: [
-                    "Dom", "Lun", "Mar", "Mer", "Xov", "Ven", "Sab"
-                ],
-                dayOfWeek: ["Domingo", "Luns", "Martes", "Mércores", "Xoves", "Venres", "Sábado"]
-            },
-            hr: { //Hrvatski
-                months: [
-                    "Siječanj", "Veljača", "Ožujak", "Travanj", "Svibanj", "Lipanj", "Srpanj", "Kolovoz", "Rujan", "Listopad", "Studeni", "Prosinac"
-                ],
-                dayOfWeekShort: [
-                    "Ned", "Pon", "Uto", "Sri", "Čet", "Pet", "Sub"
-                ],
-                dayOfWeek: ["Nedjelja", "Ponedjeljak", "Utorak", "Srijeda", "Četvrtak", "Petak", "Subota"]
-            },
-            ko: { //Korean (한국어)
-                months: [
-                    "1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월"
-                ],
-                dayOfWeekShort: [
-                    "일", "월", "화", "수", "목", "금", "토"
-                ],
-                dayOfWeek: ["일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"]
-            },
-            lt: { //Lithuanian (lietuvių)
-                months: [
-                    "Sausio", "Vasario", "Kovo", "Balandžio", "Gegužės", "Birželio", "Liepos", "Rugpjūčio", "Rugsėjo", "Spalio", "Lapkričio", "Gruodžio"
-                ],
-                dayOfWeekShort: [
-                    "Sek", "Pir", "Ant", "Tre", "Ket", "Pen", "Šeš"
-                ],
-                dayOfWeek: ["Sekmadienis", "Pirmadienis", "Antradienis", "Trečiadienis", "Ketvirtadienis", "Penktadienis", "Šeštadienis"]
-            },
-            lv: { //Latvian (Latviešu)
-                months: [
-                    "Janvāris", "Februāris", "Marts", "Aprīlis ", "Maijs", "Jūnijs", "Jūlijs", "Augusts", "Septembris", "Oktobris", "Novembris", "Decembris"
-                ],
-                dayOfWeekShort: [
-                    "Sv", "Pr", "Ot", "Tr", "Ct", "Pk", "St"
-                ],
-                dayOfWeek: ["Svētdiena", "Pirmdiena", "Otrdiena", "Trešdiena", "Ceturtdiena", "Piektdiena", "Sestdiena"]
-            },
-            mk: { //Macedonian (Македонски)
-                months: [
-                    "јануари", "февруари", "март", "април", "мај", "јуни", "јули", "август", "септември", "октомври", "ноември", "декември"
-                ],
-                dayOfWeekShort: [
-                    "нед", "пон", "вто", "сре", "чет", "пет", "саб"
-                ],
-                dayOfWeek: ["Недела", "Понеделник", "Вторник", "Среда", "Четврток", "Петок", "Сабота"]
-            },
-            mn: { //Mongolian (Монгол)
-                months: [
-                    "1-р сар", "2-р сар", "3-р сар", "4-р сар", "5-р сар", "6-р сар", "7-р сар", "8-р сар", "9-р сар", "10-р сар", "11-р сар", "12-р сар"
-                ],
-                dayOfWeekShort: [
-                    "Дав", "Мяг", "Лха", "Пүр", "Бсн", "Бям", "Ням"
-                ],
-                dayOfWeek: ["Даваа", "Мягмар", "Лхагва", "Пүрэв", "Баасан", "Бямба", "Ням"]
-            },
-            'pt-BR': { //Português(Brasil)
-                months: [
-                    "Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"
-                ],
-                dayOfWeekShort: [
-                    "Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"
-                ],
-                dayOfWeek: ["Domingo", "Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado"]
-            },
-            sk: { //Slovenčina
-                months: [
-                    "Január", "Február", "Marec", "Apríl", "Máj", "Jún", "Júl", "August", "September", "Október", "November", "December"
-                ],
-                dayOfWeekShort: [
-                    "Ne", "Po", "Ut", "St", "Št", "Pi", "So"
-                ],
-                dayOfWeek: ["Nedeľa", "Pondelok", "Utorok", "Streda", "Štvrtok", "Piatok", "Sobota"]
-            },
-            sq: { //Albanian (Shqip)
-                months: [
-                    "Janar", "Shkurt", "Mars", "Prill", "Maj", "Qershor", "Korrik", "Gusht", "Shtator", "Tetor", "Nëntor", "Dhjetor"
-                ],
-                dayOfWeekShort: [
-                    "Die", "Hën", "Mar", "Mër", "Enj", "Pre", "Shtu"
-                ],
-                dayOfWeek: ["E Diel", "E Hënë", "E Martē", "E Mërkurë", "E Enjte", "E Premte", "E Shtunë"]
-            },
-            'sr-YU': { //Serbian (Srpski)
-                months: [
-                    "Januar", "Februar", "Mart", "April", "Maj", "Jun", "Jul", "Avgust", "Septembar", "Oktobar", "Novembar", "Decembar"
-                ],
-                dayOfWeekShort: [
-                    "Ned", "Pon", "Uto", "Sre", "čet", "Pet", "Sub"
-                ],
-                dayOfWeek: ["Nedelja","Ponedeljak", "Utorak", "Sreda", "Četvrtak", "Petak", "Subota"]
-            },
-            sr: { //Serbian Cyrillic (Српски)
-                months: [
-                    "јануар", "фебруар", "март", "април", "мај", "јун", "јул", "август", "септембар", "октобар", "новембар", "децембар"
-                ],
-                dayOfWeekShort: [
-                    "нед", "пон", "уто", "сре", "чет", "пет", "суб"
-                ],
-                dayOfWeek: ["Недеља","Понедељак", "Уторак", "Среда", "Четвртак", "Петак", "Субота"]
-            },
-            sv: { //Svenska
-                months: [
-                    "Januari", "Februari", "Mars", "April", "Maj", "Juni", "Juli", "Augusti", "September", "Oktober", "November", "December"
-                ],
-                dayOfWeekShort: [
-                    "Sön", "Mån", "Tis", "Ons", "Tor", "Fre", "Lör"
-                ],
-                dayOfWeek: ["Söndag", "Måndag", "Tisdag", "Onsdag", "Torsdag", "Fredag", "Lördag"]
-            },
-            'zh-TW': { //Traditional Chinese (繁體中文)
-                months: [
-                    "一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"
-                ],
-                dayOfWeekShort: [
-                    "日", "一", "二", "三", "四", "五", "六"
-                ],
-                dayOfWeek: ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"]
-            },
-            zh: { //Simplified Chinese (简体中文)
-                months: [
-                    "一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"
-                ],
-                dayOfWeekShort: [
-                    "日", "一", "二", "三", "四", "五", "六"
-                ],
-                dayOfWeek: ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"]
-            },
-            ug:{ // Uyghur(ئۇيغۇرچە)
-                months: [
-                    "1-ئاي","2-ئاي","3-ئاي","4-ئاي","5-ئاي","6-ئاي","7-ئاي","8-ئاي","9-ئاي","10-ئاي","11-ئاي","12-ئاي"
-                ],
-                dayOfWeek: [
-                    "يەكشەنبە", "دۈشەنبە","سەيشەنبە","چارشەنبە","پەيشەنبە","جۈمە","شەنبە"
                 ]
-            },
-            he: { //Hebrew (עברית)
-                months: [
-                    'ינואר', 'פברואר', 'מרץ', 'אפריל', 'מאי', 'יוני', 'יולי', 'אוגוסט', 'ספטמבר', 'אוקטובר', 'נובמבר', 'דצמבר'
-                ],
-                dayOfWeekShort: [
-                    'א\'', 'ב\'', 'ג\'', 'ד\'', 'ה\'', 'ו\'', 'שבת'
-                ],
-                dayOfWeek: ["ראשון", "שני", "שלישי", "רביעי", "חמישי", "שישי", "שבת", "ראשון"]
-            },
-            hy: { // Armenian
-                months: [
-                    "Հունվար", "Փետրվար", "Մարտ", "Ապրիլ", "Մայիս", "Հունիս", "Հուլիս", "Օգոստոս", "Սեպտեմբեր", "Հոկտեմբեր", "Նոյեմբեր", "Դեկտեմբեր"
-                ],
-                dayOfWeekShort: [
-                    "Կի", "Երկ", "Երք", "Չոր", "Հնգ", "Ուրբ", "Շբթ"
-                ],
-                dayOfWeek: ["Կիրակի", "Երկուշաբթի", "Երեքշաբթի", "Չորեքշաբթի", "Հինգշաբթի", "Ուրբաթ", "Շաբաթ"]
-            },
-            kg: { // Kyrgyz
-                months: [
-                    'Үчтүн айы', 'Бирдин айы', 'Жалган Куран', 'Чын Куран', 'Бугу', 'Кулжа', 'Теке', 'Баш Оона', 'Аяк Оона', 'Тогуздун айы', 'Жетинин айы', 'Бештин айы'
-                ],
-                dayOfWeekShort: [
-                    "Жек", "Дүй", "Шей", "Шар", "Бей", "Жум", "Ише"
-                ],
-                dayOfWeek: [
-                    "Жекшемб", "Дүйшөмб", "Шейшемб", "Шаршемб", "Бейшемби", "Жума", "Ишенб"
-                ]
-            },
-            rm: { // Romansh
-                months: [
-                    "Schaner", "Favrer", "Mars", "Avrigl", "Matg", "Zercladur", "Fanadur", "Avust", "Settember", "October", "November", "December"
-                ],
-                dayOfWeekShort: [
-                    "Du", "Gli", "Ma", "Me", "Gie", "Ve", "So"
-                ],
-                dayOfWeek: [
-                    "Dumengia", "Glindesdi", "Mardi", "Mesemna", "Gievgia", "Venderdi", "Sonda"
-                ]
-            },
-            ka: { // Georgian
-                months: [
-                    'იანვარი', 'თებერვალი', 'მარტი', 'აპრილი', 'მაისი', 'ივნისი', 'ივლისი', 'აგვისტო', 'სექტემბერი', 'ოქტომბერი', 'ნოემბერი', 'დეკემბერი'
-                ],
-                dayOfWeekShort: [
-                    "კვ", "ორშ", "სამშ", "ოთხ", "ხუთ", "პარ", "შაბ"
-                ],
-                dayOfWeek: ["კვირა", "ორშაბათი", "სამშაბათი", "ოთხშაბათი", "ხუთშაბათი", "პარასკევი", "შაბათი"]
             }
         },
-
-        ownerDocument: document,
-        contentWindow: window,
-
         value: '',
-        rtl: false,
+        lang: 'en',
 
         format:	'Y/m/d H:i',
         formatTime:	'H:i',
@@ -549,10 +244,8 @@ var datetimepickerFactory = function ($) {
         monthChangeSpinner: true,
 
         closeOnDateSelect: false,
-        closeOnTimeSelect: true,
         closeOnWithoutClick: true,
         closeOnInputClick: true,
-        openOnFocus: true,
 
         timepicker: true,
         datepicker: true,
@@ -565,20 +258,16 @@ var datetimepickerFactory = function ($) {
         maxDate: false,
         minTime: false,
         maxTime: false,
-        minDateTime: false,
-        maxDateTime: false,
 
         allowTimes: [],
         opened: false,
         initTime: true,
         inline: false,
         theme: '',
-        touchMovedThreshold: 5,
 
         onSelectDate: function () {},
         onSelectTime: function () {},
         onChangeMonth: function () {},
-        onGetWeekOfYear: function () {},
         onChangeYear: function () {},
         onChangeDateTime: function () {},
         onShow: function () {},
@@ -588,15 +277,13 @@ var datetimepickerFactory = function ($) {
         withoutCopyright: true,
         inverseButton: false,
         hours12: false,
-        next: 'xdsoft_next',
+        next:	'xdsoft_next',
         prev : 'xdsoft_prev',
         dayOfWeekStart: 0,
         parentID: 'body',
         timeHeightInTimePicker: 25,
         timepickerScrollbar: true,
         todayButton: true,
-        prevButton: true,
-        nextButton: true,
         defaultSelect: true,
 
         scrollMonth: true,
@@ -609,152 +296,16 @@ var datetimepickerFactory = function ($) {
         allowBlank: true,
         yearStart: 1950,
         yearEnd: 2050,
-        monthStart: 0,
-        monthEnd: 11,
         style: '',
         id: '',
         fixed: false,
         roundTime: 'round', // ceil, floor
         className: '',
         weekends: [],
-        highlightedDates: [],
-        highlightedPeriods: [],
-        allowDates : [],
-        allowDateRe : null,
-        disabledDates : [],
-        disabledWeekDays: [],
         yearOffset: 0,
-        beforeShowDay: null,
-
-        enterLikeTab: true,
-        showApplyButton: false
+        beforeShowDay: null
     };
-
-    var dateHelper = null,
-        defaultDateHelper = null,
-        globalLocaleDefault = 'en',
-        globalLocale = 'en';
-
-    var dateFormatterOptionsDefault = {
-        meridiem: ['AM', 'PM']
-    };
-
-    var initDateFormatter = function(){
-        var locale = default_options.i18n[globalLocale],
-            opts = {
-                days: locale.dayOfWeek,
-                daysShort: locale.dayOfWeekShort,
-                months: locale.months,
-                monthsShort: $.map(locale.months, function(n){ return n.substring(0, 3) })
-            };
-
-        if (typeof DateFormatter === 'function') {
-            dateHelper = defaultDateHelper = new DateFormatter({
-                dateSettings: $.extend({}, dateFormatterOptionsDefault, opts)
-            });
-        }
-    };
-
-    var dateFormatters = {
-        moment: {
-            default_options:{
-                format: 'YYYY/MM/DD HH:mm',
-                formatDate: 'YYYY/MM/DD',
-                formatTime: 'HH:mm',
-            },
-            formatter: {
-                parseDate: function (date, format) {
-                    if(isFormatStandard(format)){
-                        return defaultDateHelper.parseDate(date, format);
-                    }
-                    var d = moment(date, format);
-                    return d.isValid() ? d.toDate() : false;
-                },
-
-                formatDate: function (date, format) {
-                    if(isFormatStandard(format)){
-                        return defaultDateHelper.formatDate(date, format);
-                    }
-                    return moment(date).format(format);
-                },
-
-                formatMask: function(format){
-                    return format
-                        .replace(/Y{4}/g, '9999')
-                        .replace(/Y{2}/g, '99')
-                        .replace(/M{2}/g, '19')
-                        .replace(/D{2}/g, '39')
-                        .replace(/H{2}/g, '29')
-                        .replace(/m{2}/g, '59')
-                        .replace(/s{2}/g, '59');
-                },
-            }
-        }
-    }
-
-    // for locale settings
-    $.datetimepicker = {
-        setLocale: function(locale){
-            var newLocale = default_options.i18n[locale] ? locale : globalLocaleDefault;
-            if (globalLocale !== newLocale) {
-                globalLocale = newLocale;
-                // reinit date formatter
-                initDateFormatter();
-            }
-        },
-
-        setDateFormatter: function(dateFormatter) {
-            if(typeof dateFormatter === 'string' && dateFormatters.hasOwnProperty(dateFormatter)){
-                var df = dateFormatters[dateFormatter];
-                $.extend(default_options, df.default_options);
-                dateHelper = df.formatter;
-            }
-            else {
-                dateHelper = dateFormatter;
-            }
-        },
-    };
-
-    var standardFormats = {
-        RFC_2822: 'D, d M Y H:i:s O',
-        ATOM: 'Y-m-d\TH:i:sP',
-        ISO_8601: 'Y-m-d\TH:i:sO',
-        RFC_822: 'D, d M y H:i:s O',
-        RFC_850: 'l, d-M-y H:i:s T',
-        RFC_1036: 'D, d M y H:i:s O',
-        RFC_1123: 'D, d M Y H:i:s O',
-        RSS: 'D, d M Y H:i:s O',
-        W3C: 'Y-m-d\TH:i:sP'
-    }
-
-    var isFormatStandard = function(format){
-        return Object.values(standardFormats).indexOf(format) === -1 ? false : true;
-    }
-
-    $.extend($.datetimepicker, standardFormats);
-
-    // first init date formatter
-    initDateFormatter();
-
     // fix for ie8
-    if (!window.getComputedStyle) {
-        window.getComputedStyle = function (el) {
-            this.el = el;
-            this.getPropertyValue = function (prop) {
-                var re = /(-([a-z]))/g;
-                if (prop === 'float') {
-                    prop = 'styleFloat';
-                }
-                if (re.test(prop)) {
-                    prop = prop.replace(re, function (a, b, c) {
-                        return c.toUpperCase();
-                    });
-                }
-                return el.currentStyle[prop] || null;
-            };
-            return this;
-        };
-    }
     if (!Array.prototype.indexOf) {
         Array.prototype.indexOf = function (obj, start) {
             var i, j;
@@ -764,12 +315,10 @@ var datetimepickerFactory = function ($) {
             return -1;
         };
     }
-
     Date.prototype.countDaysInMonth = function () {
         return new Date(this.getFullYear(), this.getMonth() + 1, 0).getDate();
     };
-
-    $.fn.xdsoftScroller = function (options, percent) {
+    $.fn.xdsoftScroller = function (percent) {
         return this.each(function () {
             var timeboxparent = $(this),
                 pointerEventToXY = function (e) {
@@ -785,6 +334,7 @@ var datetimepickerFactory = function ($) {
                     }
                     return out;
                 },
+                move = 0,
                 timebox,
                 parentHeight,
                 height,
@@ -798,11 +348,6 @@ var datetimepickerFactory = function ($) {
                 touchStart = false,
                 startTopScroll = 0,
                 calcOffset = function () {};
-
-            if (percent === 'hide') {
-                timeboxparent.find('.xdsoft_scrollbar').hide();
-                return;
-            }
 
             if (!$(this).hasClass('xdsoft_scroller_box')) {
                 timebox = timeboxparent.children().eq(0);
@@ -834,16 +379,16 @@ var datetimepickerFactory = function ($) {
                         startTopScroll = parseInt(scroller.css('margin-top'), 10);
                         h1 = scrollbar[0].offsetHeight;
 
-                        if (event.type === 'mousedown' || event.type === 'touchstart') {
-                            if (options.ownerDocument) {
-                                $(options.ownerDocument.body).addClass('xdsoft_noselect');
+                        if (event.type === 'mousedown') {
+                            if (document) {
+                                $(document.body).addClass('xdsoft_noselect');
                             }
-                            $([options.ownerDocument.body, options.contentWindow]).on('touchend mouseup.xdsoft_scroller', function arguments_callee() {
-                                $([options.ownerDocument.body, options.contentWindow]).off('touchend mouseup.xdsoft_scroller', arguments_callee)
+                            $([document.body, window]).on('mouseup.xdsoft_scroller', function arguments_callee() {
+                                $([document.body, window]).off('mouseup.xdsoft_scroller', arguments_callee)
                                     .off('mousemove.xdsoft_scroller', calcOffset)
                                     .removeClass('xdsoft_noselect');
                             });
-                            $(options.ownerDocument.body).on('mousemove.xdsoft_scroller', calcOffset);
+                            $(document.body).on('mousemove.xdsoft_scroller', calcOffset);
                         } else {
                             touchStart = true;
                             event.stopPropagation();
@@ -856,7 +401,7 @@ var datetimepickerFactory = function ($) {
                             calcOffset(event);
                         }
                     })
-                    .on('touchend touchcancel', function () {
+                    .on('touchend touchcancel', function (event) {
                         touchStart =  false;
                         startTopScroll = 0;
                     });
@@ -918,7 +463,7 @@ var datetimepickerFactory = function ($) {
                     }
                 });
 
-                timeboxparent.on('touchend touchcancel', function () {
+                timeboxparent.on('touchend touchcancel', function (event) {
                     start = false;
                     startTop = 0;
                 });
@@ -927,9 +472,8 @@ var datetimepickerFactory = function ($) {
         });
     };
 
-    $.fn.datetimepicker = function (opt, opt2) {
-        var result = this,
-            KEY0 = 48,
+    $.fn.datetimepicker = function (opt) {
+        var KEY0 = 48,
             KEY9 = 57,
             _KEY0 = 96,
             _KEY9 = 105,
@@ -955,11 +499,12 @@ var datetimepickerFactory = function ($) {
             lazyInitTimer = 0,
             createDateTimePicker,
             destroyDateTimePicker,
+            _xdsoft_datetime,
 
             lazyInit = function (input) {
                 input
-                    .on('open.xdsoft focusin.xdsoft mousedown.xdsoft touchstart', function initOnActionCallback() {
-                        if (input.is(':disabled') || input.data('xdsoft_datetimepicker')) {
+                    .on('open.xdsoft focusin.xdsoft mousedown.xdsoft', function initOnActionCallback(event) {
+                        if (input.is(':disabled') || input.is(':hidden') || !input.is(':visible') || input.data('xdsoft_datetimepicker')) {
                             return;
                         }
                         clearTimeout(lazyInitTimer);
@@ -969,17 +514,17 @@ var datetimepickerFactory = function ($) {
                                 createDateTimePicker(input);
                             }
                             input
-                                .off('open.xdsoft focusin.xdsoft mousedown.xdsoft touchstart', initOnActionCallback)
+                                .off('open.xdsoft focusin.xdsoft mousedown.xdsoft', initOnActionCallback)
                                 .trigger('open.xdsoft');
                         }, 100);
                     });
             };
 
         createDateTimePicker = function (input) {
-            var datetimepicker = $('<div class="xdsoft_datetimepicker xdsoft_noselect"></div>'),
+            var datetimepicker = $('<div ' + (options.id ? 'id="' + options.id + '"' : '') + ' ' + (options.style ? 'style="' + options.style + '"' : '') + ' class="xdsoft_datetimepicker xdsoft_' + options.theme + ' xdsoft_noselect ' + (options.weeks ? ' xdsoft_showweeks' : '') + options.className + '"></div>'),
                 xdsoft_copyright = $('<div class="xdsoft_copyright"><a target="_blank" href="http://xdsoft.net/jqplugins/datetimepicker/">xdsoft.net</a></div>'),
                 datepicker = $('<div class="xdsoft_datepicker active"></div>'),
-                month_picker = $('<div class="xdsoft_monthpicker"><button type="button" class="xdsoft_prev"></button><button type="button" class="xdsoft_today_button"></button>' +
+                mounth_picker = $('<div class="xdsoft_mounthpicker"><button type="button" class="xdsoft_prev"></button><button type="button" class="xdsoft_today_button"></button>' +
                     '<div class="xdsoft_label xdsoft_month"><span></span><i></i></div>' +
                     '<div class="xdsoft_label xdsoft_year"><span></span><i></i></div>' +
                     '<button type="button" class="xdsoft_next"></button></div>'),
@@ -987,47 +532,30 @@ var datetimepickerFactory = function ($) {
                 timepicker = $('<div class="xdsoft_timepicker active"><button type="button" class="xdsoft_prev"></button><div class="xdsoft_time_box"></div><button type="button" class="xdsoft_next"></button></div>'),
                 timeboxparent = timepicker.find('.xdsoft_time_box').eq(0),
                 timebox = $('<div class="xdsoft_time_variant"></div>'),
-                applyButton = $('<button type="button" class="xdsoft_save_selected blue-gradient-button">Save Selected</button>'),
-
+                scrollbar = $('<div class="xdsoft_scrollbar"></div>'),
+                scroller = $('<div class="xdsoft_scroller"></div>'),
                 monthselect = $('<div class="xdsoft_select xdsoft_monthselect"><div></div></div>'),
                 yearselect = $('<div class="xdsoft_select xdsoft_yearselect"><div></div></div>'),
                 triggerAfterOpen = false,
                 XDSoft_datetime,
-
+                //scroll_element,
                 xchangeTimer,
                 timerclick,
                 current_time_index,
                 setPos,
                 timer = 0,
-                _xdsoft_datetime,
-                forEachAncestorOf;
+                timer1 = 0;
 
-            if (options.id) {
-                datetimepicker.attr('id', options.id);
-            }
-            if (options.style) {
-                datetimepicker.attr('style', options.style);
-            }
-            if (options.weeks) {
-                datetimepicker.addClass('xdsoft_showweeks');
-            }
-            if (options.rtl) {
-                datetimepicker.addClass('xdsoft_rtl');
-            }
-
-            datetimepicker.addClass('xdsoft_' + options.theme);
-            datetimepicker.addClass(options.className);
-
-            month_picker
+            mounth_picker
                 .find('.xdsoft_month span')
                 .after(monthselect);
-            month_picker
+            mounth_picker
                 .find('.xdsoft_year span')
                 .after(yearselect);
 
-            month_picker
+            mounth_picker
                 .find('.xdsoft_month,.xdsoft_year')
-                .on('touchstart mousedown.xdsoft', function (event) {
+                .on('mousedown.xdsoft', function (event) {
                     var select = $(this).find('.xdsoft_select').eq(0),
                         val = 0,
                         top = 0,
@@ -1035,7 +563,7 @@ var datetimepickerFactory = function ($) {
                         items,
                         i;
 
-                    month_picker
+                    mounth_picker
                         .find('.xdsoft_select')
                         .hide();
                     if (_xdsoft_datetime.currentTime) {
@@ -1051,65 +579,37 @@ var datetimepickerFactory = function ($) {
                         }
                     }
 
-                    select.xdsoftScroller(options, top / (select.children()[0].offsetHeight - (select[0].clientHeight)));
+                    select.xdsoftScroller(top / (select.children()[0].offsetHeight - (select[0].clientHeight)));
                     event.stopPropagation();
                     return false;
                 });
 
-            var handleTouchMoved = function (event) {
-                var evt = event.originalEvent;
-                var touchPosition = evt.touches ? evt.touches[0] : evt;
-                this.touchStartPosition = this.touchStartPosition || touchPosition;
-                var xMovement = Math.abs(this.touchStartPosition.clientX - touchPosition.clientX);
-                var yMovement = Math.abs(this.touchStartPosition.clientY - touchPosition.clientY);
-                var distance = Math.sqrt(xMovement * xMovement + yMovement * yMovement);
-                if(distance > options.touchMovedThreshold) {
-                    this.touchMoved = true;
-                }
-            }
-
-            month_picker
+            mounth_picker
                 .find('.xdsoft_select')
-                .xdsoftScroller(options)
-                .on('touchstart mousedown.xdsoft', function (event) {
-                    var evt = event.originalEvent;
-                    this.touchMoved = false;
-                    this.touchStartPosition = evt.touches ? evt.touches[0] : evt;
+                .xdsoftScroller()
+                .on('mousedown.xdsoft', function (event) {
                     event.stopPropagation();
                     event.preventDefault();
                 })
-                .on('touchmove', '.xdsoft_option', handleTouchMoved)
-                .on('touchend mousedown.xdsoft', '.xdsoft_option', function () {
-                    if (!this.touchMoved) {
-                        if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
-                            _xdsoft_datetime.currentTime = _xdsoft_datetime.now();
-                        }
+                .on('mousedown.xdsoft', '.xdsoft_option', function (event) {
+                    var year = _xdsoft_datetime.currentTime.getFullYear();
+                    if (_xdsoft_datetime && _xdsoft_datetime.currentTime) {
+                        _xdsoft_datetime.currentTime[$(this).parent().parent().hasClass('xdsoft_monthselect') ? 'setMonth' : 'setFullYear']($(this).data('value'));
+                    }
 
-                        var year = _xdsoft_datetime.currentTime.getFullYear();
-                        if (_xdsoft_datetime && _xdsoft_datetime.currentTime) {
-                            _xdsoft_datetime.currentTime[$(this).parent().parent().hasClass('xdsoft_monthselect') ? 'setMonth' : 'setFullYear']($(this).data('value'));
-                        }
+                    $(this).parent().parent().hide();
 
-                        $(this).parent().parent().hide();
+                    datetimepicker.trigger('xchange.xdsoft');
+                    if (options.onChangeMonth && $.isFunction(options.onChangeMonth)) {
+                        options.onChangeMonth.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
+                    }
 
-                        datetimepicker.trigger('xchange.xdsoft');
-                        if (options.onChangeMonth && $.isFunction(options.onChangeMonth)) {
-                            options.onChangeMonth.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
-                        }
-
-                        if (year !== _xdsoft_datetime.currentTime.getFullYear() && $.isFunction(options.onChangeYear)) {
-                            options.onChangeYear.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
-                        }
+                    if (year !== _xdsoft_datetime.currentTime.getFullYear() && $.isFunction(options.onChangeYear)) {
+                        options.onChangeYear.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
                     }
                 });
 
-            datetimepicker.getValue = function () {
-                return _xdsoft_datetime.getCurrentTime();
-            };
-
             datetimepicker.setOptions = function (_options) {
-                var highlightedDates = {};
-
                 options = $.extend(true, {}, options, _options);
 
                 if (_options.allowTimes && $.isArray(_options.allowTimes) && _options.allowTimes.length) {
@@ -1118,83 +618,6 @@ var datetimepickerFactory = function ($) {
 
                 if (_options.weekends && $.isArray(_options.weekends) && _options.weekends.length) {
                     options.weekends = $.extend(true, [], _options.weekends);
-                }
-
-                if (_options.allowDates && $.isArray(_options.allowDates) && _options.allowDates.length) {
-                    options.allowDates = $.extend(true, [], _options.allowDates);
-                }
-
-                if (_options.allowDateRe && Object.prototype.toString.call(_options.allowDateRe)==="[object String]") {
-                    options.allowDateRe = new RegExp(_options.allowDateRe);
-                }
-
-                if (_options.highlightedDates && $.isArray(_options.highlightedDates) && _options.highlightedDates.length) {
-                    $.each(_options.highlightedDates, function (index, value) {
-                        var splitData = $.map(value.split(','), $.trim),
-                            exDesc,
-                            hDate = new HighlightedDate(dateHelper.parseDate(splitData[0], options.formatDate), splitData[1], splitData[2]), // date, desc, style
-                            keyDate = dateHelper.formatDate(hDate.date, options.formatDate);
-                        if (highlightedDates[keyDate] !== undefined) {
-                            exDesc = highlightedDates[keyDate].desc;
-                            if (exDesc && exDesc.length && hDate.desc && hDate.desc.length) {
-                                highlightedDates[keyDate].desc = exDesc + "\n" + hDate.desc;
-                            }
-                        } else {
-                            highlightedDates[keyDate] = hDate;
-                        }
-                    });
-
-                    options.highlightedDates = $.extend(true, [], highlightedDates);
-                }
-
-                if (_options.highlightedPeriods && $.isArray(_options.highlightedPeriods) && _options.highlightedPeriods.length) {
-                    highlightedDates = $.extend(true, [], options.highlightedDates);
-                    $.each(_options.highlightedPeriods, function (index, value) {
-                        var dateTest, // start date
-                            dateEnd,
-                            desc,
-                            hDate,
-                            keyDate,
-                            exDesc,
-                            style;
-                        if ($.isArray(value)) {
-                            dateTest = value[0];
-                            dateEnd = value[1];
-                            desc = value[2];
-                            style = value[3];
-                        }
-                        else {
-                            var splitData = $.map(value.split(','), $.trim);
-                            dateTest = dateHelper.parseDate(splitData[0], options.formatDate);
-                            dateEnd = dateHelper.parseDate(splitData[1], options.formatDate);
-                            desc = splitData[2];
-                            style = splitData[3];
-                        }
-
-                        while (dateTest <= dateEnd) {
-                            hDate = new HighlightedDate(dateTest, desc, style);
-                            keyDate = dateHelper.formatDate(dateTest, options.formatDate);
-                            dateTest.setDate(dateTest.getDate() + 1);
-                            if (highlightedDates[keyDate] !== undefined) {
-                                exDesc = highlightedDates[keyDate].desc;
-                                if (exDesc && exDesc.length && hDate.desc && hDate.desc.length) {
-                                    highlightedDates[keyDate].desc = exDesc + "\n" + hDate.desc;
-                                }
-                            } else {
-                                highlightedDates[keyDate] = hDate;
-                            }
-                        }
-                    });
-
-                    options.highlightedDates = $.extend(true, [], highlightedDates);
-                }
-
-                if (_options.disabledDates && $.isArray(_options.disabledDates) && _options.disabledDates.length) {
-                    options.disabledDates = $.extend(true, [], _options.disabledDates);
-                }
-
-                if (_options.disabledWeekDays && $.isArray(_options.disabledWeekDays) && _options.disabledWeekDays.length) {
-                    options.disabledWeekDays = $.extend(true, [], _options.disabledWeekDays);
                 }
 
                 if ((options.open || options.opened) && (!options.inline)) {
@@ -1225,10 +648,10 @@ var datetimepickerFactory = function ($) {
                 }
 
                 if (options.value) {
-                    _xdsoft_datetime.setCurrentTime(options.value);
                     if (input && input.val) {
-                        input.val(_xdsoft_datetime.str);
+                        input.val(options.value);
                     }
+                    _xdsoft_datetime.setCurrentTime(options.value);
                 }
 
                 if (isNaN(options.dayOfWeekStart)) {
@@ -1238,71 +661,149 @@ var datetimepickerFactory = function ($) {
                 }
 
                 if (!options.timepickerScrollbar) {
-                    timeboxparent.xdsoftScroller(options, 'hide');
+                    scrollbar.hide();
                 }
 
-                if (options.minDate && /^[\+\-](.*)$/.test(options.minDate)) {
-                    options.minDate = dateHelper.formatDate(_xdsoft_datetime.strToDateTime(options.minDate), options.formatDate);
+                if (options.minDate && /^-(.*)$/.test(options.minDate)) {
+                    options.minDate = _xdsoft_datetime.strToDateTime(options.minDate).dateFormat(options.formatDate);
                 }
 
-                if (options.maxDate &&  /^[\+\-](.*)$/.test(options.maxDate)) {
-                    options.maxDate = dateHelper.formatDate(_xdsoft_datetime.strToDateTime(options.maxDate), options.formatDate);
+                if (options.maxDate &&  /^\+(.*)$/.test(options.maxDate)) {
+                    options.maxDate = _xdsoft_datetime.strToDateTime(options.maxDate).dateFormat(options.formatDate);
                 }
 
-                if (options.minDateTime &&  /^\+(.*)$/.test(options.minDateTime)) {
-                    options.minDateTime = _xdsoft_datetime.strToDateTime(options.minDateTime).dateFormat(options.formatDate);
-                }
-
-                if (options.maxDateTime &&  /^\+(.*)$/.test(options.maxDateTime)) {
-                    options.maxDateTime = _xdsoft_datetime.strToDateTime(options.maxDateTime).dateFormat(options.formatDate);
-                }
-
-                applyButton.toggle(options.showApplyButton);
-
-                month_picker
+                mounth_picker
                     .find('.xdsoft_today_button')
                     .css('visibility', !options.todayButton ? 'hidden' : 'visible');
 
-                month_picker
-                    .find('.' + options.prev)
-                    .css('visibility', !options.prevButton ? 'hidden' : 'visible');
+                if (options.mask) {
+                    var e,
+                        getCaretPos = function (input) {
+                            try {
+                                if (document.selection && document.selection.createRange) {
+                                    var range = document.selection.createRange();
+                                    return range.getBookmark().charCodeAt(2) - 2;
+                                }
+                                if (input.setSelectionRange) {
+                                    return input.selectionStart;
+                                }
+                            } catch (e) {
+                                return 0;
+                            }
+                        },
+                        setCaretPos = function (node, pos) {
+                            node = (typeof node === "string" || node instanceof String) ? document.getElementById(node) : node;
+                            if (!node) {
+                                return false;
+                            }
+                            if (node.createTextRange) {
+                                var textRange = node.createTextRange();
+                                textRange.collapse(true);
+                                textRange.moveEnd('character', pos);
+                                textRange.moveStart('character', pos);
+                                textRange.select();
+                                return true;
+                            }
+                            if (node.setSelectionRange) {
+                                node.setSelectionRange(pos, pos);
+                                return true;
+                            }
+                            return false;
+                        },
+                        isValidValue = function (mask, value) {
+                            var reg = mask
+                                .replace(/([\[\]\/\{\}\(\)\-\.\+]{1})/g, '\\$1')
+                                .replace(/_/g, '{digit+}')
+                                .replace(/([0-9]{1})/g, '{digit$1}')
+                                .replace(/\{digit([0-9]{1})\}/g, '[0-$1_]{1}')
+                                .replace(/\{digit[\+]\}/g, '[0-9_]{1}');
+                            return (new RegExp(reg)).test(value);
+                        };
+                    input.off('keydown.xdsoft');
 
-                month_picker
-                    .find('.' + options.next)
-                    .css('visibility', !options.nextButton ? 'hidden' : 'visible');
+                    if (options.mask === true) {
+                        options.mask = options.format
+                            .replace(/Y/g, '9999')
+                            .replace(/F/g, '9999')
+                            .replace(/m/g, '19')
+                            .replace(/d/g, '39')
+                            .replace(/H/g, '29')
+                            .replace(/i/g, '59')
+                            .replace(/s/g, '59');
+                    }
 
-                setMask(options);
+                    if ($.type(options.mask) === 'string') {
+                        if (!isValidValue(options.mask, input.val())) {
+                            input.val(options.mask.replace(/[0-9]/g, '_'));
+                        }
 
+                        input.on('keydown.xdsoft', function (event) {
+                            var val = this.value,
+                                key = event.which,
+                                pos,
+                                digit;
+
+                            if (((key >= KEY0 && key <= KEY9) || (key >= _KEY0 && key <= _KEY9)) || (key === BACKSPACE || key === DEL)) {
+                                pos = getCaretPos(this);
+                                digit = (key !== BACKSPACE && key !== DEL) ? String.fromCharCode((_KEY0 <= key && key <= _KEY9) ? key - KEY0 : key) : '_';
+
+                                if ((key === BACKSPACE || key === DEL) && pos) {
+                                    pos -= 1;
+                                    digit = '_';
+                                }
+
+                                while (/[^0-9_]/.test(options.mask.substr(pos, 1)) && pos < options.mask.length && pos > 0) {
+                                    pos += (key === BACKSPACE || key === DEL) ? -1 : 1;
+                                }
+
+                                val = val.substr(0, pos) + digit + val.substr(pos + 1);
+                                if ($.trim(val) === '') {
+                                    val = options.mask.replace(/[0-9]/g, '_');
+                                } else {
+                                    if (pos === options.mask.length) {
+                                        event.preventDefault();
+                                        return false;
+                                    }
+                                }
+
+                                pos += (key === BACKSPACE || key === DEL) ? 0 : 1;
+                                while (/[^0-9_]/.test(options.mask.substr(pos, 1)) && pos < options.mask.length && pos > 0) {
+                                    pos += (key === BACKSPACE || key === DEL) ? -1 : 1;
+                                }
+
+                                if (isValidValue(options.mask, val)) {
+                                    this.value = val;
+                                    setCaretPos(this, pos);
+                                } else if ($.trim(val) === '') {
+                                    this.value = options.mask.replace(/[0-9]/g, '_');
+                                } else {
+                                    input.trigger('error_input.xdsoft');
+                                }
+                            } else {
+                                if (([AKEY, CKEY, VKEY, ZKEY, YKEY].indexOf(key) !== -1 && ctrlDown) || [ESC, ARROWUP, ARROWDOWN, ARROWLEFT, ARROWRIGHT, F5, CTRLKEY, TAB, ENTER].indexOf(key) !== -1) {
+                                    return true;
+                                }
+                            }
+
+                            event.preventDefault();
+                            return false;
+                        });
+                    }
+                }
                 if (options.validateOnBlur) {
                     input
                         .off('blur.xdsoft')
                         .on('blur.xdsoft', function () {
-                            if (options.allowBlank && (!$.trim($(this).val()).length ||
-                                (typeof options.mask === "string" && $.trim($(this).val()) === options.mask.replace(/[0-9]/g, '_')))) {
+                            if (options.allowBlank && !$.trim($(this).val()).length) {
                                 $(this).val(null);
                                 datetimepicker.data('xdsoft_datetime').empty();
+                            } else if (!Date.parseDate($(this).val(), options.format)) {
+                                $(this).val((_xdsoft_datetime.now()).dateFormat(options.format));
+                                datetimepicker.data('xdsoft_datetime').setCurrentTime($(this).val());
                             } else {
-                                var d = dateHelper.parseDate($(this).val(), options.format);
-                                if (d) { // parseDate() may skip some invalid parts like date or time, so make it clear for user: show parsed date/time
-                                    $(this).val(dateHelper.formatDate(d, options.format));
-                                } else {
-                                    var splittedHours   = +([$(this).val()[0], $(this).val()[1]].join('')),
-                                        splittedMinutes = +([$(this).val()[2], $(this).val()[3]].join(''));
-
-                                    // parse the numbers as 0312 => 03:12
-                                    if (!options.datepicker && options.timepicker && splittedHours >= 0 && splittedHours < 24 && splittedMinutes >= 0 && splittedMinutes < 60) {
-                                        $(this).val([splittedHours, splittedMinutes].map(function (item) {
-                                            return item > 9 ? item : '0' + item;
-                                        }).join(':'));
-                                    } else {
-                                        $(this).val(dateHelper.formatDate(_xdsoft_datetime.now(), options.format));
-                                    }
-                                }
                                 datetimepicker.data('xdsoft_datetime').setCurrentTime($(this).val());
                             }
-
                             datetimepicker.trigger('changedatetime.xdsoft');
-                            datetimepicker.trigger('close.xdsoft');
                         });
                 }
                 options.dayOfWeekStartPrev = (options.dayOfWeekStart === 0) ? 6 : options.dayOfWeekStart - 1;
@@ -1314,7 +815,7 @@ var datetimepickerFactory = function ($) {
 
             datetimepicker
                 .data('options', options)
-                .on('touchstart mousedown.xdsoft', function (event) {
+                .on('mousedown.xdsoft', function (event) {
                     event.stopPropagation();
                     event.preventDefault();
                     yearselect.hide();
@@ -1324,10 +825,10 @@ var datetimepickerFactory = function ($) {
 
             //scroll_element = timepicker.find('.xdsoft_time_box');
             timeboxparent.append(timebox);
-            timeboxparent.xdsoftScroller(options);
+            timeboxparent.xdsoftScroller();
 
             datetimepicker.on('afterOpen.xdsoft', function () {
-                timeboxparent.xdsoftScroller(options);
+                timeboxparent.xdsoftScroller();
             });
 
             datetimepicker
@@ -1340,9 +841,8 @@ var datetimepickerFactory = function ($) {
             }
 
             datepicker
-                .append(month_picker)
-                .append(calendar)
-                .append(applyButton);
+                .append(mounth_picker)
+                .append(calendar);
 
             $(options.parentID)
                 .append(datetimepicker);
@@ -1355,21 +855,22 @@ var datetimepickerFactory = function ($) {
                         time;
 
                     if (!norecursion && options.defaultDate) {
-                        date = _this.strToDateTime(options.defaultDate);
+                        date = _this.strToDate(options.defaultDate);
                         d.setFullYear(date.getFullYear());
                         d.setMonth(date.getMonth());
                         d.setDate(date.getDate());
                     }
 
-                    d.setFullYear(d.getFullYear());
+                    if (options.yearOffset) {
+                        d.setFullYear(d.getFullYear() + options.yearOffset);
+                    }
 
                     if (!norecursion && options.defaultTime) {
                         time = _this.strtotime(options.defaultTime);
                         d.setHours(time.getHours());
                         d.setMinutes(time.getMinutes());
-                        d.setSeconds(time.getSeconds());
-                        d.setMilliseconds(time.getMilliseconds());
                     }
+
                     return d;
                 };
 
@@ -1380,20 +881,8 @@ var datetimepickerFactory = function ($) {
                     return !isNaN(d.getTime());
                 };
 
-                _this.setCurrentTime = function (dTime, requireValidDate) {
-                    if (typeof dTime === 'string') {
-                        _this.currentTime = _this.strToDateTime(dTime);
-                    }
-                    else if (_this.isValidDate(dTime)) {
-                        _this.currentTime = dTime;
-                    }
-                    else if (!dTime && !requireValidDate && options.allowBlank && !options.inline) {
-                        _this.currentTime = null;
-                    }
-                    else {
-                        _this.currentTime = _this.now();
-                    }
-
+                _this.setCurrentTime = function (dTime) {
+                    _this.currentTime = (typeof dTime === 'string') ? _this.strToDateTime(dTime) : _this.isValidDate(dTime) ? dTime : _this.now();
                     datetimepicker.trigger('xchange.xdsoft');
                 };
 
@@ -1401,16 +890,11 @@ var datetimepickerFactory = function ($) {
                     _this.currentTime = null;
                 };
 
-                _this.getCurrentTime = function () {
+                _this.getCurrentTime = function (dTime) {
                     return _this.currentTime;
                 };
 
                 _this.nextMonth = function () {
-
-                    if (_this.currentTime === undefined || _this.currentTime === null) {
-                        _this.currentTime = _this.now();
-                    }
-
                     var month = _this.currentTime.getMonth() + 1,
                         year;
                     if (month === 12) {
@@ -1441,11 +925,6 @@ var datetimepickerFactory = function ($) {
                 };
 
                 _this.prevMonth = function () {
-
-                    if (_this.currentTime === undefined || _this.currentTime === null) {
-                        _this.currentTime = _this.now();
-                    }
-
                     var month = _this.currentTime.getMonth() - 1;
                     if (month === -1) {
                         _this.currentTime.setFullYear(_this.currentTime.getFullYear() - 1);
@@ -1466,19 +945,7 @@ var datetimepickerFactory = function ($) {
                 };
 
                 _this.getWeekOfYear = function (datetime) {
-                    if (options.onGetWeekOfYear && $.isFunction(options.onGetWeekOfYear)) {
-                        var week = options.onGetWeekOfYear.call(datetimepicker, datetime);
-                        if (typeof week !== 'undefined') {
-                            return week;
-                        }
-                    }
                     var onejan = new Date(datetime.getFullYear(), 0, 1);
-
-                    //First week of the year is th one with the first Thursday according to ISO8601
-                    if (onejan.getDay() !== 4) {
-                        onejan.setMonth(0, 1 + ((4 - onejan.getDay()+ 7) % 7));
-                    }
-
                     return Math.ceil((((datetime - onejan) / 86400000) + onejan.getDay() + 1) / 7);
                 };
 
@@ -1489,17 +956,15 @@ var datetimepickerFactory = function ($) {
                         return sDateTime;
                     }
 
-                    tmpDate = /^([+-]{1})(.*)$/.exec(sDateTime);
-
+                    tmpDate = /^(\+|\-)(.*)$/.exec(sDateTime);
                     if (tmpDate) {
-                        tmpDate[2] = dateHelper.parseDate(tmpDate[2], options.formatDate);
+                        tmpDate[2] = Date.parseDate(tmpDate[2], options.formatDate);
                     }
-
                     if (tmpDate  && tmpDate[2]) {
                         timeOffset = tmpDate[2].getTime() - (tmpDate[2].getTimezoneOffset()) * 60000;
-                        currentTime = new Date((_this.now(true)).getTime() + parseInt(tmpDate[1] + '1', 10) * timeOffset);
+                        currentTime = new Date((_xdsoft_datetime.now()).getTime() + parseInt(tmpDate[1] + '1', 10) * timeOffset);
                     } else {
-                        currentTime = sDateTime ? dateHelper.parseDate(sDateTime, options.format) : _this.now();
+                        currentTime = sDateTime ? Date.parseDate(sDateTime, options.format) : _this.now();
                     }
 
                     if (!_this.isValidDate(currentTime)) {
@@ -1514,7 +979,7 @@ var datetimepickerFactory = function ($) {
                         return sDate;
                     }
 
-                    var currentTime = sDate ? dateHelper.parseDate(sDate, options.formatDate) : _this.now(true);
+                    var currentTime = sDate ? Date.parseDate(sDate, options.formatDate) : _this.now(true);
                     if (!_this.isValidDate(currentTime)) {
                         currentTime = _this.now(true);
                     }
@@ -1525,7 +990,7 @@ var datetimepickerFactory = function ($) {
                     if (sTime && sTime instanceof Date && _this.isValidDate(sTime)) {
                         return sTime;
                     }
-                    var currentTime = sTime ? dateHelper.parseDate(sTime, options.formatTime) : _this.now(true);
+                    var currentTime = sTime ? Date.parseDate(sTime, options.formatTime) : _this.now(true);
                     if (!_this.isValidDate(currentTime)) {
                         currentTime = _this.now(true);
                     }
@@ -1533,56 +998,32 @@ var datetimepickerFactory = function ($) {
                 };
 
                 _this.str = function () {
-                    var format = options.format;
-                    if (options.yearOffset) {
-                        format = format.replace('Y', _this.currentTime.getFullYear() + options.yearOffset);
-                        format = format.replace('y', String(_this.currentTime.getFullYear() + options.yearOffset).substring(2, 4));
-                    }
-                    return dateHelper.formatDate(_this.currentTime, format);
+                    return _this.currentTime.dateFormat(options.format);
                 };
                 _this.currentTime = this.now();
             };
 
             _xdsoft_datetime = new XDSoft_datetime();
 
-            applyButton.on('touchend click', function (e) {//pathbrite
-                e.preventDefault();
-                datetimepicker.data('changed', true);
-                _xdsoft_datetime.setCurrentTime(getCurrentValue());
-                input.val(_xdsoft_datetime.str());
-                datetimepicker.trigger('close.xdsoft');
-            });
-            month_picker
+            mounth_picker
                 .find('.xdsoft_today_button')
-                .on('touchend mousedown.xdsoft', function () {
+                .on('mousedown.xdsoft', function () {
                     datetimepicker.data('changed', true);
-                    _xdsoft_datetime.setCurrentTime(0, true);
+                    _xdsoft_datetime.setCurrentTime(0);
                     datetimepicker.trigger('afterOpen.xdsoft');
                 }).on('dblclick.xdsoft', function () {
-                var currentDate = _xdsoft_datetime.getCurrentTime(), minDate, maxDate;
-                currentDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate());
-                minDate = _xdsoft_datetime.strToDate(options.minDate);
-                minDate = new Date(minDate.getFullYear(), minDate.getMonth(), minDate.getDate());
-                if (currentDate < minDate) {
-                    return;
-                }
-                maxDate = _xdsoft_datetime.strToDate(options.maxDate);
-                maxDate = new Date(maxDate.getFullYear(), maxDate.getMonth(), maxDate.getDate());
-                if (currentDate > maxDate) {
-                    return;
-                }
                 input.val(_xdsoft_datetime.str());
-                input.trigger('change');
                 datetimepicker.trigger('close.xdsoft');
             });
-            month_picker
+            mounth_picker
                 .find('.xdsoft_prev,.xdsoft_next')
-                .on('touchend mousedown.xdsoft', function () {
+                .on('mousedown.xdsoft', function () {
                     var $this = $(this),
                         timer = 0,
                         stop = false;
 
                     (function arguments_callee1(v) {
+                        var month =  _xdsoft_datetime.currentTime.getMonth();
                         if ($this.hasClass(options.next)) {
                             _xdsoft_datetime.nextMonth();
                         } else if ($this.hasClass(options.prev)) {
@@ -1595,16 +1036,16 @@ var datetimepickerFactory = function ($) {
                         }
                     }(500));
 
-                    $([options.ownerDocument.body, options.contentWindow]).on('touchend mouseup.xdsoft', function arguments_callee2() {
+                    $([document.body, window]).on('mouseup.xdsoft', function arguments_callee2() {
                         clearTimeout(timer);
                         stop = true;
-                        $([options.ownerDocument.body, options.contentWindow]).off('touchend mouseup.xdsoft', arguments_callee2);
+                        $([document.body, window]).off('mouseup.xdsoft', arguments_callee2);
                     });
                 });
 
             timepicker
                 .find('.xdsoft_prev,.xdsoft_next')
-                .on('touchend mousedown.xdsoft', function () {
+                .on('mousedown.xdsoft', function () {
                     var $this = $(this),
                         timer = 0,
                         stop = false,
@@ -1618,30 +1059,17 @@ var datetimepickerFactory = function ($) {
                         } else if ($this.hasClass(options.prev) && top - options.timeHeightInTimePicker >= 0) {
                             timebox.css('marginTop', '-' + (top - options.timeHeightInTimePicker) + 'px');
                         }
-                        /**
-                         * Fixed bug:
-                         * When using css3 transition, it will cause a bug that you cannot scroll the timepicker list.
-                         * The reason is that the transition-duration time, if you set it to 0, all things fine, otherwise, this
-                         * would cause a bug when you use jquery.css method.
-                         * Let's say: * { transition: all .5s ease; }
-                         * jquery timebox.css('marginTop') will return the original value which is before you clicking the next/prev button,
-                         * meanwhile the timebox[0].style.marginTop will return the right value which is after you clicking the
-                         * next/prev button.
-                         *
-                         * What we should do:
-                         * Replace timebox.css('marginTop') with timebox[0].style.marginTop.
-                         */
-                        timeboxparent.trigger('scroll_element.xdsoft_scroller', [Math.abs(parseInt(timebox[0].style.marginTop, 10) / (height - pheight))]);
+                        timeboxparent.trigger('scroll_element.xdsoft_scroller', [Math.abs(parseInt(timebox.css('marginTop'), 10) / (height - pheight))]);
                         period = (period > 10) ? 10 : period - 10;
                         if (!stop) {
                             timer = setTimeout(arguments_callee4, v || period);
                         }
                     }(500));
-                    $([options.ownerDocument.body, options.contentWindow]).on('touchend mouseup.xdsoft', function arguments_callee5() {
+                    $([document.body, window]).on('mouseup.xdsoft', function arguments_callee5() {
                         clearTimeout(timer);
                         stop = true;
-                        $([options.ownerDocument.body, options.contentWindow])
-                            .off('touchend mouseup.xdsoft', arguments_callee5);
+                        $([document.body, window])
+                            .off('mouseup.xdsoft', arguments_callee5);
                     });
                 });
 
@@ -1651,11 +1079,6 @@ var datetimepickerFactory = function ($) {
                 .on('xchange.xdsoft', function (event) {
                     clearTimeout(xchangeTimer);
                     xchangeTimer = setTimeout(function () {
-
-                        if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
-                            _xdsoft_datetime.currentTime = _xdsoft_datetime.now();
-                        }
-
                         var table =	'',
                             start = new Date(_xdsoft_datetime.currentTime.getFullYear(), _xdsoft_datetime.currentTime.getMonth(), 1, 12, 0, 0),
                             i = 0,
@@ -1663,10 +1086,6 @@ var datetimepickerFactory = function ($) {
                             today = _xdsoft_datetime.now(),
                             maxDate = false,
                             minDate = false,
-                            minDateTime = false,
-                            maxDateTime = false,
-                            hDate,
-                            day,
                             d,
                             y,
                             m,
@@ -1675,9 +1094,8 @@ var datetimepickerFactory = function ($) {
                             customDateSettings,
                             newRow = true,
                             time = '',
-                            h,
-                            line_time,
-                            description;
+                            h = '',
+                            line_time;
 
                         while (start.getDay() !== options.dayOfWeekStart) {
                             start.setDate(start.getDate() - 1);
@@ -1690,7 +1108,7 @@ var datetimepickerFactory = function ($) {
                         }
 
                         for (j = 0; j < 7; j += 1) {
-                            table += '<th>' + options.i18n[globalLocale].dayOfWeekShort[(j + options.dayOfWeekStart) % 7] + '</th>';
+                            table += '<th>' + options.i18n[options.lang].dayOfWeek[(j + options.dayOfWeekStart) % 7] + '</th>';
                         }
 
                         table += '</tr></thead>';
@@ -1706,31 +1124,14 @@ var datetimepickerFactory = function ($) {
                             minDate = new Date(minDate.getFullYear(), minDate.getMonth(), minDate.getDate());
                         }
 
-                        if (options.minDateTime !== false) {
-                            minDateTime = _xdsoft_datetime.strToDate(options.minDateTime);
-                            minDateTime = new Date(minDateTime.getFullYear(), minDateTime.getMonth(), minDateTime.getDate(), minDateTime.getHours(), minDateTime.getMinutes(), minDateTime.getSeconds());
-                        }
-
-                        if (options.maxDateTime !== false) {
-                            maxDateTime = _xdsoft_datetime.strToDate(options.maxDateTime);
-                            maxDateTime = new Date(maxDateTime.getFullYear(), maxDateTime.getMonth(), maxDateTime.getDate(), maxDateTime.getHours(), maxDateTime.getMinutes(), maxDateTime.getSeconds());
-                        }
-
-                        var maxDateTimeDay;
-                        if (maxDateTime !== false) {
-                            maxDateTimeDay = ((maxDateTime.getFullYear() * 12) + maxDateTime.getMonth()) * 31 + maxDateTime.getDate();
-                        }
-
                         while (i < _xdsoft_datetime.currentTime.countDaysInMonth() || start.getDay() !== options.dayOfWeekStart || _xdsoft_datetime.currentTime.getMonth() === start.getMonth()) {
                             classes = [];
                             i += 1;
 
-                            day = start.getDay();
                             d = start.getDate();
                             y = start.getFullYear();
                             m = start.getMonth();
                             w = _xdsoft_datetime.getWeekOfYear(start);
-                            description = '';
 
                             classes.push('xdsoft_date');
 
@@ -1740,32 +1141,7 @@ var datetimepickerFactory = function ($) {
                                 customDateSettings = null;
                             }
 
-                            if(options.allowDateRe && Object.prototype.toString.call(options.allowDateRe) === "[object RegExp]"){
-                                if(!options.allowDateRe.test(dateHelper.formatDate(start, options.formatDate))){
-                                    classes.push('xdsoft_disabled');
-                                }
-                            }
-
-                            if(options.allowDates && options.allowDates.length>0){
-                                if(options.allowDates.indexOf(dateHelper.formatDate(start, options.formatDate)) === -1){
-                                    classes.push('xdsoft_disabled');
-                                }
-                            }
-
-                            var currentDay = ((start.getFullYear() * 12) + start.getMonth()) * 31 + start.getDate();
-                            if ((maxDate !== false && start > maxDate) || (minDateTime !== false && start < minDateTime)  || (minDate !== false && start < minDate) || (maxDateTime !== false && currentDay > maxDateTimeDay) || (customDateSettings && customDateSettings[0] === false)) {
-                                classes.push('xdsoft_disabled');
-                            }
-
-                            if (options.disabledDates.indexOf(dateHelper.formatDate(start, options.formatDate)) !== -1) {
-                                classes.push('xdsoft_disabled');
-                            }
-
-                            if (options.disabledWeekDays.indexOf(day) !== -1) {
-                                classes.push('xdsoft_disabled');
-                            }
-
-                            if (input.is('[disabled]')) {
+                            if ((maxDate !== false && start > maxDate) || (minDate !== false && start < minDate) || (customDateSettings && customDateSettings[0] === false)) {
                                 classes.push('xdsoft_disabled');
                             }
 
@@ -1777,22 +1153,16 @@ var datetimepickerFactory = function ($) {
                                 classes.push('xdsoft_other_month');
                             }
 
-                            if ((options.defaultSelect || datetimepicker.data('changed')) && dateHelper.formatDate(_xdsoft_datetime.currentTime, options.formatDate) === dateHelper.formatDate(start, options.formatDate)) {
+                            if ((options.defaultSelect || datetimepicker.data('changed')) && _xdsoft_datetime.currentTime.dateFormat(options.formatDate) === start.dateFormat(options.formatDate)) {
                                 classes.push('xdsoft_current');
                             }
 
-                            if (dateHelper.formatDate(today, options.formatDate) === dateHelper.formatDate(start, options.formatDate)) {
+                            if (today.dateFormat(options.formatDate) === start.dateFormat(options.formatDate)) {
                                 classes.push('xdsoft_today');
                             }
 
-                            if (start.getDay() === 0 || start.getDay() === 6 || options.weekends.indexOf(dateHelper.formatDate(start, options.formatDate)) !== -1) {
+                            if (start.getDay() === 0 || start.getDay() === 6 || options.weekends.indexOf(start.dateFormat(options.formatDate)) === -1) {
                                 classes.push('xdsoft_weekend');
-                            }
-
-                            if (options.highlightedDates[dateHelper.formatDate(start, options.formatDate)] !== undefined) {
-                                hDate = options.highlightedDates[dateHelper.formatDate(start, options.formatDate)];
-                                classes.push(hDate.style === undefined ? 'xdsoft_highlighted_default' : hDate.style);
-                                description = hDate.desc === undefined ? '' : hDate.desc;
                             }
 
                             if (options.beforeShowDay && $.isFunction(options.beforeShowDay)) {
@@ -1807,7 +1177,7 @@ var datetimepickerFactory = function ($) {
                                 }
                             }
 
-                            table += '<td data-date="' + d + '" data-month="' + m + '" data-year="' + y + '"' + ' class="xdsoft_date xdsoft_day_of_week' + start.getDay() + ' ' + classes.join(' ') + '" title="' + description + '">' +
+                            table += '<td data-date="' + d + '" data-month="' + m + '" data-year="' + y + '"' + ' class="xdsoft_date xdsoft_day_of_week' + start.getDay() + ' ' + classes.join(' ') + '">' +
                                 '<div>' + d + '</div>' +
                                 '</td>';
 
@@ -1822,64 +1192,25 @@ var datetimepickerFactory = function ($) {
 
                         calendar.html(table);
 
-                        month_picker.find('.xdsoft_label span').eq(0).text(options.i18n[globalLocale].months[_xdsoft_datetime.currentTime.getMonth()]);
-                        month_picker.find('.xdsoft_label span').eq(1).text(_xdsoft_datetime.currentTime.getFullYear() + options.yearOffset);
+                        mounth_picker.find('.xdsoft_label span').eq(0).text(options.i18n[options.lang].months[_xdsoft_datetime.currentTime.getMonth()]);
+                        mounth_picker.find('.xdsoft_label span').eq(1).text(_xdsoft_datetime.currentTime.getFullYear());
 
                         // generate timebox
                         time = '';
                         h = '';
                         m = '';
-
-                        var minTimeMinutesOfDay = 0;
-                        if (options.minTime !== false) {
-                            var t = _xdsoft_datetime.strtotime(options.minTime);
-                            minTimeMinutesOfDay = 60 * t.getHours() + t.getMinutes();
-                        }
-                        var maxTimeMinutesOfDay = 24 * 60;
-                        if (options.maxTime !== false) {
-                            var t = _xdsoft_datetime.strtotime(options.maxTime);
-                            maxTimeMinutesOfDay = 60 * t.getHours() + t.getMinutes();
-                        }
-
-                        if (options.minDateTime !== false) {
-                            var t = _xdsoft_datetime.strToDateTime(options.minDateTime);
-                            var currentDayIsMinDateTimeDay = dateHelper.formatDate(_xdsoft_datetime.currentTime, options.formatDate) === dateHelper.formatDate(t, options.formatDate);
-                            if (currentDayIsMinDateTimeDay) {
-                                var m = 60 * t.getHours() + t.getMinutes();
-                                if (m > minTimeMinutesOfDay) minTimeMinutesOfDay = m;
-                            }
-                        }
-
-                        if (options.maxDateTime !== false) {
-                            var t = _xdsoft_datetime.strToDateTime(options.maxDateTime);
-                            var currentDayIsMaxDateTimeDay = dateHelper.formatDate(_xdsoft_datetime.currentTime, options.formatDate) === dateHelper.formatDate(t, options.formatDate);
-                            if (currentDayIsMaxDateTimeDay) {
-                                var m = 60 * t.getHours() + t.getMinutes();
-                                if (m < maxTimeMinutesOfDay) maxTimeMinutesOfDay = m;
-                            }
-                        }
-
                         line_time = function line_time(h, m) {
-                            var now = _xdsoft_datetime.now(), current_time,
-                                isALlowTimesInit = options.allowTimes && $.isArray(options.allowTimes) && options.allowTimes.length;
+                            var now = _xdsoft_datetime.now();
                             now.setHours(h);
                             h = parseInt(now.getHours(), 10);
                             now.setMinutes(m);
                             m = parseInt(now.getMinutes(), 10);
+
                             classes = [];
-                            var currentMinutesOfDay = 60 * h + m;
-                            if (input.is('[disabled]') || (currentMinutesOfDay >= maxTimeMinutesOfDay) || (currentMinutesOfDay < minTimeMinutesOfDay)) {
+                            if ((options.maxTime !== false && _xdsoft_datetime.strtotime(options.maxTime).getTime() < now.getTime()) || (options.minTime !== false && _xdsoft_datetime.strtotime(options.minTime).getTime() > now.getTime())) {
                                 classes.push('xdsoft_disabled');
                             }
-
-                            current_time = new Date(_xdsoft_datetime.currentTime);
-                            current_time.setHours(parseInt(_xdsoft_datetime.currentTime.getHours(), 10));
-
-                            if (!isALlowTimesInit) {
-                                current_time.setMinutes(Math[options.roundTime](_xdsoft_datetime.currentTime.getMinutes() / options.step) * options.step);
-                            }
-
-                            if ((options.initTime || options.defaultSelect || datetimepicker.data('changed')) && current_time.getHours() === parseInt(h, 10) && ((!isALlowTimesInit && options.step > 59) || current_time.getMinutes() === parseInt(m, 10))) {
+                            if ((options.initTime || options.defaultSelect || datetimepicker.data('changed')) && parseInt(_xdsoft_datetime.currentTime.getHours(), 10) === parseInt(h, 10) && (options.step > 59 || Math[options.roundTime](_xdsoft_datetime.currentTime.getMinutes() / options.step) * options.step === parseInt(m, 10))) {
                                 if (options.defaultSelect || datetimepicker.data('changed')) {
                                     classes.push('xdsoft_current');
                                 } else if (options.initTime) {
@@ -1889,15 +1220,12 @@ var datetimepickerFactory = function ($) {
                             if (parseInt(today.getHours(), 10) === parseInt(h, 10) && parseInt(today.getMinutes(), 10) === parseInt(m, 10)) {
                                 classes.push('xdsoft_today');
                             }
-                            time += '<div class="xdsoft_time ' + classes.join(' ') + '" data-hour="' + h + '" data-minute="' + m + '">' + dateHelper.formatDate(now, options.formatTime) + '</div>';
+                            time += '<div class="xdsoft_time ' + classes.join(' ') + '" data-hour="' + h + '" data-minute="' + m + '">' + now.dateFormat(options.formatTime) + '</div>';
                         };
 
                         if (!options.allowTimes || !$.isArray(options.allowTimes) || !options.allowTimes.length) {
                             for (i = 0, j = 0; i < (options.hours12 ? 12 : 24); i += 1) {
                                 for (j = 0; j < 60; j += options.step) {
-                                    var currentMinutesOfDay = i * 60 + j;
-                                    if (currentMinutesOfDay < minTimeMinutesOfDay) continue;
-                                    if (currentMinutesOfDay >= maxTimeMinutesOfDay) continue;
                                     h = (i < 10 ? '0' : '') + i;
                                     m = (j < 10 ? '0' : '') + j;
                                     line_time(h, m);
@@ -1914,15 +1242,16 @@ var datetimepickerFactory = function ($) {
                         timebox.html(time);
 
                         opt = '';
+                        i = 0;
 
-                        for (i = parseInt(options.yearStart, 10); i <= parseInt(options.yearEnd, 10); i += 1) {
-                            opt += '<div class="xdsoft_option ' + (_xdsoft_datetime.currentTime.getFullYear() === i ? 'xdsoft_current' : '') + '" data-value="' + i + '">' + (i + options.yearOffset) + '</div>';
+                        for (i = parseInt(options.yearStart, 10) + options.yearOffset; i <= parseInt(options.yearEnd, 10) + options.yearOffset; i += 1) {
+                            opt += '<div class="xdsoft_option ' + (_xdsoft_datetime.currentTime.getFullYear() === i ? 'xdsoft_current' : '') + '" data-value="' + i + '">' + i + '</div>';
                         }
                         yearselect.children().eq(0)
                             .html(opt);
 
-                        for (i = parseInt(options.monthStart, 10), opt = ''; i <= parseInt(options.monthEnd, 10); i += 1) {
-                            opt += '<div class="xdsoft_option ' + (_xdsoft_datetime.currentTime.getMonth() === i ? 'xdsoft_current' : '') + '" data-value="' + i + '">' + options.i18n[globalLocale].months[i] + '</div>';
+                        for (i = 0, opt = ''; i <= 11; i += 1) {
+                            opt += '<div class="xdsoft_option ' + (_xdsoft_datetime.currentTime.getMonth() === i ? 'xdsoft_current' : '') + '" data-value="' + i + '">' + options.i18n[options.lang].months[i] + '</div>';
                         }
                         monthselect.children().eq(0).html(opt);
                         $(datetimepicker)
@@ -1954,7 +1283,7 @@ var datetimepickerFactory = function ($) {
 
             timerclick = 0;
             calendar
-                .on('touchend click.xdsoft', 'td', function (xdevent) {
+                .on('click.xdsoft', 'td', function (xdevent) {
                     xdevent.stopPropagation();  // Prevents closing of Pop-ups, Modals and Flyouts in Bootstrap
                     timerclick += 1;
                     var $this = $(this),
@@ -1977,6 +1306,9 @@ var datetimepickerFactory = function ($) {
                     datetimepicker.trigger('select.xdsoft', [currentTime]);
 
                     input.val(_xdsoft_datetime.str());
+                    if ((timerclick > 1 || (options.closeOnDateSelect === true || (options.closeOnDateSelect === 0 && !options.timepicker))) && !options.inline) {
+                        datetimepicker.trigger('close.xdsoft');
+                    }
 
                     if (options.onSelectDate &&	$.isFunction(options.onSelectDate)) {
                         options.onSelectDate.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'), xdevent);
@@ -1985,50 +1317,42 @@ var datetimepickerFactory = function ($) {
                     datetimepicker.data('changed', true);
                     datetimepicker.trigger('xchange.xdsoft');
                     datetimepicker.trigger('changedatetime.xdsoft');
-                    if ((timerclick > 1 || (options.closeOnDateSelect === true || (options.closeOnDateSelect === false && !options.timepicker))) && !options.inline) {
-                        datetimepicker.trigger('close.xdsoft');
-                    }
                     setTimeout(function () {
                         timerclick = 0;
                     }, 200);
                 });
 
             timebox
-                .on('touchstart', 'div', function (xdevent) {
-                    this.touchMoved = false;
-                })
-                .on('touchmove', 'div', handleTouchMoved)
-                .on('touchend click.xdsoft', 'div', function (xdevent) {
-                    if (!this.touchMoved) {
-                        xdevent.stopPropagation();
-                        var $this = $(this),
-                            currentTime = _xdsoft_datetime.currentTime;
+                .on('click.xdsoft', 'div', function (xdevent) {
+                    xdevent.stopPropagation();
+                    var $this = $(this),
+                        currentTime = _xdsoft_datetime.currentTime;
 
-                        if (currentTime === undefined || currentTime === null) {
-                            _xdsoft_datetime.currentTime = _xdsoft_datetime.now();
-                            currentTime = _xdsoft_datetime.currentTime;
-                        }
-
-                        if ($this.hasClass('xdsoft_disabled')) {
-                            return false;
-                        }
-                        currentTime.setHours($this.data('hour'));
-                        currentTime.setMinutes($this.data('minute'));
-                        datetimepicker.trigger('select.xdsoft', [currentTime]);
-
-                        datetimepicker.data('input').val(_xdsoft_datetime.str());
-
-                        if (options.onSelectTime && $.isFunction(options.onSelectTime)) {
-                            options.onSelectTime.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'), xdevent);
-                        }
-                        datetimepicker.data('changed', true);
-                        datetimepicker.trigger('xchange.xdsoft');
-                        datetimepicker.trigger('changedatetime.xdsoft');
-                        if (options.inline !== true && options.closeOnTimeSelect === true) {
-                            datetimepicker.trigger('close.xdsoft');
-                        }
+                    if (currentTime === undefined || currentTime === null) {
+                        _xdsoft_datetime.currentTime = _xdsoft_datetime.now();
+                        currentTime = _xdsoft_datetime.currentTime;
                     }
+
+                    if ($this.hasClass('xdsoft_disabled')) {
+                        return false;
+                    }
+                    currentTime.setHours($this.data('hour'));
+                    currentTime.setMinutes($this.data('minute'));
+                    datetimepicker.trigger('select.xdsoft', [currentTime]);
+
+                    datetimepicker.data('input').val(_xdsoft_datetime.str());
+                    if (!options.inline) {
+                        datetimepicker.trigger('close.xdsoft');
+                    }
+
+                    if (options.onSelectTime && $.isFunction(options.onSelectTime)) {
+                        options.onSelectTime.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'), xdevent);
+                    }
+                    datetimepicker.data('changed', true);
+                    datetimepicker.trigger('xchange.xdsoft');
+                    datetimepicker.trigger('changedatetime.xdsoft');
                 });
+
 
             datepicker
                 .on('mousewheel.xdsoft', function (event) {
@@ -2092,135 +1416,29 @@ var datetimepickerFactory = function ($) {
 
             current_time_index = 0;
 
-            /**
-             * Runs the callback for each of the specified node's ancestors.
-             *
-             * Return FALSE from the callback to stop ascending.
-             *
-             * @param {DOMNode} node
-             * @param {Function} callback
-             * @returns {undefined}
-             */
-            forEachAncestorOf = function (node, callback) {
-                do {
-                    node = node.parentNode;
-
-                    if (!node || callback(node) === false) {
-                        break;
-                    }
-                } while (node.nodeName !== 'HTML');
-            };
-
-            /**
-             * Sets the position of the picker.
-             *
-             * @returns {undefined}
-             */
             setPos = function () {
-                var dateInputOffset,
-                    dateInputElem,
-                    verticalPosition,
-                    left,
-                    position,
-                    datetimepickerElem,
-                    dateInputHasFixedAncestor,
-                    $dateInput,
-                    windowWidth,
-                    verticalAnchorEdge,
-                    datetimepickerCss,
-                    windowHeight,
-                    windowScrollTop;
-
-                $dateInput = datetimepicker.data('input');
-                dateInputOffset = $dateInput.offset();
-                dateInputElem = $dateInput[0];
-
-                verticalAnchorEdge = 'top';
-                verticalPosition = (dateInputOffset.top + dateInputElem.offsetHeight) - 1;
-                left = dateInputOffset.left;
-                position = "absolute";
-
-                windowWidth = $(options.contentWindow).width();
-                windowHeight = $(options.contentWindow).height();
-                windowScrollTop = $(options.contentWindow).scrollTop();
-
-                if ((options.ownerDocument.documentElement.clientWidth - dateInputOffset.left) < datepicker.parent().outerWidth(true)) {
-                    var diff = datepicker.parent().outerWidth(true) - dateInputElem.offsetWidth;
-                    left = left - diff;
-                }
-
-                if ($dateInput.parent().css('direction') === 'rtl') {
-                    left -= (datetimepicker.outerWidth() - $dateInput.outerWidth());
-                }
-
+                var offset = datetimepicker.data('input').offset(), top = offset.top + datetimepicker.data('input')[0].offsetHeight - 1, left = offset.left, position = "absolute";
                 if (options.fixed) {
-                    verticalPosition -= windowScrollTop;
-                    left -= $(options.contentWindow).scrollLeft();
+                    top -= $(window).scrollTop();
+                    left -= $(window).scrollLeft();
                     position = "fixed";
                 } else {
-                    dateInputHasFixedAncestor = false;
-
-                    forEachAncestorOf(dateInputElem, function (ancestorNode) {
-                        if (ancestorNode === null) {
-                            return false;
-                        }
-
-                        if (options.contentWindow.getComputedStyle(ancestorNode).getPropertyValue('position') === 'fixed') {
-                            dateInputHasFixedAncestor = true;
-                            return false;
-                        }
-                    });
-
-                    if (dateInputHasFixedAncestor) {
-                        position = 'fixed';
-
-                        //If the picker won't fit entirely within the viewport then display it above the date input.
-                        if (verticalPosition + datetimepicker.outerHeight() > windowHeight + windowScrollTop) {
-                            verticalAnchorEdge = 'bottom';
-                            verticalPosition = (windowHeight + windowScrollTop) - dateInputOffset.top;
-                        } else {
-                            verticalPosition -= windowScrollTop;
-                        }
-                    } else {
-                        if (verticalPosition + datetimepicker[0].offsetHeight > windowHeight + windowScrollTop) {
-                            verticalPosition = dateInputOffset.top - datetimepicker[0].offsetHeight + 1;
-                        }
+                    if (top + datetimepicker[0].offsetHeight > $(window).height() + $(window).scrollTop()) {
+                        top = offset.top - datetimepicker[0].offsetHeight + 1;
                     }
-
-                    if (verticalPosition < 0) {
-                        verticalPosition = 0;
+                    if (top < 0) {
+                        top = 0;
                     }
-
-                    if (left + dateInputElem.offsetWidth > windowWidth) {
-                        left = windowWidth - dateInputElem.offsetWidth;
+                    if (left + datetimepicker[0].offsetWidth > $(window).width()) {
+                        left = $(window).width() - datetimepicker[0].offsetWidth;
                     }
                 }
-
-                datetimepickerElem = datetimepicker[0];
-
-                forEachAncestorOf(datetimepickerElem, function (ancestorNode) {
-                    var ancestorNodePosition;
-
-                    ancestorNodePosition = options.contentWindow.getComputedStyle(ancestorNode).getPropertyValue('position');
-
-                    if (ancestorNodePosition === 'relative' && windowWidth >= ancestorNode.offsetWidth) {
-                        left = left - ((windowWidth - ancestorNode.offsetWidth) / 2);
-                        return false;
-                    }
-                });
-
-                datetimepickerCss = {
-                    position: position,
+                datetimepicker.css({
                     left: left,
-                    top: '',  //Initialize to prevent previous values interfering with new ones.
-                    bottom: ''  //Initialize to prevent previous values interfering with new ones.
-                };
-
-                datetimepickerCss[verticalAnchorEdge] = verticalPosition;
-
-                datetimepicker.css(datetimepickerCss);
+                    top: top,
+                    position: position
+                });
             };
-
             datetimepicker
                 .on('open.xdsoft', function (event) {
                     var onShow = true;
@@ -2230,21 +1448,21 @@ var datetimepickerFactory = function ($) {
                     if (onShow !== false) {
                         datetimepicker.show();
                         setPos();
-                        $(options.contentWindow)
+                        $(window)
                             .off('resize.xdsoft', setPos)
                             .on('resize.xdsoft', setPos);
 
                         if (options.closeOnWithoutClick) {
-                            $([options.ownerDocument.body, options.contentWindow]).on('touchstart mousedown.xdsoft', function arguments_callee6() {
+                            $([document.body, window]).on('mousedown.xdsoft', function arguments_callee6() {
                                 datetimepicker.trigger('close.xdsoft');
-                                $([options.ownerDocument.body, options.contentWindow]).off('touchstart mousedown.xdsoft', arguments_callee6);
+                                $([document.body, window]).off('mousedown.xdsoft', arguments_callee6);
                             });
                         }
                     }
                 })
                 .on('close.xdsoft', function (event) {
                     var onClose = true;
-                    month_picker
+                    mounth_picker
                         .find('.xdsoft_month,.xdsoft_year')
                         .find('.xdsoft_select')
                         .hide();
@@ -2256,21 +1474,16 @@ var datetimepickerFactory = function ($) {
                     }
                     event.stopPropagation();
                 })
-                .on('toggle.xdsoft', function () {
-                    if (datetimepicker.is(':visible')) {
-                        datetimepicker.trigger('close.xdsoft');
-                    } else {
-                        datetimepicker.trigger('open.xdsoft');
-                    }
-                })
                 .data('input', input);
 
             timer = 0;
+            timer1 = 0;
 
             datetimepicker.data('xdsoft_datetime', _xdsoft_datetime);
             datetimepicker.setOptions(options);
 
             function getCurrentValue() {
+
                 var ct = false, time;
 
                 if (options.startDate) {
@@ -2279,11 +1492,8 @@ var datetimepickerFactory = function ($) {
                     ct = options.value || ((input && input.val && input.val()) ? input.val() : '');
                     if (ct) {
                         ct = _xdsoft_datetime.strToDateTime(ct);
-                        if (options.yearOffset) {
-                            ct = new Date(ct.getFullYear() - options.yearOffset, ct.getMonth(), ct.getDate(), ct.getHours(), ct.getMinutes(), ct.getSeconds(), ct.getMilliseconds());
-                        }
                     } else if (options.defaultDate) {
-                        ct = _xdsoft_datetime.strToDateTime(options.defaultDate);
+                        ct = _xdsoft_datetime.strToDate(options.defaultDate);
                         if (options.defaultTime) {
                             time = _xdsoft_datetime.strtotime(options.defaultTime);
                             ct.setHours(time.getHours());
@@ -2301,243 +1511,31 @@ var datetimepickerFactory = function ($) {
                 return ct || 0;
             }
 
-            function setMask(options) {
-
-                var isValidValue = function (mask, value) {
-                        var reg = mask
-                            .replace(/([\[\]\/\{\}\(\)\-\.\+]{1})/g, '\\$1')
-                            .replace(/_/g, '{digit+}')
-                            .replace(/([0-9]{1})/g, '{digit$1}')
-                            .replace(/\{digit([0-9]{1})\}/g, '[0-$1_]{1}')
-                            .replace(/\{digit[\+]\}/g, '[0-9_]{1}');
-                        return (new RegExp(reg)).test(value);
-                    },
-                    getCaretPos = function (input) {
-                        try {
-                            if (options.ownerDocument.selection && options.ownerDocument.selection.createRange) {
-                                var range = options.ownerDocument.selection.createRange();
-                                return range.getBookmark().charCodeAt(2) - 2;
-                            }
-                            if (input.setSelectionRange) {
-                                return input.selectionStart;
-                            }
-                        } catch (e) {
-                            return 0;
-                        }
-                    },
-                    setCaretPos = function (node, pos) {
-                        node = (typeof node === "string" || node instanceof String) ? options.ownerDocument.getElementById(node) : node;
-                        if (!node) {
-                            return false;
-                        }
-                        if (node.createTextRange) {
-                            var textRange = node.createTextRange();
-                            textRange.collapse(true);
-                            textRange.moveEnd('character', pos);
-                            textRange.moveStart('character', pos);
-                            textRange.select();
-                            return true;
-                        }
-                        if (node.setSelectionRange) {
-                            node.setSelectionRange(pos, pos);
-                            return true;
-                        }
-                        return false;
-                    };
-
-                if(options.mask) {
-                    input.off('keydown.xdsoft');
-                }
-
-                if (options.mask === true) {
-                    if (dateHelper.formatMask) {
-                        options.mask = dateHelper.formatMask(options.format)
-                    } else {
-                        options.mask = options.format
-                            .replace(/Y/g, '9999')
-                            .replace(/F/g, '9999')
-                            .replace(/m/g, '19')
-                            .replace(/d/g, '39')
-                            .replace(/H/g, '29')
-                            .replace(/i/g, '59')
-                            .replace(/s/g, '59');
-                    }
-                }
-
-                if ($.type(options.mask) === 'string') {
-                    if (!isValidValue(options.mask, input.val())) {
-                        input.val(options.mask.replace(/[0-9]/g, '_'));
-                        setCaretPos(input[0], 0);
-                    }
-
-                    input.on('paste.xdsoft', function (event) {
-                        // couple options here
-                        // 1. return false - tell them they can't paste
-                        // 2. insert over current characters - minimal validation
-                        // 3. full fledged parsing and validation
-                        // let's go option 2 for now
-
-                        // fires multiple times for some reason
-
-                        // https://stackoverflow.com/a/30496488/1366033
-                        var clipboardData = event.clipboardData || event.originalEvent.clipboardData || window.clipboardData,
-                            pastedData = clipboardData.getData('text'),
-                            val = this.value,
-                            pos = this.selectionStart
-
-                        var valueBeforeCursor = val.substr(0, pos);
-                        var valueAfterPaste = val.substr(pos + pastedData.length);
-
-                        val = valueBeforeCursor + pastedData + valueAfterPaste;
-                        pos += pastedData.length;
-
-                        if (isValidValue(options.mask, val)) {
-                            this.value = val;
-                            setCaretPos(this, pos);
-                        } else if ($.trim(val) === '') {
-                            this.value = options.mask.replace(/[0-9]/g, '_');
-                        } else {
-                            input.trigger('error_input.xdsoft');
-                        }
-
-                        event.preventDefault();
-                        return false;
-                    });
-
-                    input.on('keydown.xdsoft', function (event) {
-                        var val = this.value,
-                            key = event.which,
-                            pos = this.selectionStart,
-                            selEnd = this.selectionEnd,
-                            hasSel = pos !== selEnd,
-                            digit;
-
-                        // only alow these characters
-                        if (((key >=  KEY0 && key <=  KEY9)  ||
-                            (key >= _KEY0 && key <= _KEY9)) ||
-                            (key === BACKSPACE || key === DEL)) {
-
-                            // get char to insert which is new character or placeholder ('_')
-                            digit = (key === BACKSPACE || key === DEL) ? '_' :
-                                String.fromCharCode((_KEY0 <= key && key <= _KEY9) ? key - KEY0 : key);
-
-                            // we're deleting something, we're not at the start, and have normal cursor, move back one
-                            // if we have a selection length, cursor actually sits behind deletable char, not in front
-                            if (key === BACKSPACE && pos && !hasSel) {
-                                pos -= 1;
-                            }
-
-                            // don't stop on a separator, continue whatever direction you were going
-                            //   value char - keep incrementing position while on separator char and we still have room
-                            //   del char   - keep decrementing position while on separator char and we still have room
-                            while (true) {
-                                var maskValueAtCurPos = options.mask.substr(pos, 1);
-                                var posShorterThanMaskLength = pos < options.mask.length;
-                                var posGreaterThanZero = pos > 0;
-                                var notNumberOrPlaceholder = /[^0-9_]/;
-                                var curPosOnSep = notNumberOrPlaceholder.test(maskValueAtCurPos);
-                                var continueMovingPosition = curPosOnSep && posShorterThanMaskLength && posGreaterThanZero
-
-                                // if we hit a real char, stay where we are
-                                if (!continueMovingPosition) break;
-
-                                // hitting backspace in a selection, you can possibly go back any further - go forward
-                                pos += (key === BACKSPACE && !hasSel) ? -1 : 1;
-
-                            }
-
-
-                            if (hasSel) {
-                                // pos might have moved so re-calc length
-                                var selLength = selEnd - pos
-
-                                // if we have a selection length we will wipe out entire selection and replace with default template for that range
-                                var defaultBlank = options.mask.replace(/[0-9]/g, '_');
-                                var defaultBlankSelectionReplacement = defaultBlank.substr(pos, selLength);
-                                var selReplacementRemainder = defaultBlankSelectionReplacement.substr(1) // might be empty
-
-                                var valueBeforeSel = val.substr(0, pos);
-                                var insertChars = digit + selReplacementRemainder;
-                                var charsAfterSelection = val.substr(pos + selLength);
-
-                                val = valueBeforeSel + insertChars + charsAfterSelection
-
-                            } else {
-                                var valueBeforeCursor = val.substr(0, pos);
-                                var insertChar = digit;
-                                var valueAfterNextChar = val.substr(pos + 1);
-
-                                val = valueBeforeCursor + insertChar + valueAfterNextChar
-                            }
-
-                            if ($.trim(val) === '') {
-                                // if empty, set to default
-                                val = defaultBlank
-                            } else {
-                                // if at the last character don't need to do anything
-                                if (pos === options.mask.length) {
-                                    event.preventDefault();
-                                    return false;
-                                }
-                            }
-
-                            // resume cursor location
-                            pos += (key === BACKSPACE) ? 0 : 1;
-                            // don't stop on a separator, continue whatever direction you were going
-                            while (/[^0-9_]/.test(options.mask.substr(pos, 1)) && pos < options.mask.length && pos > 0) {
-                                pos += (key === BACKSPACE) ? 0 : 1;
-                            }
-
-                            if (isValidValue(options.mask, val)) {
-                                this.value = val;
-                                setCaretPos(this, pos);
-                            } else if ($.trim(val) === '') {
-                                this.value = options.mask.replace(/[0-9]/g, '_');
-                            } else {
-                                input.trigger('error_input.xdsoft');
-                            }
-                        } else {
-                            if (([AKEY, CKEY, VKEY, ZKEY, YKEY].indexOf(key) !== -1 && ctrlDown) || [ESC, ARROWUP, ARROWDOWN, ARROWLEFT, ARROWRIGHT, F5, CTRLKEY, TAB, ENTER].indexOf(key) !== -1) {
-                                return true;
-                            }
-                        }
-
-                        event.preventDefault();
-                        return false;
-                    });
-                }
-            }
-
             _xdsoft_datetime.setCurrentTime(getCurrentValue());
 
             input
                 .data('xdsoft_datetimepicker', datetimepicker)
-                .on('open.xdsoft focusin.xdsoft mousedown.xdsoft touchstart', function () {
-                    if (input.is(':disabled') || (input.data('xdsoft_datetimepicker').is(':visible') && options.closeOnInputClick)) {
-                        return;
-                    }
-                    if (!options.openOnFocus) {
+                .on('open.xdsoft focusin.xdsoft mousedown.xdsoft', function (event) {
+                    if (input.is(':disabled') || input.is(':hidden') || !input.is(':visible') || (input.data('xdsoft_datetimepicker').is(':visible') && options.closeOnInputClick)) {
                         return;
                     }
                     clearTimeout(timer);
                     timer = setTimeout(function () {
-                        if (input.is(':disabled')) {
+                        if (input.is(':disabled') || input.is(':hidden') || !input.is(':visible')) {
                             return;
                         }
 
                         triggerAfterOpen = true;
-                        _xdsoft_datetime.setCurrentTime(getCurrentValue(), true);
-                        if(options.mask) {
-                            setMask(options);
-                        }
+                        _xdsoft_datetime.setCurrentTime(getCurrentValue());
+
                         datetimepicker.trigger('open.xdsoft');
                     }, 100);
                 })
                 .on('keydown.xdsoft', function (event) {
-                    var elementSelector,
+                    var val = this.value, elementSelector,
                         key = event.which;
-                    if ([ENTER].indexOf(key) !== -1 && options.enterLikeTab) {
-                        elementSelector = $("input:visible,textarea:visible,button:visible,a:visible");
+                    if ([ENTER].indexOf(key) !== -1) {
+                        elementSelector = $("input:visible,textarea:visible");
                         datetimepicker.trigger('close.xdsoft');
                         elementSelector.eq(elementSelector.index(this) + 1).focus();
                         return false;
@@ -2546,9 +1544,6 @@ var datetimepickerFactory = function ($) {
                         datetimepicker.trigger('close.xdsoft');
                         return true;
                     }
-                })
-                .on('blur.xdsoft', function () {
-                    datetimepicker.trigger('close.xdsoft');
                 });
         };
         destroyDateTimePicker = function (input) {
@@ -2559,14 +1554,14 @@ var datetimepickerFactory = function ($) {
                 input
                     .data('xdsoft_datetimepicker', null)
                     .off('.xdsoft');
-                $(options.contentWindow).off('resize.xdsoft');
-                $([options.contentWindow, options.ownerDocument.body]).off('mousedown.xdsoft touchstart');
+                $(window).off('resize.xdsoft');
+                $([window, document.body]).off('mousedown.xdsoft');
                 if (input.unmousewheel) {
                     input.unmousewheel();
                 }
             }
         };
-        $(options.ownerDocument)
+        $(document)
             .off('keydown.xdsoftctrl keyup.xdsoftctrl')
             .on('keydown.xdsoftctrl', function (e) {
                 if (e.keyCode === CTRLKEY) {
@@ -2578,9 +1573,8 @@ var datetimepickerFactory = function ($) {
                     ctrlDown = false;
                 }
             });
-
-        this.each(function () {
-            var datetimepicker = $(this).data('xdsoft_datetimepicker'), $input;
+        return this.each(function () {
+            var datetimepicker = $(this).data('xdsoft_datetimepicker');
             if (datetimepicker) {
                 if ($.type(opt) === 'string') {
                     switch (opt) {
@@ -2591,27 +1585,16 @@ var datetimepickerFactory = function ($) {
                         case 'hide':
                             datetimepicker.trigger('close.xdsoft');
                             break;
-                        case 'toggle':
-                            datetimepicker.trigger('toggle.xdsoft');
-                            break;
                         case 'destroy':
                             destroyDateTimePicker($(this));
                             break;
                         case 'reset':
                             this.value = this.defaultValue;
-                            if (!this.value || !datetimepicker.data('xdsoft_datetime').isValidDate(dateHelper.parseDate(this.value, options.format))) {
+                            if (!this.value || !datetimepicker.data('xdsoft_datetime').isValidDate(Date.parseDate(this.value, options.format))) {
                                 datetimepicker.data('changed', false);
                             }
                             datetimepicker.data('xdsoft_datetime').setCurrentTime(this.value);
                             break;
-                        case 'validate':
-                            $input = datetimepicker.data('input');
-                            $input.trigger('blur.xdsoft');
-                            break;
-                        default:
-                            if (datetimepicker[opt] && $.isFunction(datetimepicker[opt])) {
-                                result = datetimepicker[opt](opt2);
-                            }
                     }
                 } else {
                     datetimepicker
@@ -2627,30 +1610,33 @@ var datetimepickerFactory = function ($) {
                 }
             }
         });
-
-        return result;
     };
-
     $.fn.datetimepicker.defaults = default_options;
+}(jQuery));
+(function () {
 
-    function HighlightedDate(date, desc, style) {
-        "use strict";
-        this.date = date;
-        this.desc = desc;
-        this.style = style;
-    }
-};
-;(function (factory) {
-    if ( typeof define === 'function' && define.amd ) {
-        // AMD. Register as an anonymous module.
-        define(['jquery', 'jquery-mousewheel'], factory);
-    } else if (typeof exports === 'object') {
-        // Node/CommonJS style for Browserify
-        module.exports = factory(require('jquery'));;
-    } else {
-        // Browser globals
-        factory(jQuery);
-    }
-}(datetimepickerFactory));
+    /*! Copyright (c) 2013 Brandon Aaron (http://brandon.aaron.sh)
+     * Licensed under the MIT License (LICENSE.txt).
+     *
+     * Version: 3.1.12
+     *
+     * Requires: jQuery 1.2.2+
+     */
+    !function(a){"function"==typeof define&&define.amd?define(["jquery"],a):"object"==typeof exports?module.exports=a:a(jQuery)}(function(a){function b(b){var g=b||window.event,h=i.call(arguments,1),j=0,l=0,m=0,n=0,o=0,p=0;if(b=a.event.fix(g),b.type="mousewheel","detail"in g&&(m=-1*g.detail),"wheelDelta"in g&&(m=g.wheelDelta),"wheelDeltaY"in g&&(m=g.wheelDeltaY),"wheelDeltaX"in g&&(l=-1*g.wheelDeltaX),"axis"in g&&g.axis===g.HORIZONTAL_AXIS&&(l=-1*m,m=0),j=0===m?l:m,"deltaY"in g&&(m=-1*g.deltaY,j=m),"deltaX"in g&&(l=g.deltaX,0===m&&(j=-1*l)),0!==m||0!==l){if(1===g.deltaMode){var q=a.data(this,"mousewheel-line-height");j*=q,m*=q,l*=q}else if(2===g.deltaMode){var r=a.data(this,"mousewheel-page-height");j*=r,m*=r,l*=r}if(n=Math.max(Math.abs(m),Math.abs(l)),(!f||f>n)&&(f=n,d(g,n)&&(f/=40)),d(g,n)&&(j/=40,l/=40,m/=40),j=Math[j>=1?"floor":"ceil"](j/f),l=Math[l>=1?"floor":"ceil"](l/f),m=Math[m>=1?"floor":"ceil"](m/f),k.settings.normalizeOffset&&this.getBoundingClientRect){var s=this.getBoundingClientRect();o=b.clientX-s.left,p=b.clientY-s.top}return b.deltaX=l,b.deltaY=m,b.deltaFactor=f,b.offsetX=o,b.offsetY=p,b.deltaMode=0,h.unshift(b,j,l,m),e&&clearTimeout(e),e=setTimeout(c,200),(a.event.dispatch||a.event.handle).apply(this,h)}}function c(){f=null}function d(a,b){return k.settings.adjustOldDeltas&&"mousewheel"===a.type&&b%120===0}var e,f,g=["wheel","mousewheel","DOMMouseScroll","MozMousePixelScroll"],h="onwheel"in document||document.documentMode>=9?["wheel"]:["mousewheel","DomMouseScroll","MozMousePixelScroll"],i=Array.prototype.slice;if(a.event.fixHooks)for(var j=g.length;j;)a.event.fixHooks[g[--j]]=a.event.mouseHooks;var k=a.event.special.mousewheel={version:"3.1.12",setup:function(){if(this.addEventListener)for(var c=h.length;c;)this.addEventListener(h[--c],b,!1);else this.onmousewheel=b;a.data(this,"mousewheel-line-height",k.getLineHeight(this)),a.data(this,"mousewheel-page-height",k.getPageHeight(this))},teardown:function(){if(this.removeEventListener)for(var c=h.length;c;)this.removeEventListener(h[--c],b,!1);else this.onmousewheel=null;a.removeData(this,"mousewheel-line-height"),a.removeData(this,"mousewheel-page-height")},getLineHeight:function(b){var c=a(b),d=c["offsetParent"in a.fn?"offsetParent":"parent"]();return d.length||(d=a("body")),parseInt(d.css("fontSize"),10)||parseInt(c.css("fontSize"),10)||16},getPageHeight:function(b){return a(b).height()},settings:{adjustOldDeltas:!0,normalizeOffset:!0}};a.fn.extend({mousewheel:function(a){return a?this.bind("mousewheel",a):this.trigger("mousewheel")},unmousewheel:function(a){return this.unbind("mousewheel",a)}})});
 
-
+// Parse and Format Library
+//http://www.xaprb.com/blog/2005/12/12/javascript-closures-for-runtime-efficiency/
+    /*
+     * Copyright (C) 2004 Baron Schwartz <baron at sequent dot org>
+     *
+     * This program is free software; you can redistribute it and/or modify it
+     * under the terms of the GNU Lesser General Public License as published by the
+     * Free Software Foundation, version 2.1.
+     *
+     * This program is distributed in the hope that it will be useful, but WITHOUT
+     * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+     * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+     * details.
+     */
+    Date.parseFunctions={count:0};Date.parseRegexes=[];Date.formatFunctions={count:0};Date.prototype.dateFormat=function(b){if(b=="unixtime"){return parseInt(this.getTime()/1000);}if(Date.formatFunctions[b]==null){Date.createNewFormat(b);}var a=Date.formatFunctions[b];return this[a]();};Date.createNewFormat=function(format){var funcName="format"+Date.formatFunctions.count++;Date.formatFunctions[format]=funcName;var code="Date.prototype."+funcName+" = function() {return ";var special=false;var ch="";for(var i=0;i<format.length;++i){ch=format.charAt(i);if(!special&&ch=="\\"){special=true;}else{if(special){special=false;code+="'"+String.escape(ch)+"' + ";}else{code+=Date.getFormatCode(ch);}}}eval(code.substring(0,code.length-3)+";}");};Date.getFormatCode=function(a){switch(a){case"d":return"String.leftPad(this.getDate(), 2, '0') + ";case"D":return"Date.dayNames[this.getDay()].substring(0, 3) + ";case"j":return"this.getDate() + ";case"l":return"Date.dayNames[this.getDay()] + ";case"S":return"this.getSuffix() + ";case"w":return"this.getDay() + ";case"z":return"this.getDayOfYear() + ";case"W":return"this.getWeekOfYear() + ";case"F":return"Date.monthNames[this.getMonth()] + ";case"m":return"String.leftPad(this.getMonth() + 1, 2, '0') + ";case"M":return"Date.monthNames[this.getMonth()].substring(0, 3) + ";case"n":return"(this.getMonth() + 1) + ";case"t":return"this.getDaysInMonth() + ";case"L":return"(this.isLeapYear() ? 1 : 0) + ";case"Y":return"this.getFullYear() + ";case"y":return"('' + this.getFullYear()).substring(2, 4) + ";case"a":return"(this.getHours() < 12 ? 'am' : 'pm') + ";case"A":return"(this.getHours() < 12 ? 'AM' : 'PM') + ";case"g":return"((this.getHours() %12) ? this.getHours() % 12 : 12) + ";case"G":return"this.getHours() + ";case"h":return"String.leftPad((this.getHours() %12) ? this.getHours() % 12 : 12, 2, '0') + ";case"H":return"String.leftPad(this.getHours(), 2, '0') + ";case"i":return"String.leftPad(this.getMinutes(), 2, '0') + ";case"s":return"String.leftPad(this.getSeconds(), 2, '0') + ";case"O":return"this.getGMTOffset() + ";case"T":return"this.getTimezone() + ";case"Z":return"(this.getTimezoneOffset() * -60) + ";default:return"'"+String.escape(a)+"' + ";}};Date.parseDate=function(a,c){if(c=="unixtime"){return new Date(!isNaN(parseInt(a))?parseInt(a)*1000:0);}if(Date.parseFunctions[c]==null){Date.createParser(c);}var b=Date.parseFunctions[c];return Date[b](a);};Date.createParser=function(format){var funcName="parse"+Date.parseFunctions.count++;var regexNum=Date.parseRegexes.length;var currentGroup=1;Date.parseFunctions[format]=funcName;var code="Date."+funcName+" = function(input) {\nvar y = -1, m = -1, d = -1, h = -1, i = -1, s = -1, z = -1;\nvar d = new Date();\ny = d.getFullYear();\nm = d.getMonth();\nd = d.getDate();\nvar results = input.match(Date.parseRegexes["+regexNum+"]);\nif (results && results.length > 0) {";var regex="";var special=false;var ch="";for(var i=0;i<format.length;++i){ch=format.charAt(i);if(!special&&ch=="\\"){special=true;}else{if(special){special=false;regex+=String.escape(ch);}else{obj=Date.formatCodeToRegex(ch,currentGroup);currentGroup+=obj.g;regex+=obj.s;if(obj.g&&obj.c){code+=obj.c;}}}}code+="if (y > 0 && z > 0){\nvar doyDate = new Date(y,0);\ndoyDate.setDate(z);\nm = doyDate.getMonth();\nd = doyDate.getDate();\n}";code+="if (y > 0 && m >= 0 && d > 0 && h >= 0 && i >= 0 && s >= 0)\n{return new Date(y, m, d, h, i, s);}\nelse if (y > 0 && m >= 0 && d > 0 && h >= 0 && i >= 0)\n{return new Date(y, m, d, h, i);}\nelse if (y > 0 && m >= 0 && d > 0 && h >= 0)\n{return new Date(y, m, d, h);}\nelse if (y > 0 && m >= 0 && d > 0)\n{return new Date(y, m, d);}\nelse if (y > 0 && m >= 0)\n{return new Date(y, m);}\nelse if (y > 0)\n{return new Date(y);}\n}return null;}";Date.parseRegexes[regexNum]=new RegExp("^"+regex+"$");eval(code);};Date.formatCodeToRegex=function(b,a){switch(b){case"D":return{g:0,c:null,s:"(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)"};case"j":case"d":return{g:1,c:"d = parseInt(results["+a+"], 10);\n",s:"(\\d{1,2})"};case"l":return{g:0,c:null,s:"(?:"+Date.dayNames.join("|")+")"};case"S":return{g:0,c:null,s:"(?:st|nd|rd|th)"};case"w":return{g:0,c:null,s:"\\d"};case"z":return{g:1,c:"z = parseInt(results["+a+"], 10);\n",s:"(\\d{1,3})"};case"W":return{g:0,c:null,s:"(?:\\d{2})"};case"F":return{g:1,c:"m = parseInt(Date.monthNumbers[results["+a+"].substring(0, 3)], 10);\n",s:"("+Date.monthNames.join("|")+")"};case"M":return{g:1,c:"m = parseInt(Date.monthNumbers[results["+a+"]], 10);\n",s:"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"};case"n":case"m":return{g:1,c:"m = parseInt(results["+a+"], 10) - 1;\n",s:"(\\d{1,2})"};case"t":return{g:0,c:null,s:"\\d{1,2}"};case"L":return{g:0,c:null,s:"(?:1|0)"};case"Y":return{g:1,c:"y = parseInt(results["+a+"], 10);\n",s:"(\\d{4})"};case"y":return{g:1,c:"var ty = parseInt(results["+a+"], 10);\ny = ty > Date.y2kYear ? 1900 + ty : 2000 + ty;\n",s:"(\\d{1,2})"};case"a":return{g:1,c:"if (results["+a+"] == 'am') {\nif (h == 12) { h = 0; }\n} else { if (h < 12) { h += 12; }}",s:"(am|pm)"};case"A":return{g:1,c:"if (results["+a+"] == 'AM') {\nif (h == 12) { h = 0; }\n} else { if (h < 12) { h += 12; }}",s:"(AM|PM)"};case"g":case"G":case"h":case"H":return{g:1,c:"h = parseInt(results["+a+"], 10);\n",s:"(\\d{1,2})"};case"i":return{g:1,c:"i = parseInt(results["+a+"], 10);\n",s:"(\\d{2})"};case"s":return{g:1,c:"s = parseInt(results["+a+"], 10);\n",s:"(\\d{2})"};case"O":return{g:0,c:null,s:"[+-]\\d{4}"};case"T":return{g:0,c:null,s:"[A-Z]{3}"};case"Z":return{g:0,c:null,s:"[+-]\\d{1,5}"};default:return{g:0,c:null,s:String.escape(b)};}};Date.prototype.getTimezone=function(){return this.toString().replace(/^.*? ([A-Z]{3}) [0-9]{4}.*$/,"$1").replace(/^.*?\(([A-Z])[a-z]+ ([A-Z])[a-z]+ ([A-Z])[a-z]+\)$/,"$1$2$3");};Date.prototype.getGMTOffset=function(){return(this.getTimezoneOffset()>0?"-":"+")+String.leftPad(Math.floor(Math.abs(this.getTimezoneOffset())/60),2,"0")+String.leftPad(Math.abs(this.getTimezoneOffset())%60,2,"0");};Date.prototype.getDayOfYear=function(){var a=0;Date.daysInMonth[1]=this.isLeapYear()?29:28;for(var b=0;b<this.getMonth();++b){a+=Date.daysInMonth[b];}return a+this.getDate();};Date.prototype.getWeekOfYear=function(){var b=this.getDayOfYear()+(4-this.getDay());var a=new Date(this.getFullYear(),0,1);var c=(7-a.getDay()+4);return String.leftPad(Math.ceil((b-c)/7)+1,2,"0");};Date.prototype.isLeapYear=function(){var a=this.getFullYear();return((a&3)==0&&(a%100||(a%400==0&&a)));};Date.prototype.getFirstDayOfMonth=function(){var a=(this.getDay()-(this.getDate()-1))%7;return(a<0)?(a+7):a;};Date.prototype.getLastDayOfMonth=function(){var a=(this.getDay()+(Date.daysInMonth[this.getMonth()]-this.getDate()))%7;return(a<0)?(a+7):a;};Date.prototype.getDaysInMonth=function(){Date.daysInMonth[1]=this.isLeapYear()?29:28;return Date.daysInMonth[this.getMonth()];};Date.prototype.getSuffix=function(){switch(this.getDate()){case 1:case 21:case 31:return"st";case 2:case 22:return"nd";case 3:case 23:return"rd";default:return"th";}};String.escape=function(a){return a.replace(/('|\\)/g,"\\$1");};String.leftPad=function(d,b,c){var a=new String(d);if(c==null){c=" ";}while(a.length<b){a=c+a;}return a;};Date.daysInMonth=[31,28,31,30,31,30,31,31,30,31,30,31];Date.monthNames=["January","February","March","April","May","June","July","August","September","October","November","December"];Date.dayNames=["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"];Date.y2kYear=50;Date.monthNumbers={Jan:0,Feb:1,Mar:2,Apr:3,May:4,Jun:5,Jul:6,Aug:7,Sep:8,Oct:9,Nov:10,Dec:11};Date.patterns={ISO8601LongPattern:"Y-m-d H:i:s",ISO8601ShortPattern:"Y-m-d",ShortDatePattern:"n/j/Y",LongDatePattern:"l, F d, Y",FullDateTimePattern:"l, F d, Y g:i:s A",MonthDayPattern:"F d",ShortTimePattern:"g:i A",LongTimePattern:"g:i:s A",SortableDateTimePattern:"Y-m-d\\TH:i:s",UniversalSortableDateTimePattern:"Y-m-d H:i:sO",YearMonthPattern:"F, Y"};
+}());

--- a/app/bundles/CoreBundle/Assets/js/libraries/7.datetimepicker.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/7.datetimepicker.js
@@ -1,2092 +1,2656 @@
 /**
- * @preserve jQuery DateTimePicker plugin v2.4.5
+ * @preserve jQuery DateTimePicker
  * @homepage http://xdsoft.net/jqplugins/datetimepicker/
- * (c) 2014, Chupurnov Valeriy.
+ * @author Chupurnov Valeriy (<chupurnov@gmail.com>)
  */
-/*global document,window,jQuery,setTimeout,clearTimeout,HighlightedDate,getCurrentValue*/
-(function ($) {
-	'use strict';
-	var default_options  = {
-		i18n: {
-			ar: { // Arabic
-				months: [
-					"كانون الثاني", "شباط", "آذار", "نيسان", "مايو", "حزيران", "تموز", "آب", "أيلول", "تشرين الأول", "تشرين الثاني", "كانون الأول"
-				],
-				dayOfWeek: [
-					"ن", "ث", "ع", "خ", "ج", "س", "ح"
-				]
-			},
-			ro: { // Romanian
-				months: [
-					"ianuarie", "februarie", "martie", "aprilie", "mai", "iunie", "iulie", "august", "septembrie", "octombrie", "noiembrie", "decembrie"
-				],
-				dayOfWeek: [
-					"l", "ma", "mi", "j", "v", "s", "d"
-				]
-			},
-			id: { // Indonesian
-				months: [
-					"Januari", "Februari", "Maret", "April", "Mei", "Juni", "Juli", "Agustus", "September", "Oktober", "November", "Desember"
-				],
-				dayOfWeek: [
-					"Min", "Sen", "Sel", "Rab", "Kam", "Jum", "Sab"
-				]
-			},
-			is: { // Icelandic
-				months: [
-					"Janúar", "Febrúar", "Mars", "Apríl", "Maí", "Júní", "Júlí", "Ágúst", "September", "Október", "Nóvember", "Desember"
-				],
-				dayOfWeek: [
-					"Sun", "Mán", "Þrið", "Mið", "Fim", "Fös", "Lau"
-				]
-			},
-			bg: { // Bulgarian
-				months: [
-					"Януари", "Февруари", "Март", "Април", "Май", "Юни", "Юли", "Август", "Септември", "Октомври", "Ноември", "Декември"
-				],
-				dayOfWeek: [
-					"Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"
-				]
-			},
-			fa: { // Persian/Farsi
-				months: [
-					'فروردین', 'اردیبهشت', 'خرداد', 'تیر', 'مرداد', 'شهریور', 'مهر', 'آبان', 'آذر', 'دی', 'بهمن', 'اسفند'
-				],
-				dayOfWeek: [
-					'یکشنبه', 'دوشنبه', 'سه شنبه', 'چهارشنبه', 'پنجشنبه', 'جمعه', 'شنبه'
-				]
-			},
-			ru: { // Russian
-				months: [
-					'Январь', 'Февраль', 'Март', 'Апрель', 'Май', 'Июнь', 'Июль', 'Август', 'Сентябрь', 'Октябрь', 'Ноябрь', 'Декабрь'
-				],
-				dayOfWeek: [
-					"Вск", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"
-				]
-			},
-			uk: { // Ukrainian
-				months: [
-					'Січень', 'Лютий', 'Березень', 'Квітень', 'Травень', 'Червень', 'Липень', 'Серпень', 'Вересень', 'Жовтень', 'Листопад', 'Грудень'
-				],
-				dayOfWeek: [
-					"Ндл", "Пнд", "Втр", "Срд", "Чтв", "Птн", "Сбт"
-				]
-			},
-			en: { // English
-				months: [
-					"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
-				],
-				dayOfWeek: [
-					"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
-				]
-			},
-			el: { // Ελληνικά
-				months: [
-					"Ιανουάριος", "Φεβρουάριος", "Μάρτιος", "Απρίλιος", "Μάιος", "Ιούνιος", "Ιούλιος", "Αύγουστος", "Σεπτέμβριος", "Οκτώβριος", "Νοέμβριος", "Δεκέμβριος"
-				],
-				dayOfWeek: [
-					"Κυρ", "Δευ", "Τρι", "Τετ", "Πεμ", "Παρ", "Σαβ"
-				]
-			},
-			de: { // German
-				months: [
-					'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'
-				],
-				dayOfWeek: [
-					"So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"
-				]
-			},
-			nl: { // Dutch
-				months: [
-					"januari", "februari", "maart", "april", "mei", "juni", "juli", "augustus", "september", "oktober", "november", "december"
-				],
-				dayOfWeek: [
-					"zo", "ma", "di", "wo", "do", "vr", "za"
-				]
-			},
-			tr: { // Turkish
-				months: [
-					"Ocak", "Şubat", "Mart", "Nisan", "Mayıs", "Haziran", "Temmuz", "Ağustos", "Eylül", "Ekim", "Kasım", "Aralık"
-				],
-				dayOfWeek: [
-					"Paz", "Pts", "Sal", "Çar", "Per", "Cum", "Cts"
-				]
-			},
-			fr: { //French
-				months: [
-					"Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"
-				],
-				dayOfWeek: [
-					"Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam"
-				]
-			},
-			es: { // Spanish
-				months: [
-					"Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"
-				],
-				dayOfWeek: [
-					"Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"
-				]
-			},
-			th: { // Thai
-				months: [
-					'มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน', 'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม'
-				],
-				dayOfWeek: [
-					'อา.', 'จ.', 'อ.', 'พ.', 'พฤ.', 'ศ.', 'ส.'
-				]
-			},
-			pl: { // Polish
-				months: [
-					"styczeń", "luty", "marzec", "kwiecień", "maj", "czerwiec", "lipiec", "sierpień", "wrzesień", "październik", "listopad", "grudzień"
-				],
-				dayOfWeek: [
-					"nd", "pn", "wt", "śr", "cz", "pt", "sb"
-				]
-			},
-			pt: { // Portuguese
-				months: [
-					"Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"
-				],
-				dayOfWeek: [
-					"Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sab"
-				]
-			},
-			ch: { // Simplified Chinese
-				months: [
-					"一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"
-				],
-				dayOfWeek: [
-					"日", "一", "二", "三", "四", "五", "六"
-				]
-			},
-			se: { // Swedish
-				months: [
-					"Januari", "Februari", "Mars", "April", "Maj", "Juni", "Juli", "Augusti", "September",  "Oktober", "November", "December"
-				],
-				dayOfWeek: [
-					"Sön", "Mån", "Tis", "Ons", "Tor", "Fre", "Lör"
-				]
-			},
-			kr: { // Korean
-				months: [
-					"1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월"
-				],
-				dayOfWeek: [
-					"일", "월", "화", "수", "목", "금", "토"
-				]
-			},
-			it: { // Italian
-				months: [
-					"Gennaio", "Febbraio", "Marzo", "Aprile", "Maggio", "Giugno", "Luglio", "Agosto", "Settembre", "Ottobre", "Novembre", "Dicembre"
-				],
-				dayOfWeek: [
-					"Dom", "Lun", "Mar", "Mer", "Gio", "Ven", "Sab"
-				]
-			},
-			da: { // Dansk
-				months: [
-					"January", "Februar", "Marts", "April", "Maj", "Juni", "July", "August", "September", "Oktober", "November", "December"
-				],
-				dayOfWeek: [
-					"Søn", "Man", "Tir", "Ons", "Tor", "Fre", "Lør"
-				]
-			},
-			no: { // Norwegian
-				months: [
-					"Januar", "Februar", "Mars", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Desember"
-				],
-				dayOfWeek: [
-					"Søn", "Man", "Tir", "Ons", "Tor", "Fre", "Lør"
-				]
-			},
-			ja: { // Japanese
-				months: [
-					"1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"
-				],
-				dayOfWeek: [
-					"日", "月", "火", "水", "木", "金", "土"
-				]
-			},
-			vi: { // Vietnamese
-				months: [
-					"Tháng 1", "Tháng 2", "Tháng 3", "Tháng 4", "Tháng 5", "Tháng 6", "Tháng 7", "Tháng 8", "Tháng 9", "Tháng 10", "Tháng 11", "Tháng 12"
-				],
-				dayOfWeek: [
-					"CN", "T2", "T3", "T4", "T5", "T6", "T7"
-				]
-			},
-			sl: { // Slovenščina
-				months: [
-					"Januar", "Februar", "Marec", "April", "Maj", "Junij", "Julij", "Avgust", "September", "Oktober", "November", "December"
-				],
-				dayOfWeek: [
-					"Ned", "Pon", "Tor", "Sre", "Čet", "Pet", "Sob"
-				]
-			},
-			cs: { // Čeština
-				months: [
-					"Leden", "Únor", "Březen", "Duben", "Květen", "Červen", "Červenec", "Srpen", "Září", "Říjen", "Listopad", "Prosinec"
-				],
-				dayOfWeek: [
-					"Ne", "Po", "Út", "St", "Čt", "Pá", "So"
-				]
-			},
-			hu: { // Hungarian
-				months: [
-					"Január", "Február", "Március", "Április", "Május", "Június", "Július", "Augusztus", "Szeptember", "Október", "November", "December"
-				],
-				dayOfWeek: [
-					"Va", "Hé", "Ke", "Sze", "Cs", "Pé", "Szo"
-				]
-			},
-			az: { //Azerbaijanian (Azeri)
-				months: [
-					"Yanvar", "Fevral", "Mart", "Aprel", "May", "Iyun", "Iyul", "Avqust", "Sentyabr", "Oktyabr", "Noyabr", "Dekabr"
-				],
-				dayOfWeek: [
-					"B", "Be", "Ça", "Ç", "Ca", "C", "Ş"
-				]
-			},
-			bs: { //Bosanski
-				months: [
-					"Januar", "Februar", "Mart", "April", "Maj", "Jun", "Jul", "Avgust", "Septembar", "Oktobar", "Novembar", "Decembar"
-				],
-				dayOfWeek: [
-					"Ned", "Pon", "Uto", "Sri", "Čet", "Pet", "Sub"
-				]
-			},
-			ca: { //Català
-				months: [
-					"Gener", "Febrer", "Març", "Abril", "Maig", "Juny", "Juliol", "Agost", "Setembre", "Octubre", "Novembre", "Desembre"
-				],
-				dayOfWeek: [
-					"Dg", "Dl", "Dt", "Dc", "Dj", "Dv", "Ds"
-				]
-			},
-			'en-GB': { //English (British)
-				months: [
-					"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
-				],
-				dayOfWeek: [
-					"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
-				]
-			},
-			et: { //"Eesti"
-				months: [
-					"Jaanuar", "Veebruar", "Märts", "Aprill", "Mai", "Juuni", "Juuli", "August", "September", "Oktoober", "November", "Detsember"
-				],
-				dayOfWeek: [
-					"P", "E", "T", "K", "N", "R", "L"
-				]
-			},
-			eu: { //Euskara
-				months: [
-					"Urtarrila", "Otsaila", "Martxoa", "Apirila", "Maiatza", "Ekaina", "Uztaila", "Abuztua", "Iraila", "Urria", "Azaroa", "Abendua"
-				],
-				dayOfWeek: [
-					"Ig.", "Al.", "Ar.", "Az.", "Og.", "Or.", "La."
-				]
-			},
-			fi: { //Finnish (Suomi)
-				months: [
-					"Tammikuu", "Helmikuu", "Maaliskuu", "Huhtikuu", "Toukokuu", "Kesäkuu", "Heinäkuu", "Elokuu", "Syyskuu", "Lokakuu", "Marraskuu", "Joulukuu"
-				],
-				dayOfWeek: [
-					"Su", "Ma", "Ti", "Ke", "To", "Pe", "La"
-				]
-			},
-			gl: { //Galego
-				months: [
-					"Xan", "Feb", "Maz", "Abr", "Mai", "Xun", "Xul", "Ago", "Set", "Out", "Nov", "Dec"
-				],
-				dayOfWeek: [
-					"Dom", "Lun", "Mar", "Mer", "Xov", "Ven", "Sab"
-				]
-			},
-			hr: { //Hrvatski
-				months: [
-					"Siječanj", "Veljača", "Ožujak", "Travanj", "Svibanj", "Lipanj", "Srpanj", "Kolovoz", "Rujan", "Listopad", "Studeni", "Prosinac"
-				],
-				dayOfWeek: [
-					"Ned", "Pon", "Uto", "Sri", "Čet", "Pet", "Sub"
-				]
-			},
-			ko: { //Korean (한국어)
-				months: [
-					"1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월"
-				],
-				dayOfWeek: [
-					"일", "월", "화", "수", "목", "금", "토"
-				]
-			},
-			lt: { //Lithuanian (lietuvių)
-				months: [
-					"Sausio", "Vasario", "Kovo", "Balandžio", "Gegužės", "Birželio", "Liepos", "Rugpjūčio", "Rugsėjo", "Spalio", "Lapkričio", "Gruodžio"
-				],
-				dayOfWeek: [
-					"Sek", "Pir", "Ant", "Tre", "Ket", "Pen", "Šeš"
-				]
-			},
-			lv: { //Latvian (Latviešu)
-				months: [
-					"Janvāris", "Februāris", "Marts", "Aprīlis ", "Maijs", "Jūnijs", "Jūlijs", "Augusts", "Septembris", "Oktobris", "Novembris", "Decembris"
-				],
-				dayOfWeek: [
-					"Sv", "Pr", "Ot", "Tr", "Ct", "Pk", "St"
-				]
-			},
-			mk: { //Macedonian (Македонски)
-				months: [
-					"јануари", "февруари", "март", "април", "мај", "јуни", "јули", "август", "септември", "октомври", "ноември", "декември"
-				],
-				dayOfWeek: [
-					"нед", "пон", "вто", "сре", "чет", "пет", "саб"
-				]
-			},
-			mn: { //Mongolian (Монгол)
-				months: [
-					"1-р сар", "2-р сар", "3-р сар", "4-р сар", "5-р сар", "6-р сар", "7-р сар", "8-р сар", "9-р сар", "10-р сар", "11-р сар", "12-р сар"
-				],
-				dayOfWeek: [
-					"Дав", "Мяг", "Лха", "Пүр", "Бсн", "Бям", "Ням"
-				]
-			},
-			'pt-BR': { //Português(Brasil)
-				months: [
-					"Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"
-				],
-				dayOfWeek: [
-					"Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"
-				]
-			},
-			sk: { //Slovenčina
-				months: [
-					"Január", "Február", "Marec", "Apríl", "Máj", "Jún", "Júl", "August", "September", "Október", "November", "December"
-				],
-				dayOfWeek: [
-					"Ne", "Po", "Ut", "St", "Št", "Pi", "So"
-				]
-			},
-			sq: { //Albanian (Shqip)
-				months: [
-					"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
-				],
-				dayOfWeek: [
-					"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
-				]
-			},
-			'sr-YU': { //Serbian (Srpski)
-				months: [
-					"Januar", "Februar", "Mart", "April", "Maj", "Jun", "Jul", "Avgust", "Septembar", "Oktobar", "Novembar", "Decembar"
-				],
-				dayOfWeek: [
-					"Ned", "Pon", "Uto", "Sre", "čet", "Pet", "Sub"
-				]
-			},
-			sr: { //Serbian Cyrillic (Српски)
-				months: [
-					"јануар", "фебруар", "март", "април", "мај", "јун", "јул", "август", "септембар", "октобар", "новембар", "децембар"
-				],
-				dayOfWeek: [
-					"нед", "пон", "уто", "сре", "чет", "пет", "суб"
-				]
-			},
-			sv: { //Svenska
-				months: [
-					"Januari", "Februari", "Mars", "April", "Maj", "Juni", "Juli", "Augusti", "September", "Oktober", "November", "December"
-				],
-				dayOfWeek: [
-					"Sön", "Mån", "Tis", "Ons", "Tor", "Fre", "Lör"
-				]
-			},
-			'zh-TW': { //Traditional Chinese (繁體中文)
-				months: [
-					"一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"
-				],
-				dayOfWeek: [
-					"日", "一", "二", "三", "四", "五", "六"
-				]
-			},
-			zh: { //Simplified Chinese (简体中文)
-				months: [
-					"一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"
-				],
-				dayOfWeek: [
-					"日", "一", "二", "三", "四", "五", "六"
-				]
-			},
-			he: { //Hebrew (עברית)
-				months: [
-					'ינואר', 'פברואר', 'מרץ', 'אפריל', 'מאי', 'יוני', 'יולי', 'אוגוסט', 'ספטמבר', 'אוקטובר', 'נובמבר', 'דצמבר'
-				],
-				dayOfWeek: [
-					'א\'', 'ב\'', 'ג\'', 'ד\'', 'ה\'', 'ו\'', 'שבת'
-				]
-			},
-			hy: { // Armenian
-				months: [
-					"Հունվար", "Փետրվար", "Մարտ", "Ապրիլ", "Մայիս", "Հունիս", "Հուլիս", "Օգոստոս", "Սեպտեմբեր", "Հոկտեմբեր", "Նոյեմբեր", "Դեկտեմբեր"
-				],
-				dayOfWeek: [
-					"Կի", "Երկ", "Երք", "Չոր", "Հնգ", "Ուրբ", "Շբթ"
-				]
-			},
-			kg: { // Kyrgyz
-				months: [
-					'Үчтүн айы', 'Бирдин айы', 'Жалган Куран', 'Чын Куран', 'Бугу', 'Кулжа', 'Теке', 'Баш Оона', 'Аяк Оона', 'Тогуздун айы', 'Жетинин айы', 'Бештин айы'
-				],
-				dayOfWeek: [
-					"Жек", "Дүй", "Шей", "Шар", "Бей", "Жум", "Ише"
-				]
-			}
-		},
-		value: '',
-		lang: 'en',
-		rtl: false,
-
-		format:	'Y/m/d H:i',
-		formatTime:	'H:i',
-		formatDate:	'Y/m/d',
-
-		startDate:	false, // new Date(), '1986/12/08', '-1970/01/05','-1970/01/05',
-		step: 60,
-		monthChangeSpinner: true,
-
-		closeOnDateSelect: false,
-		closeOnTimeSelect: true,
-		closeOnWithoutClick: true,
-		closeOnInputClick: true,
-
-		timepicker: true,
-		datepicker: true,
-		weeks: false,
-
-		defaultTime: false,	// use formatTime format (ex. '10:00' for formatTime:	'H:i')
-		defaultDate: false,	// use formatDate format (ex new Date() or '1986/12/08' or '-1970/01/05' or '-1970/01/05')
-
-		minDate: false,
-		maxDate: false,
-		minTime: false,
-		maxTime: false,
-		disabledMinTime: false,
-		disabledMaxTime: false,
-
-		allowTimes: [],
-		opened: false,
-		initTime: true,
-		inline: false,
-		theme: '',
-
-		onSelectDate: function () {},
-		onSelectTime: function () {},
-		onChangeMonth: function () {},
-		onChangeYear: function () {},
-		onChangeDateTime: function () {},
-		onShow: function () {},
-		onClose: function () {},
-		onGenerate: function () {},
-
-		withoutCopyright: true,
-		inverseButton: false,
-		hours12: false,
-		next: 'xdsoft_next',
-		prev : 'xdsoft_prev',
-		dayOfWeekStart: 0,
-		parentID: 'body',
-		timeHeightInTimePicker: 25,
-		timepickerScrollbar: true,
-		todayButton: true,
-		prevButton: true,
-		nextButton: true,
-		defaultSelect: true,
-
-		scrollMonth: true,
-		scrollTime: true,
-		scrollInput: true,
-
-		lazyInit: false,
-		mask: false,
-		validateOnBlur: true,
-		allowBlank: true,
-		yearStart: 1950,
-		yearEnd: 2050,
-		monthStart: 0,
-		monthEnd: 11,
-		style: '',
-		id: '',
-		fixed: false,
-		roundTime: 'round', // ceil, floor
-		className: '',
-		weekends: [],
-		highlightedDates: [],
-		highlightedPeriods: [],
-		disabledDates : [],
-		disabledWeekDays: [],
-		yearOffset: 0,
-		beforeShowDay: null,
-
-		enterLikeTab: true,
-		showApplyButton: false
-	};
-	// fix for ie8
-	if (!window.getComputedStyle) {
-		window.getComputedStyle = function (el, pseudo) {
-			this.el = el;
-			this.getPropertyValue = function (prop) {
-				var re = /(\-([a-z]){1})/g;
-				if (prop === 'float') {
-					prop = 'styleFloat';
-				}
-				if (re.test(prop)) {
-					prop = prop.replace(re, function (a, b, c) {
-						return c.toUpperCase();
-					});
-				}
-				return el.currentStyle[prop] || null;
-			};
-			return this;
-		};
-	}
-	if (!Array.prototype.indexOf) {
-		Array.prototype.indexOf = function (obj, start) {
-			var i, j;
-			for (i = (start || 0), j = this.length; i < j; i += 1) {
-				if (this[i] === obj) { return i; }
-			}
-			return -1;
-		};
-	}
-	Date.prototype.countDaysInMonth = function () {
-		return new Date(this.getFullYear(), this.getMonth() + 1, 0).getDate();
-	};
-	$.fn.xdsoftScroller = function (percent) {
-		return this.each(function () {
-			var timeboxparent = $(this),
-				pointerEventToXY = function (e) {
-					var out = {x: 0, y: 0},
-						touch;
-					if (e.type === 'touchstart' || e.type === 'touchmove' || e.type === 'touchend' || e.type === 'touchcancel') {
-						touch  = e.originalEvent.touches[0] || e.originalEvent.changedTouches[0];
-						out.x = touch.clientX;
-						out.y = touch.clientY;
-					} else if (e.type === 'mousedown' || e.type === 'mouseup' || e.type === 'mousemove' || e.type === 'mouseover' || e.type === 'mouseout' || e.type === 'mouseenter' || e.type === 'mouseleave') {
-						out.x = e.clientX;
-						out.y = e.clientY;
-					}
-					return out;
-				},
-				move = 0,
-				timebox,
-				parentHeight,
-				height,
-				scrollbar,
-				scroller,
-				maximumOffset = 100,
-				start = false,
-				startY = 0,
-				startTop = 0,
-				h1 = 0,
-				touchStart = false,
-				startTopScroll = 0,
-				calcOffset = function () {};
-			if (percent === 'hide') {
-				timeboxparent.find('.xdsoft_scrollbar').hide();
-				return;
-			}
-			if (!$(this).hasClass('xdsoft_scroller_box')) {
-				timebox = timeboxparent.children().eq(0);
-				parentHeight = timeboxparent[0].clientHeight;
-				height = timebox[0].offsetHeight;
-				scrollbar = $('<div class="xdsoft_scrollbar"></div>');
-				scroller = $('<div class="xdsoft_scroller"></div>');
-				scrollbar.append(scroller);
-
-				timeboxparent.addClass('xdsoft_scroller_box').append(scrollbar);
-				calcOffset = function calcOffset(event) {
-					var offset = pointerEventToXY(event).y - startY + startTopScroll;
-					if (offset < 0) {
-						offset = 0;
-					}
-					if (offset + scroller[0].offsetHeight > h1) {
-						offset = h1 - scroller[0].offsetHeight;
-					}
-					timeboxparent.trigger('scroll_element.xdsoft_scroller', [maximumOffset ? offset / maximumOffset : 0]);
-				};
-
-				scroller
-					.on('touchstart.xdsoft_scroller mousedown.xdsoft_scroller', function (event) {
-						if (!parentHeight) {
-							timeboxparent.trigger('resize_scroll.xdsoft_scroller', [percent]);
-						}
-
-						startY = pointerEventToXY(event).y;
-						startTopScroll = parseInt(scroller.css('margin-top'), 10);
-						h1 = scrollbar[0].offsetHeight;
-
-						if (event.type === 'mousedown') {
-							if (document) {
-								$(document.body).addClass('xdsoft_noselect');
-							}
-							$([document.body, window]).on('mouseup.xdsoft_scroller', function arguments_callee() {
-								$([document.body, window]).off('mouseup.xdsoft_scroller', arguments_callee)
-									.off('mousemove.xdsoft_scroller', calcOffset)
-									.removeClass('xdsoft_noselect');
-							});
-							$(document.body).on('mousemove.xdsoft_scroller', calcOffset);
-						} else {
-							touchStart = true;
-							event.stopPropagation();
-							event.preventDefault();
-						}
-					})
-					.on('touchmove', function (event) {
-						if (touchStart) {
-							event.preventDefault();
-							calcOffset(event);
-						}
-					})
-					.on('touchend touchcancel', function (event) {
-						touchStart =  false;
-						startTopScroll = 0;
-					});
-
-				timeboxparent
-					.on('scroll_element.xdsoft_scroller', function (event, percentage) {
-						if (!parentHeight) {
-							timeboxparent.trigger('resize_scroll.xdsoft_scroller', [percentage, true]);
-						}
-						percentage = percentage > 1 ? 1 : (percentage < 0 || isNaN(percentage)) ? 0 : percentage;
-
-						scroller.css('margin-top', maximumOffset * percentage);
-
-						setTimeout(function () {
-							timebox.css('marginTop', -parseInt((timebox[0].offsetHeight - parentHeight) * percentage, 10));
-						}, 10);
-					})
-					.on('resize_scroll.xdsoft_scroller', function (event, percentage, noTriggerScroll) {
-						var percent, sh;
-						parentHeight = timeboxparent[0].clientHeight;
-						height = timebox[0].offsetHeight;
-						percent = parentHeight / height;
-						sh = percent * scrollbar[0].offsetHeight;
-						if (percent > 1) {
-							scroller.hide();
-						} else {
-							scroller.show();
-							scroller.css('height', parseInt(sh > 10 ? sh : 10, 10));
-							maximumOffset = scrollbar[0].offsetHeight - scroller[0].offsetHeight;
-							if (noTriggerScroll !== true) {
-								timeboxparent.trigger('scroll_element.xdsoft_scroller', [percentage || Math.abs(parseInt(timebox.css('marginTop'), 10)) / (height - parentHeight)]);
-							}
-						}
-					});
-
-				timeboxparent.on('mousewheel', function (event) {
-					var top = Math.abs(parseInt(timebox.css('marginTop'), 10));
-
-					top = top - (event.deltaY * 20);
-					if (top < 0) {
-						top = 0;
-					}
-
-					timeboxparent.trigger('scroll_element.xdsoft_scroller', [top / (height - parentHeight)]);
-					event.stopPropagation();
-					return false;
-				});
-
-				timeboxparent.on('touchstart', function (event) {
-					start = pointerEventToXY(event);
-					startTop = Math.abs(parseInt(timebox.css('marginTop'), 10));
-				});
-
-				timeboxparent.on('touchmove', function (event) {
-					if (start) {
-						event.preventDefault();
-						var coord = pointerEventToXY(event);
-						timeboxparent.trigger('scroll_element.xdsoft_scroller', [(startTop - (coord.y - start.y)) / (height - parentHeight)]);
-					}
-				});
-
-				timeboxparent.on('touchend touchcancel', function (event) {
-					start = false;
-					startTop = 0;
-				});
-			}
-			timeboxparent.trigger('resize_scroll.xdsoft_scroller', [percent]);
-		});
-	};
-
-	$.fn.datetimepicker = function (opt) {
-		var KEY0 = 48,
-			KEY9 = 57,
-			_KEY0 = 96,
-			_KEY9 = 105,
-			CTRLKEY = 17,
-			DEL = 46,
-			ENTER = 13,
-			ESC = 27,
-			BACKSPACE = 8,
-			ARROWLEFT = 37,
-			ARROWUP = 38,
-			ARROWRIGHT = 39,
-			ARROWDOWN = 40,
-			TAB = 9,
-			F5 = 116,
-			AKEY = 65,
-			CKEY = 67,
-			VKEY = 86,
-			ZKEY = 90,
-			YKEY = 89,
-			ctrlDown	=	false,
-			options = ($.isPlainObject(opt) || !opt) ? $.extend(true, {}, default_options, opt) : $.extend(true, {}, default_options),
-
-			lazyInitTimer = 0,
-			createDateTimePicker,
-			destroyDateTimePicker,
-
-			lazyInit = function (input) {
-				input
-					.on('open.xdsoft focusin.xdsoft mousedown.xdsoft', function initOnActionCallback(event) {
-						if (input.is(':disabled') || input.data('xdsoft_datetimepicker')) {
-							return;
-						}
-						clearTimeout(lazyInitTimer);
-						lazyInitTimer = setTimeout(function () {
-
-							if (!input.data('xdsoft_datetimepicker')) {
-								createDateTimePicker(input);
-							}
-							input
-								.off('open.xdsoft focusin.xdsoft mousedown.xdsoft', initOnActionCallback)
-								.trigger('open.xdsoft');
-						}, 100);
-					});
-			};
-
-		createDateTimePicker = function (input) {
-			var datetimepicker = $('<div class="xdsoft_datetimepicker xdsoft_noselect"></div>'),
-				xdsoft_copyright = $('<div class="xdsoft_copyright"><a target="_blank" href="http://xdsoft.net/jqplugins/datetimepicker/">xdsoft.net</a></div>'),
-				datepicker = $('<div class="xdsoft_datepicker active"></div>'),
-				mounth_picker = $('<div class="xdsoft_mounthpicker"><button type="button" class="xdsoft_prev"></button><button type="button" class="xdsoft_today_button"></button>' +
-					'<div class="xdsoft_label xdsoft_month"><span></span><i></i></div>' +
-					'<div class="xdsoft_label xdsoft_year"><span></span><i></i></div>' +
-					'<button type="button" class="xdsoft_next"></button></div>'),
-				calendar = $('<div class="xdsoft_calendar"></div>'),
-				timepicker = $('<div class="xdsoft_timepicker active"><button type="button" class="xdsoft_prev"></button><div class="xdsoft_time_box"></div><button type="button" class="xdsoft_next"></button></div>'),
-				timeboxparent = timepicker.find('.xdsoft_time_box').eq(0),
-				timebox = $('<div class="xdsoft_time_variant"></div>'),
-				applyButton = $('<button type="button" class="xdsoft_save_selected blue-gradient-button">Save Selected</button>'),
-			/*scrollbar = $('<div class="xdsoft_scrollbar"></div>'),
-			 scroller = $('<div class="xdsoft_scroller"></div>'),*/
-				monthselect = $('<div class="xdsoft_select xdsoft_monthselect"><div></div></div>'),
-				yearselect = $('<div class="xdsoft_select xdsoft_yearselect"><div></div></div>'),
-				triggerAfterOpen = false,
-				XDSoft_datetime,
-			//scroll_element,
-				xchangeTimer,
-				timerclick,
-				current_time_index,
-				setPos,
-				timer = 0,
-				timer1 = 0,
-				_xdsoft_datetime;
-
-			if (options.id) {
-				datetimepicker.attr('id', options.id);
-			}
-			if (options.style) {
-				datetimepicker.attr('style', options.style);
-			}
-			if (options.weeks) {
-				datetimepicker.addClass('xdsoft_showweeks');
-			}
-			if (options.rtl) {
-				datetimepicker.addClass('xdsoft_rtl');
-			}
-
-			datetimepicker.addClass('xdsoft_' + options.theme);
-			datetimepicker.addClass(options.className);
-
-			mounth_picker
-				.find('.xdsoft_month span')
-				.after(monthselect);
-			mounth_picker
-				.find('.xdsoft_year span')
-				.after(yearselect);
-
-			mounth_picker
-				.find('.xdsoft_month,.xdsoft_year')
-				.on('mousedown.xdsoft', function (event) {
-					var select = $(this).find('.xdsoft_select').eq(0),
-						val = 0,
-						top = 0,
-						visible = select.is(':visible'),
-						items,
-						i;
-
-					mounth_picker
-						.find('.xdsoft_select')
-						.hide();
-					if (_xdsoft_datetime.currentTime) {
-						val = _xdsoft_datetime.currentTime[$(this).hasClass('xdsoft_month') ? 'getMonth' : 'getFullYear']();
-					}
-
-					select[visible ? 'hide' : 'show']();
-					for (items = select.find('div.xdsoft_option'), i = 0; i < items.length; i += 1) {
-						if (items.eq(i).data('value') === val) {
-							break;
-						} else {
-							top += items[0].offsetHeight;
-						}
-					}
-
-					select.xdsoftScroller(top / (select.children()[0].offsetHeight - (select[0].clientHeight)));
-					event.stopPropagation();
-					return false;
-				});
-
-			mounth_picker
-				.find('.xdsoft_select')
-				.xdsoftScroller()
-				.on('mousedown.xdsoft', function (event) {
-					event.stopPropagation();
-					event.preventDefault();
-				})
-				.on('mousedown.xdsoft', '.xdsoft_option', function (event) {
-
-					if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
-						_xdsoft_datetime.currentTime = _xdsoft_datetime.now();
-					}
-
-					var year = _xdsoft_datetime.currentTime.getFullYear();
-					if (_xdsoft_datetime && _xdsoft_datetime.currentTime) {
-						_xdsoft_datetime.currentTime[$(this).parent().parent().hasClass('xdsoft_monthselect') ? 'setMonth' : 'setFullYear']($(this).data('value'));
-					}
-
-					$(this).parent().parent().hide();
-
-					datetimepicker.trigger('xchange.xdsoft');
-					if (options.onChangeMonth && $.isFunction(options.onChangeMonth)) {
-						options.onChangeMonth.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
-					}
-
-					if (year !== _xdsoft_datetime.currentTime.getFullYear() && $.isFunction(options.onChangeYear)) {
-						options.onChangeYear.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
-					}
-				});
-
-			datetimepicker.setOptions = function (_options) {
-				var highlightedDates = {},
-					getCaretPos = function (input) {
-						try {
-							if (document.selection && document.selection.createRange) {
-								var range = document.selection.createRange();
-								return range.getBookmark().charCodeAt(2) - 2;
-							}
-							if (input.setSelectionRange) {
-								return input.selectionStart;
-							}
-						} catch (e) {
-							return 0;
-						}
-					},
-					setCaretPos = function (node, pos) {
-						node = (typeof node === "string" || node instanceof String) ? document.getElementById(node) : node;
-						if (!node) {
-							return false;
-						}
-						if (node.createTextRange) {
-							var textRange = node.createTextRange();
-							textRange.collapse(true);
-							textRange.moveEnd('character', pos);
-							textRange.moveStart('character', pos);
-							textRange.select();
-							return true;
-						}
-						if (node.setSelectionRange) {
-							node.setSelectionRange(pos, pos);
-							return true;
-						}
-						return false;
-					},
-					isValidValue = function (mask, value) {
-						var reg = mask
-							.replace(/([\[\]\/\{\}\(\)\-\.\+]{1})/g, '\\$1')
-							.replace(/_/g, '{digit+}')
-							.replace(/([0-9]{1})/g, '{digit$1}')
-							.replace(/\{digit([0-9]{1})\}/g, '[0-$1_]{1}')
-							.replace(/\{digit[\+]\}/g, '[0-9_]{1}');
-						return (new RegExp(reg)).test(value);
-					};
-				options = $.extend(true, {}, options, _options);
-
-				if (_options.allowTimes && $.isArray(_options.allowTimes) && _options.allowTimes.length) {
-					options.allowTimes = $.extend(true, [], _options.allowTimes);
-				}
-
-				if (_options.weekends && $.isArray(_options.weekends) && _options.weekends.length) {
-					options.weekends = $.extend(true, [], _options.weekends);
-				}
-
-				if (_options.highlightedDates && $.isArray(_options.highlightedDates) && _options.highlightedDates.length) {
-					$.each(_options.highlightedDates, function (index, value) {
-						var splitData = $.map(value.split(','), $.trim),
-							exDesc,
-							hDate = new HighlightedDate(Date.parseDate(splitData[0], options.formatDate), splitData[1], splitData[2]), // date, desc, style
-							keyDate = hDate.date.dateFormat(options.formatDate);
-						if (highlightedDates[keyDate] !== undefined) {
-							exDesc = highlightedDates[keyDate].desc;
-							if (exDesc && exDesc.length && hDate.desc && hDate.desc.length) {
-								highlightedDates[keyDate].desc = exDesc + "\n" + hDate.desc;
-							}
-						} else {
-							highlightedDates[keyDate] = hDate;
-						}
-					});
-
-					options.highlightedDates = $.extend(true, [], highlightedDates);
-				}
-
-				if (_options.highlightedPeriods && $.isArray(_options.highlightedPeriods) && _options.highlightedPeriods.length) {
-					highlightedDates = $.extend(true, [], options.highlightedDates);
-					$.each(_options.highlightedPeriods, function (index, value) {
-						var dateTest, // start date
-							dateEnd,
-							desc,
-							hDate,
-							keyDate,
-							exDesc,
-							style;
-						if ($.isArray(value)) {
-							dateTest = value[0];
-							dateEnd = value[1];
-							desc = value[2];
-							style = value[3];
-						}
-						else {
-							var splitData = $.map(value.split(','), $.trim);
-							dateTest = Date.parseDate(splitData[0], options.formatDate);
-							dateEnd = Date.parseDate(splitData[1], options.formatDate);
-							desc = splitData[2];
-							style = splitData[3];
-						}
-
-						while (dateTest <= dateEnd) {
-							hDate = new HighlightedDate(dateTest, desc, style);
-							keyDate = dateTest.dateFormat(options.formatDate);
-							dateTest.setDate(dateTest.getDate() + 1);
-							if (highlightedDates[keyDate] !== undefined) {
-								exDesc = highlightedDates[keyDate].desc;
-								if (exDesc && exDesc.length && hDate.desc && hDate.desc.length) {
-									highlightedDates[keyDate].desc = exDesc + "\n" + hDate.desc;
-								}
-							} else {
-								highlightedDates[keyDate] = hDate;
-							}
-						}
-					});
-
-					options.highlightedDates = $.extend(true, [], highlightedDates);
-				}
-
-				if (_options.disabledDates && $.isArray(_options.disabledDates) && _options.disabledDates.length) {
-					options.disabledDates = $.extend(true, [], _options.disabledDates);
-				}
-
-				if (_options.disabledWeekDays && $.isArray(_options.disabledWeekDays) && _options.disabledWeekDays.length) {
-					options.disabledWeekDays = $.extend(true, [], _options.disabledWeekDays);
-				}
-
-				if ((options.open || options.opened) && (!options.inline)) {
-					input.trigger('open.xdsoft');
-				}
-
-				if (options.inline) {
-					triggerAfterOpen = true;
-					datetimepicker.addClass('xdsoft_inline');
-					input.after(datetimepicker).hide();
-				}
-
-				if (options.inverseButton) {
-					options.next = 'xdsoft_prev';
-					options.prev = 'xdsoft_next';
-				}
-
-				if (options.datepicker) {
-					datepicker.addClass('active');
-				} else {
-					datepicker.removeClass('active');
-				}
-
-				if (options.timepicker) {
-					timepicker.addClass('active');
-				} else {
-					timepicker.removeClass('active');
-				}
-
-				if (options.value) {
-					_xdsoft_datetime.setCurrentTime(options.value);
-					if (input && input.val) {
-						input.val(_xdsoft_datetime.str);
-					}
-				}
-
-				if (isNaN(options.dayOfWeekStart)) {
-					options.dayOfWeekStart = 0;
-				} else {
-					options.dayOfWeekStart = parseInt(options.dayOfWeekStart, 10) % 7;
-				}
-
-				if (!options.timepickerScrollbar) {
-					timeboxparent.xdsoftScroller('hide');
-				}
-
-				if (options.minDate && /^[\+\-](.*)$/.test(options.minDate)) {
-					options.minDate = _xdsoft_datetime.strToDateTime(options.minDate).dateFormat(options.formatDate);
-				}
-
-				if (options.maxDate &&  /^[\+\-](.*)$/.test(options.maxDate)) {
-					options.maxDate = _xdsoft_datetime.strToDateTime(options.maxDate).dateFormat(options.formatDate);
-				}
-
-				applyButton.toggle(options.showApplyButton);
-
-				mounth_picker
-					.find('.xdsoft_today_button')
-					.css('visibility', !options.todayButton ? 'hidden' : 'visible');
-
-				mounth_picker
-					.find('.' + options.prev)
-					.css('visibility', !options.prevButton ? 'hidden' : 'visible');
-
-				mounth_picker
-					.find('.' + options.next)
-					.css('visibility', !options.nextButton ? 'hidden' : 'visible');
-
-				if (options.mask) {
-					input.off('keydown.xdsoft');
-
-					if (options.mask === true) {
-						options.mask = options.format
-							.replace(/Y/g, '9999')
-							.replace(/F/g, '9999')
-							.replace(/m/g, '19')
-							.replace(/d/g, '39')
-							.replace(/H/g, '29')
-							.replace(/i/g, '59')
-							.replace(/s/g, '59');
-					}
-
-					if ($.type(options.mask) === 'string') {
-						if (!isValidValue(options.mask, input.val())) {
-							input.val(options.mask.replace(/[0-9]/g, '_'));
-						}
-
-						input.on('keydown.xdsoft', function (event) {
-							var val = this.value,
-								key = event.which,
-								pos,
-								digit;
-
-							if (((key >= KEY0 && key <= KEY9) || (key >= _KEY0 && key <= _KEY9)) || (key === BACKSPACE || key === DEL)) {
-								pos = getCaretPos(this);
-								digit = (key !== BACKSPACE && key !== DEL) ? String.fromCharCode((_KEY0 <= key && key <= _KEY9) ? key - KEY0 : key) : '_';
-
-								if ((key === BACKSPACE || key === DEL) && pos) {
-									pos -= 1;
-									digit = '_';
-								}
-
-								while (/[^0-9_]/.test(options.mask.substr(pos, 1)) && pos < options.mask.length && pos > 0) {
-									pos += (key === BACKSPACE || key === DEL) ? -1 : 1;
-								}
-
-								val = val.substr(0, pos) + digit + val.substr(pos + 1);
-								if ($.trim(val) === '') {
-									val = options.mask.replace(/[0-9]/g, '_');
-								} else {
-									if (pos === options.mask.length) {
-										event.preventDefault();
-										return false;
-									}
-								}
-
-								pos += (key === BACKSPACE || key === DEL) ? 0 : 1;
-								while (/[^0-9_]/.test(options.mask.substr(pos, 1)) && pos < options.mask.length && pos > 0) {
-									pos += (key === BACKSPACE || key === DEL) ? -1 : 1;
-								}
-
-								if (isValidValue(options.mask, val)) {
-									this.value = val;
-									setCaretPos(this, pos);
-								} else if ($.trim(val) === '') {
-									this.value = options.mask.replace(/[0-9]/g, '_');
-								} else {
-									input.trigger('error_input.xdsoft');
-								}
-							} else {
-								if (([AKEY, CKEY, VKEY, ZKEY, YKEY].indexOf(key) !== -1 && ctrlDown) || [ESC, ARROWUP, ARROWDOWN, ARROWLEFT, ARROWRIGHT, F5, CTRLKEY, TAB, ENTER].indexOf(key) !== -1) {
-									return true;
-								}
-							}
-
-							event.preventDefault();
-							return false;
-						});
-					}
-				}
-				if (options.validateOnBlur) {
-					input
-						.off('blur.xdsoft')
-						.on('blur.xdsoft', function () {
-							if (options.allowBlank && !$.trim($(this).val()).length) {
-								$(this).val(null);
-								datetimepicker.data('xdsoft_datetime').empty();
-							} else if (!Date.parseDate($(this).val(), options.format)) {
-								var splittedHours   = +([$(this).val()[0], $(this).val()[1]].join('')),
-									splittedMinutes = +([$(this).val()[2], $(this).val()[3]].join(''));
-
-								// parse the numbers as 0312 => 03:12
-								if (!options.datepicker && options.timepicker && splittedHours >= 0 && splittedHours < 24 && splittedMinutes >= 0 && splittedMinutes < 60) {
-									$(this).val([splittedHours, splittedMinutes].map(function (item) {
-										return item > 9 ? item : '0' + item;
-									}).join(':'));
-								} else {
-									$(this).val((_xdsoft_datetime.now()).dateFormat(options.format));
-								}
-
-								datetimepicker.data('xdsoft_datetime').setCurrentTime($(this).val());
-							} else {
-								datetimepicker.data('xdsoft_datetime').setCurrentTime($(this).val());
-							}
-
-							datetimepicker.trigger('changedatetime.xdsoft');
-						});
-				}
-				options.dayOfWeekStartPrev = (options.dayOfWeekStart === 0) ? 6 : options.dayOfWeekStart - 1;
-
-				datetimepicker
-					.trigger('xchange.xdsoft')
-					.trigger('afterOpen.xdsoft');
-			};
-
-			datetimepicker
-				.data('options', options)
-				.on('mousedown.xdsoft', function (event) {
-					event.stopPropagation();
-					event.preventDefault();
-					yearselect.hide();
-					monthselect.hide();
-					return false;
-				});
-
-			//scroll_element = timepicker.find('.xdsoft_time_box');
-			timeboxparent.append(timebox);
-			timeboxparent.xdsoftScroller();
-
-			datetimepicker.on('afterOpen.xdsoft', function () {
-				timeboxparent.xdsoftScroller();
-			});
-
-			datetimepicker
-				.append(datepicker)
-				.append(timepicker);
-
-			if (options.withoutCopyright !== true) {
-				datetimepicker
-					.append(xdsoft_copyright);
-			}
-
-			datepicker
-				.append(mounth_picker)
-				.append(calendar)
-				.append(applyButton);
-
-			$(options.parentID)
-				.append(datetimepicker);
-
-			XDSoft_datetime = function () {
-				var _this = this;
-				_this.now = function (norecursion) {
-					var d = new Date(),
-						date,
-						time;
-
-					if (!norecursion && options.defaultDate) {
-						date = _this.strToDateTime(options.defaultDate);
-						d.setFullYear(date.getFullYear());
-						d.setMonth(date.getMonth());
-						d.setDate(date.getDate());
-					}
-
-					if (options.yearOffset) {
-						d.setFullYear(d.getFullYear() + options.yearOffset);
-					}
-
-					if (!norecursion && options.defaultTime) {
-						time = _this.strtotime(options.defaultTime);
-						d.setHours(time.getHours());
-						d.setMinutes(time.getMinutes());
-					}
-					return d;
-				};
-
-				_this.isValidDate = function (d) {
-					if (Object.prototype.toString.call(d) !== "[object Date]") {
-						return false;
-					}
-					return !isNaN(d.getTime());
-				};
-
-				_this.setCurrentTime = function (dTime) {
-					_this.currentTime = (typeof dTime === 'string') ? _this.strToDateTime(dTime) : _this.isValidDate(dTime) ? dTime : _this.now();
-					datetimepicker.trigger('xchange.xdsoft');
-				};
-
-				_this.empty = function () {
-					_this.currentTime = null;
-				};
-
-				_this.getCurrentTime = function (dTime) {
-					return _this.currentTime;
-				};
-
-				_this.nextMonth = function () {
-
-					if (_this.currentTime === undefined || _this.currentTime === null) {
-						_this.currentTime = _this.now();
-					}
-
-					var month = _this.currentTime.getMonth() + 1,
-						year;
-					if (month === 12) {
-						_this.currentTime.setFullYear(_this.currentTime.getFullYear() + 1);
-						month = 0;
-					}
-
-					year = _this.currentTime.getFullYear();
-
-					_this.currentTime.setDate(
-						Math.min(
-							new Date(_this.currentTime.getFullYear(), month + 1, 0).getDate(),
-							_this.currentTime.getDate()
-						)
-					);
-					_this.currentTime.setMonth(month);
-
-					if (options.onChangeMonth && $.isFunction(options.onChangeMonth)) {
-						options.onChangeMonth.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
-					}
-
-					if (year !== _this.currentTime.getFullYear() && $.isFunction(options.onChangeYear)) {
-						options.onChangeYear.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
-					}
-
-					datetimepicker.trigger('xchange.xdsoft');
-					return month;
-				};
-
-				_this.prevMonth = function () {
-
-					if (_this.currentTime === undefined || _this.currentTime === null) {
-						_this.currentTime = _this.now();
-					}
-
-					var month = _this.currentTime.getMonth() - 1;
-					if (month === -1) {
-						_this.currentTime.setFullYear(_this.currentTime.getFullYear() - 1);
-						month = 11;
-					}
-					_this.currentTime.setDate(
-						Math.min(
-							new Date(_this.currentTime.getFullYear(), month + 1, 0).getDate(),
-							_this.currentTime.getDate()
-						)
-					);
-					_this.currentTime.setMonth(month);
-					if (options.onChangeMonth && $.isFunction(options.onChangeMonth)) {
-						options.onChangeMonth.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
-					}
-					datetimepicker.trigger('xchange.xdsoft');
-					return month;
-				};
-
-				_this.getWeekOfYear = function (datetime) {
-					var onejan = new Date(datetime.getFullYear(), 0, 1);
-					return Math.ceil((((datetime - onejan) / 86400000) + onejan.getDay() + 1) / 7);
-				};
-
-				_this.strToDateTime = function (sDateTime) {
-					var tmpDate = [], timeOffset, currentTime;
-
-					if (sDateTime && sDateTime instanceof Date && _this.isValidDate(sDateTime)) {
-						return sDateTime;
-					}
-
-					tmpDate = /^(\+|\-)(.*)$/.exec(sDateTime);
-					if (tmpDate) {
-						tmpDate[2] = Date.parseDate(tmpDate[2], options.formatDate);
-					}
-					if (tmpDate  && tmpDate[2]) {
-						timeOffset = tmpDate[2].getTime() - (tmpDate[2].getTimezoneOffset()) * 60000;
-						currentTime = new Date((_this.now(true)).getTime() + parseInt(tmpDate[1] + '1', 10) * timeOffset);
-					} else {
-						currentTime = sDateTime ? Date.parseDate(sDateTime, options.format) : _this.now();
-					}
-
-					if (!_this.isValidDate(currentTime)) {
-						currentTime = _this.now();
-					}
-
-					return currentTime;
-				};
-
-				_this.strToDate = function (sDate) {
-					if (sDate && sDate instanceof Date && _this.isValidDate(sDate)) {
-						return sDate;
-					}
-
-					var currentTime = sDate ? Date.parseDate(sDate, options.formatDate) : _this.now(true);
-					if (!_this.isValidDate(currentTime)) {
-						currentTime = _this.now(true);
-					}
-					return currentTime;
-				};
-
-				_this.strtotime = function (sTime) {
-					if (sTime && sTime instanceof Date && _this.isValidDate(sTime)) {
-						return sTime;
-					}
-					var currentTime = sTime ? Date.parseDate(sTime, options.formatTime) : _this.now(true);
-					if (!_this.isValidDate(currentTime)) {
-						currentTime = _this.now(true);
-					}
-					return currentTime;
-				};
-
-				_this.str = function () {
-					return _this.currentTime.dateFormat(options.format);
-				};
-				_this.currentTime = this.now();
-			};
-
-			_xdsoft_datetime = new XDSoft_datetime();
-
-			applyButton.on('click', function (e) {//pathbrite
-				e.preventDefault();
-				datetimepicker.data('changed', true);
-				_xdsoft_datetime.setCurrentTime(getCurrentValue());
-				input.val(_xdsoft_datetime.str());
-				datetimepicker.trigger('close.xdsoft');
-			});
-			mounth_picker
-				.find('.xdsoft_today_button')
-				.on('mousedown.xdsoft', function () {
-					datetimepicker.data('changed', true);
-					_xdsoft_datetime.setCurrentTime(0);
-					datetimepicker.trigger('afterOpen.xdsoft');
-				}).on('dblclick.xdsoft', function () {
-					var currentDate = _xdsoft_datetime.getCurrentTime(), minDate, maxDate;
-					currentDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate());
-					minDate = _xdsoft_datetime.strToDate(options.minDate);
-					minDate = new Date(minDate.getFullYear(), minDate.getMonth(), minDate.getDate());
-					if (currentDate < minDate) {
-						return;
-					}
-					maxDate = _xdsoft_datetime.strToDate(options.maxDate);
-					maxDate = new Date(maxDate.getFullYear(), maxDate.getMonth(), maxDate.getDate());
-					if (currentDate > maxDate) {
-						return;
-					}
-					input.val(_xdsoft_datetime.str());
-					input.trigger('change');
-					datetimepicker.trigger('close.xdsoft');
-				});
-			mounth_picker
-				.find('.xdsoft_prev,.xdsoft_next')
-				.on('mousedown.xdsoft', function () {
-					var $this = $(this),
-						timer = 0,
-						stop = false;
-
-					(function arguments_callee1(v) {
-						if ($this.hasClass(options.next)) {
-							_xdsoft_datetime.nextMonth();
-						} else if ($this.hasClass(options.prev)) {
-							_xdsoft_datetime.prevMonth();
-						}
-						if (options.monthChangeSpinner) {
-							if (!stop) {
-								timer = setTimeout(arguments_callee1, v || 100);
-							}
-						}
-					}(500));
-
-					$([document.body, window]).on('mouseup.xdsoft', function arguments_callee2() {
-						clearTimeout(timer);
-						stop = true;
-						$([document.body, window]).off('mouseup.xdsoft', arguments_callee2);
-					});
-				});
-
-			timepicker
-				.find('.xdsoft_prev,.xdsoft_next')
-				.on('mousedown.xdsoft', function () {
-					var $this = $(this),
-						timer = 0,
-						stop = false,
-						period = 110;
-					(function arguments_callee4(v) {
-						var pheight = timeboxparent[0].clientHeight,
-							height = timebox[0].offsetHeight,
-							top = Math.abs(parseInt(timebox.css('marginTop'), 10));
-						if ($this.hasClass(options.next) && (height - pheight) - options.timeHeightInTimePicker >= top) {
-							timebox.css('marginTop', '-' + (top + options.timeHeightInTimePicker) + 'px');
-						} else if ($this.hasClass(options.prev) && top - options.timeHeightInTimePicker >= 0) {
-							timebox.css('marginTop', '-' + (top - options.timeHeightInTimePicker) + 'px');
-						}
-						timeboxparent.trigger('scroll_element.xdsoft_scroller', [Math.abs(parseInt(timebox.css('marginTop'), 10) / (height - pheight))]);
-						period = (period > 10) ? 10 : period - 10;
-						if (!stop) {
-							timer = setTimeout(arguments_callee4, v || period);
-						}
-					}(500));
-					$([document.body, window]).on('mouseup.xdsoft', function arguments_callee5() {
-						clearTimeout(timer);
-						stop = true;
-						$([document.body, window])
-							.off('mouseup.xdsoft', arguments_callee5);
-					});
-				});
-
-			xchangeTimer = 0;
-			// base handler - generating a calendar and timepicker
-			datetimepicker
-				.on('xchange.xdsoft', function (event) {
-					clearTimeout(xchangeTimer);
-					xchangeTimer = setTimeout(function () {
-
-						if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
-							_xdsoft_datetime.currentTime = _xdsoft_datetime.now();
-						}
-
-						var table =	'',
-							start = new Date(_xdsoft_datetime.currentTime.getFullYear(), _xdsoft_datetime.currentTime.getMonth(), 1, 12, 0, 0),
-							i = 0,
-							j,
-							today = _xdsoft_datetime.now(),
-							maxDate = false,
-							minDate = false,
-							hDate,
-							day,
-							d,
-							y,
-							m,
-							w,
-							classes = [],
-							customDateSettings,
-							newRow = true,
-							time = '',
-							h = '',
-							line_time,
-							description;
-
-						while (start.getDay() !== options.dayOfWeekStart) {
-							start.setDate(start.getDate() - 1);
-						}
-
-						table += '<table><thead><tr>';
-
-						if (options.weeks) {
-							table += '<th></th>';
-						}
-
-						for (j = 0; j < 7; j += 1) {
-							table += '<th>' + options.i18n[options.lang].dayOfWeek[(j + options.dayOfWeekStart) % 7] + '</th>';
-						}
-
-						table += '</tr></thead>';
-						table += '<tbody>';
-
-						if (options.maxDate !== false) {
-							maxDate = _xdsoft_datetime.strToDate(options.maxDate);
-							maxDate = new Date(maxDate.getFullYear(), maxDate.getMonth(), maxDate.getDate(), 23, 59, 59, 999);
-						}
-
-						if (options.minDate !== false) {
-							minDate = _xdsoft_datetime.strToDate(options.minDate);
-							minDate = new Date(minDate.getFullYear(), minDate.getMonth(), minDate.getDate());
-						}
-
-						while (i < _xdsoft_datetime.currentTime.countDaysInMonth() || start.getDay() !== options.dayOfWeekStart || _xdsoft_datetime.currentTime.getMonth() === start.getMonth()) {
-							classes = [];
-							i += 1;
-
-							day = start.getDay();
-							d = start.getDate();
-							y = start.getFullYear();
-							m = start.getMonth();
-							w = _xdsoft_datetime.getWeekOfYear(start);
-							description = '';
-
-							classes.push('xdsoft_date');
-
-							if (options.beforeShowDay && $.isFunction(options.beforeShowDay.call)) {
-								customDateSettings = options.beforeShowDay.call(datetimepicker, start);
-							} else {
-								customDateSettings = null;
-							}
-
-							if ((maxDate !== false && start > maxDate) || (minDate !== false && start < minDate) || (customDateSettings && customDateSettings[0] === false)) {
-								classes.push('xdsoft_disabled');
-							} else if (options.disabledDates.indexOf(start.dateFormat(options.formatDate)) !== -1) {
-								classes.push('xdsoft_disabled');
-							} else if (options.disabledWeekDays.indexOf(day) !== -1) {
-								classes.push('xdsoft_disabled');
-							}
-
-							if (customDateSettings && customDateSettings[1] !== "") {
-								classes.push(customDateSettings[1]);
-							}
-
-							if (_xdsoft_datetime.currentTime.getMonth() !== m) {
-								classes.push('xdsoft_other_month');
-							}
-
-							if ((options.defaultSelect || datetimepicker.data('changed')) && _xdsoft_datetime.currentTime.dateFormat(options.formatDate) === start.dateFormat(options.formatDate)) {
-								classes.push('xdsoft_current');
-							}
-
-							if (today.dateFormat(options.formatDate) === start.dateFormat(options.formatDate)) {
-								classes.push('xdsoft_today');
-							}
-
-							if (start.getDay() === 0 || start.getDay() === 6 || options.weekends.indexOf(start.dateFormat(options.formatDate)) !== -1) {
-								classes.push('xdsoft_weekend');
-							}
-
-							if (options.highlightedDates[start.dateFormat(options.formatDate)] !== undefined) {
-								hDate = options.highlightedDates[start.dateFormat(options.formatDate)];
-								classes.push(hDate.style === undefined ? 'xdsoft_highlighted_default' : hDate.style);
-								description = hDate.desc === undefined ? '' : hDate.desc;
-							}
-
-							if (options.beforeShowDay && $.isFunction(options.beforeShowDay)) {
-								classes.push(options.beforeShowDay(start));
-							}
-
-							if (newRow) {
-								table += '<tr>';
-								newRow = false;
-								if (options.weeks) {
-									table += '<th>' + w + '</th>';
-								}
-							}
-
-							table += '<td data-date="' + d + '" data-month="' + m + '" data-year="' + y + '"' + ' class="xdsoft_date xdsoft_day_of_week' + start.getDay() + ' ' + classes.join(' ') + '" title="' + description + '">' +
-								'<div>' + d + '</div>' +
-								'</td>';
-
-							if (start.getDay() === options.dayOfWeekStartPrev) {
-								table += '</tr>';
-								newRow = true;
-							}
-
-							start.setDate(d + 1);
-						}
-						table += '</tbody></table>';
-
-						calendar.html(table);
-
-						mounth_picker.find('.xdsoft_label span').eq(0).text(options.i18n[options.lang].months[_xdsoft_datetime.currentTime.getMonth()]);
-						mounth_picker.find('.xdsoft_label span').eq(1).text(_xdsoft_datetime.currentTime.getFullYear());
-
-						// generate timebox
-						time = '';
-						h = '';
-						m = '';
-						line_time = function line_time(h, m) {
-							var now = _xdsoft_datetime.now(), optionDateTime, current_time;
-							now.setHours(h);
-							h = parseInt(now.getHours(), 10);
-							now.setMinutes(m);
-							m = parseInt(now.getMinutes(), 10);
-							optionDateTime = new Date(_xdsoft_datetime.currentTime);
-							optionDateTime.setHours(h);
-							optionDateTime.setMinutes(m);
-							classes = [];
-							if ((options.minDateTime !== false && options.minDateTime > optionDateTime) || (options.maxTime !== false && _xdsoft_datetime.strtotime(options.maxTime).getTime() < now.getTime()) || (options.minTime !== false && _xdsoft_datetime.strtotime(options.minTime).getTime() > now.getTime())) {
-								classes.push('xdsoft_disabled');
-							}
-							if ((options.minDateTime !== false && options.minDateTime > optionDateTime) || ((options.disabledMinTime !== false && now.getTime() > _xdsoft_datetime.strtotime(options.disabledMinTime).getTime()) && (options.disabledMaxTime !== false && now.getTime() < _xdsoft_datetime.strtotime(options.disabledMaxTime).getTime()))) {
-								classes.push('xdsoft_disabled');
-							}
-
-							current_time = new Date(_xdsoft_datetime.currentTime);
-							current_time.setHours(parseInt(_xdsoft_datetime.currentTime.getHours(), 10));
-							current_time.setMinutes(Math[options.roundTime](_xdsoft_datetime.currentTime.getMinutes() / options.step) * options.step);
-
-							if ((options.initTime || options.defaultSelect || datetimepicker.data('changed')) && current_time.getHours() === parseInt(h, 10) && (options.step > 59 || current_time.getMinutes() === parseInt(m, 10))) {
-								if (options.defaultSelect || datetimepicker.data('changed')) {
-									classes.push('xdsoft_current');
-								} else if (options.initTime) {
-									classes.push('xdsoft_init_time');
-								}
-							}
-							if (parseInt(today.getHours(), 10) === parseInt(h, 10) && parseInt(today.getMinutes(), 10) === parseInt(m, 10)) {
-								classes.push('xdsoft_today');
-							}
-							time += '<div class="xdsoft_time ' + classes.join(' ') + '" data-hour="' + h + '" data-minute="' + m + '">' + now.dateFormat(options.formatTime) + '</div>';
-						};
-
-						if (!options.allowTimes || !$.isArray(options.allowTimes) || !options.allowTimes.length) {
-							for (i = 0, j = 0; i < (options.hours12 ? 12 : 24); i += 1) {
-								for (j = 0; j < 60; j += options.step) {
-									h = (i < 10 ? '0' : '') + i;
-									m = (j < 10 ? '0' : '') + j;
-									line_time(h, m);
-								}
-							}
-						} else {
-							for (i = 0; i < options.allowTimes.length; i += 1) {
-								h = _xdsoft_datetime.strtotime(options.allowTimes[i]).getHours();
-								m = _xdsoft_datetime.strtotime(options.allowTimes[i]).getMinutes();
-								line_time(h, m);
-							}
-						}
-
-						timebox.html(time);
-
-						opt = '';
-						i = 0;
-
-						for (i = parseInt(options.yearStart, 10) + options.yearOffset; i <= parseInt(options.yearEnd, 10) + options.yearOffset; i += 1) {
-							opt += '<div class="xdsoft_option ' + (_xdsoft_datetime.currentTime.getFullYear() === i ? 'xdsoft_current' : '') + '" data-value="' + i + '">' + i + '</div>';
-						}
-						yearselect.children().eq(0)
-							.html(opt);
-
-						for (i = parseInt(options.monthStart, 10), opt = ''; i <= parseInt(options.monthEnd, 10); i += 1) {
-							opt += '<div class="xdsoft_option ' + (_xdsoft_datetime.currentTime.getMonth() === i ? 'xdsoft_current' : '') + '" data-value="' + i + '">' + options.i18n[options.lang].months[i] + '</div>';
-						}
-						monthselect.children().eq(0).html(opt);
-						$(datetimepicker)
-							.trigger('generate.xdsoft');
-					}, 10);
-					event.stopPropagation();
-				})
-				.on('afterOpen.xdsoft', function () {
-					if (options.timepicker) {
-						var classType, pheight, height, top;
-						if (timebox.find('.xdsoft_current').length) {
-							classType = '.xdsoft_current';
-						} else if (timebox.find('.xdsoft_init_time').length) {
-							classType = '.xdsoft_init_time';
-						}
-						if (classType) {
-							pheight = timeboxparent[0].clientHeight;
-							height = timebox[0].offsetHeight;
-							top = timebox.find(classType).index() * options.timeHeightInTimePicker + 1;
-							if ((height - pheight) < top) {
-								top = height - pheight;
-							}
-							timeboxparent.trigger('scroll_element.xdsoft_scroller', [parseInt(top, 10) / (height - pheight)]);
-						} else {
-							timeboxparent.trigger('scroll_element.xdsoft_scroller', [0]);
-						}
-					}
-				});
-
-			timerclick = 0;
-			calendar
-				.on('click.xdsoft', 'td', function (xdevent) {
-					xdevent.stopPropagation();  // Prevents closing of Pop-ups, Modals and Flyouts in Bootstrap
-					timerclick += 1;
-					var $this = $(this),
-						currentTime = _xdsoft_datetime.currentTime;
-
-					if (currentTime === undefined || currentTime === null) {
-						_xdsoft_datetime.currentTime = _xdsoft_datetime.now();
-						currentTime = _xdsoft_datetime.currentTime;
-					}
-
-					if ($this.hasClass('xdsoft_disabled')) {
-						return false;
-					}
-
-					currentTime.setDate(1);
-					currentTime.setFullYear($this.data('year'));
-					currentTime.setMonth($this.data('month'));
-					currentTime.setDate($this.data('date'));
-
-					datetimepicker.trigger('select.xdsoft', [currentTime]);
-
-					input.val(_xdsoft_datetime.str());
-					if ((timerclick > 1 || (options.closeOnDateSelect === true || (options.closeOnDateSelect === false && !options.timepicker))) && !options.inline) {
-						datetimepicker.trigger('close.xdsoft');
-					}
-
-					if (options.onSelectDate &&	$.isFunction(options.onSelectDate)) {
-						options.onSelectDate.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'), xdevent);
-					}
-
-					datetimepicker.data('changed', true);
-					datetimepicker.trigger('xchange.xdsoft');
-					datetimepicker.trigger('changedatetime.xdsoft');
-					setTimeout(function () {
-						timerclick = 0;
-					}, 200);
-				});
-
-			timebox
-				.on('click.xdsoft', 'div', function (xdevent) {
-					xdevent.stopPropagation();
-					var $this = $(this),
-						currentTime = _xdsoft_datetime.currentTime;
-
-					if (currentTime === undefined || currentTime === null) {
-						_xdsoft_datetime.currentTime = _xdsoft_datetime.now();
-						currentTime = _xdsoft_datetime.currentTime;
-					}
-
-					if ($this.hasClass('xdsoft_disabled')) {
-						return false;
-					}
-					currentTime.setHours($this.data('hour'));
-					currentTime.setMinutes($this.data('minute'));
-					datetimepicker.trigger('select.xdsoft', [currentTime]);
-
-					datetimepicker.data('input').val(_xdsoft_datetime.str());
-
-					if (options.inline !== true && options.closeOnTimeSelect === true) {
-						datetimepicker.trigger('close.xdsoft');
-					}
-
-					if (options.onSelectTime && $.isFunction(options.onSelectTime)) {
-						options.onSelectTime.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'), xdevent);
-					}
-					datetimepicker.data('changed', true);
-					datetimepicker.trigger('xchange.xdsoft');
-					datetimepicker.trigger('changedatetime.xdsoft');
-				});
-
-
-			datepicker
-				.on('mousewheel.xdsoft', function (event) {
-					if (!options.scrollMonth) {
-						return true;
-					}
-					if (event.deltaY < 0) {
-						_xdsoft_datetime.nextMonth();
-					} else {
-						_xdsoft_datetime.prevMonth();
-					}
-					return false;
-				});
-
-			input
-				.on('mousewheel.xdsoft', function (event) {
-					if (!options.scrollInput) {
-						return true;
-					}
-					if (!options.datepicker && options.timepicker) {
-						current_time_index = timebox.find('.xdsoft_current').length ? timebox.find('.xdsoft_current').eq(0).index() : 0;
-						if (current_time_index + event.deltaY >= 0 && current_time_index + event.deltaY < timebox.children().length) {
-							current_time_index += event.deltaY;
-						}
-						if (timebox.children().eq(current_time_index).length) {
-							timebox.children().eq(current_time_index).trigger('mousedown');
-						}
-						return false;
-					}
-					if (options.datepicker && !options.timepicker) {
-						datepicker.trigger(event, [event.deltaY, event.deltaX, event.deltaY]);
-						if (input.val) {
-							input.val(_xdsoft_datetime.str());
-						}
-						datetimepicker.trigger('changedatetime.xdsoft');
-						return false;
-					}
-				});
-
-			datetimepicker
-				.on('changedatetime.xdsoft', function (event) {
-					if (options.onChangeDateTime && $.isFunction(options.onChangeDateTime)) {
-						var $input = datetimepicker.data('input');
-						options.onChangeDateTime.call(datetimepicker, _xdsoft_datetime.currentTime, $input, event);
-						delete options.value;
-						$input.trigger('change');
-					}
-				})
-				.on('generate.xdsoft', function () {
-					if (options.onGenerate && $.isFunction(options.onGenerate)) {
-						options.onGenerate.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
-					}
-					if (triggerAfterOpen) {
-						datetimepicker.trigger('afterOpen.xdsoft');
-						triggerAfterOpen = false;
-					}
-				})
-				.on('click.xdsoft', function (xdevent) {
-					xdevent.stopPropagation();
-				});
-
-			current_time_index = 0;
-
-			setPos = function () {
-				var offset = datetimepicker.data('input').offset(), top = offset.top + datetimepicker.data('input')[0].offsetHeight - 1, left = offset.left, position = "absolute", node;
-				if (datetimepicker.data('input').parent().css('direction') == 'rtl')
-					left -= (datetimepicker.outerWidth() - datetimepicker.data('input').outerWidth());
-				if (options.fixed) {
-					top -= $(window).scrollTop();
-					left -= $(window).scrollLeft();
-					position = "fixed";
-				} else {
-					if (top + datetimepicker[0].offsetHeight > $(window).height() + $(window).scrollTop()) {
-						top = offset.top - datetimepicker[0].offsetHeight + 1;
-					}
-					if (top < 0) {
-						top = 0;
-					}
-					if (left + datetimepicker[0].offsetWidth > $(window).width()) {
-						left = $(window).width() - datetimepicker[0].offsetWidth;
-					}
-				}
-
-				node = datetimepicker[0];
-				do {
-					node = node.parentNode;
-					if (window.getComputedStyle(node).getPropertyValue('position') === 'relative' && $(window).width() >= node.offsetWidth) {
-						left = left - (($(window).width() - node.offsetWidth) / 2);
-						break;
-					}
-				} while (node.nodeName !== 'HTML');
-				datetimepicker.css({
-					left: left,
-					top: top,
-					position: position
-				});
-			};
-			datetimepicker
-				.on('open.xdsoft', function (event) {
-					var onShow = true;
-					if (options.onShow && $.isFunction(options.onShow)) {
-						onShow = options.onShow.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'), event);
-					}
-					if (onShow !== false) {
-						datetimepicker.show();
-						setPos();
-						$(window)
-							.off('resize.xdsoft', setPos)
-							.on('resize.xdsoft', setPos);
-
-						if (options.closeOnWithoutClick) {
-							$([document.body, window]).on('mousedown.xdsoft', function arguments_callee6() {
-								datetimepicker.trigger('close.xdsoft');
-								$([document.body, window]).off('mousedown.xdsoft', arguments_callee6);
-							});
-						}
-					}
-				})
-				.on('close.xdsoft', function (event) {
-					var onClose = true;
-					mounth_picker
-						.find('.xdsoft_month,.xdsoft_year')
-						.find('.xdsoft_select')
-						.hide();
-					if (options.onClose && $.isFunction(options.onClose)) {
-						onClose = options.onClose.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'), event);
-					}
-					if (onClose !== false && !options.opened && !options.inline) {
-						datetimepicker.hide();
-					}
-					event.stopPropagation();
-				})
-				.on('toggle.xdsoft', function (event) {
-					if (datetimepicker.is(':visible')) {
-						datetimepicker.trigger('close.xdsoft');
-					} else {
-						datetimepicker.trigger('open.xdsoft');
-					}
-				})
-				.data('input', input);
-
-			timer = 0;
-			timer1 = 0;
-
-			datetimepicker.data('xdsoft_datetime', _xdsoft_datetime);
-			datetimepicker.setOptions(options);
-
-			function getCurrentValue() {
-				var ct = false, time;
-
-				if (options.startDate) {
-					ct = _xdsoft_datetime.strToDate(options.startDate);
-				} else {
-					ct = options.value || ((input && input.val && input.val()) ? input.val() : '');
-					if (ct) {
-						ct = _xdsoft_datetime.strToDateTime(ct);
-					} else if (options.defaultDate) {
-						ct = _xdsoft_datetime.strToDateTime(options.defaultDate);
-						if (options.defaultTime) {
-							time = _xdsoft_datetime.strtotime(options.defaultTime);
-							ct.setHours(time.getHours());
-							ct.setMinutes(time.getMinutes());
-						}
-					}
-				}
-
-				if (ct && _xdsoft_datetime.isValidDate(ct)) {
-					datetimepicker.data('changed', true);
-				} else {
-					ct = '';
-				}
-
-				return ct || 0;
-			}
-
-			_xdsoft_datetime.setCurrentTime(getCurrentValue());
-
-			input
-				.data('xdsoft_datetimepicker', datetimepicker)
-				.on('open.xdsoft focusin.xdsoft mousedown.xdsoft', function (event) {
-					if (input.is(':disabled') || (input.data('xdsoft_datetimepicker').is(':visible') && options.closeOnInputClick)) {
-						return;
-					}
-					clearTimeout(timer);
-					timer = setTimeout(function () {
-						if (input.is(':disabled')) {
-							return;
-						}
-
-						triggerAfterOpen = true;
-						_xdsoft_datetime.setCurrentTime(getCurrentValue());
-
-						datetimepicker.trigger('open.xdsoft');
-					}, 100);
-				})
-				.on('keydown.xdsoft', function (event) {
-					var val = this.value, elementSelector,
-						key = event.which;
-					if ([ENTER].indexOf(key) !== -1 && options.enterLikeTab) {
-						elementSelector = $("input:visible,textarea:visible");
-						datetimepicker.trigger('close.xdsoft');
-						elementSelector.eq(elementSelector.index(this) + 1).focus();
-						return false;
-					}
-					if ([TAB].indexOf(key) !== -1) {
-						datetimepicker.trigger('close.xdsoft');
-						return true;
-					}
-				});
-		};
-		destroyDateTimePicker = function (input) {
-			var datetimepicker = input.data('xdsoft_datetimepicker');
-			if (datetimepicker) {
-				datetimepicker.data('xdsoft_datetime', null);
-				datetimepicker.remove();
-				input
-					.data('xdsoft_datetimepicker', null)
-					.off('.xdsoft');
-				$(window).off('resize.xdsoft');
-				$([window, document.body]).off('mousedown.xdsoft');
-				if (input.unmousewheel) {
-					input.unmousewheel();
-				}
-			}
-		};
-		$(document)
-			.off('keydown.xdsoftctrl keyup.xdsoftctrl')
-			.on('keydown.xdsoftctrl', function (e) {
-				if (e.keyCode === CTRLKEY) {
-					ctrlDown = true;
-				}
-			})
-			.on('keyup.xdsoftctrl', function (e) {
-				if (e.keyCode === CTRLKEY) {
-					ctrlDown = false;
-				}
-			});
-		return this.each(function () {
-			var datetimepicker = $(this).data('xdsoft_datetimepicker'), $input;
-			if (datetimepicker) {
-				if ($.type(opt) === 'string') {
-					switch (opt) {
-						case 'show':
-							$(this).select().focus();
-							datetimepicker.trigger('open.xdsoft');
-							break;
-						case 'hide':
-							datetimepicker.trigger('close.xdsoft');
-							break;
-						case 'toggle':
-							datetimepicker.trigger('toggle.xdsoft');
-							break;
-						case 'destroy':
-							destroyDateTimePicker($(this));
-							break;
-						case 'reset':
-							this.value = this.defaultValue;
-							if (!this.value || !datetimepicker.data('xdsoft_datetime').isValidDate(Date.parseDate(this.value, options.format))) {
-								datetimepicker.data('changed', false);
-							}
-							datetimepicker.data('xdsoft_datetime').setCurrentTime(this.value);
-							break;
-						case 'validate':
-							$input = datetimepicker.data('input');
-							$input.trigger('blur.xdsoft');
-							break;
-					}
-				} else {
-					datetimepicker
-						.setOptions(opt);
-				}
-				return 0;
-			}
-			if ($.type(opt) !== 'string') {
-				if (!options.lazyInit || options.open || options.inline) {
-					createDateTimePicker($(this));
-				} else {
-					lazyInit($(this));
-				}
-			}
-		});
-	};
-	$.fn.datetimepicker.defaults = default_options;
-}(jQuery));
-
-function HighlightedDate(date, desc, style) {
-	"use strict";
-	this.date = date;
-	this.desc = desc;
-	this.style = style;
-}
-
-(function () {
-
-	/*! Copyright (c) 2013 Brandon Aaron (http://brandon.aaron.sh)
-	 * Licensed under the MIT License (LICENSE.txt).
-	 *
-	 * Version: 3.1.12
-	 *
-	 * Requires: jQuery 1.2.2+
-	 */
-	!function(a){"function"==typeof define&&define.amd?define(["jquery"],a):"object"==typeof exports?module.exports=a:a(jQuery)}(function(a){function b(b){var g=b||window.event,h=i.call(arguments,1),j=0,l=0,m=0,n=0,o=0,p=0;if(b=a.event.fix(g),b.type="mousewheel","detail"in g&&(m=-1*g.detail),"wheelDelta"in g&&(m=g.wheelDelta),"wheelDeltaY"in g&&(m=g.wheelDeltaY),"wheelDeltaX"in g&&(l=-1*g.wheelDeltaX),"axis"in g&&g.axis===g.HORIZONTAL_AXIS&&(l=-1*m,m=0),j=0===m?l:m,"deltaY"in g&&(m=-1*g.deltaY,j=m),"deltaX"in g&&(l=g.deltaX,0===m&&(j=-1*l)),0!==m||0!==l){if(1===g.deltaMode){var q=a.data(this,"mousewheel-line-height");j*=q,m*=q,l*=q}else if(2===g.deltaMode){var r=a.data(this,"mousewheel-page-height");j*=r,m*=r,l*=r}if(n=Math.max(Math.abs(m),Math.abs(l)),(!f||f>n)&&(f=n,d(g,n)&&(f/=40)),d(g,n)&&(j/=40,l/=40,m/=40),j=Math[j>=1?"floor":"ceil"](j/f),l=Math[l>=1?"floor":"ceil"](l/f),m=Math[m>=1?"floor":"ceil"](m/f),k.settings.normalizeOffset&&this.getBoundingClientRect){var s=this.getBoundingClientRect();o=b.clientX-s.left,p=b.clientY-s.top}return b.deltaX=l,b.deltaY=m,b.deltaFactor=f,b.offsetX=o,b.offsetY=p,b.deltaMode=0,h.unshift(b,j,l,m),e&&clearTimeout(e),e=setTimeout(c,200),(a.event.dispatch||a.event.handle).apply(this,h)}}function c(){f=null}function d(a,b){return k.settings.adjustOldDeltas&&"mousewheel"===a.type&&b%120===0}var e,f,g=["wheel","mousewheel","DOMMouseScroll","MozMousePixelScroll"],h="onwheel"in document||document.documentMode>=9?["wheel"]:["mousewheel","DomMouseScroll","MozMousePixelScroll"],i=Array.prototype.slice;if(a.event.fixHooks)for(var j=g.length;j;)a.event.fixHooks[g[--j]]=a.event.mouseHooks;var k=a.event.special.mousewheel={version:"3.1.12",setup:function(){if(this.addEventListener)for(var c=h.length;c;)this.addEventListener(h[--c],b,!1);else this.onmousewheel=b;a.data(this,"mousewheel-line-height",k.getLineHeight(this)),a.data(this,"mousewheel-page-height",k.getPageHeight(this))},teardown:function(){if(this.removeEventListener)for(var c=h.length;c;)this.removeEventListener(h[--c],b,!1);else this.onmousewheel=null;a.removeData(this,"mousewheel-line-height"),a.removeData(this,"mousewheel-page-height")},getLineHeight:function(b){var c=a(b),d=c["offsetParent"in a.fn?"offsetParent":"parent"]();return d.length||(d=a("body")),parseInt(d.css("fontSize"),10)||parseInt(c.css("fontSize"),10)||16},getPageHeight:function(b){return a(b).height()},settings:{adjustOldDeltas:!0,normalizeOffset:!0}};a.fn.extend({mousewheel:function(a){return a?this.bind("mousewheel",a):this.trigger("mousewheel")},unmousewheel:function(a){return this.unbind("mousewheel",a)}})});
-
-// Parse and Format Library
-//http://www.xaprb.com/blog/2005/12/12/javascript-closures-for-runtime-efficiency/
-	/*
-	 * Copyright (C) 2004 Baron Schwartz <baron at sequent dot org>
-	 *
-	 * This program is free software; you can redistribute it and/or modify it
-	 * under the terms of the GNU Lesser General Public License as published by the
-	 * Free Software Foundation, version 2.1.
-	 *
-	 * This program is distributed in the hope that it will be useful, but WITHOUT
-	 * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-	 * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
-	 * details.
-	 */
-	Date.parseFunctions={count:0};Date.parseRegexes=[];Date.formatFunctions={count:0};Date.prototype.dateFormat=function(b){if(b=="unixtime"){return parseInt(this.getTime()/1000);}if(Date.formatFunctions[b]==null){Date.createNewFormat(b);}var a=Date.formatFunctions[b];return this[a]();};Date.createNewFormat=function(format){var funcName="format"+Date.formatFunctions.count++;Date.formatFunctions[format]=funcName;var codePrefix="Date.prototype."+funcName+" = function() {return ";var code="";var special=false;var ch="";for(var i=0;i<format.length;++i){ch=format.charAt(i);if(!special&&ch=="\\"){special=true;}else{if(special){special=false;code+="'"+String.escape(ch)+"' + ";}else{code+=Date.getFormatCode(ch);}}}if(code.length==0){code="\"\"";}else{code=code.substring(0,code.length-3);}eval(codePrefix+code+";}");};Date.getFormatCode=function(a){switch(a){case"d":return"String.leftPad(this.getDate(), 2, '0') + ";case"D":return"Date.dayNames[this.getDay()].substring(0, 3) + ";case"j":return"this.getDate() + ";case"l":return"Date.dayNames[this.getDay()] + ";case"S":return"this.getSuffix() + ";case"w":return"this.getDay() + ";case"z":return"this.getDayOfYear() + ";case"W":return"this.getWeekOfYear() + ";case"F":return"Date.monthNames[this.getMonth()] + ";case"m":return"String.leftPad(this.getMonth() + 1, 2, '0') + ";case"M":return"Date.monthNames[this.getMonth()].substring(0, 3) + ";case"n":return"(this.getMonth() + 1) + ";case"t":return"this.getDaysInMonth() + ";case"L":return"(this.isLeapYear() ? 1 : 0) + ";case"Y":return"this.getFullYear() + ";case"y":return"('' + this.getFullYear()).substring(2, 4) + ";case"a":return"(this.getHours() < 12 ? 'am' : 'pm') + ";case"A":return"(this.getHours() < 12 ? 'AM' : 'PM') + ";case"g":return"((this.getHours() %12) ? this.getHours() % 12 : 12) + ";case"G":return"this.getHours() + ";case"h":return"String.leftPad((this.getHours() %12) ? this.getHours() % 12 : 12, 2, '0') + ";case"H":return"String.leftPad(this.getHours(), 2, '0') + ";case"i":return"String.leftPad(this.getMinutes(), 2, '0') + ";case"s":return"String.leftPad(this.getSeconds(), 2, '0') + ";case"O":return"this.getGMTOffset() + ";case"T":return"this.getTimezone() + ";case"Z":return"(this.getTimezoneOffset() * -60) + ";default:return"'"+String.escape(a)+"' + ";}};Date.parseDate=function(a,c){if(c=="unixtime"){return new Date(!isNaN(parseInt(a))?parseInt(a)*1000:0);}if(Date.parseFunctions[c]==null){Date.createParser(c);}var b=Date.parseFunctions[c];return Date[b](a);};Date.createParser=function(format){var funcName="parse"+Date.parseFunctions.count++;var regexNum=Date.parseRegexes.length;var currentGroup=1;Date.parseFunctions[format]=funcName;var code="Date."+funcName+" = function(input) {\nvar y = -1, m = -1, d = -1, h = -1, i = -1, s = -1, z = -1;\nvar d = new Date();\ny = d.getFullYear();\nm = d.getMonth();\nd = d.getDate();\nvar results = input.match(Date.parseRegexes["+regexNum+"]);\nif (results && results.length > 0) {";var regex="";var special=false;var ch="";for(var i=0;i<format.length;++i){ch=format.charAt(i);if(!special&&ch=="\\"){special=true;}else{if(special){special=false;regex+=String.escape(ch);}else{obj=Date.formatCodeToRegex(ch,currentGroup);currentGroup+=obj.g;regex+=obj.s;if(obj.g&&obj.c){code+=obj.c;}}}}code+="if (y > 0 && z > 0){\nvar doyDate = new Date(y,0);\ndoyDate.setDate(z);\nm = doyDate.getMonth();\nd = doyDate.getDate();\n}";code+="if (y > 0 && m >= 0 && d > 0 && h >= 0 && i >= 0 && s >= 0)\n{return new Date(y, m, d, h, i, s);}\nelse if (y > 0 && m >= 0 && d > 0 && h >= 0 && i >= 0)\n{return new Date(y, m, d, h, i);}\nelse if (y > 0 && m >= 0 && d > 0 && h >= 0)\n{return new Date(y, m, d, h);}\nelse if (y > 0 && m >= 0 && d > 0)\n{return new Date(y, m, d);}\nelse if (y > 0 && m >= 0)\n{return new Date(y, m);}\nelse if (y > 0)\n{return new Date(y);}\n}return null;}";Date.parseRegexes[regexNum]=new RegExp("^"+regex+"$",'i');eval(code);};Date.formatCodeToRegex=function(b,a){switch(b){case"D":return{g:0,c:null,s:"(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)"};case"j":case"d":return{g:1,c:"d = parseInt(results["+a+"], 10);\n",s:"(\\d{1,2})"};case"l":return{g:0,c:null,s:"(?:"+Date.dayNames.join("|")+")"};case"S":return{g:0,c:null,s:"(?:st|nd|rd|th)"};case"w":return{g:0,c:null,s:"\\d"};case"z":return{g:1,c:"z = parseInt(results["+a+"], 10);\n",s:"(\\d{1,3})"};case"W":return{g:0,c:null,s:"(?:\\d{2})"};case"F":return{g:1,c:"m = parseInt(Date.monthNumbers[results["+a+"].substring(0, 3)], 10);\n",s:"("+Date.monthNames.join("|")+")"};case"M":return{g:1,c:"m = parseInt(Date.monthNumbers[results["+a+"]], 10);\n",s:"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"};case"n":case"m":return{g:1,c:"m = parseInt(results["+a+"], 10) - 1;\n",s:"(\\d{1,2})"};case"t":return{g:0,c:null,s:"\\d{1,2}"};case"L":return{g:0,c:null,s:"(?:1|0)"};case"Y":return{g:1,c:"y = parseInt(results["+a+"], 10);\n",s:"(\\d{4})"};case"y":return{g:1,c:"var ty = parseInt(results["+a+"], 10);\ny = ty > Date.y2kYear ? 1900 + ty : 2000 + ty;\n",s:"(\\d{1,2})"};case"a":return{g:1,c:"if (results["+a+"] == 'am') {\nif (h == 12) { h = 0; }\n} else { if (h < 12) { h += 12; }}",s:"(am|pm)"};case"A":return{g:1,c:"if (results["+a+"] == 'AM') {\nif (h == 12) { h = 0; }\n} else { if (h < 12) { h += 12; }}",s:"(AM|PM)"};case"g":case"G":case"h":case"H":return{g:1,c:"h = parseInt(results["+a+"], 10);\n",s:"(\\d{1,2})"};case"i":return{g:1,c:"i = parseInt(results["+a+"], 10);\n",s:"(\\d{2})"};case"s":return{g:1,c:"s = parseInt(results["+a+"], 10);\n",s:"(\\d{2})"};case"O":return{g:0,c:null,s:"[+-]\\d{4}"};case"T":return{g:0,c:null,s:"[A-Z]{3}"};case"Z":return{g:0,c:null,s:"[+-]\\d{1,5}"};default:return{g:0,c:null,s:String.escape(b)};}};Date.prototype.getTimezone=function(){return this.toString().replace(/^.*? ([A-Z]{3}) [0-9]{4}.*$/,"$1").replace(/^.*?\(([A-Z])[a-z]+ ([A-Z])[a-z]+ ([A-Z])[a-z]+\)$/,"$1$2$3");};Date.prototype.getGMTOffset=function(){return(this.getTimezoneOffset()>0?"-":"+")+String.leftPad(Math.floor(Math.abs(this.getTimezoneOffset())/60),2,"0")+String.leftPad(Math.abs(this.getTimezoneOffset())%60,2,"0");};Date.prototype.getDayOfYear=function(){var a=0;Date.daysInMonth[1]=this.isLeapYear()?29:28;for(var b=0;b<this.getMonth();++b){a+=Date.daysInMonth[b];}return a+this.getDate();};Date.prototype.getWeekOfYear=function(){var b=this.getDayOfYear()+(4-this.getDay());var a=new Date(this.getFullYear(),0,1);var c=(7-a.getDay()+4);return String.leftPad(Math.ceil((b-c)/7)+1,2,"0");};Date.prototype.isLeapYear=function(){var a=this.getFullYear();return((a&3)==0&&(a%100||(a%400==0&&a)));};Date.prototype.getFirstDayOfMonth=function(){var a=(this.getDay()-(this.getDate()-1))%7;return(a<0)?(a+7):a;};Date.prototype.getLastDayOfMonth=function(){var a=(this.getDay()+(Date.daysInMonth[this.getMonth()]-this.getDate()))%7;return(a<0)?(a+7):a;};Date.prototype.getDaysInMonth=function(){Date.daysInMonth[1]=this.isLeapYear()?29:28;return Date.daysInMonth[this.getMonth()];};Date.prototype.getSuffix=function(){switch(this.getDate()){case 1:case 21:case 31:return"st";case 2:case 22:return"nd";case 3:case 23:return"rd";default:return"th";}};String.escape=function(a){return a.replace(/('|\\)/g,"\\$1");};String.leftPad=function(d,b,c){var a=new String(d);if(c==null){c=" ";}while(a.length<b){a=c+a;}return a;};Date.daysInMonth=[31,28,31,30,31,30,31,31,30,31,30,31];Date.monthNames=["January","February","March","April","May","June","July","August","September","October","November","December"];Date.dayNames=["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"];Date.y2kYear=50;Date.monthNumbers={Jan:0,Feb:1,Mar:2,Apr:3,May:4,Jun:5,Jul:6,Aug:7,Sep:8,Oct:9,Nov:10,Dec:11};Date.patterns={ISO8601LongPattern:"Y-m-d H:i:s",ISO8601ShortPattern:"Y-m-d",ShortDatePattern:"n/j/Y",LongDatePattern:"l, F d, Y",FullDateTimePattern:"l, F d, Y g:i:s A",MonthDayPattern:"F d",ShortTimePattern:"g:i A",LongTimePattern:"g:i:s A",SortableDateTimePattern:"Y-m-d\\TH:i:s",UniversalSortableDateTimePattern:"Y-m-d H:i:sO",YearMonthPattern:"F, Y"};
-}());
+
+/**
+ * @param {jQuery} $
+ */
+var datetimepickerFactory = function ($) {
+    'use strict';
+
+    var default_options  = {
+        i18n: {
+            ar: { // Arabic
+                months: [
+                    "كانون الثاني", "شباط", "آذار", "نيسان", "مايو", "حزيران", "تموز", "آب", "أيلول", "تشرين الأول", "تشرين الثاني", "كانون الأول"
+                ],
+                dayOfWeekShort: [
+                    "ن", "ث", "ع", "خ", "ج", "س", "ح"
+                ],
+                dayOfWeek: ["الأحد", "الاثنين", "الثلاثاء", "الأربعاء", "الخميس", "الجمعة", "السبت", "الأحد"]
+            },
+            ro: { // Romanian
+                months: [
+                    "Ianuarie", "Februarie", "Martie", "Aprilie", "Mai", "Iunie", "Iulie", "August", "Septembrie", "Octombrie", "Noiembrie", "Decembrie"
+                ],
+                dayOfWeekShort: [
+                    "Du", "Lu", "Ma", "Mi", "Jo", "Vi", "Sâ"
+                ],
+                dayOfWeek: ["Duminică", "Luni", "Marţi", "Miercuri", "Joi", "Vineri", "Sâmbătă"]
+            },
+            id: { // Indonesian
+                months: [
+                    "Januari", "Februari", "Maret", "April", "Mei", "Juni", "Juli", "Agustus", "September", "Oktober", "November", "Desember"
+                ],
+                dayOfWeekShort: [
+                    "Min", "Sen", "Sel", "Rab", "Kam", "Jum", "Sab"
+                ],
+                dayOfWeek: ["Minggu", "Senin", "Selasa", "Rabu", "Kamis", "Jumat", "Sabtu"]
+            },
+            is: { // Icelandic
+                months: [
+                    "Janúar", "Febrúar", "Mars", "Apríl", "Maí", "Júní", "Júlí", "Ágúst", "September", "Október", "Nóvember", "Desember"
+                ],
+                dayOfWeekShort: [
+                    "Sun", "Mán", "Þrið", "Mið", "Fim", "Fös", "Lau"
+                ],
+                dayOfWeek: ["Sunnudagur", "Mánudagur", "Þriðjudagur", "Miðvikudagur", "Fimmtudagur", "Föstudagur", "Laugardagur"]
+            },
+            bg: { // Bulgarian
+                months: [
+                    "Януари", "Февруари", "Март", "Април", "Май", "Юни", "Юли", "Август", "Септември", "Октомври", "Ноември", "Декември"
+                ],
+                dayOfWeekShort: [
+                    "Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"
+                ],
+                dayOfWeek: ["Неделя", "Понеделник", "Вторник", "Сряда", "Четвъртък", "Петък", "Събота"]
+            },
+            fa: { // Persian/Farsi
+                months: [
+                    'فروردین', 'اردیبهشت', 'خرداد', 'تیر', 'مرداد', 'شهریور', 'مهر', 'آبان', 'آذر', 'دی', 'بهمن', 'اسفند'
+                ],
+                dayOfWeekShort: [
+                    'یکشنبه', 'دوشنبه', 'سه شنبه', 'چهارشنبه', 'پنجشنبه', 'جمعه', 'شنبه'
+                ],
+                dayOfWeek: ["یک‌شنبه", "دوشنبه", "سه‌شنبه", "چهارشنبه", "پنج‌شنبه", "جمعه", "شنبه", "یک‌شنبه"]
+            },
+            ru: { // Russian
+                months: [
+                    'Январь', 'Февраль', 'Март', 'Апрель', 'Май', 'Июнь', 'Июль', 'Август', 'Сентябрь', 'Октябрь', 'Ноябрь', 'Декабрь'
+                ],
+                dayOfWeekShort: [
+                    "Вс", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"
+                ],
+                dayOfWeek: ["Воскресенье", "Понедельник", "Вторник", "Среда", "Четверг", "Пятница", "Суббота"]
+            },
+            uk: { // Ukrainian
+                months: [
+                    'Січень', 'Лютий', 'Березень', 'Квітень', 'Травень', 'Червень', 'Липень', 'Серпень', 'Вересень', 'Жовтень', 'Листопад', 'Грудень'
+                ],
+                dayOfWeekShort: [
+                    "Ндл", "Пнд", "Втр", "Срд", "Чтв", "Птн", "Сбт"
+                ],
+                dayOfWeek: ["Неділя", "Понеділок", "Вівторок", "Середа", "Четвер", "П'ятниця", "Субота"]
+            },
+            en: { // English
+                months: [
+                    "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
+                ],
+                dayOfWeekShort: [
+                    "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
+                ],
+                dayOfWeek: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+            },
+            el: { // Ελληνικά
+                months: [
+                    "Ιανουάριος", "Φεβρουάριος", "Μάρτιος", "Απρίλιος", "Μάιος", "Ιούνιος", "Ιούλιος", "Αύγουστος", "Σεπτέμβριος", "Οκτώβριος", "Νοέμβριος", "Δεκέμβριος"
+                ],
+                dayOfWeekShort: [
+                    "Κυρ", "Δευ", "Τρι", "Τετ", "Πεμ", "Παρ", "Σαβ"
+                ],
+                dayOfWeek: ["Κυριακή", "Δευτέρα", "Τρίτη", "Τετάρτη", "Πέμπτη", "Παρασκευή", "Σάββατο"]
+            },
+            de: { // German
+                months: [
+                    'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'
+                ],
+                dayOfWeekShort: [
+                    "So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"
+                ],
+                dayOfWeek: ["Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"]
+            },
+            nl: { // Dutch
+                months: [
+                    "januari", "februari", "maart", "april", "mei", "juni", "juli", "augustus", "september", "oktober", "november", "december"
+                ],
+                dayOfWeekShort: [
+                    "zo", "ma", "di", "wo", "do", "vr", "za"
+                ],
+                dayOfWeek: ["zondag", "maandag", "dinsdag", "woensdag", "donderdag", "vrijdag", "zaterdag"]
+            },
+            tr: { // Turkish
+                months: [
+                    "Ocak", "Şubat", "Mart", "Nisan", "Mayıs", "Haziran", "Temmuz", "Ağustos", "Eylül", "Ekim", "Kasım", "Aralık"
+                ],
+                dayOfWeekShort: [
+                    "Paz", "Pts", "Sal", "Çar", "Per", "Cum", "Cts"
+                ],
+                dayOfWeek: ["Pazar", "Pazartesi", "Salı", "Çarşamba", "Perşembe", "Cuma", "Cumartesi"]
+            },
+            fr: { //French
+                months: [
+                    "Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"
+                ],
+                dayOfWeekShort: [
+                    "Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam"
+                ],
+                dayOfWeek: ["dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi"]
+            },
+            es: { // Spanish
+                months: [
+                    "Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"
+                ],
+                dayOfWeekShort: [
+                    "Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"
+                ],
+                dayOfWeek: ["Domingo", "Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado"]
+            },
+            th: { // Thai
+                months: [
+                    'มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน', 'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม'
+                ],
+                dayOfWeekShort: [
+                    'อา.', 'จ.', 'อ.', 'พ.', 'พฤ.', 'ศ.', 'ส.'
+                ],
+                dayOfWeek: ["อาทิตย์", "จันทร์", "อังคาร", "พุธ", "พฤหัส", "ศุกร์", "เสาร์", "อาทิตย์"]
+            },
+            pl: { // Polish
+                months: [
+                    "styczeń", "luty", "marzec", "kwiecień", "maj", "czerwiec", "lipiec", "sierpień", "wrzesień", "październik", "listopad", "grudzień"
+                ],
+                dayOfWeekShort: [
+                    "nd", "pn", "wt", "śr", "cz", "pt", "sb"
+                ],
+                dayOfWeek: ["niedziela", "poniedziałek", "wtorek", "środa", "czwartek", "piątek", "sobota"]
+            },
+            pt: { // Portuguese
+                months: [
+                    "Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"
+                ],
+                dayOfWeekShort: [
+                    "Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sab"
+                ],
+                dayOfWeek: ["Domingo", "Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado"]
+            },
+            ch: { // Simplified Chinese
+                months: [
+                    "一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"
+                ],
+                dayOfWeekShort: [
+                    "日", "一", "二", "三", "四", "五", "六"
+                ]
+            },
+            se: { // Swedish
+                months: [
+                    "Januari", "Februari", "Mars", "April", "Maj", "Juni", "Juli", "Augusti", "September",  "Oktober", "November", "December"
+                ],
+                dayOfWeekShort: [
+                    "Sön", "Mån", "Tis", "Ons", "Tor", "Fre", "Lör"
+                ]
+            },
+            km: { // Khmer (ភាសាខ្មែរ)
+                months: [
+                    "មករា​", "កុម្ភៈ", "មិនា​", "មេសា​", "ឧសភា​", "មិថុនា​", "កក្កដា​", "សីហា​", "កញ្ញា​", "តុលា​", "វិច្ឆិកា", "ធ្នូ​"
+                ],
+                dayOfWeekShort: ["អាទិ​", "ច័ន្ទ​", "អង្គារ​", "ពុធ​", "ព្រហ​​", "សុក្រ​", "សៅរ៍"],
+                dayOfWeek: ["អាទិត្យ​", "ច័ន្ទ​", "អង្គារ​", "ពុធ​", "ព្រហស្បតិ៍​", "សុក្រ​", "សៅរ៍"]
+            },
+            kr: { // Korean
+                months: [
+                    "1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월"
+                ],
+                dayOfWeekShort: [
+                    "일", "월", "화", "수", "목", "금", "토"
+                ],
+                dayOfWeek: ["일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"]
+            },
+            it: { // Italian
+                months: [
+                    "Gennaio", "Febbraio", "Marzo", "Aprile", "Maggio", "Giugno", "Luglio", "Agosto", "Settembre", "Ottobre", "Novembre", "Dicembre"
+                ],
+                dayOfWeekShort: [
+                    "Dom", "Lun", "Mar", "Mer", "Gio", "Ven", "Sab"
+                ],
+                dayOfWeek: ["Domenica", "Lunedì", "Martedì", "Mercoledì", "Giovedì", "Venerdì", "Sabato"]
+            },
+            da: { // Dansk
+                months: [
+                    "Januar", "Februar", "Marts", "April", "Maj", "Juni", "Juli", "August", "September", "Oktober", "November", "December"
+                ],
+                dayOfWeekShort: [
+                    "Søn", "Man", "Tir", "Ons", "Tor", "Fre", "Lør"
+                ],
+                dayOfWeek: ["søndag", "mandag", "tirsdag", "onsdag", "torsdag", "fredag", "lørdag"]
+            },
+            no: { // Norwegian
+                months: [
+                    "Januar", "Februar", "Mars", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Desember"
+                ],
+                dayOfWeekShort: [
+                    "Søn", "Man", "Tir", "Ons", "Tor", "Fre", "Lør"
+                ],
+                dayOfWeek: ['Søndag', 'Mandag', 'Tirsdag', 'Onsdag', 'Torsdag', 'Fredag', 'Lørdag']
+            },
+            ja: { // Japanese
+                months: [
+                    "1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"
+                ],
+                dayOfWeekShort: [
+                    "日", "月", "火", "水", "木", "金", "土"
+                ],
+                dayOfWeek: ["日曜", "月曜", "火曜", "水曜", "木曜", "金曜", "土曜"]
+            },
+            vi: { // Vietnamese
+                months: [
+                    "Tháng 1", "Tháng 2", "Tháng 3", "Tháng 4", "Tháng 5", "Tháng 6", "Tháng 7", "Tháng 8", "Tháng 9", "Tháng 10", "Tháng 11", "Tháng 12"
+                ],
+                dayOfWeekShort: [
+                    "CN", "T2", "T3", "T4", "T5", "T6", "T7"
+                ],
+                dayOfWeek: ["Chủ nhật", "Thứ hai", "Thứ ba", "Thứ tư", "Thứ năm", "Thứ sáu", "Thứ bảy"]
+            },
+            sl: { // Slovenščina
+                months: [
+                    "Januar", "Februar", "Marec", "April", "Maj", "Junij", "Julij", "Avgust", "September", "Oktober", "November", "December"
+                ],
+                dayOfWeekShort: [
+                    "Ned", "Pon", "Tor", "Sre", "Čet", "Pet", "Sob"
+                ],
+                dayOfWeek: ["Nedelja", "Ponedeljek", "Torek", "Sreda", "Četrtek", "Petek", "Sobota"]
+            },
+            cs: { // Čeština
+                months: [
+                    "Leden", "Únor", "Březen", "Duben", "Květen", "Červen", "Červenec", "Srpen", "Září", "Říjen", "Listopad", "Prosinec"
+                ],
+                dayOfWeekShort: [
+                    "Ne", "Po", "Út", "St", "Čt", "Pá", "So"
+                ]
+            },
+            hu: { // Hungarian
+                months: [
+                    "Január", "Február", "Március", "Április", "Május", "Június", "Július", "Augusztus", "Szeptember", "Október", "November", "December"
+                ],
+                dayOfWeekShort: [
+                    "Va", "Hé", "Ke", "Sze", "Cs", "Pé", "Szo"
+                ],
+                dayOfWeek: ["vasárnap", "hétfő", "kedd", "szerda", "csütörtök", "péntek", "szombat"]
+            },
+            az: { //Azerbaijanian (Azeri)
+                months: [
+                    "Yanvar", "Fevral", "Mart", "Aprel", "May", "Iyun", "Iyul", "Avqust", "Sentyabr", "Oktyabr", "Noyabr", "Dekabr"
+                ],
+                dayOfWeekShort: [
+                    "B", "Be", "Ça", "Ç", "Ca", "C", "Ş"
+                ],
+                dayOfWeek: ["Bazar", "Bazar ertəsi", "Çərşənbə axşamı", "Çərşənbə", "Cümə axşamı", "Cümə", "Şənbə"]
+            },
+            bs: { //Bosanski
+                months: [
+                    "Januar", "Februar", "Mart", "April", "Maj", "Jun", "Jul", "Avgust", "Septembar", "Oktobar", "Novembar", "Decembar"
+                ],
+                dayOfWeekShort: [
+                    "Ned", "Pon", "Uto", "Sri", "Čet", "Pet", "Sub"
+                ],
+                dayOfWeek: ["Nedjelja","Ponedjeljak", "Utorak", "Srijeda", "Četvrtak", "Petak", "Subota"]
+            },
+            ca: { //Català
+                months: [
+                    "Gener", "Febrer", "Març", "Abril", "Maig", "Juny", "Juliol", "Agost", "Setembre", "Octubre", "Novembre", "Desembre"
+                ],
+                dayOfWeekShort: [
+                    "Dg", "Dl", "Dt", "Dc", "Dj", "Dv", "Ds"
+                ],
+                dayOfWeek: ["Diumenge", "Dilluns", "Dimarts", "Dimecres", "Dijous", "Divendres", "Dissabte"]
+            },
+            'en-GB': { //English (British)
+                months: [
+                    "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
+                ],
+                dayOfWeekShort: [
+                    "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
+                ],
+                dayOfWeek: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+            },
+            et: { //"Eesti"
+                months: [
+                    "Jaanuar", "Veebruar", "Märts", "Aprill", "Mai", "Juuni", "Juuli", "August", "September", "Oktoober", "November", "Detsember"
+                ],
+                dayOfWeekShort: [
+                    "P", "E", "T", "K", "N", "R", "L"
+                ],
+                dayOfWeek: ["Pühapäev", "Esmaspäev", "Teisipäev", "Kolmapäev", "Neljapäev", "Reede", "Laupäev"]
+            },
+            eu: { //Euskara
+                months: [
+                    "Urtarrila", "Otsaila", "Martxoa", "Apirila", "Maiatza", "Ekaina", "Uztaila", "Abuztua", "Iraila", "Urria", "Azaroa", "Abendua"
+                ],
+                dayOfWeekShort: [
+                    "Ig.", "Al.", "Ar.", "Az.", "Og.", "Or.", "La."
+                ],
+                dayOfWeek: ['Igandea', 'Astelehena', 'Asteartea', 'Asteazkena', 'Osteguna', 'Ostirala', 'Larunbata']
+            },
+            fi: { //Finnish (Suomi)
+                months: [
+                    "Tammikuu", "Helmikuu", "Maaliskuu", "Huhtikuu", "Toukokuu", "Kesäkuu", "Heinäkuu", "Elokuu", "Syyskuu", "Lokakuu", "Marraskuu", "Joulukuu"
+                ],
+                dayOfWeekShort: [
+                    "Su", "Ma", "Ti", "Ke", "To", "Pe", "La"
+                ],
+                dayOfWeek: ["sunnuntai", "maanantai", "tiistai", "keskiviikko", "torstai", "perjantai", "lauantai"]
+            },
+            gl: { //Galego
+                months: [
+                    "Xan", "Feb", "Maz", "Abr", "Mai", "Xun", "Xul", "Ago", "Set", "Out", "Nov", "Dec"
+                ],
+                dayOfWeekShort: [
+                    "Dom", "Lun", "Mar", "Mer", "Xov", "Ven", "Sab"
+                ],
+                dayOfWeek: ["Domingo", "Luns", "Martes", "Mércores", "Xoves", "Venres", "Sábado"]
+            },
+            hr: { //Hrvatski
+                months: [
+                    "Siječanj", "Veljača", "Ožujak", "Travanj", "Svibanj", "Lipanj", "Srpanj", "Kolovoz", "Rujan", "Listopad", "Studeni", "Prosinac"
+                ],
+                dayOfWeekShort: [
+                    "Ned", "Pon", "Uto", "Sri", "Čet", "Pet", "Sub"
+                ],
+                dayOfWeek: ["Nedjelja", "Ponedjeljak", "Utorak", "Srijeda", "Četvrtak", "Petak", "Subota"]
+            },
+            ko: { //Korean (한국어)
+                months: [
+                    "1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월"
+                ],
+                dayOfWeekShort: [
+                    "일", "월", "화", "수", "목", "금", "토"
+                ],
+                dayOfWeek: ["일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"]
+            },
+            lt: { //Lithuanian (lietuvių)
+                months: [
+                    "Sausio", "Vasario", "Kovo", "Balandžio", "Gegužės", "Birželio", "Liepos", "Rugpjūčio", "Rugsėjo", "Spalio", "Lapkričio", "Gruodžio"
+                ],
+                dayOfWeekShort: [
+                    "Sek", "Pir", "Ant", "Tre", "Ket", "Pen", "Šeš"
+                ],
+                dayOfWeek: ["Sekmadienis", "Pirmadienis", "Antradienis", "Trečiadienis", "Ketvirtadienis", "Penktadienis", "Šeštadienis"]
+            },
+            lv: { //Latvian (Latviešu)
+                months: [
+                    "Janvāris", "Februāris", "Marts", "Aprīlis ", "Maijs", "Jūnijs", "Jūlijs", "Augusts", "Septembris", "Oktobris", "Novembris", "Decembris"
+                ],
+                dayOfWeekShort: [
+                    "Sv", "Pr", "Ot", "Tr", "Ct", "Pk", "St"
+                ],
+                dayOfWeek: ["Svētdiena", "Pirmdiena", "Otrdiena", "Trešdiena", "Ceturtdiena", "Piektdiena", "Sestdiena"]
+            },
+            mk: { //Macedonian (Македонски)
+                months: [
+                    "јануари", "февруари", "март", "април", "мај", "јуни", "јули", "август", "септември", "октомври", "ноември", "декември"
+                ],
+                dayOfWeekShort: [
+                    "нед", "пон", "вто", "сре", "чет", "пет", "саб"
+                ],
+                dayOfWeek: ["Недела", "Понеделник", "Вторник", "Среда", "Четврток", "Петок", "Сабота"]
+            },
+            mn: { //Mongolian (Монгол)
+                months: [
+                    "1-р сар", "2-р сар", "3-р сар", "4-р сар", "5-р сар", "6-р сар", "7-р сар", "8-р сар", "9-р сар", "10-р сар", "11-р сар", "12-р сар"
+                ],
+                dayOfWeekShort: [
+                    "Дав", "Мяг", "Лха", "Пүр", "Бсн", "Бям", "Ням"
+                ],
+                dayOfWeek: ["Даваа", "Мягмар", "Лхагва", "Пүрэв", "Баасан", "Бямба", "Ням"]
+            },
+            'pt-BR': { //Português(Brasil)
+                months: [
+                    "Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"
+                ],
+                dayOfWeekShort: [
+                    "Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"
+                ],
+                dayOfWeek: ["Domingo", "Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado"]
+            },
+            sk: { //Slovenčina
+                months: [
+                    "Január", "Február", "Marec", "Apríl", "Máj", "Jún", "Júl", "August", "September", "Október", "November", "December"
+                ],
+                dayOfWeekShort: [
+                    "Ne", "Po", "Ut", "St", "Št", "Pi", "So"
+                ],
+                dayOfWeek: ["Nedeľa", "Pondelok", "Utorok", "Streda", "Štvrtok", "Piatok", "Sobota"]
+            },
+            sq: { //Albanian (Shqip)
+                months: [
+                    "Janar", "Shkurt", "Mars", "Prill", "Maj", "Qershor", "Korrik", "Gusht", "Shtator", "Tetor", "Nëntor", "Dhjetor"
+                ],
+                dayOfWeekShort: [
+                    "Die", "Hën", "Mar", "Mër", "Enj", "Pre", "Shtu"
+                ],
+                dayOfWeek: ["E Diel", "E Hënë", "E Martē", "E Mërkurë", "E Enjte", "E Premte", "E Shtunë"]
+            },
+            'sr-YU': { //Serbian (Srpski)
+                months: [
+                    "Januar", "Februar", "Mart", "April", "Maj", "Jun", "Jul", "Avgust", "Septembar", "Oktobar", "Novembar", "Decembar"
+                ],
+                dayOfWeekShort: [
+                    "Ned", "Pon", "Uto", "Sre", "čet", "Pet", "Sub"
+                ],
+                dayOfWeek: ["Nedelja","Ponedeljak", "Utorak", "Sreda", "Četvrtak", "Petak", "Subota"]
+            },
+            sr: { //Serbian Cyrillic (Српски)
+                months: [
+                    "јануар", "фебруар", "март", "април", "мај", "јун", "јул", "август", "септембар", "октобар", "новембар", "децембар"
+                ],
+                dayOfWeekShort: [
+                    "нед", "пон", "уто", "сре", "чет", "пет", "суб"
+                ],
+                dayOfWeek: ["Недеља","Понедељак", "Уторак", "Среда", "Четвртак", "Петак", "Субота"]
+            },
+            sv: { //Svenska
+                months: [
+                    "Januari", "Februari", "Mars", "April", "Maj", "Juni", "Juli", "Augusti", "September", "Oktober", "November", "December"
+                ],
+                dayOfWeekShort: [
+                    "Sön", "Mån", "Tis", "Ons", "Tor", "Fre", "Lör"
+                ],
+                dayOfWeek: ["Söndag", "Måndag", "Tisdag", "Onsdag", "Torsdag", "Fredag", "Lördag"]
+            },
+            'zh-TW': { //Traditional Chinese (繁體中文)
+                months: [
+                    "一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"
+                ],
+                dayOfWeekShort: [
+                    "日", "一", "二", "三", "四", "五", "六"
+                ],
+                dayOfWeek: ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"]
+            },
+            zh: { //Simplified Chinese (简体中文)
+                months: [
+                    "一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"
+                ],
+                dayOfWeekShort: [
+                    "日", "一", "二", "三", "四", "五", "六"
+                ],
+                dayOfWeek: ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"]
+            },
+            ug:{ // Uyghur(ئۇيغۇرچە)
+                months: [
+                    "1-ئاي","2-ئاي","3-ئاي","4-ئاي","5-ئاي","6-ئاي","7-ئاي","8-ئاي","9-ئاي","10-ئاي","11-ئاي","12-ئاي"
+                ],
+                dayOfWeek: [
+                    "يەكشەنبە", "دۈشەنبە","سەيشەنبە","چارشەنبە","پەيشەنبە","جۈمە","شەنبە"
+                ]
+            },
+            he: { //Hebrew (עברית)
+                months: [
+                    'ינואר', 'פברואר', 'מרץ', 'אפריל', 'מאי', 'יוני', 'יולי', 'אוגוסט', 'ספטמבר', 'אוקטובר', 'נובמבר', 'דצמבר'
+                ],
+                dayOfWeekShort: [
+                    'א\'', 'ב\'', 'ג\'', 'ד\'', 'ה\'', 'ו\'', 'שבת'
+                ],
+                dayOfWeek: ["ראשון", "שני", "שלישי", "רביעי", "חמישי", "שישי", "שבת", "ראשון"]
+            },
+            hy: { // Armenian
+                months: [
+                    "Հունվար", "Փետրվար", "Մարտ", "Ապրիլ", "Մայիս", "Հունիս", "Հուլիս", "Օգոստոս", "Սեպտեմբեր", "Հոկտեմբեր", "Նոյեմբեր", "Դեկտեմբեր"
+                ],
+                dayOfWeekShort: [
+                    "Կի", "Երկ", "Երք", "Չոր", "Հնգ", "Ուրբ", "Շբթ"
+                ],
+                dayOfWeek: ["Կիրակի", "Երկուշաբթի", "Երեքշաբթի", "Չորեքշաբթի", "Հինգշաբթի", "Ուրբաթ", "Շաբաթ"]
+            },
+            kg: { // Kyrgyz
+                months: [
+                    'Үчтүн айы', 'Бирдин айы', 'Жалган Куран', 'Чын Куран', 'Бугу', 'Кулжа', 'Теке', 'Баш Оона', 'Аяк Оона', 'Тогуздун айы', 'Жетинин айы', 'Бештин айы'
+                ],
+                dayOfWeekShort: [
+                    "Жек", "Дүй", "Шей", "Шар", "Бей", "Жум", "Ише"
+                ],
+                dayOfWeek: [
+                    "Жекшемб", "Дүйшөмб", "Шейшемб", "Шаршемб", "Бейшемби", "Жума", "Ишенб"
+                ]
+            },
+            rm: { // Romansh
+                months: [
+                    "Schaner", "Favrer", "Mars", "Avrigl", "Matg", "Zercladur", "Fanadur", "Avust", "Settember", "October", "November", "December"
+                ],
+                dayOfWeekShort: [
+                    "Du", "Gli", "Ma", "Me", "Gie", "Ve", "So"
+                ],
+                dayOfWeek: [
+                    "Dumengia", "Glindesdi", "Mardi", "Mesemna", "Gievgia", "Venderdi", "Sonda"
+                ]
+            },
+            ka: { // Georgian
+                months: [
+                    'იანვარი', 'თებერვალი', 'მარტი', 'აპრილი', 'მაისი', 'ივნისი', 'ივლისი', 'აგვისტო', 'სექტემბერი', 'ოქტომბერი', 'ნოემბერი', 'დეკემბერი'
+                ],
+                dayOfWeekShort: [
+                    "კვ", "ორშ", "სამშ", "ოთხ", "ხუთ", "პარ", "შაბ"
+                ],
+                dayOfWeek: ["კვირა", "ორშაბათი", "სამშაბათი", "ოთხშაბათი", "ხუთშაბათი", "პარასკევი", "შაბათი"]
+            }
+        },
+
+        ownerDocument: document,
+        contentWindow: window,
+
+        value: '',
+        rtl: false,
+
+        format:	'Y/m/d H:i',
+        formatTime:	'H:i',
+        formatDate:	'Y/m/d',
+
+        startDate:	false, // new Date(), '1986/12/08', '-1970/01/05','-1970/01/05',
+        step: 60,
+        monthChangeSpinner: true,
+
+        closeOnDateSelect: false,
+        closeOnTimeSelect: true,
+        closeOnWithoutClick: true,
+        closeOnInputClick: true,
+        openOnFocus: true,
+
+        timepicker: true,
+        datepicker: true,
+        weeks: false,
+
+        defaultTime: false,	// use formatTime format (ex. '10:00' for formatTime:	'H:i')
+        defaultDate: false,	// use formatDate format (ex new Date() or '1986/12/08' or '-1970/01/05' or '-1970/01/05')
+
+        minDate: false,
+        maxDate: false,
+        minTime: false,
+        maxTime: false,
+        minDateTime: false,
+        maxDateTime: false,
+
+        allowTimes: [],
+        opened: false,
+        initTime: true,
+        inline: false,
+        theme: '',
+        touchMovedThreshold: 5,
+
+        onSelectDate: function () {},
+        onSelectTime: function () {},
+        onChangeMonth: function () {},
+        onGetWeekOfYear: function () {},
+        onChangeYear: function () {},
+        onChangeDateTime: function () {},
+        onShow: function () {},
+        onClose: function () {},
+        onGenerate: function () {},
+
+        withoutCopyright: true,
+        inverseButton: false,
+        hours12: false,
+        next: 'xdsoft_next',
+        prev : 'xdsoft_prev',
+        dayOfWeekStart: 0,
+        parentID: 'body',
+        timeHeightInTimePicker: 25,
+        timepickerScrollbar: true,
+        todayButton: true,
+        prevButton: true,
+        nextButton: true,
+        defaultSelect: true,
+
+        scrollMonth: true,
+        scrollTime: true,
+        scrollInput: true,
+
+        lazyInit: false,
+        mask: false,
+        validateOnBlur: true,
+        allowBlank: true,
+        yearStart: 1950,
+        yearEnd: 2050,
+        monthStart: 0,
+        monthEnd: 11,
+        style: '',
+        id: '',
+        fixed: false,
+        roundTime: 'round', // ceil, floor
+        className: '',
+        weekends: [],
+        highlightedDates: [],
+        highlightedPeriods: [],
+        allowDates : [],
+        allowDateRe : null,
+        disabledDates : [],
+        disabledWeekDays: [],
+        yearOffset: 0,
+        beforeShowDay: null,
+
+        enterLikeTab: true,
+        showApplyButton: false
+    };
+
+    var dateHelper = null,
+        defaultDateHelper = null,
+        globalLocaleDefault = 'en',
+        globalLocale = 'en';
+
+    var dateFormatterOptionsDefault = {
+        meridiem: ['AM', 'PM']
+    };
+
+    var initDateFormatter = function(){
+        var locale = default_options.i18n[globalLocale],
+            opts = {
+                days: locale.dayOfWeek,
+                daysShort: locale.dayOfWeekShort,
+                months: locale.months,
+                monthsShort: $.map(locale.months, function(n){ return n.substring(0, 3) })
+            };
+
+        if (typeof DateFormatter === 'function') {
+            dateHelper = defaultDateHelper = new DateFormatter({
+                dateSettings: $.extend({}, dateFormatterOptionsDefault, opts)
+            });
+        }
+    };
+
+    var dateFormatters = {
+        moment: {
+            default_options:{
+                format: 'YYYY/MM/DD HH:mm',
+                formatDate: 'YYYY/MM/DD',
+                formatTime: 'HH:mm',
+            },
+            formatter: {
+                parseDate: function (date, format) {
+                    if(isFormatStandard(format)){
+                        return defaultDateHelper.parseDate(date, format);
+                    }
+                    var d = moment(date, format);
+                    return d.isValid() ? d.toDate() : false;
+                },
+
+                formatDate: function (date, format) {
+                    if(isFormatStandard(format)){
+                        return defaultDateHelper.formatDate(date, format);
+                    }
+                    return moment(date).format(format);
+                },
+
+                formatMask: function(format){
+                    return format
+                        .replace(/Y{4}/g, '9999')
+                        .replace(/Y{2}/g, '99')
+                        .replace(/M{2}/g, '19')
+                        .replace(/D{2}/g, '39')
+                        .replace(/H{2}/g, '29')
+                        .replace(/m{2}/g, '59')
+                        .replace(/s{2}/g, '59');
+                },
+            }
+        }
+    }
+
+    // for locale settings
+    $.datetimepicker = {
+        setLocale: function(locale){
+            var newLocale = default_options.i18n[locale] ? locale : globalLocaleDefault;
+            if (globalLocale !== newLocale) {
+                globalLocale = newLocale;
+                // reinit date formatter
+                initDateFormatter();
+            }
+        },
+
+        setDateFormatter: function(dateFormatter) {
+            if(typeof dateFormatter === 'string' && dateFormatters.hasOwnProperty(dateFormatter)){
+                var df = dateFormatters[dateFormatter];
+                $.extend(default_options, df.default_options);
+                dateHelper = df.formatter;
+            }
+            else {
+                dateHelper = dateFormatter;
+            }
+        },
+    };
+
+    var standardFormats = {
+        RFC_2822: 'D, d M Y H:i:s O',
+        ATOM: 'Y-m-d\TH:i:sP',
+        ISO_8601: 'Y-m-d\TH:i:sO',
+        RFC_822: 'D, d M y H:i:s O',
+        RFC_850: 'l, d-M-y H:i:s T',
+        RFC_1036: 'D, d M y H:i:s O',
+        RFC_1123: 'D, d M Y H:i:s O',
+        RSS: 'D, d M Y H:i:s O',
+        W3C: 'Y-m-d\TH:i:sP'
+    }
+
+    var isFormatStandard = function(format){
+        return Object.values(standardFormats).indexOf(format) === -1 ? false : true;
+    }
+
+    $.extend($.datetimepicker, standardFormats);
+
+    // first init date formatter
+    initDateFormatter();
+
+    // fix for ie8
+    if (!window.getComputedStyle) {
+        window.getComputedStyle = function (el) {
+            this.el = el;
+            this.getPropertyValue = function (prop) {
+                var re = /(-([a-z]))/g;
+                if (prop === 'float') {
+                    prop = 'styleFloat';
+                }
+                if (re.test(prop)) {
+                    prop = prop.replace(re, function (a, b, c) {
+                        return c.toUpperCase();
+                    });
+                }
+                return el.currentStyle[prop] || null;
+            };
+            return this;
+        };
+    }
+    if (!Array.prototype.indexOf) {
+        Array.prototype.indexOf = function (obj, start) {
+            var i, j;
+            for (i = (start || 0), j = this.length; i < j; i += 1) {
+                if (this[i] === obj) { return i; }
+            }
+            return -1;
+        };
+    }
+
+    Date.prototype.countDaysInMonth = function () {
+        return new Date(this.getFullYear(), this.getMonth() + 1, 0).getDate();
+    };
+
+    $.fn.xdsoftScroller = function (options, percent) {
+        return this.each(function () {
+            var timeboxparent = $(this),
+                pointerEventToXY = function (e) {
+                    var out = {x: 0, y: 0},
+                        touch;
+                    if (e.type === 'touchstart' || e.type === 'touchmove' || e.type === 'touchend' || e.type === 'touchcancel') {
+                        touch  = e.originalEvent.touches[0] || e.originalEvent.changedTouches[0];
+                        out.x = touch.clientX;
+                        out.y = touch.clientY;
+                    } else if (e.type === 'mousedown' || e.type === 'mouseup' || e.type === 'mousemove' || e.type === 'mouseover' || e.type === 'mouseout' || e.type === 'mouseenter' || e.type === 'mouseleave') {
+                        out.x = e.clientX;
+                        out.y = e.clientY;
+                    }
+                    return out;
+                },
+                timebox,
+                parentHeight,
+                height,
+                scrollbar,
+                scroller,
+                maximumOffset = 100,
+                start = false,
+                startY = 0,
+                startTop = 0,
+                h1 = 0,
+                touchStart = false,
+                startTopScroll = 0,
+                calcOffset = function () {};
+
+            if (percent === 'hide') {
+                timeboxparent.find('.xdsoft_scrollbar').hide();
+                return;
+            }
+
+            if (!$(this).hasClass('xdsoft_scroller_box')) {
+                timebox = timeboxparent.children().eq(0);
+                parentHeight = timeboxparent[0].clientHeight;
+                height = timebox[0].offsetHeight;
+                scrollbar = $('<div class="xdsoft_scrollbar"></div>');
+                scroller = $('<div class="xdsoft_scroller"></div>');
+                scrollbar.append(scroller);
+
+                timeboxparent.addClass('xdsoft_scroller_box').append(scrollbar);
+                calcOffset = function calcOffset(event) {
+                    var offset = pointerEventToXY(event).y - startY + startTopScroll;
+                    if (offset < 0) {
+                        offset = 0;
+                    }
+                    if (offset + scroller[0].offsetHeight > h1) {
+                        offset = h1 - scroller[0].offsetHeight;
+                    }
+                    timeboxparent.trigger('scroll_element.xdsoft_scroller', [maximumOffset ? offset / maximumOffset : 0]);
+                };
+
+                scroller
+                    .on('touchstart.xdsoft_scroller mousedown.xdsoft_scroller', function (event) {
+                        if (!parentHeight) {
+                            timeboxparent.trigger('resize_scroll.xdsoft_scroller', [percent]);
+                        }
+
+                        startY = pointerEventToXY(event).y;
+                        startTopScroll = parseInt(scroller.css('margin-top'), 10);
+                        h1 = scrollbar[0].offsetHeight;
+
+                        if (event.type === 'mousedown' || event.type === 'touchstart') {
+                            if (options.ownerDocument) {
+                                $(options.ownerDocument.body).addClass('xdsoft_noselect');
+                            }
+                            $([options.ownerDocument.body, options.contentWindow]).on('touchend mouseup.xdsoft_scroller', function arguments_callee() {
+                                $([options.ownerDocument.body, options.contentWindow]).off('touchend mouseup.xdsoft_scroller', arguments_callee)
+                                    .off('mousemove.xdsoft_scroller', calcOffset)
+                                    .removeClass('xdsoft_noselect');
+                            });
+                            $(options.ownerDocument.body).on('mousemove.xdsoft_scroller', calcOffset);
+                        } else {
+                            touchStart = true;
+                            event.stopPropagation();
+                            event.preventDefault();
+                        }
+                    })
+                    .on('touchmove', function (event) {
+                        if (touchStart) {
+                            event.preventDefault();
+                            calcOffset(event);
+                        }
+                    })
+                    .on('touchend touchcancel', function () {
+                        touchStart =  false;
+                        startTopScroll = 0;
+                    });
+
+                timeboxparent
+                    .on('scroll_element.xdsoft_scroller', function (event, percentage) {
+                        if (!parentHeight) {
+                            timeboxparent.trigger('resize_scroll.xdsoft_scroller', [percentage, true]);
+                        }
+                        percentage = percentage > 1 ? 1 : (percentage < 0 || isNaN(percentage)) ? 0 : percentage;
+
+                        scroller.css('margin-top', maximumOffset * percentage);
+
+                        setTimeout(function () {
+                            timebox.css('marginTop', -parseInt((timebox[0].offsetHeight - parentHeight) * percentage, 10));
+                        }, 10);
+                    })
+                    .on('resize_scroll.xdsoft_scroller', function (event, percentage, noTriggerScroll) {
+                        var percent, sh;
+                        parentHeight = timeboxparent[0].clientHeight;
+                        height = timebox[0].offsetHeight;
+                        percent = parentHeight / height;
+                        sh = percent * scrollbar[0].offsetHeight;
+                        if (percent > 1) {
+                            scroller.hide();
+                        } else {
+                            scroller.show();
+                            scroller.css('height', parseInt(sh > 10 ? sh : 10, 10));
+                            maximumOffset = scrollbar[0].offsetHeight - scroller[0].offsetHeight;
+                            if (noTriggerScroll !== true) {
+                                timeboxparent.trigger('scroll_element.xdsoft_scroller', [percentage || Math.abs(parseInt(timebox.css('marginTop'), 10)) / (height - parentHeight)]);
+                            }
+                        }
+                    });
+
+                timeboxparent.on('mousewheel', function (event) {
+                    var top = Math.abs(parseInt(timebox.css('marginTop'), 10));
+
+                    top = top - (event.deltaY * 20);
+                    if (top < 0) {
+                        top = 0;
+                    }
+
+                    timeboxparent.trigger('scroll_element.xdsoft_scroller', [top / (height - parentHeight)]);
+                    event.stopPropagation();
+                    return false;
+                });
+
+                timeboxparent.on('touchstart', function (event) {
+                    start = pointerEventToXY(event);
+                    startTop = Math.abs(parseInt(timebox.css('marginTop'), 10));
+                });
+
+                timeboxparent.on('touchmove', function (event) {
+                    if (start) {
+                        event.preventDefault();
+                        var coord = pointerEventToXY(event);
+                        timeboxparent.trigger('scroll_element.xdsoft_scroller', [(startTop - (coord.y - start.y)) / (height - parentHeight)]);
+                    }
+                });
+
+                timeboxparent.on('touchend touchcancel', function () {
+                    start = false;
+                    startTop = 0;
+                });
+            }
+            timeboxparent.trigger('resize_scroll.xdsoft_scroller', [percent]);
+        });
+    };
+
+    $.fn.datetimepicker = function (opt, opt2) {
+        var result = this,
+            KEY0 = 48,
+            KEY9 = 57,
+            _KEY0 = 96,
+            _KEY9 = 105,
+            CTRLKEY = 17,
+            DEL = 46,
+            ENTER = 13,
+            ESC = 27,
+            BACKSPACE = 8,
+            ARROWLEFT = 37,
+            ARROWUP = 38,
+            ARROWRIGHT = 39,
+            ARROWDOWN = 40,
+            TAB = 9,
+            F5 = 116,
+            AKEY = 65,
+            CKEY = 67,
+            VKEY = 86,
+            ZKEY = 90,
+            YKEY = 89,
+            ctrlDown	=	false,
+            options = ($.isPlainObject(opt) || !opt) ? $.extend(true, {}, default_options, opt) : $.extend(true, {}, default_options),
+
+            lazyInitTimer = 0,
+            createDateTimePicker,
+            destroyDateTimePicker,
+
+            lazyInit = function (input) {
+                input
+                    .on('open.xdsoft focusin.xdsoft mousedown.xdsoft touchstart', function initOnActionCallback() {
+                        if (input.is(':disabled') || input.data('xdsoft_datetimepicker')) {
+                            return;
+                        }
+                        clearTimeout(lazyInitTimer);
+                        lazyInitTimer = setTimeout(function () {
+
+                            if (!input.data('xdsoft_datetimepicker')) {
+                                createDateTimePicker(input);
+                            }
+                            input
+                                .off('open.xdsoft focusin.xdsoft mousedown.xdsoft touchstart', initOnActionCallback)
+                                .trigger('open.xdsoft');
+                        }, 100);
+                    });
+            };
+
+        createDateTimePicker = function (input) {
+            var datetimepicker = $('<div class="xdsoft_datetimepicker xdsoft_noselect"></div>'),
+                xdsoft_copyright = $('<div class="xdsoft_copyright"><a target="_blank" href="http://xdsoft.net/jqplugins/datetimepicker/">xdsoft.net</a></div>'),
+                datepicker = $('<div class="xdsoft_datepicker active"></div>'),
+                month_picker = $('<div class="xdsoft_monthpicker"><button type="button" class="xdsoft_prev"></button><button type="button" class="xdsoft_today_button"></button>' +
+                    '<div class="xdsoft_label xdsoft_month"><span></span><i></i></div>' +
+                    '<div class="xdsoft_label xdsoft_year"><span></span><i></i></div>' +
+                    '<button type="button" class="xdsoft_next"></button></div>'),
+                calendar = $('<div class="xdsoft_calendar"></div>'),
+                timepicker = $('<div class="xdsoft_timepicker active"><button type="button" class="xdsoft_prev"></button><div class="xdsoft_time_box"></div><button type="button" class="xdsoft_next"></button></div>'),
+                timeboxparent = timepicker.find('.xdsoft_time_box').eq(0),
+                timebox = $('<div class="xdsoft_time_variant"></div>'),
+                applyButton = $('<button type="button" class="xdsoft_save_selected blue-gradient-button">Save Selected</button>'),
+
+                monthselect = $('<div class="xdsoft_select xdsoft_monthselect"><div></div></div>'),
+                yearselect = $('<div class="xdsoft_select xdsoft_yearselect"><div></div></div>'),
+                triggerAfterOpen = false,
+                XDSoft_datetime,
+
+                xchangeTimer,
+                timerclick,
+                current_time_index,
+                setPos,
+                timer = 0,
+                _xdsoft_datetime,
+                forEachAncestorOf;
+
+            if (options.id) {
+                datetimepicker.attr('id', options.id);
+            }
+            if (options.style) {
+                datetimepicker.attr('style', options.style);
+            }
+            if (options.weeks) {
+                datetimepicker.addClass('xdsoft_showweeks');
+            }
+            if (options.rtl) {
+                datetimepicker.addClass('xdsoft_rtl');
+            }
+
+            datetimepicker.addClass('xdsoft_' + options.theme);
+            datetimepicker.addClass(options.className);
+
+            month_picker
+                .find('.xdsoft_month span')
+                .after(monthselect);
+            month_picker
+                .find('.xdsoft_year span')
+                .after(yearselect);
+
+            month_picker
+                .find('.xdsoft_month,.xdsoft_year')
+                .on('touchstart mousedown.xdsoft', function (event) {
+                    var select = $(this).find('.xdsoft_select').eq(0),
+                        val = 0,
+                        top = 0,
+                        visible = select.is(':visible'),
+                        items,
+                        i;
+
+                    month_picker
+                        .find('.xdsoft_select')
+                        .hide();
+                    if (_xdsoft_datetime.currentTime) {
+                        val = _xdsoft_datetime.currentTime[$(this).hasClass('xdsoft_month') ? 'getMonth' : 'getFullYear']();
+                    }
+
+                    select[visible ? 'hide' : 'show']();
+                    for (items = select.find('div.xdsoft_option'), i = 0; i < items.length; i += 1) {
+                        if (items.eq(i).data('value') === val) {
+                            break;
+                        } else {
+                            top += items[0].offsetHeight;
+                        }
+                    }
+
+                    select.xdsoftScroller(options, top / (select.children()[0].offsetHeight - (select[0].clientHeight)));
+                    event.stopPropagation();
+                    return false;
+                });
+
+            var handleTouchMoved = function (event) {
+                var evt = event.originalEvent;
+                var touchPosition = evt.touches ? evt.touches[0] : evt;
+                this.touchStartPosition = this.touchStartPosition || touchPosition;
+                var xMovement = Math.abs(this.touchStartPosition.clientX - touchPosition.clientX);
+                var yMovement = Math.abs(this.touchStartPosition.clientY - touchPosition.clientY);
+                var distance = Math.sqrt(xMovement * xMovement + yMovement * yMovement);
+                if(distance > options.touchMovedThreshold) {
+                    this.touchMoved = true;
+                }
+            }
+
+            month_picker
+                .find('.xdsoft_select')
+                .xdsoftScroller(options)
+                .on('touchstart mousedown.xdsoft', function (event) {
+                    var evt = event.originalEvent;
+                    this.touchMoved = false;
+                    this.touchStartPosition = evt.touches ? evt.touches[0] : evt;
+                    event.stopPropagation();
+                    event.preventDefault();
+                })
+                .on('touchmove', '.xdsoft_option', handleTouchMoved)
+                .on('touchend mousedown.xdsoft', '.xdsoft_option', function () {
+                    if (!this.touchMoved) {
+                        if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
+                            _xdsoft_datetime.currentTime = _xdsoft_datetime.now();
+                        }
+
+                        var year = _xdsoft_datetime.currentTime.getFullYear();
+                        if (_xdsoft_datetime && _xdsoft_datetime.currentTime) {
+                            _xdsoft_datetime.currentTime[$(this).parent().parent().hasClass('xdsoft_monthselect') ? 'setMonth' : 'setFullYear']($(this).data('value'));
+                        }
+
+                        $(this).parent().parent().hide();
+
+                        datetimepicker.trigger('xchange.xdsoft');
+                        if (options.onChangeMonth && $.isFunction(options.onChangeMonth)) {
+                            options.onChangeMonth.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
+                        }
+
+                        if (year !== _xdsoft_datetime.currentTime.getFullYear() && $.isFunction(options.onChangeYear)) {
+                            options.onChangeYear.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
+                        }
+                    }
+                });
+
+            datetimepicker.getValue = function () {
+                return _xdsoft_datetime.getCurrentTime();
+            };
+
+            datetimepicker.setOptions = function (_options) {
+                var highlightedDates = {};
+
+                options = $.extend(true, {}, options, _options);
+
+                if (_options.allowTimes && $.isArray(_options.allowTimes) && _options.allowTimes.length) {
+                    options.allowTimes = $.extend(true, [], _options.allowTimes);
+                }
+
+                if (_options.weekends && $.isArray(_options.weekends) && _options.weekends.length) {
+                    options.weekends = $.extend(true, [], _options.weekends);
+                }
+
+                if (_options.allowDates && $.isArray(_options.allowDates) && _options.allowDates.length) {
+                    options.allowDates = $.extend(true, [], _options.allowDates);
+                }
+
+                if (_options.allowDateRe && Object.prototype.toString.call(_options.allowDateRe)==="[object String]") {
+                    options.allowDateRe = new RegExp(_options.allowDateRe);
+                }
+
+                if (_options.highlightedDates && $.isArray(_options.highlightedDates) && _options.highlightedDates.length) {
+                    $.each(_options.highlightedDates, function (index, value) {
+                        var splitData = $.map(value.split(','), $.trim),
+                            exDesc,
+                            hDate = new HighlightedDate(dateHelper.parseDate(splitData[0], options.formatDate), splitData[1], splitData[2]), // date, desc, style
+                            keyDate = dateHelper.formatDate(hDate.date, options.formatDate);
+                        if (highlightedDates[keyDate] !== undefined) {
+                            exDesc = highlightedDates[keyDate].desc;
+                            if (exDesc && exDesc.length && hDate.desc && hDate.desc.length) {
+                                highlightedDates[keyDate].desc = exDesc + "\n" + hDate.desc;
+                            }
+                        } else {
+                            highlightedDates[keyDate] = hDate;
+                        }
+                    });
+
+                    options.highlightedDates = $.extend(true, [], highlightedDates);
+                }
+
+                if (_options.highlightedPeriods && $.isArray(_options.highlightedPeriods) && _options.highlightedPeriods.length) {
+                    highlightedDates = $.extend(true, [], options.highlightedDates);
+                    $.each(_options.highlightedPeriods, function (index, value) {
+                        var dateTest, // start date
+                            dateEnd,
+                            desc,
+                            hDate,
+                            keyDate,
+                            exDesc,
+                            style;
+                        if ($.isArray(value)) {
+                            dateTest = value[0];
+                            dateEnd = value[1];
+                            desc = value[2];
+                            style = value[3];
+                        }
+                        else {
+                            var splitData = $.map(value.split(','), $.trim);
+                            dateTest = dateHelper.parseDate(splitData[0], options.formatDate);
+                            dateEnd = dateHelper.parseDate(splitData[1], options.formatDate);
+                            desc = splitData[2];
+                            style = splitData[3];
+                        }
+
+                        while (dateTest <= dateEnd) {
+                            hDate = new HighlightedDate(dateTest, desc, style);
+                            keyDate = dateHelper.formatDate(dateTest, options.formatDate);
+                            dateTest.setDate(dateTest.getDate() + 1);
+                            if (highlightedDates[keyDate] !== undefined) {
+                                exDesc = highlightedDates[keyDate].desc;
+                                if (exDesc && exDesc.length && hDate.desc && hDate.desc.length) {
+                                    highlightedDates[keyDate].desc = exDesc + "\n" + hDate.desc;
+                                }
+                            } else {
+                                highlightedDates[keyDate] = hDate;
+                            }
+                        }
+                    });
+
+                    options.highlightedDates = $.extend(true, [], highlightedDates);
+                }
+
+                if (_options.disabledDates && $.isArray(_options.disabledDates) && _options.disabledDates.length) {
+                    options.disabledDates = $.extend(true, [], _options.disabledDates);
+                }
+
+                if (_options.disabledWeekDays && $.isArray(_options.disabledWeekDays) && _options.disabledWeekDays.length) {
+                    options.disabledWeekDays = $.extend(true, [], _options.disabledWeekDays);
+                }
+
+                if ((options.open || options.opened) && (!options.inline)) {
+                    input.trigger('open.xdsoft');
+                }
+
+                if (options.inline) {
+                    triggerAfterOpen = true;
+                    datetimepicker.addClass('xdsoft_inline');
+                    input.after(datetimepicker).hide();
+                }
+
+                if (options.inverseButton) {
+                    options.next = 'xdsoft_prev';
+                    options.prev = 'xdsoft_next';
+                }
+
+                if (options.datepicker) {
+                    datepicker.addClass('active');
+                } else {
+                    datepicker.removeClass('active');
+                }
+
+                if (options.timepicker) {
+                    timepicker.addClass('active');
+                } else {
+                    timepicker.removeClass('active');
+                }
+
+                if (options.value) {
+                    _xdsoft_datetime.setCurrentTime(options.value);
+                    if (input && input.val) {
+                        input.val(_xdsoft_datetime.str);
+                    }
+                }
+
+                if (isNaN(options.dayOfWeekStart)) {
+                    options.dayOfWeekStart = 0;
+                } else {
+                    options.dayOfWeekStart = parseInt(options.dayOfWeekStart, 10) % 7;
+                }
+
+                if (!options.timepickerScrollbar) {
+                    timeboxparent.xdsoftScroller(options, 'hide');
+                }
+
+                if (options.minDate && /^[\+\-](.*)$/.test(options.minDate)) {
+                    options.minDate = dateHelper.formatDate(_xdsoft_datetime.strToDateTime(options.minDate), options.formatDate);
+                }
+
+                if (options.maxDate &&  /^[\+\-](.*)$/.test(options.maxDate)) {
+                    options.maxDate = dateHelper.formatDate(_xdsoft_datetime.strToDateTime(options.maxDate), options.formatDate);
+                }
+
+                if (options.minDateTime &&  /^\+(.*)$/.test(options.minDateTime)) {
+                    options.minDateTime = _xdsoft_datetime.strToDateTime(options.minDateTime).dateFormat(options.formatDate);
+                }
+
+                if (options.maxDateTime &&  /^\+(.*)$/.test(options.maxDateTime)) {
+                    options.maxDateTime = _xdsoft_datetime.strToDateTime(options.maxDateTime).dateFormat(options.formatDate);
+                }
+
+                applyButton.toggle(options.showApplyButton);
+
+                month_picker
+                    .find('.xdsoft_today_button')
+                    .css('visibility', !options.todayButton ? 'hidden' : 'visible');
+
+                month_picker
+                    .find('.' + options.prev)
+                    .css('visibility', !options.prevButton ? 'hidden' : 'visible');
+
+                month_picker
+                    .find('.' + options.next)
+                    .css('visibility', !options.nextButton ? 'hidden' : 'visible');
+
+                setMask(options);
+
+                if (options.validateOnBlur) {
+                    input
+                        .off('blur.xdsoft')
+                        .on('blur.xdsoft', function () {
+                            if (options.allowBlank && (!$.trim($(this).val()).length ||
+                                (typeof options.mask === "string" && $.trim($(this).val()) === options.mask.replace(/[0-9]/g, '_')))) {
+                                $(this).val(null);
+                                datetimepicker.data('xdsoft_datetime').empty();
+                            } else {
+                                var d = dateHelper.parseDate($(this).val(), options.format);
+                                if (d) { // parseDate() may skip some invalid parts like date or time, so make it clear for user: show parsed date/time
+                                    $(this).val(dateHelper.formatDate(d, options.format));
+                                } else {
+                                    var splittedHours   = +([$(this).val()[0], $(this).val()[1]].join('')),
+                                        splittedMinutes = +([$(this).val()[2], $(this).val()[3]].join(''));
+
+                                    // parse the numbers as 0312 => 03:12
+                                    if (!options.datepicker && options.timepicker && splittedHours >= 0 && splittedHours < 24 && splittedMinutes >= 0 && splittedMinutes < 60) {
+                                        $(this).val([splittedHours, splittedMinutes].map(function (item) {
+                                            return item > 9 ? item : '0' + item;
+                                        }).join(':'));
+                                    } else {
+                                        $(this).val(dateHelper.formatDate(_xdsoft_datetime.now(), options.format));
+                                    }
+                                }
+                                datetimepicker.data('xdsoft_datetime').setCurrentTime($(this).val());
+                            }
+
+                            datetimepicker.trigger('changedatetime.xdsoft');
+                            datetimepicker.trigger('close.xdsoft');
+                        });
+                }
+                options.dayOfWeekStartPrev = (options.dayOfWeekStart === 0) ? 6 : options.dayOfWeekStart - 1;
+
+                datetimepicker
+                    .trigger('xchange.xdsoft')
+                    .trigger('afterOpen.xdsoft');
+            };
+
+            datetimepicker
+                .data('options', options)
+                .on('touchstart mousedown.xdsoft', function (event) {
+                    event.stopPropagation();
+                    event.preventDefault();
+                    yearselect.hide();
+                    monthselect.hide();
+                    return false;
+                });
+
+            //scroll_element = timepicker.find('.xdsoft_time_box');
+            timeboxparent.append(timebox);
+            timeboxparent.xdsoftScroller(options);
+
+            datetimepicker.on('afterOpen.xdsoft', function () {
+                timeboxparent.xdsoftScroller(options);
+            });
+
+            datetimepicker
+                .append(datepicker)
+                .append(timepicker);
+
+            if (options.withoutCopyright !== true) {
+                datetimepicker
+                    .append(xdsoft_copyright);
+            }
+
+            datepicker
+                .append(month_picker)
+                .append(calendar)
+                .append(applyButton);
+
+            $(options.parentID)
+                .append(datetimepicker);
+
+            XDSoft_datetime = function () {
+                var _this = this;
+                _this.now = function (norecursion) {
+                    var d = new Date(),
+                        date,
+                        time;
+
+                    if (!norecursion && options.defaultDate) {
+                        date = _this.strToDateTime(options.defaultDate);
+                        d.setFullYear(date.getFullYear());
+                        d.setMonth(date.getMonth());
+                        d.setDate(date.getDate());
+                    }
+
+                    d.setFullYear(d.getFullYear());
+
+                    if (!norecursion && options.defaultTime) {
+                        time = _this.strtotime(options.defaultTime);
+                        d.setHours(time.getHours());
+                        d.setMinutes(time.getMinutes());
+                        d.setSeconds(time.getSeconds());
+                        d.setMilliseconds(time.getMilliseconds());
+                    }
+                    return d;
+                };
+
+                _this.isValidDate = function (d) {
+                    if (Object.prototype.toString.call(d) !== "[object Date]") {
+                        return false;
+                    }
+                    return !isNaN(d.getTime());
+                };
+
+                _this.setCurrentTime = function (dTime, requireValidDate) {
+                    if (typeof dTime === 'string') {
+                        _this.currentTime = _this.strToDateTime(dTime);
+                    }
+                    else if (_this.isValidDate(dTime)) {
+                        _this.currentTime = dTime;
+                    }
+                    else if (!dTime && !requireValidDate && options.allowBlank && !options.inline) {
+                        _this.currentTime = null;
+                    }
+                    else {
+                        _this.currentTime = _this.now();
+                    }
+
+                    datetimepicker.trigger('xchange.xdsoft');
+                };
+
+                _this.empty = function () {
+                    _this.currentTime = null;
+                };
+
+                _this.getCurrentTime = function () {
+                    return _this.currentTime;
+                };
+
+                _this.nextMonth = function () {
+
+                    if (_this.currentTime === undefined || _this.currentTime === null) {
+                        _this.currentTime = _this.now();
+                    }
+
+                    var month = _this.currentTime.getMonth() + 1,
+                        year;
+                    if (month === 12) {
+                        _this.currentTime.setFullYear(_this.currentTime.getFullYear() + 1);
+                        month = 0;
+                    }
+
+                    year = _this.currentTime.getFullYear();
+
+                    _this.currentTime.setDate(
+                        Math.min(
+                            new Date(_this.currentTime.getFullYear(), month + 1, 0).getDate(),
+                            _this.currentTime.getDate()
+                        )
+                    );
+                    _this.currentTime.setMonth(month);
+
+                    if (options.onChangeMonth && $.isFunction(options.onChangeMonth)) {
+                        options.onChangeMonth.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
+                    }
+
+                    if (year !== _this.currentTime.getFullYear() && $.isFunction(options.onChangeYear)) {
+                        options.onChangeYear.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
+                    }
+
+                    datetimepicker.trigger('xchange.xdsoft');
+                    return month;
+                };
+
+                _this.prevMonth = function () {
+
+                    if (_this.currentTime === undefined || _this.currentTime === null) {
+                        _this.currentTime = _this.now();
+                    }
+
+                    var month = _this.currentTime.getMonth() - 1;
+                    if (month === -1) {
+                        _this.currentTime.setFullYear(_this.currentTime.getFullYear() - 1);
+                        month = 11;
+                    }
+                    _this.currentTime.setDate(
+                        Math.min(
+                            new Date(_this.currentTime.getFullYear(), month + 1, 0).getDate(),
+                            _this.currentTime.getDate()
+                        )
+                    );
+                    _this.currentTime.setMonth(month);
+                    if (options.onChangeMonth && $.isFunction(options.onChangeMonth)) {
+                        options.onChangeMonth.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
+                    }
+                    datetimepicker.trigger('xchange.xdsoft');
+                    return month;
+                };
+
+                _this.getWeekOfYear = function (datetime) {
+                    if (options.onGetWeekOfYear && $.isFunction(options.onGetWeekOfYear)) {
+                        var week = options.onGetWeekOfYear.call(datetimepicker, datetime);
+                        if (typeof week !== 'undefined') {
+                            return week;
+                        }
+                    }
+                    var onejan = new Date(datetime.getFullYear(), 0, 1);
+
+                    //First week of the year is th one with the first Thursday according to ISO8601
+                    if (onejan.getDay() !== 4) {
+                        onejan.setMonth(0, 1 + ((4 - onejan.getDay()+ 7) % 7));
+                    }
+
+                    return Math.ceil((((datetime - onejan) / 86400000) + onejan.getDay() + 1) / 7);
+                };
+
+                _this.strToDateTime = function (sDateTime) {
+                    var tmpDate = [], timeOffset, currentTime;
+
+                    if (sDateTime && sDateTime instanceof Date && _this.isValidDate(sDateTime)) {
+                        return sDateTime;
+                    }
+
+                    tmpDate = /^([+-]{1})(.*)$/.exec(sDateTime);
+
+                    if (tmpDate) {
+                        tmpDate[2] = dateHelper.parseDate(tmpDate[2], options.formatDate);
+                    }
+
+                    if (tmpDate  && tmpDate[2]) {
+                        timeOffset = tmpDate[2].getTime() - (tmpDate[2].getTimezoneOffset()) * 60000;
+                        currentTime = new Date((_this.now(true)).getTime() + parseInt(tmpDate[1] + '1', 10) * timeOffset);
+                    } else {
+                        currentTime = sDateTime ? dateHelper.parseDate(sDateTime, options.format) : _this.now();
+                    }
+
+                    if (!_this.isValidDate(currentTime)) {
+                        currentTime = _this.now();
+                    }
+
+                    return currentTime;
+                };
+
+                _this.strToDate = function (sDate) {
+                    if (sDate && sDate instanceof Date && _this.isValidDate(sDate)) {
+                        return sDate;
+                    }
+
+                    var currentTime = sDate ? dateHelper.parseDate(sDate, options.formatDate) : _this.now(true);
+                    if (!_this.isValidDate(currentTime)) {
+                        currentTime = _this.now(true);
+                    }
+                    return currentTime;
+                };
+
+                _this.strtotime = function (sTime) {
+                    if (sTime && sTime instanceof Date && _this.isValidDate(sTime)) {
+                        return sTime;
+                    }
+                    var currentTime = sTime ? dateHelper.parseDate(sTime, options.formatTime) : _this.now(true);
+                    if (!_this.isValidDate(currentTime)) {
+                        currentTime = _this.now(true);
+                    }
+                    return currentTime;
+                };
+
+                _this.str = function () {
+                    var format = options.format;
+                    if (options.yearOffset) {
+                        format = format.replace('Y', _this.currentTime.getFullYear() + options.yearOffset);
+                        format = format.replace('y', String(_this.currentTime.getFullYear() + options.yearOffset).substring(2, 4));
+                    }
+                    return dateHelper.formatDate(_this.currentTime, format);
+                };
+                _this.currentTime = this.now();
+            };
+
+            _xdsoft_datetime = new XDSoft_datetime();
+
+            applyButton.on('touchend click', function (e) {//pathbrite
+                e.preventDefault();
+                datetimepicker.data('changed', true);
+                _xdsoft_datetime.setCurrentTime(getCurrentValue());
+                input.val(_xdsoft_datetime.str());
+                datetimepicker.trigger('close.xdsoft');
+            });
+            month_picker
+                .find('.xdsoft_today_button')
+                .on('touchend mousedown.xdsoft', function () {
+                    datetimepicker.data('changed', true);
+                    _xdsoft_datetime.setCurrentTime(0, true);
+                    datetimepicker.trigger('afterOpen.xdsoft');
+                }).on('dblclick.xdsoft', function () {
+                var currentDate = _xdsoft_datetime.getCurrentTime(), minDate, maxDate;
+                currentDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate());
+                minDate = _xdsoft_datetime.strToDate(options.minDate);
+                minDate = new Date(minDate.getFullYear(), minDate.getMonth(), minDate.getDate());
+                if (currentDate < minDate) {
+                    return;
+                }
+                maxDate = _xdsoft_datetime.strToDate(options.maxDate);
+                maxDate = new Date(maxDate.getFullYear(), maxDate.getMonth(), maxDate.getDate());
+                if (currentDate > maxDate) {
+                    return;
+                }
+                input.val(_xdsoft_datetime.str());
+                input.trigger('change');
+                datetimepicker.trigger('close.xdsoft');
+            });
+            month_picker
+                .find('.xdsoft_prev,.xdsoft_next')
+                .on('touchend mousedown.xdsoft', function () {
+                    var $this = $(this),
+                        timer = 0,
+                        stop = false;
+
+                    (function arguments_callee1(v) {
+                        if ($this.hasClass(options.next)) {
+                            _xdsoft_datetime.nextMonth();
+                        } else if ($this.hasClass(options.prev)) {
+                            _xdsoft_datetime.prevMonth();
+                        }
+                        if (options.monthChangeSpinner) {
+                            if (!stop) {
+                                timer = setTimeout(arguments_callee1, v || 100);
+                            }
+                        }
+                    }(500));
+
+                    $([options.ownerDocument.body, options.contentWindow]).on('touchend mouseup.xdsoft', function arguments_callee2() {
+                        clearTimeout(timer);
+                        stop = true;
+                        $([options.ownerDocument.body, options.contentWindow]).off('touchend mouseup.xdsoft', arguments_callee2);
+                    });
+                });
+
+            timepicker
+                .find('.xdsoft_prev,.xdsoft_next')
+                .on('touchend mousedown.xdsoft', function () {
+                    var $this = $(this),
+                        timer = 0,
+                        stop = false,
+                        period = 110;
+                    (function arguments_callee4(v) {
+                        var pheight = timeboxparent[0].clientHeight,
+                            height = timebox[0].offsetHeight,
+                            top = Math.abs(parseInt(timebox.css('marginTop'), 10));
+                        if ($this.hasClass(options.next) && (height - pheight) - options.timeHeightInTimePicker >= top) {
+                            timebox.css('marginTop', '-' + (top + options.timeHeightInTimePicker) + 'px');
+                        } else if ($this.hasClass(options.prev) && top - options.timeHeightInTimePicker >= 0) {
+                            timebox.css('marginTop', '-' + (top - options.timeHeightInTimePicker) + 'px');
+                        }
+                        /**
+                         * Fixed bug:
+                         * When using css3 transition, it will cause a bug that you cannot scroll the timepicker list.
+                         * The reason is that the transition-duration time, if you set it to 0, all things fine, otherwise, this
+                         * would cause a bug when you use jquery.css method.
+                         * Let's say: * { transition: all .5s ease; }
+                         * jquery timebox.css('marginTop') will return the original value which is before you clicking the next/prev button,
+                         * meanwhile the timebox[0].style.marginTop will return the right value which is after you clicking the
+                         * next/prev button.
+                         *
+                         * What we should do:
+                         * Replace timebox.css('marginTop') with timebox[0].style.marginTop.
+                         */
+                        timeboxparent.trigger('scroll_element.xdsoft_scroller', [Math.abs(parseInt(timebox[0].style.marginTop, 10) / (height - pheight))]);
+                        period = (period > 10) ? 10 : period - 10;
+                        if (!stop) {
+                            timer = setTimeout(arguments_callee4, v || period);
+                        }
+                    }(500));
+                    $([options.ownerDocument.body, options.contentWindow]).on('touchend mouseup.xdsoft', function arguments_callee5() {
+                        clearTimeout(timer);
+                        stop = true;
+                        $([options.ownerDocument.body, options.contentWindow])
+                            .off('touchend mouseup.xdsoft', arguments_callee5);
+                    });
+                });
+
+            xchangeTimer = 0;
+            // base handler - generating a calendar and timepicker
+            datetimepicker
+                .on('xchange.xdsoft', function (event) {
+                    clearTimeout(xchangeTimer);
+                    xchangeTimer = setTimeout(function () {
+
+                        if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
+                            _xdsoft_datetime.currentTime = _xdsoft_datetime.now();
+                        }
+
+                        var table =	'',
+                            start = new Date(_xdsoft_datetime.currentTime.getFullYear(), _xdsoft_datetime.currentTime.getMonth(), 1, 12, 0, 0),
+                            i = 0,
+                            j,
+                            today = _xdsoft_datetime.now(),
+                            maxDate = false,
+                            minDate = false,
+                            minDateTime = false,
+                            maxDateTime = false,
+                            hDate,
+                            day,
+                            d,
+                            y,
+                            m,
+                            w,
+                            classes = [],
+                            customDateSettings,
+                            newRow = true,
+                            time = '',
+                            h,
+                            line_time,
+                            description;
+
+                        while (start.getDay() !== options.dayOfWeekStart) {
+                            start.setDate(start.getDate() - 1);
+                        }
+
+                        table += '<table><thead><tr>';
+
+                        if (options.weeks) {
+                            table += '<th></th>';
+                        }
+
+                        for (j = 0; j < 7; j += 1) {
+                            table += '<th>' + options.i18n[globalLocale].dayOfWeekShort[(j + options.dayOfWeekStart) % 7] + '</th>';
+                        }
+
+                        table += '</tr></thead>';
+                        table += '<tbody>';
+
+                        if (options.maxDate !== false) {
+                            maxDate = _xdsoft_datetime.strToDate(options.maxDate);
+                            maxDate = new Date(maxDate.getFullYear(), maxDate.getMonth(), maxDate.getDate(), 23, 59, 59, 999);
+                        }
+
+                        if (options.minDate !== false) {
+                            minDate = _xdsoft_datetime.strToDate(options.minDate);
+                            minDate = new Date(minDate.getFullYear(), minDate.getMonth(), minDate.getDate());
+                        }
+
+                        if (options.minDateTime !== false) {
+                            minDateTime = _xdsoft_datetime.strToDate(options.minDateTime);
+                            minDateTime = new Date(minDateTime.getFullYear(), minDateTime.getMonth(), minDateTime.getDate(), minDateTime.getHours(), minDateTime.getMinutes(), minDateTime.getSeconds());
+                        }
+
+                        if (options.maxDateTime !== false) {
+                            maxDateTime = _xdsoft_datetime.strToDate(options.maxDateTime);
+                            maxDateTime = new Date(maxDateTime.getFullYear(), maxDateTime.getMonth(), maxDateTime.getDate(), maxDateTime.getHours(), maxDateTime.getMinutes(), maxDateTime.getSeconds());
+                        }
+
+                        var maxDateTimeDay;
+                        if (maxDateTime !== false) {
+                            maxDateTimeDay = ((maxDateTime.getFullYear() * 12) + maxDateTime.getMonth()) * 31 + maxDateTime.getDate();
+                        }
+
+                        while (i < _xdsoft_datetime.currentTime.countDaysInMonth() || start.getDay() !== options.dayOfWeekStart || _xdsoft_datetime.currentTime.getMonth() === start.getMonth()) {
+                            classes = [];
+                            i += 1;
+
+                            day = start.getDay();
+                            d = start.getDate();
+                            y = start.getFullYear();
+                            m = start.getMonth();
+                            w = _xdsoft_datetime.getWeekOfYear(start);
+                            description = '';
+
+                            classes.push('xdsoft_date');
+
+                            if (options.beforeShowDay && $.isFunction(options.beforeShowDay.call)) {
+                                customDateSettings = options.beforeShowDay.call(datetimepicker, start);
+                            } else {
+                                customDateSettings = null;
+                            }
+
+                            if(options.allowDateRe && Object.prototype.toString.call(options.allowDateRe) === "[object RegExp]"){
+                                if(!options.allowDateRe.test(dateHelper.formatDate(start, options.formatDate))){
+                                    classes.push('xdsoft_disabled');
+                                }
+                            }
+
+                            if(options.allowDates && options.allowDates.length>0){
+                                if(options.allowDates.indexOf(dateHelper.formatDate(start, options.formatDate)) === -1){
+                                    classes.push('xdsoft_disabled');
+                                }
+                            }
+
+                            var currentDay = ((start.getFullYear() * 12) + start.getMonth()) * 31 + start.getDate();
+                            if ((maxDate !== false && start > maxDate) || (minDateTime !== false && start < minDateTime)  || (minDate !== false && start < minDate) || (maxDateTime !== false && currentDay > maxDateTimeDay) || (customDateSettings && customDateSettings[0] === false)) {
+                                classes.push('xdsoft_disabled');
+                            }
+
+                            if (options.disabledDates.indexOf(dateHelper.formatDate(start, options.formatDate)) !== -1) {
+                                classes.push('xdsoft_disabled');
+                            }
+
+                            if (options.disabledWeekDays.indexOf(day) !== -1) {
+                                classes.push('xdsoft_disabled');
+                            }
+
+                            if (input.is('[disabled]')) {
+                                classes.push('xdsoft_disabled');
+                            }
+
+                            if (customDateSettings && customDateSettings[1] !== "") {
+                                classes.push(customDateSettings[1]);
+                            }
+
+                            if (_xdsoft_datetime.currentTime.getMonth() !== m) {
+                                classes.push('xdsoft_other_month');
+                            }
+
+                            if ((options.defaultSelect || datetimepicker.data('changed')) && dateHelper.formatDate(_xdsoft_datetime.currentTime, options.formatDate) === dateHelper.formatDate(start, options.formatDate)) {
+                                classes.push('xdsoft_current');
+                            }
+
+                            if (dateHelper.formatDate(today, options.formatDate) === dateHelper.formatDate(start, options.formatDate)) {
+                                classes.push('xdsoft_today');
+                            }
+
+                            if (start.getDay() === 0 || start.getDay() === 6 || options.weekends.indexOf(dateHelper.formatDate(start, options.formatDate)) !== -1) {
+                                classes.push('xdsoft_weekend');
+                            }
+
+                            if (options.highlightedDates[dateHelper.formatDate(start, options.formatDate)] !== undefined) {
+                                hDate = options.highlightedDates[dateHelper.formatDate(start, options.formatDate)];
+                                classes.push(hDate.style === undefined ? 'xdsoft_highlighted_default' : hDate.style);
+                                description = hDate.desc === undefined ? '' : hDate.desc;
+                            }
+
+                            if (options.beforeShowDay && $.isFunction(options.beforeShowDay)) {
+                                classes.push(options.beforeShowDay(start));
+                            }
+
+                            if (newRow) {
+                                table += '<tr>';
+                                newRow = false;
+                                if (options.weeks) {
+                                    table += '<th>' + w + '</th>';
+                                }
+                            }
+
+                            table += '<td data-date="' + d + '" data-month="' + m + '" data-year="' + y + '"' + ' class="xdsoft_date xdsoft_day_of_week' + start.getDay() + ' ' + classes.join(' ') + '" title="' + description + '">' +
+                                '<div>' + d + '</div>' +
+                                '</td>';
+
+                            if (start.getDay() === options.dayOfWeekStartPrev) {
+                                table += '</tr>';
+                                newRow = true;
+                            }
+
+                            start.setDate(d + 1);
+                        }
+                        table += '</tbody></table>';
+
+                        calendar.html(table);
+
+                        month_picker.find('.xdsoft_label span').eq(0).text(options.i18n[globalLocale].months[_xdsoft_datetime.currentTime.getMonth()]);
+                        month_picker.find('.xdsoft_label span').eq(1).text(_xdsoft_datetime.currentTime.getFullYear() + options.yearOffset);
+
+                        // generate timebox
+                        time = '';
+                        h = '';
+                        m = '';
+
+                        var minTimeMinutesOfDay = 0;
+                        if (options.minTime !== false) {
+                            var t = _xdsoft_datetime.strtotime(options.minTime);
+                            minTimeMinutesOfDay = 60 * t.getHours() + t.getMinutes();
+                        }
+                        var maxTimeMinutesOfDay = 24 * 60;
+                        if (options.maxTime !== false) {
+                            var t = _xdsoft_datetime.strtotime(options.maxTime);
+                            maxTimeMinutesOfDay = 60 * t.getHours() + t.getMinutes();
+                        }
+
+                        if (options.minDateTime !== false) {
+                            var t = _xdsoft_datetime.strToDateTime(options.minDateTime);
+                            var currentDayIsMinDateTimeDay = dateHelper.formatDate(_xdsoft_datetime.currentTime, options.formatDate) === dateHelper.formatDate(t, options.formatDate);
+                            if (currentDayIsMinDateTimeDay) {
+                                var m = 60 * t.getHours() + t.getMinutes();
+                                if (m > minTimeMinutesOfDay) minTimeMinutesOfDay = m;
+                            }
+                        }
+
+                        if (options.maxDateTime !== false) {
+                            var t = _xdsoft_datetime.strToDateTime(options.maxDateTime);
+                            var currentDayIsMaxDateTimeDay = dateHelper.formatDate(_xdsoft_datetime.currentTime, options.formatDate) === dateHelper.formatDate(t, options.formatDate);
+                            if (currentDayIsMaxDateTimeDay) {
+                                var m = 60 * t.getHours() + t.getMinutes();
+                                if (m < maxTimeMinutesOfDay) maxTimeMinutesOfDay = m;
+                            }
+                        }
+
+                        line_time = function line_time(h, m) {
+                            var now = _xdsoft_datetime.now(), current_time,
+                                isALlowTimesInit = options.allowTimes && $.isArray(options.allowTimes) && options.allowTimes.length;
+                            now.setHours(h);
+                            h = parseInt(now.getHours(), 10);
+                            now.setMinutes(m);
+                            m = parseInt(now.getMinutes(), 10);
+                            classes = [];
+                            var currentMinutesOfDay = 60 * h + m;
+                            if (input.is('[disabled]') || (currentMinutesOfDay >= maxTimeMinutesOfDay) || (currentMinutesOfDay < minTimeMinutesOfDay)) {
+                                classes.push('xdsoft_disabled');
+                            }
+
+                            current_time = new Date(_xdsoft_datetime.currentTime);
+                            current_time.setHours(parseInt(_xdsoft_datetime.currentTime.getHours(), 10));
+
+                            if (!isALlowTimesInit) {
+                                current_time.setMinutes(Math[options.roundTime](_xdsoft_datetime.currentTime.getMinutes() / options.step) * options.step);
+                            }
+
+                            if ((options.initTime || options.defaultSelect || datetimepicker.data('changed')) && current_time.getHours() === parseInt(h, 10) && ((!isALlowTimesInit && options.step > 59) || current_time.getMinutes() === parseInt(m, 10))) {
+                                if (options.defaultSelect || datetimepicker.data('changed')) {
+                                    classes.push('xdsoft_current');
+                                } else if (options.initTime) {
+                                    classes.push('xdsoft_init_time');
+                                }
+                            }
+                            if (parseInt(today.getHours(), 10) === parseInt(h, 10) && parseInt(today.getMinutes(), 10) === parseInt(m, 10)) {
+                                classes.push('xdsoft_today');
+                            }
+                            time += '<div class="xdsoft_time ' + classes.join(' ') + '" data-hour="' + h + '" data-minute="' + m + '">' + dateHelper.formatDate(now, options.formatTime) + '</div>';
+                        };
+
+                        if (!options.allowTimes || !$.isArray(options.allowTimes) || !options.allowTimes.length) {
+                            for (i = 0, j = 0; i < (options.hours12 ? 12 : 24); i += 1) {
+                                for (j = 0; j < 60; j += options.step) {
+                                    var currentMinutesOfDay = i * 60 + j;
+                                    if (currentMinutesOfDay < minTimeMinutesOfDay) continue;
+                                    if (currentMinutesOfDay >= maxTimeMinutesOfDay) continue;
+                                    h = (i < 10 ? '0' : '') + i;
+                                    m = (j < 10 ? '0' : '') + j;
+                                    line_time(h, m);
+                                }
+                            }
+                        } else {
+                            for (i = 0; i < options.allowTimes.length; i += 1) {
+                                h = _xdsoft_datetime.strtotime(options.allowTimes[i]).getHours();
+                                m = _xdsoft_datetime.strtotime(options.allowTimes[i]).getMinutes();
+                                line_time(h, m);
+                            }
+                        }
+
+                        timebox.html(time);
+
+                        opt = '';
+
+                        for (i = parseInt(options.yearStart, 10); i <= parseInt(options.yearEnd, 10); i += 1) {
+                            opt += '<div class="xdsoft_option ' + (_xdsoft_datetime.currentTime.getFullYear() === i ? 'xdsoft_current' : '') + '" data-value="' + i + '">' + (i + options.yearOffset) + '</div>';
+                        }
+                        yearselect.children().eq(0)
+                            .html(opt);
+
+                        for (i = parseInt(options.monthStart, 10), opt = ''; i <= parseInt(options.monthEnd, 10); i += 1) {
+                            opt += '<div class="xdsoft_option ' + (_xdsoft_datetime.currentTime.getMonth() === i ? 'xdsoft_current' : '') + '" data-value="' + i + '">' + options.i18n[globalLocale].months[i] + '</div>';
+                        }
+                        monthselect.children().eq(0).html(opt);
+                        $(datetimepicker)
+                            .trigger('generate.xdsoft');
+                    }, 10);
+                    event.stopPropagation();
+                })
+                .on('afterOpen.xdsoft', function () {
+                    if (options.timepicker) {
+                        var classType, pheight, height, top;
+                        if (timebox.find('.xdsoft_current').length) {
+                            classType = '.xdsoft_current';
+                        } else if (timebox.find('.xdsoft_init_time').length) {
+                            classType = '.xdsoft_init_time';
+                        }
+                        if (classType) {
+                            pheight = timeboxparent[0].clientHeight;
+                            height = timebox[0].offsetHeight;
+                            top = timebox.find(classType).index() * options.timeHeightInTimePicker + 1;
+                            if ((height - pheight) < top) {
+                                top = height - pheight;
+                            }
+                            timeboxparent.trigger('scroll_element.xdsoft_scroller', [parseInt(top, 10) / (height - pheight)]);
+                        } else {
+                            timeboxparent.trigger('scroll_element.xdsoft_scroller', [0]);
+                        }
+                    }
+                });
+
+            timerclick = 0;
+            calendar
+                .on('touchend click.xdsoft', 'td', function (xdevent) {
+                    xdevent.stopPropagation();  // Prevents closing of Pop-ups, Modals and Flyouts in Bootstrap
+                    timerclick += 1;
+                    var $this = $(this),
+                        currentTime = _xdsoft_datetime.currentTime;
+
+                    if (currentTime === undefined || currentTime === null) {
+                        _xdsoft_datetime.currentTime = _xdsoft_datetime.now();
+                        currentTime = _xdsoft_datetime.currentTime;
+                    }
+
+                    if ($this.hasClass('xdsoft_disabled')) {
+                        return false;
+                    }
+
+                    currentTime.setDate(1);
+                    currentTime.setFullYear($this.data('year'));
+                    currentTime.setMonth($this.data('month'));
+                    currentTime.setDate($this.data('date'));
+
+                    datetimepicker.trigger('select.xdsoft', [currentTime]);
+
+                    input.val(_xdsoft_datetime.str());
+
+                    if (options.onSelectDate &&	$.isFunction(options.onSelectDate)) {
+                        options.onSelectDate.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'), xdevent);
+                    }
+
+                    datetimepicker.data('changed', true);
+                    datetimepicker.trigger('xchange.xdsoft');
+                    datetimepicker.trigger('changedatetime.xdsoft');
+                    if ((timerclick > 1 || (options.closeOnDateSelect === true || (options.closeOnDateSelect === false && !options.timepicker))) && !options.inline) {
+                        datetimepicker.trigger('close.xdsoft');
+                    }
+                    setTimeout(function () {
+                        timerclick = 0;
+                    }, 200);
+                });
+
+            timebox
+                .on('touchstart', 'div', function (xdevent) {
+                    this.touchMoved = false;
+                })
+                .on('touchmove', 'div', handleTouchMoved)
+                .on('touchend click.xdsoft', 'div', function (xdevent) {
+                    if (!this.touchMoved) {
+                        xdevent.stopPropagation();
+                        var $this = $(this),
+                            currentTime = _xdsoft_datetime.currentTime;
+
+                        if (currentTime === undefined || currentTime === null) {
+                            _xdsoft_datetime.currentTime = _xdsoft_datetime.now();
+                            currentTime = _xdsoft_datetime.currentTime;
+                        }
+
+                        if ($this.hasClass('xdsoft_disabled')) {
+                            return false;
+                        }
+                        currentTime.setHours($this.data('hour'));
+                        currentTime.setMinutes($this.data('minute'));
+                        datetimepicker.trigger('select.xdsoft', [currentTime]);
+
+                        datetimepicker.data('input').val(_xdsoft_datetime.str());
+
+                        if (options.onSelectTime && $.isFunction(options.onSelectTime)) {
+                            options.onSelectTime.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'), xdevent);
+                        }
+                        datetimepicker.data('changed', true);
+                        datetimepicker.trigger('xchange.xdsoft');
+                        datetimepicker.trigger('changedatetime.xdsoft');
+                        if (options.inline !== true && options.closeOnTimeSelect === true) {
+                            datetimepicker.trigger('close.xdsoft');
+                        }
+                    }
+                });
+
+            datepicker
+                .on('mousewheel.xdsoft', function (event) {
+                    if (!options.scrollMonth) {
+                        return true;
+                    }
+                    if (event.deltaY < 0) {
+                        _xdsoft_datetime.nextMonth();
+                    } else {
+                        _xdsoft_datetime.prevMonth();
+                    }
+                    return false;
+                });
+
+            input
+                .on('mousewheel.xdsoft', function (event) {
+                    if (!options.scrollInput) {
+                        return true;
+                    }
+                    if (!options.datepicker && options.timepicker) {
+                        current_time_index = timebox.find('.xdsoft_current').length ? timebox.find('.xdsoft_current').eq(0).index() : 0;
+                        if (current_time_index + event.deltaY >= 0 && current_time_index + event.deltaY < timebox.children().length) {
+                            current_time_index += event.deltaY;
+                        }
+                        if (timebox.children().eq(current_time_index).length) {
+                            timebox.children().eq(current_time_index).trigger('mousedown');
+                        }
+                        return false;
+                    }
+                    if (options.datepicker && !options.timepicker) {
+                        datepicker.trigger(event, [event.deltaY, event.deltaX, event.deltaY]);
+                        if (input.val) {
+                            input.val(_xdsoft_datetime.str());
+                        }
+                        datetimepicker.trigger('changedatetime.xdsoft');
+                        return false;
+                    }
+                });
+
+            datetimepicker
+                .on('changedatetime.xdsoft', function (event) {
+                    if (options.onChangeDateTime && $.isFunction(options.onChangeDateTime)) {
+                        var $input = datetimepicker.data('input');
+                        options.onChangeDateTime.call(datetimepicker, _xdsoft_datetime.currentTime, $input, event);
+                        delete options.value;
+                        $input.trigger('change');
+                    }
+                })
+                .on('generate.xdsoft', function () {
+                    if (options.onGenerate && $.isFunction(options.onGenerate)) {
+                        options.onGenerate.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
+                    }
+                    if (triggerAfterOpen) {
+                        datetimepicker.trigger('afterOpen.xdsoft');
+                        triggerAfterOpen = false;
+                    }
+                })
+                .on('click.xdsoft', function (xdevent) {
+                    xdevent.stopPropagation();
+                });
+
+            current_time_index = 0;
+
+            /**
+             * Runs the callback for each of the specified node's ancestors.
+             *
+             * Return FALSE from the callback to stop ascending.
+             *
+             * @param {DOMNode} node
+             * @param {Function} callback
+             * @returns {undefined}
+             */
+            forEachAncestorOf = function (node, callback) {
+                do {
+                    node = node.parentNode;
+
+                    if (!node || callback(node) === false) {
+                        break;
+                    }
+                } while (node.nodeName !== 'HTML');
+            };
+
+            /**
+             * Sets the position of the picker.
+             *
+             * @returns {undefined}
+             */
+            setPos = function () {
+                var dateInputOffset,
+                    dateInputElem,
+                    verticalPosition,
+                    left,
+                    position,
+                    datetimepickerElem,
+                    dateInputHasFixedAncestor,
+                    $dateInput,
+                    windowWidth,
+                    verticalAnchorEdge,
+                    datetimepickerCss,
+                    windowHeight,
+                    windowScrollTop;
+
+                $dateInput = datetimepicker.data('input');
+                dateInputOffset = $dateInput.offset();
+                dateInputElem = $dateInput[0];
+
+                verticalAnchorEdge = 'top';
+                verticalPosition = (dateInputOffset.top + dateInputElem.offsetHeight) - 1;
+                left = dateInputOffset.left;
+                position = "absolute";
+
+                windowWidth = $(options.contentWindow).width();
+                windowHeight = $(options.contentWindow).height();
+                windowScrollTop = $(options.contentWindow).scrollTop();
+
+                if ((options.ownerDocument.documentElement.clientWidth - dateInputOffset.left) < datepicker.parent().outerWidth(true)) {
+                    var diff = datepicker.parent().outerWidth(true) - dateInputElem.offsetWidth;
+                    left = left - diff;
+                }
+
+                if ($dateInput.parent().css('direction') === 'rtl') {
+                    left -= (datetimepicker.outerWidth() - $dateInput.outerWidth());
+                }
+
+                if (options.fixed) {
+                    verticalPosition -= windowScrollTop;
+                    left -= $(options.contentWindow).scrollLeft();
+                    position = "fixed";
+                } else {
+                    dateInputHasFixedAncestor = false;
+
+                    forEachAncestorOf(dateInputElem, function (ancestorNode) {
+                        if (ancestorNode === null) {
+                            return false;
+                        }
+
+                        if (options.contentWindow.getComputedStyle(ancestorNode).getPropertyValue('position') === 'fixed') {
+                            dateInputHasFixedAncestor = true;
+                            return false;
+                        }
+                    });
+
+                    if (dateInputHasFixedAncestor) {
+                        position = 'fixed';
+
+                        //If the picker won't fit entirely within the viewport then display it above the date input.
+                        if (verticalPosition + datetimepicker.outerHeight() > windowHeight + windowScrollTop) {
+                            verticalAnchorEdge = 'bottom';
+                            verticalPosition = (windowHeight + windowScrollTop) - dateInputOffset.top;
+                        } else {
+                            verticalPosition -= windowScrollTop;
+                        }
+                    } else {
+                        if (verticalPosition + datetimepicker[0].offsetHeight > windowHeight + windowScrollTop) {
+                            verticalPosition = dateInputOffset.top - datetimepicker[0].offsetHeight + 1;
+                        }
+                    }
+
+                    if (verticalPosition < 0) {
+                        verticalPosition = 0;
+                    }
+
+                    if (left + dateInputElem.offsetWidth > windowWidth) {
+                        left = windowWidth - dateInputElem.offsetWidth;
+                    }
+                }
+
+                datetimepickerElem = datetimepicker[0];
+
+                forEachAncestorOf(datetimepickerElem, function (ancestorNode) {
+                    var ancestorNodePosition;
+
+                    ancestorNodePosition = options.contentWindow.getComputedStyle(ancestorNode).getPropertyValue('position');
+
+                    if (ancestorNodePosition === 'relative' && windowWidth >= ancestorNode.offsetWidth) {
+                        left = left - ((windowWidth - ancestorNode.offsetWidth) / 2);
+                        return false;
+                    }
+                });
+
+                datetimepickerCss = {
+                    position: position,
+                    left: left,
+                    top: '',  //Initialize to prevent previous values interfering with new ones.
+                    bottom: ''  //Initialize to prevent previous values interfering with new ones.
+                };
+
+                datetimepickerCss[verticalAnchorEdge] = verticalPosition;
+
+                datetimepicker.css(datetimepickerCss);
+            };
+
+            datetimepicker
+                .on('open.xdsoft', function (event) {
+                    var onShow = true;
+                    if (options.onShow && $.isFunction(options.onShow)) {
+                        onShow = options.onShow.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'), event);
+                    }
+                    if (onShow !== false) {
+                        datetimepicker.show();
+                        setPos();
+                        $(options.contentWindow)
+                            .off('resize.xdsoft', setPos)
+                            .on('resize.xdsoft', setPos);
+
+                        if (options.closeOnWithoutClick) {
+                            $([options.ownerDocument.body, options.contentWindow]).on('touchstart mousedown.xdsoft', function arguments_callee6() {
+                                datetimepicker.trigger('close.xdsoft');
+                                $([options.ownerDocument.body, options.contentWindow]).off('touchstart mousedown.xdsoft', arguments_callee6);
+                            });
+                        }
+                    }
+                })
+                .on('close.xdsoft', function (event) {
+                    var onClose = true;
+                    month_picker
+                        .find('.xdsoft_month,.xdsoft_year')
+                        .find('.xdsoft_select')
+                        .hide();
+                    if (options.onClose && $.isFunction(options.onClose)) {
+                        onClose = options.onClose.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'), event);
+                    }
+                    if (onClose !== false && !options.opened && !options.inline) {
+                        datetimepicker.hide();
+                    }
+                    event.stopPropagation();
+                })
+                .on('toggle.xdsoft', function () {
+                    if (datetimepicker.is(':visible')) {
+                        datetimepicker.trigger('close.xdsoft');
+                    } else {
+                        datetimepicker.trigger('open.xdsoft');
+                    }
+                })
+                .data('input', input);
+
+            timer = 0;
+
+            datetimepicker.data('xdsoft_datetime', _xdsoft_datetime);
+            datetimepicker.setOptions(options);
+
+            function getCurrentValue() {
+                var ct = false, time;
+
+                if (options.startDate) {
+                    ct = _xdsoft_datetime.strToDate(options.startDate);
+                } else {
+                    ct = options.value || ((input && input.val && input.val()) ? input.val() : '');
+                    if (ct) {
+                        ct = _xdsoft_datetime.strToDateTime(ct);
+                        if (options.yearOffset) {
+                            ct = new Date(ct.getFullYear() - options.yearOffset, ct.getMonth(), ct.getDate(), ct.getHours(), ct.getMinutes(), ct.getSeconds(), ct.getMilliseconds());
+                        }
+                    } else if (options.defaultDate) {
+                        ct = _xdsoft_datetime.strToDateTime(options.defaultDate);
+                        if (options.defaultTime) {
+                            time = _xdsoft_datetime.strtotime(options.defaultTime);
+                            ct.setHours(time.getHours());
+                            ct.setMinutes(time.getMinutes());
+                        }
+                    }
+                }
+
+                if (ct && _xdsoft_datetime.isValidDate(ct)) {
+                    datetimepicker.data('changed', true);
+                } else {
+                    ct = '';
+                }
+
+                return ct || 0;
+            }
+
+            function setMask(options) {
+
+                var isValidValue = function (mask, value) {
+                        var reg = mask
+                            .replace(/([\[\]\/\{\}\(\)\-\.\+]{1})/g, '\\$1')
+                            .replace(/_/g, '{digit+}')
+                            .replace(/([0-9]{1})/g, '{digit$1}')
+                            .replace(/\{digit([0-9]{1})\}/g, '[0-$1_]{1}')
+                            .replace(/\{digit[\+]\}/g, '[0-9_]{1}');
+                        return (new RegExp(reg)).test(value);
+                    },
+                    getCaretPos = function (input) {
+                        try {
+                            if (options.ownerDocument.selection && options.ownerDocument.selection.createRange) {
+                                var range = options.ownerDocument.selection.createRange();
+                                return range.getBookmark().charCodeAt(2) - 2;
+                            }
+                            if (input.setSelectionRange) {
+                                return input.selectionStart;
+                            }
+                        } catch (e) {
+                            return 0;
+                        }
+                    },
+                    setCaretPos = function (node, pos) {
+                        node = (typeof node === "string" || node instanceof String) ? options.ownerDocument.getElementById(node) : node;
+                        if (!node) {
+                            return false;
+                        }
+                        if (node.createTextRange) {
+                            var textRange = node.createTextRange();
+                            textRange.collapse(true);
+                            textRange.moveEnd('character', pos);
+                            textRange.moveStart('character', pos);
+                            textRange.select();
+                            return true;
+                        }
+                        if (node.setSelectionRange) {
+                            node.setSelectionRange(pos, pos);
+                            return true;
+                        }
+                        return false;
+                    };
+
+                if(options.mask) {
+                    input.off('keydown.xdsoft');
+                }
+
+                if (options.mask === true) {
+                    if (dateHelper.formatMask) {
+                        options.mask = dateHelper.formatMask(options.format)
+                    } else {
+                        options.mask = options.format
+                            .replace(/Y/g, '9999')
+                            .replace(/F/g, '9999')
+                            .replace(/m/g, '19')
+                            .replace(/d/g, '39')
+                            .replace(/H/g, '29')
+                            .replace(/i/g, '59')
+                            .replace(/s/g, '59');
+                    }
+                }
+
+                if ($.type(options.mask) === 'string') {
+                    if (!isValidValue(options.mask, input.val())) {
+                        input.val(options.mask.replace(/[0-9]/g, '_'));
+                        setCaretPos(input[0], 0);
+                    }
+
+                    input.on('paste.xdsoft', function (event) {
+                        // couple options here
+                        // 1. return false - tell them they can't paste
+                        // 2. insert over current characters - minimal validation
+                        // 3. full fledged parsing and validation
+                        // let's go option 2 for now
+
+                        // fires multiple times for some reason
+
+                        // https://stackoverflow.com/a/30496488/1366033
+                        var clipboardData = event.clipboardData || event.originalEvent.clipboardData || window.clipboardData,
+                            pastedData = clipboardData.getData('text'),
+                            val = this.value,
+                            pos = this.selectionStart
+
+                        var valueBeforeCursor = val.substr(0, pos);
+                        var valueAfterPaste = val.substr(pos + pastedData.length);
+
+                        val = valueBeforeCursor + pastedData + valueAfterPaste;
+                        pos += pastedData.length;
+
+                        if (isValidValue(options.mask, val)) {
+                            this.value = val;
+                            setCaretPos(this, pos);
+                        } else if ($.trim(val) === '') {
+                            this.value = options.mask.replace(/[0-9]/g, '_');
+                        } else {
+                            input.trigger('error_input.xdsoft');
+                        }
+
+                        event.preventDefault();
+                        return false;
+                    });
+
+                    input.on('keydown.xdsoft', function (event) {
+                        var val = this.value,
+                            key = event.which,
+                            pos = this.selectionStart,
+                            selEnd = this.selectionEnd,
+                            hasSel = pos !== selEnd,
+                            digit;
+
+                        // only alow these characters
+                        if (((key >=  KEY0 && key <=  KEY9)  ||
+                            (key >= _KEY0 && key <= _KEY9)) ||
+                            (key === BACKSPACE || key === DEL)) {
+
+                            // get char to insert which is new character or placeholder ('_')
+                            digit = (key === BACKSPACE || key === DEL) ? '_' :
+                                String.fromCharCode((_KEY0 <= key && key <= _KEY9) ? key - KEY0 : key);
+
+                            // we're deleting something, we're not at the start, and have normal cursor, move back one
+                            // if we have a selection length, cursor actually sits behind deletable char, not in front
+                            if (key === BACKSPACE && pos && !hasSel) {
+                                pos -= 1;
+                            }
+
+                            // don't stop on a separator, continue whatever direction you were going
+                            //   value char - keep incrementing position while on separator char and we still have room
+                            //   del char   - keep decrementing position while on separator char and we still have room
+                            while (true) {
+                                var maskValueAtCurPos = options.mask.substr(pos, 1);
+                                var posShorterThanMaskLength = pos < options.mask.length;
+                                var posGreaterThanZero = pos > 0;
+                                var notNumberOrPlaceholder = /[^0-9_]/;
+                                var curPosOnSep = notNumberOrPlaceholder.test(maskValueAtCurPos);
+                                var continueMovingPosition = curPosOnSep && posShorterThanMaskLength && posGreaterThanZero
+
+                                // if we hit a real char, stay where we are
+                                if (!continueMovingPosition) break;
+
+                                // hitting backspace in a selection, you can possibly go back any further - go forward
+                                pos += (key === BACKSPACE && !hasSel) ? -1 : 1;
+
+                            }
+
+
+                            if (hasSel) {
+                                // pos might have moved so re-calc length
+                                var selLength = selEnd - pos
+
+                                // if we have a selection length we will wipe out entire selection and replace with default template for that range
+                                var defaultBlank = options.mask.replace(/[0-9]/g, '_');
+                                var defaultBlankSelectionReplacement = defaultBlank.substr(pos, selLength);
+                                var selReplacementRemainder = defaultBlankSelectionReplacement.substr(1) // might be empty
+
+                                var valueBeforeSel = val.substr(0, pos);
+                                var insertChars = digit + selReplacementRemainder;
+                                var charsAfterSelection = val.substr(pos + selLength);
+
+                                val = valueBeforeSel + insertChars + charsAfterSelection
+
+                            } else {
+                                var valueBeforeCursor = val.substr(0, pos);
+                                var insertChar = digit;
+                                var valueAfterNextChar = val.substr(pos + 1);
+
+                                val = valueBeforeCursor + insertChar + valueAfterNextChar
+                            }
+
+                            if ($.trim(val) === '') {
+                                // if empty, set to default
+                                val = defaultBlank
+                            } else {
+                                // if at the last character don't need to do anything
+                                if (pos === options.mask.length) {
+                                    event.preventDefault();
+                                    return false;
+                                }
+                            }
+
+                            // resume cursor location
+                            pos += (key === BACKSPACE) ? 0 : 1;
+                            // don't stop on a separator, continue whatever direction you were going
+                            while (/[^0-9_]/.test(options.mask.substr(pos, 1)) && pos < options.mask.length && pos > 0) {
+                                pos += (key === BACKSPACE) ? 0 : 1;
+                            }
+
+                            if (isValidValue(options.mask, val)) {
+                                this.value = val;
+                                setCaretPos(this, pos);
+                            } else if ($.trim(val) === '') {
+                                this.value = options.mask.replace(/[0-9]/g, '_');
+                            } else {
+                                input.trigger('error_input.xdsoft');
+                            }
+                        } else {
+                            if (([AKEY, CKEY, VKEY, ZKEY, YKEY].indexOf(key) !== -1 && ctrlDown) || [ESC, ARROWUP, ARROWDOWN, ARROWLEFT, ARROWRIGHT, F5, CTRLKEY, TAB, ENTER].indexOf(key) !== -1) {
+                                return true;
+                            }
+                        }
+
+                        event.preventDefault();
+                        return false;
+                    });
+                }
+            }
+
+            _xdsoft_datetime.setCurrentTime(getCurrentValue());
+
+            input
+                .data('xdsoft_datetimepicker', datetimepicker)
+                .on('open.xdsoft focusin.xdsoft mousedown.xdsoft touchstart', function () {
+                    if (input.is(':disabled') || (input.data('xdsoft_datetimepicker').is(':visible') && options.closeOnInputClick)) {
+                        return;
+                    }
+                    if (!options.openOnFocus) {
+                        return;
+                    }
+                    clearTimeout(timer);
+                    timer = setTimeout(function () {
+                        if (input.is(':disabled')) {
+                            return;
+                        }
+
+                        triggerAfterOpen = true;
+                        _xdsoft_datetime.setCurrentTime(getCurrentValue(), true);
+                        if(options.mask) {
+                            setMask(options);
+                        }
+                        datetimepicker.trigger('open.xdsoft');
+                    }, 100);
+                })
+                .on('keydown.xdsoft', function (event) {
+                    var elementSelector,
+                        key = event.which;
+                    if ([ENTER].indexOf(key) !== -1 && options.enterLikeTab) {
+                        elementSelector = $("input:visible,textarea:visible,button:visible,a:visible");
+                        datetimepicker.trigger('close.xdsoft');
+                        elementSelector.eq(elementSelector.index(this) + 1).focus();
+                        return false;
+                    }
+                    if ([TAB].indexOf(key) !== -1) {
+                        datetimepicker.trigger('close.xdsoft');
+                        return true;
+                    }
+                })
+                .on('blur.xdsoft', function () {
+                    datetimepicker.trigger('close.xdsoft');
+                });
+        };
+        destroyDateTimePicker = function (input) {
+            var datetimepicker = input.data('xdsoft_datetimepicker');
+            if (datetimepicker) {
+                datetimepicker.data('xdsoft_datetime', null);
+                datetimepicker.remove();
+                input
+                    .data('xdsoft_datetimepicker', null)
+                    .off('.xdsoft');
+                $(options.contentWindow).off('resize.xdsoft');
+                $([options.contentWindow, options.ownerDocument.body]).off('mousedown.xdsoft touchstart');
+                if (input.unmousewheel) {
+                    input.unmousewheel();
+                }
+            }
+        };
+        $(options.ownerDocument)
+            .off('keydown.xdsoftctrl keyup.xdsoftctrl')
+            .on('keydown.xdsoftctrl', function (e) {
+                if (e.keyCode === CTRLKEY) {
+                    ctrlDown = true;
+                }
+            })
+            .on('keyup.xdsoftctrl', function (e) {
+                if (e.keyCode === CTRLKEY) {
+                    ctrlDown = false;
+                }
+            });
+
+        this.each(function () {
+            var datetimepicker = $(this).data('xdsoft_datetimepicker'), $input;
+            if (datetimepicker) {
+                if ($.type(opt) === 'string') {
+                    switch (opt) {
+                        case 'show':
+                            $(this).select().focus();
+                            datetimepicker.trigger('open.xdsoft');
+                            break;
+                        case 'hide':
+                            datetimepicker.trigger('close.xdsoft');
+                            break;
+                        case 'toggle':
+                            datetimepicker.trigger('toggle.xdsoft');
+                            break;
+                        case 'destroy':
+                            destroyDateTimePicker($(this));
+                            break;
+                        case 'reset':
+                            this.value = this.defaultValue;
+                            if (!this.value || !datetimepicker.data('xdsoft_datetime').isValidDate(dateHelper.parseDate(this.value, options.format))) {
+                                datetimepicker.data('changed', false);
+                            }
+                            datetimepicker.data('xdsoft_datetime').setCurrentTime(this.value);
+                            break;
+                        case 'validate':
+                            $input = datetimepicker.data('input');
+                            $input.trigger('blur.xdsoft');
+                            break;
+                        default:
+                            if (datetimepicker[opt] && $.isFunction(datetimepicker[opt])) {
+                                result = datetimepicker[opt](opt2);
+                            }
+                    }
+                } else {
+                    datetimepicker
+                        .setOptions(opt);
+                }
+                return 0;
+            }
+            if ($.type(opt) !== 'string') {
+                if (!options.lazyInit || options.open || options.inline) {
+                    createDateTimePicker($(this));
+                } else {
+                    lazyInit($(this));
+                }
+            }
+        });
+
+        return result;
+    };
+
+    $.fn.datetimepicker.defaults = default_options;
+
+    function HighlightedDate(date, desc, style) {
+        "use strict";
+        this.date = date;
+        this.desc = desc;
+        this.style = style;
+    }
+};
+;(function (factory) {
+    if ( typeof define === 'function' && define.amd ) {
+        // AMD. Register as an anonymous module.
+        define(['jquery', 'jquery-mousewheel'], factory);
+    } else if (typeof exports === 'object') {
+        // Node/CommonJS style for Browserify
+        module.exports = factory(require('jquery'));;
+    } else {
+        // Browser globals
+        factory(jQuery);
+    }
+}(datetimepickerFactory));
+
+

--- a/app/bundles/CoreBundle/Assets/js/libraries/7.datetimepicker.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/7.datetimepicker.js
@@ -904,7 +904,7 @@ var datetimepickerFactory = function ($) {
                 timeboxparent.on('mousewheel', function (event) {
                     var top = Math.abs(parseInt(timebox.css('marginTop'), 10));
 
-                    top = top - (event.deltaY * 20);
+                    top = top - (event.deltaY * 1);
                     if (top < 0) {
                         top = 0;
                     }

--- a/app/bundles/CoreBundle/Assets/js/libraries/7.datetimepicker.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/7.datetimepicker.js
@@ -1,153 +1,193 @@
-/**
- * @preserve jQuery DateTimePicker plugin v2.3.8
+/*!
+ * @copyright Copyright &copy; Kartik Visweswaran, Krajee.com, 2014 - 2016
+ * @version 1.3.4
+ *
+ * Date formatter utility library that allows formatting date/time variables or Date objects using PHP DateTime format.
+ * @see http://php.net/manual/en/function.date.php
+ *
+ * For more JQuery plugins visit http://plugins.krajee.com
+ * For more Yii related demos visit http://demos.krajee.com
+ */var DateFormatter;!function(){"use strict";var t,e,r,n,a,u,i;u=864e5,i=3600,t=function(t,e){return"string"==typeof t&&"string"==typeof e&&t.toLowerCase()===e.toLowerCase()},e=function(t,r,n){var a=n||"0",u=t.toString();return u.length<r?e(a+u,r):u},r=function(t){var e,n;for(t=t||{},e=1;e<arguments.length;e++)if(n=arguments[e])for(var a in n)n.hasOwnProperty(a)&&("object"==typeof n[a]?r(t[a],n[a]):t[a]=n[a]);return t},n=function(t,e){for(var r=0;r<e.length;r++)if(e[r].toLowerCase()===t.toLowerCase())return r;return-1},a={dateSettings:{days:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],daysShort:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],months:["January","February","March","April","May","June","July","August","September","October","November","December"],monthsShort:["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],meridiem:["AM","PM"],ordinal:function(t){var e=t%10,r={1:"st",2:"nd",3:"rd"};return 1!==Math.floor(t%100/10)&&r[e]?r[e]:"th"}},separators:/[ \-+\/\.T:@]/g,validParts:/[dDjlNSwzWFmMntLoYyaABgGhHisueTIOPZcrU]/g,intParts:/[djwNzmnyYhHgGis]/g,tzParts:/\b(?:[PMCEA][SDP]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g,tzClip:/[^-+\dA-Z]/g},DateFormatter=function(t){var e=this,n=r(a,t);e.dateSettings=n.dateSettings,e.separators=n.separators,e.validParts=n.validParts,e.intParts=n.intParts,e.tzParts=n.tzParts,e.tzClip=n.tzClip},DateFormatter.prototype={constructor:DateFormatter,getMonth:function(t){var e,r=this;return e=n(t,r.dateSettings.monthsShort)+1,0===e&&(e=n(t,r.dateSettings.months)+1),e},parseDate:function(e,r){var n,a,u,i,s,o,c,f,l,h,d=this,g=!1,m=!1,p=d.dateSettings,y={date:null,year:null,month:null,day:null,hour:0,min:0,sec:0};if(!e)return null;if(e instanceof Date)return e;if("U"===r)return u=parseInt(e),u?new Date(1e3*u):e;switch(typeof e){case"number":return new Date(e);case"string":break;default:return null}if(n=r.match(d.validParts),!n||0===n.length)throw new Error("Invalid date format definition.");for(a=e.replace(d.separators,"\x00").split("\x00"),u=0;u<a.length;u++)switch(i=a[u],s=parseInt(i),n[u]){case"y":case"Y":if(!s)return null;l=i.length,y.year=2===l?parseInt((70>s?"20":"19")+i):s,g=!0;break;case"m":case"n":case"M":case"F":if(isNaN(s)){if(o=d.getMonth(i),!(o>0))return null;y.month=o}else{if(!(s>=1&&12>=s))return null;y.month=s}g=!0;break;case"d":case"j":if(!(s>=1&&31>=s))return null;y.day=s,g=!0;break;case"g":case"h":if(c=n.indexOf("a")>-1?n.indexOf("a"):n.indexOf("A")>-1?n.indexOf("A"):-1,h=a[c],c>-1)f=t(h,p.meridiem[0])?0:t(h,p.meridiem[1])?12:-1,s>=1&&12>=s&&f>-1?y.hour=s+f-1:s>=0&&23>=s&&(y.hour=s);else{if(!(s>=0&&23>=s))return null;y.hour=s}m=!0;break;case"G":case"H":if(!(s>=0&&23>=s))return null;y.hour=s,m=!0;break;case"i":if(!(s>=0&&59>=s))return null;y.min=s,m=!0;break;case"s":if(!(s>=0&&59>=s))return null;y.sec=s,m=!0}if(g===!0&&y.year&&y.month&&y.day)y.date=new Date(y.year,y.month-1,y.day,y.hour,y.min,y.sec,0);else{if(m!==!0)return null;y.date=new Date(0,0,0,y.hour,y.min,y.sec,0)}return y.date},guessDate:function(t,e){if("string"!=typeof t)return t;var r,n,a,u,i,s,o=this,c=t.replace(o.separators,"\x00").split("\x00"),f=/^[djmn]/g,l=e.match(o.validParts),h=new Date,d=0;if(!f.test(l[0]))return t;for(a=0;a<c.length;a++){if(d=2,i=c[a],s=parseInt(i.substr(0,2)),isNaN(s))return null;switch(a){case 0:"m"===l[0]||"n"===l[0]?h.setMonth(s-1):h.setDate(s);break;case 1:"m"===l[0]||"n"===l[0]?h.setDate(s):h.setMonth(s-1);break;case 2:if(n=h.getFullYear(),r=i.length,d=4>r?r:4,n=parseInt(4>r?n.toString().substr(0,4-r)+i:i.substr(0,4)),!n)return null;h.setFullYear(n);break;case 3:h.setHours(s);break;case 4:h.setMinutes(s);break;case 5:h.setSeconds(s)}u=i.substr(d),u.length>0&&c.splice(a+1,0,u)}return h},parseFormat:function(t,r){var n,a=this,s=a.dateSettings,o=/\\?(.?)/gi,c=function(t,e){return n[t]?n[t]():e};return n={d:function(){return e(n.j(),2)},D:function(){return s.daysShort[n.w()]},j:function(){return r.getDate()},l:function(){return s.days[n.w()]},N:function(){return n.w()||7},w:function(){return r.getDay()},z:function(){var t=new Date(n.Y(),n.n()-1,n.j()),e=new Date(n.Y(),0,1);return Math.round((t-e)/u)},W:function(){var t=new Date(n.Y(),n.n()-1,n.j()-n.N()+3),r=new Date(t.getFullYear(),0,4);return e(1+Math.round((t-r)/u/7),2)},F:function(){return s.months[r.getMonth()]},m:function(){return e(n.n(),2)},M:function(){return s.monthsShort[r.getMonth()]},n:function(){return r.getMonth()+1},t:function(){return new Date(n.Y(),n.n(),0).getDate()},L:function(){var t=n.Y();return t%4===0&&t%100!==0||t%400===0?1:0},o:function(){var t=n.n(),e=n.W(),r=n.Y();return r+(12===t&&9>e?1:1===t&&e>9?-1:0)},Y:function(){return r.getFullYear()},y:function(){return n.Y().toString().slice(-2)},a:function(){return n.A().toLowerCase()},A:function(){var t=n.G()<12?0:1;return s.meridiem[t]},B:function(){var t=r.getUTCHours()*i,n=60*r.getUTCMinutes(),a=r.getUTCSeconds();return e(Math.floor((t+n+a+i)/86.4)%1e3,3)},g:function(){return n.G()%12||12},G:function(){return r.getHours()},h:function(){return e(n.g(),2)},H:function(){return e(n.G(),2)},i:function(){return e(r.getMinutes(),2)},s:function(){return e(r.getSeconds(),2)},u:function(){return e(1e3*r.getMilliseconds(),6)},e:function(){var t=/\((.*)\)/.exec(String(r))[1];return t||"Coordinated Universal Time"},I:function(){var t=new Date(n.Y(),0),e=Date.UTC(n.Y(),0),r=new Date(n.Y(),6),a=Date.UTC(n.Y(),6);return t-e!==r-a?1:0},O:function(){var t=r.getTimezoneOffset(),n=Math.abs(t);return(t>0?"-":"+")+e(100*Math.floor(n/60)+n%60,4)},P:function(){var t=n.O();return t.substr(0,3)+":"+t.substr(3,2)},T:function(){var t=(String(r).match(a.tzParts)||[""]).pop().replace(a.tzClip,"");return t||"UTC"},Z:function(){return 60*-r.getTimezoneOffset()},c:function(){return"Y-m-d\\TH:i:sP".replace(o,c)},r:function(){return"D, d M Y H:i:s O".replace(o,c)},U:function(){return r.getTime()/1e3||0}},c(t,t)},formatDate:function(t,e){var r,n,a,u,i,s=this,o="",c="\\";if("string"==typeof t&&(t=s.parseDate(t,e),!t))return null;if(t instanceof Date){for(a=e.length,r=0;a>r;r++)i=e.charAt(r),"S"!==i&&i!==c&&(r>0&&e.charAt(r-1)===c?o+=i:(u=s.parseFormat(i,t),r!==a-1&&s.intParts.test(i)&&"S"===e.charAt(r+1)&&(n=parseInt(u)||0,u+=s.dateSettings.ordinal(n)),o+=u));return o}return""}}}();/**
+ * @preserve jQuery DateTimePicker
  * @homepage http://xdsoft.net/jqplugins/datetimepicker/
- * (c) 2014, Chupurnov Valeriy.
+ * @author Chupurnov Valeriy (<chupurnov@gmail.com>)
  */
-(function ($) {
+
+/**
+ * @param {jQuery} $
+ */
+var datetimepickerFactory = function ($) {
     'use strict';
+
     var default_options  = {
         i18n: {
             ar: { // Arabic
                 months: [
                     "كانون الثاني", "شباط", "آذار", "نيسان", "مايو", "حزيران", "تموز", "آب", "أيلول", "تشرين الأول", "تشرين الثاني", "كانون الأول"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "ن", "ث", "ع", "خ", "ج", "س", "ح"
-                ]
+                ],
+                dayOfWeek: ["الأحد", "الاثنين", "الثلاثاء", "الأربعاء", "الخميس", "الجمعة", "السبت", "الأحد"]
             },
             ro: { // Romanian
                 months: [
-                    "ianuarie", "februarie", "martie", "aprilie", "mai", "iunie", "iulie", "august", "septembrie", "octombrie", "noiembrie", "decembrie"
+                    "Ianuarie", "Februarie", "Martie", "Aprilie", "Mai", "Iunie", "Iulie", "August", "Septembrie", "Octombrie", "Noiembrie", "Decembrie"
                 ],
-                dayOfWeek: [
-                    "l", "ma", "mi", "j", "v", "s", "d"
-                ]
+                dayOfWeekShort: [
+                    "Du", "Lu", "Ma", "Mi", "Jo", "Vi", "Sâ"
+                ],
+                dayOfWeek: ["Duminică", "Luni", "Marţi", "Miercuri", "Joi", "Vineri", "Sâmbătă"]
             },
             id: { // Indonesian
                 months: [
                     "Januari", "Februari", "Maret", "April", "Mei", "Juni", "Juli", "Agustus", "September", "Oktober", "November", "Desember"
                 ],
-                dayOfWeek: [
-                    "Sen", "Sel", "Rab", "Kam", "Jum", "Sab", "Min"
-                ]
+                dayOfWeekShort: [
+                    "Min", "Sen", "Sel", "Rab", "Kam", "Jum", "Sab"
+                ],
+                dayOfWeek: ["Minggu", "Senin", "Selasa", "Rabu", "Kamis", "Jumat", "Sabtu"]
+            },
+            is: { // Icelandic
+                months: [
+                    "Janúar", "Febrúar", "Mars", "Apríl", "Maí", "Júní", "Júlí", "Ágúst", "September", "Október", "Nóvember", "Desember"
+                ],
+                dayOfWeekShort: [
+                    "Sun", "Mán", "Þrið", "Mið", "Fim", "Fös", "Lau"
+                ],
+                dayOfWeek: ["Sunnudagur", "Mánudagur", "Þriðjudagur", "Miðvikudagur", "Fimmtudagur", "Föstudagur", "Laugardagur"]
             },
             bg: { // Bulgarian
                 months: [
                     "Януари", "Февруари", "Март", "Април", "Май", "Юни", "Юли", "Август", "Септември", "Октомври", "Ноември", "Декември"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"
-                ]
+                ],
+                dayOfWeek: ["Неделя", "Понеделник", "Вторник", "Сряда", "Четвъртък", "Петък", "Събота"]
             },
             fa: { // Persian/Farsi
                 months: [
                     'فروردین', 'اردیبهشت', 'خرداد', 'تیر', 'مرداد', 'شهریور', 'مهر', 'آبان', 'آذر', 'دی', 'بهمن', 'اسفند'
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     'یکشنبه', 'دوشنبه', 'سه شنبه', 'چهارشنبه', 'پنجشنبه', 'جمعه', 'شنبه'
-                ]
+                ],
+                dayOfWeek: ["یک‌شنبه", "دوشنبه", "سه‌شنبه", "چهارشنبه", "پنج‌شنبه", "جمعه", "شنبه", "یک‌شنبه"]
             },
             ru: { // Russian
                 months: [
                     'Январь', 'Февраль', 'Март', 'Апрель', 'Май', 'Июнь', 'Июль', 'Август', 'Сентябрь', 'Октябрь', 'Ноябрь', 'Декабрь'
                 ],
-                dayOfWeek: [
-                    "Вск", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"
-                ]
+                dayOfWeekShort: [
+                    "Вс", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"
+                ],
+                dayOfWeek: ["Воскресенье", "Понедельник", "Вторник", "Среда", "Четверг", "Пятница", "Суббота"]
             },
             uk: { // Ukrainian
                 months: [
                     'Січень', 'Лютий', 'Березень', 'Квітень', 'Травень', 'Червень', 'Липень', 'Серпень', 'Вересень', 'Жовтень', 'Листопад', 'Грудень'
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "Ндл", "Пнд", "Втр", "Срд", "Чтв", "Птн", "Сбт"
-                ]
+                ],
+                dayOfWeek: ["Неділя", "Понеділок", "Вівторок", "Середа", "Четвер", "П'ятниця", "Субота"]
             },
             en: { // English
                 months: [
                     "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
-                ]
+                ],
+                dayOfWeek: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
             },
             el: { // Ελληνικά
                 months: [
                     "Ιανουάριος", "Φεβρουάριος", "Μάρτιος", "Απρίλιος", "Μάιος", "Ιούνιος", "Ιούλιος", "Αύγουστος", "Σεπτέμβριος", "Οκτώβριος", "Νοέμβριος", "Δεκέμβριος"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "Κυρ", "Δευ", "Τρι", "Τετ", "Πεμ", "Παρ", "Σαβ"
-                ]
+                ],
+                dayOfWeek: ["Κυριακή", "Δευτέρα", "Τρίτη", "Τετάρτη", "Πέμπτη", "Παρασκευή", "Σάββατο"]
             },
             de: { // German
                 months: [
                     'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"
-                ]
+                ],
+                dayOfWeek: ["Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"]
             },
             nl: { // Dutch
                 months: [
                     "januari", "februari", "maart", "april", "mei", "juni", "juli", "augustus", "september", "oktober", "november", "december"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "zo", "ma", "di", "wo", "do", "vr", "za"
-                ]
+                ],
+                dayOfWeek: ["zondag", "maandag", "dinsdag", "woensdag", "donderdag", "vrijdag", "zaterdag"]
             },
             tr: { // Turkish
                 months: [
                     "Ocak", "Şubat", "Mart", "Nisan", "Mayıs", "Haziran", "Temmuz", "Ağustos", "Eylül", "Ekim", "Kasım", "Aralık"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "Paz", "Pts", "Sal", "Çar", "Per", "Cum", "Cts"
-                ]
+                ],
+                dayOfWeek: ["Pazar", "Pazartesi", "Salı", "Çarşamba", "Perşembe", "Cuma", "Cumartesi"]
             },
             fr: { //French
                 months: [
                     "Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam"
-                ]
+                ],
+                dayOfWeek: ["dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi"]
             },
             es: { // Spanish
                 months: [
                     "Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"
-                ]
+                ],
+                dayOfWeek: ["Domingo", "Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado"]
             },
             th: { // Thai
                 months: [
                     'มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน', 'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม'
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     'อา.', 'จ.', 'อ.', 'พ.', 'พฤ.', 'ศ.', 'ส.'
-                ]
+                ],
+                dayOfWeek: ["อาทิตย์", "จันทร์", "อังคาร", "พุธ", "พฤหัส", "ศุกร์", "เสาร์", "อาทิตย์"]
             },
             pl: { // Polish
                 months: [
                     "styczeń", "luty", "marzec", "kwiecień", "maj", "czerwiec", "lipiec", "sierpień", "wrzesień", "październik", "listopad", "grudzień"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "nd", "pn", "wt", "śr", "cz", "pt", "sb"
-                ]
+                ],
+                dayOfWeek: ["niedziela", "poniedziałek", "wtorek", "środa", "czwartek", "piątek", "sobota"]
             },
             pt: { // Portuguese
                 months: [
                     "Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sab"
-                ]
+                ],
+                dayOfWeek: ["Domingo", "Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado"]
             },
             ch: { // Simplified Chinese
                 months: [
                     "一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "日", "一", "二", "三", "四", "五", "六"
                 ]
             },
@@ -155,71 +195,85 @@
                 months: [
                     "Januari", "Februari", "Mars", "April", "Maj", "Juni", "Juli", "Augusti", "September",  "Oktober", "November", "December"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "Sön", "Mån", "Tis", "Ons", "Tor", "Fre", "Lör"
                 ]
+            },
+            km: { // Khmer (ភាសាខ្មែរ)
+                months: [
+                    "មករា​", "កុម្ភៈ", "មិនា​", "មេសា​", "ឧសភា​", "មិថុនា​", "កក្កដា​", "សីហា​", "កញ្ញា​", "តុលា​", "វិច្ឆិកា", "ធ្នូ​"
+                ],
+                dayOfWeekShort: ["អាទិ​", "ច័ន្ទ​", "អង្គារ​", "ពុធ​", "ព្រហ​​", "សុក្រ​", "សៅរ៍"],
+                dayOfWeek: ["អាទិត្យ​", "ច័ន្ទ​", "អង្គារ​", "ពុធ​", "ព្រហស្បតិ៍​", "សុក្រ​", "សៅរ៍"]
             },
             kr: { // Korean
                 months: [
                     "1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "일", "월", "화", "수", "목", "금", "토"
-                ]
+                ],
+                dayOfWeek: ["일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"]
             },
             it: { // Italian
                 months: [
                     "Gennaio", "Febbraio", "Marzo", "Aprile", "Maggio", "Giugno", "Luglio", "Agosto", "Settembre", "Ottobre", "Novembre", "Dicembre"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "Dom", "Lun", "Mar", "Mer", "Gio", "Ven", "Sab"
-                ]
+                ],
+                dayOfWeek: ["Domenica", "Lunedì", "Martedì", "Mercoledì", "Giovedì", "Venerdì", "Sabato"]
             },
             da: { // Dansk
                 months: [
-                    "January", "Februar", "Marts", "April", "Maj", "Juni", "July", "August", "September", "Oktober", "November", "December"
+                    "Januar", "Februar", "Marts", "April", "Maj", "Juni", "Juli", "August", "September", "Oktober", "November", "December"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "Søn", "Man", "Tir", "Ons", "Tor", "Fre", "Lør"
-                ]
+                ],
+                dayOfWeek: ["søndag", "mandag", "tirsdag", "onsdag", "torsdag", "fredag", "lørdag"]
             },
             no: { // Norwegian
                 months: [
                     "Januar", "Februar", "Mars", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Desember"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "Søn", "Man", "Tir", "Ons", "Tor", "Fre", "Lør"
-                ]
+                ],
+                dayOfWeek: ['Søndag', 'Mandag', 'Tirsdag', 'Onsdag', 'Torsdag', 'Fredag', 'Lørdag']
             },
             ja: { // Japanese
                 months: [
                     "1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "日", "月", "火", "水", "木", "金", "土"
-                ]
+                ],
+                dayOfWeek: ["日曜", "月曜", "火曜", "水曜", "木曜", "金曜", "土曜"]
             },
             vi: { // Vietnamese
                 months: [
                     "Tháng 1", "Tháng 2", "Tháng 3", "Tháng 4", "Tháng 5", "Tháng 6", "Tháng 7", "Tháng 8", "Tháng 9", "Tháng 10", "Tháng 11", "Tháng 12"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "CN", "T2", "T3", "T4", "T5", "T6", "T7"
-                ]
+                ],
+                dayOfWeek: ["Chủ nhật", "Thứ hai", "Thứ ba", "Thứ tư", "Thứ năm", "Thứ sáu", "Thứ bảy"]
             },
             sl: { // Slovenščina
                 months: [
                     "Januar", "Februar", "Marec", "April", "Maj", "Junij", "Julij", "Avgust", "September", "Oktober", "November", "December"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "Ned", "Pon", "Tor", "Sre", "Čet", "Pet", "Sob"
-                ]
+                ],
+                dayOfWeek: ["Nedelja", "Ponedeljek", "Torek", "Sreda", "Četrtek", "Petek", "Sobota"]
             },
             cs: { // Čeština
                 months: [
                     "Leden", "Únor", "Březen", "Duben", "Květen", "Červen", "Červenec", "Srpen", "Září", "Říjen", "Listopad", "Prosinec"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "Ne", "Po", "Út", "St", "Čt", "Pá", "So"
                 ]
             },
@@ -227,13 +281,273 @@
                 months: [
                     "Január", "Február", "Március", "Április", "Május", "Június", "Július", "Augusztus", "Szeptember", "Október", "November", "December"
                 ],
-                dayOfWeek: [
+                dayOfWeekShort: [
                     "Va", "Hé", "Ke", "Sze", "Cs", "Pé", "Szo"
+                ],
+                dayOfWeek: ["vasárnap", "hétfő", "kedd", "szerda", "csütörtök", "péntek", "szombat"]
+            },
+            az: { //Azerbaijanian (Azeri)
+                months: [
+                    "Yanvar", "Fevral", "Mart", "Aprel", "May", "Iyun", "Iyul", "Avqust", "Sentyabr", "Oktyabr", "Noyabr", "Dekabr"
+                ],
+                dayOfWeekShort: [
+                    "B", "Be", "Ça", "Ç", "Ca", "C", "Ş"
+                ],
+                dayOfWeek: ["Bazar", "Bazar ertəsi", "Çərşənbə axşamı", "Çərşənbə", "Cümə axşamı", "Cümə", "Şənbə"]
+            },
+            bs: { //Bosanski
+                months: [
+                    "Januar", "Februar", "Mart", "April", "Maj", "Jun", "Jul", "Avgust", "Septembar", "Oktobar", "Novembar", "Decembar"
+                ],
+                dayOfWeekShort: [
+                    "Ned", "Pon", "Uto", "Sri", "Čet", "Pet", "Sub"
+                ],
+                dayOfWeek: ["Nedjelja","Ponedjeljak", "Utorak", "Srijeda", "Četvrtak", "Petak", "Subota"]
+            },
+            ca: { //Català
+                months: [
+                    "Gener", "Febrer", "Març", "Abril", "Maig", "Juny", "Juliol", "Agost", "Setembre", "Octubre", "Novembre", "Desembre"
+                ],
+                dayOfWeekShort: [
+                    "Dg", "Dl", "Dt", "Dc", "Dj", "Dv", "Ds"
+                ],
+                dayOfWeek: ["Diumenge", "Dilluns", "Dimarts", "Dimecres", "Dijous", "Divendres", "Dissabte"]
+            },
+            'en-GB': { //English (British)
+                months: [
+                    "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
+                ],
+                dayOfWeekShort: [
+                    "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
+                ],
+                dayOfWeek: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+            },
+            et: { //"Eesti"
+                months: [
+                    "Jaanuar", "Veebruar", "Märts", "Aprill", "Mai", "Juuni", "Juuli", "August", "September", "Oktoober", "November", "Detsember"
+                ],
+                dayOfWeekShort: [
+                    "P", "E", "T", "K", "N", "R", "L"
+                ],
+                dayOfWeek: ["Pühapäev", "Esmaspäev", "Teisipäev", "Kolmapäev", "Neljapäev", "Reede", "Laupäev"]
+            },
+            eu: { //Euskara
+                months: [
+                    "Urtarrila", "Otsaila", "Martxoa", "Apirila", "Maiatza", "Ekaina", "Uztaila", "Abuztua", "Iraila", "Urria", "Azaroa", "Abendua"
+                ],
+                dayOfWeekShort: [
+                    "Ig.", "Al.", "Ar.", "Az.", "Og.", "Or.", "La."
+                ],
+                dayOfWeek: ['Igandea', 'Astelehena', 'Asteartea', 'Asteazkena', 'Osteguna', 'Ostirala', 'Larunbata']
+            },
+            fi: { //Finnish (Suomi)
+                months: [
+                    "Tammikuu", "Helmikuu", "Maaliskuu", "Huhtikuu", "Toukokuu", "Kesäkuu", "Heinäkuu", "Elokuu", "Syyskuu", "Lokakuu", "Marraskuu", "Joulukuu"
+                ],
+                dayOfWeekShort: [
+                    "Su", "Ma", "Ti", "Ke", "To", "Pe", "La"
+                ],
+                dayOfWeek: ["sunnuntai", "maanantai", "tiistai", "keskiviikko", "torstai", "perjantai", "lauantai"]
+            },
+            gl: { //Galego
+                months: [
+                    "Xan", "Feb", "Maz", "Abr", "Mai", "Xun", "Xul", "Ago", "Set", "Out", "Nov", "Dec"
+                ],
+                dayOfWeekShort: [
+                    "Dom", "Lun", "Mar", "Mer", "Xov", "Ven", "Sab"
+                ],
+                dayOfWeek: ["Domingo", "Luns", "Martes", "Mércores", "Xoves", "Venres", "Sábado"]
+            },
+            hr: { //Hrvatski
+                months: [
+                    "Siječanj", "Veljača", "Ožujak", "Travanj", "Svibanj", "Lipanj", "Srpanj", "Kolovoz", "Rujan", "Listopad", "Studeni", "Prosinac"
+                ],
+                dayOfWeekShort: [
+                    "Ned", "Pon", "Uto", "Sri", "Čet", "Pet", "Sub"
+                ],
+                dayOfWeek: ["Nedjelja", "Ponedjeljak", "Utorak", "Srijeda", "Četvrtak", "Petak", "Subota"]
+            },
+            ko: { //Korean (한국어)
+                months: [
+                    "1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월"
+                ],
+                dayOfWeekShort: [
+                    "일", "월", "화", "수", "목", "금", "토"
+                ],
+                dayOfWeek: ["일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"]
+            },
+            lt: { //Lithuanian (lietuvių)
+                months: [
+                    "Sausio", "Vasario", "Kovo", "Balandžio", "Gegužės", "Birželio", "Liepos", "Rugpjūčio", "Rugsėjo", "Spalio", "Lapkričio", "Gruodžio"
+                ],
+                dayOfWeekShort: [
+                    "Sek", "Pir", "Ant", "Tre", "Ket", "Pen", "Šeš"
+                ],
+                dayOfWeek: ["Sekmadienis", "Pirmadienis", "Antradienis", "Trečiadienis", "Ketvirtadienis", "Penktadienis", "Šeštadienis"]
+            },
+            lv: { //Latvian (Latviešu)
+                months: [
+                    "Janvāris", "Februāris", "Marts", "Aprīlis ", "Maijs", "Jūnijs", "Jūlijs", "Augusts", "Septembris", "Oktobris", "Novembris", "Decembris"
+                ],
+                dayOfWeekShort: [
+                    "Sv", "Pr", "Ot", "Tr", "Ct", "Pk", "St"
+                ],
+                dayOfWeek: ["Svētdiena", "Pirmdiena", "Otrdiena", "Trešdiena", "Ceturtdiena", "Piektdiena", "Sestdiena"]
+            },
+            mk: { //Macedonian (Македонски)
+                months: [
+                    "јануари", "февруари", "март", "април", "мај", "јуни", "јули", "август", "септември", "октомври", "ноември", "декември"
+                ],
+                dayOfWeekShort: [
+                    "нед", "пон", "вто", "сре", "чет", "пет", "саб"
+                ],
+                dayOfWeek: ["Недела", "Понеделник", "Вторник", "Среда", "Четврток", "Петок", "Сабота"]
+            },
+            mn: { //Mongolian (Монгол)
+                months: [
+                    "1-р сар", "2-р сар", "3-р сар", "4-р сар", "5-р сар", "6-р сар", "7-р сар", "8-р сар", "9-р сар", "10-р сар", "11-р сар", "12-р сар"
+                ],
+                dayOfWeekShort: [
+                    "Дав", "Мяг", "Лха", "Пүр", "Бсн", "Бям", "Ням"
+                ],
+                dayOfWeek: ["Даваа", "Мягмар", "Лхагва", "Пүрэв", "Баасан", "Бямба", "Ням"]
+            },
+            'pt-BR': { //Português(Brasil)
+                months: [
+                    "Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"
+                ],
+                dayOfWeekShort: [
+                    "Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"
+                ],
+                dayOfWeek: ["Domingo", "Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado"]
+            },
+            sk: { //Slovenčina
+                months: [
+                    "Január", "Február", "Marec", "Apríl", "Máj", "Jún", "Júl", "August", "September", "Október", "November", "December"
+                ],
+                dayOfWeekShort: [
+                    "Ne", "Po", "Ut", "St", "Št", "Pi", "So"
+                ],
+                dayOfWeek: ["Nedeľa", "Pondelok", "Utorok", "Streda", "Štvrtok", "Piatok", "Sobota"]
+            },
+            sq: { //Albanian (Shqip)
+                months: [
+                    "Janar", "Shkurt", "Mars", "Prill", "Maj", "Qershor", "Korrik", "Gusht", "Shtator", "Tetor", "Nëntor", "Dhjetor"
+                ],
+                dayOfWeekShort: [
+                    "Die", "Hën", "Mar", "Mër", "Enj", "Pre", "Shtu"
+                ],
+                dayOfWeek: ["E Diel", "E Hënë", "E Martē", "E Mërkurë", "E Enjte", "E Premte", "E Shtunë"]
+            },
+            'sr-YU': { //Serbian (Srpski)
+                months: [
+                    "Januar", "Februar", "Mart", "April", "Maj", "Jun", "Jul", "Avgust", "Septembar", "Oktobar", "Novembar", "Decembar"
+                ],
+                dayOfWeekShort: [
+                    "Ned", "Pon", "Uto", "Sre", "čet", "Pet", "Sub"
+                ],
+                dayOfWeek: ["Nedelja","Ponedeljak", "Utorak", "Sreda", "Četvrtak", "Petak", "Subota"]
+            },
+            sr: { //Serbian Cyrillic (Српски)
+                months: [
+                    "јануар", "фебруар", "март", "април", "мај", "јун", "јул", "август", "септембар", "октобар", "новембар", "децембар"
+                ],
+                dayOfWeekShort: [
+                    "нед", "пон", "уто", "сре", "чет", "пет", "суб"
+                ],
+                dayOfWeek: ["Недеља","Понедељак", "Уторак", "Среда", "Четвртак", "Петак", "Субота"]
+            },
+            sv: { //Svenska
+                months: [
+                    "Januari", "Februari", "Mars", "April", "Maj", "Juni", "Juli", "Augusti", "September", "Oktober", "November", "December"
+                ],
+                dayOfWeekShort: [
+                    "Sön", "Mån", "Tis", "Ons", "Tor", "Fre", "Lör"
+                ],
+                dayOfWeek: ["Söndag", "Måndag", "Tisdag", "Onsdag", "Torsdag", "Fredag", "Lördag"]
+            },
+            'zh-TW': { //Traditional Chinese (繁體中文)
+                months: [
+                    "一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"
+                ],
+                dayOfWeekShort: [
+                    "日", "一", "二", "三", "四", "五", "六"
+                ],
+                dayOfWeek: ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"]
+            },
+            zh: { //Simplified Chinese (简体中文)
+                months: [
+                    "一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"
+                ],
+                dayOfWeekShort: [
+                    "日", "一", "二", "三", "四", "五", "六"
+                ],
+                dayOfWeek: ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"]
+            },
+            ug:{ // Uyghur(ئۇيغۇرچە)
+                months: [
+                    "1-ئاي","2-ئاي","3-ئاي","4-ئاي","5-ئاي","6-ئاي","7-ئاي","8-ئاي","9-ئاي","10-ئاي","11-ئاي","12-ئاي"
+                ],
+                dayOfWeek: [
+                    "يەكشەنبە", "دۈشەنبە","سەيشەنبە","چارشەنبە","پەيشەنبە","جۈمە","شەنبە"
                 ]
+            },
+            he: { //Hebrew (עברית)
+                months: [
+                    'ינואר', 'פברואר', 'מרץ', 'אפריל', 'מאי', 'יוני', 'יולי', 'אוגוסט', 'ספטמבר', 'אוקטובר', 'נובמבר', 'דצמבר'
+                ],
+                dayOfWeekShort: [
+                    'א\'', 'ב\'', 'ג\'', 'ד\'', 'ה\'', 'ו\'', 'שבת'
+                ],
+                dayOfWeek: ["ראשון", "שני", "שלישי", "רביעי", "חמישי", "שישי", "שבת", "ראשון"]
+            },
+            hy: { // Armenian
+                months: [
+                    "Հունվար", "Փետրվար", "Մարտ", "Ապրիլ", "Մայիս", "Հունիս", "Հուլիս", "Օգոստոս", "Սեպտեմբեր", "Հոկտեմբեր", "Նոյեմբեր", "Դեկտեմբեր"
+                ],
+                dayOfWeekShort: [
+                    "Կի", "Երկ", "Երք", "Չոր", "Հնգ", "Ուրբ", "Շբթ"
+                ],
+                dayOfWeek: ["Կիրակի", "Երկուշաբթի", "Երեքշաբթի", "Չորեքշաբթի", "Հինգշաբթի", "Ուրբաթ", "Շաբաթ"]
+            },
+            kg: { // Kyrgyz
+                months: [
+                    'Үчтүн айы', 'Бирдин айы', 'Жалган Куран', 'Чын Куран', 'Бугу', 'Кулжа', 'Теке', 'Баш Оона', 'Аяк Оона', 'Тогуздун айы', 'Жетинин айы', 'Бештин айы'
+                ],
+                dayOfWeekShort: [
+                    "Жек", "Дүй", "Шей", "Шар", "Бей", "Жум", "Ише"
+                ],
+                dayOfWeek: [
+                    "Жекшемб", "Дүйшөмб", "Шейшемб", "Шаршемб", "Бейшемби", "Жума", "Ишенб"
+                ]
+            },
+            rm: { // Romansh
+                months: [
+                    "Schaner", "Favrer", "Mars", "Avrigl", "Matg", "Zercladur", "Fanadur", "Avust", "Settember", "October", "November", "December"
+                ],
+                dayOfWeekShort: [
+                    "Du", "Gli", "Ma", "Me", "Gie", "Ve", "So"
+                ],
+                dayOfWeek: [
+                    "Dumengia", "Glindesdi", "Mardi", "Mesemna", "Gievgia", "Venderdi", "Sonda"
+                ]
+            },
+            ka: { // Georgian
+                months: [
+                    'იანვარი', 'თებერვალი', 'მარტი', 'აპრილი', 'მაისი', 'ივნისი', 'ივლისი', 'აგვისტო', 'სექტემბერი', 'ოქტომბერი', 'ნოემბერი', 'დეკემბერი'
+                ],
+                dayOfWeekShort: [
+                    "კვ", "ორშ", "სამშ", "ოთხ", "ხუთ", "პარ", "შაბ"
+                ],
+                dayOfWeek: ["კვირა", "ორშაბათი", "სამშაბათი", "ოთხშაბათი", "ხუთშაბათი", "პარასკევი", "შაბათი"]
             }
         },
+
+        ownerDocument: document,
+        contentWindow: window,
+
         value: '',
-        lang: 'en',
+        rtl: false,
 
         format:	'Y/m/d H:i',
         formatTime:	'H:i',
@@ -244,8 +558,10 @@
         monthChangeSpinner: true,
 
         closeOnDateSelect: false,
+        closeOnTimeSelect: true,
         closeOnWithoutClick: true,
         closeOnInputClick: true,
+        openOnFocus: true,
 
         timepicker: true,
         datepicker: true,
@@ -258,16 +574,20 @@
         maxDate: false,
         minTime: false,
         maxTime: false,
+        minDateTime: false,
+        maxDateTime: false,
 
         allowTimes: [],
         opened: false,
         initTime: true,
         inline: false,
         theme: '',
+        touchMovedThreshold: 5,
 
         onSelectDate: function () {},
         onSelectTime: function () {},
         onChangeMonth: function () {},
+        onGetWeekOfYear: function () {},
         onChangeYear: function () {},
         onChangeDateTime: function () {},
         onShow: function () {},
@@ -277,13 +597,15 @@
         withoutCopyright: true,
         inverseButton: false,
         hours12: false,
-        next:	'xdsoft_next',
+        next: 'xdsoft_next',
         prev : 'xdsoft_prev',
         dayOfWeekStart: 0,
         parentID: 'body',
         timeHeightInTimePicker: 25,
         timepickerScrollbar: true,
         todayButton: true,
+        prevButton: true,
+        nextButton: true,
         defaultSelect: true,
 
         scrollMonth: true,
@@ -296,16 +618,152 @@
         allowBlank: true,
         yearStart: 1950,
         yearEnd: 2050,
+        monthStart: 0,
+        monthEnd: 11,
         style: '',
         id: '',
         fixed: false,
         roundTime: 'round', // ceil, floor
         className: '',
         weekends: [],
+        highlightedDates: [],
+        highlightedPeriods: [],
+        allowDates : [],
+        allowDateRe : null,
+        disabledDates : [],
+        disabledWeekDays: [],
         yearOffset: 0,
-        beforeShowDay: null
+        beforeShowDay: null,
+
+        enterLikeTab: true,
+        showApplyButton: false
     };
+
+    var dateHelper = null,
+        defaultDateHelper = null,
+        globalLocaleDefault = 'en',
+        globalLocale = 'en';
+
+    var dateFormatterOptionsDefault = {
+        meridiem: ['AM', 'PM']
+    };
+
+    var initDateFormatter = function(){
+        var locale = default_options.i18n[globalLocale],
+            opts = {
+                days: locale.dayOfWeek,
+                daysShort: locale.dayOfWeekShort,
+                months: locale.months,
+                monthsShort: $.map(locale.months, function(n){ return n.substring(0, 3) })
+            };
+
+        if (typeof DateFormatter === 'function') {
+            dateHelper = defaultDateHelper = new DateFormatter({
+                dateSettings: $.extend({}, dateFormatterOptionsDefault, opts)
+            });
+        }
+    };
+
+    var dateFormatters = {
+        moment: {
+            default_options:{
+                format: 'YYYY/MM/DD HH:mm',
+                formatDate: 'YYYY/MM/DD',
+                formatTime: 'HH:mm',
+            },
+            formatter: {
+                parseDate: function (date, format) {
+                    if(isFormatStandard(format)){
+                        return defaultDateHelper.parseDate(date, format);
+                    }
+                    var d = moment(date, format);
+                    return d.isValid() ? d.toDate() : false;
+                },
+
+                formatDate: function (date, format) {
+                    if(isFormatStandard(format)){
+                        return defaultDateHelper.formatDate(date, format);
+                    }
+                    return moment(date).format(format);
+                },
+
+                formatMask: function(format){
+                    return format
+                        .replace(/Y{4}/g, '9999')
+                        .replace(/Y{2}/g, '99')
+                        .replace(/M{2}/g, '19')
+                        .replace(/D{2}/g, '39')
+                        .replace(/H{2}/g, '29')
+                        .replace(/m{2}/g, '59')
+                        .replace(/s{2}/g, '59');
+                },
+            }
+        }
+    }
+
+    // for locale settings
+    $.datetimepicker = {
+        setLocale: function(locale){
+            var newLocale = default_options.i18n[locale] ? locale : globalLocaleDefault;
+            if (globalLocale !== newLocale) {
+                globalLocale = newLocale;
+                // reinit date formatter
+                initDateFormatter();
+            }
+        },
+
+        setDateFormatter: function(dateFormatter) {
+            if(typeof dateFormatter === 'string' && dateFormatters.hasOwnProperty(dateFormatter)){
+                var df = dateFormatters[dateFormatter];
+                $.extend(default_options, df.default_options);
+                dateHelper = df.formatter;
+            }
+            else {
+                dateHelper = dateFormatter;
+            }
+        },
+    };
+
+    var standardFormats = {
+        RFC_2822: 'D, d M Y H:i:s O',
+        ATOM: 'Y-m-d\TH:i:sP',
+        ISO_8601: 'Y-m-d\TH:i:sO',
+        RFC_822: 'D, d M y H:i:s O',
+        RFC_850: 'l, d-M-y H:i:s T',
+        RFC_1036: 'D, d M y H:i:s O',
+        RFC_1123: 'D, d M Y H:i:s O',
+        RSS: 'D, d M Y H:i:s O',
+        W3C: 'Y-m-d\TH:i:sP'
+    }
+
+    var isFormatStandard = function(format){
+        return Object.values(standardFormats).indexOf(format) === -1 ? false : true;
+    }
+
+    $.extend($.datetimepicker, standardFormats);
+
+    // first init date formatter
+    initDateFormatter();
+
     // fix for ie8
+    if (!window.getComputedStyle) {
+        window.getComputedStyle = function (el) {
+            this.el = el;
+            this.getPropertyValue = function (prop) {
+                var re = /(-([a-z]))/g;
+                if (prop === 'float') {
+                    prop = 'styleFloat';
+                }
+                if (re.test(prop)) {
+                    prop = prop.replace(re, function (a, b, c) {
+                        return c.toUpperCase();
+                    });
+                }
+                return el.currentStyle[prop] || null;
+            };
+            return this;
+        };
+    }
     if (!Array.prototype.indexOf) {
         Array.prototype.indexOf = function (obj, start) {
             var i, j;
@@ -315,10 +773,12 @@
             return -1;
         };
     }
+
     Date.prototype.countDaysInMonth = function () {
         return new Date(this.getFullYear(), this.getMonth() + 1, 0).getDate();
     };
-    $.fn.xdsoftScroller = function (percent) {
+
+    $.fn.xdsoftScroller = function (options, percent) {
         return this.each(function () {
             var timeboxparent = $(this),
                 pointerEventToXY = function (e) {
@@ -334,7 +794,6 @@
                     }
                     return out;
                 },
-                move = 0,
                 timebox,
                 parentHeight,
                 height,
@@ -348,6 +807,11 @@
                 touchStart = false,
                 startTopScroll = 0,
                 calcOffset = function () {};
+
+            if (percent === 'hide') {
+                timeboxparent.find('.xdsoft_scrollbar').hide();
+                return;
+            }
 
             if (!$(this).hasClass('xdsoft_scroller_box')) {
                 timebox = timeboxparent.children().eq(0);
@@ -379,16 +843,16 @@
                         startTopScroll = parseInt(scroller.css('margin-top'), 10);
                         h1 = scrollbar[0].offsetHeight;
 
-                        if (event.type === 'mousedown') {
-                            if (document) {
-                                $(document.body).addClass('xdsoft_noselect');
+                        if (event.type === 'mousedown' || event.type === 'touchstart') {
+                            if (options.ownerDocument) {
+                                $(options.ownerDocument.body).addClass('xdsoft_noselect');
                             }
-                            $([document.body, window]).on('mouseup.xdsoft_scroller', function arguments_callee() {
-                                $([document.body, window]).off('mouseup.xdsoft_scroller', arguments_callee)
+                            $([options.ownerDocument.body, options.contentWindow]).on('touchend mouseup.xdsoft_scroller', function arguments_callee() {
+                                $([options.ownerDocument.body, options.contentWindow]).off('touchend mouseup.xdsoft_scroller', arguments_callee)
                                     .off('mousemove.xdsoft_scroller', calcOffset)
                                     .removeClass('xdsoft_noselect');
                             });
-                            $(document.body).on('mousemove.xdsoft_scroller', calcOffset);
+                            $(options.ownerDocument.body).on('mousemove.xdsoft_scroller', calcOffset);
                         } else {
                             touchStart = true;
                             event.stopPropagation();
@@ -401,7 +865,7 @@
                             calcOffset(event);
                         }
                     })
-                    .on('touchend touchcancel', function (event) {
+                    .on('touchend touchcancel', function () {
                         touchStart =  false;
                         startTopScroll = 0;
                     });
@@ -463,7 +927,7 @@
                     }
                 });
 
-                timeboxparent.on('touchend touchcancel', function (event) {
+                timeboxparent.on('touchend touchcancel', function () {
                     start = false;
                     startTop = 0;
                 });
@@ -472,8 +936,9 @@
         });
     };
 
-    $.fn.datetimepicker = function (opt) {
-        var KEY0 = 48,
+    $.fn.datetimepicker = function (opt, opt2) {
+        var result = this,
+            KEY0 = 48,
             KEY9 = 57,
             _KEY0 = 96,
             _KEY9 = 105,
@@ -499,12 +964,11 @@
             lazyInitTimer = 0,
             createDateTimePicker,
             destroyDateTimePicker,
-            _xdsoft_datetime,
 
             lazyInit = function (input) {
                 input
-                    .on('open.xdsoft focusin.xdsoft mousedown.xdsoft', function initOnActionCallback(event) {
-                        if (input.is(':disabled') || input.is(':hidden') || !input.is(':visible') || input.data('xdsoft_datetimepicker')) {
+                    .on('open.xdsoft focusin.xdsoft mousedown.xdsoft touchstart', function initOnActionCallback() {
+                        if (input.is(':disabled') || input.data('xdsoft_datetimepicker')) {
                             return;
                         }
                         clearTimeout(lazyInitTimer);
@@ -514,17 +978,17 @@
                                 createDateTimePicker(input);
                             }
                             input
-                                .off('open.xdsoft focusin.xdsoft mousedown.xdsoft', initOnActionCallback)
+                                .off('open.xdsoft focusin.xdsoft mousedown.xdsoft touchstart', initOnActionCallback)
                                 .trigger('open.xdsoft');
                         }, 100);
                     });
             };
 
         createDateTimePicker = function (input) {
-            var datetimepicker = $('<div ' + (options.id ? 'id="' + options.id + '"' : '') + ' ' + (options.style ? 'style="' + options.style + '"' : '') + ' class="xdsoft_datetimepicker xdsoft_' + options.theme + ' xdsoft_noselect ' + (options.weeks ? ' xdsoft_showweeks' : '') + options.className + '"></div>'),
+            var datetimepicker = $('<div class="xdsoft_datetimepicker xdsoft_noselect"></div>'),
                 xdsoft_copyright = $('<div class="xdsoft_copyright"><a target="_blank" href="http://xdsoft.net/jqplugins/datetimepicker/">xdsoft.net</a></div>'),
                 datepicker = $('<div class="xdsoft_datepicker active"></div>'),
-                mounth_picker = $('<div class="xdsoft_mounthpicker"><button type="button" class="xdsoft_prev"></button><button type="button" class="xdsoft_today_button"></button>' +
+                month_picker = $('<div class="xdsoft_monthpicker"><button type="button" class="xdsoft_prev"></button><button type="button" class="xdsoft_today_button"></button>' +
                     '<div class="xdsoft_label xdsoft_month"><span></span><i></i></div>' +
                     '<div class="xdsoft_label xdsoft_year"><span></span><i></i></div>' +
                     '<button type="button" class="xdsoft_next"></button></div>'),
@@ -532,30 +996,47 @@
                 timepicker = $('<div class="xdsoft_timepicker active"><button type="button" class="xdsoft_prev"></button><div class="xdsoft_time_box"></div><button type="button" class="xdsoft_next"></button></div>'),
                 timeboxparent = timepicker.find('.xdsoft_time_box').eq(0),
                 timebox = $('<div class="xdsoft_time_variant"></div>'),
-                scrollbar = $('<div class="xdsoft_scrollbar"></div>'),
-                scroller = $('<div class="xdsoft_scroller"></div>'),
+                applyButton = $('<button type="button" class="xdsoft_save_selected blue-gradient-button">Save Selected</button>'),
+
                 monthselect = $('<div class="xdsoft_select xdsoft_monthselect"><div></div></div>'),
                 yearselect = $('<div class="xdsoft_select xdsoft_yearselect"><div></div></div>'),
                 triggerAfterOpen = false,
                 XDSoft_datetime,
-                //scroll_element,
+
                 xchangeTimer,
                 timerclick,
                 current_time_index,
                 setPos,
                 timer = 0,
-                timer1 = 0;
+                _xdsoft_datetime,
+                forEachAncestorOf;
 
-            mounth_picker
+            if (options.id) {
+                datetimepicker.attr('id', options.id);
+            }
+            if (options.style) {
+                datetimepicker.attr('style', options.style);
+            }
+            if (options.weeks) {
+                datetimepicker.addClass('xdsoft_showweeks');
+            }
+            if (options.rtl) {
+                datetimepicker.addClass('xdsoft_rtl');
+            }
+
+            datetimepicker.addClass('xdsoft_' + options.theme);
+            datetimepicker.addClass(options.className);
+
+            month_picker
                 .find('.xdsoft_month span')
                 .after(monthselect);
-            mounth_picker
+            month_picker
                 .find('.xdsoft_year span')
                 .after(yearselect);
 
-            mounth_picker
+            month_picker
                 .find('.xdsoft_month,.xdsoft_year')
-                .on('mousedown.xdsoft', function (event) {
+                .on('touchstart mousedown.xdsoft', function (event) {
                     var select = $(this).find('.xdsoft_select').eq(0),
                         val = 0,
                         top = 0,
@@ -563,7 +1044,7 @@
                         items,
                         i;
 
-                    mounth_picker
+                    month_picker
                         .find('.xdsoft_select')
                         .hide();
                     if (_xdsoft_datetime.currentTime) {
@@ -579,37 +1060,65 @@
                         }
                     }
 
-                    select.xdsoftScroller(top / (select.children()[0].offsetHeight - (select[0].clientHeight)));
+                    select.xdsoftScroller(options, top / (select.children()[0].offsetHeight - (select[0].clientHeight)));
                     event.stopPropagation();
                     return false;
                 });
 
-            mounth_picker
+            var handleTouchMoved = function (event) {
+                var evt = event.originalEvent;
+                var touchPosition = evt.touches ? evt.touches[0] : evt;
+                this.touchStartPosition = this.touchStartPosition || touchPosition;
+                var xMovement = Math.abs(this.touchStartPosition.clientX - touchPosition.clientX);
+                var yMovement = Math.abs(this.touchStartPosition.clientY - touchPosition.clientY);
+                var distance = Math.sqrt(xMovement * xMovement + yMovement * yMovement);
+                if(distance > options.touchMovedThreshold) {
+                    this.touchMoved = true;
+                }
+            }
+
+            month_picker
                 .find('.xdsoft_select')
-                .xdsoftScroller()
-                .on('mousedown.xdsoft', function (event) {
+                .xdsoftScroller(options)
+                .on('touchstart mousedown.xdsoft', function (event) {
+                    var evt = event.originalEvent;
+                    this.touchMoved = false;
+                    this.touchStartPosition = evt.touches ? evt.touches[0] : evt;
                     event.stopPropagation();
                     event.preventDefault();
                 })
-                .on('mousedown.xdsoft', '.xdsoft_option', function (event) {
-                    var year = _xdsoft_datetime.currentTime.getFullYear();
-                    if (_xdsoft_datetime && _xdsoft_datetime.currentTime) {
-                        _xdsoft_datetime.currentTime[$(this).parent().parent().hasClass('xdsoft_monthselect') ? 'setMonth' : 'setFullYear']($(this).data('value'));
-                    }
+                .on('touchmove', '.xdsoft_option', handleTouchMoved)
+                .on('touchend mousedown.xdsoft', '.xdsoft_option', function () {
+                    if (!this.touchMoved) {
+                        if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
+                            _xdsoft_datetime.currentTime = _xdsoft_datetime.now();
+                        }
 
-                    $(this).parent().parent().hide();
+                        var year = _xdsoft_datetime.currentTime.getFullYear();
+                        if (_xdsoft_datetime && _xdsoft_datetime.currentTime) {
+                            _xdsoft_datetime.currentTime[$(this).parent().parent().hasClass('xdsoft_monthselect') ? 'setMonth' : 'setFullYear']($(this).data('value'));
+                        }
 
-                    datetimepicker.trigger('xchange.xdsoft');
-                    if (options.onChangeMonth && $.isFunction(options.onChangeMonth)) {
-                        options.onChangeMonth.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
-                    }
+                        $(this).parent().parent().hide();
 
-                    if (year !== _xdsoft_datetime.currentTime.getFullYear() && $.isFunction(options.onChangeYear)) {
-                        options.onChangeYear.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
+                        datetimepicker.trigger('xchange.xdsoft');
+                        if (options.onChangeMonth && $.isFunction(options.onChangeMonth)) {
+                            options.onChangeMonth.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
+                        }
+
+                        if (year !== _xdsoft_datetime.currentTime.getFullYear() && $.isFunction(options.onChangeYear)) {
+                            options.onChangeYear.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'));
+                        }
                     }
                 });
 
+            datetimepicker.getValue = function () {
+                return _xdsoft_datetime.getCurrentTime();
+            };
+
             datetimepicker.setOptions = function (_options) {
+                var highlightedDates = {};
+
                 options = $.extend(true, {}, options, _options);
 
                 if (_options.allowTimes && $.isArray(_options.allowTimes) && _options.allowTimes.length) {
@@ -618,6 +1127,83 @@
 
                 if (_options.weekends && $.isArray(_options.weekends) && _options.weekends.length) {
                     options.weekends = $.extend(true, [], _options.weekends);
+                }
+
+                if (_options.allowDates && $.isArray(_options.allowDates) && _options.allowDates.length) {
+                    options.allowDates = $.extend(true, [], _options.allowDates);
+                }
+
+                if (_options.allowDateRe && Object.prototype.toString.call(_options.allowDateRe)==="[object String]") {
+                    options.allowDateRe = new RegExp(_options.allowDateRe);
+                }
+
+                if (_options.highlightedDates && $.isArray(_options.highlightedDates) && _options.highlightedDates.length) {
+                    $.each(_options.highlightedDates, function (index, value) {
+                        var splitData = $.map(value.split(','), $.trim),
+                            exDesc,
+                            hDate = new HighlightedDate(dateHelper.parseDate(splitData[0], options.formatDate), splitData[1], splitData[2]), // date, desc, style
+                            keyDate = dateHelper.formatDate(hDate.date, options.formatDate);
+                        if (highlightedDates[keyDate] !== undefined) {
+                            exDesc = highlightedDates[keyDate].desc;
+                            if (exDesc && exDesc.length && hDate.desc && hDate.desc.length) {
+                                highlightedDates[keyDate].desc = exDesc + "\n" + hDate.desc;
+                            }
+                        } else {
+                            highlightedDates[keyDate] = hDate;
+                        }
+                    });
+
+                    options.highlightedDates = $.extend(true, [], highlightedDates);
+                }
+
+                if (_options.highlightedPeriods && $.isArray(_options.highlightedPeriods) && _options.highlightedPeriods.length) {
+                    highlightedDates = $.extend(true, [], options.highlightedDates);
+                    $.each(_options.highlightedPeriods, function (index, value) {
+                        var dateTest, // start date
+                            dateEnd,
+                            desc,
+                            hDate,
+                            keyDate,
+                            exDesc,
+                            style;
+                        if ($.isArray(value)) {
+                            dateTest = value[0];
+                            dateEnd = value[1];
+                            desc = value[2];
+                            style = value[3];
+                        }
+                        else {
+                            var splitData = $.map(value.split(','), $.trim);
+                            dateTest = dateHelper.parseDate(splitData[0], options.formatDate);
+                            dateEnd = dateHelper.parseDate(splitData[1], options.formatDate);
+                            desc = splitData[2];
+                            style = splitData[3];
+                        }
+
+                        while (dateTest <= dateEnd) {
+                            hDate = new HighlightedDate(dateTest, desc, style);
+                            keyDate = dateHelper.formatDate(dateTest, options.formatDate);
+                            dateTest.setDate(dateTest.getDate() + 1);
+                            if (highlightedDates[keyDate] !== undefined) {
+                                exDesc = highlightedDates[keyDate].desc;
+                                if (exDesc && exDesc.length && hDate.desc && hDate.desc.length) {
+                                    highlightedDates[keyDate].desc = exDesc + "\n" + hDate.desc;
+                                }
+                            } else {
+                                highlightedDates[keyDate] = hDate;
+                            }
+                        }
+                    });
+
+                    options.highlightedDates = $.extend(true, [], highlightedDates);
+                }
+
+                if (_options.disabledDates && $.isArray(_options.disabledDates) && _options.disabledDates.length) {
+                    options.disabledDates = $.extend(true, [], _options.disabledDates);
+                }
+
+                if (_options.disabledWeekDays && $.isArray(_options.disabledWeekDays) && _options.disabledWeekDays.length) {
+                    options.disabledWeekDays = $.extend(true, [], _options.disabledWeekDays);
                 }
 
                 if ((options.open || options.opened) && (!options.inline)) {
@@ -648,10 +1234,10 @@
                 }
 
                 if (options.value) {
-                    if (input && input.val) {
-                        input.val(options.value);
-                    }
                     _xdsoft_datetime.setCurrentTime(options.value);
+                    if (input && input.val) {
+                        input.val(_xdsoft_datetime.str);
+                    }
                 }
 
                 if (isNaN(options.dayOfWeekStart)) {
@@ -661,149 +1247,71 @@
                 }
 
                 if (!options.timepickerScrollbar) {
-                    scrollbar.hide();
+                    timeboxparent.xdsoftScroller(options, 'hide');
                 }
 
-                if (options.minDate && /^-(.*)$/.test(options.minDate)) {
-                    options.minDate = _xdsoft_datetime.strToDateTime(options.minDate).dateFormat(options.formatDate);
+                if (options.minDate && /^[\+\-](.*)$/.test(options.minDate)) {
+                    options.minDate = dateHelper.formatDate(_xdsoft_datetime.strToDateTime(options.minDate), options.formatDate);
                 }
 
-                if (options.maxDate &&  /^\+(.*)$/.test(options.maxDate)) {
-                    options.maxDate = _xdsoft_datetime.strToDateTime(options.maxDate).dateFormat(options.formatDate);
+                if (options.maxDate &&  /^[\+\-](.*)$/.test(options.maxDate)) {
+                    options.maxDate = dateHelper.formatDate(_xdsoft_datetime.strToDateTime(options.maxDate), options.formatDate);
                 }
 
-                mounth_picker
+                if (options.minDateTime &&  /^\+(.*)$/.test(options.minDateTime)) {
+                    options.minDateTime = _xdsoft_datetime.strToDateTime(options.minDateTime).dateFormat(options.formatDate);
+                }
+
+                if (options.maxDateTime &&  /^\+(.*)$/.test(options.maxDateTime)) {
+                    options.maxDateTime = _xdsoft_datetime.strToDateTime(options.maxDateTime).dateFormat(options.formatDate);
+                }
+
+                applyButton.toggle(options.showApplyButton);
+
+                month_picker
                     .find('.xdsoft_today_button')
                     .css('visibility', !options.todayButton ? 'hidden' : 'visible');
 
-                if (options.mask) {
-                    var e,
-                        getCaretPos = function (input) {
-                            try {
-                                if (document.selection && document.selection.createRange) {
-                                    var range = document.selection.createRange();
-                                    return range.getBookmark().charCodeAt(2) - 2;
-                                }
-                                if (input.setSelectionRange) {
-                                    return input.selectionStart;
-                                }
-                            } catch (e) {
-                                return 0;
-                            }
-                        },
-                        setCaretPos = function (node, pos) {
-                            node = (typeof node === "string" || node instanceof String) ? document.getElementById(node) : node;
-                            if (!node) {
-                                return false;
-                            }
-                            if (node.createTextRange) {
-                                var textRange = node.createTextRange();
-                                textRange.collapse(true);
-                                textRange.moveEnd('character', pos);
-                                textRange.moveStart('character', pos);
-                                textRange.select();
-                                return true;
-                            }
-                            if (node.setSelectionRange) {
-                                node.setSelectionRange(pos, pos);
-                                return true;
-                            }
-                            return false;
-                        },
-                        isValidValue = function (mask, value) {
-                            var reg = mask
-                                .replace(/([\[\]\/\{\}\(\)\-\.\+]{1})/g, '\\$1')
-                                .replace(/_/g, '{digit+}')
-                                .replace(/([0-9]{1})/g, '{digit$1}')
-                                .replace(/\{digit([0-9]{1})\}/g, '[0-$1_]{1}')
-                                .replace(/\{digit[\+]\}/g, '[0-9_]{1}');
-                            return (new RegExp(reg)).test(value);
-                        };
-                    input.off('keydown.xdsoft');
+                month_picker
+                    .find('.' + options.prev)
+                    .css('visibility', !options.prevButton ? 'hidden' : 'visible');
 
-                    if (options.mask === true) {
-                        options.mask = options.format
-                            .replace(/Y/g, '9999')
-                            .replace(/F/g, '9999')
-                            .replace(/m/g, '19')
-                            .replace(/d/g, '39')
-                            .replace(/H/g, '29')
-                            .replace(/i/g, '59')
-                            .replace(/s/g, '59');
-                    }
+                month_picker
+                    .find('.' + options.next)
+                    .css('visibility', !options.nextButton ? 'hidden' : 'visible');
 
-                    if ($.type(options.mask) === 'string') {
-                        if (!isValidValue(options.mask, input.val())) {
-                            input.val(options.mask.replace(/[0-9]/g, '_'));
-                        }
+                setMask(options);
 
-                        input.on('keydown.xdsoft', function (event) {
-                            var val = this.value,
-                                key = event.which,
-                                pos,
-                                digit;
-
-                            if (((key >= KEY0 && key <= KEY9) || (key >= _KEY0 && key <= _KEY9)) || (key === BACKSPACE || key === DEL)) {
-                                pos = getCaretPos(this);
-                                digit = (key !== BACKSPACE && key !== DEL) ? String.fromCharCode((_KEY0 <= key && key <= _KEY9) ? key - KEY0 : key) : '_';
-
-                                if ((key === BACKSPACE || key === DEL) && pos) {
-                                    pos -= 1;
-                                    digit = '_';
-                                }
-
-                                while (/[^0-9_]/.test(options.mask.substr(pos, 1)) && pos < options.mask.length && pos > 0) {
-                                    pos += (key === BACKSPACE || key === DEL) ? -1 : 1;
-                                }
-
-                                val = val.substr(0, pos) + digit + val.substr(pos + 1);
-                                if ($.trim(val) === '') {
-                                    val = options.mask.replace(/[0-9]/g, '_');
-                                } else {
-                                    if (pos === options.mask.length) {
-                                        event.preventDefault();
-                                        return false;
-                                    }
-                                }
-
-                                pos += (key === BACKSPACE || key === DEL) ? 0 : 1;
-                                while (/[^0-9_]/.test(options.mask.substr(pos, 1)) && pos < options.mask.length && pos > 0) {
-                                    pos += (key === BACKSPACE || key === DEL) ? -1 : 1;
-                                }
-
-                                if (isValidValue(options.mask, val)) {
-                                    this.value = val;
-                                    setCaretPos(this, pos);
-                                } else if ($.trim(val) === '') {
-                                    this.value = options.mask.replace(/[0-9]/g, '_');
-                                } else {
-                                    input.trigger('error_input.xdsoft');
-                                }
-                            } else {
-                                if (([AKEY, CKEY, VKEY, ZKEY, YKEY].indexOf(key) !== -1 && ctrlDown) || [ESC, ARROWUP, ARROWDOWN, ARROWLEFT, ARROWRIGHT, F5, CTRLKEY, TAB, ENTER].indexOf(key) !== -1) {
-                                    return true;
-                                }
-                            }
-
-                            event.preventDefault();
-                            return false;
-                        });
-                    }
-                }
                 if (options.validateOnBlur) {
                     input
                         .off('blur.xdsoft')
                         .on('blur.xdsoft', function () {
-                            if (options.allowBlank && !$.trim($(this).val()).length) {
+                            if (options.allowBlank && (!$.trim($(this).val()).length ||
+                                (typeof options.mask === "string" && $.trim($(this).val()) === options.mask.replace(/[0-9]/g, '_')))) {
                                 $(this).val(null);
                                 datetimepicker.data('xdsoft_datetime').empty();
-                            } else if (!Date.parseDate($(this).val(), options.format)) {
-                                $(this).val((_xdsoft_datetime.now()).dateFormat(options.format));
-                                datetimepicker.data('xdsoft_datetime').setCurrentTime($(this).val());
                             } else {
+                                var d = dateHelper.parseDate($(this).val(), options.format);
+                                if (d) { // parseDate() may skip some invalid parts like date or time, so make it clear for user: show parsed date/time
+                                    $(this).val(dateHelper.formatDate(d, options.format));
+                                } else {
+                                    var splittedHours   = +([$(this).val()[0], $(this).val()[1]].join('')),
+                                        splittedMinutes = +([$(this).val()[2], $(this).val()[3]].join(''));
+
+                                    // parse the numbers as 0312 => 03:12
+                                    if (!options.datepicker && options.timepicker && splittedHours >= 0 && splittedHours < 24 && splittedMinutes >= 0 && splittedMinutes < 60) {
+                                        $(this).val([splittedHours, splittedMinutes].map(function (item) {
+                                            return item > 9 ? item : '0' + item;
+                                        }).join(':'));
+                                    } else {
+                                        $(this).val(dateHelper.formatDate(_xdsoft_datetime.now(), options.format));
+                                    }
+                                }
                                 datetimepicker.data('xdsoft_datetime').setCurrentTime($(this).val());
                             }
+
                             datetimepicker.trigger('changedatetime.xdsoft');
+                            datetimepicker.trigger('close.xdsoft');
                         });
                 }
                 options.dayOfWeekStartPrev = (options.dayOfWeekStart === 0) ? 6 : options.dayOfWeekStart - 1;
@@ -815,7 +1323,7 @@
 
             datetimepicker
                 .data('options', options)
-                .on('mousedown.xdsoft', function (event) {
+                .on('touchstart mousedown.xdsoft', function (event) {
                     event.stopPropagation();
                     event.preventDefault();
                     yearselect.hide();
@@ -825,10 +1333,10 @@
 
             //scroll_element = timepicker.find('.xdsoft_time_box');
             timeboxparent.append(timebox);
-            timeboxparent.xdsoftScroller();
+            timeboxparent.xdsoftScroller(options);
 
             datetimepicker.on('afterOpen.xdsoft', function () {
-                timeboxparent.xdsoftScroller();
+                timeboxparent.xdsoftScroller(options);
             });
 
             datetimepicker
@@ -841,8 +1349,9 @@
             }
 
             datepicker
-                .append(mounth_picker)
-                .append(calendar);
+                .append(month_picker)
+                .append(calendar)
+                .append(applyButton);
 
             $(options.parentID)
                 .append(datetimepicker);
@@ -855,22 +1364,21 @@
                         time;
 
                     if (!norecursion && options.defaultDate) {
-                        date = _this.strToDate(options.defaultDate);
+                        date = _this.strToDateTime(options.defaultDate);
                         d.setFullYear(date.getFullYear());
                         d.setMonth(date.getMonth());
                         d.setDate(date.getDate());
                     }
 
-                    if (options.yearOffset) {
-                        d.setFullYear(d.getFullYear() + options.yearOffset);
-                    }
+                    d.setFullYear(d.getFullYear());
 
                     if (!norecursion && options.defaultTime) {
                         time = _this.strtotime(options.defaultTime);
                         d.setHours(time.getHours());
                         d.setMinutes(time.getMinutes());
+                        d.setSeconds(time.getSeconds());
+                        d.setMilliseconds(time.getMilliseconds());
                     }
-
                     return d;
                 };
 
@@ -881,8 +1389,20 @@
                     return !isNaN(d.getTime());
                 };
 
-                _this.setCurrentTime = function (dTime) {
-                    _this.currentTime = (typeof dTime === 'string') ? _this.strToDateTime(dTime) : _this.isValidDate(dTime) ? dTime : _this.now();
+                _this.setCurrentTime = function (dTime, requireValidDate) {
+                    if (typeof dTime === 'string') {
+                        _this.currentTime = _this.strToDateTime(dTime);
+                    }
+                    else if (_this.isValidDate(dTime)) {
+                        _this.currentTime = dTime;
+                    }
+                    else if (!dTime && !requireValidDate && options.allowBlank && !options.inline) {
+                        _this.currentTime = null;
+                    }
+                    else {
+                        _this.currentTime = _this.now();
+                    }
+
                     datetimepicker.trigger('xchange.xdsoft');
                 };
 
@@ -890,11 +1410,16 @@
                     _this.currentTime = null;
                 };
 
-                _this.getCurrentTime = function (dTime) {
+                _this.getCurrentTime = function () {
                     return _this.currentTime;
                 };
 
                 _this.nextMonth = function () {
+
+                    if (_this.currentTime === undefined || _this.currentTime === null) {
+                        _this.currentTime = _this.now();
+                    }
+
                     var month = _this.currentTime.getMonth() + 1,
                         year;
                     if (month === 12) {
@@ -925,6 +1450,11 @@
                 };
 
                 _this.prevMonth = function () {
+
+                    if (_this.currentTime === undefined || _this.currentTime === null) {
+                        _this.currentTime = _this.now();
+                    }
+
                     var month = _this.currentTime.getMonth() - 1;
                     if (month === -1) {
                         _this.currentTime.setFullYear(_this.currentTime.getFullYear() - 1);
@@ -945,7 +1475,19 @@
                 };
 
                 _this.getWeekOfYear = function (datetime) {
+                    if (options.onGetWeekOfYear && $.isFunction(options.onGetWeekOfYear)) {
+                        var week = options.onGetWeekOfYear.call(datetimepicker, datetime);
+                        if (typeof week !== 'undefined') {
+                            return week;
+                        }
+                    }
                     var onejan = new Date(datetime.getFullYear(), 0, 1);
+
+                    //First week of the year is th one with the first Thursday according to ISO8601
+                    if (onejan.getDay() !== 4) {
+                        onejan.setMonth(0, 1 + ((4 - onejan.getDay()+ 7) % 7));
+                    }
+
                     return Math.ceil((((datetime - onejan) / 86400000) + onejan.getDay() + 1) / 7);
                 };
 
@@ -956,15 +1498,17 @@
                         return sDateTime;
                     }
 
-                    tmpDate = /^(\+|\-)(.*)$/.exec(sDateTime);
+                    tmpDate = /^([+-]{1})(.*)$/.exec(sDateTime);
+
                     if (tmpDate) {
-                        tmpDate[2] = Date.parseDate(tmpDate[2], options.formatDate);
+                        tmpDate[2] = dateHelper.parseDate(tmpDate[2], options.formatDate);
                     }
+
                     if (tmpDate  && tmpDate[2]) {
                         timeOffset = tmpDate[2].getTime() - (tmpDate[2].getTimezoneOffset()) * 60000;
-                        currentTime = new Date((_xdsoft_datetime.now()).getTime() + parseInt(tmpDate[1] + '1', 10) * timeOffset);
+                        currentTime = new Date((_this.now(true)).getTime() + parseInt(tmpDate[1] + '1', 10) * timeOffset);
                     } else {
-                        currentTime = sDateTime ? Date.parseDate(sDateTime, options.format) : _this.now();
+                        currentTime = sDateTime ? dateHelper.parseDate(sDateTime, options.format) : _this.now();
                     }
 
                     if (!_this.isValidDate(currentTime)) {
@@ -979,7 +1523,7 @@
                         return sDate;
                     }
 
-                    var currentTime = sDate ? Date.parseDate(sDate, options.formatDate) : _this.now(true);
+                    var currentTime = sDate ? dateHelper.parseDate(sDate, options.formatDate) : _this.now(true);
                     if (!_this.isValidDate(currentTime)) {
                         currentTime = _this.now(true);
                     }
@@ -990,7 +1534,7 @@
                     if (sTime && sTime instanceof Date && _this.isValidDate(sTime)) {
                         return sTime;
                     }
-                    var currentTime = sTime ? Date.parseDate(sTime, options.formatTime) : _this.now(true);
+                    var currentTime = sTime ? dateHelper.parseDate(sTime, options.formatTime) : _this.now(true);
                     if (!_this.isValidDate(currentTime)) {
                         currentTime = _this.now(true);
                     }
@@ -998,32 +1542,56 @@
                 };
 
                 _this.str = function () {
-                    return _this.currentTime.dateFormat(options.format);
+                    var format = options.format;
+                    if (options.yearOffset) {
+                        format = format.replace('Y', _this.currentTime.getFullYear() + options.yearOffset);
+                        format = format.replace('y', String(_this.currentTime.getFullYear() + options.yearOffset).substring(2, 4));
+                    }
+                    return dateHelper.formatDate(_this.currentTime, format);
                 };
                 _this.currentTime = this.now();
             };
 
             _xdsoft_datetime = new XDSoft_datetime();
 
-            mounth_picker
-                .find('.xdsoft_today_button')
-                .on('mousedown.xdsoft', function () {
-                    datetimepicker.data('changed', true);
-                    _xdsoft_datetime.setCurrentTime(0);
-                    datetimepicker.trigger('afterOpen.xdsoft');
-                }).on('dblclick.xdsoft', function () {
+            applyButton.on('touchend click', function (e) {//pathbrite
+                e.preventDefault();
+                datetimepicker.data('changed', true);
+                _xdsoft_datetime.setCurrentTime(getCurrentValue());
                 input.val(_xdsoft_datetime.str());
                 datetimepicker.trigger('close.xdsoft');
             });
-            mounth_picker
+            month_picker
+                .find('.xdsoft_today_button')
+                .on('touchend mousedown.xdsoft', function () {
+                    datetimepicker.data('changed', true);
+                    _xdsoft_datetime.setCurrentTime(0, true);
+                    datetimepicker.trigger('afterOpen.xdsoft');
+                }).on('dblclick.xdsoft', function () {
+                var currentDate = _xdsoft_datetime.getCurrentTime(), minDate, maxDate;
+                currentDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate());
+                minDate = _xdsoft_datetime.strToDate(options.minDate);
+                minDate = new Date(minDate.getFullYear(), minDate.getMonth(), minDate.getDate());
+                if (currentDate < minDate) {
+                    return;
+                }
+                maxDate = _xdsoft_datetime.strToDate(options.maxDate);
+                maxDate = new Date(maxDate.getFullYear(), maxDate.getMonth(), maxDate.getDate());
+                if (currentDate > maxDate) {
+                    return;
+                }
+                input.val(_xdsoft_datetime.str());
+                input.trigger('change');
+                datetimepicker.trigger('close.xdsoft');
+            });
+            month_picker
                 .find('.xdsoft_prev,.xdsoft_next')
-                .on('mousedown.xdsoft', function () {
+                .on('touchend mousedown.xdsoft', function () {
                     var $this = $(this),
                         timer = 0,
                         stop = false;
 
                     (function arguments_callee1(v) {
-                        var month =  _xdsoft_datetime.currentTime.getMonth();
                         if ($this.hasClass(options.next)) {
                             _xdsoft_datetime.nextMonth();
                         } else if ($this.hasClass(options.prev)) {
@@ -1036,16 +1604,16 @@
                         }
                     }(500));
 
-                    $([document.body, window]).on('mouseup.xdsoft', function arguments_callee2() {
+                    $([options.ownerDocument.body, options.contentWindow]).on('touchend mouseup.xdsoft', function arguments_callee2() {
                         clearTimeout(timer);
                         stop = true;
-                        $([document.body, window]).off('mouseup.xdsoft', arguments_callee2);
+                        $([options.ownerDocument.body, options.contentWindow]).off('touchend mouseup.xdsoft', arguments_callee2);
                     });
                 });
 
             timepicker
                 .find('.xdsoft_prev,.xdsoft_next')
-                .on('mousedown.xdsoft', function () {
+                .on('touchend mousedown.xdsoft', function () {
                     var $this = $(this),
                         timer = 0,
                         stop = false,
@@ -1059,17 +1627,30 @@
                         } else if ($this.hasClass(options.prev) && top - options.timeHeightInTimePicker >= 0) {
                             timebox.css('marginTop', '-' + (top - options.timeHeightInTimePicker) + 'px');
                         }
-                        timeboxparent.trigger('scroll_element.xdsoft_scroller', [Math.abs(parseInt(timebox.css('marginTop'), 10) / (height - pheight))]);
+                        /**
+                         * Fixed bug:
+                         * When using css3 transition, it will cause a bug that you cannot scroll the timepicker list.
+                         * The reason is that the transition-duration time, if you set it to 0, all things fine, otherwise, this
+                         * would cause a bug when you use jquery.css method.
+                         * Let's say: * { transition: all .5s ease; }
+                         * jquery timebox.css('marginTop') will return the original value which is before you clicking the next/prev button,
+                         * meanwhile the timebox[0].style.marginTop will return the right value which is after you clicking the
+                         * next/prev button.
+                         *
+                         * What we should do:
+                         * Replace timebox.css('marginTop') with timebox[0].style.marginTop.
+                         */
+                        timeboxparent.trigger('scroll_element.xdsoft_scroller', [Math.abs(parseInt(timebox[0].style.marginTop, 10) / (height - pheight))]);
                         period = (period > 10) ? 10 : period - 10;
                         if (!stop) {
                             timer = setTimeout(arguments_callee4, v || period);
                         }
                     }(500));
-                    $([document.body, window]).on('mouseup.xdsoft', function arguments_callee5() {
+                    $([options.ownerDocument.body, options.contentWindow]).on('touchend mouseup.xdsoft', function arguments_callee5() {
                         clearTimeout(timer);
                         stop = true;
-                        $([document.body, window])
-                            .off('mouseup.xdsoft', arguments_callee5);
+                        $([options.ownerDocument.body, options.contentWindow])
+                            .off('touchend mouseup.xdsoft', arguments_callee5);
                     });
                 });
 
@@ -1079,6 +1660,11 @@
                 .on('xchange.xdsoft', function (event) {
                     clearTimeout(xchangeTimer);
                     xchangeTimer = setTimeout(function () {
+
+                        if (_xdsoft_datetime.currentTime === undefined || _xdsoft_datetime.currentTime === null) {
+                            _xdsoft_datetime.currentTime = _xdsoft_datetime.now();
+                        }
+
                         var table =	'',
                             start = new Date(_xdsoft_datetime.currentTime.getFullYear(), _xdsoft_datetime.currentTime.getMonth(), 1, 12, 0, 0),
                             i = 0,
@@ -1086,6 +1672,10 @@
                             today = _xdsoft_datetime.now(),
                             maxDate = false,
                             minDate = false,
+                            minDateTime = false,
+                            maxDateTime = false,
+                            hDate,
+                            day,
                             d,
                             y,
                             m,
@@ -1094,8 +1684,9 @@
                             customDateSettings,
                             newRow = true,
                             time = '',
-                            h = '',
-                            line_time;
+                            h,
+                            line_time,
+                            description;
 
                         while (start.getDay() !== options.dayOfWeekStart) {
                             start.setDate(start.getDate() - 1);
@@ -1108,7 +1699,7 @@
                         }
 
                         for (j = 0; j < 7; j += 1) {
-                            table += '<th>' + options.i18n[options.lang].dayOfWeek[(j + options.dayOfWeekStart) % 7] + '</th>';
+                            table += '<th>' + options.i18n[globalLocale].dayOfWeekShort[(j + options.dayOfWeekStart) % 7] + '</th>';
                         }
 
                         table += '</tr></thead>';
@@ -1124,14 +1715,31 @@
                             minDate = new Date(minDate.getFullYear(), minDate.getMonth(), minDate.getDate());
                         }
 
+                        if (options.minDateTime !== false) {
+                            minDateTime = _xdsoft_datetime.strToDate(options.minDateTime);
+                            minDateTime = new Date(minDateTime.getFullYear(), minDateTime.getMonth(), minDateTime.getDate(), minDateTime.getHours(), minDateTime.getMinutes(), minDateTime.getSeconds());
+                        }
+
+                        if (options.maxDateTime !== false) {
+                            maxDateTime = _xdsoft_datetime.strToDate(options.maxDateTime);
+                            maxDateTime = new Date(maxDateTime.getFullYear(), maxDateTime.getMonth(), maxDateTime.getDate(), maxDateTime.getHours(), maxDateTime.getMinutes(), maxDateTime.getSeconds());
+                        }
+
+                        var maxDateTimeDay;
+                        if (maxDateTime !== false) {
+                            maxDateTimeDay = ((maxDateTime.getFullYear() * 12) + maxDateTime.getMonth()) * 31 + maxDateTime.getDate();
+                        }
+
                         while (i < _xdsoft_datetime.currentTime.countDaysInMonth() || start.getDay() !== options.dayOfWeekStart || _xdsoft_datetime.currentTime.getMonth() === start.getMonth()) {
                             classes = [];
                             i += 1;
 
+                            day = start.getDay();
                             d = start.getDate();
                             y = start.getFullYear();
                             m = start.getMonth();
                             w = _xdsoft_datetime.getWeekOfYear(start);
+                            description = '';
 
                             classes.push('xdsoft_date');
 
@@ -1141,7 +1749,32 @@
                                 customDateSettings = null;
                             }
 
-                            if ((maxDate !== false && start > maxDate) || (minDate !== false && start < minDate) || (customDateSettings && customDateSettings[0] === false)) {
+                            if(options.allowDateRe && Object.prototype.toString.call(options.allowDateRe) === "[object RegExp]"){
+                                if(!options.allowDateRe.test(dateHelper.formatDate(start, options.formatDate))){
+                                    classes.push('xdsoft_disabled');
+                                }
+                            }
+
+                            if(options.allowDates && options.allowDates.length>0){
+                                if(options.allowDates.indexOf(dateHelper.formatDate(start, options.formatDate)) === -1){
+                                    classes.push('xdsoft_disabled');
+                                }
+                            }
+
+                            var currentDay = ((start.getFullYear() * 12) + start.getMonth()) * 31 + start.getDate();
+                            if ((maxDate !== false && start > maxDate) || (minDateTime !== false && start < minDateTime)  || (minDate !== false && start < minDate) || (maxDateTime !== false && currentDay > maxDateTimeDay) || (customDateSettings && customDateSettings[0] === false)) {
+                                classes.push('xdsoft_disabled');
+                            }
+
+                            if (options.disabledDates.indexOf(dateHelper.formatDate(start, options.formatDate)) !== -1) {
+                                classes.push('xdsoft_disabled');
+                            }
+
+                            if (options.disabledWeekDays.indexOf(day) !== -1) {
+                                classes.push('xdsoft_disabled');
+                            }
+
+                            if (input.is('[disabled]')) {
                                 classes.push('xdsoft_disabled');
                             }
 
@@ -1153,16 +1786,22 @@
                                 classes.push('xdsoft_other_month');
                             }
 
-                            if ((options.defaultSelect || datetimepicker.data('changed')) && _xdsoft_datetime.currentTime.dateFormat(options.formatDate) === start.dateFormat(options.formatDate)) {
+                            if ((options.defaultSelect || datetimepicker.data('changed')) && dateHelper.formatDate(_xdsoft_datetime.currentTime, options.formatDate) === dateHelper.formatDate(start, options.formatDate)) {
                                 classes.push('xdsoft_current');
                             }
 
-                            if (today.dateFormat(options.formatDate) === start.dateFormat(options.formatDate)) {
+                            if (dateHelper.formatDate(today, options.formatDate) === dateHelper.formatDate(start, options.formatDate)) {
                                 classes.push('xdsoft_today');
                             }
 
-                            if (start.getDay() === 0 || start.getDay() === 6 || options.weekends.indexOf(start.dateFormat(options.formatDate)) === -1) {
+                            if (start.getDay() === 0 || start.getDay() === 6 || options.weekends.indexOf(dateHelper.formatDate(start, options.formatDate)) !== -1) {
                                 classes.push('xdsoft_weekend');
+                            }
+
+                            if (options.highlightedDates[dateHelper.formatDate(start, options.formatDate)] !== undefined) {
+                                hDate = options.highlightedDates[dateHelper.formatDate(start, options.formatDate)];
+                                classes.push(hDate.style === undefined ? 'xdsoft_highlighted_default' : hDate.style);
+                                description = hDate.desc === undefined ? '' : hDate.desc;
                             }
 
                             if (options.beforeShowDay && $.isFunction(options.beforeShowDay)) {
@@ -1177,7 +1816,7 @@
                                 }
                             }
 
-                            table += '<td data-date="' + d + '" data-month="' + m + '" data-year="' + y + '"' + ' class="xdsoft_date xdsoft_day_of_week' + start.getDay() + ' ' + classes.join(' ') + '">' +
+                            table += '<td data-date="' + d + '" data-month="' + m + '" data-year="' + y + '"' + ' class="xdsoft_date xdsoft_day_of_week' + start.getDay() + ' ' + classes.join(' ') + '" title="' + description + '">' +
                                 '<div>' + d + '</div>' +
                                 '</td>';
 
@@ -1192,25 +1831,64 @@
 
                         calendar.html(table);
 
-                        mounth_picker.find('.xdsoft_label span').eq(0).text(options.i18n[options.lang].months[_xdsoft_datetime.currentTime.getMonth()]);
-                        mounth_picker.find('.xdsoft_label span').eq(1).text(_xdsoft_datetime.currentTime.getFullYear());
+                        month_picker.find('.xdsoft_label span').eq(0).text(options.i18n[globalLocale].months[_xdsoft_datetime.currentTime.getMonth()]);
+                        month_picker.find('.xdsoft_label span').eq(1).text(_xdsoft_datetime.currentTime.getFullYear() + options.yearOffset);
 
                         // generate timebox
                         time = '';
                         h = '';
                         m = '';
+
+                        var minTimeMinutesOfDay = 0;
+                        if (options.minTime !== false) {
+                            var t = _xdsoft_datetime.strtotime(options.minTime);
+                            minTimeMinutesOfDay = 60 * t.getHours() + t.getMinutes();
+                        }
+                        var maxTimeMinutesOfDay = 24 * 60;
+                        if (options.maxTime !== false) {
+                            var t = _xdsoft_datetime.strtotime(options.maxTime);
+                            maxTimeMinutesOfDay = 60 * t.getHours() + t.getMinutes();
+                        }
+
+                        if (options.minDateTime !== false) {
+                            var t = _xdsoft_datetime.strToDateTime(options.minDateTime);
+                            var currentDayIsMinDateTimeDay = dateHelper.formatDate(_xdsoft_datetime.currentTime, options.formatDate) === dateHelper.formatDate(t, options.formatDate);
+                            if (currentDayIsMinDateTimeDay) {
+                                var m = 60 * t.getHours() + t.getMinutes();
+                                if (m > minTimeMinutesOfDay) minTimeMinutesOfDay = m;
+                            }
+                        }
+
+                        if (options.maxDateTime !== false) {
+                            var t = _xdsoft_datetime.strToDateTime(options.maxDateTime);
+                            var currentDayIsMaxDateTimeDay = dateHelper.formatDate(_xdsoft_datetime.currentTime, options.formatDate) === dateHelper.formatDate(t, options.formatDate);
+                            if (currentDayIsMaxDateTimeDay) {
+                                var m = 60 * t.getHours() + t.getMinutes();
+                                if (m < maxTimeMinutesOfDay) maxTimeMinutesOfDay = m;
+                            }
+                        }
+
                         line_time = function line_time(h, m) {
-                            var now = _xdsoft_datetime.now();
+                            var now = _xdsoft_datetime.now(), current_time,
+                                isALlowTimesInit = options.allowTimes && $.isArray(options.allowTimes) && options.allowTimes.length;
                             now.setHours(h);
                             h = parseInt(now.getHours(), 10);
                             now.setMinutes(m);
                             m = parseInt(now.getMinutes(), 10);
-
                             classes = [];
-                            if ((options.maxTime !== false && _xdsoft_datetime.strtotime(options.maxTime).getTime() < now.getTime()) || (options.minTime !== false && _xdsoft_datetime.strtotime(options.minTime).getTime() > now.getTime())) {
+                            var currentMinutesOfDay = 60 * h + m;
+                            if (input.is('[disabled]') || (currentMinutesOfDay >= maxTimeMinutesOfDay) || (currentMinutesOfDay < minTimeMinutesOfDay)) {
                                 classes.push('xdsoft_disabled');
                             }
-                            if ((options.initTime || options.defaultSelect || datetimepicker.data('changed')) && parseInt(_xdsoft_datetime.currentTime.getHours(), 10) === parseInt(h, 10) && (options.step > 59 || Math[options.roundTime](_xdsoft_datetime.currentTime.getMinutes() / options.step) * options.step === parseInt(m, 10))) {
+
+                            current_time = new Date(_xdsoft_datetime.currentTime);
+                            current_time.setHours(parseInt(_xdsoft_datetime.currentTime.getHours(), 10));
+
+                            if (!isALlowTimesInit) {
+                                current_time.setMinutes(Math[options.roundTime](_xdsoft_datetime.currentTime.getMinutes() / options.step) * options.step);
+                            }
+
+                            if ((options.initTime || options.defaultSelect || datetimepicker.data('changed')) && current_time.getHours() === parseInt(h, 10) && ((!isALlowTimesInit && options.step > 59) || current_time.getMinutes() === parseInt(m, 10))) {
                                 if (options.defaultSelect || datetimepicker.data('changed')) {
                                     classes.push('xdsoft_current');
                                 } else if (options.initTime) {
@@ -1220,12 +1898,15 @@
                             if (parseInt(today.getHours(), 10) === parseInt(h, 10) && parseInt(today.getMinutes(), 10) === parseInt(m, 10)) {
                                 classes.push('xdsoft_today');
                             }
-                            time += '<div class="xdsoft_time ' + classes.join(' ') + '" data-hour="' + h + '" data-minute="' + m + '">' + now.dateFormat(options.formatTime) + '</div>';
+                            time += '<div class="xdsoft_time ' + classes.join(' ') + '" data-hour="' + h + '" data-minute="' + m + '">' + dateHelper.formatDate(now, options.formatTime) + '</div>';
                         };
 
                         if (!options.allowTimes || !$.isArray(options.allowTimes) || !options.allowTimes.length) {
                             for (i = 0, j = 0; i < (options.hours12 ? 12 : 24); i += 1) {
                                 for (j = 0; j < 60; j += options.step) {
+                                    var currentMinutesOfDay = i * 60 + j;
+                                    if (currentMinutesOfDay < minTimeMinutesOfDay) continue;
+                                    if (currentMinutesOfDay >= maxTimeMinutesOfDay) continue;
                                     h = (i < 10 ? '0' : '') + i;
                                     m = (j < 10 ? '0' : '') + j;
                                     line_time(h, m);
@@ -1242,16 +1923,15 @@
                         timebox.html(time);
 
                         opt = '';
-                        i = 0;
 
-                        for (i = parseInt(options.yearStart, 10) + options.yearOffset; i <= parseInt(options.yearEnd, 10) + options.yearOffset; i += 1) {
-                            opt += '<div class="xdsoft_option ' + (_xdsoft_datetime.currentTime.getFullYear() === i ? 'xdsoft_current' : '') + '" data-value="' + i + '">' + i + '</div>';
+                        for (i = parseInt(options.yearStart, 10); i <= parseInt(options.yearEnd, 10); i += 1) {
+                            opt += '<div class="xdsoft_option ' + (_xdsoft_datetime.currentTime.getFullYear() === i ? 'xdsoft_current' : '') + '" data-value="' + i + '">' + (i + options.yearOffset) + '</div>';
                         }
                         yearselect.children().eq(0)
                             .html(opt);
 
-                        for (i = 0, opt = ''; i <= 11; i += 1) {
-                            opt += '<div class="xdsoft_option ' + (_xdsoft_datetime.currentTime.getMonth() === i ? 'xdsoft_current' : '') + '" data-value="' + i + '">' + options.i18n[options.lang].months[i] + '</div>';
+                        for (i = parseInt(options.monthStart, 10), opt = ''; i <= parseInt(options.monthEnd, 10); i += 1) {
+                            opt += '<div class="xdsoft_option ' + (_xdsoft_datetime.currentTime.getMonth() === i ? 'xdsoft_current' : '') + '" data-value="' + i + '">' + options.i18n[globalLocale].months[i] + '</div>';
                         }
                         monthselect.children().eq(0).html(opt);
                         $(datetimepicker)
@@ -1283,7 +1963,7 @@
 
             timerclick = 0;
             calendar
-                .on('click.xdsoft', 'td', function (xdevent) {
+                .on('touchend click.xdsoft', 'td', function (xdevent) {
                     xdevent.stopPropagation();  // Prevents closing of Pop-ups, Modals and Flyouts in Bootstrap
                     timerclick += 1;
                     var $this = $(this),
@@ -1306,9 +1986,6 @@
                     datetimepicker.trigger('select.xdsoft', [currentTime]);
 
                     input.val(_xdsoft_datetime.str());
-                    if ((timerclick > 1 || (options.closeOnDateSelect === true || (options.closeOnDateSelect === 0 && !options.timepicker))) && !options.inline) {
-                        datetimepicker.trigger('close.xdsoft');
-                    }
 
                     if (options.onSelectDate &&	$.isFunction(options.onSelectDate)) {
                         options.onSelectDate.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'), xdevent);
@@ -1317,42 +1994,50 @@
                     datetimepicker.data('changed', true);
                     datetimepicker.trigger('xchange.xdsoft');
                     datetimepicker.trigger('changedatetime.xdsoft');
+                    if ((timerclick > 1 || (options.closeOnDateSelect === true || (options.closeOnDateSelect === false && !options.timepicker))) && !options.inline) {
+                        datetimepicker.trigger('close.xdsoft');
+                    }
                     setTimeout(function () {
                         timerclick = 0;
                     }, 200);
                 });
 
             timebox
-                .on('click.xdsoft', 'div', function (xdevent) {
-                    xdevent.stopPropagation();
-                    var $this = $(this),
-                        currentTime = _xdsoft_datetime.currentTime;
+                .on('touchstart', 'div', function (xdevent) {
+                    this.touchMoved = false;
+                })
+                .on('touchmove', 'div', handleTouchMoved)
+                .on('touchend click.xdsoft', 'div', function (xdevent) {
+                    if (!this.touchMoved) {
+                        xdevent.stopPropagation();
+                        var $this = $(this),
+                            currentTime = _xdsoft_datetime.currentTime;
 
-                    if (currentTime === undefined || currentTime === null) {
-                        _xdsoft_datetime.currentTime = _xdsoft_datetime.now();
-                        currentTime = _xdsoft_datetime.currentTime;
-                    }
+                        if (currentTime === undefined || currentTime === null) {
+                            _xdsoft_datetime.currentTime = _xdsoft_datetime.now();
+                            currentTime = _xdsoft_datetime.currentTime;
+                        }
 
-                    if ($this.hasClass('xdsoft_disabled')) {
-                        return false;
-                    }
-                    currentTime.setHours($this.data('hour'));
-                    currentTime.setMinutes($this.data('minute'));
-                    datetimepicker.trigger('select.xdsoft', [currentTime]);
+                        if ($this.hasClass('xdsoft_disabled')) {
+                            return false;
+                        }
+                        currentTime.setHours($this.data('hour'));
+                        currentTime.setMinutes($this.data('minute'));
+                        datetimepicker.trigger('select.xdsoft', [currentTime]);
 
-                    datetimepicker.data('input').val(_xdsoft_datetime.str());
-                    if (!options.inline) {
-                        datetimepicker.trigger('close.xdsoft');
-                    }
+                        datetimepicker.data('input').val(_xdsoft_datetime.str());
 
-                    if (options.onSelectTime && $.isFunction(options.onSelectTime)) {
-                        options.onSelectTime.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'), xdevent);
+                        if (options.onSelectTime && $.isFunction(options.onSelectTime)) {
+                            options.onSelectTime.call(datetimepicker, _xdsoft_datetime.currentTime, datetimepicker.data('input'), xdevent);
+                        }
+                        datetimepicker.data('changed', true);
+                        datetimepicker.trigger('xchange.xdsoft');
+                        datetimepicker.trigger('changedatetime.xdsoft');
+                        if (options.inline !== true && options.closeOnTimeSelect === true) {
+                            datetimepicker.trigger('close.xdsoft');
+                        }
                     }
-                    datetimepicker.data('changed', true);
-                    datetimepicker.trigger('xchange.xdsoft');
-                    datetimepicker.trigger('changedatetime.xdsoft');
                 });
-
 
             datepicker
                 .on('mousewheel.xdsoft', function (event) {
@@ -1416,29 +2101,135 @@
 
             current_time_index = 0;
 
+            /**
+             * Runs the callback for each of the specified node's ancestors.
+             *
+             * Return FALSE from the callback to stop ascending.
+             *
+             * @param {DOMNode} node
+             * @param {Function} callback
+             * @returns {undefined}
+             */
+            forEachAncestorOf = function (node, callback) {
+                do {
+                    node = node.parentNode;
+
+                    if (!node || callback(node) === false) {
+                        break;
+                    }
+                } while (node.nodeName !== 'HTML');
+            };
+
+            /**
+             * Sets the position of the picker.
+             *
+             * @returns {undefined}
+             */
             setPos = function () {
-                var offset = datetimepicker.data('input').offset(), top = offset.top + datetimepicker.data('input')[0].offsetHeight - 1, left = offset.left, position = "absolute";
+                var dateInputOffset,
+                    dateInputElem,
+                    verticalPosition,
+                    left,
+                    position,
+                    datetimepickerElem,
+                    dateInputHasFixedAncestor,
+                    $dateInput,
+                    windowWidth,
+                    verticalAnchorEdge,
+                    datetimepickerCss,
+                    windowHeight,
+                    windowScrollTop;
+
+                $dateInput = datetimepicker.data('input');
+                dateInputOffset = $dateInput.offset();
+                dateInputElem = $dateInput[0];
+
+                verticalAnchorEdge = 'top';
+                verticalPosition = (dateInputOffset.top + dateInputElem.offsetHeight) - 1;
+                left = dateInputOffset.left;
+                position = "absolute";
+
+                windowWidth = $(options.contentWindow).width();
+                windowHeight = $(options.contentWindow).height();
+                windowScrollTop = $(options.contentWindow).scrollTop();
+
+                if ((options.ownerDocument.documentElement.clientWidth - dateInputOffset.left) < datepicker.parent().outerWidth(true)) {
+                    var diff = datepicker.parent().outerWidth(true) - dateInputElem.offsetWidth;
+                    left = left - diff;
+                }
+
+                if ($dateInput.parent().css('direction') === 'rtl') {
+                    left -= (datetimepicker.outerWidth() - $dateInput.outerWidth());
+                }
+
                 if (options.fixed) {
-                    top -= $(window).scrollTop();
-                    left -= $(window).scrollLeft();
+                    verticalPosition -= windowScrollTop;
+                    left -= $(options.contentWindow).scrollLeft();
                     position = "fixed";
                 } else {
-                    if (top + datetimepicker[0].offsetHeight > $(window).height() + $(window).scrollTop()) {
-                        top = offset.top - datetimepicker[0].offsetHeight + 1;
+                    dateInputHasFixedAncestor = false;
+
+                    forEachAncestorOf(dateInputElem, function (ancestorNode) {
+                        if (ancestorNode === null) {
+                            return false;
+                        }
+
+                        if (options.contentWindow.getComputedStyle(ancestorNode).getPropertyValue('position') === 'fixed') {
+                            dateInputHasFixedAncestor = true;
+                            return false;
+                        }
+                    });
+
+                    if (dateInputHasFixedAncestor) {
+                        position = 'fixed';
+
+                        //If the picker won't fit entirely within the viewport then display it above the date input.
+                        if (verticalPosition + datetimepicker.outerHeight() > windowHeight + windowScrollTop) {
+                            verticalAnchorEdge = 'bottom';
+                            verticalPosition = (windowHeight + windowScrollTop) - dateInputOffset.top;
+                        } else {
+                            verticalPosition -= windowScrollTop;
+                        }
+                    } else {
+                        if (verticalPosition + datetimepicker[0].offsetHeight > windowHeight + windowScrollTop) {
+                            verticalPosition = dateInputOffset.top - datetimepicker[0].offsetHeight + 1;
+                        }
                     }
-                    if (top < 0) {
-                        top = 0;
+
+                    if (verticalPosition < 0) {
+                        verticalPosition = 0;
                     }
-                    if (left + datetimepicker[0].offsetWidth > $(window).width()) {
-                        left = $(window).width() - datetimepicker[0].offsetWidth;
+
+                    if (left + dateInputElem.offsetWidth > windowWidth) {
+                        left = windowWidth - dateInputElem.offsetWidth;
                     }
                 }
-                datetimepicker.css({
-                    left: left,
-                    top: top,
-                    position: position
+
+                datetimepickerElem = datetimepicker[0];
+
+                forEachAncestorOf(datetimepickerElem, function (ancestorNode) {
+                    var ancestorNodePosition;
+
+                    ancestorNodePosition = options.contentWindow.getComputedStyle(ancestorNode).getPropertyValue('position');
+
+                    if (ancestorNodePosition === 'relative' && windowWidth >= ancestorNode.offsetWidth) {
+                        left = left - ((windowWidth - ancestorNode.offsetWidth) / 2);
+                        return false;
+                    }
                 });
+
+                datetimepickerCss = {
+                    position: position,
+                    left: left,
+                    top: '',  //Initialize to prevent previous values interfering with new ones.
+                    bottom: ''  //Initialize to prevent previous values interfering with new ones.
+                };
+
+                datetimepickerCss[verticalAnchorEdge] = verticalPosition;
+
+                datetimepicker.css(datetimepickerCss);
             };
+
             datetimepicker
                 .on('open.xdsoft', function (event) {
                     var onShow = true;
@@ -1448,21 +2239,21 @@
                     if (onShow !== false) {
                         datetimepicker.show();
                         setPos();
-                        $(window)
+                        $(options.contentWindow)
                             .off('resize.xdsoft', setPos)
                             .on('resize.xdsoft', setPos);
 
                         if (options.closeOnWithoutClick) {
-                            $([document.body, window]).on('mousedown.xdsoft', function arguments_callee6() {
+                            $([options.ownerDocument.body, options.contentWindow]).on('touchstart mousedown.xdsoft', function arguments_callee6() {
                                 datetimepicker.trigger('close.xdsoft');
-                                $([document.body, window]).off('mousedown.xdsoft', arguments_callee6);
+                                $([options.ownerDocument.body, options.contentWindow]).off('touchstart mousedown.xdsoft', arguments_callee6);
                             });
                         }
                     }
                 })
                 .on('close.xdsoft', function (event) {
                     var onClose = true;
-                    mounth_picker
+                    month_picker
                         .find('.xdsoft_month,.xdsoft_year')
                         .find('.xdsoft_select')
                         .hide();
@@ -1474,16 +2265,21 @@
                     }
                     event.stopPropagation();
                 })
+                .on('toggle.xdsoft', function () {
+                    if (datetimepicker.is(':visible')) {
+                        datetimepicker.trigger('close.xdsoft');
+                    } else {
+                        datetimepicker.trigger('open.xdsoft');
+                    }
+                })
                 .data('input', input);
 
             timer = 0;
-            timer1 = 0;
 
             datetimepicker.data('xdsoft_datetime', _xdsoft_datetime);
             datetimepicker.setOptions(options);
 
             function getCurrentValue() {
-
                 var ct = false, time;
 
                 if (options.startDate) {
@@ -1492,8 +2288,11 @@
                     ct = options.value || ((input && input.val && input.val()) ? input.val() : '');
                     if (ct) {
                         ct = _xdsoft_datetime.strToDateTime(ct);
+                        if (options.yearOffset) {
+                            ct = new Date(ct.getFullYear() - options.yearOffset, ct.getMonth(), ct.getDate(), ct.getHours(), ct.getMinutes(), ct.getSeconds(), ct.getMilliseconds());
+                        }
                     } else if (options.defaultDate) {
-                        ct = _xdsoft_datetime.strToDate(options.defaultDate);
+                        ct = _xdsoft_datetime.strToDateTime(options.defaultDate);
                         if (options.defaultTime) {
                             time = _xdsoft_datetime.strtotime(options.defaultTime);
                             ct.setHours(time.getHours());
@@ -1511,31 +2310,243 @@
                 return ct || 0;
             }
 
+            function setMask(options) {
+
+                var isValidValue = function (mask, value) {
+                        var reg = mask
+                            .replace(/([\[\]\/\{\}\(\)\-\.\+]{1})/g, '\\$1')
+                            .replace(/_/g, '{digit+}')
+                            .replace(/([0-9]{1})/g, '{digit$1}')
+                            .replace(/\{digit([0-9]{1})\}/g, '[0-$1_]{1}')
+                            .replace(/\{digit[\+]\}/g, '[0-9_]{1}');
+                        return (new RegExp(reg)).test(value);
+                    },
+                    getCaretPos = function (input) {
+                        try {
+                            if (options.ownerDocument.selection && options.ownerDocument.selection.createRange) {
+                                var range = options.ownerDocument.selection.createRange();
+                                return range.getBookmark().charCodeAt(2) - 2;
+                            }
+                            if (input.setSelectionRange) {
+                                return input.selectionStart;
+                            }
+                        } catch (e) {
+                            return 0;
+                        }
+                    },
+                    setCaretPos = function (node, pos) {
+                        node = (typeof node === "string" || node instanceof String) ? options.ownerDocument.getElementById(node) : node;
+                        if (!node) {
+                            return false;
+                        }
+                        if (node.createTextRange) {
+                            var textRange = node.createTextRange();
+                            textRange.collapse(true);
+                            textRange.moveEnd('character', pos);
+                            textRange.moveStart('character', pos);
+                            textRange.select();
+                            return true;
+                        }
+                        if (node.setSelectionRange) {
+                            node.setSelectionRange(pos, pos);
+                            return true;
+                        }
+                        return false;
+                    };
+
+                if(options.mask) {
+                    input.off('keydown.xdsoft');
+                }
+
+                if (options.mask === true) {
+                    if (dateHelper.formatMask) {
+                        options.mask = dateHelper.formatMask(options.format)
+                    } else {
+                        options.mask = options.format
+                            .replace(/Y/g, '9999')
+                            .replace(/F/g, '9999')
+                            .replace(/m/g, '19')
+                            .replace(/d/g, '39')
+                            .replace(/H/g, '29')
+                            .replace(/i/g, '59')
+                            .replace(/s/g, '59');
+                    }
+                }
+
+                if ($.type(options.mask) === 'string') {
+                    if (!isValidValue(options.mask, input.val())) {
+                        input.val(options.mask.replace(/[0-9]/g, '_'));
+                        setCaretPos(input[0], 0);
+                    }
+
+                    input.on('paste.xdsoft', function (event) {
+                        // couple options here
+                        // 1. return false - tell them they can't paste
+                        // 2. insert over current characters - minimal validation
+                        // 3. full fledged parsing and validation
+                        // let's go option 2 for now
+
+                        // fires multiple times for some reason
+
+                        // https://stackoverflow.com/a/30496488/1366033
+                        var clipboardData = event.clipboardData || event.originalEvent.clipboardData || window.clipboardData,
+                            pastedData = clipboardData.getData('text'),
+                            val = this.value,
+                            pos = this.selectionStart
+
+                        var valueBeforeCursor = val.substr(0, pos);
+                        var valueAfterPaste = val.substr(pos + pastedData.length);
+
+                        val = valueBeforeCursor + pastedData + valueAfterPaste;
+                        pos += pastedData.length;
+
+                        if (isValidValue(options.mask, val)) {
+                            this.value = val;
+                            setCaretPos(this, pos);
+                        } else if ($.trim(val) === '') {
+                            this.value = options.mask.replace(/[0-9]/g, '_');
+                        } else {
+                            input.trigger('error_input.xdsoft');
+                        }
+
+                        event.preventDefault();
+                        return false;
+                    });
+
+                    input.on('keydown.xdsoft', function (event) {
+                        var val = this.value,
+                            key = event.which,
+                            pos = this.selectionStart,
+                            selEnd = this.selectionEnd,
+                            hasSel = pos !== selEnd,
+                            digit;
+
+                        // only alow these characters
+                        if (((key >=  KEY0 && key <=  KEY9)  ||
+                            (key >= _KEY0 && key <= _KEY9)) ||
+                            (key === BACKSPACE || key === DEL)) {
+
+                            // get char to insert which is new character or placeholder ('_')
+                            digit = (key === BACKSPACE || key === DEL) ? '_' :
+                                String.fromCharCode((_KEY0 <= key && key <= _KEY9) ? key - KEY0 : key);
+
+                            // we're deleting something, we're not at the start, and have normal cursor, move back one
+                            // if we have a selection length, cursor actually sits behind deletable char, not in front
+                            if (key === BACKSPACE && pos && !hasSel) {
+                                pos -= 1;
+                            }
+
+                            // don't stop on a separator, continue whatever direction you were going
+                            //   value char - keep incrementing position while on separator char and we still have room
+                            //   del char   - keep decrementing position while on separator char and we still have room
+                            while (true) {
+                                var maskValueAtCurPos = options.mask.substr(pos, 1);
+                                var posShorterThanMaskLength = pos < options.mask.length;
+                                var posGreaterThanZero = pos > 0;
+                                var notNumberOrPlaceholder = /[^0-9_]/;
+                                var curPosOnSep = notNumberOrPlaceholder.test(maskValueAtCurPos);
+                                var continueMovingPosition = curPosOnSep && posShorterThanMaskLength && posGreaterThanZero
+
+                                // if we hit a real char, stay where we are
+                                if (!continueMovingPosition) break;
+
+                                // hitting backspace in a selection, you can possibly go back any further - go forward
+                                pos += (key === BACKSPACE && !hasSel) ? -1 : 1;
+
+                            }
+
+
+                            if (hasSel) {
+                                // pos might have moved so re-calc length
+                                var selLength = selEnd - pos
+
+                                // if we have a selection length we will wipe out entire selection and replace with default template for that range
+                                var defaultBlank = options.mask.replace(/[0-9]/g, '_');
+                                var defaultBlankSelectionReplacement = defaultBlank.substr(pos, selLength);
+                                var selReplacementRemainder = defaultBlankSelectionReplacement.substr(1) // might be empty
+
+                                var valueBeforeSel = val.substr(0, pos);
+                                var insertChars = digit + selReplacementRemainder;
+                                var charsAfterSelection = val.substr(pos + selLength);
+
+                                val = valueBeforeSel + insertChars + charsAfterSelection
+
+                            } else {
+                                var valueBeforeCursor = val.substr(0, pos);
+                                var insertChar = digit;
+                                var valueAfterNextChar = val.substr(pos + 1);
+
+                                val = valueBeforeCursor + insertChar + valueAfterNextChar
+                            }
+
+                            if ($.trim(val) === '') {
+                                // if empty, set to default
+                                val = defaultBlank
+                            } else {
+                                // if at the last character don't need to do anything
+                                if (pos === options.mask.length) {
+                                    event.preventDefault();
+                                    return false;
+                                }
+                            }
+
+                            // resume cursor location
+                            pos += (key === BACKSPACE) ? 0 : 1;
+                            // don't stop on a separator, continue whatever direction you were going
+                            while (/[^0-9_]/.test(options.mask.substr(pos, 1)) && pos < options.mask.length && pos > 0) {
+                                pos += (key === BACKSPACE) ? 0 : 1;
+                            }
+
+                            if (isValidValue(options.mask, val)) {
+                                this.value = val;
+                                setCaretPos(this, pos);
+                            } else if ($.trim(val) === '') {
+                                this.value = options.mask.replace(/[0-9]/g, '_');
+                            } else {
+                                input.trigger('error_input.xdsoft');
+                            }
+                        } else {
+                            if (([AKEY, CKEY, VKEY, ZKEY, YKEY].indexOf(key) !== -1 && ctrlDown) || [ESC, ARROWUP, ARROWDOWN, ARROWLEFT, ARROWRIGHT, F5, CTRLKEY, TAB, ENTER].indexOf(key) !== -1) {
+                                return true;
+                            }
+                        }
+
+                        event.preventDefault();
+                        return false;
+                    });
+                }
+            }
+
             _xdsoft_datetime.setCurrentTime(getCurrentValue());
 
             input
                 .data('xdsoft_datetimepicker', datetimepicker)
-                .on('open.xdsoft focusin.xdsoft mousedown.xdsoft', function (event) {
-                    if (input.is(':disabled') || input.is(':hidden') || !input.is(':visible') || (input.data('xdsoft_datetimepicker').is(':visible') && options.closeOnInputClick)) {
+                .on('open.xdsoft focusin.xdsoft mousedown.xdsoft touchstart', function () {
+                    if (input.is(':disabled') || (input.data('xdsoft_datetimepicker').is(':visible') && options.closeOnInputClick)) {
+                        return;
+                    }
+                    if (!options.openOnFocus) {
                         return;
                     }
                     clearTimeout(timer);
                     timer = setTimeout(function () {
-                        if (input.is(':disabled') || input.is(':hidden') || !input.is(':visible')) {
+                        if (input.is(':disabled')) {
                             return;
                         }
 
                         triggerAfterOpen = true;
-                        _xdsoft_datetime.setCurrentTime(getCurrentValue());
-
+                        _xdsoft_datetime.setCurrentTime(getCurrentValue(), true);
+                        if(options.mask) {
+                            setMask(options);
+                        }
                         datetimepicker.trigger('open.xdsoft');
                     }, 100);
                 })
                 .on('keydown.xdsoft', function (event) {
-                    var val = this.value, elementSelector,
+                    var elementSelector,
                         key = event.which;
-                    if ([ENTER].indexOf(key) !== -1) {
-                        elementSelector = $("input:visible,textarea:visible");
+                    if ([ENTER].indexOf(key) !== -1 && options.enterLikeTab) {
+                        elementSelector = $("input:visible,textarea:visible,button:visible,a:visible");
                         datetimepicker.trigger('close.xdsoft');
                         elementSelector.eq(elementSelector.index(this) + 1).focus();
                         return false;
@@ -1544,6 +2555,9 @@
                         datetimepicker.trigger('close.xdsoft');
                         return true;
                     }
+                })
+                .on('blur.xdsoft', function () {
+                    datetimepicker.trigger('close.xdsoft');
                 });
         };
         destroyDateTimePicker = function (input) {
@@ -1554,14 +2568,14 @@
                 input
                     .data('xdsoft_datetimepicker', null)
                     .off('.xdsoft');
-                $(window).off('resize.xdsoft');
-                $([window, document.body]).off('mousedown.xdsoft');
+                $(options.contentWindow).off('resize.xdsoft');
+                $([options.contentWindow, options.ownerDocument.body]).off('mousedown.xdsoft touchstart');
                 if (input.unmousewheel) {
                     input.unmousewheel();
                 }
             }
         };
-        $(document)
+        $(options.ownerDocument)
             .off('keydown.xdsoftctrl keyup.xdsoftctrl')
             .on('keydown.xdsoftctrl', function (e) {
                 if (e.keyCode === CTRLKEY) {
@@ -1573,8 +2587,9 @@
                     ctrlDown = false;
                 }
             });
-        return this.each(function () {
-            var datetimepicker = $(this).data('xdsoft_datetimepicker');
+
+        this.each(function () {
+            var datetimepicker = $(this).data('xdsoft_datetimepicker'), $input;
             if (datetimepicker) {
                 if ($.type(opt) === 'string') {
                     switch (opt) {
@@ -1585,16 +2600,27 @@
                         case 'hide':
                             datetimepicker.trigger('close.xdsoft');
                             break;
+                        case 'toggle':
+                            datetimepicker.trigger('toggle.xdsoft');
+                            break;
                         case 'destroy':
                             destroyDateTimePicker($(this));
                             break;
                         case 'reset':
                             this.value = this.defaultValue;
-                            if (!this.value || !datetimepicker.data('xdsoft_datetime').isValidDate(Date.parseDate(this.value, options.format))) {
+                            if (!this.value || !datetimepicker.data('xdsoft_datetime').isValidDate(dateHelper.parseDate(this.value, options.format))) {
                                 datetimepicker.data('changed', false);
                             }
                             datetimepicker.data('xdsoft_datetime').setCurrentTime(this.value);
                             break;
+                        case 'validate':
+                            $input = datetimepicker.data('input');
+                            $input.trigger('blur.xdsoft');
+                            break;
+                        default:
+                            if (datetimepicker[opt] && $.isFunction(datetimepicker[opt])) {
+                                result = datetimepicker[opt](opt2);
+                            }
                     }
                 } else {
                     datetimepicker
@@ -1610,33 +2636,251 @@
                 }
             }
         });
+
+        return result;
     };
+
     $.fn.datetimepicker.defaults = default_options;
-}(jQuery));
-(function () {
 
-    /*! Copyright (c) 2013 Brandon Aaron (http://brandon.aaron.sh)
-     * Licensed under the MIT License (LICENSE.txt).
-     *
-     * Version: 3.1.12
-     *
-     * Requires: jQuery 1.2.2+
-     */
-    !function(a){"function"==typeof define&&define.amd?define(["jquery"],a):"object"==typeof exports?module.exports=a:a(jQuery)}(function(a){function b(b){var g=b||window.event,h=i.call(arguments,1),j=0,l=0,m=0,n=0,o=0,p=0;if(b=a.event.fix(g),b.type="mousewheel","detail"in g&&(m=-1*g.detail),"wheelDelta"in g&&(m=g.wheelDelta),"wheelDeltaY"in g&&(m=g.wheelDeltaY),"wheelDeltaX"in g&&(l=-1*g.wheelDeltaX),"axis"in g&&g.axis===g.HORIZONTAL_AXIS&&(l=-1*m,m=0),j=0===m?l:m,"deltaY"in g&&(m=-1*g.deltaY,j=m),"deltaX"in g&&(l=g.deltaX,0===m&&(j=-1*l)),0!==m||0!==l){if(1===g.deltaMode){var q=a.data(this,"mousewheel-line-height");j*=q,m*=q,l*=q}else if(2===g.deltaMode){var r=a.data(this,"mousewheel-page-height");j*=r,m*=r,l*=r}if(n=Math.max(Math.abs(m),Math.abs(l)),(!f||f>n)&&(f=n,d(g,n)&&(f/=40)),d(g,n)&&(j/=40,l/=40,m/=40),j=Math[j>=1?"floor":"ceil"](j/f),l=Math[l>=1?"floor":"ceil"](l/f),m=Math[m>=1?"floor":"ceil"](m/f),k.settings.normalizeOffset&&this.getBoundingClientRect){var s=this.getBoundingClientRect();o=b.clientX-s.left,p=b.clientY-s.top}return b.deltaX=l,b.deltaY=m,b.deltaFactor=f,b.offsetX=o,b.offsetY=p,b.deltaMode=0,h.unshift(b,j,l,m),e&&clearTimeout(e),e=setTimeout(c,200),(a.event.dispatch||a.event.handle).apply(this,h)}}function c(){f=null}function d(a,b){return k.settings.adjustOldDeltas&&"mousewheel"===a.type&&b%120===0}var e,f,g=["wheel","mousewheel","DOMMouseScroll","MozMousePixelScroll"],h="onwheel"in document||document.documentMode>=9?["wheel"]:["mousewheel","DomMouseScroll","MozMousePixelScroll"],i=Array.prototype.slice;if(a.event.fixHooks)for(var j=g.length;j;)a.event.fixHooks[g[--j]]=a.event.mouseHooks;var k=a.event.special.mousewheel={version:"3.1.12",setup:function(){if(this.addEventListener)for(var c=h.length;c;)this.addEventListener(h[--c],b,!1);else this.onmousewheel=b;a.data(this,"mousewheel-line-height",k.getLineHeight(this)),a.data(this,"mousewheel-page-height",k.getPageHeight(this))},teardown:function(){if(this.removeEventListener)for(var c=h.length;c;)this.removeEventListener(h[--c],b,!1);else this.onmousewheel=null;a.removeData(this,"mousewheel-line-height"),a.removeData(this,"mousewheel-page-height")},getLineHeight:function(b){var c=a(b),d=c["offsetParent"in a.fn?"offsetParent":"parent"]();return d.length||(d=a("body")),parseInt(d.css("fontSize"),10)||parseInt(c.css("fontSize"),10)||16},getPageHeight:function(b){return a(b).height()},settings:{adjustOldDeltas:!0,normalizeOffset:!0}};a.fn.extend({mousewheel:function(a){return a?this.bind("mousewheel",a):this.trigger("mousewheel")},unmousewheel:function(a){return this.unbind("mousewheel",a)}})});
+    function HighlightedDate(date, desc, style) {
+        "use strict";
+        this.date = date;
+        this.desc = desc;
+        this.style = style;
+    }
+};
+;(function (factory) {
+    if ( typeof define === 'function' && define.amd ) {
+        // AMD. Register as an anonymous module.
+        define(['jquery', 'jquery-mousewheel'], factory);
+    } else if (typeof exports === 'object') {
+        // Node/CommonJS style for Browserify
+        module.exports = factory(require('jquery'));;
+    } else {
+        // Browser globals
+        factory(jQuery);
+    }
+}(datetimepickerFactory));
 
-// Parse and Format Library
-//http://www.xaprb.com/blog/2005/12/12/javascript-closures-for-runtime-efficiency/
-    /*
-     * Copyright (C) 2004 Baron Schwartz <baron at sequent dot org>
-     *
-     * This program is free software; you can redistribute it and/or modify it
-     * under the terms of the GNU Lesser General Public License as published by the
-     * Free Software Foundation, version 2.1.
-     *
-     * This program is distributed in the hope that it will be useful, but WITHOUT
-     * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-     * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
-     * details.
-     */
-    Date.parseFunctions={count:0};Date.parseRegexes=[];Date.formatFunctions={count:0};Date.prototype.dateFormat=function(b){if(b=="unixtime"){return parseInt(this.getTime()/1000);}if(Date.formatFunctions[b]==null){Date.createNewFormat(b);}var a=Date.formatFunctions[b];return this[a]();};Date.createNewFormat=function(format){var funcName="format"+Date.formatFunctions.count++;Date.formatFunctions[format]=funcName;var code="Date.prototype."+funcName+" = function() {return ";var special=false;var ch="";for(var i=0;i<format.length;++i){ch=format.charAt(i);if(!special&&ch=="\\"){special=true;}else{if(special){special=false;code+="'"+String.escape(ch)+"' + ";}else{code+=Date.getFormatCode(ch);}}}eval(code.substring(0,code.length-3)+";}");};Date.getFormatCode=function(a){switch(a){case"d":return"String.leftPad(this.getDate(), 2, '0') + ";case"D":return"Date.dayNames[this.getDay()].substring(0, 3) + ";case"j":return"this.getDate() + ";case"l":return"Date.dayNames[this.getDay()] + ";case"S":return"this.getSuffix() + ";case"w":return"this.getDay() + ";case"z":return"this.getDayOfYear() + ";case"W":return"this.getWeekOfYear() + ";case"F":return"Date.monthNames[this.getMonth()] + ";case"m":return"String.leftPad(this.getMonth() + 1, 2, '0') + ";case"M":return"Date.monthNames[this.getMonth()].substring(0, 3) + ";case"n":return"(this.getMonth() + 1) + ";case"t":return"this.getDaysInMonth() + ";case"L":return"(this.isLeapYear() ? 1 : 0) + ";case"Y":return"this.getFullYear() + ";case"y":return"('' + this.getFullYear()).substring(2, 4) + ";case"a":return"(this.getHours() < 12 ? 'am' : 'pm') + ";case"A":return"(this.getHours() < 12 ? 'AM' : 'PM') + ";case"g":return"((this.getHours() %12) ? this.getHours() % 12 : 12) + ";case"G":return"this.getHours() + ";case"h":return"String.leftPad((this.getHours() %12) ? this.getHours() % 12 : 12, 2, '0') + ";case"H":return"String.leftPad(this.getHours(), 2, '0') + ";case"i":return"String.leftPad(this.getMinutes(), 2, '0') + ";case"s":return"String.leftPad(this.getSeconds(), 2, '0') + ";case"O":return"this.getGMTOffset() + ";case"T":return"this.getTimezone() + ";case"Z":return"(this.getTimezoneOffset() * -60) + ";default:return"'"+String.escape(a)+"' + ";}};Date.parseDate=function(a,c){if(c=="unixtime"){return new Date(!isNaN(parseInt(a))?parseInt(a)*1000:0);}if(Date.parseFunctions[c]==null){Date.createParser(c);}var b=Date.parseFunctions[c];return Date[b](a);};Date.createParser=function(format){var funcName="parse"+Date.parseFunctions.count++;var regexNum=Date.parseRegexes.length;var currentGroup=1;Date.parseFunctions[format]=funcName;var code="Date."+funcName+" = function(input) {\nvar y = -1, m = -1, d = -1, h = -1, i = -1, s = -1, z = -1;\nvar d = new Date();\ny = d.getFullYear();\nm = d.getMonth();\nd = d.getDate();\nvar results = input.match(Date.parseRegexes["+regexNum+"]);\nif (results && results.length > 0) {";var regex="";var special=false;var ch="";for(var i=0;i<format.length;++i){ch=format.charAt(i);if(!special&&ch=="\\"){special=true;}else{if(special){special=false;regex+=String.escape(ch);}else{obj=Date.formatCodeToRegex(ch,currentGroup);currentGroup+=obj.g;regex+=obj.s;if(obj.g&&obj.c){code+=obj.c;}}}}code+="if (y > 0 && z > 0){\nvar doyDate = new Date(y,0);\ndoyDate.setDate(z);\nm = doyDate.getMonth();\nd = doyDate.getDate();\n}";code+="if (y > 0 && m >= 0 && d > 0 && h >= 0 && i >= 0 && s >= 0)\n{return new Date(y, m, d, h, i, s);}\nelse if (y > 0 && m >= 0 && d > 0 && h >= 0 && i >= 0)\n{return new Date(y, m, d, h, i);}\nelse if (y > 0 && m >= 0 && d > 0 && h >= 0)\n{return new Date(y, m, d, h);}\nelse if (y > 0 && m >= 0 && d > 0)\n{return new Date(y, m, d);}\nelse if (y > 0 && m >= 0)\n{return new Date(y, m);}\nelse if (y > 0)\n{return new Date(y);}\n}return null;}";Date.parseRegexes[regexNum]=new RegExp("^"+regex+"$");eval(code);};Date.formatCodeToRegex=function(b,a){switch(b){case"D":return{g:0,c:null,s:"(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)"};case"j":case"d":return{g:1,c:"d = parseInt(results["+a+"], 10);\n",s:"(\\d{1,2})"};case"l":return{g:0,c:null,s:"(?:"+Date.dayNames.join("|")+")"};case"S":return{g:0,c:null,s:"(?:st|nd|rd|th)"};case"w":return{g:0,c:null,s:"\\d"};case"z":return{g:1,c:"z = parseInt(results["+a+"], 10);\n",s:"(\\d{1,3})"};case"W":return{g:0,c:null,s:"(?:\\d{2})"};case"F":return{g:1,c:"m = parseInt(Date.monthNumbers[results["+a+"].substring(0, 3)], 10);\n",s:"("+Date.monthNames.join("|")+")"};case"M":return{g:1,c:"m = parseInt(Date.monthNumbers[results["+a+"]], 10);\n",s:"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"};case"n":case"m":return{g:1,c:"m = parseInt(results["+a+"], 10) - 1;\n",s:"(\\d{1,2})"};case"t":return{g:0,c:null,s:"\\d{1,2}"};case"L":return{g:0,c:null,s:"(?:1|0)"};case"Y":return{g:1,c:"y = parseInt(results["+a+"], 10);\n",s:"(\\d{4})"};case"y":return{g:1,c:"var ty = parseInt(results["+a+"], 10);\ny = ty > Date.y2kYear ? 1900 + ty : 2000 + ty;\n",s:"(\\d{1,2})"};case"a":return{g:1,c:"if (results["+a+"] == 'am') {\nif (h == 12) { h = 0; }\n} else { if (h < 12) { h += 12; }}",s:"(am|pm)"};case"A":return{g:1,c:"if (results["+a+"] == 'AM') {\nif (h == 12) { h = 0; }\n} else { if (h < 12) { h += 12; }}",s:"(AM|PM)"};case"g":case"G":case"h":case"H":return{g:1,c:"h = parseInt(results["+a+"], 10);\n",s:"(\\d{1,2})"};case"i":return{g:1,c:"i = parseInt(results["+a+"], 10);\n",s:"(\\d{2})"};case"s":return{g:1,c:"s = parseInt(results["+a+"], 10);\n",s:"(\\d{2})"};case"O":return{g:0,c:null,s:"[+-]\\d{4}"};case"T":return{g:0,c:null,s:"[A-Z]{3}"};case"Z":return{g:0,c:null,s:"[+-]\\d{1,5}"};default:return{g:0,c:null,s:String.escape(b)};}};Date.prototype.getTimezone=function(){return this.toString().replace(/^.*? ([A-Z]{3}) [0-9]{4}.*$/,"$1").replace(/^.*?\(([A-Z])[a-z]+ ([A-Z])[a-z]+ ([A-Z])[a-z]+\)$/,"$1$2$3");};Date.prototype.getGMTOffset=function(){return(this.getTimezoneOffset()>0?"-":"+")+String.leftPad(Math.floor(Math.abs(this.getTimezoneOffset())/60),2,"0")+String.leftPad(Math.abs(this.getTimezoneOffset())%60,2,"0");};Date.prototype.getDayOfYear=function(){var a=0;Date.daysInMonth[1]=this.isLeapYear()?29:28;for(var b=0;b<this.getMonth();++b){a+=Date.daysInMonth[b];}return a+this.getDate();};Date.prototype.getWeekOfYear=function(){var b=this.getDayOfYear()+(4-this.getDay());var a=new Date(this.getFullYear(),0,1);var c=(7-a.getDay()+4);return String.leftPad(Math.ceil((b-c)/7)+1,2,"0");};Date.prototype.isLeapYear=function(){var a=this.getFullYear();return((a&3)==0&&(a%100||(a%400==0&&a)));};Date.prototype.getFirstDayOfMonth=function(){var a=(this.getDay()-(this.getDate()-1))%7;return(a<0)?(a+7):a;};Date.prototype.getLastDayOfMonth=function(){var a=(this.getDay()+(Date.daysInMonth[this.getMonth()]-this.getDate()))%7;return(a<0)?(a+7):a;};Date.prototype.getDaysInMonth=function(){Date.daysInMonth[1]=this.isLeapYear()?29:28;return Date.daysInMonth[this.getMonth()];};Date.prototype.getSuffix=function(){switch(this.getDate()){case 1:case 21:case 31:return"st";case 2:case 22:return"nd";case 3:case 23:return"rd";default:return"th";}};String.escape=function(a){return a.replace(/('|\\)/g,"\\$1");};String.leftPad=function(d,b,c){var a=new String(d);if(c==null){c=" ";}while(a.length<b){a=c+a;}return a;};Date.daysInMonth=[31,28,31,30,31,30,31,31,30,31,30,31];Date.monthNames=["January","February","March","April","May","June","July","August","September","October","November","December"];Date.dayNames=["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"];Date.y2kYear=50;Date.monthNumbers={Jan:0,Feb:1,Mar:2,Apr:3,May:4,Jun:5,Jul:6,Aug:7,Sep:8,Oct:9,Nov:10,Dec:11};Date.patterns={ISO8601LongPattern:"Y-m-d H:i:s",ISO8601ShortPattern:"Y-m-d",ShortDatePattern:"n/j/Y",LongDatePattern:"l, F d, Y",FullDateTimePattern:"l, F d, Y g:i:s A",MonthDayPattern:"F d",ShortTimePattern:"g:i A",LongTimePattern:"g:i:s A",SortableDateTimePattern:"Y-m-d\\TH:i:s",UniversalSortableDateTimePattern:"Y-m-d H:i:sO",YearMonthPattern:"F, Y"};
-}());
+
+/*!
+ * jQuery Mousewheel 3.1.13
+ *
+ * Copyright jQuery Foundation and other contributors
+ * Released under the MIT license
+ * http://jquery.org/license
+ */
+
+(function (factory) {
+    if ( typeof define === 'function' && define.amd ) {
+        // AMD. Register as an anonymous module.
+        define(['jquery'], factory);
+    } else if (typeof exports === 'object') {
+        // Node/CommonJS style for Browserify
+        module.exports = factory;
+    } else {
+        // Browser globals
+        factory(jQuery);
+    }
+}(function ($) {
+
+    var toFix  = ['wheel', 'mousewheel', 'DOMMouseScroll', 'MozMousePixelScroll'],
+        toBind = ( 'onwheel' in document || document.documentMode >= 9 ) ?
+            ['wheel'] : ['mousewheel', 'DomMouseScroll', 'MozMousePixelScroll'],
+        slice  = Array.prototype.slice,
+        nullLowestDeltaTimeout, lowestDelta;
+
+    if ( $.event.fixHooks ) {
+        for ( var i = toFix.length; i; ) {
+            $.event.fixHooks[ toFix[--i] ] = $.event.mouseHooks;
+        }
+    }
+
+    var special = $.event.special.mousewheel = {
+        version: '3.1.12',
+
+        setup: function() {
+            if ( this.addEventListener ) {
+                for ( var i = toBind.length; i; ) {
+                    this.addEventListener( toBind[--i], handler, false );
+                }
+            } else {
+                this.onmousewheel = handler;
+            }
+            // Store the line height and page height for this particular element
+            $.data(this, 'mousewheel-line-height', special.getLineHeight(this));
+            $.data(this, 'mousewheel-page-height', special.getPageHeight(this));
+        },
+
+        teardown: function() {
+            if ( this.removeEventListener ) {
+                for ( var i = toBind.length; i; ) {
+                    this.removeEventListener( toBind[--i], handler, false );
+                }
+            } else {
+                this.onmousewheel = null;
+            }
+            // Clean up the data we added to the element
+            $.removeData(this, 'mousewheel-line-height');
+            $.removeData(this, 'mousewheel-page-height');
+        },
+
+        getLineHeight: function(elem) {
+            var $elem = $(elem),
+                $parent = $elem['offsetParent' in $.fn ? 'offsetParent' : 'parent']();
+            if (!$parent.length) {
+                $parent = $('body');
+            }
+            return parseInt($parent.css('fontSize'), 10) || parseInt($elem.css('fontSize'), 10) || 16;
+        },
+
+        getPageHeight: function(elem) {
+            return $(elem).height();
+        },
+
+        settings: {
+            adjustOldDeltas: true, // see shouldAdjustOldDeltas() below
+            normalizeOffset: true  // calls getBoundingClientRect for each event
+        }
+    };
+
+    $.fn.extend({
+        mousewheel: function(fn) {
+            return fn ? this.bind('mousewheel', fn) : this.trigger('mousewheel');
+        },
+
+        unmousewheel: function(fn) {
+            return this.unbind('mousewheel', fn);
+        }
+    });
+
+
+    function handler(event) {
+        var orgEvent   = event || window.event,
+            args       = slice.call(arguments, 1),
+            delta      = 0,
+            deltaX     = 0,
+            deltaY     = 0,
+            absDelta   = 0,
+            offsetX    = 0,
+            offsetY    = 0;
+        event = $.event.fix(orgEvent);
+        event.type = 'mousewheel';
+
+        // Old school scrollwheel delta
+        if ( 'detail'      in orgEvent ) { deltaY = orgEvent.detail * -1;      }
+        if ( 'wheelDelta'  in orgEvent ) { deltaY = orgEvent.wheelDelta;       }
+        if ( 'wheelDeltaY' in orgEvent ) { deltaY = orgEvent.wheelDeltaY;      }
+        if ( 'wheelDeltaX' in orgEvent ) { deltaX = orgEvent.wheelDeltaX * -1; }
+
+        // Firefox < 17 horizontal scrolling related to DOMMouseScroll event
+        if ( 'axis' in orgEvent && orgEvent.axis === orgEvent.HORIZONTAL_AXIS ) {
+            deltaX = deltaY * -1;
+            deltaY = 0;
+        }
+
+        // Set delta to be deltaY or deltaX if deltaY is 0 for backwards compatabilitiy
+        delta = deltaY === 0 ? deltaX : deltaY;
+
+        // New school wheel delta (wheel event)
+        if ( 'deltaY' in orgEvent ) {
+            deltaY = orgEvent.deltaY * -1;
+            delta  = deltaY;
+        }
+        if ( 'deltaX' in orgEvent ) {
+            deltaX = orgEvent.deltaX;
+            if ( deltaY === 0 ) { delta  = deltaX * -1; }
+        }
+
+        // No change actually happened, no reason to go any further
+        if ( deltaY === 0 && deltaX === 0 ) { return; }
+
+        // Need to convert lines and pages to pixels if we aren't already in pixels
+        // There are three delta modes:
+        //   * deltaMode 0 is by pixels, nothing to do
+        //   * deltaMode 1 is by lines
+        //   * deltaMode 2 is by pages
+        if ( orgEvent.deltaMode === 1 ) {
+            var lineHeight = $.data(this, 'mousewheel-line-height');
+            delta  *= lineHeight;
+            deltaY *= lineHeight;
+            deltaX *= lineHeight;
+        } else if ( orgEvent.deltaMode === 2 ) {
+            var pageHeight = $.data(this, 'mousewheel-page-height');
+            delta  *= pageHeight;
+            deltaY *= pageHeight;
+            deltaX *= pageHeight;
+        }
+
+        // Store lowest absolute delta to normalize the delta values
+        absDelta = Math.max( Math.abs(deltaY), Math.abs(deltaX) );
+
+        if ( !lowestDelta || absDelta < lowestDelta ) {
+            lowestDelta = absDelta;
+
+            // Adjust older deltas if necessary
+            if ( shouldAdjustOldDeltas(orgEvent, absDelta) ) {
+                lowestDelta /= 40;
+            }
+        }
+
+        // Adjust older deltas if necessary
+        if ( shouldAdjustOldDeltas(orgEvent, absDelta) ) {
+            // Divide all the things by 40!
+            delta  /= 40;
+            deltaX /= 40;
+            deltaY /= 40;
+        }
+
+        // Get a whole, normalized value for the deltas
+        delta  = Math[ delta  >= 1 ? 'floor' : 'ceil' ](delta  / lowestDelta);
+        deltaX = Math[ deltaX >= 1 ? 'floor' : 'ceil' ](deltaX / lowestDelta);
+        deltaY = Math[ deltaY >= 1 ? 'floor' : 'ceil' ](deltaY / lowestDelta);
+
+        // Normalise offsetX and offsetY properties
+        if ( special.settings.normalizeOffset && this.getBoundingClientRect ) {
+            var boundingRect = this.getBoundingClientRect();
+            offsetX = event.clientX - boundingRect.left;
+            offsetY = event.clientY - boundingRect.top;
+        }
+
+        // Add information to the event object
+        event.deltaX = deltaX;
+        event.deltaY = deltaY;
+        event.deltaFactor = lowestDelta;
+        event.offsetX = offsetX;
+        event.offsetY = offsetY;
+        // Go ahead and set deltaMode to 0 since we converted to pixels
+        // Although this is a little odd since we overwrite the deltaX/Y
+        // properties with normalized deltas.
+        event.deltaMode = 0;
+
+        // Add event and delta to the front of the arguments
+        args.unshift(event, delta, deltaX, deltaY);
+
+        // Clearout lowestDelta after sometime to better
+        // handle multiple device types that give different
+        // a different lowestDelta
+        // Ex: trackpad = 3 and mouse wheel = 120
+        if (nullLowestDeltaTimeout) { clearTimeout(nullLowestDeltaTimeout); }
+        nullLowestDeltaTimeout = setTimeout(nullLowestDelta, 200);
+
+        return ($.event.dispatch || $.event.handle).apply(this, args);
+    }
+
+    function nullLowestDelta() {
+        lowestDelta = null;
+    }
+
+    function shouldAdjustOldDeltas(orgEvent, absDelta) {
+        // If this is an older event and the delta is divisable by 120,
+        // then we are assuming that the browser is treating this as an
+        // older mouse wheel event and that we should divide the deltas
+        // by 40 to try and get a more usable deltaFactor.
+        // Side note, this actually impacts the reported scroll distance
+        // in older browsers and can cause scrolling to be slower than native.
+        // Turn this off by setting $.event.special.mousewheel.settings.adjustOldDeltas to false.
+        return special.settings.adjustOldDeltas && orgEvent.type === 'mousewheel' && absDelta % 120 === 0;
+    }
+
+}));

--- a/app/bundles/CoreBundle/Assets/js/libraries/7.datetimepicker.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/7.datetimepicker.js
@@ -904,7 +904,7 @@ var datetimepickerFactory = function ($) {
                 timeboxparent.on('mousewheel', function (event) {
                     var top = Math.abs(parseInt(timebox.css('marginTop'), 10));
 
-                    top = top - (event.deltaY * 1);
+                    top = top - (event.deltaY * 20);
                     if (top < 0) {
                         top = 0;
                     }

--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -619,6 +619,7 @@ Mautic.addDynamicContentFilter = function (selectedFilter, jQueryVariant) {
             lazyInit: true,
             validateOnBlur: false,
             allowBlank: true,
+            scrollMonth: false,
             scrollInput: false
         });
     } else if (fieldType == 'date') {
@@ -628,6 +629,7 @@ Mautic.addDynamicContentFilter = function (selectedFilter, jQueryVariant) {
             lazyInit: true,
             validateOnBlur: false,
             allowBlank: true,
+            scrollMonth: false,
             scrollInput: false,
             closeOnDateSelect: true
         });
@@ -638,6 +640,7 @@ Mautic.addDynamicContentFilter = function (selectedFilter, jQueryVariant) {
             lazyInit: true,
             validateOnBlur: false,
             allowBlank: true,
+            scrollMonth: false,
             scrollInput: false
         });
     } else if (fieldType == 'lookup_id') {

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -609,6 +609,7 @@ Mautic.addLeadListFilter = function (elId, elObj) {
             lazyInit: true,
             validateOnBlur: false,
             allowBlank: true,
+            scrollMonth: false,
             scrollInput: false
         });
     } else if (fieldType == 'date') {
@@ -618,6 +619,7 @@ Mautic.addLeadListFilter = function (elId, elObj) {
             lazyInit: true,
             validateOnBlur: false,
             allowBlank: true,
+            scrollMonth: false,
             scrollInput: false,
             closeOnDateSelect: true
         });
@@ -628,6 +630,7 @@ Mautic.addLeadListFilter = function (elId, elObj) {
             lazyInit: true,
             validateOnBlur: false,
             allowBlank: true,
+            scrollMonth: false,
             scrollInput: false
         });
     } else if (fieldType == 'lookup_id') {

--- a/app/bundles/ReportBundle/Views/Report/details_data.html.php
+++ b/app/bundles/ReportBundle/Views/Report/details_data.html.php
@@ -213,14 +213,18 @@ $graphContent = $view->render(
         mQuery('.datetimepicker').datetimepicker({
             format:'Y-m-d H:i:s',
             closeOnDateSelect: true,
-            validateOnBlur: false
+            validateOnBlur: false,
+            scrollMonth: false,
+            scrollInput: false
         });
     });
     mQuery(document).ready(function() {
         mQuery('.datepicker').datetimepicker({
             format:'Y-m-d',
             closeOnDateSelect: true,
-            validateOnBlur: false
+            validateOnBlur: false,
+            scrollMonth: false,
+            scrollInput: false
         });
     });
 </script>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
A common annoyance, especially to those with a Mac, is that touching the mousewheel or touch pad while over a date-range causes the date to spin wildly months into the past or future. This has resulted in some accidentally slow page loads as months are crunched for charts when not needed.

![craziness](https://i.imgur.com/i6Fu3Rl.gif)

This has been resolved (supposedly) by https://github.com/xdan/datetimepicker/issues/179. But upgrading the library hasn't done it. *sigh*

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Hover over a date field on the dashboard.
2. Flick your mouse wheel (or magic mouse) gently.
3. Days/weeks/months flash by.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Hover over a date field on the dashboard.
3. Flick your mouse wheel (or magic mouse) gently.
4. Nothing should happen.
5. The date pickers should still function as one would otherwise expect.