### PR TITLE
Fix for preference center save button styles

### DIFF
--- a/app/bundles/CoreBundle/Views/Slots/saveprefsbutton.html.php
+++ b/app/bundles/CoreBundle/Views/Slots/saveprefsbutton.html.php
@@ -8,6 +8,9 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
+$style      = isset($saveprefsbutton['style']) ? $saveprefsbutton['style'] : 'display:inline-block;text-decoration:none;border-color:#4e5d9d;border-width: 10px 20px;border-style:solid; text-decoration: none; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px; background-color: #4e5d9d; display: inline-block;font-size: 16px; color: #ffffff;';
+$background = isset($saveprefsbutton['background']) ? $saveprefsbutton['background'] : '';
+
 if (isset($form)) {
     // add form tag
     echo '<script src="'.$view['assets']->getUrl('app/bundles/PageBundle/Assets/js/prefcenter.js').'"></script>';
@@ -15,9 +18,10 @@ if (isset($form)) {
 }
 ?>
     <a href="javascript:void(null)"
-       class="button btn btn-default btn-save"
-       <?php if (isset($form)) : ?>onclick="saveUnsubscribePreferences('<?php echo $form->vars['id']; ?>')"<?php endif; ?>
-       style="display:inline-block;text-decoration:none;border-color:#4e5d9d;border-width: 10px 20px;border-style:solid; text-decoration: none; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px; background-color: #4e5d9d; display: inline-block;font-size: 16px; color: #ffffff; ">
+        class="button btn btn-default btn-save"
+        <?php if (isset($form)) : ?>onclick="saveUnsubscribePreferences('<?php echo $form->vars['id']; ?>')"<?php endif; ?>
+        style="<?php echo $style; ?>"
+        background="<?php echo $background; ?>">
         <?php echo $view['translator']->trans('mautic.page.form.saveprefs'); ?>
     </a>
     <div style="clear:both"></div>

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -374,8 +374,14 @@ class BuilderSubscriber extends CommonSubscriber
                 $divContent = $xpath->query('//*[@data-slot="saveprefsbutton"]');
                 for ($i = 0; $i < $divContent->length; ++$i) {
                     $slot            = $divContent->item($i);
+                    $saveButton      = $xpath->query('//*[@data-slot="saveprefsbutton"]//a')->item(0);
                     $slot->nodeValue = self::saveprefsRegex;
                     $content         = $dom->saveHTML();
+
+                    $params['saveprefsbutton'] = [
+                        'style'      => $saveButton->getAttribute('style'),
+                        'background' => $saveButton->getAttribute('background'),
+                    ];
                 }
 
                 unset($slot, $xpath, $dom);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | /
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The preference center save button styles are saved in the landing page HTML but were changed on the preference center landing page load when replacing the preference center static HTML with dynamic. This PR use the styles of the save button from the builder an applies it to the replaced button.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a preference center landing page with red save button.
2. Create an email with the unsubscribe text token and assign the preference center landing page to it.
3. Send it to your testing segment.
4. Click the unsubscribe link. Notice the button is the default Mautic blue. Not red.

#### Steps to test this PR:
1. Checkout this PR
2. Reload the unsubscribe page. The button is red now.