### PR TITLE
Fixed issue where query parameters were not included in plaintext URLs

### DIFF
--- a/app/bundles/CoreBundle/Helper/UrlHelper.php
+++ b/app/bundles/CoreBundle/Helper/UrlHelper.php
@@ -166,7 +166,7 @@ class UrlHelper
             }
         }
 
-        $regex = '_(?:(?:https?|ftp)://)(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!127(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)(?:\.(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)*(?:\.(?:[a-z\x{00a1}-\x{ffff}]{2,})))(?::\d{2,5})?(?:/[^\s`!()\[\]{};:\'".,<>?«»“”‘’]*)?_ius';
+        $regex = '_(?:(?:https?|ftp)://)(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!127(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)(?:\.(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)*(?:\.(?:[a-z\x{00a1}-\x{ffff}]{2,})))(?::\d{2,5})?(?:/[^\s]*)?_ius';
         if (!preg_match_all($regex, $text, $matches)) {
             return $urls;
         }
@@ -174,9 +174,12 @@ class UrlHelper
         $urls = array_merge($urls, $matches[0]);
 
         foreach ($urls as $key => $url) {
+            // Remove dangling punctuation
+            $urls[$key] = $url = self::removeTrailingNonAlphaNumeric($url);
+
             // We don't want to match URLs in token default values
             // like {contactfield=website|http://ignore.this.url}
-            if (preg_match_all("#{(.*?)\|$url}#", $text, $matches)) {
+            if (preg_match_all("#{(.*?)\|".preg_quote($url).'}#', $text, $matches)) {
                 unset($urls[$key]);
 
                 // We know this is a URL due to the default so let's include it as a trackable
@@ -258,5 +261,29 @@ class UrlHelper
         }
 
         return $url;
+    }
+
+    /**
+     * @param string $string
+     *
+     * @return string
+     */
+    private static function removeTrailingNonAlphaNumeric($string)
+    {
+        // Special handling of closing bracket
+        if (substr($string, -1) === '}' && preg_match('/^[^{\r\n]*\}.*?$/', $string)) {
+            $string = substr($string, 0, -1);
+
+            return self::removeTrailingNonAlphaNumeric($string);
+        }
+
+        // Ensure only alphanumeric allowed
+        if (!preg_match("/^.*?[a-zA-Z0-9}\/]$/i", $string)) {
+            $string = substr($string, 0, -1);
+
+            return self::removeTrailingNonAlphaNumeric($string);
+        }
+
+        return $string;
     }
 }

--- a/app/bundles/CoreBundle/Tests/unit/Helper/UrlHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Helper/UrlHelperTest.php
@@ -107,7 +107,8 @@ class UrlHelperTest extends \PHPUnit_Framework_TestCase
     public function testGetUrlsFromPlaintextWithSymbols()
     {
         $this->assertEquals(
-            ['https://example.org/with/square/brackets',
+            [
+                'https://example.org/with/square/brackets',
                 'https://example.org/square/brackets/with/slash/and/comma/',
                 'https://example.org/with/parentheses',
                 'https://example.org/with/braces',
@@ -120,20 +121,30 @@ class UrlHelperTest extends \PHPUnit_Framework_TestCase
                 'https://example.org/with/double-quotes',
                 'https://example.org/with/exclamation',
                 'https://example.org/with/quotation',
-                ],
-            UrlHelper::getUrlsFromPlaintext('This text contains URL with the square brackets [https://example.org/with/square/brackets]
-                also the square brackets with a slash and a comma [https://example.org/square/brackets/with/slash/and/comma/],
-                or parentheses (https://example.org/with/parentheses),
-                or braces {https://example.org/with/braces}
-                or greater than symbol <https://example.org/with/greater-than-symbol>
-                even with just a comma: https://example.org/with/comma,
-                or with a dot: https://example.org/with/dot.
-                https://example.org/with/colon: It is cool!
-                This website https://example.org/with/semi-colon; Very awesome!
-                A single example \'https://example.org/with/simple-quotes\'
-                A double example "https://example.org/with/double-quotes"
-                Thanks for this https://example.org/with/exclamation!
-                Someone said “https://example.org/with/quotation”')
+                'https://example.org/with/query?utm_campaign=hello',
+                'https://example.org/with/tokenized-query?foo={contactfield=bar}&bar=foo',
+                'https://example.org/with/just-tokenized-query?foo={contactfield=bar}',
+            ],
+            UrlHelper::getUrlsFromPlaintext(
+                <<<STRING
+This text contains URL with the square brackets [https://example.org/with/square/brackets]
+also the square brackets with a slash and a comma [https://example.org/square/brackets/with/slash/and/comma/],
+or parentheses (https://example.org/with/parentheses),
+or braces {https://example.org/with/braces}
+or greater than symbol <https://example.org/with/greater-than-symbol>
+even with just a comma: https://example.org/with/comma,
+or with a dot: https://example.org/with/dot.
+https://example.org/with/colon: It is cool!
+This website https://example.org/with/semi-colon; Very awesome!
+A single example 'https://example.org/with/simple-quotes'
+A double example "https://example.org/with/double-quotes"
+Thanks for this https://example.org/with/exclamation!
+Someone said “https://example.org/with/quotation”
+Checkout my UTM tags https://example.org/with/query?utm_campaign=hello.
+Hey what about https://example.org/with/tokenized-query?foo={contactfield=bar}&bar=foo.
+What happens with this https://example.org/with/just-tokenized-query?foo={contactfield=bar}?
+STRING
+            )
         );
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y 
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
https://github.com/mautic/mautic/pull/6474 introduced a bug where query parameters were not picked up for plaintext URLs. This is particularly problematic with SMS using short URLs. I couldn't create a regex to make all cases happy so ended up doing the dangling non-alphanumeric handling outside the regex. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup a URL shortener in Mautic's configuration
2. Send a text message with `https://example.org/with/query?utm_campaign=hello`
3. Notice that `utm_campaign=hello` is outside the shortened URL and if clicked is not part of the URL redirected to.

#### Steps to test this PR:
1. Repeat and the utm tag should not be part of the shortened URL but is part of the URL redirected to
2. Can also test https://github.com/mautic/mautic/issues/6452 to ensure it is still addressed (unit tests are still passing)
3. Run updated unit tests.