### PR TITLE
Fix segment filters without object

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/FilterTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterTrait.php
@@ -60,6 +60,10 @@ trait FilterTrait
 
         $field = [];
 
+        if (!isset($data['object'])) {
+            $data['object'] = 'lead';
+        }
+
         if (isset($data['object']) && isset($options['fields'][$data['object']][$fieldName])) {
             $field = $options['fields'][$data['object']][$fieldName];
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Segments created at 2016 after  upgrade to 2.14.2 has empty operators in filter list. 

![image](https://user-images.githubusercontent.com/462477/49326112-6cb6b400-f54d-11e8-97b4-f60a6abef22e.png)

I noticed, these filters hasn't object .  After this fix  works properly

![image](https://user-images.githubusercontent.com/462477/49326130-b1424f80-f54d-11e8-9b2b-fb21dfc302f9.png)

@Maxell92 as author of https://github.com/mautic/mautic/pull/5755 do you see any another idea? This is mine filters DB json

![image](https://user-images.githubusercontent.com/462477/49326156-17c76d80-f54e-11e8-9a88-5e682a15a896.png)


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
