### PR TITLE
Remove lead entity last active index

### DIFF
--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -294,8 +294,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
             ->addLifecycleEvent('checkAttributionDate', 'prePersist')
             ->addLifecycleEvent('checkDateAdded', 'prePersist')
             ->addIndex(['date_added'], 'lead_date_added')
-            ->addIndex(['date_identified'], 'date_identified')
-            ->addIndex(['last_active'], 'last_active_search');
+            ->addIndex(['date_identified'], 'date_identified');
 
         $builder->createField('id', 'integer')
             ->makePrimaryKey()


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Remove index last_active_search from this PR https://github.com/mautic/mautic/pull/6279
This index already added by FieldModel https://github.com/kuzmany/mautic/blob/928661ba87ecc8970568dce899404cd9d09fe7ae/app/bundles/LeadBundle/Model/FieldModel.php#L494-L494

Yes, it caused a lot of ugly issues with `php app/console d:s:u --force`  remove a lot of columns and indexes. Script fail because it's duplicate index statement and everything after this line is removed from db  schema.

Discussed here https://github.com/mautic/mautic/issues/7167

#### Steps to test this PR:
1. Code review is enought
