### PR TITLE
Fix report filters for bounce and unsubscribe ratio

### DIFF
--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -139,7 +139,7 @@ class ReportSubscriber extends CommonSubscriber
                 'alias'   => 'unsubscribed_ratio',
                 'label'   => 'mautic.email.report.unsubscribed_ratio',
                 'type'    => 'string',
-                'formula' => 'IFNULL((SELECT ROUND((SUM(IF('.$doNotContact.'id IS NOT NULL AND dnc.reason='.DoNotContact::UNSUBSCRIBED.', 1, 0))/'.$prefix.'sent_count)*100, 1) FROM lead_donotcontact dnc), \'0.0\')',
+                'formula' => 'IFNULL((SELECT ROUND((SUM(IF('.$doNotContact.'id IS NOT NULL AND dnc.reason='.DoNotContact::UNSUBSCRIBED.', 1, 0))/'.$prefix.'sent_count)*100, 1) FROM '.MAUTIC_TABLE_PREFIX.'lead_donotcontact dnc), \'0.0\')',
                 'suffix'  => '%',
             ],
             'bounced' => [
@@ -152,7 +152,7 @@ class ReportSubscriber extends CommonSubscriber
                 'alias'   => 'bounced_ratio',
                 'label'   => 'mautic.email.report.bounced_ratio',
                 'type'    => 'string',
-                'formula' => 'IFNULL((SELECT ROUND((SUM(IF('.$doNotContact.'id IS NOT NULL AND dnc.reason='.DoNotContact::BOUNCED.', 1, 0))/'.$prefix.'sent_count)*100, 1) FROM lead_donotcontact dnc), \'0.0\')',
+                'formula' => 'IFNULL((SELECT ROUND((SUM(IF('.$doNotContact.'id IS NOT NULL AND dnc.reason='.DoNotContact::BOUNCED.', 1, 0))/'.$prefix.'sent_count)*100, 1) FROM '.MAUTIC_TABLE_PREFIX.'lead_donotcontact dnc), \'0.0\')',
                 'suffix'  => '%',
             ],
             $prefix.'revision' => [

--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -110,13 +110,13 @@ class ReportSubscriber extends CommonSubscriber
                 'alias'   => 'hits',
                 'label'   => 'mautic.email.report.hits_count',
                 'type'    => 'string',
-                'formula' => $channelUrlTrackables.'hits',
+                'formula' => 'IFNULL('.$channelUrlTrackables.'hits, 0)',
             ],
             'unique_hits' => [
                 'alias'   => 'unique_hits',
                 'label'   => 'mautic.email.report.unique_hits_count',
                 'type'    => 'string',
-                'formula' => $channelUrlTrackables.'unique_hits',
+                'formula' => 'IFNULL('.$channelUrlTrackables.'unique_hits, 0)',
             ],
             'hits_ratio' => [
                 'alias'   => 'hits_ratio',

--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -99,7 +99,8 @@ class ReportSubscriber extends CommonSubscriber
                 'alias'   => 'read_ratio',
                 'label'   => 'mautic.email.report.read_ratio',
                 'type'    => 'string',
-                'formula' => 'CONCAT(ROUND(('.$prefix.'read_count/'.$prefix.'sent_count)*100, 1),\'%\')',
+                'formula' => 'IFNULL(ROUND(('.$prefix.'read_count/'.$prefix.'sent_count)*100, 1), \'0.0\')',
+                'suffix'  => '%',
             ],
             $prefix.'sent_count' => [
                 'label' => 'mautic.email.report.sent_count',
@@ -121,13 +122,15 @@ class ReportSubscriber extends CommonSubscriber
                 'alias'   => 'hits_ratio',
                 'label'   => 'mautic.email.report.hits_ratio',
                 'type'    => 'string',
-                'formula' => 'CONCAT(ROUND('.$channelUrlTrackables.'hits/('.$prefix.'sent_count)*100, 1),\'%\')',
+                'formula' => 'IFNULL(ROUND('.$channelUrlTrackables.'hits/('.$prefix.'sent_count)*100, 1), \'0.0\')',
+                'suffix'  => '%',
             ],
             'unique_ratio' => [
                 'alias'   => 'unique_ratio',
                 'label'   => 'mautic.email.report.unique_ratio',
                 'type'    => 'string',
-                'formula' => 'CONCAT(ROUND('.$channelUrlTrackables.'unique_hits/('.$prefix.'sent_count)*100, 1),\'%\')',
+                'formula' => 'IFNULL(ROUND('.$channelUrlTrackables.'unique_hits/('.$prefix.'sent_count)*100, 1), \'0.0\')',
+                'suffix'  => '%',
             ],
             'unsubscribed' => [
                 'alias'   => 'unsubscribed',

--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -139,7 +139,8 @@ class ReportSubscriber extends CommonSubscriber
                 'alias'   => 'unsubscribed_ratio',
                 'label'   => 'mautic.email.report.unsubscribed_ratio',
                 'type'    => 'string',
-                'formula' => 'CONCAT(ROUND((SUM(IF('.$doNotContact.'id IS NOT NULL AND dnc.reason='.DoNotContact::UNSUBSCRIBED.' , 1, 0))/'.$prefix.'sent_count)*100, 1),\'%\')',
+                'formula' => 'IFNULL((SELECT ROUND((SUM(IF('.$doNotContact.'id IS NOT NULL AND dnc.reason='.DoNotContact::UNSUBSCRIBED.', 1, 0))/'.$prefix.'sent_count)*100, 1) FROM lead_donotcontact dnc), \'0.0\')',
+                'suffix'  => '%',
             ],
             'bounced' => [
                 'alias'   => 'bounced',
@@ -151,7 +152,8 @@ class ReportSubscriber extends CommonSubscriber
                 'alias'   => 'bounced_ratio',
                 'label'   => 'mautic.email.report.bounced_ratio',
                 'type'    => 'string',
-                'formula' => 'CONCAT(ROUND((SUM(IF('.$doNotContact.'id IS NOT NULL AND dnc.reason='.DoNotContact::BOUNCED.' , 1, 0))/'.$prefix.'sent_count)*100, 1),\'%\')',
+                'formula' => 'IFNULL((SELECT ROUND((SUM(IF('.$doNotContact.'id IS NOT NULL AND dnc.reason='.DoNotContact::BOUNCED.', 1, 0))/'.$prefix.'sent_count)*100, 1) FROM lead_donotcontact dnc), \'0.0\')',
+                'suffix'  => '%',
             ],
             $prefix.'revision' => [
                 'label' => 'mautic.email.report.revision',

--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -316,7 +316,9 @@ final class MauticReportBuilder implements ReportBuilderInterface
                     // support for prefix and suffix to value in query
                     $prefix     = isset($fieldOptions['prefix']) ? $fieldOptions['prefix'] : '';
                     $suffix     = isset($fieldOptions['suffix']) ? $fieldOptions['suffix'] : '';
-                    $selectText = 'CONCAT(\''.$prefix.'\', '.$selectText.',\''.$suffix.'\')';
+                    if ($prefix || $suffix) {
+                        $selectText = 'CONCAT(\''.$prefix.'\', '.$selectText.',\''.$suffix.'\')';
+                    }
 
                     if (isset($fieldOptions['alias'])) {
                         $selectText .= ' AS '.$fieldOptions['alias'];

--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -313,6 +313,10 @@ final class MauticReportBuilder implements ReportBuilderInterface
                         }
                     }
 
