### PR TITLE
Fix default Gravatar URL for non-Apache servers

### DIFF
--- a/app/bundles/CoreBundle/Helper/UrlHelper.php
+++ b/app/bundles/CoreBundle/Helper/UrlHelper.php
@@ -89,16 +89,14 @@ class UrlHelper
     {
         $path = $host = $scheme = '';
 
-        $base = 'http';
-        if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') {
-            $base .= 's';
-        }
-        $base .= '://';
-        if ($_SERVER['SERVER_PORT'] != '80') {
-            $base .= $_SERVER['SERVER_NAME'].':'.$_SERVER['SERVER_PORT'].$_SERVER['REQUEST_URI'];
-        } else {
-            $base .= $_SERVER['SERVER_NAME'].$_SERVER['REQUEST_URI'];
-        }
+        $ssl    = !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on';
+        $scheme = strtolower($_SERVER['SERVER_PROTOCOL']);
+        $scheme = substr($scheme, 0, strpos($scheme, '/')).($ssl ? 's' : '');
+        $port   = $_SERVER['SERVER_PORT'];
+        $port   = ((!$ssl && $port == '80') || ($ssl && $port == '443')) ? '' : ":$port";
+        $host   = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : null;
+        $host   = isset($host) ? $host : $_SERVER['SERVER_NAME'].$port;
+        $base   = "$scheme://$host".$_SERVER['REQUEST_URI'];
 
         $base = str_replace('/index_dev.php', '', $base);
         $base = str_replace('/index.php', '', $base);


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #4114
| BC breaks? | No
| Deprecations? | No

#### Description:
The `UrlHelper::rel2abs` function previously generated incorrect absolute URLs for some server configurations (such as an nginx default server).  This PR changes the algorithm to be more generic, producing an absolute URL that more closely matches what the browser is using.

#### Steps to reproduce the bug:
1. Run mautic under nginx or other server that doesn't set `SERVER_NAME` by default, or where `SERVER_NAME` is the canonical host rather than the actual host
2. View a contact who does not have a Gravatar
3. Inspect the avatar URL - the `d=` will be followed by an encoded relative URL rather than an absolute one, causing a broken image 

#### Steps to test this PR:
1. Run mautic under nginx or other server that doesn't set `SERVER_NAME` by default, or where `SERVER_NAME` is the canonical host rather than the actual host
2. View a contact who does not have a Gravatar
3. Inspect the avatar URL - the `d=` should be followed by an encoded absolute URL, causing a working default avatar to be shown.