### PR TITLE
Fix SugarCrm sync priority

### DIFF
--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -1254,7 +1254,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
         $config                  = $this->mergeConfigToFeatureSettings();
         $integrationEntityRepo   = $this->em->getRepository('MauticPluginBundle:IntegrationEntity');
         $mauticData              = $leadsToUpdate              = $fields              = [];
-        $fieldsToUpdateInSugar   = isset($config['update_mautic']) ? array_keys($config['update_mautic'], 1) : [];
+        $fieldsToUpdateInSugar   = isset($config['update_mautic']) ? array_keys($config['update_mautic'], 0) : [];
         $leadFields              = $config['leadFields'];
         if (!empty($leadFields)) {
             if ($keys = array_keys($leadFields, 'mauticContactTimelineLink')) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Resolve wrong sync priority in SugarCRM within pushLeads function.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Install and configure SugarCRM
2. Map fields for Contact
3. Put `First Name` for Contact on Mautic priority
4. Create a contact with an `Email` and a `First Name` in SugarCrm
5. Run sync with command `mautic:integration:fetchleads`
6. Create a standalone form with `Email` field and `First Name` field
7. Add form action "Push contact to integration" and choose "SugarCrm"
8. Go to this form in private navigation and submit it with `Email` of previous created Lead but use an other `First Name`.
9. `First Name` is not pushed to SugarCrm.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7377)
2. Repeat step above
3. `First Name` is pushed to SugarCrm.
