### PR TITLE
Fix scheduled jump to event campaign action 

### DIFF
--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -190,6 +190,7 @@ return [
                     'mautic.campaign.repository.event',
                     'mautic.campaign.event_executioner',
                     'translator',
+                    'mautic.campaign.repository.lead',
                 ],
             ],
         ],

--- a/app/bundles/CampaignBundle/EventListener/CampaignActionJumpToEventSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignActionJumpToEventSubscriber.php
@@ -12,7 +12,6 @@
 namespace Mautic\CampaignBundle\EventListener;
 
 use Mautic\CampaignBundle\CampaignEvents;
-use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\EventRepository;
 use Mautic\CampaignBundle\Entity\LeadRepository;
@@ -48,9 +47,6 @@ class CampaignActionJumpToEventSubscriber implements EventSubscriberInterface
      */
     private $leadRepository;
 
-    /**
-     * CampaignActionJumpToEvent constructor.
-     */
     public function __construct(EventRepository $eventRepository, EventExecutioner $eventExecutioner, TranslatorInterface $translator, LeadRepository $leadRepository)
     {
         $this->eventRepository  = $eventRepository;
@@ -146,7 +142,7 @@ class CampaignActionJumpToEventSubscriber implements EventSubscriberInterface
                 continue;
             }
 
