### PR TITLE
Fix api datetime format

### DIFF
--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -82,7 +82,7 @@ trait RequestTrait
                             if ($timestamp) {
                                 switch ($type) {
                                     case 'datetime':
-                                        $params[$name] = (new \DateTime(date('Y-m-d H:i:s', $timestamp)))->format('Y-m-d H:i:s');
+                                        $params[$name] = (new \DateTime(date('Y-m-d H:i:s', $timestamp)))->format('Y-m-d H:i');
                                         break;
                                     case 'date':
                                         $params[$name] = (new \DateTime(date('Y-m-d', $timestamp)))->format('Y-m-d');


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fix `This value is not valid.` when you submit datetime field with API.

API format datetime like this : `Y-m-d H:i:s`
But all form want : `yyyy-MM-dd HH:mm`

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Configure API tester with your instance
2. Set post request with url : `/api/notes/new`
3. Set params :
```
lead => id_of_a_lead
text => foo
type => general
dateTime => 2019-02-20T08:26:19+00:00
```
4. Send request
5. Erreur response : 
```
"error": {
        "message": "dateTime: This value is not valid. (`error` is deprecated as of 2.6.0 and will be removed in 3.0. Use the `errors` array instead.)",
        "code": 400,
        "details": {
            "dateTime": [
                "This value is not valid."
            ]
        }
}
```

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7299)
2. Retry request
3. It's good!
