### PR TITLE
Remove redirect from mail settings page

### DIFF
--- a/app/bundles/ConfigBundle/Assets/js/config.js
+++ b/app/bundles/ConfigBundle/Assets/js/config.js
@@ -14,3 +14,63 @@ Mautic.removeConfigValue = function(action, el) {
         }
 	});
 };
+
+/**
+ *
+ * @returns string|false
+ */
+Mautic.parseQuery = function (query) {
+    var vars = query.split('&');
+    var queryString = {};
+    for (var i = 0; i < vars.length; i++) {
+        var pair = vars[i].split('=');
+        var key = decodeURIComponent(pair[0]);
+        var value = decodeURIComponent(pair[1]);
+        // If first entry with this name
+        if (typeof queryString[key] === 'undefined') {
+            queryString[key] = decodeURIComponent(value);
+            // If second entry with this name
+        } else if (typeof queryString[key] === 'string') {
+            var arr = [queryString[key], decodeURIComponent(value)];
+            queryString[key] = arr;
+            // If third or later entry with this name
+        } else {
+            queryString[key].push(decodeURIComponent(value));
+        }
+    }
+    return queryString;
+}
+
+Mautic.parseUrlHashParameter = function(url) {
+    var url = url.split('#');
+    if ('undefined' != typeof url[1]) {
+        return url[1];
+    }
+
+    return false;
+}
+
+Mautic.observeConfigTabs = function() {
+
+    if (!mQuery('#config_coreconfig_last_shown_tab').length) {
+        return;
+    }
+
+    var parameters = Mautic.parseQuery(window.location.search.substr(1));
+    if ('undefiend' != typeof parameters['tab']) {
+        mQuery('#config_coreconfig_last_shown_tab').val(parameters['tab']);
+        mQuery('a[data-toggle="tab"]').each(function (i, tab) {
+            if (mQuery(tab).attr('href') == ('#' + parameters['tab'])) {
+                mQuery(tab).tab('show');
+            }
+        });
+    }
+
+    mQuery('a[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab = Mautic.parseUrlHashParameter(e.target.href);
+        if (tab) {
+            mQuery('#config_coreconfig_last_shown_tab').val(tab);
+        }
+    });
+}
+mQuery(Mautic.observeConfigTabs);

--- a/app/bundles/ConfigBundle/Controller/ConfigController.php
+++ b/app/bundles/ConfigBundle/Controller/ConfigController.php
@@ -63,6 +63,7 @@ class ConfigController extends FormController
         /** @var \Mautic\CoreBundle\Configurator\Configurator $configurator */
         $configurator = $this->get('mautic.configurator');
         $isWritabale  = $configurator->isFileWritable();
+        $openTab      = null;
 
         // Check for a submitted form and process it
         if ($this->request->getMethod() == 'POST') {
@@ -132,6 +133,10 @@ class ConfigController extends FormController
                             /** @var \Mautic\CoreBundle\Helper\CacheHelper $cacheHelper */
                             $cacheHelper = $this->get('mautic.helper.cache');
                             $cacheHelper->clearContainerFile();
+
+                            if ($isValid && !empty($formData['coreconfig']['last_shown_tab'])) {
+                                $openTab = $formData['coreconfig']['last_shown_tab'];
+                            }
                         } catch (\RuntimeException $exception) {
                             $this->addFlash('mautic.config.config.error.not.updated', ['%exception%' => $exception->getMessage()], 'error');
                         }
@@ -148,7 +153,12 @@ class ConfigController extends FormController
             // If the form is saved or cancelled, redirect back to the dashboard
             if ($cancelled || $isValid) {
                 if (!$cancelled && $this->isFormApplied($form)) {
-                    return $this->delegateRedirect($this->generateUrl('mautic_config_action', ['objectAction' => 'edit']));
+                    $redirectParameters = ['objectAction' => 'edit'];
+                    if ($openTab) {
+                        $redirectParameters['tab'] = $openTab;
+                    }
+
+                    return $this->delegateRedirect($this->generateUrl('mautic_config_action', $redirectParameters));
                 } else {
                     return $this->delegateRedirect($this->generateUrl('mautic_dashboard_index'));
                 }

--- a/app/bundles/CoreBundle/Form/Type/ConfigType.php
+++ b/app/bundles/CoreBundle/Form/Type/ConfigType.php
@@ -101,6 +101,8 @@ class ConfigType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $builder->add('last_shown_tab', 'hidden');
+
         $builder->add(
             'site_url',
             'text',

--- a/app/bundles/CoreBundle/Views/FormTheme/Config/_config_coreconfig_widget.html.php
+++ b/app/bundles/CoreBundle/Views/FormTheme/Config/_config_coreconfig_widget.html.php
@@ -27,6 +27,7 @@ $template  = '<div class="col-md-6">{content}</div>';
             <?php echo $view['form']->rowIfExists($fields, 'log_path', $template); ?>
             <?php echo $view['form']->rowIfExists($fields, 'theme', $template); ?>
             <?php echo $view['form']->rowIfExists($fields, 'image_path', $template); ?>
+            <?php echo $view['form']->rowIfExists($fields, 'last_shown_tab'); ?>
         </div>
     </div>
 </div>


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When a users is setting up the mail send settings in MCF, it requires changes to be applied. When the user clicks apply, it applies and then redirects them to the system settings page. This requires them to navigate back to the email settings page and then scroll. This is far from critical but is annoying for a user that likes to apply changes.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Click on configuration
2. Click on email settings
3. Changes something
4. Click apply
5. Notice that you are on the first tab

#### Steps to test this PR:
1. Click on configuration
2. Click on email settings
3. Changes something
4. Click apply
5. You are on the same tab
6. This will work for every tab on the configuration page. If you click Apply, you will stay on the same tab.