### PR TITLE
Fix issue with regex with  underscore in URL 

### DIFF
--- a/app/bundles/CoreBundle/Helper/UrlHelper.php
+++ b/app/bundles/CoreBundle/Helper/UrlHelper.php
@@ -179,7 +179,7 @@ class UrlHelper
 
             // We don't want to match URLs in token default values
             // like {contactfield=website|http://ignore.this.url}
-            if (preg_match_all("#{(.*?)\|".preg_quote($url).'}#', $text, $matches)) {
+            if (preg_match_all("/{(.*?)\|".preg_quote($url, '/').'}/', $text, $matches)) {
                 unset($urls[$key]);
 
                 // We know this is a URL due to the default so let's include it as a trackable

--- a/app/bundles/CoreBundle/Tests/unit/Helper/UrlHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Helper/UrlHelperTest.php
@@ -124,7 +124,7 @@ class UrlHelperTest extends \PHPUnit_Framework_TestCase
                 'https://example.org/with/query?utm_campaign=hello',
                 'https://example.org/with/tokenized-query?foo={contactfield=bar}&bar=foo',
                 'https://example.org/with/just-tokenized-query?foo={contactfield=bar}',
-                'https://example.org/with/query?utm_campaign=_hello#_underscore-teest',
+                'https://example.org/with/query?utm_campaign=_hello#_underscore-test',
             ],
             UrlHelper::getUrlsFromPlaintext(
                 <<<STRING
@@ -144,7 +144,7 @@ Someone said “https://example.org/with/quotation”
 Checkout my UTM tags https://example.org/with/query?utm_campaign=hello.
 Hey what about https://example.org/with/tokenized-query?foo={contactfield=bar}&bar=foo.
 What happens with this https://example.org/with/just-tokenized-query?foo={contactfield=bar}?
-Underscore test https://example.org/with/query?utm_campaign=_hello#_underscore-teest
+Underscore test https://example.org/with/query?utm_campaign=_hello#_underscore-test
 STRING
             )
         );

--- a/app/bundles/CoreBundle/Tests/unit/Helper/UrlHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Helper/UrlHelperTest.php
@@ -124,6 +124,7 @@ class UrlHelperTest extends \PHPUnit_Framework_TestCase
                 'https://example.org/with/query?utm_campaign=hello',
                 'https://example.org/with/tokenized-query?foo={contactfield=bar}&bar=foo',
                 'https://example.org/with/just-tokenized-query?foo={contactfield=bar}',
+                'https://example.org/with/query?utm_campaign=_hello#_underscore-teest',
             ],
             UrlHelper::getUrlsFromPlaintext(
                 <<<STRING
@@ -143,6 +144,7 @@ Someone said “https://example.org/with/quotation”
 Checkout my UTM tags https://example.org/with/query?utm_campaign=hello.
 Hey what about https://example.org/with/tokenized-query?foo={contactfield=bar}&bar=foo.
 What happens with this https://example.org/with/just-tokenized-query?foo={contactfield=bar}?
+Underscore test https://example.org/with/query?utm_campaign=_hello#_underscore-teest
 STRING
             )
         );


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR fixed  error:

`Warning: preg_match_all(): Unknown modifier '\'`

More https://stackoverflow.com/questions/47185669/preg-match-all-unknown-modifier

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Create email 
2.  Create link https://domain.tld/some-alias_t#_ga=2.2dd
3. Send email
4. Should return error above (check logs)

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7169)
2.  Repeat all steps
3. Should works now
