### PR TITLE
Handle aggregator fields on subscribed (emailed) reports.

### DIFF
--- a/app/bundles/ReportBundle/Crate/ReportDataResult.php
+++ b/app/bundles/ReportBundle/Crate/ReportDataResult.php
@@ -95,8 +95,7 @@ class ReportDataResult
 
         $row = $this->data[0];
         foreach ($row as $k => $v) {
-            $dataColumn = $data['dataColumns'][$k];
-
+            $dataColumn      = $data['dataColumns'][$k];
             $this->headers[] = $data['columns'][$dataColumn]['label'];
         }
     }
@@ -112,9 +111,12 @@ class ReportDataResult
 
         $row = $this->data[0];
         foreach ($row as $k => $v) {
-            $dataColumn = $data['dataColumns'][$k];
-
-            $this->types[$k] = $data['columns'][$dataColumn]['type'];
+            if (array_key_exists($k, $data['aggregatorColumns'])) {
+                $this->types[$k] = 'int';
+            } else {
+                $dataColumn      = $data['dataColumns'][$k];
+                $this->types[$k] = $data['columns'][$dataColumn]['type'];
+            }
         }
     }
 }

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -558,13 +558,13 @@ class ReportModel extends FormModel
 
         foreach ($aggregatorColumns as $aggregatorColumn) {
             $selectedColumns[] = $aggregatorColumn['column'];
+            // add aggregator columns to dataColumns also
+            $dataColumns[$aggregatorColumn['function'].' '.$aggregatorColumn['column']]           = $aggregatorColumn['column'];
+            $dataAggregatorColumns[$aggregatorColumn['function'].' '.$aggregatorColumn['column']] = $aggregatorColumn['column'];
         }
         // Build a reference for column to data column (without table prefix)
         foreach ($tableDetails['columns'] as $dbColumn => &$columnData) {
             $dataColumns[$columnData['alias']] = $dbColumn;
-            // add aggregator columns to dataColumns also
-            $dataColumns[$aggregatorColumn['function'].' '.$aggregatorColumn['column']]           = $aggregatorColumn['column'];
-            $dataAggregatorColumns[$aggregatorColumn['function'].' '.$aggregatorColumn['column']] = $aggregatorColumn['column'];
         }
 
         $orderBy    = $this->session->get('mautic.report.'.$entity->getId().'.orderby', '');

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\ReportBundle\Model;
 
+use Doctrine\DBAL\Connections\MasterSlaveConnection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Mautic\ChannelBundle\Helper\ChannelListHelper;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
@@ -155,14 +156,23 @@ class ReportModel extends FormModel
             $options['action'] = $action;
         }
 
-        $options = array_merge($options, [
-            'read_only'  => false,
-            'table_list' => $this->getTableData(),
-        ]);
+        $options = array_merge(
+            $options,
+            [
+                'read_only'  => false,
+                'table_list' => $this->getTableData(),
+            ]
+        );
 
         // Fire the REPORT_ON_BUILD event off to get the table/column data
 
-        $reportGenerator = new ReportGenerator($this->dispatcher, $this->em->getConnection(), $entity, $this->channelListHelper, $formFactory);
+        $reportGenerator = new ReportGenerator(
+            $this->dispatcher,
+            $this->em->getConnection(),
+            $entity,
+            $this->channelListHelper,
+            $formFactory
+        );
 
         return $reportGenerator->getForm($entity, $options);
     }
@@ -243,7 +253,13 @@ class ReportModel extends FormModel
                 //build them
                 $eventContext = ('all' == $context) ? '' : $context;
 
-                $event = new ReportBuilderEvent($this->translator, $this->channelListHelper, $eventContext, $this->fieldModel->getPublishedFieldArrays(), $this->reportHelper);
+                $event = new ReportBuilderEvent(
+                    $this->translator,
+                    $this->channelListHelper,
+                    $eventContext,
+                    $this->fieldModel->getPublishedFieldArrays(),
+                    $this->reportHelper
+                );
                 $this->dispatcher->dispatch(ReportEvents::REPORT_ON_BUILD, $event);
 
                 $tables = $event->getTables();
@@ -365,14 +381,15 @@ class ReportModel extends FormModel
      *
      * @param string $context
      *
