### PR TITLE
Remove object filtering within alias generator

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -29,7 +29,7 @@ class LeadFieldRepository extends CommonRepository
      *
      * @return array
      */
-    public function getAliases($exludingId, $publishedOnly = false, $includeEntityFields = true, $object = 'lead')
+    public function getAliases($exludingId, $publishedOnly = false, $includeEntityFields = true, $object = null)
     {
         $q = $this->_em->getConnection()->createQueryBuilder()
             ->select('l.alias')
@@ -47,9 +47,11 @@ class LeadFieldRepository extends CommonRepository
                 ->setParameter(':true', true, 'boolean');
         }
 
-        $q->andWhere(
-            $q->expr()->eq('l.object', ':object')
-        )->setParameter('object', $object);
+        if ($object) {
+            $q->andWhere(
+                $q->expr()->eq('l.object', ':object')
+            )->setParameter('object', $object);
+        }
 
         $results = $q->execute()->fetchAll();
         $aliases = [];

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -29,7 +29,7 @@ class LeadFieldRepository extends CommonRepository
      *
      * @return array
      */
-    public function getAliases($exludingId, $publishedOnly = false, $includeEntityFields = true, $object = null)
+    public function getAliases($exludingId, $publishedOnly = false, $includeEntityFields = true, $object = 'lead')
     {
         $q = $this->_em->getConnection()->createQueryBuilder()
             ->select('l.alias')

--- a/app/bundles/LeadBundle/Helper/FieldAliasHelper.php
+++ b/app/bundles/LeadBundle/Helper/FieldAliasHelper.php
@@ -52,7 +52,7 @@ class FieldAliasHelper
         // make sure alias is not already taken
         $repo      = $this->fieldModel->getRepository();
         $testAlias = $alias;
-        $aliases   = $repo->getAliases($field->getId(), false, true, $field->getObject());
+        $aliases   = $repo->getAliases($field->getId());
         $count     = (int) in_array($testAlias, $aliases);
         $aliasTag  = $count;
 

--- a/app/bundles/LeadBundle/Helper/FieldAliasHelper.php
+++ b/app/bundles/LeadBundle/Helper/FieldAliasHelper.php
@@ -52,7 +52,7 @@ class FieldAliasHelper
         // make sure alias is not already taken
         $repo      = $this->fieldModel->getRepository();
         $testAlias = $alias;
-        $aliases   = $repo->getAliases($field->getId());
+        $aliases   = $repo->getAliases($field->getId(), false, true, null);
         $count     = (int) in_array($testAlias, $aliases);
         $aliasTag  = $count;
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The custom field alias is not unique when you leave alias field empty because the validator/generator makes the difference between an alias for a custom company field or a custom contact field.

**Exemple of bug**: when you launch contact .csv import, only the alias is taken into account for fields mapping, it does not matter if the field is a company type or a contact type. So the company field always erased the contact field if they have the same alias.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a contact custom field with label `Custom field` leave alias blank
2. Create a company custom field with label `Custom field` leave alias blank
3. Two field with the same alias is now present

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7210)
2. Remove previous company field with custom label `Custom field`
3. Try to recreate the same, now the validator rename alias as expected `custom_field1`
