### PR TITLE
Possible fix for #7294

### DIFF
--- a/app/bundles/ConfigBundle/Controller/ConfigController.php
+++ b/app/bundles/ConfigBundle/Controller/ConfigController.php
@@ -35,10 +35,10 @@ class ConfigController extends FormController
      *
      * @return array
      */
-    protected function filterNormDataForLogging(array $data): array
+    protected function filterNormDataForLogging(array $data)
     {
         foreach ($data as $key => $value) {
-            if (is_array( $value )) {
+            if (is_array($value)) {
                 $value = $this->filterNormDataForLogging($value);
             }
 

--- a/app/bundles/ConfigBundle/Controller/ConfigController.php
+++ b/app/bundles/ConfigBundle/Controller/ConfigController.php
@@ -26,6 +26,33 @@ use Symfony\Component\HttpFoundation\Response;
 class ConfigController extends FormController
 {
     /**
+     * Recursively filters the specified array and replaces any UploadedFile instances with their contents
+     * (or NULL if the file cannot be read).
+     *
+     * @see https://github.com/mautic/mautic/issues/7294
+     *
+     * @param array $data
+     *
+     * @return array
+     */
+    protected function filterNormDataForLogging(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if (is_array( $value )) {
+                $value = $this->filterNormDataForLogging($value);
+            }
+
+            if ($value instanceof UploadedFile) {
+                $value = @file_get_contents($value->getFilename());
+            }
+
+            $data[$key] = $value;
+        }
+
+        return $data;
+    }
+    
+    /**
      * Controller action for editing the application configuration.
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\Response
@@ -77,7 +104,7 @@ class ConfigController extends FormController
                     $configEvent = new ConfigEvent($formData, $post);
                     $configEvent
                         ->setOriginalNormData($originalNormData)
-                        ->setNormData($form->getNormData());
+                        ->setNormData($this->filterNormDataForLogging($form->getNormData()));
                     $dispatcher->dispatch(ConfigEvents::CONFIG_PRE_SAVE, $configEvent);
                     $formValues = $configEvent->getConfig();
 

--- a/app/bundles/ConfigBundle/Controller/ConfigController.php
+++ b/app/bundles/ConfigBundle/Controller/ConfigController.php
@@ -52,7 +52,7 @@ class ConfigController extends FormController
 
         return $data;
     }
-    
+
     /**
      * Controller action for editing the application configuration.
      *

--- a/app/bundles/ConfigBundle/Controller/ConfigController.php
+++ b/app/bundles/ConfigBundle/Controller/ConfigController.php
@@ -17,6 +17,7 @@ use Mautic\ConfigBundle\Event\ConfigEvent;
 use Mautic\CoreBundle\Controller\FormController;
 use Mautic\CoreBundle\Helper\EncryptionHelper;
 use Symfony\Component\Form\FormError;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 


### PR DESCRIPTION
When the configuration is updated a `ConfigEvent` is dispatched carrying both the original form submission data and a normalized version. In the normalized version files are represented by `UploadedFile` instances.

The event is being picked up by the audit logger which attempts to store it in the database by serializing the configuration into a string. According to https://github.com/symfony/symfony-docs/pull/8180 `UploadedFile` instances cannot be serialized and throw an exception, which possibly what is happening in #7294.

With the above PR I am passing the normalized data through a filter which replaces all `UploadedFile` instances (recursively) with their contents (maybe the content is not the best idea?) when being passed to the event, allowing for the whole thing to be further serialized.

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #7294 
| BC breaks? | No
| Deprecations? | No

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to upload an IDP metadata file under Configuration / User/Authentication Settings.