### PR TITLE
Add multiselect length validator class

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -829,6 +829,10 @@ return [
                     'mautic.lead.repository.company_lead',
                 ],
             ],
+            'mautic.lead.validator.length' => [
+                'class'     => Mautic\LeadBundle\Validator\Constraints\LengthValidator::class,
+                'tag'       => 'validator.constraint_validator',
+            ],
         ],
         'repositories' => [
             'mautic.lead.repository.company' => [

--- a/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
@@ -13,11 +13,11 @@ namespace Mautic\LeadBundle\Form\Type;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Helper\FormFieldHelper;
+use Mautic\LeadBundle\Validator\Constraints\Length;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Validator\Constraints\Email;
-use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 trait EntityFieldsBuildFormTrait

--- a/app/bundles/LeadBundle/Tests/Validator/Constraints/LengthTest.php
+++ b/app/bundles/LeadBundle/Tests/Validator/Constraints/LengthTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Validator\Constraints;
+
+use Mautic\LeadBundle\Validator\Constraints\Length;
+use Mautic\LeadBundle\Validator\Constraints\LengthValidator;
+
+class LengthTest extends \PHPUnit_Framework_TestCase
+{
+    public function testValidateBy()
+    {
+        $constraint = new Length(['min' => 3]);
+        $this->assertEquals(LengthValidator::class, $constraint->validatedBy());
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Validator/Constraints/LengthValidatorTest.php
+++ b/app/bundles/LeadBundle/Tests/Validator/Constraints/LengthValidatorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Validator\Constraints;
+
+use Mautic\LeadBundle\Validator\Constraints\Length;
+use Mautic\LeadBundle\Validator\Constraints\LengthValidator;
+
+class LengthValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testValidate()
+    {
+        $constraint = new Length(['min' => 3]);
+        $validator  = new LengthValidator();
+        $this->assertNull($validator->validate('valid', $constraint));
+        // Not thrownig Symfony\Component\Validator\Exception\UnexpectedTypeException
+        $this->assertNull($validator->validate(['0', '1'], $constraint));
+    }
+}

--- a/app/bundles/LeadBundle/Validator/Constraints/Length.php
+++ b/app/bundles/LeadBundle/Validator/Constraints/Length.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraints\Length as SymfonyLength;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ */
+class Length extends SymfonyLength
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return \get_class($this).'Validator';
+    }
+}

--- a/app/bundles/LeadBundle/Validator/Constraints/LengthValidator.php
+++ b/app/bundles/LeadBundle/Validator/Constraints/LengthValidator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Validator\Constraints;
+
+use Mautic\LeadBundle\Helper\FormFieldHelper;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\LengthValidator as SymfonyLengthValidator;
+
+class LengthValidator extends SymfonyLengthValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (is_array($value)) {
+            $value = FormFieldHelper::formatList(FormFieldHelper::FORMAT_BAR, $value);
+        }
+
+        parent::validate($value, $constraint);
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7344 | discussion in PR https://github.com/mautic/mautic/pull/7103 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Adds missing Length validator able to validate arrays.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create multiselect custom field for contact
2. Try to save new info about contact in mautic UI

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. or same as in reproduction steps
