### PR TITLE
Prevent exceptions if a campaign jump target is removed.

### DIFF
--- a/app/bundles/CampaignBundle/EventListener/CampaignActionJumpToEventSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignActionJumpToEventSubscriber.php
@@ -95,6 +95,11 @@ class CampaignActionJumpToEventSubscriber implements EventSubscriberInterface
      * Process campaign.jump_to_event actions.
      *
      * @param PendingEvent $campaignEvent
+     *
+     * @throws \Mautic\CampaignBundle\Executioner\Dispatcher\Exception\LogNotProcessedException
+     * @throws \Mautic\CampaignBundle\Executioner\Dispatcher\Exception\LogPassedAndFailedException
+     * @throws \Mautic\CampaignBundle\Executioner\Exception\CannotProcessEventException
+     * @throws \Mautic\CampaignBundle\Executioner\Scheduler\Exception\NotSchedulableException
      */
     public function onJumpToEvent(PendingEvent $campaignEvent)
     {
@@ -102,10 +107,10 @@ class CampaignActionJumpToEventSubscriber implements EventSubscriberInterface
         $jumpTarget = $this->getJumpTargetForEvent($event, 'e.id');
 
         if ($jumpTarget === null) {
-            $campaignEvent->passWithError($jumpTarget, $this->translator->trans('mautic.campaign.campaign.jump_to_event.target_not_exist'));
+            $campaignEvent->passWithError($event, $this->translator->trans('mautic.campaign.campaign.jump_to_event.target_not_exist'));
+        } else {
+            $this->eventExecutioner->executeForContacts($jumpTarget, $campaignEvent->getContacts());
         }
-
-        $this->eventExecutioner->executeForContacts($jumpTarget, $campaignEvent->getContacts());
 
         $campaignEvent->passRemaining();
     }


### PR DESCRIPTION
Previously a null was passed to passWithError, and then an execution,
causing a spooling error that never resolves.

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If a jump-to event target is deleted/unpublished it can result in an exception which puts your campaign in a downward spiral of sadness.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a campaign with two events, one jumping to the other.
2. Delete the destination event
3. Run mautic:campaign:trigger and watch logs, you'll see an exception.
4. Repeat step 3 till the inevitable heat death of the universe.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create a campaign with two events, one jumping to the other. Save.
3. Edit the campaign and delete the destination event.
4. Add a lead to the campaign.
5. Wait about 15min and check out the lead. They should have gone through that jump event, but not the deleted one. You should have a SINGLE notification of a failed campaign event, and no more.
