### PR TITLE
Fix email preview with date custom column

### DIFF
--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -23,6 +23,11 @@ trait MatchFilterForLeadTrait
      */
     protected function matchFilterForLead(array $filter, array $lead)
     {
+        if ($lead['id'] == 0) {
+            // Lead in generated for preview with faked data
+            return false;
+        }
+
         $groups   = [];
         $groupNum = 0;
 

--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -23,7 +23,7 @@ trait MatchFilterForLeadTrait
      */
     protected function matchFilterForLead(array $filter, array $lead)
     {
-        if ($lead['id'] == 0) {
+        if (empty($lead['id'])) {
             // Lead in generated for preview with faked data
             return false;
         }


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If you are using custom column of type `date` in email, preview produces `Uncaught PHP Exception`

```Uncaught PHP Exception Exception: "DateTime::__construct(): Failed to parse time string ([1. reg. dato]) at position 0 ([): Unexpected character" at /usr/local/share/mautic/production/releases/2018.12.02-2/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php line 79```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create `date` custom column 
2. Create email and use token of that column in content.
3. Click `preview`

#### Steps to test this PR:
1. Same as reproduction steps.
