### PR TITLE
fix 500 by remove of . on .lp.lead_id

### DIFF
--- a/app/bundles/LeadBundle/Entity/PointsChangeLogRepository.php
+++ b/app/bundles/LeadBundle/Entity/PointsChangeLogRepository.php
@@ -33,7 +33,7 @@ class PointsChangeLogRepository extends CommonRepository
     {
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->from(MAUTIC_TABLE_PREFIX.'lead_points_change_log', 'lp')
-            ->select('lp.event_name as eventName, lp.action_name as actionName, lp.date_added as dateAdded, lp.type, lp.delta, lp.id, .lp.lead_id');
+            ->select('lp.event_name as eventName, lp.action_name as actionName, lp.date_added as dateAdded, lp.type, lp.delta, lp.id, lp.lead_id');
 
         if ($leadId) {
             $query->where('lp.lead_id = '.(int) $leadId);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

An error on a SQL join was generating 500 error. Just removed an extra `.` from `.lp.lead_id`.

```
[2018-12-13 13:47:11] mautic.CRITICAL: Uncaught PHP Exception Doctrine\DBAL\Exception\SyntaxErrorException: "An exception occurred while executing 'SELECT lp.event_name as eventName, lp.action_name as actionName, lp.date_added as dateAdded, lp.type, lp.delta, lp.id, .lp.lead_id FROM lead_points_change_log lp WHERE lp.lead_id = 202 ORDER BY lp.date_added DESC LIMIT 25':  SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '.lp.lead_id FROM lead_points_change_log lp WHERE lp.lead_id = 202 ORDER BY lp.da' at line 1" at /path/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php line 90 {"exception":"[object] (Doctrine\\DBAL\\Exception\\SyntaxErrorException(code: 0): An exception occurred while executing 'SELECT lp.event_name as eventName, lp.action_name as actionName, lp.date_added as dateAdded, lp.type, lp.delta, lp.id, .lp.lead_id FROM lead_points_change_log lp WHERE lp.lead_id = 202 ORDER BY lp.date_added DESC LIMIT 25':\n\nSQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '.lp.lead_id FROM lead_points_change_log lp WHERE lp.lead_id = 202 ORDER BY lp.da' at line 1 at /path/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:90, Doctrine\\DBAL\\Driver\\PDOException(code: 42000): SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '.lp.lead_id FROM lead_points_change_log lp WHERE lp.lead_id = 202 ORDER BY lp.da' at line 1 at /path/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:106, PDOException(code: 42000): SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '.lp.lead_id FROM lead_points_change_log lp WHERE lp.lead_id = 202 ORDER BY lp.da' at line 1 at /path/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:104)"} []
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
Hard to say how it came through, but obviously if you try to view or edit a contact that has events that generate this SQL query... It may throw the error. 

#### Steps to test this PR:
Maybe just a code review is necessary ?