### PR TITLE
Segments - date relative local timezone

### DIFF
--- a/app/bundles/CoreBundle/Helper/DateTimeHelper.php
+++ b/app/bundles/CoreBundle/Helper/DateTimeHelper.php
@@ -75,7 +75,7 @@ class DateTimeHelper
         $this->timezone = $timezone;
 
         $this->utc   = new \DateTimeZone('UTC');
-        $this->local = new \DateTimeZone(date_default_timezone_get());
+        $this->local = new \DateTimeZone($timezone);
 
         if ($datetime instanceof \DateTime) {
             $this->datetime = $datetime;

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -1088,6 +1088,13 @@ return [
                 'arguments' => [
                     'mautic.lead.model.lead_segment_decorator_date',
                     'mautic.lead.model.relative_date',
+                    'mautic.lead.model.lead_segment.timezoneResolver',
+                ],
+            ],
+            'mautic.lead.model.lead_segment.timezoneResolver' => [
+                'class'     => \Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver::class,
+                'arguments' => [
+                    'mautic.helper.core_parameters',
                 ],
             ],
             'mautic.lead.model.random_parameter_name' => [

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionAbstract.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionAbstract.php
@@ -125,7 +125,7 @@ abstract class DateOptionAbstract implements FilterDecoratorInterface
      */
     public function getParameterValue(ContactSegmentFilterCrate $contactSegmentFilterCrate)
     {
-        $dateTimeHelper = $this->dateDecorator->getDefaultDate();
+        $dateTimeHelper = $this->dateOptionParameters->getDefaultDate();
 
         $this->modifyBaseDate($dateTimeHelper);
 
@@ -141,7 +141,7 @@ abstract class DateOptionAbstract implements FilterDecoratorInterface
             $dateTimeHelper->modify($modifier);
         }
 
-        return $dateTimeHelper->toUtcString($dateFormat);
+        return $dateTimeHelper->toLocalString($dateFormat);
     }
 
     /**

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionFactory.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionFactory.php
@@ -43,12 +43,19 @@ class DateOptionFactory
      */
     private $relativeDate;
 
+    /**
+     * @var TimezoneResolver
+     */
+    private $timezoneResolver;
+
     public function __construct(
         DateDecorator $dateDecorator,
-        RelativeDate $relativeDate
+        RelativeDate $relativeDate,
+        TimezoneResolver $timezoneResolver
     ) {
-        $this->dateDecorator = $dateDecorator;
-        $this->relativeDate  = $relativeDate;
+        $this->dateDecorator    = $dateDecorator;
+        $this->relativeDate     = $relativeDate;
+        $this->timezoneResolver = $timezoneResolver;
     }
 
     /**
@@ -60,7 +67,8 @@ class DateOptionFactory
     {
         $originalValue        = $leadSegmentFilterCrate->getFilter();
         $relativeDateStrings  = $this->relativeDate->getRelativeDateStrings();
-        $dateOptionParameters = new DateOptionParameters($leadSegmentFilterCrate, $relativeDateStrings);
+
+        $dateOptionParameters = new DateOptionParameters($leadSegmentFilterCrate, $relativeDateStrings, $this->timezoneResolver);
 
         $timeframe = $dateOptionParameters->getTimeframe();
 
@@ -71,11 +79,7 @@ class DateOptionFactory
         switch ($timeframe) {
             case 'birthday':
             case 'anniversary':
-            case $timeframe && (
-                    false !== strpos($timeframe, 'anniversary') ||
-                    false !== strpos($timeframe, 'birthday')
-                ):
-                return new DateAnniversary($this->dateDecorator);
+                return new DateAnniversary($this->dateDecorator, $dateOptionParameters);
             case 'today':
                 return new DateDayToday($this->dateDecorator, $dateOptionParameters);
             case 'tomorrow':
@@ -105,7 +109,7 @@ class DateOptionFactory
                     false !== strpos($timeframe[0], '+') || // +5 days
                     false !== strpos($timeframe, ' ago')    // 5 days ago
                 ):
-                return new DateRelativeInterval($this->dateDecorator, $originalValue);
+                return new DateRelativeInterval($this->dateDecorator, $originalValue, $dateOptionParameters);
             default:
                 return new DateDefault($this->dateDecorator, $originalValue);
         }

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionParameters.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionParameters.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\LeadBundle\Segment\Decorator\Date;
 
+use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 
 class DateOptionParameters
@@ -36,15 +37,26 @@ class DateOptionParameters
     private $shouldUseLastDayOfRange;
 
     /**
+     * @var DateTimeHelper
+     */
+    private $dateTimeHelper;
+
+    /**
      * @param ContactSegmentFilterCrate $leadSegmentFilterCrate
      * @param array                     $relativeDateStrings
+     * @param TimezoneResolver          $timezoneResolver
      */
-    public function __construct(ContactSegmentFilterCrate $leadSegmentFilterCrate, array $relativeDateStrings)
-    {
+    public function __construct(
+        ContactSegmentFilterCrate $leadSegmentFilterCrate,
+        array $relativeDateStrings,
+        TimezoneResolver $timezoneResolver
+    ) {
         $this->hasTimePart             = $leadSegmentFilterCrate->hasTimeParts();
         $this->timeframe               = $this->parseTimeFrame($leadSegmentFilterCrate, $relativeDateStrings);
         $this->requiresBetween         = in_array($leadSegmentFilterCrate->getOperator(), ['=', '!='], true);
         $this->shouldUseLastDayOfRange = in_array($leadSegmentFilterCrate->getOperator(), ['gt', 'lte'], true);
+
+        $this->setDateTimeHelper($timezoneResolver);
     }
 
     /**
@@ -84,6 +96,14 @@ class DateOptionParameters
     }
 
     /**
+     * @return DateTimeHelper
+     */
+    public function getDefaultDate()
+    {
+        return $this->dateTimeHelper;
+    }
+
+    /**
      * @param ContactSegmentFilterCrate $leadSegmentFilterCrate
      * @param array                     $relativeDateStrings
      *
@@ -99,5 +119,10 @@ class DateOptionParameters
         }
 
         return str_replace('mautic.lead.list.', '', $key);
+    }
+
+    private function setDateTimeHelper(TimezoneResolver $timezoneResolver)
+    {
+        $this->dateTimeHelper = $timezoneResolver->getDefaultDate($this->hasTimePart());
     }
 }

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Day/DateDayAbstract.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Day/DateDayAbstract.php
@@ -30,7 +30,7 @@ abstract class DateDayAbstract extends DateOptionAbstract
      */
     protected function getValueForBetweenRange(DateTimeHelper $dateTimeHelper)
     {
-        return $dateTimeHelper->toUtcString('Y-m-d%');
+        return $dateTimeHelper->toLocalString('Y-m-d%');
     }
 
     /**

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Month/DateMonthAbstract.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Month/DateMonthAbstract.php
@@ -30,7 +30,7 @@ abstract class DateMonthAbstract extends DateOptionAbstract
      */
     protected function getValueForBetweenRange(DateTimeHelper $dateTimeHelper)
     {
-        return $dateTimeHelper->toUtcString('Y-m-%');
+        return $dateTimeHelper->toLocalString('Y-m-%');
     }
 
     /**

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateAnniversary.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateAnniversary.php
@@ -12,6 +12,7 @@
 namespace Mautic\LeadBundle\Segment\Decorator\Date\Other;
 
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
+use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 use Mautic\LeadBundle\Segment\Decorator\FilterDecoratorInterface;
 
@@ -23,11 +24,18 @@ class DateAnniversary implements FilterDecoratorInterface
     private $dateDecorator;
 
     /**
-     * @param DateDecorator $dateDecorator
+     * @var DateOptionParameters
      */
-    public function __construct(DateDecorator $dateDecorator)
+    private $dateOptionParameters;
+
+    /**
+     * @param DateDecorator        $dateDecorator
+     * @param DateOptionParameters $dateOptionParameters
+     */
+    public function __construct(DateDecorator $dateDecorator, DateOptionParameters $dateOptionParameters)
     {
-        $this->dateDecorator = $dateDecorator;
+        $this->dateDecorator        = $dateDecorator;
+        $this->dateOptionParameters = $dateOptionParameters;
     }
 
     /**
@@ -78,11 +86,9 @@ class DateAnniversary implements FilterDecoratorInterface
      */
     public function getParameterValue(ContactSegmentFilterCrate $contactSegmentFilterCrate)
     {
-        $filter         =  $contactSegmentFilterCrate->getFilter();
-        $relativeFilter =  trim(str_replace(['anniversary', 'birthday'], '', $filter));
-        $dateTimeHelper = $this->dateDecorator->getDefaultDate($relativeFilter);
+        $dateTimeHelper = $this->dateOptionParameters->getDefaultDate();
 
-        return $dateTimeHelper->toUtcString('%-m-d');
+        return $dateTimeHelper->toLocalString('%-m-d');
     }
 
     /**

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateRelativeInterval.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateRelativeInterval.php
@@ -12,6 +12,7 @@
 namespace Mautic\LeadBundle\Segment\Decorator\Date\Other;
 
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
+use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 use Mautic\LeadBundle\Segment\Decorator\FilterDecoratorInterface;
 
@@ -28,13 +29,23 @@ class DateRelativeInterval implements FilterDecoratorInterface
     private $originalValue;
 
     /**
-     * @param DateDecorator $dateDecorator
-     * @param string        $originalValue
+     * @var DateOptionParameters
      */
-    public function __construct(DateDecorator $dateDecorator, $originalValue)
-    {
-        $this->dateDecorator = $dateDecorator;
-        $this->originalValue = $originalValue;
+    private $dateOptionParameters;
+
+    /**
+     * @param DateDecorator        $dateDecorator
+     * @param string               $originalValue
+     * @param DateOptionParameters $dateOptionParameters
+     */
+    public function __construct(
+        DateDecorator $dateDecorator,
+        $originalValue,
+        DateOptionParameters $dateOptionParameters
+    ) {
+        $this->dateDecorator        = $dateDecorator;
+        $this->originalValue        = $originalValue;
+        $this->dateOptionParameters = $dateOptionParameters;
     }
 
     /**
@@ -92,7 +103,7 @@ class DateRelativeInterval implements FilterDecoratorInterface
      */
     public function getParameterValue(ContactSegmentFilterCrate $contactSegmentFilterCrate)
     {
-        $date = $this->dateDecorator->getDefaultDate();
+        $date = $this->dateOptionParameters->getDefaultDate();
         $date->modify($this->originalValue);
 
         $operator = $this->getOperator($contactSegmentFilterCrate);
@@ -101,7 +112,7 @@ class DateRelativeInterval implements FilterDecoratorInterface
             $format .= '%';
         }
 
-        return $date->toUtcString($format);
+        return $date->toLocalString($format);
     }
 
     /**

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/TimezoneResolver.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/TimezoneResolver.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Segment\Decorator\Date;
+
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\DateTimeHelper;
+
+class TimezoneResolver
+{
+    /**
+     * @var CoreParametersHelper
+     */
+    private $coreParametersHelper;
+
+    public function __construct(
+        CoreParametersHelper $coreParametersHelper
+    ) {
+        $this->coreParametersHelper = $coreParametersHelper;
+    }
+
+    /**
+     * @param bool $hasTimePart
+     *
+     * @return DateTimeHelper
+     */
+    public function getDefaultDate($hasTimePart)
+    {
+        /**
+         * $hasTimePart tells us if field in a database is date or datetime
+         * All datetime fields are stored in UTC
+         * Date field, however, is always stored in a local time (there is no time information, so it cannot be converted to UTC).
+         *
+         * We will generate default date according to this. We need midnight as a default date (for relative intervals like "today" or "-1 day"
+         *  1) in UTC for datetime fields
+         *  2) in the local timezone for date fields
+         *
+         * Later we use toLocalString() method - it gives us midnight in UTC for first condition and midnight in local timezone for second option.
+         */
+        $timezone = $hasTimePart ? 'UTC' : $this->coreParametersHelper->getParameter('default_timezone', 'UTC');
+
+        $date = new \DateTime('midnight today', new \DateTimeZone($timezone));
+
+        return new DateTimeHelper($date, null, $timezone);
+    }
+}

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Week/DateWeekAbstract.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Week/DateWeekAbstract.php
@@ -31,11 +31,11 @@ abstract class DateWeekAbstract extends DateOptionAbstract
     protected function getValueForBetweenRange(DateTimeHelper $dateTimeHelper)
     {
         $dateFormat = $this->dateOptionParameters->hasTimePart() ? 'Y-m-d H:i:s' : 'Y-m-d';
-        $startWith  = $dateTimeHelper->toUtcString($dateFormat);
+        $startWith  = $dateTimeHelper->toLocalString($dateFormat);
 
         $modifier = $this->getModifierForBetweenRange().' -1 second';
         $dateTimeHelper->modify($modifier);
-        $endWith = $dateTimeHelper->toUtcString($dateFormat);
+        $endWith = $dateTimeHelper->toLocalString($dateFormat);
 
         return [$startWith, $endWith];
     }

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Year/DateYearAbstract.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Year/DateYearAbstract.php
@@ -30,7 +30,7 @@ abstract class DateYearAbstract extends DateOptionAbstract
      */
     protected function getValueForBetweenRange(DateTimeHelper $dateTimeHelper)
     {
-        return $dateTimeHelper->toUtcString('Y-%');
+        return $dateTimeHelper->toLocalString('Y-%');
     }
 
     /**

--- a/app/bundles/LeadBundle/Segment/Decorator/DateDecorator.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/DateDecorator.php
@@ -54,6 +54,8 @@ class DateDecorator extends CustomMappedDecorator
     }
 
     /**
+     * @deprecated Use DateOptionParameters->getDefaultDate() which takes timezone into account
+     *
      * @param null|string $relativeDate
      *
      * @return DateTimeHelper
@@ -64,8 +66,8 @@ class DateDecorator extends CustomMappedDecorator
 
         if ($relativeDate) {
             return new DateTimeHelper($relativeDate, null, $timezone);
-        } else {
-            return new DateTimeHelper('midnight today', null, $timezone);
         }
+
+        return new DateTimeHelper('midnight today', null, $timezone);
     }
 }

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/DateOptionFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/DateOptionFactoryTest.php
@@ -22,6 +22,7 @@ use Mautic\LeadBundle\Segment\Decorator\Date\Month\DateMonthThis;
 use Mautic\LeadBundle\Segment\Decorator\Date\Other\DateAnniversary;
 use Mautic\LeadBundle\Segment\Decorator\Date\Other\DateDefault;
 use Mautic\LeadBundle\Segment\Decorator\Date\Other\DateRelativeInterval;
+use Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver;
 use Mautic\LeadBundle\Segment\Decorator\Date\Week\DateWeekLast;
 use Mautic\LeadBundle\Segment\Decorator\Date\Week\DateWeekNext;
 use Mautic\LeadBundle\Segment\Decorator\Date\Week\DateWeekThis;
@@ -262,8 +263,9 @@ class DateOptionFactoryTest extends \PHPUnit_Framework_TestCase
      */
     private function getFilterDecorator($filterName)
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
-        $relativeDate  = $this->createMock(RelativeDate::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $relativeDate     = $this->createMock(RelativeDate::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $relativeDate->method('getRelativeDateStrings')
             ->willReturn(
@@ -285,7 +287,7 @@ class DateOptionFactoryTest extends \PHPUnit_Framework_TestCase
                 ]
             );
 
-        $dateOptionFactory = new DateOptionFactory($dateDecorator, $relativeDate);
+        $dateOptionFactory = new DateOptionFactory($dateDecorator, $relativeDate, $timezoneResolver);
 
         $filter                    = [
             'glue'     => 'and',

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayTodayTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayTodayTest.php
@@ -15,6 +15,7 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
 use Mautic\LeadBundle\Segment\Decorator\Date\Day\DateDayToday;
+use Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 
 class DateDayTodayTest extends \PHPUnit_Framework_TestCase
@@ -24,13 +25,14 @@ class DateDayTodayTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $filter        = [
             'operator' => '=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateDayToday($dateDecorator, $dateOptionParameters);
 
@@ -42,7 +44,8 @@ class DateDayTodayTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorLessOrEqual()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $dateDecorator->method('getOperator')
             ->with()
@@ -52,7 +55,7 @@ class DateDayTodayTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lte',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateDayToday($dateDecorator, $dateOptionParameters);
 
@@ -64,11 +67,12 @@ class DateDayTodayTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('2018-03-02', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -76,7 +80,7 @@ class DateDayTodayTest extends \PHPUnit_Framework_TestCase
             'operator' => '!=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateDayToday($dateDecorator, $dateOptionParameters);
 
@@ -88,11 +92,12 @@ class DateDayTodayTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueSingle()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('2018-03-02', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -100,7 +105,7 @@ class DateDayTodayTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lt',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateDayToday($dateDecorator, $dateOptionParameters);
 

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayTomorrowTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayTomorrowTest.php
@@ -15,6 +15,7 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
 use Mautic\LeadBundle\Segment\Decorator\Date\Day\DateDayTomorrow;
+use Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 
 class DateDayTomorrowTest extends \PHPUnit_Framework_TestCase
@@ -24,13 +25,14 @@ class DateDayTomorrowTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $filter        = [
             'operator' => '=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateDayTomorrow($dateDecorator, $dateOptionParameters);
 
@@ -42,7 +44,8 @@ class DateDayTomorrowTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorLessOrEqual()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $dateDecorator->method('getOperator')
             ->with()
@@ -52,7 +55,7 @@ class DateDayTomorrowTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lte',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateDayTomorrow($dateDecorator, $dateOptionParameters);
 
@@ -64,11 +67,12 @@ class DateDayTomorrowTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('2018-03-02', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -76,7 +80,7 @@ class DateDayTomorrowTest extends \PHPUnit_Framework_TestCase
             'operator' => '!=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateDayTomorrow($dateDecorator, $dateOptionParameters);
 
@@ -88,11 +92,12 @@ class DateDayTomorrowTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueSingle()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('2018-03-02', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -100,7 +105,7 @@ class DateDayTomorrowTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lt',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateDayTomorrow($dateDecorator, $dateOptionParameters);
 

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayYesterdayTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayYesterdayTest.php
@@ -15,6 +15,7 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
 use Mautic\LeadBundle\Segment\Decorator\Date\Day\DateDayYesterday;
+use Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 
 class DateDayYesterdayTest extends \PHPUnit_Framework_TestCase
@@ -24,13 +25,14 @@ class DateDayYesterdayTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $filter        = [
             'operator' => '=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateDayYesterday($dateDecorator, $dateOptionParameters);
 
@@ -42,7 +44,8 @@ class DateDayYesterdayTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorLessOrEqual()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $dateDecorator->method('getOperator')
             ->with()
@@ -52,7 +55,7 @@ class DateDayYesterdayTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lte',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateDayYesterday($dateDecorator, $dateOptionParameters);
 
@@ -64,11 +67,12 @@ class DateDayYesterdayTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('2018-03-02', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -76,7 +80,7 @@ class DateDayYesterdayTest extends \PHPUnit_Framework_TestCase
             'operator' => '!=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateDayYesterday($dateDecorator, $dateOptionParameters);
 
@@ -88,11 +92,12 @@ class DateDayYesterdayTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueSingle()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('2018-03-02', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -100,7 +105,7 @@ class DateDayYesterdayTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lt',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateDayYesterday($dateDecorator, $dateOptionParameters);
 

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Month/DateMonthLastTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Month/DateMonthLastTest.php
@@ -15,6 +15,7 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
 use Mautic\LeadBundle\Segment\Decorator\Date\Month\DateMonthLast;
+use Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 
 class DateMonthLastTest extends \PHPUnit_Framework_TestCase
@@ -24,13 +25,14 @@ class DateMonthLastTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $filter        = [
             'operator' => '=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateMonthLast($dateDecorator, $dateOptionParameters);
 
@@ -42,7 +44,8 @@ class DateMonthLastTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorLessOrEqual()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $dateDecorator->method('getOperator')
             ->with()
@@ -52,7 +55,7 @@ class DateMonthLastTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lte',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateMonthLast($dateDecorator, $dateOptionParameters);
 
@@ -64,11 +67,12 @@ class DateMonthLastTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -76,7 +80,7 @@ class DateMonthLastTest extends \PHPUnit_Framework_TestCase
             'operator' => '!=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateMonthLast($dateDecorator, $dateOptionParameters);
 
@@ -90,11 +94,12 @@ class DateMonthLastTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueSingle()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -102,7 +107,7 @@ class DateMonthLastTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lt',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateMonthLast($dateDecorator, $dateOptionParameters);
 

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Month/DateMonthNextTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Month/DateMonthNextTest.php
@@ -15,6 +15,7 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
 use Mautic\LeadBundle\Segment\Decorator\Date\Month\DateMonthNext;
+use Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 
 class DateMonthNextTest extends \PHPUnit_Framework_TestCase
@@ -24,13 +25,14 @@ class DateMonthNextTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $filter        = [
             'operator' => '=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateMonthNext($dateDecorator, $dateOptionParameters);
 
@@ -42,7 +44,8 @@ class DateMonthNextTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorLessOrEqual()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $dateDecorator->method('getOperator')
             ->with()
@@ -52,7 +55,7 @@ class DateMonthNextTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lte',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateMonthNext($dateDecorator, $dateOptionParameters);
 
@@ -64,11 +67,12 @@ class DateMonthNextTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -76,7 +80,7 @@ class DateMonthNextTest extends \PHPUnit_Framework_TestCase
             'operator' => '!=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateMonthNext($dateDecorator, $dateOptionParameters);
 
@@ -90,11 +94,12 @@ class DateMonthNextTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueSingle()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -102,7 +107,7 @@ class DateMonthNextTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lt',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateMonthNext($dateDecorator, $dateOptionParameters);
 

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Month/DateMonthThisTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Month/DateMonthThisTest.php
@@ -15,6 +15,7 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
 use Mautic\LeadBundle\Segment\Decorator\Date\Month\DateMonthThis;
+use Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 
 class DateMonthThisTest extends \PHPUnit_Framework_TestCase
@@ -24,13 +25,14 @@ class DateMonthThisTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $filter        = [
             'operator' => '=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateMonthThis($dateDecorator, $dateOptionParameters);
 
@@ -42,7 +44,8 @@ class DateMonthThisTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorLessOrEqual()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $dateDecorator->method('getOperator')
             ->with()
@@ -52,7 +55,7 @@ class DateMonthThisTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lte',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateMonthThis($dateDecorator, $dateOptionParameters);
 
@@ -64,11 +67,12 @@ class DateMonthThisTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -76,7 +80,7 @@ class DateMonthThisTest extends \PHPUnit_Framework_TestCase
             'operator' => '!=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateMonthThis($dateDecorator, $dateOptionParameters);
 
@@ -90,11 +94,12 @@ class DateMonthThisTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueSingle()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -102,7 +107,7 @@ class DateMonthThisTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lt',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateMonthThis($dateDecorator, $dateOptionParameters);
 

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateAnniversaryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateAnniversaryTest.php
@@ -13,7 +13,9 @@ namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Other;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
+use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
 use Mautic\LeadBundle\Segment\Decorator\Date\Other\DateAnniversary;
+use Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 
 class DateAnniversaryTest extends \PHPUnit_Framework_TestCase
@@ -24,9 +26,17 @@ class DateAnniversaryTest extends \PHPUnit_Framework_TestCase
     public function testGetOperator()
     {
         $dateDecorator             = $this->createMock(DateDecorator::class);
+        $timezoneResolver          = $this->createMock(TimezoneResolver::class);
+
+        $filter        = [
+            'operator' => '=',
+        ];
+        $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
+
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate([]);
 
-        $filterDecorator = new DateAnniversary($dateDecorator);
+        $filterDecorator = new DateAnniversary($dateDecorator, $dateOptionParameters);
 
         $this->assertEquals('like', $filterDecorator->getOperator($contactSegmentFilterCrate));
     }
@@ -36,17 +46,24 @@ class DateAnniversaryTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValue()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('2018-03-02', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
+        $filter        = [
+            'operator' => '=',
+        ];
+        $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
+
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate([]);
 
-        $filterDecorator = new DateAnniversary($dateDecorator);
+        $filterDecorator = new DateAnniversary($dateDecorator, $dateOptionParameters);
 
         $this->assertEquals('%-03-02', $filterDecorator->getParameterValue($contactSegmentFilterCrate));
     }

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateRelativeIntervalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateRelativeIntervalTest.php
@@ -13,7 +13,9 @@ namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Other;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
+use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
 use Mautic\LeadBundle\Segment\Decorator\Date\Other\DateRelativeInterval;
+use Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 
 class DateRelativeIntervalTest extends \PHPUnit_Framework_TestCase
@@ -23,13 +25,16 @@ class DateRelativeIntervalTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorEqual()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
+
         $filter        = [
             'operator' => '=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
-        $filterDecorator = new DateRelativeInterval($dateDecorator, '+5 days');
+        $filterDecorator = new DateRelativeInterval($dateDecorator, '+5 days', $dateOptionParameters);
 
         $this->assertEquals('like', $filterDecorator->getOperator($contactSegmentFilterCrate));
     }
@@ -39,13 +44,16 @@ class DateRelativeIntervalTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorNotEqual()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
+
         $filter        = [
             'operator' => '!=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
-        $filterDecorator = new DateRelativeInterval($dateDecorator, '+5 days');
+        $filterDecorator = new DateRelativeInterval($dateDecorator, '+5 days', $dateOptionParameters);
 
         $this->assertEquals('notLike', $filterDecorator->getOperator($contactSegmentFilterCrate));
     }
@@ -55,7 +63,8 @@ class DateRelativeIntervalTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorLessOrEqual()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $dateDecorator->method('getOperator')
             ->with()
@@ -65,8 +74,9 @@ class DateRelativeIntervalTest extends \PHPUnit_Framework_TestCase
             'operator' => '=<',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
-        $filterDecorator = new DateRelativeInterval($dateDecorator, '+5 days');
+        $filterDecorator = new DateRelativeInterval($dateDecorator, '+5 days', $dateOptionParameters);
 
         $this->assertEquals('==<<', $filterDecorator->getOperator($contactSegmentFilterCrate));
     }
@@ -76,11 +86,12 @@ class DateRelativeIntervalTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValuePlusDaysWithGreaterOperator()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('2018-03-02', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -88,8 +99,9 @@ class DateRelativeIntervalTest extends \PHPUnit_Framework_TestCase
             'operator' => '>',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
-        $filterDecorator = new DateRelativeInterval($dateDecorator, '+5 days');
+        $filterDecorator = new DateRelativeInterval($dateDecorator, '+5 days', $dateOptionParameters);
 
         $this->assertEquals('2018-03-07', $filterDecorator->getParameterValue($contactSegmentFilterCrate));
     }
@@ -99,11 +111,12 @@ class DateRelativeIntervalTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueMinusMonthWithNotEqualOperator()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('2018-03-02', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -111,8 +124,9 @@ class DateRelativeIntervalTest extends \PHPUnit_Framework_TestCase
             'operator' => '!=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
-        $filterDecorator = new DateRelativeInterval($dateDecorator, '-3 months');
+        $filterDecorator = new DateRelativeInterval($dateDecorator, '-3 months', $dateOptionParameters);
 
         $this->assertEquals('2017-12-02%', $filterDecorator->getParameterValue($contactSegmentFilterCrate));
     }
@@ -122,11 +136,12 @@ class DateRelativeIntervalTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueDaysAgoWithNotEqualOperator()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('2018-03-02', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -134,8 +149,9 @@ class DateRelativeIntervalTest extends \PHPUnit_Framework_TestCase
             'operator' => '!=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
-        $filterDecorator = new DateRelativeInterval($dateDecorator, '5 days ago');
+        $filterDecorator = new DateRelativeInterval($dateDecorator, '5 days ago', $dateOptionParameters);
 
         $this->assertEquals('2018-02-25%', $filterDecorator->getParameterValue($contactSegmentFilterCrate));
     }
@@ -145,11 +161,12 @@ class DateRelativeIntervalTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueYearsAgoWithGreaterOperator()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('2018-03-02', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -157,8 +174,9 @@ class DateRelativeIntervalTest extends \PHPUnit_Framework_TestCase
             'operator' => '>',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
-        $filterDecorator = new DateRelativeInterval($dateDecorator, '2 years ago');
+        $filterDecorator = new DateRelativeInterval($dateDecorator, '2 years ago', $dateOptionParameters);
 
         $this->assertEquals('2016-03-02', $filterDecorator->getParameterValue($contactSegmentFilterCrate));
     }
@@ -168,11 +186,12 @@ class DateRelativeIntervalTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueDaysWithEqualOperator()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('2018-03-02', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -180,8 +199,9 @@ class DateRelativeIntervalTest extends \PHPUnit_Framework_TestCase
             'operator' => '=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
-        $filterDecorator = new DateRelativeInterval($dateDecorator, '5 days');
+        $filterDecorator = new DateRelativeInterval($dateDecorator, '5 days', $dateOptionParameters);
 
         $this->assertEquals('2018-03-07%', $filterDecorator->getParameterValue($contactSegmentFilterCrate));
     }

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
@@ -160,7 +160,7 @@ class RelativeDateFunctionalTest extends MauticWebTestCase
         /** @var LeadRepository $leadRepository */
         $leadRepository = $this->container->get('doctrine.orm.default_entity_manager')->getRepository(Lead::class);
 
-        $date = new \DateTime($initialTime);
+        $date = new \DateTime($initialTime, new \DateTimeZone('UTC'));
         $date->modify($dateModifier);
 
         $lead = new Lead();

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Week/DateWeekLastTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Week/DateWeekLastTest.php
@@ -14,6 +14,7 @@ namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Week;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
+use Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver;
 use Mautic\LeadBundle\Segment\Decorator\Date\Week\DateWeekLast;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 
@@ -24,13 +25,14 @@ class DateWeekLastTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $filter        = [
             'operator' => '=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekLast($dateDecorator, $dateOptionParameters);
 
@@ -42,7 +44,8 @@ class DateWeekLastTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorLessOrEqual()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
         $dateDecorator->method('getOperator')
             ->with()
             ->willReturn('=<');
@@ -51,7 +54,7 @@ class DateWeekLastTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lte',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekLast($dateDecorator, $dateOptionParameters);
 
@@ -63,11 +66,12 @@ class DateWeekLastTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -75,7 +79,7 @@ class DateWeekLastTest extends \PHPUnit_Framework_TestCase
             'operator' => '!=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekLast($dateDecorator, $dateOptionParameters);
 
@@ -96,11 +100,12 @@ class DateWeekLastTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueSingle()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -108,7 +113,7 @@ class DateWeekLastTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lt',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekLast($dateDecorator, $dateOptionParameters);
 
@@ -122,10 +127,11 @@ class DateWeekLastTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueforGreaterOperatorIncludesSunday()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -133,7 +139,7 @@ class DateWeekLastTest extends \PHPUnit_Framework_TestCase
             'operator' => 'gt',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekLast($dateDecorator, $dateOptionParameters);
 
@@ -147,10 +153,11 @@ class DateWeekLastTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueForLessThanOperatorIncludesSunday()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -158,7 +165,7 @@ class DateWeekLastTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lte',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekLast($dateDecorator, $dateOptionParameters);
 

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Week/DateWeekNextTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Week/DateWeekNextTest.php
@@ -14,6 +14,7 @@ namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Week;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
+use Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver;
 use Mautic\LeadBundle\Segment\Decorator\Date\Week\DateWeekNext;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 
@@ -24,13 +25,14 @@ class DateWeekNextTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $filter        = [
             'operator' => '=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekNext($dateDecorator, $dateOptionParameters);
 
@@ -42,7 +44,8 @@ class DateWeekNextTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorLessOrEqual()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
         $dateDecorator->method('getOperator')
             ->with()
             ->willReturn('=<');
@@ -51,7 +54,7 @@ class DateWeekNextTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lte',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekNext($dateDecorator, $dateOptionParameters);
 
@@ -63,11 +66,12 @@ class DateWeekNextTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -75,7 +79,7 @@ class DateWeekNextTest extends \PHPUnit_Framework_TestCase
             'operator' => '!=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekNext($dateDecorator, $dateOptionParameters);
 
@@ -96,11 +100,12 @@ class DateWeekNextTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueSingle()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -108,7 +113,7 @@ class DateWeekNextTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lt',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekNext($dateDecorator, $dateOptionParameters);
 
@@ -122,10 +127,11 @@ class DateWeekNextTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueforGreaterOperatorIncludesSunday()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -133,7 +139,7 @@ class DateWeekNextTest extends \PHPUnit_Framework_TestCase
             'operator' => 'gt',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekNext($dateDecorator, $dateOptionParameters);
 
@@ -147,10 +153,11 @@ class DateWeekNextTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueForLessThanOperatorIncludesSunday()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -158,7 +165,7 @@ class DateWeekNextTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lte',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekNext($dateDecorator, $dateOptionParameters);
 

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Week/DateWeekThisTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Week/DateWeekThisTest.php
@@ -14,6 +14,7 @@ namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Week;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
+use Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver;
 use Mautic\LeadBundle\Segment\Decorator\Date\Week\DateWeekThis;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 
@@ -24,13 +25,14 @@ class DateWeekThisTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $filter        = [
             'operator' => '=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekThis($dateDecorator, $dateOptionParameters);
 
@@ -42,7 +44,8 @@ class DateWeekThisTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorLessOrEqual()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
         $dateDecorator->method('getOperator')
             ->with()
             ->willReturn('=<');
@@ -51,7 +54,7 @@ class DateWeekThisTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lte',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekThis($dateDecorator, $dateOptionParameters);
 
@@ -63,11 +66,12 @@ class DateWeekThisTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -75,7 +79,7 @@ class DateWeekThisTest extends \PHPUnit_Framework_TestCase
             'operator' => '!=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekThis($dateDecorator, $dateOptionParameters);
 
@@ -96,11 +100,12 @@ class DateWeekThisTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueSingle()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -108,7 +113,7 @@ class DateWeekThisTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lt',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekThis($dateDecorator, $dateOptionParameters);
 
@@ -122,10 +127,11 @@ class DateWeekThisTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueforGreaterOperatorIncludesSunday()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -133,7 +139,7 @@ class DateWeekThisTest extends \PHPUnit_Framework_TestCase
             'operator' => 'gt',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekThis($dateDecorator, $dateOptionParameters);
 
@@ -147,10 +153,11 @@ class DateWeekThisTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueForLessThanOperatorIncludesSunday()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -158,7 +165,7 @@ class DateWeekThisTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lte',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateWeekThis($dateDecorator, $dateOptionParameters);
 

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Year/DateYearLastTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Year/DateYearLastTest.php
@@ -14,6 +14,7 @@ namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Year;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
+use Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver;
 use Mautic\LeadBundle\Segment\Decorator\Date\Year\DateYearLast;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 
@@ -24,13 +25,14 @@ class DateYearLastTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $filter        = [
             'operator' => '=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateYearLast($dateDecorator, $dateOptionParameters);
 
@@ -42,7 +44,8 @@ class DateYearLastTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorLessOrEqual()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $dateDecorator->method('getOperator')
             ->with()
@@ -52,7 +55,7 @@ class DateYearLastTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lte',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateYearLast($dateDecorator, $dateOptionParameters);
 
@@ -64,11 +67,12 @@ class DateYearLastTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -76,7 +80,7 @@ class DateYearLastTest extends \PHPUnit_Framework_TestCase
             'operator' => '!=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateYearLast($dateDecorator, $dateOptionParameters);
 
@@ -90,11 +94,12 @@ class DateYearLastTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueSingle()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -102,7 +107,7 @@ class DateYearLastTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lt',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateYearLast($dateDecorator, $dateOptionParameters);
 

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Year/DateYearNextTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Year/DateYearNextTest.php
@@ -14,6 +14,7 @@ namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Year;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
+use Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver;
 use Mautic\LeadBundle\Segment\Decorator\Date\Year\DateYearNext;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 
@@ -24,13 +25,14 @@ class DateYearNextTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $filter        = [
             'operator' => '=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateYearNext($dateDecorator, $dateOptionParameters);
 
@@ -42,7 +44,8 @@ class DateYearNextTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorLessOrEqual()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $dateDecorator->method('getOperator')
             ->with()
@@ -52,7 +55,7 @@ class DateYearNextTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lte',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateYearNext($dateDecorator, $dateOptionParameters);
 
@@ -64,11 +67,12 @@ class DateYearNextTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -76,7 +80,7 @@ class DateYearNextTest extends \PHPUnit_Framework_TestCase
             'operator' => '!=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateYearNext($dateDecorator, $dateOptionParameters);
 
@@ -90,11 +94,12 @@ class DateYearNextTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueSingle()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -102,7 +107,7 @@ class DateYearNextTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lt',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateYearNext($dateDecorator, $dateOptionParameters);
 

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Year/DateYearThisTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Year/DateYearThisTest.php
@@ -14,6 +14,7 @@ namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Year;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
+use Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver;
 use Mautic\LeadBundle\Segment\Decorator\Date\Year\DateYearThis;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 
@@ -24,13 +25,14 @@ class DateYearThisTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $filter        = [
             'operator' => '=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateYearThis($dateDecorator, $dateOptionParameters);
 
@@ -42,7 +44,8 @@ class DateYearThisTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOperatorLessOrEqual()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $dateDecorator->method('getOperator')
             ->with()
@@ -52,7 +55,7 @@ class DateYearThisTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lte',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateYearThis($dateDecorator, $dateOptionParameters);
 
@@ -64,11 +67,12 @@ class DateYearThisTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueBetween()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -76,7 +80,7 @@ class DateYearThisTest extends \PHPUnit_Framework_TestCase
             'operator' => '!=',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateYearThis($dateDecorator, $dateOptionParameters);
 
@@ -90,11 +94,12 @@ class DateYearThisTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameterValueSingle()
     {
-        $dateDecorator = $this->createMock(DateDecorator::class);
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
         $date = new DateTimeHelper('', null, 'local');
 
-        $dateDecorator->method('getDefaultDate')
+        $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
@@ -102,7 +107,7 @@ class DateYearThisTest extends \PHPUnit_Framework_TestCase
             'operator' => 'lt',
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
-        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, []);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateYearThis($dateDecorator, $dateOptionParameters);
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |
| BC breaks? | N
| Deprecations? | Y

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When we store datetime in db we always store it in utc so all comparisons are done in utc. The same thing doesn't work for date fields however. They are always stored as-is and thus we need to compare them in instance-local timezone instead of utc otherwise the comparison doesn't work correctly and the higher is the timezone offset the higher is the chance we make an error.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
- Instance timezone is set to new york (utc-5)
- It is 2018-01-01 22:00 localtime and I create a new contact with custom date field set to 2018-01-01 (today)
- I create a segment that pulls contacts where the custom field is today
- the contact I just created will not be part of the segment

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat same process and contact will be added.

You can use `Antarctica/McMurdo` timezone for testing too (UTC+13)

#### List deprecations along with the new alternative:
1. `DateDecorator->getDefaultDate()` > `DateOptionParameters->getDefaultDate()`
