### PR TITLE
Handle error in PageSubscriber on page hit with styling fixed

### DIFF
--- a/app/bundles/PageBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PageSubscriber.php
@@ -195,7 +195,12 @@ class PageSubscriber extends CommonSubscriber
         $page                   = $pageId ? $pageRepo->find((int) $pageId) : null;
         $lead                   = $leadId ? $leadRepo->find((int) $leadId) : null;
 
-        $this->pageModel->processPageHit($hit, $page, $request, $lead, $trackingNewlyGenerated, false);
-        $event->setResult(QueueConsumerResults::ACKNOWLEDGE);
+        if ($hit != null && $lead != null) {
+            $this->pageModel->processPageHit($hit, $page, $request, $lead, $trackingNewlyGenerated, false);
+            $event->setResult(QueueConsumerResults::ACKNOWLEDGE);
+        } else {
+            $this->factory->getLogger()->log('error', 'Error processing page hit ' . $pageId . ' for ' . $leadId);
+            $event->setResult(QueueConsumerResults::REJECT);
+        }
     }
 }

--- a/app/bundles/PageBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PageSubscriber.php
@@ -199,7 +199,7 @@ class PageSubscriber extends CommonSubscriber
             $this->pageModel->processPageHit($hit, $page, $request, $lead, $trackingNewlyGenerated, false);
             $event->setResult(QueueConsumerResults::ACKNOWLEDGE);
         } else {
-            $this->factory->getLogger()->log('error', 'Error processing page hit ' . $pageId . ' for ' . $leadId);
+            $this->factory->getLogger()->log('error', 'Error processing page hit '.$pageId.' for '.$leadId);
             $event->setResult(QueueConsumerResults::REJECT);
         }
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

When there's a missing hit record, the whole page hit daemon gets stuck. This at least marks this job as rejected, and logs the error.

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Run the command **/usr/bin/php /opt/mautic/app/console mautic:queue:process -i page_hit**

#### Steps to test this PR:
1. https://mautibox.com/7030

Related to #5452 #6770