### PR TITLE
Prevent destroySlots for code mode If builder was never  loaded

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -109,7 +109,9 @@ Mautic.launchBuilder = function (formName, actionName) {
         Mautic.activateButtonLoadingIndicator(applyBtn);
         Mautic.sendBuilderContentToTextarea(function() {
             // Trigger slot:destroy event
-            document.getElementById('builder-template-content').contentWindow.Mautic.destroySlots();
+            if(typeof document.getElementById('builder-template-content').contentWindow.Mautic !== 'undefined') {
+                document.getElementById('builder-template-content').contentWindow.Mautic.destroySlots();
+            }
             // Clear the customize forms
             mQuery('#slot-form-container, #section-form-container').html('');
             Mautic.inBuilderSubmissionOn(form);
@@ -164,7 +166,8 @@ Mautic.isInViewport = function(el) {
 };
 
 /**
- * Adds a hidded field which adds inBuilder=1 param to the request and will be returned in the response
+ * Adds a hidded field which adds inBuilder=1 param to the request and will be
+ * returned in the response
  *
  * @param jQuery object of form
  */
@@ -483,7 +486,8 @@ Mautic.closeBuilder = function(model) {
 };
 
 /**
- * Copies the HTML from the builder to the textarea and sanitizes it along the way.
+ * Copies the HTML from the builder to the textarea and sanitizes it along the
+ * way.
  *
  * @param Function callback
  * @param bool keepBuilderContent
@@ -542,7 +546,8 @@ Mautic.domToString = function(dom) {
 };
 
 /**
- * Removes stuff the Builder needs for it's magic but cannot be in the HTML result
+ * Removes stuff the Builder needs for it's magic but cannot be in the HTML
+ * result
  *
  * @param  object htmlContent
  */
@@ -563,8 +568,8 @@ Mautic.sanitizeHtmlBeforeSave = function(htmlContent) {
 };
 
 /**
- * Clones full HTML document by creating a virtual iframe, putting the HTML into it and
- * reading it back. This is async process.
+ * Clones full HTML document by creating a virtual iframe, putting the HTML
+ * into it and reading it back. This is async process.
  *
  * @param  object   content
  * @param  Function callback(clonedContent)

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -565,7 +565,8 @@ Mautic.sanitizeHtmlBeforeSave = function(htmlContent) {
 };
 
 /**
- * Clones full HTML document by creating a virtual iframe, putting the HTML into it and reading it back. This is async process.
+ * Clones full HTML document by creating a virtual iframe, putting the HTML into it and
+ * reading it back. This is async process.
  *
  * @param  object   content
  * @param  Function callback(clonedContent)

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -166,8 +166,7 @@ Mautic.isInViewport = function(el) {
 };
 
 /**
- * Adds a hidded field which adds inBuilder=1 param to the request and will be
- * returned in the response
+ * Adds a hidded field which adds inBuilder=1 param to the request and will be returned in the response
  *
  * @param jQuery object of form
  */
@@ -486,8 +485,7 @@ Mautic.closeBuilder = function(model) {
 };
 
 /**
- * Copies the HTML from the builder to the textarea and sanitizes it along the
- * way.
+ * Copies the HTML from the builder to the textarea and sanitizes it along the way.
  *
  * @param Function callback
  * @param bool keepBuilderContent
@@ -546,8 +544,7 @@ Mautic.domToString = function(dom) {
 };
 
 /**
- * Removes stuff the Builder needs for it's magic but cannot be in the HTML
- * result
+ * Removes stuff the Builder needs for it's magic but cannot be in the HTML result
  *
  * @param  object htmlContent
  */
@@ -568,8 +565,7 @@ Mautic.sanitizeHtmlBeforeSave = function(htmlContent) {
 };
 
 /**
- * Clones full HTML document by creating a virtual iframe, putting the HTML
- * into it and reading it back. This is async process.
+ * Clones full HTML document by creating a virtual iframe, putting the HTML into it and reading it back. This is async process.
  *
  * @param  object   content
  * @param  Function callback(clonedContent)

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -460,7 +460,9 @@ Mautic.closeBuilder = function(model) {
                 delete Mautic.codeMode;
             } else {
                 // Trigger slot:destroy event
-                document.getElementById('builder-template-content').contentWindow.Mautic.destroySlots();
+                if(typeof document.getElementById('builder-template-content').contentWindow.Mautic !== 'undefined') {
+                    document.getElementById('builder-template-content').contentWindow.Mautic.destroySlots();
+                }
 
                 // Clear the customize forms
                 mQuery('#slot-form-container, #section-form-container').html('');


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7340
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Noticed issues https://github.com/mautic/mautic/issues/7340
Error happen whe we never init builder with slots and will force use code mode. 

On production server require regenerate assets `php app/console mautic:assets:generate`


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Use firefox
2. Create a new email (add object and name)
3. Choose code mode
4. Copy and paste this html 
```
<!DOCTYPE html>
<html>
<body>
<h1>Test Heading</h1>
<p>Test paragraph.</p>
</body>
</html>
```
5. Click on apply
6. See that it still tries to load
![image](https://user-images.githubusercontent.com/31535432/54704796-c0203280-4b3b-11e9-9473-a9f62ff7710d.png)
And check the console inspector, you will see an error
<img width="824" alt="Capture d’écran 2019-03-20 à 18 09 51" src="https://user-images.githubusercontent.com/31535432/54704845-d62df300-4b3b-11e9-8ba1-6b0e5065914f.png">
7. Repeat this step with google chrome and you won't get a problem.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps
3. Apply button should works properly
