### PR TITLE
Support multiple templates of the same type

### DIFF
--- a/app/bundles/CoreBundle/Event/CustomContentEvent.php
+++ b/app/bundles/CoreBundle/Event/CustomContentEvent.php
@@ -84,7 +84,10 @@ class CustomContentEvent extends Event
      */
     public function addTemplate($template, array $vars = [])
     {
-        $this->templates[$template] = $vars;
+        $this->templates[] = [
+            'template' => $template,
+            'vars'     => $vars,
+        ];
     }
 
     /**

--- a/app/bundles/CoreBundle/Templating/Helper/ContentHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/ContentHelper.php
@@ -61,7 +61,7 @@ class ContentHelper extends Helper
             $viewName = $vars['mauticTemplate'];
         }
 
-        /** @var ContentEvent $event */
+        /** @var CustomContentEvent $event */
         $event = $this->dispatcher->dispatch(
             CoreEvents::VIEW_INJECT_CUSTOM_CONTENT,
             new CustomContentEvent($viewName, $context, $vars)
@@ -69,9 +69,9 @@ class ContentHelper extends Helper
 
         $content = $event->getContent();
 
-        if ($templates = $event->getTemplates()) {
-            foreach ($templates as $template => $templateVars) {
-                $content[] = $this->templating->render($template, array_merge($vars, $templateVars));
+        if ($templatProps = $event->getTemplates()) {
+            foreach ($templatProps as $props) {
+                $content[] = $this->templating->render($props['template'], array_merge($vars, $props['vars']));
             }
         }
 

--- a/app/bundles/CoreBundle/Views/Helper/tableheader.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/tableheader.html.php
@@ -37,21 +37,20 @@ if (!empty($checkall)):
     endswitch;
 ?>
 <th class="col-actions" <?php if (!empty($tooltip)): ?> data-toggle="tooltip" title="" data-placement="top" data-original-title="<?php echo $view['translator']->trans($tooltip); ?>"<?php endif; ?>>
-    <?php if ($view['buttons']->getButtonCount()): ?>
     <div class="input-group input-group-sm">
-    <span class="input-group-addon">
-        <input type="checkbox" id="customcheckbox-one0" value="1" data-toggle="checkall" data-target="<?php echo $target; ?>">
-    </span>
+        <span class="input-group-addon">
+            <input type="checkbox" id="customcheckbox-one0" value="1" data-toggle="checkall" data-target="<?php echo $target; ?>">
+        </span>
 
-    <div class="input-group-btn">
-        <button type="button" disabled class="btn btn-default btn-sm dropdown-toggle btn-nospin" data-toggle="dropdown">
-            <i class="fa fa-angle-down "></i>
-        </button>
-        <ul class="pull-<?php echo $pull; ?> page-list-actions dropdown-menu" role="menu">
-            <?php echo $view['buttons']->renderButtons(); ?>
-        </ul>
+        <div class="input-group-btn">
+            <button type="button" disabled class="btn btn-default btn-sm dropdown-toggle btn-nospin" data-toggle="dropdown">
+                <i class="fa fa-angle-down "></i>
+            </button>
+            <ul class="pull-<?php echo $pull; ?> page-list-actions dropdown-menu" role="menu">
+                <?php echo $view['buttons']->renderButtons(); ?>
+            </ul>
+        </div>
     </div>
-    <?php endif; ?>
 </th>
 <?php elseif (empty($sessionVar)) : ?>
 <th<?php echo (!empty($class)) ? ' class="'.$class.'"' : ''; ?>>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | I don't think so
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When injecting some template through the `CoreEvents::VIEW_INJECT_CUSTOM_CONTENT` event it doesn't allow to add multiple templates of the same type because the template type is used as a key in the array. Here is our use case:

We have a plugin which adds several new tabs on the contact detail. So we do it like this:
```
foreach ($tabLinks as $tabLinkData) {
    $event->addTemplate('TestBundle:SubscribedEvents/Tab:link.html.php', $tabLinkData);
}
```
But it will always add only 1 tab link. The last one in the `$tabLinks` array. Hence we suggest to change the key to auto-incremented int instead of the template type.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Hard to do without the plugin, but code-review should suffice.

#### Steps to test this PR:
1. Hard to do without the plugin, but code-review should suffice. Maybe just ensure that the contact detail page have all tabs it used to and you can click through them.