### PR TITLE
Fix invalid datetime format with fetchlead command

### DIFF
--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -314,13 +314,6 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
         $config        = $this->mergeConfigToFeatureSettings([]);
         $matchedFields = $this->populateMauticLeadData($data, $config, 'company');
 
-        // Default to new company
-        $company         = new Company();
-        $existingCompany = IdentifyCompanyHelper::identifyLeadsCompany($matchedFields, null, $this->companyModel);
-        if (!empty($existingCompany[2])) {
-            $company = $existingCompany[2];
-        }
-
         $companyFieldTypes = $this->fieldModel->getFieldListWithProperties('company');
         foreach ($matchedFields as $companyField => $value) {
             if (isset($companyFieldTypes[$companyField]['type'])) {
@@ -338,6 +331,13 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
                         break;
                 }
             }
+        }
+
+        // Default to new company
+        $company         = new Company();
+        $existingCompany = IdentifyCompanyHelper::identifyLeadsCompany($matchedFields, null, $this->companyModel);
+        if (!empty($existingCompany[2])) {
+            $company = $existingCompany[2];
         }
 
         if (!empty($existingCompany[2])) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Complement of https://github.com/mautic/mautic/pull/6483
Prevent `SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect date`

When create new company with fetchlead command `php app/console mautic:integration:fetchleads --time-interval=2minutes --integration=Salesforce`, cause of code order, matchedFields are not transformed for SQL.

I think this PR need only code checking, I have juste inverted code.