### PR TITLE
Add company mapping and api key for ExtremeIpLookup

### DIFF
--- a/app/bundles/CoreBundle/IpLookup/ExtremeIpLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/ExtremeIpLookup.php
@@ -30,7 +30,7 @@ class ExtremeIpLookup extends AbstractRemoteDataLookup
      */
     protected function getUrl()
     {
-        return 'https://extreme-ip-lookup.com/json/'.$this->ip;
+        return 'https://extreme-ip-lookup.com/json/'.$this->ip."?key={$this->auth}";
     }
 
     /**
@@ -51,6 +51,9 @@ class ExtremeIpLookup extends AbstractRemoteDataLookup
                         break;
                     case 'city':
                         $key = 'city';
+                        break;
+                    case 'businessName':
+                        $key = 'company';
                         break;
                 }
 

--- a/app/bundles/CoreBundle/IpLookup/ExtremeIpLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/ExtremeIpLookup.php
@@ -31,6 +31,7 @@ class ExtremeIpLookup extends AbstractRemoteDataLookup
     protected function getUrl()
     {
         $auth = !empty($this->auth) ? "?key={$this->auth}" : '';
+
         return 'https://extreme-ip-lookup.com/json/'.$this->ip.$auth;
     }
 

--- a/app/bundles/CoreBundle/IpLookup/ExtremeIpLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/ExtremeIpLookup.php
@@ -30,7 +30,8 @@ class ExtremeIpLookup extends AbstractRemoteDataLookup
      */
     protected function getUrl()
     {
-        return 'https://extreme-ip-lookup.com/json/'.$this->ip."?key={$this->auth}";
+        $auth = !empty($this->auth) ? "?key={$this->auth}" : '';
+        return 'https://extreme-ip-lookup.com/json/'.$this->ip.$auth;
     }
 
     /**

--- a/app/bundles/CoreBundle/IpLookup/ExtremeIpLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/ExtremeIpLookup.php
@@ -30,7 +30,7 @@ class ExtremeIpLookup extends AbstractRemoteDataLookup
      */
     protected function getUrl()
     {
-        $auth = !empty($this->auth) ? "?key={$this->auth}" : '';
+        $auth = !empty($this->auth) ? '?key='.$this->auth : '';
 
         return 'https://extreme-ip-lookup.com/json/'.$this->ip.$auth;
     }

--- a/app/bundles/CoreBundle/IpLookup/ExtremeIpLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/ExtremeIpLookup.php
@@ -55,7 +55,7 @@ class ExtremeIpLookup extends AbstractRemoteDataLookup
                         $key = 'city';
                         break;
                     case 'businessName':
-                        $key = 'company';
+                        $key = 'organization';
                         break;
                 }
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Enhancement
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | None

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When using the Extreme Ip Lookup service, the company name was not mapped with mautic company field. Also, if you subscribed to a Pro service to unlock the limit of API call, the API key was not used.

#### Steps to test this PR:
**A bit annoying because you need a pro account to test the API key. But just reviewing the code should be enough.**

1. Load up [this PR](https://mautibox.com/-)
2. Connect your pro account
3. Wait some visits on your webpage tracked
4. See that when the county and city is coming you now also have the company
5. See that if you exceed 50 requests per minute you have a limitation without API key
6. Add an API key and see that this limitation is gone.