### PR TITLE
Return 500 for response code if the exception response code is outside HTTP range

### DIFF
--- a/plugins/MauticCrmBundle/Controller/PipedriveController.php
+++ b/plugins/MauticCrmBundle/Controller/PipedriveController.php
@@ -84,8 +84,8 @@ class PipedriveController extends CommonController
                     $companyImport->delete($params['previous']);
                     break;
                 case self::USER_UPDATE_EVENT:
-                $ownerImport = $this->getOwnerImport($pipedriveIntegration);
-                $ownerImport->create($data[0]);
+                    $ownerImport = $this->getOwnerImport($pipedriveIntegration);
+                    $ownerImport->create($data[0]);
                     break;
                 default:
                     $response = [
@@ -96,10 +96,24 @@ class PipedriveController extends CommonController
             return new JsonResponse([
                 'status'  => 'error',
                 'message' => $e->getMessage(),
-            ], $e->getCode());
+            ], $this->getErrorCodeFromException($e));
         }
 
         return new JsonResponse($response, Response::HTTP_OK);
+    }
+
+    /**
+     * Transform unknown Exception codes into 500 code.
+     *
+     * @param \Exception $e
+     *
+     * @return int
+     */
+    private function getErrorCodeFromException(\Exception $e)
+    {
+        $code = $e->getCode();
+
+        return (is_int($code) && $code >= 400 && $code < 600) ? $code : 500;
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If you experience errors in Pipedrive, it's possible that your log is filled with `The HTTP status code "0" is not valid` exceptions. This PR will default to the current behavior unless the exception code is < 400 or > 600, in which case it will return a 500 error response to prevent these errors.