-            $jumpTarget = $this->getJumpTargetForEvent($event);
+            $jumpTarget = $this->getJumpTargetForEvent($event, 'e.tempId');
 
             if (null !== $jumpTarget) {
                 $event->setProperties(array_merge(
@@ -167,12 +163,8 @@ class CampaignActionJumpToEventSubscriber implements EventSubscriberInterface
 
     /**
      * Inspect a jump event and get its target.
-     *
-     * @param mixed $column
-     *
-     * @return Event|null
      */
-    private function getJumpTargetForEvent(Event $event, $column = 'e.tempId')
+    private function getJumpTargetForEvent(Event $event, string $column): ?Event
     {
         $properties  = $event->getProperties();
         $jumpToEvent = $this->eventRepository->getEntities([

--- a/app/bundles/CampaignBundle/EventListener/CampaignActionJumpToEventSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignActionJumpToEventSubscriber.php
@@ -28,12 +28,24 @@ class CampaignActionJumpToEventSubscriber implements EventSubscriberInterface
 {
     const EVENT_NAME = 'campaign.jump_to_event';
 
+    /**
+     * @var EventRepository
+     */
     private $eventRepository;
 
+    /**
+     * @var EventExecutioner
+     */
     private $eventExecutioner;
 
+    /**
+     * @var TranslatorInterface
+     */
     private $translator;
 
+    /**
+     * @var LeadRepository
+     */
     private $leadRepository;
 
     /**

--- a/app/bundles/CampaignBundle/EventListener/CampaignActionJumpToEventSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignActionJumpToEventSubscriber.php
@@ -15,6 +15,7 @@ use Mautic\CampaignBundle\CampaignEvents;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\EventRepository;
+use Mautic\CampaignBundle\Entity\LeadRepository;
 use Mautic\CampaignBundle\Event\CampaignBuilderEvent;
 use Mautic\CampaignBundle\Event\CampaignEvent;
 use Mautic\CampaignBundle\Event\PendingEvent;

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignActionJumpToEventSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignActionJumpToEventSubscriberTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CampaignBundle\Tests\EventListener;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Entity\EventRepository;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CampaignBundle\Entity\LeadRepository;
+use Mautic\CampaignBundle\Event\CampaignEvent;
+use Mautic\CampaignBundle\Event\PendingEvent;
+use Mautic\CampaignBundle\EventCollector\Accessor\Event\ActionAccessor;
+use Mautic\CampaignBundle\EventListener\CampaignActionJumpToEventSubscriber;
+use Mautic\CampaignBundle\Executioner\EventExecutioner;
+use Mautic\CampaignBundle\Executioner\Result\Counter;
+use Mautic\CampaignBundle\Executioner\Result\Responses;
+use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\Translator;
+
+final class CampaignActionJumpToEventSubscriberTest extends TestCase
+{
+    public function testOnJumpToEventWhenEventDoesNotExist(): void
+    {
+        $event    = new Event();
+        $campaign = new Campaign();
+        $leadLog  = new class() extends LeadEventLog {
+            public function getId()
+            {
+                return 456;
+            }
+        };
+        $contact = new class() extends Lead {
+            public function getId()
+            {
+                return 789;
+            }
+        };
+        $leadLog->setLead($contact);
+
+        $eventRepository = new class($campaign) extends EventRepository {
+            private $campaign;
+
+            public function __construct(Campaign $campaign)
+            {
+                $this->campaign = $campaign;
+            }
+
+            public function getEntities(array $args = [])
+            {
+                Assert::assertSame(
+                    [
+                        'ignore_paginator' => true,
+                        'filter'           => [
+                            'force' => [
+                                [
+                                    'column' => 'e.id',
+                                    'value'  => 123,
+                                    'expr'   => 'eq',
+                                ],
+                                [
+                                    'column' => 'e.campaign',
+                                    'value'  => $this->campaign,
+                                    'expr'   => 'eq',
+                                ],
+                            ],
+                        ],
+                    ],
+                    $args
+                );
+
+                return []; // No entity found.
+            }
+        };
+
+        $eventExecutioner = new class() extends EventExecutioner {
+            public function __construct()
+            {
+            }
+        };
+        $translator = new class() extends Translator {
+            public function __construct()
+            {
+            }
+
+            public function trans($id, array $parameters = [], $domain = null, $locale = null)
+            {
+                Assert::assertSame('mautic.campaign.campaign.jump_to_event.target_not_exist', $id);
+
+                return $id;
+            }
+        };
+        $leadRepository = new class() extends LeadRepository {
+            public function __construct()
+            {
+            }
+        };
+        $subscriber = new CampaignActionJumpToEventSubscriber(
+            $eventRepository,
+            $eventExecutioner,
+            $translator,
+            $leadRepository
+        );
+
+        $event->setProperties(['jumpToEvent' => 123]);
+        $event->setCampaign($campaign);
+
+        $pendingEvent = new PendingEvent(new ActionAccessor([]), $event, new ArrayCollection([$leadLog->getId() => $leadLog]));
+
+        $subscriber->onJumpToEvent($pendingEvent);
+
+        Assert::assertCount(1, $pendingEvent->getSuccessful());
+        Assert::assertCount(0, $pendingEvent->getFailures());
+
+        Assert::AssertSame(
+            [
+                'failed' => 1,
+                'reason' => 'mautic.campaign.campaign.jump_to_event.target_not_exist',
+            ],
+            $leadLog->getMetadata()
+        );
+    }
+
+    public function testOnJumpToEventWhenEventExists(): void
+    {
+        $event    = new Event();
+        $campaign = new class() extends Campaign {
+            public function getId()
+            {
+                return 111;
+            }
+        };
+        $leadLog = new class() extends LeadEventLog {
+            public function getId()
+            {
+                return 456;
+            }
+        };
+        $contact = new class() extends Lead {
+            public function getId()
+            {
+                return 789;
+            }
+        };
+        $leadLog->setLead($contact);
+
+        $eventRepository = new class($campaign) extends EventRepository {
+            private $campaign;
+
+            public function __construct(Campaign $campaign)
+            {
+                $this->campaign = $campaign;
+            }
+
+            public function getEntities(array $args = [])
+            {
+                Assert::assertSame(
+                    [
+                        'ignore_paginator' => true,
+                        'filter'           => [
+                            'force' => [
+                                [
+                                    'column' => 'e.id',
+                                    'value'  => 123,
+                                    'expr'   => 'eq',
+                                ],
+                                [
+                                    'column' => 'e.campaign',
+                                    'value'  => $this->campaign,
+                                    'expr'   => 'eq',
+                                ],
+                            ],
+                        ],
+                    ],
+                    $args
+                );
+
+                return [
+                    new class() extends Event {
+                        public function getId()
+                        {
+                            return 222;
+                        }
+                    },
+                ];
+            }
+        };
+
+        $eventExecutioner = new class() extends EventExecutioner {
+            public function __construct()
+            {
+            }
+
+            public function executeForContacts(Event $event, ArrayCollection $contacts, ?Counter $counter = null, $isInactiveEvent = false)
+            {
+                Assert::assertSame(222, $event->getId());
+                Assert::assertCount(1, $contacts);
+                Assert::assertSame(789, $contacts->first()->getId());
+            }
+        };
+        $translator = new class() extends Translator {
+            public function __construct()
+            {
+            }
+        };
+        $leadRepository = new class() extends LeadRepository {
+            public function __construct()
+            {
+            }
+
+            public function incrementCampaignRotationForContacts(array $contactIds, $campaignId)
+            {
+                Assert::assertSame([789], $contactIds);
+                Assert::assertSame(111, $campaignId);
+            }
+        };
+        $subscriber = new CampaignActionJumpToEventSubscriber(
+            $eventRepository,
+            $eventExecutioner,
+            $translator,
+            $leadRepository
+        );
+
+        $event->setProperties(['jumpToEvent' => 123]);
+        $event->setCampaign($campaign);
+
+        $pendingEvent = new PendingEvent(new ActionAccessor([]), $event, new ArrayCollection([$leadLog->getId() => $leadLog]));
+
+        $subscriber->onJumpToEvent($pendingEvent);
+
+        Assert::assertCount(1, $pendingEvent->getSuccessful());
+        Assert::assertCount(0, $pendingEvent->getFailures());
+        Assert::AssertSame([], $leadLog->getMetadata());
+    }
+}

--- a/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
@@ -40,59 +40,26 @@ use Psr\Log\LoggerInterface;
 
 class EventExecutionerTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @var EventCollector|\PHPUnit\Framework\MockObject\MockObject
-     */
     private $eventCollector;
 
-    /**
-     * @var EventLogger|\PHPUnit\Framework\MockObject\MockObject
-     */
     private $eventLogger;
 
-    /**
-     * @var ActionExecutioner|\PHPUnit\Framework\MockObject\MockObject
-     */
     private $actionExecutioner;
 
-    /**
-     * @var ConditionExecutioner|\PHPUnit\Framework\MockObject\MockObject
-     */
     private $conditionExecutioner;
 
-    /**
-     * @var DecisionExecutioner|\PHPUnit\Framework\MockObject\MockObject
-     */
     private $decisionExecutioner;
 
-    /**
-     * @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
     private $logger;
 
-    /**
-     * @var EventScheduler|\PHPUnit\Framework\MockObject\MockObject
-     */
     private $eventScheduler;
 
-    /**
-     * @var RemovedContactTracker|\PHPUnit\Framework\MockObject\MockObject
-     */
     private $removedContactTracker;
 
-    /**
-     * @var LeadRepository|\PHPUnit\Framework\MockObject\MockObject
-     */
     private $leadRepository;
 
-    /**
-     * @var EventRepository|MockBuilder
-     */
     private $eventRepository;
 
-    /**
-     * @var Translator|MockBuilder
-     */
     private $translator;
 
     protected function setUp(): void
@@ -286,7 +253,7 @@ class EventExecutionerTest extends \PHPUnit\Framework\TestCase
         $this->eventRepository->method('getEntities')
             ->willReturn([]);
 
-        $subscriber = new CampaignActionJumpToEventSubscriber($this->eventRepository, $this->getEventExecutioner(), $this->translator);
+        $subscriber = new CampaignActionJumpToEventSubscriber($this->eventRepository, $this->getEventExecutioner(), $this->translator, $this->leadRepository);
         $subscriber->onJumpToEvent($pendingEvent);
 
         $this->assertEquals(count($pendingEvent->getSuccessful()), 1);

--- a/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
@@ -40,26 +40,59 @@ use Psr\Log\LoggerInterface;
 
 class EventExecutionerTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var EventCollector|\PHPUnit\Framework\MockObject\MockObject
+     */
     private $eventCollector;
 
+    /**
+     * @var EventLogger|\PHPUnit\Framework\MockObject\MockObject
+     */
     private $eventLogger;
 
+    /**
+     * @var ActionExecutioner|\PHPUnit\Framework\MockObject\MockObject
+     */
     private $actionExecutioner;
 
+    /**
+     * @var ConditionExecutioner|\PHPUnit\Framework\MockObject\MockObject
+     */
     private $conditionExecutioner;
 
+    /**
+     * @var DecisionExecutioner|\PHPUnit\Framework\MockObject\MockObject
+     */
     private $decisionExecutioner;
 
+    /**
+     * @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
     private $logger;
 
+    /**
+     * @var EventScheduler|\PHPUnit\Framework\MockObject\MockObject
+     */
     private $eventScheduler;
 
+    /**
+     * @var RemovedContactTracker|\PHPUnit\Framework\MockObject\MockObject
+     */
     private $removedContactTracker;
 
+    /**
+     * @var LeadRepository|\PHPUnit\Framework\MockObject\MockObject
+     */
     private $leadRepository;
 
+    /**
+     * @var EventRepository|MockBuilder
+     */
     private $eventRepository;
 
+    /**
+     * @var Translator|MockBuilder
+     */
     private $translator;
 
     protected function setUp(): void


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
I've notice to issues with Jump to event campaign actions:

1,  Contact Ids for scheduled campaign action are not load properly because this line https://github.com/mautic/mautic/pull/7129/files#diff-446760f223392e6d37ebd6f1580d27c9R108

`$campaignEvent->getContacts()`
load contacts but keys are event ids, but later need contact ids as key https://github.com/kuzmany/mautic/blob/b6edbb4489ea51dfa0c3cd1a57361da4337c98de/app/bundles/CampaignBundle/Executioner/Logger/EventLogger.php#L215-L215

2,  Also jump to event action  don't recalculate rotation ID with this error:

` Integrity constraint violation: 1062 Duplicate entry '37-13447-3' for key 'campaign_rotation'`

This happend If you want to repeat some condition/action by jump to action. 
PR prevent duplicate ID


![image](https://user-images.githubusercontent.com/462477/56689363-33890700-66db-11e9-8417-dc119322658f.png)



[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Test schedule campaign action jump to event
Yes, your campaign should run same condition two times
![image](https://user-images.githubusercontent.com/462477/56689363-33890700-66db-11e9-8417-dc119322658f.png)
2. Should return error after scheduled event is triggered

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Test schedule camapign action jump to event

