### PR TITLE
Add query string to the base URL for the pagination limit select as the pagination buttons does it

### DIFF
--- a/app/bundles/CoreBundle/Views/Helper/pagination.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/pagination.html.php
@@ -102,7 +102,7 @@ foreach ($responsiveViewports as $viewport):
         <?php if (empty($fixedLimit)): ?>
             <div class="pull-right">
                 <?php $class = (!empty($paginationClass)) ? " input-{$paginationClass}" : ''; ?>
-                <select autocomplete="false" class="form-control not-chosen pagination-limit<?php echo $class; ?>" onchange="Mautic.limitTableData('<?php echo $sessionVar; ?>',this.value,'<?php echo $tmpl; ?>','<?php echo $target; ?>'<?php if (!empty($baseUrl)): ?>, '<?php echo $baseUrl; ?>'<?php endif; ?>);">
+                <select autocomplete="false" class="form-control not-chosen pagination-limit<?php echo $class; ?>" onchange="Mautic.limitTableData('<?php echo $sessionVar; ?>',this.value,'<?php echo $tmpl; ?>','<?php echo $target; ?>'<?php if (!empty($baseUrl)): ?>, '<?php echo $baseUrl.$queryString; ?>'<?php endif; ?>);">
                     <?php foreach ($limitOptions as $value => $label): ?>
                         <?php $selected = ($limit === $value) ? ' selected="selected"' : ''; ?>
                         <option<?php echo $selected; ?> value="<?php echo $view->escape($value); ?>">


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | /
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When calling table pagination template with a query string like this:
```
    <div class="panel-footer">
        <?php echo $view->render(
            'MauticCoreBundle:Helper:pagination.html.php',
            [
                'totalItems'  => $itemCount,
                'page'        => $page,
                'limit'       => $limit,
                'baseUrl'     => $route,
                'queryString' => "&contactId={$contactId}",
                'sessionVar'  => 'an.item',
                'routeBase'   => RouteProvider::ROUTE_LIST,
            ]
        ); ?>
    </div>
```
It adds the `queryString` to the buttons (1, 2, 3, ...) (line 86), but it will not add it to the limit select URL. So both pagination actions goes to different URL.

This PR unifies the actions to be the same.

#### Steps to test this PR:
1. Just code review and dis/agree with me 