### PR TITLE
Use site_url to build form cache

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -213,6 +213,17 @@ return [
                     'templating.helper.assets',
                 ],
             ],
+            'mautic.core.subscriber.router' => [
+                'class'     => \Mautic\CoreBundle\EventListener\RouterSubscriber::class,
+                'arguments' => [
+                    'router',
+                    '%router.request_context.scheme%',
+                    '%router.request_context.host%',
+                    '%request_listener.https_port%',
+                    '%request_listener.http_port%',
+                    '%router.request_context.base_url%',
+                ],
+            ],
         ],
         'forms' => [
             'mautic.form.type.spacer' => [

--- a/app/bundles/CoreBundle/EventListener/RouterSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/RouterSubscriber.php
@@ -74,11 +74,15 @@ class RouterSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            KernelEvents::REQUEST => ['setRouterRequestContext', 0],
+            KernelEvents::REQUEST => ['setRouterRequestContext', 1],
         ];
     }
 
     /**
+     * This forces generated routes to be the same as what is configured as Mautic's site_url
+     * in order to prevent mismatches between cached URLs generated during web requests and URLs generated
+     * via CLI/cron jobs.
+     *
      * @param GetResponseEvent $event
      */
     public function setRouterRequestContext(GetResponseEvent $event)

--- a/app/bundles/CoreBundle/EventListener/RouterSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/RouterSubscriber.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\RouterInterface;
+
+class RouterSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var string|null
+     */
+    private $baseUrl;
+
+    /**
+     * @var string|null
+     */
+    private $scheme;
+
+    /**
+     * @var string|null
+     */
+    private $host;
+
+    /**
+     * @var string|null
+     */
+    private $httpsPort;
+
+    /**
+     * @var string|null
+     */
+    private $httpPort;
+
+    /**
+     * RouterSubscriber constructor.
+     *
+     * @param RouterInterface $router
+     * @param null|string     $scheme
+     * @param null|string     $host
+     * @param null|string     $httpsPort
+     * @param null|string     $httpPort
+     * @param null|string     $baseUrl
+     */
+    public function __construct(RouterInterface $router, $scheme, $host, $httpsPort, $httpPort, $baseUrl)
+    {
+        $this->router    = $router;
+        $this->scheme    = $scheme;
+        $this->host      = $host;
+        $this->httpsPort = $httpsPort;
+        $this->httpPort  = $httpPort;
+        $this->baseUrl   = $baseUrl;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => ['setRouterRequestContext', 0],
+        ];
+    }
+
+    /**
+     * @param GetResponseEvent $event
+     */
+    public function setRouterRequestContext(GetResponseEvent $event)
+    {
+        if (empty($this->host)) {
+            return;
+        }
+
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        if ('dev' === MAUTIC_ENV) {
+            $this->baseUrl = '/index_dev.php'.$this->baseUrl;
+        }
+
+        $context = $this->router->getContext();
+        $context->setBaseUrl($this->baseUrl);
+        $context->setScheme($this->scheme);
+        $context->setHost($this->host);
+        $context->setHttpPort($this->httpPort);
+        $context->setHttpsPort($this->httpsPort);
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When URLs are generated through the router in a web request, the router uses the request to set host, etc. This is normally fine except when you can access the site through multiple URLs (http, https). For forms, the HTML is cached with an action of whatever URL is used to access Mautic. If this mismatches the site_url, the form will fail to submit. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Edit config file's site_url to some other host (it can be bogus)
2. Clear the cache
3. Create a new form
4. View the form's manual copy HTML and look for the form's action
5. Notice that it is the host you used to access Mautic and not what is set in site_url

#### Steps to test this PR:
1. Repeat and this time the host will match site_url instead