### PR TITLE
Accept all 2xx messages as successes

### DIFF
--- a/app/bundles/WebhookBundle/Controller/AjaxController.php
+++ b/app/bundles/WebhookBundle/Controller/AjaxController.php
@@ -62,8 +62,8 @@ class AjaxController extends CommonAjaxController
                 .'</span></div>',
         ];
 
-        // if we get a 200 response convert to success message
-        if ($response->code == 200) {
+        // if we get a 2xx response convert to success message
+        if (substr($response->code, 0, 1) == 2) {
             $dataArray['html'] =
                 '<div class="has-success"><span class="help-block">'
                 .$this->translator->trans('mautic.webhook.label.success')


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Previously, sending a Test Payload from the Edit Webhook screen would display "Error Detected!" if anything apart from a straight HTTP 200 status code was returned from the Webhook POST Url. That led to some confusion, as many backends use HTTP 201 and HTTP 202 to indicate that something was created or changed respectively. Besides, all the [HTTP statuses](https://httpstatuses.com/) starting with 2 are successes.

To stop situations where a backend returning e.g. 201 Created is treated as an error by Mautic, this PR changes the check from 'Is the status code == 200' to 'Is the first position in the status code a 2', thus covering all the 2xx status codes.

(This is my first PR so I apologize if I missed something in the procedure, but it's a very simple PR)

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Go to Settings -> Webhook and create a webhook
3. Set up a Webhook POST Url which will return a 2xx response code that is not 200 - for example, 201 or 202
4. Send a Test Payload
5. You should no longer encounter an "Error Detected"