### PR TITLE
Fix "check all" checkbox for tables loaded via ajax

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/8a.adminre.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/8a.adminre.js
@@ -375,6 +375,7 @@ if (typeof jQuery === "undefined") { throw new Error("This application requires 
 
                 // clicker
                 $(document).on("change", toggler, function () {
+                    target = $(toggler).data("target");
                     // checked / unchecked
                     if($(this).is(":checked")) {
                         selectrow(this, "checked");


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This issue this PR is fixing happens when the table is loaded via AJAX in a tab. In this scenario the `target` is null and later it will find all `parentsUntil(null)` which means all and removes the `active` class from them. Normally, there is no harm in that, but tabs use `active` class too and when removed the content disappears.

The solution I suggest is to read the target on change event. Not only on load which is useless for content loaded asynchronously.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. A plugin is needed for this. But code-review will do.

#### Steps to test this PR:
1. Make sure that selecting and unselecting all checkboxes on a table still works.