### PR TITLE
Fix DNC  enable/disable channel from Mautic prefs center

### DIFF
--- a/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
+++ b/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
@@ -174,18 +174,17 @@ trait FrequencyRuleTrait
      */
     protected function persistFrequencyRuleFormData(Lead $lead, array $formData, array $allChannels, $leadChannels, $currentChannelId = null)
     {
-        /** @var LeadModel $model */
-        $model = $this->getModel('lead');
+        /** @var LeadModel $leadModel */
+        $leadModel = $this->getModel('lead.lead');
+
+        /** @var \Mautic\LeadBundle\Model\DoNotContact $dncModel */
+        $dncModel = $this->getModel('lead.dnc');
 
         // iF subscribed_channels are enabled in form, then touch DNC
         if (isset($this->request->request->get('lead_contact_frequency_rules')['lead_channels']['subscribed_channels'])) {
             foreach ($formData['lead_channels']['subscribed_channels'] as $contactChannel) {
                 if (!isset($leadChannels[$contactChannel])) {
-                    $contactable = $model->isContactable($lead, $contactChannel);
-                    if ($contactable == DoNotContact::UNSUBSCRIBED) {
-                        // Only resubscribe if the contact did not opt out themselves
-                        $model->removeDncForLead($lead, $contactChannel);
-                    }
+                    $dncModel->addDncForContact($lead->getId(), $contactChannel, DoNotContact::IS_CONTACTABLE);
                 }
             }
             $dncChannels = array_diff($allChannels, $formData['lead_channels']['subscribed_channels']);
@@ -194,15 +193,10 @@ trait FrequencyRuleTrait
                     if ($currentChannelId) {
                         $channel = [$channel => $currentChannelId];
                     }
-                    $model->addDncForLead(
-                            $lead,
-                            $channel,
-                            'user',
-                            ($this->isPublicView) ? DoNotContact::UNSUBSCRIBED : DoNotContact::MANUAL
-                        );
+                    $dncModel->addDncForContact($lead->getId(), $channel, ($this->isPublicView) ? DoNotContact::UNSUBSCRIBED : DoNotContact::MANUAL, 'user');
                 }
             }
         }
-        $model->setFrequencyRules($lead, $formData, $this->leadLists);
+        $leadModel->setFrequencyRules($lead, $formData, $this->leadLists);
     }
 }

--- a/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
+++ b/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
@@ -181,7 +181,7 @@ trait FrequencyRuleTrait
         $dncModel = $this->getModel('lead.dnc');
 
         // iF subscribed_channels are enabled in form, then touch DNC
-        if (isset($this->request->request->get('lead_contact_frequency_rules')['lead_channels']['subscribed_channels'])) {
+        if (isset($this->request->request->get('lead_contact_frequency_rules')['lead_channels'])) {
             foreach ($formData['lead_channels']['subscribed_channels'] as $contactChannel) {
                 if (!isset($leadChannels[$contactChannel])) {
                     $dncModel->removeDncForContact($lead->getId(), $contactChannel);

--- a/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
+++ b/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
@@ -184,7 +184,7 @@ trait FrequencyRuleTrait
         if (isset($this->request->request->get('lead_contact_frequency_rules')['lead_channels']['subscribed_channels'])) {
             foreach ($formData['lead_channels']['subscribed_channels'] as $contactChannel) {
                 if (!isset($leadChannels[$contactChannel])) {
-                    $dncModel->addDncForContact($lead->getId(), $contactChannel, DoNotContact::IS_CONTACTABLE);
+                    $dncModel->removeDncForContact($lead->getId(), $contactChannel);
                 }
             }
             $dncChannels = array_diff($allChannels, $formData['lead_channels']['subscribed_channels']);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7296
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Noticed in 2.15 staging cannot remove DNC from Mautic for contact. 
This PR fixed it

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to contact profile
2. Disable email channel from contact profile
3. Then try enable it and see Do Not Contact label in profile

![image](https://user-images.githubusercontent.com/462477/53885387-e31bf400-401d-11e9-9329-87e042da7cc5.png)


#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat steps and enable/disable channel from prefs center in Mautic should works properly
