### PR TITLE
Fix International phone number validation message 

### DIFF
--- a/app/bundles/FormBundle/EventListener/FormValidationSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormValidationSubscriber.php
@@ -64,7 +64,6 @@ class FormValidationSubscriber extends CommonSubscriber
                 if (!empty($field->getValidation()['international_validationmsg'])) {
                     $event->failedValidation($field->getValidation()['international_validationmsg']);
                 } else {
-                    $event->failedValidation($this->translator->trans('mautic.form.submission.phone.invalid'));
                 }
             }
         }

--- a/app/bundles/FormBundle/EventListener/FormValidationSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormValidationSubscriber.php
@@ -64,6 +64,7 @@ class FormValidationSubscriber extends CommonSubscriber
                 if (!empty($field->getValidation()['international_validationmsg'])) {
                     $event->failedValidation($field->getValidation()['international_validationmsg']);
                 } else {
+                    $event->failedValidation($this->translator->trans('mautic.form.submission.phone.invalid', [], 'validators'));
                 }
             }
         }

--- a/app/bundles/FormBundle/EventListener/FormValidationSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormValidationSubscriber.php
@@ -48,7 +48,9 @@ class FormValidationSubscriber extends CommonSubscriber
     }
 
     /**
-     * @param Events\ValidationEvent $event
+     * Custom validation     *.
+     *
+     *@param Events\ValidationEvent $event
      */
     public function onFormValidate(Events\ValidationEvent $event)
     {

--- a/app/bundles/FormBundle/Form/Type/FormFieldTelType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldTelType.php
@@ -62,6 +62,7 @@ class FormFieldTelType extends AbstractType
                     'tooltip'      => $this->translator->trans('mautic.core.form.default').': '.$this->translator->trans('mautic.form.submission.phone.invalid', [], 'validators'),
                     'data-show-on' => '{"formfield_validation_international_1": "checked"}',
                 ],
+                'required' => false,
             ]
         );
     }

--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -13,7 +13,6 @@ namespace Mautic\FormBundle\Helper;
 
 use Mautic\CoreBundle\Helper\AbstractFormFieldHelper;
 use Mautic\FormBundle\Entity\Field;
-use Mautic\FormBundle\Validator\Constraint\PhoneNumberConstraint;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Blank;
 use Symfony\Component\Validator\Constraints\Email;
@@ -68,11 +67,7 @@ class FormFieldHelper extends AbstractFormFieldHelper
         'password'  => [],
         'radiogrp'  => [],
         'select'    => [],
-        'tel'       => [
-            'constraints' => [
-                PhoneNumberConstraint::class => ['message' => 'mautic.form.submission.phone.invalid'],
-            ],
-        ],
+        'tel'       => [],
         'text'      => [],
         'textarea'  => [],
         'url'       => [


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7002
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fix for 2.15.0 beta for https://github.com/mautic/mautic/issues/7002


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7010)
2. Test phone valadtion (required, international phone number format with default and custom message)

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
