### PR TITLE
Fix segment filters without object

### DIFF
--- a/app/bundles/LeadBundle/Form/DataTransformer/FieldFilterTransformer.php
+++ b/app/bundles/LeadBundle/Form/DataTransformer/FieldFilterTransformer.php
@@ -20,14 +20,21 @@ class FieldFilterTransformer implements DataTransformerInterface
     private $relativeDateStrings;
 
     /**
-     * @param $translator
+     * @var array
      */
-    public function __construct($translator)
+    private $default;
+
+    /**
+     * @param       $translator
+     * @param array $default
+     */
+    public function __construct($translator, $default = [])
     {
         $this->relativeDateStrings = LeadListRepository::getRelativeDateTranslationKeys();
         foreach ($this->relativeDateStrings as &$string) {
             $string = $translator->trans($string);
         }
+        $this->default = $default;
     }
 
     /**
@@ -44,6 +51,9 @@ class FieldFilterTransformer implements DataTransformerInterface
         }
 
         foreach ($rawFilters as $k => $f) {
+            if (!empty($this->default)) {
+                $rawFilters[$k] = array_merge($this->default, $rawFilters[$k]);
+            }
             if ($f['type'] == 'datetime') {
                 if (in_array($f['filter'], $this->relativeDateStrings) or stristr($f['filter'][0], '-') or stristr($f['filter'][0], '+')) {
                     continue;

--- a/app/bundles/LeadBundle/Form/Type/ListType.php
+++ b/app/bundles/LeadBundle/Form/Type/ListType.php
@@ -193,7 +193,7 @@ class ListType extends AbstractType
 
         $builder->add('isPublished', 'yesno_button_group');
 
-        $filterModalTransformer = new FieldFilterTransformer($this->translator);
+        $filterModalTransformer = new FieldFilterTransformer($this->translator, ['object'=>'lead']);
         $builder->add(
             $builder->create(
                 'filters',


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR resolve issue from PR https://github.com/mautic/mautic/pull/6946 which was reverted later https://github.com/mautic/mautic/pull/7168

Client  instance with segment filters created in 2016-08-31  stop working and not displyed in filters correctly (empty operators selectbox...). In that time Mautic didn't support feature lead/company object.

![image](https://user-images.githubusercontent.com/462477/52630569-e4457f80-2ebc-11e9-85b7-d86e0f7e6a0b.png)

 I noticed that there due no object in filters columns:

![image](https://user-images.githubusercontent.com/462477/52630497-b4967780-2ebc-11e9-8cf1-1a6856c692fb.png)

This PR added default value to FieldFilterTransformer for that fix. 
Then works properly

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Hard to tell.  You can try create segment with filter, and removed object from filters 
2. Then can  seee similar issue like on screenshots above

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Try same like from steps to reproduce
3: Filter should works properly