### PR TITLE
Remove redundant left join in reports

### DIFF
--- a/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
@@ -409,8 +409,10 @@ class ReportSubscriber extends CommonSubscriber
 
             $chartQuery->applyDateFilters($queryBuilder, 'date_added', 'l');
 
-            $queryBuilder->resetQueryPart('join');
-            $queryBuilder->leftJoin('lp', MAUTIC_TABLE_PREFIX.'leads', 'l', 'l.id = lp.lead_id');
+            if ($queryBuilder->getQueryPart('from')[0]['alias'] === 'lp') {
+                $queryBuilder->resetQueryPart('join');
+                $queryBuilder->leftJoin('lp', MAUTIC_TABLE_PREFIX.'leads', 'l', 'l.id = lp.lead_id');
+            }
 
             switch ($g) {
                 case 'mautic.lead.graph.pie.attribution_stages':


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Issues addressed (#s or URLs) | https://github.com/mautic-inc/mautic-internal/issues/1212 https://github.com/mautic/mautic/issues/6806
| BC breaks? | N
| Deprecations? | N

[//]: # ( Required: )
#### Description:
Newly introduced bug causes table aliased **lp** to be included each time without being sure that the table has been joined.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Check https://github.com/mautic/mautic/issues/6806

#### Steps to test this PR:
1. Verify https://github.com/mautic/mautic/issues/6806 is fixed.
2. Verify PR https://github.com/mautic/mautic/pull/6479 is still correct.