### PR TITLE
Multiple value on List-Unsubscribe header

### DIFF
--- a/app/bundles/EmailBundle/EventListener/ProcessUnsubscribeSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ProcessUnsubscribeSubscriber.php
@@ -96,7 +96,7 @@ class ProcessUnsubscribeSubscriber implements EventSubscriberInterface
             $unsubscribeEmail = "<mailto:$unsubscribeEmail>";
             if ($existing) {
                 if (strpos($existing, $unsubscribeEmail) === false) {
-                    $updatedHeader = $unsubscribeEmail . ', ' . $existing;
+                    $updatedHeader = $unsubscribeEmail.', '.$existing;
                 } else {
                     $updatedHeader = $existing;
                 }

--- a/app/bundles/EmailBundle/EventListener/ProcessUnsubscribeSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ProcessUnsubscribeSubscriber.php
@@ -94,7 +94,15 @@ class ProcessUnsubscribeSubscriber implements EventSubscriberInterface
             $headers          = $event->getTextHeaders();
             $existing         = (isset($headers['List-Unsubscribe'])) ? $headers['List-Unsubscribe'] : '';
             $unsubscribeEmail = "<mailto:$unsubscribeEmail>";
-            $updatedHeader    = ($existing) ? $unsubscribeEmail.', '.$existing : $unsubscribeEmail;
+            if ($existing) {
+                if (strpos($existing, $unsubscribeEmail) === false) {
+                    $updatedHeader = $unsubscribeEmail . ', ' . $existing;
+                } else {
+                    $updatedHeader = $existing;
+                }
+            } else {
+                $updatedHeader = $unsubscribeEmail;
+            }
 
             $event->addTextHeader('List-Unsubscribe', $updatedHeader);
         }

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1473,7 +1473,7 @@ class MailHelper
             if (!empty($headers['List-Unsubscribe'])) {
                 if (strpos($headers['List-Unsubscribe'], $listUnsubscribeHeader) === false) {
                     // Ensure Mautic's is always part of this header
-                    $headers['List-Unsubscribe'] .= ',' . $listUnsubscribeHeader;
+                    $headers['List-Unsubscribe'] .= ','.$listUnsubscribeHeader;
                 }
             } else {
                 $headers['List-Unsubscribe'] = $listUnsubscribeHeader;

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1470,8 +1470,8 @@ class MailHelper
 
         $listUnsubscribeHeader = $this->getUnsubscribeHeader();
         if ($listUnsubscribeHeader) {
-            if (strpos($headers['List-Unsubscribe'], $listUnsubscribeHeader) === false) {
-                if (!empty($headers['List-Unsubscribe'])) {
+            if (!empty($headers['List-Unsubscribe'])) {
+                if (strpos($headers['List-Unsubscribe'], $listUnsubscribeHeader) === false) {
                     // Ensure Mautic's is always part of this header
                     $headers['List-Unsubscribe'] .= ',' . $listUnsubscribeHeader;
                 }

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1470,9 +1470,11 @@ class MailHelper
 
         $listUnsubscribeHeader = $this->getUnsubscribeHeader();
         if ($listUnsubscribeHeader) {
-            if (!empty($headers['List-Unsubscribe'])) {
-                // Ensure Mautic's is always part of this header
-                $headers['List-Unsubscribe'] .= ','.$listUnsubscribeHeader;
+            if (strpos($headers['List-Unsubscribe'], $listUnsubscribeHeader) === false) {
+                if (!empty($headers['List-Unsubscribe'])) {
+                    // Ensure Mautic's is always part of this header
+                    $headers['List-Unsubscribe'] .= ',' . $listUnsubscribeHeader;
+                }
             } else {
                 $headers['List-Unsubscribe'] = $listUnsubscribeHeader;
             }
@@ -2117,6 +2119,11 @@ class MailHelper
                     $messageHeaders->addTextHeader($headerKey, $headerValue);
                 }
             }
+        }
+
+        if (array_key_exists('List-Unsubscribe', $headers)) {
+            unset($headers['List-Unsubscribe']);
+            $this->setCustomHeaders($headers, false);
         }
     }
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y |
| New feature? | N |
| Automated tests included? | N |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

#### Description:
Issue is described in #6339 and kudos to @StudioMaX for providing the solution. Multiple value on List-Unsubscribe header in every email sent via Mautic if using the Monitored Inbox feature. This happens to all emails sent directly, campaigns, broadcasts, or actions on the form. In large systems this will cause running out of hard-drive, since each mail `/spool` taking 10-20MB of disc-space!

#### Steps to reproduce the bug:
1. Complete all fields in Monitored Inbox Settings.
2. Perform the procedure to send emails to contacts in any way.
3. Check the header of email that the contact received.
