### PR TITLE
MailHelper: Reset transport as well on reset, solves connection drops

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -658,6 +658,7 @@ class MailHelper
         $this->fatal            = false;
         $this->idHashState      = true;
         $this->useGlobalFrom    = false;
+        $this->checkIfTransportNeedsRestart(true);
 
         $this->logger->clear();
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

#### Description:

This PR improves the way the connection to an external SMTP server is reset. In particular, when using Amazon SES, on regular basis we saw the following error in the logs:

```
mautic.ERROR: [MAIL ERROR] Expected response code 250 but got code "", with message "" Log data: >> MAIL FROM:<***@****.net>  <<  !! Expected response code 250 but got code "", with message "" (code: 0) (send);
```
This seems to be related to a connection losses, so to solve those, this PR closes the connection upon resetting the `MailHelper`.  It is hard to reproduce this exact bug, but at least if feels very natural to close the connection upon a reset, and in our environment this has solved the issue.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Send out many emails in different campaigns
2. Observe occasional errors as the one above

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Send out many emails in different campaigns
3. Notice the errors being gone :-)
