### PR TITLE
Fix memory leak: do not cache query containing many IDs

### DIFF
--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -134,6 +134,7 @@ trait CustomFieldRepositoryTrait
                 $q->orderBy('ORD', 'ASC');
 
                 $results = $q->getQuery()
+                    ->useQueryCache(false) // the query contains ID's, so there is no use in caching it
                     ->getResult();
 
                 //assign fields


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #6537
| BC breaks? | N
| Deprecations? | N

#### Description:
In [CustomFieldRepositoryTrait.php](https://github.com/mautic/mautic/blob/staging/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php#L117), lines 117-122, when loading a batch of leads, a query is constructed that looks like:
```
(CASE
  WHEN l.id = 1 THEN 0
  WHEN l.id = 2 THEN 1
  WHEN l.id = 42 THEN 2
  WHEN l.id = 7 THEN 3
[...]
ELSE 100 END)
```

Apart from the fact that this leads to quite verbose queries, this leads to a memory leak in `mautic:campaigns:trigger` (and possibly other places). The problem is that this query contains concrete ID's (instead of passing them in as parameters as we usually do in an ORM) and that Doctrine caches queries (and their parsed results), but when retrieving new batches of contacts the IDs are different, so many similar queries are cached and eat up the memory. This fix simply turns of the query caching for this particular query, and thereby fixes #6537 .

I do think the code should be refactored because this query is inefficient (and I plan to do so), but that is more work, so this PR is a quick win solving the issue, and is a (in my opinion) clear improvement.

#### Steps to reproduce the bug:
1. See #6537

#### Steps to test this PR:
1. Apply this patch and do the same steps


