### PR TITLE
Add LeadEventLog to params list for config object

### DIFF
--- a/app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
@@ -58,6 +58,7 @@ class CampaignSubscriber extends CommonSubscriber
     {
         $config                  = $event->getConfig();
         $config['campaignEvent'] = $event->getEvent();
+        $config['leadEventLog']  = $event->getLogEntry();
         $lead                    = $event->getLead();
         $errors                  = [];
         $success                 = $this->pushToIntegration($config, $lead, $errors);


### PR DESCRIPTION
This allows data about the original event log instance to be able to push integrations that may need this information. It will also allow an integration to modify the event log instance (for instance change the trigger_date and reset to is_scheduled).

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | N/A
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
the $config var holds data about the CampaignLeadEvent but doesnt include the actual log instance that triggered the event. This could be useful to downstream pushLead integrations.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Run standard UnitTests

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
