### PR TITLE
Dispatch Event from SendGridApiMessage

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -479,6 +479,7 @@ return [
                     'mautic.transport.sendgrid_api.mail.personalization',
                     'mautic.transport.sendgrid_api.mail.metadata',
                     'mautic.transport.sendgrid_api.mail.attachment',
+                    'event_dispatcher',
                 ],
             ],
             'mautic.transport.sendgrid_api.response' => [

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/Event/GetMailMessageEvent.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/Event/GetMailMessageEvent.php
@@ -26,7 +26,7 @@ class GetMailMessageEvent extends Event
     /**
      * Constructor.
      *
-     * @param Mail $mail
+     * @param Mail               $mail
      * @param Swift_Mime_Message $message
      */
     public function __construct(Mail $mail, Swift_Mime_Message $message)

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/Event/GetMailMessageEvent.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/Event/GetMailMessageEvent.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Swiftmailer\SendGrid\Event;
+
+use SendGrid\Mail;
+use Swift_Mime_Message;
+use Symfony\Component\EventDispatcher\Event;
+
+class GetMailMessageEvent extends Event
+{
+    /** @var Mail */
+    private $mail;
+
+    /** @var Swift_Mime_Message */
+    private $message;
+
+    /**
+     * Constructor.
+     *
+     * @param Mail $mail
+     * @param Swift_Mime_Message $message
+     */
+    public function __construct(Mail $mail, Swift_Mime_Message $message)
+    {
+        $this->mail    = $mail;
+        $this->message = $message;
+    }
+
+    /**
+     * Get mail.
+     *
+     * @return Mail
+     */
+    public function getMail()
+    {
+        return $this->mail;
+    }
+
+    /**
+     * Get message.
+     *
+     * @return Swift_Mime_Message
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+}

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridApiMessage.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridApiMessage.php
@@ -11,11 +11,13 @@
 
 namespace Mautic\EmailBundle\Swiftmailer\SendGrid;
 
+use Mautic\EmailBundle\Swiftmailer\SendGrid\Event\GetMailMessageEvent;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailAttachment;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailBase;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailMetadata;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailPersonalization;
 use SendGrid\Mail;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class SendGridApiMessage
 {
@@ -39,16 +41,23 @@ class SendGridApiMessage
      */
     private $sendGridMailAttachment;
 
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
     public function __construct(
         SendGridMailBase $sendGridMailBase,
         SendGridMailPersonalization $sendGridMailPersonalization,
         SendGridMailMetadata $sendGridMailMetadata,
-        SendGridMailAttachment $sendGridMailAttachment
+        SendGridMailAttachment $sendGridMailAttachment,
+        EventDispatcherInterface $dispatcher
     ) {
         $this->sendGridMailBase            = $sendGridMailBase;
         $this->sendGridMailPersonalization = $sendGridMailPersonalization;
         $this->sendGridMailMetadata        = $sendGridMailMetadata;
         $this->sendGridMailAttachment      = $sendGridMailAttachment;
+        $this->dispatcher                  = $dispatcher;
     }
 
     /**
@@ -64,6 +73,21 @@ class SendGridApiMessage
         $this->sendGridMailMetadata->addMetadataToMail($mail, $message);
         $this->sendGridMailAttachment->addAttachmentsToMail($mail, $message);
 
+        $this->dispatchGetMailMessageEvent($mail, $message);
+
         return $mail;
+    }
+
+    /**
+     * Dispatch GET_MAIL_MESSAGE event.
+     *
+     * @param Mail                $mail
+     * @param \Swift_Mime_Message $message
+     */
+    private function dispatchGetMailMessageEvent(Mail $mail, \Swift_Mime_Message $message)
+    {
+        $event = new GetMailMessageEvent($mail, $message);
+
+        $this->dispatcher->dispatch(SendGridMailEvents::GET_MAIL_MESSAGE, $event);
     }
 }

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridMailEvents.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridMailEvents.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Swiftmailer\SendGrid;
+
+final class SendGridMailEvents
+{
+    /**
+     * The mautic.email.swiftmailer.sendgrid_api.get_mail_message event is
+     * dispatched by the mautic.transport.sendgrid_api.message service
+     * as the last step before returning a SendGrid\Mail instance in the
+     * getMessage method.
+     *
+     * The event listener receives an instance of
+     * \Mautic\EmailBundle\Swiftmailer\SendGrid\Event\GetMailMessageEvent.
+     *
+     * @var string
+     */
+    const GET_MAIL_MESSAGE = 'mautic.email.swiftmailer.sendgrid_api.get_mail_message';
+}

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Event/GetMailMessageEventTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Event/GetMailMessageEventTest.php
@@ -1,0 +1,189 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Swiftmailer\SendGrid\Event;
+
+use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\Event\GetMailMessageEvent;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailAttachment;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailBase;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailMetadata;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailPersonalization;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridApiMessage;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridMailEvents;
+use SendGrid\Mail;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class GetMailMessageEventTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests that a subscriber with nothing to add will not call any methods
+     * on the Mail instance.
+     */
+    public function testNoMailChanges()
+    {
+        $dispatcher = new EventDispatcher();
+        $subscriber = new TestGetMailMessageSubscriber(); // nothing to to
+        $dispatcher->addSubscriber($subscriber);
+
+        $message = $this->getMockBuilder(MauticMessage::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mail = $this->getMockBuilder(Mail::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mail->expects($this->never())
+            ->method('addCategory');
+
+        $mail->expects($this->never())
+            ->method('addCustomArg');
+
+        $apiMessage = $this->createSendgridApiMessage($dispatcher, $mail, $message);
+
+        $apiMail = $apiMessage->getMessage($message);
+    }
+
+    /**
+     * Tests that multiple subscribers will be able to update the Mail.
+     */
+    public function testMultipleSubscribers()
+    {
+        $dispatcher = new EventDispatcher();
+
+        $dispatcher->addSubscriber(new TestGetMailMessageSubscriber(['foo', 'bar']));
+        $dispatcher->addSubscriber(new TestGetMailMessageSubscriber([], ['baz' => 'qux']));
+        $dispatcher->addSubscriber(new TestGetMailMessageSubscriber(['quux', 'quuz'], ['corge' => 'grault', 'garply' => 'thud']));
+
+        $message = $this->getMockBuilder(MauticMessage::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mail = $this->getMockBuilder(Mail::class)
+            ->disableOriginalConstructor()
+            ->setMethodsExcept(['addCategory', 'getCategories', 'addCustomArg', 'getCustomArgs'])
+            ->getMock();
+
+        $apiMessage = $this->createSendgridApiMessage($dispatcher, $mail, $message);
+        $apiMail    = $apiMessage->getMessage($message);
+
+        $categories = $apiMail->getCategories();
+        $customArgs = $apiMail->getCustomArgs();
+
+        // Test that all categories were added.
+        $this->assertContains('foo', $categories);
+        $this->assertContains('bar', $categories);
+        $this->assertContains('quux', $categories);
+        $this->assertContains('quuz', $categories);
+
+        // Test that all custom args were added.
+        $this->assertArraySubset(['baz' => 'qux'], $customArgs);
+        $this->assertArraySubset(['corge' => 'grault', 'garply' => 'thud'], $customArgs);
+    }
+
+    /**
+     * Create sendgrid api message.
+     *
+     * @param EventDispatcherInterface $dispatcher
+     *
+     * @return SendGridApiMessage
+     */
+    protected function createSendgridApiMessage(EventDispatcherInterface $dispatcher, Mail $mail, \Swift_Mime_Message $message)
+    {
+        $sendGridMailBase = $this->getMockBuilder(SendGridMailBase::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $sendGridMailPersonalization = $this->getMockBuilder(SendGridMailPersonalization::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $sendGridMailMetadata = $this->getMockBuilder(SendGridMailMetadata::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $sendGridMailAttachment = $this->getMockBuilder(SendGridMailAttachment::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $sendGridApiMessage = new SendGridApiMessage(
+            $sendGridMailBase,
+            $sendGridMailPersonalization,
+            $sendGridMailMetadata,
+            $sendGridMailAttachment,
+            $dispatcher
+        );
+
+        $sendGridMailBase->expects($this->once())
+            ->method('getSendGridMail')
+            ->with($message)
+            ->willReturn($mail);
+
+        return $sendGridApiMessage;
+    }
+}
+
+/**
+ * Test subscriber to add 'categories' and 'custom args' to the event Mail if
+ * so instantiated.
+ */
+class TestGetMailMessageSubscriber implements EventSubscriberInterface
+{
+    /** @var array */
+    protected $categories = [];
+
+    /** @var array */
+    protected $customArgs = [];
+
+    /**
+     * Get subscribed events.
+     *
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            SendGridMailEvents::GET_MAIL_MESSAGE => ['onGetMailMessage', 0],
+        ];
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param array $categories
+     */
+    public function __construct($categories = [], $customArgs = [])
+    {
+        $this->categories = $categories;
+        $this->customArgs = $customArgs;
+    }
+
+    /**
+     * @param GetMailMessageEvent $event
+     */
+    public function onGetMailMessage(GetMailMessageEvent $event)
+    {
+        $mail = $event->getMail();
+
+        // Add subscriber instance categories to event Mail
+        foreach ($this->categories as $category) {
+            $mail->addCategory($category);
+        }
+
+        // Add subscriber instance custom args to event Mail
+        foreach ($this->customArgs as $key => $value) {
+            $mail->addCustomArg($key, $value);
+        }
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/SendGridApiMessageTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/SendGridApiMessageTest.php
@@ -11,12 +11,15 @@
 
 namespace Mautic\EmailBundle\Tests\Swiftmailer\SendGrid;
 
+use Mautic\EmailBundle\Swiftmailer\SendGrid\Event\GetMailMessageEvent;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailAttachment;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailBase;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailMetadata;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailPersonalization;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridApiMessage;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridMailEvents;
 use SendGrid\Mail;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class SendGridApiMessageTest extends \PHPUnit_Framework_TestCase
 {
@@ -38,6 +41,8 @@ class SendGridApiMessageTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $dispatcher = $this->createMock(EventDispatcher::class);
+
         $mail = $this->getMockBuilder(Mail::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -46,7 +51,7 @@ class SendGridApiMessageTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $sendGridApiMessage = new SendGridApiMessage($sendGridMailBase, $sendGridMailPersonalization, $sendGridMailMetadata, $sendGridMailAttachment);
+        $sendGridApiMessage = new SendGridApiMessage($sendGridMailBase, $sendGridMailPersonalization, $sendGridMailMetadata, $sendGridMailAttachment, $dispatcher);
 
         $sendGridMailBase->expects($this->once())
             ->method('getSendGridMail')
@@ -64,6 +69,13 @@ class SendGridApiMessageTest extends \PHPUnit_Framework_TestCase
         $sendGridMailAttachment->expects($this->once())
             ->method('addAttachmentsToMail')
             ->with($mail, $message);
+
+        $dispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with(
+                $this->equalTo(SendGridMailEvents::GET_MAIL_MESSAGE),
+                $this->isInstanceOf(GetMailMessageEvent::class)
+            );
 
         $result = $sendGridApiMessage->getMessage($message);
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | Maybe
| Deprecations? | N

#### Description:

Replaces #6695.

This feature introduces an event, dispatched by the **SendGridApiMessage** class when its `getMessage()` method is called. The event is named `mautic.email.swiftmailer.sendgrid_api.get_mail_message`, or `SendGridMailEvents::GET_MAIL_MESSAGE`; and is an instance of [GetMailMessageEvent][]. The event allows its subscribers to access the **SendGrid\Mail** and **Swift_Mime_Message** instances immediately before the **Mail** is returned by `SendGridApiMessage#getMessage()`.

[GetMailMessageEvent]: https://github.com/mautic/mautic/blob/566e93c9f966a90f68f14ebaf69ab091ae61683d/app/bundles/EmailBundle/Swiftmailer/SendGrid/Event/GetMailMessageEvent.php

Prior to this feature, there was not an obvious avenue for adding additional information such as `categories` and `custom_args` to a [SendGrid API][] send.

[SendGrid API]: https://sendgrid.com/docs/api-reference/

There are no default subscribers included along with this functionality; aside from the one defined within the test suite, which is for unit testing only. Without defining and registering a listener on the *get_mail_message* event, this PR should not have any effect on the content of outbound SendGrid mail API requests.

#### Steps to test this PR:

##### PHPUnit

1.  Test that the **SendGridApiMessage** class still works:
    `$ bin/phpunit --configuration app/phpunit.xml.dist --filter SendGridApiMessage`
2.  Test that _EventSubscribers_ on `SendGridMailEvents::GET_MAIL_MESSAGE` can access and manipulate the outgoing **SendGrid\Mail** instance:
    `$ bin/phpunit --configuration app/phpunit.xml.dist --filter GetMailMessageEvent`

##### Real-world use

1. Create a plugin which registers an _EventSubscriber_ on `SendGridMailEvents::GET_MAIL_MESSAGE`.
2. Define in the subscriber a method that will call `$event->getMail()` to access the **[SendGrid\Mail][sendgrid-mail]** instance. Manipulate that instance, doing something like adding _categories_ or _custom args_. For example: `$event->addCategory('<some-category>')`, where `<some-category>` is replaced with an ASCII string you wish to have SendGrid associated with the outgoing email; or `$event->addCustomArg('<key>', '<value>')`.
3. Send an email via the *mailer_transport* `'mautic.transport.sendgrid_api`.
4. Check the SendGrid administration interface for that message. If capturing mail events via SendGrid [Event Webhook][], any [Custom Arguments][] set on outgoing mail should be available as properties on event objects.

[sendgrid-mail]: https://github.com/sendgrid/sendgrid-php/blob/v6.2.0/lib/helpers/mail/Mail.php#L1006
[Event Webhook]: https://sendgrid.com/docs/for-developers/tracking-events/
[Custom Arguments]: https://sendgrid.com/docs/for-developers/tracking-events/event/#custom-arguments

#### List backwards compatibility breaks:

1. An **EventDispatcher** must be passed via constructor injection to the **SendGridApiMessage** class. A constructor argument has been added as well as the relevant service configuration changes. Any use of the **SendGridApiMessage** class not covered by the scope of this codebase may be subject to breakage.
2. The aforementioned service constructor argument change and configuration edits will require the application kernel cache to be cleared and rebuilt. Probably a good idea to wipe the APC cache if applicable.
