### PR TITLE
Fix menu depth condition

### DIFF
--- a/app/bundles/CoreBundle/Views/Menu/main.html.php
+++ b/app/bundles/CoreBundle/Views/Menu/main.html.php
@@ -60,7 +60,7 @@ if ($item->hasChildren() && $options['depth'] !== 0 && $item->getDisplayChildren
         if (!isset($labelAttributes['class'])) {
             $labelAttributes['class'] = 'nav-item-name';
         }
-        $labelPull = $extras['depth'] === 0 ? ' pull-left' : '';
+        $labelPull = empty($extras['depth']) ? ' pull-left' : '';
         $labelAttributes['class'] .= ' text'.$labelPull;
 
         echo "<span{$view['menu']->parseAttributes($labelAttributes)}>{$view['translator']->trans($child->getLabel())}</span>";


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
I found bug in menu when trying to instal plugin which is under development. I don't know precisely how is this happening, but it was failing on `undefined`.
So I decided to make this small fix which is not affecting original condition itself, but enhancing what is recognized as not defined or zero.
