### PR TITLE
Fix lead fields being overwritten by empty values when editing unique ids via REST API

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
+++ b/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
@@ -105,9 +105,9 @@ trait CustomFieldsApiControllerTrait
      * @param Lead|Company $entity
      * @param Form         $form
      * @param array        $parameters
-     * @param bool         $isPost
+     * @param bool         $isPostOrPatch
      */
-    protected function setCustomFieldValues($entity, $form, $parameters, $isPost = false)
+    protected function setCustomFieldValues($entity, $form, $parameters, $isPostOrPatch = false)
     {
         //set the custom field values
         //pull the data from the form in order to apply the form's formatting
@@ -115,14 +115,14 @@ trait CustomFieldsApiControllerTrait
             $parameters[$f->getName()] = $f->getData();
         }
 
-        if ($isPost) {
+        if ($isPostOrPatch) {
             // Don't overwrite the contacts accumulated points
             if (isset($parameters['points']) && empty($parameters['points'])) {
                 unset($parameters['points']);
             }
 
-            // When merging a contact because of a unique identifier match in POST /api/contacts//new, all 0 values must be unset because
-            // we have to assume 0 was not meant to overwrite an existing value. Other empty values will be caught by LeadModel::setCustomFieldValues
+            // When merging a contact because of a unique identifier match in POST /api/contacts//new or PATCH /api/contacts//edit all 0 values must be unset because
+            // we have to assume 0 was not meant to overwrite an existing value. Other empty values will be caught by LeadModel::setFieldValues
             $parameters = array_filter(
                 $parameters,
                 function ($value) {
@@ -135,6 +135,6 @@ trait CustomFieldsApiControllerTrait
             );
         }
 
-        $this->model->setFieldValues($entity, $parameters, !$isPost);
+        $this->model->setFieldValues($entity, $parameters, !$isPostOrPatch);
     }
 }

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -679,7 +679,8 @@ class LeadApiController extends CommonApiController
             unset($parameters['frequencyRules']);
         }
 
-        $this->setCustomFieldValues($entity, $form, $parameters, 'POST' === $this->request->getMethod());
+        $isPostOrPatch = 'POST' === $this->request->getMethod() || 'PATCH' === $this->request->getMethod();
+        $this->setCustomFieldValues($entity, $form, $parameters, $isPostOrPatch);
     }
 
     /**


### PR DESCRIPTION


**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | No
| Deprecations? | No

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
A fix for empty values overwriting fields when leads are merged as a result of editing a unique field with the REST API. This is done via adding a check for the `PATCH` method in additon to the existing `POST` method check in the `LeadApiController` `preSaveEntity` method.

This is useful for merging an anonymous lead generated via the tracking JS with an existing lead via the API.

Note: If an edit request is made with `PUT` fields may still be overwritten with empty values when a merge occurs.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a a non-anonymous lead, and assign a value to a unique id field.
2. Create an anonymous lead with no data.
3. Assign the value of the unique id field from the lead in step 1 to the same field from the lead in step 2 via the REST API using the `PATCH` method and the route `/api/contacts/{ID}/edit` in order to trigger a merge.
4. Look up the merged lead in mautic and verify all the non-anonymous lead data has been erased.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat steps 1-3 of the bug reproduction steps above.
3. Verify that the merged lead retains the data from the non-anonymous lead.
