### PR TITLE
Add batch to mautic:maintenance:cleanup command

### DIFF
--- a/app/bundles/LeadBundle/EventListener/MaintenanceSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/MaintenanceSubscriber.php
@@ -71,21 +71,39 @@ class MaintenanceSubscriber extends CommonSubscriber
             }
             $rows = $qb->execute()->fetchColumn();
         } else {
-            $qb->delete(MAUTIC_TABLE_PREFIX.'leads')
-              ->where($qb->expr()->lte('last_active', ':date'));
+            $qb->select('l.id')->from(MAUTIC_TABLE_PREFIX.'leads', 'l')
+              ->where($qb->expr()->lte('l.last_active', ':date'));
 
             if ($event->isGdpr() === false) {
-                $qb->andWhere($qb->expr()->isNull('date_identified'));
+                $qb->andWhere($qb->expr()->isNull('l.date_identified'));
             } else {
                 $qb->orWhere(
                   $qb->expr()->andX(
-                    $qb->expr()->lte('date_added', ':date2'),
-                    $qb->expr()->isNull('last_active')
+                    $qb->expr()->lte('l.date_added', ':date2'),
+                    $qb->expr()->isNull('l.last_active')
                   ));
                 $qb->setParameter('date2', $event->getDate()->format('Y-m-d H:i:s'));
             }
 
-            $rows = $qb->execute();
+            $rows = 0;
+            $qb->setMaxResults(2000)->setFirstResult(0);
+
+            $qb2 = $this->db->createQueryBuilder();
+            while (true) {
+                $leadsIds = array_column($qb->execute()->fetchAll(), 'id');
+
+                if (sizeof($leadsIds) === 0) {
+                    break;
+                }
+
+                $rows += $qb2->delete(MAUTIC_TABLE_PREFIX.'leads')
+                  ->where(
+                    $qb2->expr()->in(
+                      'id', $leadsIds
+                    )
+                  )
+                  ->execute();
+            }
         }
 
         $event->setStat($this->translator->trans('mautic.maintenance.visitors'), $rows, $qb->getSQL(), $qb->getParameters());

--- a/app/bundles/LeadBundle/EventListener/MaintenanceSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/MaintenanceSubscriber.php
@@ -86,23 +86,22 @@ class MaintenanceSubscriber extends CommonSubscriber
             }
 
             $rows = 0;
-            $qb->setMaxResults(2000)->setFirstResult(0);
+            $qb->setMaxResults(10000)->setFirstResult(0);
 
             $qb2 = $this->db->createQueryBuilder();
             while (true) {
                 $leadsIds = array_column($qb->execute()->fetchAll(), 'id');
-
                 if (sizeof($leadsIds) === 0) {
                     break;
                 }
-
-                $rows += $qb2->delete(MAUTIC_TABLE_PREFIX.'leads')
-                  ->where(
-                    $qb2->expr()->in(
-                      'id', $leadsIds
-                    )
-                  )
-                  ->execute();
+                foreach ($leadsIds as $leadId) {
+                    $rows += $qb2->delete(MAUTIC_TABLE_PREFIX.'leads')
+                      ->where(
+                        $qb2->expr()->eq(
+                          'id', $leadId
+                        )
+                      )->execute();
+                }
             }
         }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| Enhancement | ✅ 
| Automated tests included? |N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Add DELETE batch to `mautic:maintenance:cleanup` command to avoid table locking and perform cleaning on a live database with millions raws

#### Steps to test this PR:
1. Run `mautic:maintenance:cleanup` command on a huge database
2. Check your lead are still insert, update while command running