### PR TITLE
If present, give NewRelic transactional awareness for console commands.

### DIFF
--- a/app/bundles/CoreBundle/Command/ModeratedCommand.php
+++ b/app/bundles/CoreBundle/Command/ModeratedCommand.php
@@ -72,6 +72,29 @@ abstract class ModeratedCommand extends ContainerAwareCommand
         $this->bypassLocking  = $input->getOption('bypass-locking');
         $lockMode             = $input->getOption('lock_mode');
 
+        // If NewRelic is enabled relay the context of this transaction for debugging.
+        try {
+            if (
+                function_exists('newrelic_name_transaction')
+                && $nrCommand = (string) $input->getArgument('command')
+            ) {
+                call_user_func('newrelic_name_transaction', $nrCommand);
+                if (
+                    function_exists('newrelic_add_custom_parameter')
+                    && $nrOptions = $input->getOptions()
+                ) {
+                    foreach ($nrOptions as $key => $value) {
+                        call_user_func(
+                            'newrelic_add_custom_parameter',
+                            (string) $key,
+                            (string) $value
+                        );
+                    }
+                }
+            }
+        } catch (\Exception $e) {
+        }
+
         if (!in_array($lockMode, ['pid', 'file_lock'])) {
             $output->writeln('<error>Unknown locking method specified.</error>');
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Y
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Out of the box NewRelic works exceptionally well to help us fine-tune large Mautic instances. However, one place it falls short is the diagnosis of issues in console commands (cron tasks). This is due to a
symfony2 stack issue. All console commands show up as “unknown” conflating performance issues and the like. Example:
![Unknown transaction for all non-web](https://i.imgur.com/tPZwENX.png)

This small code addition fixes this by handing over all console data to NewRelic APM for moderated Mautic commands. We have tried more elegant ways of doing this, but this simple cut-and-dried approach has performed better. This will have zero impact to those without NewRelic APM installed.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. All moderated cron tasks should behave as usual. So schedule one event and check that it fires.
