### PR TITLE
Fix cache warmup on first load

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -527,7 +527,9 @@ class AppKernel extends Kernel
 
         // Warm up the cache if classes.php is missing or in dev mode
         if (!$fresh && $this->container->has('cache_warmer')) {
-            $this->container->get('cache_warmer')->warmUp($this->container->getParameter('kernel.cache_dir'));
+            $warmer = $this->container->get('cache_warmer');
+            $warmer->enableOptionalWarmers();
+            $warmer->warmUp($this->container->getParameter('kernel.cache_dir'));
         }
     }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Since code has been modified for PHP 7.0.0 inside `index.php` : 
```
if (version_compare(PHP_VERSION, '7.0.0', '<')) {
    $kernel->loadClassCache();
}
```
loadClassCache is never called which prevents proper warming of the cache.
classes.php is never created during user browsing, it's only generated if you launch Symfony command `cache:warmup` or `cache:clear` without --no-warmup arg.

Cause of lack of `classes.php`, application tries to generate a cache warm-up on each request and rewrites a large number of files (initializeContainer() inside AppKernel.php L.506).

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Clear your prod cache folder
2. Go to one page of Mautic
3. Look inside the new prod cache folder

![cache-before](https://user-images.githubusercontent.com/27768270/54113977-aec38180-43e9-11e9-97d8-0505b2e0f004.PNG)


#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7318)
2. Clear your prod cache folder
3. Go to one page of Mautic
4. Look inside the new prod cache folder

![cache-after](https://user-images.githubusercontent.com/27768270/54114028-cbf85000-43e9-11e9-9571-97c0fe2068e6.PNG)

