### PR TITLE
Fix for non Outlook condition in email builder

### DIFF
--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -401,13 +401,25 @@ class InputHelper
         } else {
             // Special handling for doctype
             $doctypeFound = preg_match('/(<!DOCTYPE(.*?)>)/is', $value, $doctype);
-
             // Special handling for CDATA tags
             $value = str_replace(['<![CDATA[', ']]>'], ['<mcdata>', '</mcdata>'], $value, $cdataCount);
-
             // Special handling for conditional blocks
-            $value = preg_replace("/<!--\[if(.*?)\]><!-(.*?)->(.*?)<!--<!\[endif\]-->/is", '<mconditionnonoutlook><mif>$1</mif>$3</mconditionnonoutlook>', $value, -1, $conditionsFoundNonOutlook);
-            $value = preg_replace("/<!--\[if(.*?)\]>(.*?)<!\[endif\]-->/is", '<mcondition><mif>$1</mif>$2</mcondition>', $value, -1, $conditionsFound);
+            preg_match_all("/<!--\[if(.*?)\]>(.*?)(?:\<\!\-\-)?<!\[endif\]-->/is", $value, $matches);
+            if (!empty($matches[0])) {
+                $from = [];
+                $to   = [];
+                foreach ($matches[0] as $key=>$match) {
+                    $from[]   = $match;
+                    $startTag = '<mcondition>';
+                    $endTag   = '</mcondition>';
+                    if (false !== strpos($match, '<!--<![endif]-->')) {
+                        $startTag = '<mconditionnonoutlook>';
+                        $endTag   = '</mconditionnonoutlook>';
+                    }
+                    $to[] = $startTag.'<mif>'.$matches[1][$key].'</mif>'.$matches[2][$key].$endTag;
+                }
+                $value = str_replace($from, $to, $value);
+            }
 
             // Slecial handling for XML tags used in Outlook optimized emails <o:*/> and <w:/>
             $value = preg_replace_callback(
@@ -426,7 +438,7 @@ class InputHelper
                 $value, -1, $needsScriptDecoding);
 
             // Special handling for HTML comments
-            $value = str_replace(['<!--', '-->'], ['<mcomment>', '</mcomment>'], $value, $commentCount);
+            $value = str_replace(['<!-->', '<!--', '-->'], ['<mcomment></mcomment>', '<mcomment>', '</mcomment>'], $value, $commentCount);
 
             $value = self::getFilter(true)->clean($value, 'html');
 
@@ -439,13 +451,9 @@ class InputHelper
                 $value = str_replace(['<mcdata>', '</mcdata>'], ['<![CDATA[', ']]>'], $value);
             }
 
-            if ($conditionsFoundNonOutlook) {
-                // Special handling for non Outlook conditional blocks
-                $value = preg_replace("/<mconditionnonoutlook><mif>(.*?)<\/mif>(.*?)<\/mconditionnonoutlook>/is", '<!--[if$1]><!-- -->$2<!--<![endif]-->', $value);
-            }
-
-            if ($conditionsFound) {
+            if (!empty($matches[0])) {
                 // Special handling for conditional blocks
+                $value = preg_replace("/<mconditionnonoutlook><mif>(.*?)<\/mif>(.*?)<\/mconditionnonoutlook>/is", '<!--[if$1]>$2<!--<![endif]-->', $value);
                 $value = preg_replace("/<mcondition><mif>(.*?)<\/mif>(.*?)<\/mcondition>/is", '<!--[if$1]>$2<![endif]-->', $value);
             }
 

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -439,14 +439,14 @@ class InputHelper
                 $value = str_replace(['<mcdata>', '</mcdata>'], ['<![CDATA[', ']]>'], $value);
             }
 
-            if ($conditionsFound) {
-                // Special handling for conditional blocks
-                $value = preg_replace("/<mcondition><mif>(.*?)<\/mif>(.*?)<\/mcondition>/is", '<!--[if$1]>$2<![endif]-->', $value);
-            }
-
             if ($conditionsFoundNonOutlook) {
                 // Special handling for non Outlook conditional blocks
                 $value = preg_replace("/<mconditionnonoutlook><mif>(.*?)<\/mif>(.*?)<\/mconditionnonoutlook>/is", '<!--[if$1]><!-- -->$2<!--<![endif]-->', $value);
+            }
+
+            if ($conditionsFound) {
+                // Special handling for conditional blocks
+                $value = preg_replace("/<mcondition><mif>(.*?)<\/mif>(.*?)<\/mcondition>/is", '<!--[if$1]>$2<![endif]-->', $value);
             }
 
             if ($commentCount) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7048
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR https://github.com/mautic/mautic/pull/6938 fixed non outlook condition in HTML email code generated by MJML mainly.  Wrong order made mismatch with translate code back to correct format. This PR should fixed it.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new email in the Mautic email builder.
2. Selecting the code mode instead of a template, use the HTML at https://gist.github.com/yrammos/3394aefd8fe388846f5f97c09a895f1b (FWIW, this HTML was generated by MJML).
3. Click on “apply”.
4. The progress wheel keeps on spinning indefinitely.
5. In an effort to circumnavigate the problem and still save the email, click on “close”.
6. Click on “Save”.
7. Reopen the builder and look at the preview of the rendered email.
8. The email does not have the intended appearance because the builder has apparently altered the HTML.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Try steps to reproduce and template should works properly.