-     * @return \stdClass [filterList => [], definitions => [], operatorChoices =>  [], operatorHtml => [], filterListHtml => '']
+     * @return \stdClass [filterList => [], definitions => [], operatorChoices =>  [], operatorHtml => [],
+     *                   filterListHtml => '']
      */
     public function getFilterList($context = 'all')
     {
         $tableData = $this->getTableData($context);
 
-        $return  = new \stdClass();
-        $filters = (isset($tableData['filters'])) ? $tableData['filters']
+        $return                  = new \stdClass();
+        $filters                 = (isset($tableData['filters'])) ? $tableData['filters']
             : (isset($tableData['columns']) ? $tableData['columns'] : []);
         $return->choices         = [];
         $return->choiceHtml      = '';
@@ -412,7 +429,9 @@ class ReportModel extends FormModel
 
         // First sort
         foreach ($graphData as $key => $details) {
-            $return->choices[$key] = $this->translator->trans($key).' ('.$this->translator->trans('mautic.report.graph.'.$details['type']).')';
+            $return->choices[$key] = $this->translator->trans($key).' ('.$this->translator->trans(
+                    'mautic.report.graph.'.$details['type']
+                ).')';
         }
         natsort($return->choices);
 
@@ -545,22 +564,30 @@ class ReportModel extends FormModel
 
         $paginate        = !empty($options['paginate']);
         $reportPage      = isset($options['reportPage']) ? $options['reportPage'] : 1;
-        $data            = $graphs            = [];
-        $reportGenerator = new ReportGenerator($this->dispatcher, $this->em->getConnection(), $entity, $this->channelListHelper, $formFactory);
+        $data            = $graphs = [];
+        $reportGenerator = new ReportGenerator(
+            $this->dispatcher,
+            $this->getConnection(),
+            $entity,
+            $this->channelListHelper,
+            $formFactory
+        );
 
         $selectedColumns = $entity->getColumns();
-        $totalResults    = $limit    = 0;
+        $totalResults    = $limit = 0;
 
         // Prepare the query builder
-        $tableDetails = $this->getTableData($entity->getSource());
-
+        $tableDetails      = $this->getTableData($entity->getSource());
+        $dataColumns       = $dataAggregatorColumns = [];
         $aggregatorColumns = ($aggregators = $entity->getAggregators()) ? $aggregators : [];
 
         foreach ($aggregatorColumns as $aggregatorColumn) {
             $selectedColumns[] = $aggregatorColumn['column'];
+            // add aggregator columns to dataColumns also
+            $dataColumns[$aggregatorColumn['function'].' '.$aggregatorColumn['column']]           = $aggregatorColumn['column'];
+            $dataAggregatorColumns[$aggregatorColumn['function'].' '.$aggregatorColumn['column']] = $aggregatorColumn['column'];
         }
         // Build a reference for column to data column (without table prefix)
-        $dataColumns = [];
         foreach ($tableDetails['columns'] as $dbColumn => &$columnData) {
             $dataColumns[$columnData['alias']] = $dbColumn;
         }
@@ -658,7 +685,6 @@ class ReportModel extends FormModel
                         ->setMaxResults($limit);
                 }
             }
-
             $queryTime = microtime(true);
             $data      = $query->execute()->fetchAll();
             $queryTime = round((microtime(true) - $queryTime) * 1000);
@@ -699,17 +725,18 @@ class ReportModel extends FormModel
         }
 
         return [
-            'totalResults'    => $totalResults,
-            'data'            => $data,
-            'dataColumns'     => $dataColumns,
-            'graphs'          => $graphs,
-            'contentTemplate' => $contentTemplate,
-            'columns'         => $tableDetails['columns'],
-            'limit'           => ($paginate) ? $limit : 0,
-            'page'            => ($paginate) ? $reportPage : 1,
-            'dateFrom'        => $dataOptions['dateFrom'],
-            'dateTo'          => $dataOptions['dateTo'],
-            'debug'           => $debugData,
+            'totalResults'      => $totalResults,
+            'data'              => $data,
+            'dataColumns'       => $dataColumns,
+            'graphs'            => $graphs,
+            'contentTemplate'   => $contentTemplate,
+            'columns'           => $tableDetails['columns'],
+            'limit'             => ($paginate) ? $limit : 0,
+            'page'              => ($paginate) ? $reportPage : 1,
+            'dateFrom'          => $dataOptions['dateFrom'],
+            'dateTo'            => $dataOptions['dateTo'],
+            'debug'             => $debugData,
+            'aggregatorColumns' => $dataAggregatorColumns,
         ];
     }
 
@@ -718,7 +745,8 @@ class ReportModel extends FormModel
      */
     public function getReportsWithGraphs()
     {
-        $ownedBy = $this->security->isGranted('report:reports:viewother') ? null : $this->userHelper->getUser()->getId();
+        $ownedBy = $this->security->isGranted('report:reports:viewother') ? null : $this->userHelper->getUser()->getId(
+        );
 
         return $this->getRepository()->findReportsWithGraphs($ownedBy);
     }
@@ -771,5 +799,17 @@ class ReportModel extends FormModel
         }
 
         return (int) $countQb->execute()->fetchColumn();
+    }
+
+    /**
+     * @return \Doctrine\DBAL\Connection
+     */
+    private function getConnection()
+    {
+        if ($this->em->getConnection() instanceof MasterSlaveConnection) {
+            $this->em->getConnection()->connect('slave');
+        }
+
+        return $this->em->getConnection();
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  YES
| New feature? |  NO
| Automated tests included? | NO
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If an Aggregator column is added to a report definition (COUNT of Contact ID for example) on a subsscribed/emailed report, the data definitions when creating headers for file export cant find a field alias to match column header because it now contains the aggregator word. Also, the resulting columns outputs the wrong type (assume original field type, for example boolean, rather than a type that applies to the aggregation - usually int.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new report that includes Leads
2. Add a Aggregation column for COUNT
3. Schedule report to be emailed daily
4. add an email address to send the report to
5. run console command mautic:report:schedule to kick off report send.
6. error received: `[2019-02-18 19:08:56] mautic.WARNING: Command `mautic:reports:scheduler` exited with status code 1


  [Symfony\Component\Debug\Exception\ContextErrorException]
  Notice: Undefined index: COUNT l.id`

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. repeat steps above

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
