### PR TITLE
7177: Implemented method to bind parameters when using "where in" exp…

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -1460,10 +1460,9 @@ class CommonRepository extends EntityRepository
     public function buildWhereInParameters($valuesArray)
     {
         $newArray = [];
-        foreach ($valuesArray as $key => &$value) {
+        foreach ($valuesArray as $key => $value) {
             $newArray[':id'.$key] = $value;
         }
-        unset($value);
 
         return $newArray;
     }

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -1451,6 +1451,22 @@ class CommonRepository extends EntityRepository
     }
 
     /**
+     * Build an associative array out of an indexed array using PDO bounding notation
+     * @param $valuesArray
+     * @return array
+     */
+    public function buildWhereInParameters($valuesArray)
+    {
+        $newArray = array();
+        foreach ($valuesArray as $key => &$value) {
+            $newArray[":id" . $key] = $value;
+        }
+        unset ($value);
+
+        return $newArray;
+    }
+
+    /**
      * @param \Doctrine\ORM\QueryBuilder $q
      * @param array                      $args
      */

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -1451,17 +1451,19 @@ class CommonRepository extends EntityRepository
     }
 
     /**
-     * Build an associative array out of an indexed array using PDO bounding notation
+     * Build an associative array out of an indexed array using PDO bounding notation.
+     *
      * @param $valuesArray
+     *
      * @return array
      */
     public function buildWhereInParameters($valuesArray)
     {
-        $newArray = array();
+        $newArray = [];
         foreach ($valuesArray as $key => &$value) {
-            $newArray[":id" . $key] = $value;
+            $newArray[':id'.$key] = $value;
         }
-        unset ($value);
+        unset($value);
 
         return $newArray;
     }

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -112,9 +112,10 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
             ->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
 
         if (is_array($value)) {
+            $mappings = $this->buildWhereInParameters($value);
             $q->where(
-                $q->expr()->in($col, $value)
-            );
+                $q->expr()->in($col, array_keys($mappings))
+            )->setParameters($mappings);
         } else {
             $q->where("$col = :search")
                 ->setParameter('search', $value);


### PR DESCRIPTION
…ression

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? |
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | No
| Deprecations? | No

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: When building Leads, ExpressionBuilder got an array of strings which resulted into a MySql syntax error due to missing quotes. Added a method to CommonRepository which receives an array (either indexed or associative) and returns an associative array consisting of bounding keys and there corresponding values

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. php app/console mautic:citrix:sync --env=prod

#### Steps to test this PR:
1. php app/console mautic:citrix:sync --env=prod

#### List deprecations along with the new alternative: none
#### List backwards compatibility breaks: none

Courtesy of GosuTeacher.