### PR TITLE
Prevent exception if ct comes in empty which prevents the redirect

### DIFF
--- a/app/bundles/CoreBundle/Helper/ClickthroughHelper.php
+++ b/app/bundles/CoreBundle/Helper/ClickthroughHelper.php
@@ -31,12 +31,16 @@ class ClickthroughHelper
      * @param      $string
      * @param bool $urlDecode
      *
-     * @return mixed
+     * @return array
      */
     public static function decodeArrayFromUrl($string, $urlDecode = true)
     {
         $raw     = $urlDecode ? urldecode($string) : $string;
         $decoded = base64_decode($raw);
+
+        if (empty($decoded)) {
+            return [];
+        }
 
         if (strpos(strtolower($decoded), 'a') !== 0) {
             throw new \InvalidArgumentException(sprintf('The string %s is not a serialized array.', $decoded));

--- a/app/bundles/CoreBundle/Tests/unit/Helper/ClickthroughHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Helper/ClickthroughHelperTest.php
@@ -28,4 +28,11 @@ class ClickthroughHelperTest extends \PHPUnit_Framework_TestCase
 
         ClickthroughHelper::decodeArrayFromUrl(urlencode(base64_encode(serialize(new \stdClass()))));
     }
+
+    public function testEmptyStringDoesNotThrowException()
+    {
+        $array = [];
+
+        $this->assertEquals($array, ClickthroughHelper::decodeArrayFromUrl(''));
+    }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Seems there are some email clients that are not parsing the ct query parameter and thus leaving it empty leading to an exception. This handles that scenario gracefully so that the redirect still happens. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Send an email with a link
2. Copy the link rather than clicking on it
3. Paste into a browser and delete everything after ct= and go
4. It should result in an exception

#### Steps to test this PR:
1. Repeat and the link will still redirect 
