### PR TITLE
Fix #7045 - API access to list custom fields

### DIFF
--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -29,11 +29,11 @@ class FieldController extends FormController
     public function indexAction($page = 1)
     {
         //set some permissions
-        $permissions = $this->get('mautic.security')->isGranted(['lead:fields:full'], 'RETURN_ARRAY');
+        $permissions = $this->get('mautic.security')->isGranted(['lead:fields:view', 'lead:fields:full'], 'RETURN_ARRAY');
 
         $session = $this->get('session');
 
-        if (!$permissions['lead:fields:full']) {
+        if (!$permissions['lead:fields:view']) {
             return $this->accessDenied();
         }
 

--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -33,7 +33,7 @@ class FieldController extends FormController
 
         $session = $this->get('session');
 
-        if (!$permissions['lead:fields:view']) {
+        if (!$permissions['lead:fields:view'] && !$permissions['lead:fields:full']) {
             return $this->accessDenied();
         }
 

--- a/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
+++ b/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
@@ -31,6 +31,7 @@ class LeadPermissions extends AbstractPermissions
                 'full'        => 1024,
             ],
             'fields' => [
+                'view' => 1,
                 'full' => 1024,
             ],
         ];
@@ -74,6 +75,7 @@ class LeadPermissions extends AbstractPermissions
 
         $builder->add('lead:fields', 'permissionlist', [
             'choices' => [
+                'view' => 'mautic.core.permissions.view',
                 'full' => 'mautic.core.permissions.manage',
             ],
             'label'  => 'mautic.lead.permissions.fields',

--- a/app/bundles/LeadBundle/Views/Field/list.html.php
+++ b/app/bundles/LeadBundle/Views/Field/list.html.php
@@ -51,9 +51,9 @@ if ($tmpl == 'index') {
                             [
                                 'item'            => $item,
                                 'templateButtons' => [
-                                    'edit'   => true,
-                                    'clone'  => true,
-                                    'delete' => $item->isFixed() ? false : true,
+                                    'edit'   => $permissions['lead:fields:full'],
+                                    'clone'  => $permissions['lead:fields:full'],
+                                    'delete' => $item->isFixed() ? false : $permissions['lead:fields:full'],
                                 ],
                                 'routeBase' => 'contactfield',
                                 'langVar'   => 'lead.field',


### PR DESCRIPTION
closes #7045 

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #7045 
| BC breaks? | 
| Deprecations? | 

#### Description:
Listing custom fields via the API currently requires **full admin access**; even specifying the "Manage" permission for custom fields is insufficient.  This PR adds the missing `view` permission (fixing the admin privilege requirement), and makes it possible to grant *only* that permission to a role (so you can allow reading the field list without also allowing field management).

#### Steps to reproduce the bug:
1. Create a role without admin privileges, but with "Custom Fields - Manage"
2. Create a user with that role
3. Fetch /api/fields/contact using that user's credentials and see a 403 error

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create a role without admin privileges, and either the View or Manage permissions for Custom Fields
3. Fetch /api/fields/contact using that user's credentials and see the field list
