### PR TITLE
Add the ability to embed the owner's information in an email using to tokens

### DIFF
--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1387,7 +1387,8 @@ class EmailController extends FormController
                         $field = "[$field]";
                     }
                 );
-                $fields['id'] = 0;
+                $fields['id']       = 0;
+                $fields['owner_id'] = 0;
 
                 $errors = [];
                 foreach ($emails as $email) {

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1476,7 +1476,8 @@ class EmailController extends FormController
                 $field = "[$field]";
             }
         );
-        $fields['id'] = 0;
+        $fields['id']       = 0;
+        $fields['owner_id'] = 0;
 
         // Send to current user
         $user  = $this->user;

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -520,7 +520,8 @@ class PublicController extends CommonFormController
                 $field = "[$field]";
             }
         );
-        $fields['id'] = 0;
+        $fields['id']       = 0;
+        $fields['owner_id'] = 0;
 
         // Generate and replace tokens
         $event = new EmailSendEvent(

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -2051,9 +2051,7 @@ class MailHelper
         $owner = false;
 
         if ($this->factory->getParameter('mailer_is_owner') && is_array($contact) && isset($contact['id'])) {
-            if (!isset($contact['owner_id'])) {
-                $contact['owner_id'] = 0;
-            } elseif (isset($contact['owner_id'])) {
+            if (isset($contact['owner_id'])) {
                 if (isset(self::$leadOwners[$contact['owner_id']])) {
                     $owner = self::$leadOwners[$contact['owner_id']];
                 } elseif ($owner = $this->factory->getModel('lead')->getRepository()->getLeadOwner($contact['owner_id'])) {

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -382,6 +382,12 @@ return [
             'mautic.lead.emailbundle.subscriber' => [
                 'class' => 'Mautic\LeadBundle\EventListener\EmailSubscriber',
             ],
+            'mautic.lead.emailbundle.subscriber.owner' => [
+                'class'     => 'Mautic\LeadBundle\EventListener\OwnerSubscriber',
+                'arguments' => [
+                    'mautic.lead.model.lead',
+                ],
+            ],
             'mautic.lead.formbundle.subscriber' => [
                 'class'     => 'Mautic\LeadBundle\EventListener\FormSubscriber',
                 'arguments' => [

--- a/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
@@ -117,7 +117,7 @@ class OwnerSubscriber implements EventSubscriberInterface
         return [
             self::buildToken('email')      => '[Owner Email]',
             self::buildToken('first_name') => '[Owner First Name]',
-            self::buildToken('last_name')  => '[Last Name]',
+            self::buildToken('last_name')  => '[Owner Last Name]',
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
@@ -59,9 +59,7 @@ class OwnerSubscriber implements EventSubscriberInterface
      */
     public function onEmailDisplay(EmailSendEvent $event)
     {
-        $event->addToken(self::buildToken('email'), '[Owner Email]');
-        $event->addToken(self::buildToken('first_name'), '[Owner First Name]');
-        $event->addToken(self::buildToken('last_name'), '[Owner Last Name]');
+        $event->addTokens($this->getFakeTokens());
     }
 
     /**
@@ -72,14 +70,20 @@ class OwnerSubscriber implements EventSubscriberInterface
         $contact = $event->getLead();
 
         if (isset($contact['owner_id']) === false) {
-            $this->addEmptyTokens($event);
+            $event->addTokens($this->getEmptyTokens());
+
+            return;
+        }
+
+        if ($contact['owner_id'] === 0) {
+            $event->addTokens($this->getFakeTokens());
 
             return;
         }
 
         $owner = $this->leadModel->getRepository()->getLeadOwner($contact['owner_id']);
         if ($owner === false) {
-            $this->addEmptyTokens($event);
+            $event->addTokens($this->getEmptyTokens());
 
             return;
         }
@@ -92,13 +96,29 @@ class OwnerSubscriber implements EventSubscriberInterface
     /**
      * Used to replace all owner tokens with emptiness so not to email out tokens.
      *
-     * @param EmailSendEvent $event
+     * @return array
      */
-    private function addEmptyTokens(EmailSendEvent $event)
+    private function getEmptyTokens()
     {
-        $event->addToken(self::buildToken('email'), '');
-        $event->addToken(self::buildToken('first_name'), '');
-        $event->addToken(self::buildToken('last_name'), '');
+        return [
+            self::buildToken('email')      => '',
+            self::buildToken('first_name') => '',
+            self::buildToken('last_name')  => '',
+        ];
+    }
+
+    /**
+     * Used to replace all owner tokens with emptiness so not to email out tokens.
+     *
+     * @return array
+     */
+    private function getFakeTokens()
+    {
+        return [
+            self::buildToken('email')      => '[Owner Email]',
+            self::buildToken('first_name') => '[Owner First Name]',
+            self::buildToken('last_name')  => '[Last Name]',
+        ];
     }
 
     /**

--- a/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * @copyright   2014 Mautic Contributors. All rights reserved
+ * @copyright   2019 Mautic Contributors. All rights reserved
  * @author      Mautic
  *
  * @link        http://mautic.org
@@ -17,9 +17,6 @@ use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-/**
- * Class EmailSubscriber.
- */
 class OwnerSubscriber implements EventSubscriberInterface
 {
     /**
@@ -104,6 +101,13 @@ class OwnerSubscriber implements EventSubscriberInterface
         $event->addToken(self::buildToken('last_name'), '');
     }
 
+    /**
+     * Creates a token using defined pattern.
+     *
+     * @param string $field
+     *
+     * @return string
+     */
     private static function buildToken($field)
     {
         return sprintf(self::$ownerFieldSprintf, $field);

--- a/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\EventListener;
+
+use Mautic\EmailBundle\EmailEvents;
+use Mautic\EmailBundle\Event\EmailBuilderEvent;
+use Mautic\EmailBundle\Event\EmailSendEvent;
+use Mautic\LeadBundle\Model\LeadModel;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class EmailSubscriber.
+ */
+class OwnerSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var string
+     */
+    private static $ownerFieldSprintf = '{ownerfield=%s}';
+
+    /** @var LeadModel */
+    private $leadModel;
+
+    public function __construct(LeadModel $leadModel)
+    {
+        $this->leadModel = $leadModel;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            EmailEvents::EMAIL_ON_BUILD   => ['onEmailBuild', 0],
+            EmailEvents::EMAIL_ON_SEND    => ['onEmailGenerate', 0],
+            EmailEvents::EMAIL_ON_DISPLAY => ['onEmailDisplay', 0],
+        ];
+    }
+
+    /**
+     * @param EmailBuilderEvent $event
+     */
+    public function onEmailBuild(EmailBuilderEvent $event)
+    {
+        $event->addToken(self::buildToken('email'), 'Owner Email');
+        $event->addToken(self::buildToken('first_name'), 'Owner First Name');
+        $event->addToken(self::buildToken('last_name'), 'Owner Last Name');
+    }
+
+    /**
+     * @param EmailSendEvent $event
+     */
+    public function onEmailDisplay(EmailSendEvent $event)
+    {
+        $event->addToken(self::buildToken('email'), '[Owner Email]');
+        $event->addToken(self::buildToken('first_name'), '[Owner First Name]');
+        $event->addToken(self::buildToken('last_name'), '[Owner Last Name]');
+    }
+
+    /**
+     * @param EmailSendEvent $event
+     */
+    public function onEmailGenerate(EmailSendEvent $event)
+    {
+        $contact = $event->getLead();
+
+        if (isset($contact['owner_id']) === false) {
+            $this->addEmptyTokens($event);
+
+            return;
+        }
+
+        $owner = $this->leadModel->getRepository()->getLeadOwner($contact['owner_id']);
+        if ($owner === false) {
+            $this->addEmptyTokens($event);
+
+            return;
+        }
+
+        $event->addToken(self::buildToken('email'), (string) $owner['email']);
+        $event->addToken(self::buildToken('first_name'), (string) $owner['first_name']);
+        $event->addToken(self::buildToken('last_name'), (string) $owner['last_name']);
+    }
+
+    /**
+     * Used to replace all owner tokens with emptiness so not to email out tokens.
+     *
+     * @param EmailSendEvent $event
+     */
+    private function addEmptyTokens(EmailSendEvent $event)
+    {
+        $event->addToken(self::buildToken('email'), '');
+        $event->addToken(self::buildToken('first_name'), '');
+        $event->addToken(self::buildToken('last_name'), '');
+    }
+
+    private static function buildToken($field)
+    {
+        return sprintf(self::$ownerFieldSprintf, $field);
+    }
+}

--- a/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
@@ -286,7 +286,7 @@ class OwnerSubscriberTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return Translator
+     * @return Translator|\PHPUnit_Framework_MockObject_MockObject
      */
     protected function getMockTranslator()
     {

--- a/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
@@ -1,0 +1,303 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\EventListener;
+
+use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\CoreBundle\Translation\Translator;
+use Mautic\EmailBundle\Event\EmailBuilderEvent;
+use Mautic\EmailBundle\Event\EmailSendEvent;
+use Mautic\EmailBundle\Helper\MailHelper;
+use Mautic\EmailBundle\MonitoredEmail\Mailbox;
+use Mautic\EmailBundle\Tests\Helper\Transport\SmtpTransport;
+use Mautic\LeadBundle\Entity\LeadRepository;
+use Mautic\LeadBundle\EventListener\OwnerSubscriber;
+use Mautic\LeadBundle\Model\LeadModel;
+use Monolog\Logger;
+
+class OwnerSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    protected $contacts = [
+        [
+            'id'        => 1,
+            'email'     => 'contact1@somewhere.com',
+            'firstname' => 'Contact',
+            'lastname'  => '1',
+            'owner_id'  => 3,
+        ],
+        [
+            'id'        => 2,
+            'email'     => 'contact2@somewhere.com',
+            'firstname' => 'Contact',
+            'lastname'  => '2',
+            'owner_id'  => 0,
+        ],
+        [
+            'id'        => 3,
+            'email'     => 'contact3@somewhere.com',
+            'firstname' => 'Contact',
+            'lastname'  => '3',
+            'owner_id'  => 2,
+        ],
+        [
+            'id'        => 4,
+            'email'     => 'contact4@somewhere.com',
+            'firstname' => 'Contact',
+            'lastname'  => '4',
+            'owner_id'  => 1,
+        ],
+        [
+            'id'        => 5,
+            'email'     => 'contact5@somewhere.com',
+            'firstname' => 'Contact',
+            'lastname'  => '5',
+            'owner_id'  => null,
+        ],
+    ];
+
+    public function setUp()
+    {
+        defined('MAUTIC_ENV') or define('MAUTIC_ENV', 'test');
+    }
+
+    public function testOnEmailBuild()
+    {
+        $subscriber = new OwnerSubscriber($this->getMockFactory()->getModel('lead'));
+        $event      = new EmailBuilderEvent($this->getMockTranslator());
+        $subscriber->onEmailBuild($event);
+
+        $tokens = $event->getTokens();
+        $this->assertArrayHasKey('{ownerfield=email}', $tokens);
+        $this->assertArrayHasKey('{ownerfield=first_name}', $tokens);
+        $this->assertArrayHasKey('{ownerfield=last_name}', $tokens);
+
+        $this->assertEquals('Owner Email', $tokens['{ownerfield=email}']);
+        $this->assertEquals('Owner First Name', $tokens['{ownerfield=first_name}']);
+        $this->assertEquals('Owner Last Name', $tokens['{ownerfield=last_name}']);
+    }
+
+    public function testOnEmailGenerate()
+    {
+        $subscriber = new OwnerSubscriber($this->getMockFactory()->getModel('lead'));
+
+        $mailer = $this->getMockMailer($this->contacts[0]);
+        $event  = new EmailSendEvent($mailer);
+        $subscriber->onEmailGenerate($event);
+
+        $tokens = $event->getTokens();
+        $this->assertArrayHasKey('{ownerfield=email}', $tokens);
+        $this->assertArrayHasKey('{ownerfield=first_name}', $tokens);
+        $this->assertArrayHasKey('{ownerfield=last_name}', $tokens);
+
+        $this->assertEquals('owner3@owner.com', $tokens['{ownerfield=email}']);
+        $this->assertEquals('John', $tokens['{ownerfield=first_name}']);
+        $this->assertEquals('S&#39;mith', $tokens['{ownerfield=last_name}']);
+    }
+
+    public function testOnEmailGenerateWithFakeOwner()
+    {
+        $subscriber = new OwnerSubscriber($this->getMockFactory()->getModel('lead'));
+
+        $mailer = $this->getMockMailer($this->contacts[1]);
+        $event  = new EmailSendEvent($mailer);
+        $subscriber->onEmailGenerate($event);
+
+        $tokens = $event->getTokens();
+        $this->assertArrayHasKey('{ownerfield=email}', $tokens);
+        $this->assertArrayHasKey('{ownerfield=first_name}', $tokens);
+        $this->assertArrayHasKey('{ownerfield=last_name}', $tokens);
+
+        $this->assertEquals('[Owner Email]', $tokens['{ownerfield=email}']);
+        $this->assertEquals('[Owner First Name]', $tokens['{ownerfield=first_name}']);
+        $this->assertEquals('[Owner Last Name]', $tokens['{ownerfield=last_name}']);
+    }
+
+    public function testOnEmailGenerateWithNoOwner()
+    {
+        $subscriber = new OwnerSubscriber($this->getMockFactory()->getModel('lead'));
+
+        $mailer = $this->getMockMailer($this->contacts[4]);
+        $event  = new EmailSendEvent($mailer);
+        $subscriber->onEmailGenerate($event);
+
+        $tokens = $event->getTokens();
+        $this->assertArrayHasKey('{ownerfield=email}', $tokens);
+        $this->assertArrayHasKey('{ownerfield=first_name}', $tokens);
+        $this->assertArrayHasKey('{ownerfield=last_name}', $tokens);
+
+        $this->assertEquals('', $tokens['{ownerfield=email}']);
+        $this->assertEquals('', $tokens['{ownerfield=first_name}']);
+        $this->assertEquals('', $tokens['{ownerfield=last_name}']);
+    }
+
+    public function testOnEmailDisplay()
+    {
+        $subscriber = new OwnerSubscriber($this->getMockFactory()->getModel('lead'));
+
+        $mailer = $this->getMockMailer($this->contacts[0]);
+        $event  = new EmailSendEvent($mailer);
+        $subscriber->onEmailDisplay($event);
+
+        $tokens = $event->getTokens();
+        $this->assertArrayHasKey('{ownerfield=email}', $tokens);
+        $this->assertArrayHasKey('{ownerfield=first_name}', $tokens);
+        $this->assertArrayHasKey('{ownerfield=last_name}', $tokens);
+    }
+
+    public function testOnEmailDisplayWithFakeOwner()
+    {
+        $subscriber = new OwnerSubscriber($this->getMockFactory()->getModel('lead'));
+
+        $mailer = $this->getMockMailer($this->contacts[1]);
+        $event  = new EmailSendEvent($mailer);
+        $subscriber->onEmailDisplay($event);
+
+        $tokens = $event->getTokens();
+        $this->assertArrayHasKey('{ownerfield=email}', $tokens);
+        $this->assertArrayHasKey('{ownerfield=first_name}', $tokens);
+        $this->assertArrayHasKey('{ownerfield=last_name}', $tokens);
+
+        $this->assertEquals('[Owner Email]', $tokens['{ownerfield=email}']);
+        $this->assertEquals('[Owner First Name]', $tokens['{ownerfield=first_name}']);
+        $this->assertEquals('[Owner Last Name]', $tokens['{ownerfield=last_name}']);
+    }
+
+    public function testOnEmailDisplayWithNoOwner()
+    {
+        $subscriber = new OwnerSubscriber($this->getMockFactory()->getModel('lead'));
+
+        $mailer = $this->getMockMailer($this->contacts[4]);
+        $event  = new EmailSendEvent($mailer);
+        $subscriber->onEmailDisplay($event);
+
+        $tokens = $event->getTokens();
+        $this->assertArrayHasKey('{ownerfield=email}', $tokens);
+        $this->assertArrayHasKey('{ownerfield=first_name}', $tokens);
+        $this->assertArrayHasKey('{ownerfield=last_name}', $tokens);
+
+        $this->assertEquals('', $tokens['{ownerfield=email}']);
+        $this->assertEquals('', $tokens['{ownerfield=first_name}']);
+        $this->assertEquals('', $tokens['{ownerfield=last_name}']);
+    }
+
+    /**
+     * @param bool  $mailIsOwner
+     * @param array $parameterMap
+     *
+     * @return MauticFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockFactory($mailIsOwner = true, $parameterMap = [])
+    {
+        $mockLeadRepository = $this->getMockBuilder(LeadRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockLeadRepository->method('getLeadOwner')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        [1, ['id' => 1, 'email' => 'owner1@owner.com', 'first_name' => '', 'last_name' => '', 'signature' => 'owner 1']],
+                        [2, ['id' => 2, 'email' => 'owner2@owner.com', 'first_name' => '', 'last_name' => '', 'signature' => 'owner 2']],
+                        [3, ['id' => 3, 'email' => 'owner3@owner.com', 'first_name' => 'John', 'last_name' => 'S&#39;mith', 'signature' => 'owner 2']],
+                    ]
+                )
+            );
+
+        $mockLeadModel = $this->getMockBuilder(LeadModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockLeadModel->method('getRepository')
+            ->willReturn($mockLeadRepository);
+
+        /** @var MauticFactory|\PHPUnit_Framework_MockObject_MockObject $mockFactory */
+        $mockFactory = $this->getMockBuilder(MauticFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $parameterMap = array_merge(
+            [
+                ['mailer_return_path', false, null],
+                ['mailer_spool_type', false, 'memory'],
+                ['mailer_is_owner', false, $mailIsOwner],
+            ],
+            $parameterMap
+        );
+
+        $mockFactory->method('getParameter')
+            ->will(
+                $this->returnValueMap($parameterMap)
+            );
+        $mockFactory->method('getModel')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['lead', $mockLeadModel],
+                    ]
+                )
+            );
+
+        $mockLogger = $this->getMockBuilder(Logger::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockFactory->method('getLogger')
+            ->willReturn($mockLogger);
+
+        $mockMailboxHelper = $this->getMockBuilder(Mailbox::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockMailboxHelper->method('isConfigured')
+            ->willReturn(false);
+
+        $mockFactory->method('getHelper')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['mailbox', $mockMailboxHelper],
+                    ]
+                )
+            );
+
+        return $mockFactory;
+    }
+
+    protected function getMockMailer(array $lead)
+    {
+        $parameterMap = [
+            ['mailer_custom_headers', [], ['X-Mautic-Test' => 'test', 'X-Mautic-Test2' => 'test']],
+        ];
+        /** @var MauticFactory $mockFactory */
+        $mockFactory = $this->getMockFactory(true, $parameterMap);
+
+        $transport   = new SmtpTransport();
+        $swiftMailer = new \Swift_Mailer($transport);
+        $mailer      = new MailHelper($mockFactory, $swiftMailer, ['nobody@nowhere.com' => 'No Body']);
+        $mailer->setLead($lead);
+
+        return $mailer;
+    }
+
+    /**
+     * @return Translator
+     */
+    protected function getMockTranslator()
+    {
+        /** @var Translator|\PHPUnit_Framework_MockObject_MockObject $translator */
+        $translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $translator->expects($this->any())
+            ->method('hasId')
+            ->will($this->returnValue(false));
+
+        return $translator;
+    }
+}


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Submitted against _staging_ branch? | Y
| Bug fix? | N
| New feature? | Y
| Automated tests included? | Y
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | #3079 #1176
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Adding three new tokens for a contact's owner to be used in an email.

* {ownerfield=first_name}
* {ownerfield=last_name}
* {ownerfield=email}

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create an email using one of the new tokens above
3. Create a contact with an assigned Owner
4. Send email to Contact
5. Check email for owner's information

- [X] Preview an Email should replace "{ownerfield=first_name}" with "[Owner First Name]"
- [X] Send a Contact an Email should replace "{ownerfield=first_name}" with the current logged in user first name
- [X] Send an email from Campaign to a Contact with an Owner should replace "{ownerfield=first_name}" with with the owner's first name
- [X] Send an email from Campaign to a Contact without an Owner should replace "{ownerfield=first_name}" with with "" (empty string)
- [X] All of the above should happen for tokens within dynamic content blocks

#### Topics for discussion

##### AvailableTokens 

- [ ] Resolved

###### Currently included

* First Name
* Last Name
* Email

###### Could also include

* Position
* Role

##### Token Name (format)

- [ ] Resolved

###### Currently using
* {ownerfield=first_name}

###### Could do instead

* {contactfield=owner_first_name}
  * Did this originally, didn't really like it.
* {ownerfield=first_name}
  * Currently only contactfield and leadfield are used, it might make more sense to use this to keep away from collisions with custom fields
* {contactfield=owner.first_name}
  * We're describing a field of contact, but it's foreign field. This might make more sense to avoid collisions with custom fields, and used a fairly recognizable dot-notation format for related records
* {contactfield=ownerfirst_name}
  * This is how company fields are done currently. I really don't like it.

##### Default Values

- [ ] Resolved

Needed to add default values so that the tokens don't end up in a final email if there is no owner of the contact.

###### Currently

* first_name = (empty string)
* last_name = (empty string)
* email = (empty string)

###### Could

* first_name = From Name
* last_name = (empty string)
* email = From Address

* all = Leave the token showing (I think bad)