### PR TITLE
Fix #6986 - Immediate Webhooks broken on 2.15

### DIFF
--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -237,8 +237,6 @@ class WebhookModel extends FormModel
             return;
         }
 
-        $webhookList = [];
-
         /** @var \Mautic\WebhookBundle\Entity\Event $event */
         foreach ($webhookEvents as $event) {
             $webhook = $event->getWebhook();

--- a/app/bundles/WebhookBundle/Tests/Model/WebhookModelTest.php
+++ b/app/bundles/WebhookBundle/Tests/Model/WebhookModelTest.php
@@ -117,7 +117,6 @@ class WebhookModelTest extends \PHPUnit_Framework_TestCase
         $queue->setPayload('{"the": "payload"}');
         $queue->setEvent($event);
         $queue->setDateAdded(new \DateTime('2018-04-10T15:04:57+00:00'));
-        $webhook->addQueue($queue);
 
         $this->parametersHelperMock->expects($this->at(5))
             ->method('getParameter')
@@ -133,7 +132,7 @@ class WebhookModelTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $this->assertEquals($expectedPayload, $this->initModel()->getWebhookPayload($webhook));
+        $this->assertEquals($expectedPayload, $this->initModel()->getWebhookPayload($webhook, $queue));
     }
 
     private function initModel()


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Yes 
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #6986 #6594
| BC breaks? | 
| Deprecations? | 

#### Description:
This PR fixes the webhook processing bug introduced by #6594, by removing the unneeded (and incorrect) out-of-band queueing logic for immediate-mode webhooks.  The behavior of queued webhooks is unchanged.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Using 2.15.0-beta, try using immediate webhooks; they are not sent.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Try both immediate and queued webhooks
