### PR TITLE
Fix bug with signature when creating/editing a user through the API

### DIFF
--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -110,6 +110,11 @@ trait RequestTrait
             $masks['description'] = 'html';
         }
 
+        if (!isset($masks['signature'])) {
+            // Add signature to support HTML
+            $masks['signature'] = 'html';
+        }
+
         $params = InputHelper::_($params, $masks);
     }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL |  No
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? |  No
| Deprecations? |  No

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixes an issue when creating / editing a user through the API, html tags were stripped out, but from Front-end html worked fine.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make a post request through the API with signature => `'<p>Test</p>'`
2. Open Mautic user profile, only 'Test' will be visible.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Make an API with signature => `'<p>Test</p>'`
3. Open Mautic user profile, only `'<p>Test</p>'` will be visible.

#### List deprecations along with the new alternative:
1. None
2. 

#### List backwards compatibility breaks:
1. None
2. 
