### PR TITLE
Add option to lock command with flock

### DIFF
--- a/app/bundles/CoreBundle/Command/ModeratedCommand.php
+++ b/app/bundles/CoreBundle/Command/ModeratedCommand.php
@@ -15,12 +15,14 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\LockHandler;
 
 abstract class ModeratedCommand extends ContainerAwareCommand
 {
-    const MODE_LOCK = 'lock';
-    const MODE_PID  = 'pid';
+    const MODE_LOCK   = 'lock';
+    const MODE_PID    = 'pid';
+    const MODE_FLOCK  = 'flock';
 
     protected $checkFile;
     protected $moderationKey;
@@ -31,6 +33,8 @@ abstract class ModeratedCommand extends ContainerAwareCommand
     protected $lockHandler;
     protected $lockFile;
     private $bypassLocking;
+
+    private $flockHandle;
 
     /* @var OutputInterface $output */
     protected $output;
@@ -54,7 +58,7 @@ abstract class ModeratedCommand extends ContainerAwareCommand
                 '--lock_mode',
                 '-x',
                 InputOption::VALUE_REQUIRED,
-                'Force use of PID or FILE LOCK for semaphore. Allowed value are "pid" or "file_lock". By default, lock will try with pid, if not available will use file system',
+                'Allowed value are "pid" , "file_lock" or "flock". By default, lock will try with pid, if not available will use file system',
                 'pid'
             );
     }
@@ -72,7 +76,7 @@ abstract class ModeratedCommand extends ContainerAwareCommand
         $this->bypassLocking  = $input->getOption('bypass-locking');
         $lockMode             = $input->getOption('lock_mode');
 
-        if (!in_array($lockMode, ['pid', 'file_lock'])) {
+        if (!in_array($lockMode, ['pid', 'file_lock', 'flock'])) {
             $output->writeln('<error>Unknown locking method specified.</error>');
 
             return false;
@@ -125,6 +129,9 @@ abstract class ModeratedCommand extends ContainerAwareCommand
         if (self::MODE_LOCK == $this->moderationMode) {
             $this->lockHandler->release();
         }
+        if (self::MODE_FLOCK == $this->moderationMode) {
+            fclose($this->flockHandle);
+        }
 
         // Attempt to keep things tidy
         @unlink($this->lockFile);
@@ -176,6 +183,36 @@ abstract class ModeratedCommand extends ContainerAwareCommand
 
                 return true;
             }
+        } elseif ($lockMode === self::MODE_FLOCK && !$force) {
+            $this->moderationMode = self::MODE_FLOCK;
+            $error                = null;
+            // Silence error reporting
+            set_error_handler(function ($errno, $msg) use (&$error) {
+                $error = $msg;
+            });
+
+            if (!$this->flockHandle = fopen($this->lockFile, 'r+') ?: fopen($this->lockFile, 'r')) {
+                if ($this->flockHandle = fopen($this->lockFile, 'x')) {
+                    chmod($this->lockFile, 0666);
+                } elseif (!$this->flockHandle = fopen($this->lockFile, 'r+') ?: fopen($this->lockFile, 'r')) {
+                    usleep(100);
+                    $this->flockHandle = fopen($this->lockFile, 'r+') ?: fopen($this->lockFile, 'r');
+                }
+            }
+
+            restore_error_handler();
+
+            if (!$this->flockHandle) {
+                throw new IOException($error, 0, null, $this->lockFile);
+            }
+            if (!flock($this->flockHandle, LOCK_EX | LOCK_NB)) {
+                fclose($this->flockHandle);
+                $this->flockHandle = null;
+
+                return false;
+            }
+
+            return true;
         }
 
         // in anycase, fallback on file system


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Add option `flock` on `--lock-mode` argument.

This way to use flock is compatible with NFS V4 disk mounting in a distributed environment.
The open `LOCK_EX` no longer work when a file is open in read-only mode.

The code is greatly inspired  from last lock component repository from SF4 (https://symfony.com/doc/current/components/lock.html)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. open 2 consoles.
2. run a long execution segment update with `mautic:segment:update -x flock` in first console.
3. run the same command in the second console... you must see "Script in progress." message
4. interrupt script in the first console, 
5. run the command in the second console, that should work.


