### PR TITLE
Allow contact to be manually added back to a campaign after manual removal.

### DIFF
--- a/app/bundles/CampaignBundle/Membership/Action/Adder.php
+++ b/app/bundles/CampaignBundle/Membership/Action/Adder.php
@@ -80,13 +80,13 @@ class Adder
      */
     public function updateExistingMembership(CampaignMember $campaignMember, $isManualAction)
     {
-        if (!$campaignMember->getCampaign()->allowRestart()) {
+        $wasRemoved = $campaignMember->wasManuallyRemoved();
+        if (!($wasRemoved && $isManualAction) && !$campaignMember->getCampaign()->allowRestart()) {
             // A contact cannot restart this campaign
 
             throw new ContactCannotBeAddedToCampaignException();
         }
 
-        $wasRemoved = $campaignMember->wasManuallyRemoved();
         if ($wasRemoved && !$isManualAction && null === $campaignMember->getDateLastExited()) {
             // Prevent contacts from being added back if they were manually removed but automatically added back
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If you manually remove a lead from a campaign it is unintentionally permanent.
2.14.0-beta to 2.15.0-beta are affected.

![Lead removing and re-adding campaign not working via ui](https://i.imgur.com/X47Gs1A.gif)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. View a lead.
2. Open the campaign dropdown to: Remove the lead from the campaign.
3. Open the campaign dropdown to: Add the lead back to the campaign.
4. Open the campaign dropdown to: Verify that the lead is back on the campaign (they aren't).

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create a test campaign.
3. Edit any lead, and add the lead to the campaign manually.
4. Remove the lead from the campaign.
5. Add the lead BACK to the campaign.
6. Verify the lead is now back on the campaign.