### PR TITLE
Add check to prevent BR inside IMG

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/froala/froala_editor.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/froala/froala_editor.js
@@ -4242,7 +4242,9 @@
               editor.selection.restore();
             }
             else {
-              editor.$el.html('<br/>');
+              if (!editor.$el.is('img')) {
+                  editor.$el.html('<br/>');
+              }
             }
           }
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Froala add BR inside IMG tag, this breaks the template with blank space.

![screenshot_2019-01-21 51327488-b44bbd80-1a71-11e9-9310-85862e0d26f8 png image png 1788 x 1278 pixels - redimensionnee 7](https://user-images.githubusercontent.com/27768270/51484105-f9862d00-1d9a-11e9-8fb3-222c8afbc7de.png)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create an email
2. Choose a template with images
3. Click on an image and replace it
4. Froala add BR inside IMG tag

![img-br](https://user-images.githubusercontent.com/27768270/51483946-998f8680-1d9a-11e9-93b7-a83c0558e549.png)


#### Steps to test this PR:
1. Load up [this PR](https://github.com/mautic/mautic/pull/7153)
2. Clear cache and regenerate assets
3. Repeat step above, no BR is added.
