### PR TITLE
Sparkpost error handling update

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -534,6 +534,7 @@ return [
                     'translator',
                     'mautic.email.model.transport_callback',
                     'mautic.sparkpost.factory',
+                    'monolog.logger.mautic',
                 ],
             ],
             'mautic.sparkpost.factory' => [

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -526,6 +526,14 @@ return [
                     'setPassword' => ['%mautic.mailer_password%'],
                 ],
             ],
+            'mautic.transport.sparkpost.client' => [
+                'class'     => \SparkPost\SparkPost::class,
+                'factory'   => ['@mautic.sparkpost.factory', 'create'],
+                'arguments' => [
+                    '',
+                    '%mautic.mailer_api_key%',
+                ],
+            ],
             'mautic.transport.sparkpost' => [
                 'class'        => 'Mautic\EmailBundle\Swiftmailer\Transport\SparkpostTransport',
                 'serviceAlias' => 'swiftmailer.mailer.transport.%s',
@@ -533,6 +541,7 @@ return [
                     '%mautic.mailer_api_key%',
                     'translator',
                     'mautic.email.model.transport_callback',
+                    'mautic.transport.sparkpost.client',
                 ],
             ],
             'mautic.sparkpost.factory' => [

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -526,14 +526,6 @@ return [
                     'setPassword' => ['%mautic.mailer_password%'],
                 ],
             ],
