### PR TITLE
 Fix error:  Got a packet bigger than 'max_allowed_packet' bytes 

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -506,7 +506,7 @@ class LeadRepository extends CommonRepository
                 )
             );
 
-        $this->updateQueryFromContactLimiter('cl', $qb, $limiter, true);
+        $this->updateQueryFromContactLimiter('cl', $qb, $limiter, false);
         $this->updateQueryWithSegmentMembershipExclusion($segments, $qb);
 
         $results = $qb->execute()->fetchAll();


### PR DESCRIPTION
…llowed_packet'

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

We had issue If large campaign (hundred thousands contacts) want to remove contacts from campaign. The query contains in statement with all contact IDs. I notice, that countID  not allow limiter to that query https://github.com/mautic/mautic/pull/6973/files#diff-a40153b383e4af2f8e5ae77a534a264aR509

![image](https://user-images.githubusercontent.com/462477/49579512-bbe55600-f94c-11e8-91ae-3378f78de3db.png)

`'SQLSTATE[08S01]: Communication link failure: 1153 Got a packet bigger than 'max_allowed_packet' bytes'`


#### Steps to test this PR:
1. Large segment added to campaign
2.  Rebuild campaign membership
3. Then change segment source in campaign
4. See error in logs
