### PR TITLE
Fix illegal offset type error.

### DIFF
--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -99,7 +99,7 @@ class LeadSubscriber extends CommonSubscriber
 
                     $removeLeads = [];
                     foreach ($leads as $l) {
-                        $lists = (isset($leadLists[$l])) ? $leadLists[$l] : [];
+                        $lists = (isset($leadLists[$l['id']])) ? $leadLists[$l['id']] : [];
                         if (array_intersect(array_keys($lists), $campaignLists[$c['id']])) {
                             continue;
                         } else {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? |N/A
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A 
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N
| Deprecations? | N 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: 
The following error is produced whenever a segment that has an associated campaign (pulling contacts from said segment) is updated and removes contacts via mautic:segments:update: 
`PHP Warning:  Illegal offset type in isset or empty in /path/to/mautic/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php on line 102`

It seems that the code is trying to access $leadLists using $l, which is an array, when it is expecting the lead id.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a segment and add some users to it.
2. Create a campaign, utilizing the aforementioned segment as a source.
3. Run `php /path/to/mautic/app/console mautic:segments:update`.
4. Remove users from the segment.
5. Run `php /path/to/mautic/app/console mautic:segments:update`.
6. The error mentioned above should be logged.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Perform bug reproduction steps 1-5.
3. Confirm that errors are no longer logged.