### PR TITLE
Add dispatcher to ContactSegmentFilterDictionary

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -998,7 +998,7 @@ return [
             ],
             'mautic.lead.repository.lead_segment_filter_descriptor' => [
                 'class'     => \Mautic\LeadBundle\Services\ContactSegmentFilterDictionary::class,
-                'arguments' => [],
+                'arguments' => ['event_dispatcher'],
             ],
             'mautic.lead.repository.lead_segment_query_builder' => [
                 'class'     => Mautic\LeadBundle\Segment\Query\ContactSegmentQueryBuilder::class,

--- a/app/bundles/LeadBundle/Event/LeadListDictionaryGeneratedEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListDictionaryGeneratedEvent.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * @copyright  2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class LeadListDictionaryGeneratedEvent extends Event
+{
+    /**
+     * @var array
+     */
+    private $translations;
+
+    public function __construct($translations)
+    {
+        $this->translations = $translations;
+    }
+
+    /**
+     * @param $key
+     * @param $options
+     */
+    public function addTranslation($key, $options)
+    {
+        $this->translations[$key]= $options;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTranslations()
+    {
+        return $this->translations;
+    }
+
+    /**
+     * @param array $translations
+     */
+    public function setTranslations($translations)
+    {
+        $this->translations = $translations;
+    }
+}

--- a/app/bundles/LeadBundle/Event/LeadListDictionaryGeneratedEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListDictionaryGeneratedEvent.php
@@ -27,7 +27,7 @@ class LeadListDictionaryGeneratedEvent extends Event
 
     /**
      * @param $key
-     * @param $options
+     * @param array $options
      */
     public function addTranslation($key, $options)
     {

--- a/app/bundles/LeadBundle/Event/LeadListFiltersChoicesEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFiltersChoicesEvent.php
@@ -85,6 +85,10 @@ class LeadListFiltersChoicesEvent extends CommonEvent
      */
     public function addChoice($object, $choiceKey, $choiceConfig)
     {
+        if (!isset($this->choices[$object])) {
+            $this->choices[$object] = [];
+        }
+
         if (!array_key_exists($choiceKey, $this->choices[$object])) {
             $this->choices[$object][$choiceKey] = $choiceConfig;
         }

--- a/app/bundles/LeadBundle/LeadEvents.php
+++ b/app/bundles/LeadBundle/LeadEvents.php
@@ -554,6 +554,16 @@ final class LeadEvents
     const LIST_FILTERS_QUERYBUILDER_GENERATED = 'mautic.list_filters_querybuilder_generated';
 
     /**
+     * The mautic.list_filters_dictionary_generated event is dispatched when the ContactSegmentFilterDictionary for filters was generated.
+     *
+     * The event listener receives a
+     * Mautic\LeadBundle\Event\LeadListQueryBuilderGeneratedEvent instance.
+     *
+     * @var string
+     */
+    const LIST_FILTERS_DICTIONARY_GENERATED = 'mautic.list_filters_dictionary_generated';
+
+    /**
      * The mautic.list_filters_on_filtering event is dispatched when the lists are updated.
      *
      * The event listener receives a

--- a/app/bundles/LeadBundle/LeadEvents.php
+++ b/app/bundles/LeadBundle/LeadEvents.php
@@ -557,7 +557,7 @@ final class LeadEvents
      * The mautic.list_filters_dictionary_generated event is dispatched when the ContactSegmentFilterDictionary for filters was generated.
      *
      * The event listener receives a
-     * Mautic\LeadBundle\Event\LeadListQueryBuilderGeneratedEvent instance.
+     * Mautic\LeadBundle\Event\LeadListDictionaryGeneratedEvent instance.
      *
      * @var string
      */

--- a/app/bundles/LeadBundle/Services/ContactSegmentFilterDictionary.php
+++ b/app/bundles/LeadBundle/Services/ContactSegmentFilterDictionary.php
@@ -11,6 +11,8 @@
 
 namespace Mautic\LeadBundle\Services;
 
+use Mautic\LeadBundle\Event\LeadListDictionaryGeneratedEvent;
+use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Segment\Query\Filter\BaseFilterQueryBuilder;
 use Mautic\LeadBundle\Segment\Query\Filter\DoNotContactFilterQueryBuilder;
 use Mautic\LeadBundle\Segment\Query\Filter\ForeignFuncFilterQueryBuilder;
@@ -18,13 +20,26 @@ use Mautic\LeadBundle\Segment\Query\Filter\ForeignValueFilterQueryBuilder;
 use Mautic\LeadBundle\Segment\Query\Filter\IntegrationCampaignFilterQueryBuilder;
 use Mautic\LeadBundle\Segment\Query\Filter\SegmentReferenceFilterQueryBuilder;
 use Mautic\LeadBundle\Segment\Query\Filter\SessionsFilterQueryBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ContactSegmentFilterDictionary extends \ArrayIterator
 {
     private $translations;
 
-    public function __construct()
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * ContactSegmentFilterDictionary constructor.
+     *
+     * @param EventDispatcherInterface $dispatcher
+     */
+    public function __construct(EventDispatcherInterface $dispatcher)
     {
+        $this->dispatcher = $dispatcher;
+
         $this->translations['lead_email_read_count'] = [
             'type'                => ForeignFuncFilterQueryBuilder::getServiceId(),
             'foreign_table'       => 'email_stats',
@@ -230,6 +245,13 @@ class ContactSegmentFilterDictionary extends \ArrayIterator
             'field'         => 'campaign_id',
             'where'         => 'campaign_leads.manually_removed = 0',
         ];
+
+        if ($this->dispatcher->hasListeners(LeadEvents::LIST_FILTERS_DICTIONARY_GENERATED)) {
+            $event = new LeadListDictionaryGeneratedEvent($this->translations);
+            $this->dispatcher->dispatch(LeadEvents::LIST_FILTERS_DICTIONARY_GENERATED, $event);
+            $this->translations = $event->getTranslations();
+            $event              = null;
+        }
 
         parent::__construct($this->translations);
     }

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/CustomMappedDecoratorTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/CustomMappedDecoratorTest.php
@@ -15,6 +15,7 @@ use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterOperator;
 use Mautic\LeadBundle\Segment\Decorator\CustomMappedDecorator;
 use Mautic\LeadBundle\Services\ContactSegmentFilterDictionary;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class CustomMappedDecoratorTest extends \PHPUnit_Framework_TestCase
 {
@@ -72,7 +73,7 @@ class CustomMappedDecoratorTest extends \PHPUnit_Framework_TestCase
     private function getDecorator()
     {
         $contactSegmentFilterOperator   = $this->createMock(ContactSegmentFilterOperator::class);
-        $contactSegmentFilterDictionary = new ContactSegmentFilterDictionary();
+        $contactSegmentFilterDictionary = new ContactSegmentFilterDictionary($this->createMock(EventDispatcherInterface::class));
 
         return new CustomMappedDecorator($contactSegmentFilterOperator, $contactSegmentFilterDictionary);
     }

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
@@ -11,7 +11,6 @@
 
 namespace Mautic\LeadBundle\Tests\Segment\Decorator;
 
-use JMS\Serializer\EventDispatcher\EventDispatcherInterface;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\BaseDecorator;
 use Mautic\LeadBundle\Segment\Decorator\CompanyDecorator;
@@ -20,6 +19,7 @@ use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionFactory;
 use Mautic\LeadBundle\Segment\Decorator\DecoratorFactory;
 use Mautic\LeadBundle\Segment\Decorator\FilterDecoratorInterface;
 use Mautic\LeadBundle\Services\ContactSegmentFilterDictionary;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class DecoratorFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -93,7 +93,7 @@ class DecoratorFactoryTest extends \PHPUnit_Framework_TestCase
      */
     private function getDecoratorFactory()
     {
-        $contactSegmentFilterDictionary = new ContactSegmentFilterDictionary();
+        $contactSegmentFilterDictionary = new ContactSegmentFilterDictionary($this->createMock(EventDispatcherInterface::class));
         $baseDecorator                  = $this->createMock(BaseDecorator::class);
         $customMappedDecorator          = $this->createMock(CustomMappedDecorator::class);
         $companyDecorator               = $this->createMock(CompanyDecorator::class);

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\LeadBundle\Tests\Segment\Decorator;
 
+use JMS\Serializer\EventDispatcher\EventDispatcherInterface;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\BaseDecorator;
 use Mautic\LeadBundle\Segment\Decorator\CompanyDecorator;
@@ -63,7 +64,7 @@ class DecoratorFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testDateDecorator()
     {
-        $contactSegmentFilterDictionary = new ContactSegmentFilterDictionary();
+        $contactSegmentFilterDictionary = new ContactSegmentFilterDictionary($this->createMock(EventDispatcherInterface::class));
         $baseDecorator                  = $this->createMock(BaseDecorator::class);
         $customMappedDecorator          = $this->createMock(CustomMappedDecorator::class);
         $companyDecorator               = $this->createMock(CompanyDecorator::class);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR added option to add listener to ContactSegmentFilterDictionary.
Useful If you're using your own filters in segment builder. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2.  Hope just code review is enough. Otherwise devs should try create EventListener for LeadEvents::LIST_FILTERS_DICTIONARY_GENERATED and extend translation by addTranslation
