### PR TITLE
Prevent $connector from getting serialized into the $details array

### DIFF
--- a/app/bundles/CoreBundle/IpLookup/AbstractLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/AbstractLookup.php
@@ -28,6 +28,11 @@ abstract class AbstractLookup
     public $extra        = '';
 
     /**
+     * @var Http|null
+     */
+    protected $connector;
+
+    /**
      * @var string IP Address
      */
     protected $ip;
@@ -106,14 +111,17 @@ abstract class AbstractLookup
      */
     public function getDetails()
     {
-        $reflect = new \ReflectionClass($this);
-        $props   = $reflect->getProperties(\ReflectionProperty::IS_PUBLIC);
-
-        $details = [];
-        foreach ($props as $prop) {
-            $details[$prop->getName()] = $prop->getValue($this);
-        }
-
-        return $details;
+        return [
+            'city'         => $this->city,
+            'region'       => $this->region,
+            'zipcode'      => $this->zipcode,
+            'country'      => $this->country,
+            'latitude'     => $this->latitude,
+            'longitude'    => $this->longitude,
+            'isp'          => $this->isp,
+            'organization' => $this->organization,
+            'timezone'     => $this->timezone,
+            'extra'        => $this->extra,
+        ];
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Somehow, Joomla's Http object is serialized for some but not for all IP address details. 

```
Uncaught PHP Exception Doctrine\DBAL\Types\ConversionException: "Serialized array includes null-byte. This cannot be saved as a text. Please check if you not provided object with protected or private members. Serialized Array: a:11:{s:4:"city";s:6:"Tirana";s:6:"region";s:15:"Qarku i Tiranes";s:7:"zipcode";N;s:7:"country";s:7:"Albania";s:8:"latitude";d:41.3275;s:9:"longitude";d:19.8189;s:3:"isp";s:0:"";s:12:"organization";s:0:"";s:8:"timezone";s:13:"Europe/Tirane";s:5:"extra";s:0:"";s:9:"connector";O:16:"Joomla\Http\Http":2:{s:10:"__NULL_BYTE__*__NULL_BYTE__options";a:0:{}s:12:"__NULL_BYTE__*__NULL_BYTE__transport";O:26:"Joomla\Http\Transport\Curl":1:{s:10:"__NULL_BYTE__*__NULL_BYTE__options";a:0:{}}}}" at app/bundles/CoreBundle/Doctrine/Type/ArrayType.php line 48
```

It was because the old IP address code used Reflection to get the properties but $connector was not defined and thus considered public. No idea why this is not more widespread. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. No idea :-) 
