### PR TITLE
add flag to allow override of services

### DIFF
--- a/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php
+++ b/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php
@@ -31,6 +31,8 @@ class MauticCoreExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
+        $canOverrideServices = $this->canOverrideServices($container);
+
         $bundles = array_merge($container->getParameter('mautic.bundles'), $container->getParameter('mautic.plugin.bundles'));
 
         // Store menu renderer options to create unique renderering classes per menu
@@ -72,7 +74,7 @@ class MauticCoreExtension extends Extension
                     }
 
                     foreach ($services as $name => $details) {
-                        if (isset($serviceNames[$name])) {
+                        if (isset($serviceNames[$name]) && !$canOverrideServices) {
                             throw new \InvalidArgumentException("$name is already registered");
                         }
                         $serviceNames[$name] = true;
@@ -344,5 +346,20 @@ class MauticCoreExtension extends Extension
             // Reference
             $definitionArguments[] = new Reference($argument);
         }
+    }
+
+    /**
+     * Returns true if the parameter 'plugin_allow_overrides' is set to true
+     *
+     * @param ContainerBuilder $container
+     * @return bool
+     */
+    private function canOverrideServices(ContainerBuilder $container)
+    {
+        try {
+            return (bool)$container->getParameter('mautic.plugin_allow_overrides');
+        } catch (\Symfony\Component\DependencyInjection\Exception\InvalidArgumentException $e) {}
+
+        return false;
     }
 }

--- a/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php
+++ b/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php
@@ -349,16 +349,18 @@ class MauticCoreExtension extends Extension
     }
 
     /**
-     * Returns true if the parameter 'plugin_allow_overrides' is set to true
+     * Returns true if the parameter 'plugin_allow_overrides' is set to true.
      *
      * @param ContainerBuilder $container
+     *
      * @return bool
      */
     private function canOverrideServices(ContainerBuilder $container)
     {
         try {
-            return (bool)$container->getParameter('mautic.plugin_allow_overrides');
-        } catch (\Symfony\Component\DependencyInjection\Exception\InvalidArgumentException $e) {}
+            return (bool) $container->getParameter('mautic.plugin_allow_overrides');
+        } catch (\Symfony\Component\DependencyInjection\Exception\InvalidArgumentException $e) {
+        }
 
         return false;
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N 
| New feature? | Y 
| Automated tests included? | N 
| Related user documentation PR URL | N 
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/121 
| Issues addressed (#s or URLs) |  
| BC breaks? | N 
| Deprecations? | N 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Some integrators willing to tightly integrate Mautic with their ecosystem might need to extend the behavior of some core services.
The only way so far is to fork the project and to modify the code of the core.
This PR aims at giving to integrators a way of overriding the core services using the plugins, without need to fork or modify the core, thus enhancing the easiness of extension of the product.
To enable this behavior a parameter `plugin_allow_overrides` should be set equal to `true` in the `app/config/local.php` file.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

#### Steps to test this PR:
1. Install Mautic
2. Unzip this sample plugin that overrides a service in the `plugins` folder [SampleBundle.zip](https://github.com/mautic/mautic/files/3019335/SampleBundle.zip)
3. Clear the cache
4. Open Mautic in the browser, you should get an exception saying that "mautic.lead.model.list is already registered"
5. Add the parameter `plugin_allow_overrides` equal to `true` in the `app/config/local.php` file
6. Clear the cache
7. Open Mautic in the browser, you shouldn't get any exception and see the app correctly


#### List deprecations along with the new alternative:

#### List backwards compatibility breaks: