### PR TITLE
Fix object in segment filter

### DIFF
--- a/app/bundles/LeadBundle/Event/LeadListFiltersChoicesEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFiltersChoicesEvent.php
@@ -85,6 +85,10 @@ class LeadListFiltersChoicesEvent extends CommonEvent
      */
     public function addChoice($object, $choiceKey, $choiceConfig)
     {
+        if (!isset($this->choices[$object])) {
+            $this->choices[$object] = [];
+        }
+
         if (!array_key_exists($choiceKey, $this->choices[$object])) {
             $this->choices[$object][$choiceKey] = $choiceConfig;
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If we extend segments filter by plugin, some notice  error on dispatcher

```
  
   LeadEvents::LIST_FILTERS_CHOICES_ON_GENERATE => [
                ['onListFiltersGenerate', 0],
            ],
```


Then use owne group/object (event)

`        $event->addChoice('event', 'event_date', $config);`

This return notice and this PR fixed it.


#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2.  Just code review should be enought
