### PR TITLE
7250: Fix for Email to Contact API request with assets (reference to …

### DIFF
--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -124,9 +124,10 @@ class EmailApiController extends CommonApiController
                 return $lead;
             }
 
-            $post     = $this->request->request->all();
-            $tokens   = (!empty($post['tokens'])) ? $post['tokens'] : [];
-            $response = ['success' => false];
+            $post       = $this->request->request->all();
+            $tokens     = (!empty($post['tokens'])) ? $post['tokens'] : [];
+            $assetsIds  = (!empty($post['assetAttachments'])) ? $post['assetAttachments'] : [];
+            $response   = ['success' => false];
 
             $cleanTokens = [];
 
@@ -145,9 +146,10 @@ class EmailApiController extends CommonApiController
                 $entity,
                 $leadFields,
                 [
-                    'source'        => ['api', 0],
-                    'tokens'        => $cleanTokens,
-                    'return_errors' => true,
+                    'source'            => ['api', 0],
+                    'tokens'            => $cleanTokens,
+                    'assetAttachments'  => $assetsIds,
+                    'return_errors'     => true,
                 ]
             );
 

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -802,7 +802,8 @@ class MailHelper
             // Stash attachment to be processed by the transport
             $this->message->addAttachment($filePath, $fileName, $contentType, $inline);
         } else {
-            if (file_exists($filePath) && is_readable($filePath)) {
+            // filePath can contain the value of a local file path or the value of an URL where the file can be found
+            if (filter_var($filePath, FILTER_VALIDATE_URL) || (file_exists($filePath) && is_readable($filePath))) {
                 try {
                     $attachment = \Swift_Attachment::fromPath($filePath);
 


### PR DESCRIPTION
…these was lost at some point), fix for attaching remote files (there was a check if file existed which prevented forwarding the file path to sender - file path which was actually an URL)

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | Not needed
| Related developer documentation PR URL | Not needed
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7250
| BC breaks? | No
| Deprecations? | No

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Trying to send Email to Contact through API, I noticed the assets' ids sent on "assetAttachments" request parameter were lost at some point in code. Fixing this lead to this issue (https://github.com/mautic/mautic/issues/7250) which was caused by a check if file existed on disk before sending it to Swift_Attachment. This check didn't take into account that the asset might be remote located and that the filePath represented an URL making it impossible to pas this check.
I added a FILTER_VALIDATE_URL to check if filePath is valid.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try sending Email to Contact with attachments: first make Create Asset API call and forward the returned asset ids to Email to Contact API call through assetAttachments array. The create asset call needs to have the following parameters: storageLocation: "remote" and file: "a valid URL where a file can be downloaded from".
2. Check if received e-mail contains any attachments.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
