### PR TITLE
Do not record unnecessary isPublished changes

### DIFF
--- a/app/bundles/CoreBundle/Entity/FormEntity.php
+++ b/app/bundles/CoreBundle/Entity/FormEntity.php
@@ -387,9 +387,9 @@ class FormEntity extends CommonEntity
      */
     public function setIsPublished($isPublished)
     {
-        $this->isChanged('isPublished', $isPublished);
+        $this->isChanged('isPublished', (bool) $isPublished);
 
-        $this->isPublished = $isPublished;
+        $this->isPublished = (bool) $isPublished;
 
         return $this;
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

On every change of any entity we store a change which is not really a change but bad value type comparison. Consider this audit log changes:
```
array (
  'title' => 
  array (
    0 => NULL,
    1 => 'test',
  ),
  'template' => 
  array (
    0 => NULL,
    1 => 'blank',
  ),
  'isPublished' => 
  array (
    0 => true,
    1 => 1,
  ),
  'alias' => 
  array (
    0 => NULL,
    1 => 'test',
  ),
)
```
It makes sense, except the `isPublished` part. It tells us that `true` was changed to `1` which means the same thing. This is just clattering our databases with unnecessary information.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Edit a landing page for example. No need to make any change. Just save.
2. Check the `audit_log` table, the latest row. It will have the unnecessary `isPublished` field change recorded.

#### Steps to test this PR:
1. Repeat the steps to reproduce.
2. The `isPublished` change is not there.
3. Make sure that if you change the published status the change is recorded.
