### PR TITLE
Fixes issue with not recognizing IP ranges in the do not track list

### DIFF
--- a/app/bundles/CoreBundle/Entity/IpAddress.php
+++ b/app/bundles/CoreBundle/Entity/IpAddress.php
@@ -189,10 +189,10 @@ class IpAddress
                     // has a netmask range
                     // https://gist.github.com/tott/7684443
                     list($range, $netmask) = explode('/', $ip, 2);
-                    $range_decimal    = ip2long($range);
-                    $ip_decimal       = ip2long($this->ipAddress);
-                    $wildcard_decimal = pow(2, (32 - $netmask)) - 1;
-                    $netmask_decimal  = ~$wildcard_decimal;
+                    $range_decimal         = ip2long($range);
+                    $ip_decimal            = ip2long($this->ipAddress);
+                    $wildcard_decimal      = pow(2, (32 - $netmask)) - 1;
+                    $netmask_decimal       = ~$wildcard_decimal;
 
                     if ((($ip_decimal & $netmask_decimal) == ($range_decimal & $netmask_decimal))) {
                         return false;

--- a/app/bundles/CoreBundle/Entity/IpAddress.php
+++ b/app/bundles/CoreBundle/Entity/IpAddress.php
@@ -185,22 +185,24 @@ class IpAddress
     {
         if (!empty($this->doNotTrack)) {
             foreach ($this->doNotTrack as $ip) {
-                if (strpos($ip, '/') == false) {
-                    if (preg_match('/'.str_replace('.', '\\.', $ip).'/', $this->ipAddress)) {
-                        return false;
-                    }
-                } else {
+                if (strpos($ip, '/') !== false) {
                     // has a netmask range
                     // https://gist.github.com/tott/7684443
                     list($range, $netmask) = explode('/', $ip, 2);
-                    $range_decimal         = ip2long($range);
-                    $ip_decimal            = ip2long($ip);
-                    $wildcard_decimal      = pow(2, (32 - $netmask)) - 1;
-                    $netmask_decimal       = ~$wildcard_decimal;
+                    $range_decimal    = ip2long($range);
+                    $ip_decimal       = ip2long($this->ipAddress);
+                    $wildcard_decimal = pow(2, (32 - $netmask)) - 1;
+                    $netmask_decimal  = ~$wildcard_decimal;
 
                     if ((($ip_decimal & $netmask_decimal) == ($range_decimal & $netmask_decimal))) {
                         return false;
                     }
+
+                    continue;
+                }
+
+                if (preg_match('/'.str_replace('.', '\\.', $ip).'/', $this->ipAddress)) {
+                    return false;
                 }
             }
         }

--- a/app/bundles/CoreBundle/Tests/unit/Entity/IpAddressTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Entity/IpAddressTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+
+namespace Mautic\CoreBundle\Tests\Entity;
+
+
+use Mautic\CoreBundle\Entity\IpAddress;
+
+class IpAddressTest extends \PHPUnit_Framework_TestCase
+{
+    public function testExactIp()
+    {
+        $ipAddress = new IpAddress();
+        $ipAddress->setDoNotTrackList(
+            [
+                '192.168.0.1'
+            ]
+        );
+        $ipAddress->setIpAddress('192.168.0.1');
+        $this->assertFalse($ipAddress->isTrackable());
+
+        $ipAddress->setIpAddress('192.168.0.2');
+        $this->assertTrue($ipAddress->isTrackable());
+    }
+
+    public function testIpRange()
+    {
+        // HostMin:   172.16.0.1
+        // HostMax:   172.31.255.255
+        $ipAddress = new IpAddress();
+        $ipAddress->setDoNotTrackList(
+            [
+                '172.16.0.0/12',
+            ]
+        );
+
+        $ipAddress->setIpAddress('172.16.0.1');
+        $this->assertFalse($ipAddress->isTrackable());
+
+        $ipAddress->setIpAddress('172.31.255.254');
+        $this->assertFalse($ipAddress->isTrackable());
+
+        $ipAddress->setIpAddress('172.15.1.32');
+        $this->assertTrue($ipAddress->isTrackable());
+
+        $ipAddress->setIpAddress('172.32.0.0');
+        $this->assertTrue($ipAddress->isTrackable());
+    }
+
+    public function testIpWildcard()
+    {
+        $ipAddress = new IpAddress();
+        $ipAddress->setDoNotTrackList(
+            [
+                '172.15.1.*',
+            ]
+        );
+        $ipAddress->setIpAddress('172.15.1.1');
+        $this->assertFalse($ipAddress->isTrackable());
+
+        $ipAddress->setIpAddress('172.16.1.1');
+        $this->assertTrue($ipAddress->isTrackable());
+    }
+}

--- a/app/bundles/CoreBundle/Tests/unit/Entity/IpAddressTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Entity/IpAddressTest.php
@@ -9,9 +9,7 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-
 namespace Mautic\CoreBundle\Tests\Entity;
-
 
 use Mautic\CoreBundle\Entity\IpAddress;
 
@@ -22,7 +20,7 @@ class IpAddressTest extends \PHPUnit_Framework_TestCase
         $ipAddress = new IpAddress();
         $ipAddress->setDoNotTrackList(
             [
-                '192.168.0.1'
+                '192.168.0.1',
             ]
         );
         $ipAddress->setIpAddress('192.168.0.1');


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  Y
| New feature? | 
| Automated tests included? | Y 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When using IP ranges in the list of IPs to not track in Mautic's configuration (i.e. 111.111.0.0/12), Mautic used the blocked IP to compare against itself so the given IP was never detected as not trackable. This fixes that and includes unit tests for each of the supported scenarios. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. See the tests


#### Steps to test this PR:
1. Code review and run the new unit tests

