### PR TITLE
Fix for "Send Email" campaign action randomly selecting a different email upon edit

### DIFF
--- a/app/bundles/CategoryBundle/Assets/js/category.js
+++ b/app/bundles/CategoryBundle/Assets/js/category.js
@@ -12,6 +12,6 @@ Mautic.categoryOnLoad = function (container, response) {
         mQuery(".category-select option:last").prev().before(newOption);
         newOption.prop('selected', true);
 
-        mQuery('.category-select').val(resposne.categoryId).trigger("chosen:updated");
+        mQuery('.category-select').val(response.categoryId).trigger("chosen:updated");
     }
 };

--- a/app/bundles/CategoryBundle/Assets/js/category.js
+++ b/app/bundles/CategoryBundle/Assets/js/category.js
@@ -12,6 +12,6 @@ Mautic.categoryOnLoad = function (container, response) {
         mQuery(".category-select option:last").prev().before(newOption);
         newOption.prop('selected', true);
 
-        mQuery('.category-select').trigger("chosen:updated");
+        mQuery('.category-select').val(resposne.categoryId).trigger("chosen:updated");
     }
 };

--- a/app/bundles/CoreBundle/Assets/js/6.forms.js
+++ b/app/bundles/CoreBundle/Assets/js/6.forms.js
@@ -468,7 +468,7 @@ Mautic.updateEntitySelect = function (response) {
         }
 
         newOption.prop('selected', true);
-        mQueryParent(el).trigger("chosen:updated");
+        mQueryParent(el).val(response.id).trigger("chosen:updated");
     }
 
     if (window.opener) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
After editing an email from the campaign builder (Action --> Send Email --> Edit Email button on the popup), Mautic randomly selects a different email to send. This could cause customers to have the wrong email in the campaign, unless the user is paying attention and notices that the "Email to send" has changed.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create Campaign
2. Add action "Send email"
3. Select email to send
4. Click "Edit email"
5. Make a change to the email (can be in the builder, publish/unpublish date, subject, internal name, etc.)
6. Click "Save and Close" in edit window
7. See that the "Email to send" has been changed

#### Steps to test this PR:
1. redo reproduction steps
2. same email will be selected instead
