### PR TITLE
Webhook callbacks not working after 2.15.0 upgrade

### DIFF
--- a/app/bundles/EmailBundle/Event/TransportWebhookEvent.php
+++ b/app/bundles/EmailBundle/Event/TransportWebhookEvent.php
@@ -53,7 +53,7 @@ class TransportWebhookEvent extends Event
      */
     public function getRequest()
     {
-        $this->request = $request;
+        return $this->request;
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #6250, #6449, #5561 (just guessing here after reading through these issues)
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fixes a runtime error on transport callbacks, where a class getter method was attempting to set the value, rather than returning the current instance value.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. For me it was happening when I was trying to verify the SNS callback for the Amazon transport, and it was stuck in PendingConfirmation status. Digging into it showed the offending line in the php error log. But would likely affect any transport setup/bounce callbacks.

#### Steps to test this PR:
1. If using Amazon you can add a new SNS subscription. If you already have an existing subscription that was verified in an earlier version of Mautic, you can also trigger the error by causing a bounce via one of the [simulator email addresses](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mailbox-simulator.html).