-            'mautic.transport.sparkpost.client' => [
-                'class'     => \SparkPost\SparkPost::class,
-                'factory'   => ['@mautic.sparkpost.factory', 'create'],
-                'arguments' => [
-                    '',
-                    '%mautic.mailer_api_key%',
-                ],
-            ],
             'mautic.transport.sparkpost' => [
                 'class'        => 'Mautic\EmailBundle\Swiftmailer\Transport\SparkpostTransport',
                 'serviceAlias' => 'swiftmailer.mailer.transport.%s',
@@ -541,7 +533,7 @@ return [
                     '%mautic.mailer_api_key%',
                     'translator',
                     'mautic.email.model.transport_callback',
-                    'mautic.transport.sparkpost.client',
+                    'mautic.sparkpost.factory',
                 ],
             ],
             'mautic.sparkpost.factory' => [

--- a/app/bundles/EmailBundle/Swiftmailer/Sparkpost/SparkpostFactory.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Sparkpost/SparkpostFactory.php
@@ -27,7 +27,7 @@ final class SparkpostFactory implements SparkpostFactoryInterface
      *
      * @return SparkPost
      */
-    public function create($host = '', $apiKey, $port = null)
+    public function create($host, $apiKey, $port = null)
     {
         if ((strpos($host, '://') === false && substr($host, 0, 1) != '/')) {
             $host = 'https://'.$host;

--- a/app/bundles/EmailBundle/Swiftmailer/Sparkpost/SparkpostFactory.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Sparkpost/SparkpostFactory.php
@@ -5,9 +5,6 @@ namespace Mautic\EmailBundle\Swiftmailer\Sparkpost;
 use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 use SparkPost\SparkPost;
 
-/**
- * Class SparkpostFactory.
- */
 final class SparkpostFactory implements SparkpostFactoryInterface
 {
     /**
@@ -16,8 +13,6 @@ final class SparkpostFactory implements SparkpostFactoryInterface
     private $client;
 
     /**
-     * SparkpostFactory constructor.
-     *
      * @param GuzzleAdapter $client
      */
     public function __construct(GuzzleAdapter $client)
@@ -26,24 +21,25 @@ final class SparkpostFactory implements SparkpostFactoryInterface
     }
 
     /**
-     * @param      $host
-     * @param      $apiKey
-     * @param null $port
+     * @param string   $host
+     * @param string   $apiKey
+     * @param int|null $port
      *
-     * @return mixed|SparkPost
+     * @return SparkPost
      */
-    public function create($host, $apiKey, $port = null)
+    public function create($host = '', $apiKey, $port = null)
     {
         if ((strpos($host, '://') === false && substr($host, 0, 1) != '/')) {
             $host = 'https://'.$host;
         }
 
         $options = [
-            'host'     => '',
-            'protocol' => 'https',
-            'port'     => $port,
-            'key'      => ($apiKey) ?: 1234, // prevent Exception: You must provide an API key
+            'key' => ($apiKey) ?: 1234, // prevent Exception: You must provide an API key
         ];
+
+        if ($port) {
+            $options['port'] = $port;
+        }
 
         $hostInfo = parse_url($host);
         if ($hostInfo) {

--- a/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportMessageTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportMessageTest.php
@@ -16,6 +16,7 @@ use Mautic\EmailBundle\Model\TransportCallback;
 use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
 use Mautic\EmailBundle\Swiftmailer\Sparkpost\SparkpostFactoryInterface;
 use Mautic\EmailBundle\Swiftmailer\Transport\SparkpostTransport;
+use Psr\Log\LoggerInterface;
 
 class SparkpostTransportMessageTest extends \PHPUnit_Framework_TestCase
 {
@@ -24,6 +25,7 @@ class SparkpostTransportMessageTest extends \PHPUnit_Framework_TestCase
         $translator        = $this->createMock(Translator::class);
         $transportCallback = $this->createMock(TransportCallback::class);
         $sparkpostFactory  = $this->createMock(SparkpostFactoryInterface::class);
+        $logger            = $this->createMock(LoggerInterface::class);
 
         $message = new MauticMessage('Test subject', 'First Name: {formfield=first_name}');
         $message->addFrom('from@xx.xx');
@@ -55,7 +57,7 @@ class SparkpostTransportMessageTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $sparkpost = new SparkpostTransport('1234', $translator, $transportCallback, $sparkpostFactory);
+        $sparkpost = new SparkpostTransport('1234', $translator, $transportCallback, $sparkpostFactory, $logger);
 
         $sparkpostMessage = $sparkpost->getSparkPostMessage($message);
 

--- a/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportMessageTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportMessageTest.php
@@ -14,8 +14,8 @@ namespace Mautic\EmailBundle\Tests\Transport;
 use Mautic\CoreBundle\Translation\Translator;
 use Mautic\EmailBundle\Model\TransportCallback;
 use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
+use Mautic\EmailBundle\Swiftmailer\Sparkpost\SparkpostFactoryInterface;
 use Mautic\EmailBundle\Swiftmailer\Transport\SparkpostTransport;
-use SparkPost\SparkPost;
 
 class SparkpostTransportMessageTest extends \PHPUnit_Framework_TestCase
 {
@@ -23,7 +23,7 @@ class SparkpostTransportMessageTest extends \PHPUnit_Framework_TestCase
     {
         $translator        = $this->createMock(Translator::class);
         $transportCallback = $this->createMock(TransportCallback::class);
-        $sparkpostClient   = $this->createMock(SparkPost::class);
+        $sparkpostFactory  = $this->createMock(SparkpostFactoryInterface::class);
 
         $message = new MauticMessage('Test subject', 'First Name: {formfield=first_name}');
         $message->addFrom('from@xx.xx');
@@ -55,7 +55,7 @@ class SparkpostTransportMessageTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $sparkpost = new SparkpostTransport('1234', $translator, $transportCallback, $sparkpostClient);
+        $sparkpost = new SparkpostTransport('1234', $translator, $transportCallback, $sparkpostFactory);
 
         $sparkpostMessage = $sparkpost->getSparkPostMessage($message);
 

--- a/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportMessageTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportMessageTest.php
@@ -15,6 +15,7 @@ use Mautic\CoreBundle\Translation\Translator;
 use Mautic\EmailBundle\Model\TransportCallback;
 use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
 use Mautic\EmailBundle\Swiftmailer\Transport\SparkpostTransport;
+use SparkPost\SparkPost;
 
 class SparkpostTransportMessageTest extends \PHPUnit_Framework_TestCase
 {
@@ -22,6 +23,7 @@ class SparkpostTransportMessageTest extends \PHPUnit_Framework_TestCase
     {
         $translator        = $this->createMock(Translator::class);
         $transportCallback = $this->createMock(TransportCallback::class);
+        $sparkpostClient   = $this->createMock(SparkPost::class);
 
         $message = new MauticMessage('Test subject', 'First Name: {formfield=first_name}');
         $message->addFrom('from@xx.xx');
@@ -53,7 +55,7 @@ class SparkpostTransportMessageTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $sparkpost = new SparkpostTransport('1234', $translator, $transportCallback);
+        $sparkpost = new SparkpostTransport('1234', $translator, $transportCallback, $sparkpostClient);
 
         $sparkpostMessage = $sparkpost->getSparkPostMessage($message);
 

--- a/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportTest.php
@@ -20,6 +20,7 @@ use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
 use Mautic\EmailBundle\Swiftmailer\Sparkpost\SparkpostFactoryInterface;
 use Mautic\EmailBundle\Swiftmailer\Transport\SparkpostTransport;
 use Mautic\LeadBundle\Entity\DoNotContact;
+use Psr\Log\LoggerInterface;
 use SparkPost\SparkPost;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -37,6 +38,7 @@ class SparkpostTransportTest extends \PHPUnit_Framework_TestCase
     private $sparkpostFactory;
     private $sparkpostClient;
     private $sparkpostTransport;
+    private $logger;
 
     protected function setUp()
     {
@@ -51,12 +53,14 @@ class SparkpostTransportTest extends \PHPUnit_Framework_TestCase
         $this->message            = $this->createMock(MauticMessage::class);
         $this->headers            = $this->createMock(\Swift_Mime_HeaderSet::class);
         $this->sparkpostFactory   = $this->createMock(SparkpostFactoryInterface::class);
+        $this->logger             = $this->createMock(LoggerInterface::class);
         $this->sparkpostClient    = new SparkPost($this->httpClient, ['key' => '1234']);
         $this->sparkpostTransport = new SparkpostTransport(
             '1234',
             $this->translator,
             $this->transportCallback,
-            $this->sparkpostFactory
+            $this->sparkpostFactory,
+            $this->logger
         );
 
         $this->translator->method('trans')

--- a/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportTest.php
@@ -11,31 +11,67 @@
 
 namespace Mautic\EmailBundle\Tests\Transport;
 
-use Mautic\CoreBundle\Translation\Translator;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Stream;
+use Http\Adapter\Guzzle6\Client;
+use Http\Promise\Promise;
 use Mautic\EmailBundle\Model\TransportCallback;
+use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
 use Mautic\EmailBundle\Swiftmailer\Transport\SparkpostTransport;
 use Mautic\LeadBundle\Entity\DoNotContact;
+use SparkPost\SparkPost;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class SparkpostTransportTest extends \PHPUnit_Framework_TestCase
 {
+    private $translator;
+    private $transportCallback;
+    private $httpClient;
+    private $promise;
+    private $response;
+    private $stream;
+    private $message;
+    private $headers;
+    private $sparkpostClient;
+    private $sparkpostTransport;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->translator         = $this->createMock(TranslatorInterface::class);
+        $this->transportCallback  = $this->createMock(TransportCallback::class);
+        $this->httpClient         = $this->createMock(Client::class);
+        $this->promise            = $this->createMock(Promise::class);
+        $this->response           = $this->createMock(Response::class);
+        $this->stream             = $this->createMock(Stream::class);
+        $this->message            = $this->createMock(MauticMessage::class);
+        $this->headers            = $this->createMock(\Swift_Mime_HeaderSet::class);
+        $this->sparkpostClient    = new SparkPost($this->httpClient, ['key' => '1234']);
+        $this->sparkpostTransport = new SparkpostTransport(
+            '1234',
+            $this->translator,
+            $this->transportCallback,
+            $this->sparkpostClient
+        );
+
+        $this->translator->method('trans')
+            ->willReturnCallback(function ($key) {
+                return $key;
+            });
+
+        $this->httpClient->method('sendAsyncRequest')->willReturn($this->promise);
+        $this->promise->method('wait')->willReturn($this->response);
+        $this->message->method('getChildren')->willReturn([]);
+        $this->message->method('getHeaders')->willReturn($this->headers);
+        $this->headers->method('getAll')->willReturn([]);
+        $this->response->method('getBody')->willReturn($this->stream);
+    }
+
     public function testWebhookPayloadIsProcessed()
     {
-        $translator = $this->getMockBuilder(Translator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $translator->method('trans')
-            ->willReturnCallback(
-                function ($key) {
-                    return $key;
-                }
-            );
-
-        $transportCallback = $this->getMockBuilder(TransportCallback::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $transportCallback->expects($this->exactly(6))
+        $this->transportCallback->expects($this->exactly(6))
             ->method('addFailureByHashId')
             ->withConsecutive(
                 [$this->equalTo('1'), 'MAIL REFUSED - IP (17.99.99.99) is in black list', DoNotContact::BOUNCED],
@@ -45,9 +81,9 @@ class SparkpostTransportTest extends \PHPUnit_Framework_TestCase
                 [$this->equalTo('5'), 'unsubscribed', DoNotContact::UNSUBSCRIBED],
                 [$this->equalTo('6'), 'unsubscribed', DoNotContact::UNSUBSCRIBED]
                 // cc recipient type is ignored so addFailureByHashId should not be called
-        );
+            );
 
-        $transportCallback->expects($this->once())
+        $this->transportCallback->expects($this->once())
             ->method('addFailureByAddress')
             ->with(
                 'bounce@example.com',
@@ -55,9 +91,64 @@ class SparkpostTransportTest extends \PHPUnit_Framework_TestCase
                 DoNotContact::BOUNCED
             );
 
-        $sparkpost = new SparkpostTransport('1234', $translator, $transportCallback);
+        $this->sparkpostTransport->processCallbackRequest($this->getRequestWithPayload());
+    }
 
-        $sparkpost->processCallbackRequest($this->getRequestWithPayload());
+    /**
+     * @see https://www.sparkpost.com/blog/error-handling-transmissions-api/
+     */
+    public function testSendWithOldErrorResponse()
+    {
+        $payload = '{  
+            "errors":[  
+              {
+                "description":"Unconfigured or unverified sending domain.",
+                "code":"1902",
+                "message":"Invalid domain"
+              }
+            ]
+        }';
+
+        $this->message->method('getMetadata')->willReturn(['jane@doe.email' => ['leadId' => 21]]);
+        $this->message->method('getSubject')->willReturn('Top secret');
+        $this->message->method('getFrom')->willReturn(['john@doe.email' => 'John']);
+        $this->message->method('getTo')->willReturn(['jane@doe.email' => 'Jane']);
+        $this->response->method('getStatusCode')->willReturn(200);
+        $this->stream->method('__toString')->willReturn($payload);
+        $this->transportCallback
+            ->expects($this->once())
+            ->method('addFailureByContactId')
+            ->with(21, 'Unconfigured or unverified sending domain.', DoNotContact::BOUNCED, null);
+
+        $this->sparkpostTransport->send($this->message);
+    }
+
+    /**
+     * @see https://www.sparkpost.com/blog/error-handling-transmissions-api/
+     */
+    public function testSendWithNewErrorResponse()
+    {
+        $payload = '{  
+            "errors":[  
+              {
+                "code":"1902",
+                "message":"Invalid domain"
+              }
+            ]
+        }';
+
+        $this->message->method('getMetadata')->willReturn(['jane@doe.email' => ['leadId' => 21]]);
+        $this->message->method('getSubject')->willReturn('Top secret');
+        $this->message->method('getFrom')->willReturn(['john@doe.email' => 'John']);
+        $this->message->method('getTo')->willReturn(['jane@doe.email' => 'Jane']);
+        $this->response->method('getStatusCode')->willReturn(200);
+        $this->stream->method('__toString')->willReturn($payload);
+        $this->transportCallback
+            ->expects($this->once())
+            ->method('addFailureByContactId')
+            ->with(21, 'Invalid domain', DoNotContact::BOUNCED, null);
+
+        $this->sparkpostTransport->send($this->message);
     }
 
     private function getRequestWithPayload()

--- a/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportTest.php
@@ -17,6 +17,7 @@ use Http\Adapter\Guzzle6\Client;
 use Http\Promise\Promise;
 use Mautic\EmailBundle\Model\TransportCallback;
 use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
+use Mautic\EmailBundle\Swiftmailer\Sparkpost\SparkpostFactoryInterface;
 use Mautic\EmailBundle\Swiftmailer\Transport\SparkpostTransport;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use SparkPost\SparkPost;
@@ -33,6 +34,7 @@ class SparkpostTransportTest extends \PHPUnit_Framework_TestCase
     private $stream;
     private $message;
     private $headers;
+    private $sparkpostFactory;
     private $sparkpostClient;
     private $sparkpostTransport;
 
@@ -48,12 +50,13 @@ class SparkpostTransportTest extends \PHPUnit_Framework_TestCase
         $this->stream             = $this->createMock(Stream::class);
         $this->message            = $this->createMock(MauticMessage::class);
         $this->headers            = $this->createMock(\Swift_Mime_HeaderSet::class);
+        $this->sparkpostFactory   = $this->createMock(SparkpostFactoryInterface::class);
         $this->sparkpostClient    = new SparkPost($this->httpClient, ['key' => '1234']);
         $this->sparkpostTransport = new SparkpostTransport(
             '1234',
             $this->translator,
             $this->transportCallback,
-            $this->sparkpostClient
+            $this->sparkpostFactory
         );
 
         $this->translator->method('trans')
@@ -67,6 +70,7 @@ class SparkpostTransportTest extends \PHPUnit_Framework_TestCase
         $this->message->method('getHeaders')->willReturn($this->headers);
         $this->headers->method('getAll')->willReturn([]);
         $this->response->method('getBody')->willReturn($this->stream);
+        $this->sparkpostFactory->method('create')->willReturn($this->sparkpostClient);
     }
 
     public function testWebhookPayloadIsProcessed()


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | Y

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
[Sparkpost is removing](https://www.sparkpost.com/blog/error-handling-transmissions-api/) `description` property from the error responses. This PR addresses that. And while writing tests for the `send()` method I had to use the SparkpostFactory that was used for Momentum, update it for Sparkpost to use the default values and make some other changes to make the tests pass. I think some of them are bugs.

Another change is that Sparkpost won't control email template validation on send. This PR implements pre-check to validate email template. The send will not happen if the template is invalid.

#### Steps to test this PR:
1. Make sure you use the Sparkpost email transport
2. Send individual and segment email with some tokens in it.
3. Ensure that the emails were delivered properly.