### PR TITLE
Optimize report if email id filter exists

### DIFF
--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -368,6 +368,13 @@ class ReportSubscriber extends CommonSubscriber
                         )
                         ->where('cut2.channel = \'email\' AND ph.source = \'email\'')
                         ->groupBy('cut2.channel_id, ph.lead_id');
+
+                    if ($event->hasFilter('e.id')) {
+                        $filterParam = $event->createParameterName();
+                        $qbcut->andWhere("cut2.channel_id = :{$filterParam}");
+                        $qb->setParameter($filterParam, $event->getFilterValue('e.id'), \PDO::PARAM_INT);
+                    }
+
                     $qb->leftJoin(
                         'e',
                         sprintf('(%s)', $qbcut->getSQL()),

--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -365,6 +365,26 @@ class Report extends FormEntity implements SchedulerInterface
     }
 
     /**
+     * Get filter value from a specific filter.
+     *
+     * @param string $column
+     *
+     * @return mixed
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function getFilterValue($column)
+    {
+        foreach ($this->getFilters() as $field) {
+            if ($column === $field['column']) {
+                return $field['value'];
+            }
+        }
+
+        throw new \UnexpectedValueException("Column {$column} doesn't have any filter.");
+    }
+
+    /**
      * @return mixed
      */
     public function getDescription()

--- a/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
@@ -432,6 +432,20 @@ class ReportGeneratorEvent extends AbstractReportEvent
     }
 
     /**
+     * Get filter value from a specific filter.
+     *
+     * @param string $column
+     *
+     * @return mixed
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function getFilterValue($column)
+    {
+        return $this->getReport()->getFilterValue($column);
+    }
+
+    /**
      * Check if the report has a groupBy columns selected.
      *
      *

--- a/app/bundles/ReportBundle/Tests/Entity/ReportTest.php
+++ b/app/bundles/ReportBundle/Tests/Entity/ReportTest.php
@@ -86,6 +86,41 @@ class ReportTest extends \PHPUnit_Framework_TestCase
         $report->ensureIsWeeklyScheduled();
     }
 
+    public function testGetFilterValueIfFIltersAreEmpty()
+    {
+        $report = $this->getInvalidReport();
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->assertSame('1234', $report->getFilterValue('e.test'));
+    }
+
+    public function testGetFilterValueIfExists()
+    {
+        $report = $this->getInvalidReport();
+        $report->setFilters([
+            [
+                'column' => 'e.test',
+                'value'  => '1234',
+            ],
+        ]);
+
+        $this->assertSame('1234', $report->getFilterValue('e.test'));
+    }
+
+    public function testGetFilterValueIfDoesNotExist()
+    {
+        $report = $this->getInvalidReport();
+        $report->setFilters([
+            [
+                'column' => 'e.test',
+                'value'  => '1234',
+            ],
+        ]);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $report->getFilterValue('I need coffee');
+    }
+
     /**
      * @return Report
      */


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Speed enhancement
| New feature? | Speed enhancement
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

One of the Mautic instance we maintain has a report that is time-outing on export. This is the report configuration:

```
INSERT INTO `mautic_reports` (`id`, `is_published`, `date_added`, `created_by`, `created_by_user`, `date_modified`, `modified_by`, `modified_by_user`, `checked_out`, `checked_out_by`, `checked_out_by_user`, `name`, `description`, `system`, `source`, `columns`, `filters`, `table_order`, `graphs`, `group_by`, `aggregators`, `settings`, `is_scheduled`, `schedule_unit`, `to_address`, `schedule_day`, `schedule_month_frequency`)
VALUES
	(9, 1, '2018-11-28 18:30:58', NULL, 'Anthony Sinisi', '2019-01-15 12:49:41', 1, 'John Linhart', '2019-01-15 10:49:36', 1, 'John Linhart', 'Email Click Report', NULL, 0, 'email.stats', 'a:16:{i:0;s:6:\"e.name\";i:1;s:11:\"l.firstname\";i:2;s:10:\"l.lastname\";i:3;s:7:\"l.email\";i:4;s:10:\"l.address1\";i:5;s:10:\"l.address2\";i:6;s:13:\"l.attribution\";i:7;s:18:\"l.attribution_date\";i:8;s:10:\"l.birthday\";i:9;s:6:\"l.city\";i:10;s:7:\"l.phone\";i:11;s:18:\"l.preferred_locale\";i:12;s:7:\"l.state\";i:13;s:10:\"l.timezone\";i:14;s:9:\"l.zipcode\";i:15;s:8:\"l.gender\";}', 'a:3:{i:2;a:5:{s:6:\"column\";s:6:\"is_hit\";s:4:\"glue\";s:3:\"and\";s:5:\"value\";s:1:\"1\";s:7:\"dynamic\";i:1;s:9:\"condition\";s:2:\"eq\";}i:5;a:5:{s:6:\"column\";s:4:\"e.id\";s:4:\"glue\";s:3:\"and\";s:5:\"value\";s:4:\"1180\";s:7:\"dynamic\";i:1;s:9:\"condition\";s:2:\"eq\";}i:6;a:5:{s:6:\"column\";s:12:\"unsubscribed\";s:4:\"glue\";s:3:\"and\";s:5:\"value\";s:1:\"1\";s:7:\"dynamic\";N;s:9:\"condition\";s:3:\"neq\";}}', 'a:0:{}', 'a:0:{}', 'a:0:{}', 'a:0:{}', '{\"showGraphsAboveTable\":0,\"showDynamicFilters\":0,\"hideDateRangeFilter\":0}', 1, 'DAILY', '', NULL, NULL);

```