+                    $prefix     = isset($fieldOptions['prefix']) ? $fieldOptions['prefix'] : '';
+                    $suffix     = isset($fieldOptions['suffix']) ? $fieldOptions['suffix'] : '';
+                    $selectText = 'CONCAT(\''.$prefix.'\', '.$selectText.',\''.$suffix.'\')';
+
                     if (isset($fieldOptions['alias'])) {
                         $selectText .= ' AS '.$fieldOptions['alias'];
                     }

--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -313,6 +313,7 @@ final class MauticReportBuilder implements ReportBuilderInterface
                         }
                     }
 
+                    // support for prefix and suffix to value in query
                     $prefix     = isset($fieldOptions['prefix']) ? $fieldOptions['prefix'] : '';
                     $suffix     = isset($fieldOptions['suffix']) ? $fieldOptions['suffix'] : '';
                     $selectText = 'CONCAT(\''.$prefix.'\', '.$selectText.',\''.$suffix.'\')';


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7054
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Unsubscribed and bounce ratio in report filters doesn't work because aggregated columns can't work in WHERE statement.  This PR fixed it.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a report and choose email as data source
![image](https://user-images.githubusercontent.com/31535432/50449423-9df58a80-0927-11e9-94e3-ec8ba3978c69.png)
2. add some columns.
3. Save. See that there is no problem with the report
4. Now go back editing the report and add unsubscribe ratio (or bounce ratio) as a filter. Choose greater than and choose a number
![image](https://user-images.githubusercontent.com/31535432/50449466-deed9f00-0927-11e9-851a-a7a06f46c949.png)
5. Save and close. See error 500
![image](https://user-images.githubusercontent.com/31535432/50449474-ee6ce800-0927-11e9-8890-4f026d1fcf20.png)

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7070)
2. Repeat all steps and see If unsubscribe and bounce ratio works properly.

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
