### PR TITLE
Fix error create new email in campaign builder

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/6.forms.js
+++ b/app/bundles/CoreBundle/Assets/js/6.forms.js
@@ -389,7 +389,8 @@ Mautic.updateEntitySelect = function (response) {
 
         var sortOptions = function (options) {
             return options.sort(function (a, b) {
-                var alc = a.text.toLowerCase(), blc = b.text.toLowerCase();
+                var alc = a.text ? a.text.toLowerCase() : mQuery(a).attr("label").toLowerCase();
+                var blc = b.text ? b.text.toLowerCase() : mQuery(b).attr("label").toLowerCase();
                 return alc > blc ? 1 : alc < blc ? -1 : 0;
             });
         }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:

 Fix an error when trying to create a new email in page campaign builder. The error occurs if we have already 2 or more emails with different languages.
The error occurs because we can not order the email groups

#### Steps to reproduce the bug:
1. Create 2 segment emails with different languages.
2. Create a new campaign. In this campaign try to send an new email.
3. Fill all required fileds in the new window , and click to apply
4. Can see that we can not apply a new segment email.

#### Steps to test this PR:
1. Load up this PR
2. Do step 1-3
3. Verify that the new email has added, an can be selected in the list `Email to send `