Or if you prefer UI then this is how it looks like:
![screenshot 2019-01-15 at 13 48 42](https://user-images.githubusercontent.com/1235442/51181762-529e1e80-18cc-11e9-926e-bca6b3120f16.png)

It generates query like this:
```
SELECT e.name AS e_name, l.firstname AS firstname, l.lastname AS lastname, l.email AS email, l.address1 AS address1, l.address2 AS address2, l.attribution AS attribution, l.attribution_date AS attribution_date, l.birthday AS birthday, l.city AS city, l.phone AS phone, l.preferred_locale AS preferred_locale, l.state AS state, l.timezone AS timezone, l.zipcode AS zipcode, l.gender AS gender FROM mautic_email_stats es LEFT JOIN mautic_emails e ON e.id = es.email_id LEFT JOIN mautic_leads l ON l.id = es.lead_id LEFT JOIN mautic_ip_addresses i ON i.id = es.ip_id LEFT JOIN mautic_emails vp ON vp.id = e.variant_parent_id LEFT JOIN mautic_categories c ON c.id = e.category_id LEFT JOIN (SELECT COUNT(ph.id) AS hits, COUNT(DISTINCT(ph.redirect_id)) AS unique_hits, cut2.channel_id, ph.lead_id FROM mautic_channel_url_trackables cut2 INNER JOIN mautic_page_hits ph ON cut2.redirect_id = ph.redirect_id AND cut2.channel_id = ph.source_id WHERE cut2.channel = 'email' AND ph.source = 'email' GROUP BY cut2.channel_id, ph.lead_id) cut ON e.id = cut.channel_id AND es.lead_id = cut.lead_id LEFT JOIN mautic_lead_donotcontact dnc ON e.id = dnc.channel_id AND dnc.channel='email' AND es.lead_id = dnc.lead_id WHERE (es.date_sent IS NULL OR (es.date_sent BETWEEN '2018-12-15 23:00:00' AND '2019-01-15 12:51:46')) AND ((IF(cut.hits is NULL, 0, 1) = '1') AND (e.id = 1180) AND (IF(dnc.id IS NOT NULL AND dnc.reason=1, 1, 0) <> '1')) LIMIT 30 OFFSET 0
```
And this is the changed query:
```
SELECT e.name AS e_name, l.firstname AS firstname, l.lastname AS lastname, l.email AS email, l.address1 AS address1, l.address2 AS address2, l.attribution AS attribution, l.attribution_date AS attribution_date, l.birthday AS birthday, l.city AS city, l.phone AS phone, l.preferred_locale AS preferred_locale, l.state AS state, l.timezone AS timezone, l.zipcode AS zipcode, l.gender AS gender FROM mautic_email_stats es LEFT JOIN mautic_emails e ON e.id = es.email_id LEFT JOIN mautic_leads l ON l.id = es.lead_id LEFT JOIN mautic_ip_addresses i ON i.id = es.ip_id LEFT JOIN mautic_emails vp ON vp.id = e.variant_parent_id LEFT JOIN mautic_categories c ON c.id = e.category_id LEFT JOIN (SELECT COUNT(ph.id) AS hits, COUNT(DISTINCT(ph.redirect_id)) AS unique_hits, cut2.channel_id, ph.lead_id FROM mautic_channel_url_trackables cut2 INNER JOIN mautic_page_hits ph ON cut2.redirect_id = ph.redirect_id AND cut2.channel_id = ph.source_id WHERE (cut2.channel = 'email' AND ph.source = 'email') AND (cut2.channel_id = '1180') GROUP BY cut2.channel_id, ph.lead_id) cut ON e.id = cut.channel_id AND es.lead_id = cut.lead_id LEFT JOIN mautic_lead_donotcontact dnc ON e.id = dnc.channel_id AND dnc.channel='email' AND es.lead_id = dnc.lead_id WHERE (es.date_sent IS NULL OR (es.date_sent BETWEEN '2018-12-15 23:00:00' AND '2019-01-15 12:33:54')) AND ((IF(cut.hits is NULL, 0, 1) = '1') AND (e.id = 1180) AND (IF(dnc.id IS NOT NULL AND dnc.reason=1, 1, 0) <> '1')) LIMIT 30 OFFSET 0
```
If you cannot spot the difference, `AND (cut2.channel_id = '1180')` is added somewhere in the middle.

This change speeds up the query on our client's database from 40 seconds to 240 ms

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. You'd need quite a big database to see the slow execution, but to ensure the report still returns the same data, configure the same report or insert it via the provided INSERT query.
2. Change the email ID to some existing value so it would show some data.

#### Steps to test this PR:
1. Checkout this PR
2. Refresh the filter. It should load faster and show the same data.