### PR TITLE
Fix to multiselect in ContactSegmentFilterCrate

### DIFF
--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
@@ -196,7 +196,7 @@ class ContactSegmentFilterCrate
 
         if ('multiselect' === $this->getType() && in_array($operator, ['in', '!in'])) {
             $neg            = strpos($operator, '!') === false ? '' : '!';
-            $this->operator = $neg.$this->getType();
+            $this->operator = $neg.'in';
 
             return;
         }

--- a/app/bundles/LeadBundle/Segment/Decorator/BaseDecorator.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/BaseDecorator.php
@@ -140,6 +140,8 @@ class BaseDecorator implements FilterDecoratorInterface
             case 'regexp':
             case '!regexp':
                 return $this->prepareRegex($filter);
+            case 'in':
+            case '!in':
             case 'multiselect':
             case '!multiselect':
                 $filter = (array) $filter;

--- a/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterCrateTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterCrateTest.php
@@ -166,7 +166,7 @@ class ContactSegmentFilterCrateTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($contactSegmentFilterCrate->isContactType());
         $this->assertFalse($contactSegmentFilterCrate->isCompanyType());
         $this->assertSame([2, 4], $contactSegmentFilterCrate->getFilter());
-        $this->assertSame('multiselect', $contactSegmentFilterCrate->getOperator());
+        $this->assertSame('in', $contactSegmentFilterCrate->getOperator());
         $this->assertFalse($contactSegmentFilterCrate->isBooleanType());
         $this->assertFalse($contactSegmentFilterCrate->isDateType());
         $this->assertFalse($contactSegmentFilterCrate->hasTimeParts());
@@ -194,7 +194,7 @@ class ContactSegmentFilterCrateTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($contactSegmentFilterCrate->isContactType());
         $this->assertFalse($contactSegmentFilterCrate->isCompanyType());
         $this->assertSame([2, 4], $contactSegmentFilterCrate->getFilter());
-        $this->assertSame('!multiselect', $contactSegmentFilterCrate->getOperator());
+        $this->assertSame('!in', $contactSegmentFilterCrate->getOperator());
         $this->assertFalse($contactSegmentFilterCrate->isBooleanType());
         $this->assertFalse($contactSegmentFilterCrate->isDateType());
         $this->assertFalse($contactSegmentFilterCrate->hasTimeParts());


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fix multiselect segment filter.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create multiselect custom contact field
2. Add to contact one of value of new multiselect custom contact field
3.  Create segment with this custom multiselect field
4: Run segmetns rebuild command
5: See none of contact was assigned to segment

#### Steps to tests
1. Repeat all steps
2. Contacts should be added to segment after run segment rebuild command
