### PR TITLE
Show error when user tries to create a column that already exists

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -1211,6 +1211,93 @@ return [
                     'monolog.logger.mautic',
                 ],
             ],
+            'mautic.lead.field.schema_definition' => [
+                'class'     => Mautic\LeadBundle\Field\SchemaDefinition::class,
+            ],
+            'mautic.lead.field.custom_field_column' => [
+                'class'     => Mautic\LeadBundle\Field\CustomFieldColumn::class,
+                'arguments' => [
+                    'mautic.schema.helper.column',
+                    'mautic.lead.field.schema_definition',
+                    'monolog.logger.mautic',
+                    'mautic.lead.field.lead_field_saver',
+                    'mautic.lead.field.custom_field_index',
+                    'mautic.lead.field.dispatcher.field_column_dispatcher',
+                    'translator',
+                ],
+            ],
+            'mautic.lead.field.custom_field_index' => [
+                'class'     => Mautic\LeadBundle\Field\CustomFieldIndex::class,
+                'arguments' => [
+                    'mautic.schema.helper.index',
+                    'monolog.logger.mautic',
+                    'mautic.lead.field.fields_with_unique_identifier',
+                ],
+            ],
+            'mautic.lead.field.dispatcher.field_save_dispatcher' => [
+                'class'     => Mautic\LeadBundle\Field\Dispatcher\FieldSaveDispatcher::class,
+                'arguments' => [
+                    'event_dispatcher',
+                    'doctrine.orm.entity_manager',
+                ],
+            ],
+            'mautic.lead.field.dispatcher.field_column_dispatcher' => [
+                'class'     => Mautic\LeadBundle\Field\Dispatcher\FieldColumnDispatcher::class,
+                'arguments' => [
+                    'event_dispatcher',
+                    'mautic.lead.field.settings.background_settings',
+                ],
+            ],
+            'mautic.lead.field.dispatcher.field_column_background_dispatcher' => [
+                'class'     => Mautic\LeadBundle\Field\Dispatcher\FieldColumnBackgroundJobDispatcher::class,
+                'arguments' => [
+                    'event_dispatcher',
+                ],
+            ],
+            'mautic.lead.field.fields_with_unique_identifier' => [
+                'class'     => Mautic\LeadBundle\Field\FieldsWithUniqueIdentifier::class,
+                'arguments' => [
+                    'mautic.lead.field.field_list',
+                ],
+            ],
+            'mautic.lead.field.field_list' => [
+                'class'     => Mautic\LeadBundle\Field\FieldList::class,
+                'arguments' => [
+                    'mautic.lead.repository.field',
+                    'translator',
+                ],
+            ],
+            'mautic.lead.field.lead_field_saver' => [
+                'class'     => Mautic\LeadBundle\Field\LeadFieldSaver::class,
+                'arguments' => [
+                    'mautic.lead.repository.field',
+                    'mautic.lead.field.dispatcher.field_save_dispatcher',
+                ],
+            ],
+            'mautic.lead.field.settings.background_settings' => [
+                'class'     => Mautic\LeadBundle\Field\Settings\BackgroundSettings::class,
+                'arguments' => [
+                    'mautic.helper.core_parameters',
+                ],
+            ],
+            'mautic.lead.field.settings.background_service' => [
+                'class'     => Mautic\LeadBundle\Field\BackgroundService::class,
+                'arguments' => [
+                    'mautic.lead.model.field',
+                    'mautic.lead.field.custom_field_column',
+                    'mautic.lead.field.lead_field_saver',
+                    'mautic.lead.field.dispatcher.field_column_background_dispatcher',
+                    'mautic.lead.field.notification.custom_field',
+                ],
+            ],
+            'mautic.lead.field.notification.custom_field' => [
+                'class'     => Mautic\LeadBundle\Field\Notification\CustomFieldNotification::class,
+                'arguments' => [
+                    'mautic.core.model.notification',
+                    'mautic.user.model.user',
+                    'translator',
+                ],
+            ],
         ],
         'command' => [
             'mautic.lead.command.deduplicate' => [

--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -13,6 +13,7 @@ namespace Mautic\LeadBundle\Controller;
 
 use Doctrine\DBAL\DBALException;
 use Mautic\CoreBundle\Controller\FormController;
+use Mautic\CoreBundle\Exception\SchemaException;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Model\FieldModel;
 use Symfony\Component\Form\FormError;
@@ -158,6 +159,10 @@ class FieldController extends FormController
                             $model->saveEntity($field);
                         } catch (DBALException $ee) {
                             $flashMessage = $ee->getMessage();
+                        } catch (SchemaException $e) {
+                            $flashMessage = $e->getMessage();
+                            $form['alias']->addError(new FormError($e->getMessage()));
+                            $valid = false;
                         } catch (\Exception $e) {
                             $form['alias']->addError(
                                     new FormError(

--- a/app/bundles/LeadBundle/Field/CustomFieldColumn.php
+++ b/app/bundles/LeadBundle/Field/CustomFieldColumn.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Field;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception\DriverException;
+use Mautic\CoreBundle\Doctrine\Helper\ColumnSchemaHelper;
+use Mautic\CoreBundle\Exception\SchemaException;
+use Mautic\LeadBundle\Entity\LeadField;
+use Mautic\LeadBundle\Exception\NoListenerException;
+use Mautic\LeadBundle\Field\Dispatcher\FieldColumnDispatcher;
+use Mautic\LeadBundle\Field\Exception\AbortColumnCreateException;
+use Mautic\LeadBundle\Field\Exception\CustomFieldLimitException;
+use Monolog\Logger;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class CustomFieldColumn
+{
+    /**
+     * @var ColumnSchemaHelper
+     */
+    private $columnSchemaHelper;
+
+    /**
+     * @var SchemaDefinition
+     */
+    private $schemaDefinition;
+
+    /**
+     * @var Logger
+     */
+    private $logger;
+
+    /**
+     * @var LeadFieldSaver
+     */
+    private $leadFieldSaver;
+
+    /**
+     * @var CustomFieldIndex
+     */
+    private $customFieldIndex;
+
+    /**
+     * @var FieldColumnDispatcher
+     */
+    private $fieldColumnDispatcher;
+
+    /**
+     * @param ColumnSchemaHelper    $columnSchemaHelper
+     * @param SchemaDefinition      $schemaDefinition
+     * @param Logger                $logger
+     * @param LeadFieldSaver        $leadFieldSaver
+     * @param CustomFieldIndex      $customFieldIndex
+     * @param FieldColumnDispatcher $fieldColumnDispatcher
+     * @param TranslatorInterface   $translator
+     */
+    public function __construct(
+        ColumnSchemaHelper $columnSchemaHelper,
+        SchemaDefinition $schemaDefinition,
+        Logger $logger,
+        LeadFieldSaver $leadFieldSaver,
+        CustomFieldIndex $customFieldIndex,
+        FieldColumnDispatcher $fieldColumnDispatcher,
+        TranslatorInterface $translator
+    ) {
+        $this->columnSchemaHelper    = $columnSchemaHelper;
+        $this->schemaDefinition      = $schemaDefinition;
+        $this->logger                = $logger;
+        $this->leadFieldSaver        = $leadFieldSaver;
+        $this->customFieldIndex      = $customFieldIndex;
+        $this->fieldColumnDispatcher = $fieldColumnDispatcher;
+        $this->translator            = $translator;
+    }
+
+    /**
+     * @param LeadField $leadField
+     *
+     * @throws AbortColumnCreateException
+     * @throws CustomFieldLimitException
+     * @throws DBALException
+     * @throws DriverException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     * @throws \Mautic\CoreBundle\Exception\SchemaException
+     */
+    public function createLeadColumn(LeadField $leadField)
+    {
+        $leadsSchema = $this->columnSchemaHelper->setName($leadField->getCustomFieldObject());
+
+        // We do not need to do anything if the column already exists
+        // But we have to check if the LeadField entity is new.
+        // In such case we must throw an exception to warn users that the column already exists.
+        try {
+            if ($leadsSchema->checkColumnExists($leadField->getAlias(), $leadField->isNew())) {
+                return;
+            }
+        } catch (SchemaException $e) {
+            // We use slightly different error message if the column already exists in this case.
+            throw new SchemaException($this->translator->trans('mautic.lead.field.column.already.exists', ['%field%' => $leadField->getName()], 'validators'));
+        }
+
+        try {
+            $this->fieldColumnDispatcher->dispatchPreAddColumnEvent($leadField);
+        } catch (NoListenerException $e) {
+        }
+
+        $this->processCreateLeadColumn($leadField);
+    }
+
+    /**
+     * Create the field as its own column in the leads table.
+     *
+     * @param LeadField $leadField
+     * @param bool      $saveLeadField
+     *
+     * @throws CustomFieldLimitException
+     * @throws DriverException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     * @throws \Mautic\CoreBundle\Exception\SchemaException
+     */
+    public function processCreateLeadColumn(LeadField $leadField, $saveLeadField = true)
+    {
+        $leadsSchema = $this->columnSchemaHelper->setName($leadField->getCustomFieldObject());
+
+        // Check if column do not exist. This method could be called from plugins too.
+        if ($leadsSchema->checkColumnExists($leadField->getAlias())) {
+            return;
+        }
+
+        $schemaDefinition = $this->schemaDefinition::getSchemaDefinition(
+            $leadField->getAlias(),
+            $leadField->getType(),
+            $leadField->getIsUniqueIdentifier()
+        );
+
+        $leadsSchema->addColumn($schemaDefinition);
+
+        try {
+            $leadsSchema->executeChanges();
+        } catch (DriverException $e) {
+            $this->logger->addWarning($e->getMessage());
+
+            if ($e->getErrorCode() === 1118 /* ER_TOO_BIG_ROWSIZE */) {
+                throw new CustomFieldLimitException('mautic.lead.field.max_column_error');
+            }
+
+            throw $e;
+        }
+
+        if ($saveLeadField) {
+            //$leadField is a new entity (this is not executed for update), it was successfully added to the lead table > save it
+            $this->leadFieldSaver->saveLeadFieldEntity($leadField, true);
+        }
+
+        if ('string' === $schemaDefinition['type']) {
+            $this->customFieldIndex->addIndexOnColumn($leadField);
+        }
+    }
+}

--- a/app/bundles/LeadBundle/Translations/en_US/validators.ini
+++ b/app/bundles/LeadBundle/Translations/en_US/validators.ini
@@ -8,6 +8,7 @@ mautic.lead.field.failed="There was an error creating the new column to the cont
 mautic.lead.field.label.notblank="A label is required."
 mautic.lead.field.select.listmissing="A list for the select box must be specified. Separate each option with a vertical bar. I.e. Green|Blue|Red"
 mautic.lead.field.typenotrecognized="There's a field type not recognized."
+mautic.lead.field.column.already.exists="There was an error creating the custom field %field% because it already exists."
 mautic.lead.field.value.invalid="Some field 'Values' are invalid. Authorized characters are a-z A-Z 0-9 - _"
 mautic.lead.import.filenotreadable="Unable to read the imported csv file."
 mautic.lead.import.filetoolarge="The file exceeds the maximum allowed upload size of %upload_max_filesize%."


### PR DESCRIPTION
Show error when user tries to create a column that already exists

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL |  /
| Related developer documentation PR URL | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
We must warn user if he/she tries to create a custom field that already exists.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a custom field.
2.  Delete a row that belongs to this field from mautic_lead_fields table.
3. Try to create a column with the same name.
4. The application will tell you that everything is OK but you cannot see a new custom field in the list of custom fields.

#### Steps to test this PR:
1. Create a custom field.
2.  Delete a row that belongs to this field from mautic_lead_fields table.
3. Try to create a column with the same name.
4. You will see an error that this column already exists.