### PR TITLE
Bug/campaign membership removal

### DIFF
--- a/app/bundles/LeadBundle/Services/ContactSegmentFilterDictionary.php
+++ b/app/bundles/LeadBundle/Services/ContactSegmentFilterDictionary.php
@@ -228,6 +228,7 @@ class ContactSegmentFilterDictionary extends \ArrayIterator
             'type'          => ForeignValueFilterQueryBuilder::getServiceId(),
             'foreign_table' => 'campaign_leads',
             'field'         => 'campaign_id',
+            'where'         => 'campaign_leads.manually_removed = 0',
         ];
 
         parent::__construct($this->translations);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #7004
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Allows leads to be removed from a segment based on campaign membership if manually removed from the campaign.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create a new Campaign called "Test Campaign" that takes leads from the "US" segment, and does any action (such as add 1 point).
3. Create another Segment called "Has been in Test Campaign". Use the field "Campaign Membership" and choose our "Test Campaign". 
4. Wait for the 8 test leads to get into the "Has been in Test Campaign" segment.
5. Edit one of those leads, and remove them from the "Test Campaign" manually.
6. The segment should update and remove said lead from the segment.