### PR TITLE
Install command and service

### DIFF
--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -1,0 +1,378 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\InstallBundle\Command;
+
+use Mautic\InstallBundle\Install\InstallService;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+/**
+ * CLI Command to install Mautic.
+ * Class InstallCommand.
+ */
+class InstallCommand extends ContainerAwareCommand
+{
+    const CHECK_STEP    = 0;
+    const DOCTRINE_STEP = 1;
+    const USER_STEP     = 2;
+    const EMAIL_STEP    = 3;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('mautic:install')
+            ->setDescription('Installs Mautic')
+            ->setHelp('This command allows you to trigger the install process.')
+            ->addArgument(
+                'site_url',
+                InputArgument::REQUIRED,
+                'Site URL.',
+                null
+            )
+            ->addArgument(
+                'step',
+                InputArgument::OPTIONAL,
+                'Install process start index. 0 for requirements check, 1 for database, 2 for admin, 3 for configuration. Each successful step will trigger the next until completion.',
+                0
+            )
+            ->addOption(
+                '--force',
+                '-f',
+                InputOption::VALUE_NONE,
+                'Do not ask confirmation if recommendations triggered.',
+                null
+            )
+            ->addOption(
+                '--db_driver',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Database driver.',
+                'pdo_mysql'
+            )
+            ->addOption(
+                '--db_host',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Database host.',
+                'localhost'
+            )
+            ->addOption(
+                '--db_port',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Database host.',
+                3306
+            )
+            ->addOption(
+                '--db_name',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Database name.',
+                'mautic'
+            )
+            ->addOption(
+                '--db_user',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Database user.',
+                'mautic'
+            )
+            ->addOption(
+                '--db_password',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Database password.',
+                null
+            )
+            ->addOption(
+                '--db_table_prefix',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Database tables prefix.',
+                null
+            )
+            ->addOption(
+                '--db_backup_tables',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Backup database tables if they exist; otherwise drop them.',
+                true
+            )
+            ->addOption(
+                '--db_backup_prefix',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Database backup tables prefix.',
+                'bak_'
+            )
+            ->addOption(
+                '--admin_firstname',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Admin first name.',
+                'Admin'
+            )
+            ->addOption(
+                '--admin_lastname',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Admin last name.',
+                'Mautic'
+            )
+            ->addOption(
+                '--admin_username',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Admin username.',
+                'admin'
+            )
+            ->addOption(
+                '--admin_email',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Admin email.',
+                null
+            )
+            ->addOption(
+                '--admin_password',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Admin user.',
+                null
+            )
+        ;
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $container    = $this->getContainer();
+        /** @var \Mautic\InstallBundle\Install\InstallService $installer */
+        $installer = $container->get('mautic.install.service');
+
+        $output->writeln([
+            'Mautic Install',
+            '==============',
+            '',
+        ]);
+
+        // Check Mautic is not already installed
+        if ($installer->checkIfInstalled()) {
+            $output->writeln('Mautic already installed');
+
+            return 0;
+        }
+
+        // Build objects to pass to the install service from local.php or command line options
+        $output->writeln('Parsing options and arguments...');
+        $options = $input->getOptions();
+
+        $dbParams     = [];
+        $adminOptions = [];
+        foreach ($options as $opt => $value) {
+            if ($value !== null) {
+                if ((substr($opt, 0, 3) === 'db_')) {
+                    $dbParams[substr($opt, 4)] = $value;
+                } elseif ((substr($opt, 0, 6) === 'admin_')) {
+                    $adminOptions[substr($opt, 7)] = $value;
+                }
+            }
+        }
+
+        $dbParams  = array_merge($dbParams, $installer->localConfigParameters());
+        $siteUrl   = $input->getArgument('site_url');
+        $allParams = array_merge($dbParams, ['site_url' => $siteUrl]);
+        $step      = $input->getArgument('step');
+
+        switch ($step) {
+            default:
+            case self::CHECK_STEP:
+                $output->writeln('Checking installation requirements...');
+                $messages = $this->stepAction($installer, ['site_url' => $siteUrl], $step);
+                if (is_array($messages) && !empty($messages)) {
+                    if (isset($messages['requirements']) && !empty($messages['requirements'])) {
+                        // Stop install if requirements not met
+                        $output->writeln('Missing requirements:');
+                        $this->handleInstallerErrors($output, $messages['requirements']);
+                        $output->writeln('Install canceled');
+
+                        return -$step;
+                    } elseif (isset($messages['optional']) && !empty($messages['optional'])) {
+                        $output->writeln('Missing optional settings:');
+                        $this->handleInstallerErrors($output, $messages['optional']);
+
+                        if (!isset($options['force'])) {
+                            // Ask user to confirm install when optional settings missing
+                            $helper   = $this->getHelper('question');
+                            $question = new ConfirmationQuestion('Continue with install anyway? ', false);
+
+                            if (!$helper->ask($input, $output, $question)) {
+                                return -$step;
+                            }
+                        }
+                    }
+                }
+                $output->writeln('Ready to Install!');
+
+            case self::DOCTRINE_STEP:
+                $step = self::DOCTRINE_STEP;
+                $output->writeln('Creating database...');
+                $messages = $this->stepAction($installer, $dbParams, $step);
+                if (is_array($messages) && !empty($messages)) {
+                    $this->handleInstallerErrors($output, $messages);
+
+                    return -$step;
+                }
+
+                $output->writeln('Creating schema...');
+                $messages = $this->stepAction($installer, $dbParams, $step + .1);
+                if (is_array($messages) && !empty($messages)) {
+                    $this->handleInstallerErrors($output, $messages);
+
+                    return -$step;
+                }
+
+                $output->writeln('Loading fixtures...');
+                $messages = $this->stepAction($installer, $dbParams, $step + .2);
+                if (is_array($messages) && !empty($messages)) {
+                    $this->handleInstallerErrors($output, $messages);
+
+                    return -$step;
+                }
+
+            case self::USER_STEP:
+                $step = self::USER_STEP;
+                $output->writeln('Creating admin user...');
+                $messages = $this->stepAction($installer, $adminOptions, $step);
+                if (is_array($messages) && !empty($messages)) {
+                    $this->handleInstallerErrors($output, $messages);
+
+                    return -$step;
+                }
+
+            case self::EMAIL_STEP:
+                $step = self::EMAIL_STEP;
+                $output->writeln('Email configuration and final steps...');
+                $messages = $this->stepAction($installer, $allParams, $step);
+                if (is_array($messages) && !empty($messages)) {
+                    $this->handleInstallerErrors($output, $messages);
+
+                    return -$step;
+                }
+        }
+
+        $output->writeln([
+            '',
+            '================',
+            'Install complete',
+            '================',
+        ]);
+
+        return 0;
+    }
+
+    /**
+     * Controller action for install steps.
+     *
+     * @param InstallService $installer The install process
+     * @param array          $params    The install parameters
+     * @param int            $index     The step number to process
+     *
+     * @return int|array|bool
+     *
+     * @throws \Exception
+     */
+    protected function stepAction(InstallService $installer, $params, $index = 0)
+    {
+        if (strpos($index, '.') !== false) {
+            list($index, $subIndex) = explode('.', $index);
+        }
+
+        $step = $installer->getStep($index);
+
+        $messages = false;
+        switch ($index) {
+            case self::CHECK_STEP:
+                // Check installation requirements
+                $step->site_url           = $params['site_url'];
+                $messages                 = [];
+                $messages['requirements'] = $installer->checkRequirements($step);
+                $messages['optional']     = $installer->checkOptionalSettings($step);
+                break;
+
+            case self::DOCTRINE_STEP:
+                if (!isset($subIndex)) {
+                    // Install database
+                    $messages = $installer->createDatabaseStep($step, $params);
+                } else {
+                    switch ((int) $subIndex) {
+                        case 1:
+                            // Install schema
+                            $messages = $installer->createSchemaStep($params);
+                            break;
+
+                        case 2:
+                            // Install fixtures
+                            $messages = $installer->createFixturesStep($this->getContainer());
+                            break;
+                    }
+                }
+                break;
+
+            case self::USER_STEP:
+                // Create admin user
+                $messages = $installer->createAdminUserStep($params);
+                break;
+
+            case self::EMAIL_STEP:
+                // Save email configuration
+                $messages = $installer->saveConfiguration($params, $step);
+                break;
+        }
+
+        if (is_bool($messages) && $messages === true) {
+            $siteUrl  = $params['site_url'];
+            $messages = $installer->createFinalConfigStep($siteUrl);
+
+            if (is_bool($messages) && $messages === true) {
+                $installer->finalMigrationStep();
+            }
+        }
+
+        return $messages;
+    }
+
+    /**
+     * @param OutputInterface $output
+     * @param array           $messages
+     */
+    private function handleInstallerErrors(OutputInterface $output, array $messages)
+    {
+        foreach ($messages as $type => $message) {
+            $output->write("[$type] $message");
+        }
+
+        $output->writeln([
+            '',
+        ]);
+    }
+}

--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -333,6 +333,7 @@ class InstallCommand extends ContainerAwareCommand
                 // Keep on with next step
                 $step = self::DOCTRINE_STEP;
 
+                // no break
             case self::DOCTRINE_STEP:
                 $output->writeln($step.' - Creating database...');
                 $messages = $this->stepAction($installer, $dbParams, $step);
@@ -371,6 +372,7 @@ class InstallCommand extends ContainerAwareCommand
                 // Keep on with next step
                 $step = self::USER_STEP;
 
+                // no break
             case self::USER_STEP:
                 $output->writeln($step.' - Creating admin user...');
                 $messages = $this->stepAction($installer, $adminParam, $step);
@@ -385,6 +387,7 @@ class InstallCommand extends ContainerAwareCommand
                 // Keep on with next step
                 $step = self::EMAIL_STEP;
 
+                // no break
             case self::EMAIL_STEP:
                 $output->writeln($step.' - Email configuration and final steps...');
                 $messages = $this->stepAction($installer, $allParams, $step);
@@ -421,7 +424,7 @@ class InstallCommand extends ContainerAwareCommand
      */
     protected function stepAction(InstallService $installer, $params, $index = 0)
     {
-        if (strpos($index, '.') !== false) {
+        if (false !== strpos($index, '.')) {
             list($index, $subIndex) = explode('.', $index);
         }
 
@@ -487,11 +490,11 @@ class InstallCommand extends ContainerAwareCommand
                 break;
         }
 
-        if (is_bool($messages) && $messages === true) {
+        if (is_bool($messages) && true === $messages) {
             $siteUrl  = $params['site_url'];
             $messages = $installer->createFinalConfigStep($siteUrl);
 
-            if (is_bool($messages) && $messages === true) {
+            if (is_bool($messages) && true === $messages) {
                 $installer->finalMigrationStep();
             }
         }
@@ -500,8 +503,7 @@ class InstallCommand extends ContainerAwareCommand
     }
 
     /**
-     * @param OutputInterface $output
-     * @param array           $messages
+     * Handle install command errors.
      */
     private function handleInstallerErrors(OutputInterface $output, array $messages)
     {

--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -68,28 +68,28 @@ class InstallCommand extends ContainerAwareCommand
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Database host.',
-                'localhost'
+                null
             )
             ->addOption(
                 '--db_port',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Database host.',
-                3306
+                'Database port.',
+                null
             )
             ->addOption(
                 '--db_name',
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Database name.',
-                'mautic'
+                null
             )
             ->addOption(
                 '--db_user',
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Database user.',
-                'mautic'
+                null
             )
             ->addOption(
                 '--db_password',
@@ -173,7 +173,7 @@ class InstallCommand extends ContainerAwareCommand
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Mail transport.',
-                'mail'
+                null
             )
             ->addOption(
                 '--mailer_host',
@@ -222,14 +222,14 @@ class InstallCommand extends ContainerAwareCommand
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Spool mode (file|memory).',
-                'memory'
+                null
             )
             ->addOption(
                 '--mailer_spool_path',
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Spool path.',
-                '%kernel.root_dir%/spool'
+                null
             )
         ;
         parent::configure();
@@ -264,6 +264,17 @@ class InstallCommand extends ContainerAwareCommand
         $dbParams   = [];
         $adminParam = [];
         $allParams  = $installer->localConfigParameters();
+
+        // Initialize DB and admin params from local.php
+        foreach ($allParams as $opt => $value) {
+            if (0 === strpos($opt, 'db_')) {
+                $dbParams[substr($opt, 3)] = $value;
+            } elseif (0 === strpos($opt, 'admin_')) {
+                $adminParam[substr($opt, 6)] = $value;
+            }
+        }
+
+        // Initialize DB and admin params from cli options
         foreach ($options as $opt => $value) {
             if (!empty($value)) {
                 if (0 === strpos($opt, 'db_')) {

--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -28,11 +28,6 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class InstallCommand extends ContainerAwareCommand
 {
-    const CHECK_STEP    = 0;
-    const DOCTRINE_STEP = 1;
-    const USER_STEP     = 2;
-    const EMAIL_STEP    = 3;
-
     /**
      * {@inheritdoc}
      */
@@ -249,18 +244,18 @@ class InstallCommand extends ContainerAwareCommand
         /** @var \Mautic\InstallBundle\Install\InstallService $installer */
         $installer = $container->get('mautic.install.service');
 
-        $output->writeln([
-            'Mautic Install',
-            '==============',
-            '',
-        ]);
-
         // Check Mautic is not already installed
         if ($installer->checkIfInstalled()) {
             $output->writeln('Mautic already installed');
 
             return 0;
         }
+
+        $output->writeln([
+            'Mautic Install',
+            '==============',
+            '',
+        ]);
 
         // Build objects to pass to the install service from local.php or command line options
         $output->writeln('Parsing options and arguments...');
@@ -303,7 +298,7 @@ class InstallCommand extends ContainerAwareCommand
 
         switch ($step) {
             default:
-            case self::CHECK_STEP:
+            case InstallService::CHECK_STEP:
                 $output->writeln($step.' - Checking installation requirements...');
                 $messages = $this->stepAction($installer, ['site_url' => $siteUrl], $step);
                 if (is_array($messages) && !empty($messages)) {
@@ -331,10 +326,10 @@ class InstallCommand extends ContainerAwareCommand
                 }
                 $output->writeln('Ready to Install!');
                 // Keep on with next step
-                $step = self::DOCTRINE_STEP;
+                $step = InstallService::DOCTRINE_STEP;
 
                 // no break
-            case self::DOCTRINE_STEP:
+            case InstallService::DOCTRINE_STEP:
                 $output->writeln($step.' - Creating database...');
                 $messages = $this->stepAction($installer, $dbParams, $step);
                 if (is_array($messages) && !empty($messages)) {
@@ -345,7 +340,7 @@ class InstallCommand extends ContainerAwareCommand
 
                     return -$step;
                 }
-                $step = self::DOCTRINE_STEP + .1;
+                $step = InstallService::DOCTRINE_STEP + .1;
 
                 $output->writeln($step.' - Creating schema...');
                 $messages = $this->stepAction($installer, $dbParams, $step);
@@ -355,9 +350,9 @@ class InstallCommand extends ContainerAwareCommand
 
                     $output->writeln('Install canceled');
 
-                    return -self::DOCTRINE_STEP;
+                    return -InstallService::DOCTRINE_STEP;
                 }
-                $step = self::DOCTRINE_STEP + .2;
+                $step = InstallService::DOCTRINE_STEP + .2;
 
                 $output->writeln($step.' - Loading fixtures...');
                 $messages = $this->stepAction($installer, $dbParams, $step);
@@ -367,13 +362,13 @@ class InstallCommand extends ContainerAwareCommand
 
                     $output->writeln('Install canceled');
 
-                    return -self::DOCTRINE_STEP;
+                    return -InstallService::DOCTRINE_STEP;
                 }
                 // Keep on with next step
-                $step = self::USER_STEP;
+                $step = InstallService::USER_STEP;
 
                 // no break
-            case self::USER_STEP:
+            case InstallService::USER_STEP:
                 $output->writeln($step.' - Creating admin user...');
                 $messages = $this->stepAction($installer, $adminParam, $step);
                 if (is_array($messages) && !empty($messages)) {
@@ -385,10 +380,10 @@ class InstallCommand extends ContainerAwareCommand
                     return -$step;
                 }
                 // Keep on with next step
-                $step = self::EMAIL_STEP;
+                $step = InstallService::EMAIL_STEP;
 
                 // no break
-            case self::EMAIL_STEP:
+            case InstallService::EMAIL_STEP:
                 $output->writeln($step.' - Email configuration and final steps...');
                 $messages = $this->stepAction($installer, $allParams, $step);
                 if (is_array($messages) && !empty($messages)) {
@@ -432,7 +427,7 @@ class InstallCommand extends ContainerAwareCommand
 
         $messages = false;
         switch ($index) {
-            case self::CHECK_STEP:
+            case InstallService::CHECK_STEP:
                 // Check installation requirements
                 if ($step instanceof CheckStep) {
                     // Set all step fields based on parameters
@@ -444,7 +439,7 @@ class InstallCommand extends ContainerAwareCommand
                 $messages['optional']     = $installer->checkOptionalSettings($step);
                 break;
 
-            case self::DOCTRINE_STEP:
+            case InstallService::DOCTRINE_STEP:
                 if ($step instanceof DoctrineStep) {
                     // Set all step fields based on parameters
                     foreach ($step as $key => $value) {
@@ -471,12 +466,12 @@ class InstallCommand extends ContainerAwareCommand
                 }
                 break;
 
-            case self::USER_STEP:
+            case InstallService::USER_STEP:
                 // Create admin user
                 $messages = $installer->createAdminUserStep($params);
                 break;
 
-            case self::EMAIL_STEP:
+            case InstallService::EMAIL_STEP:
                 // Save email configuration
                 if ($step instanceof EmailStep) {
                     // Set all step fields based on parameters

--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -165,7 +165,7 @@ class InstallCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $container    = $this->getContainer();
+        $container = $this->getContainer();
         /** @var \Mautic\InstallBundle\Install\InstallService $installer */
         $installer = $container->get('mautic.install.service');
 

--- a/app/bundles/InstallBundle/Config/config.php
+++ b/app/bundles/InstallBundle/Config/config.php
@@ -131,6 +131,7 @@ return [
                     'doctrine.orm.entity_manager',
                     'translator',
                     'kernel',
+                    'validator',
                     'security.encoder_factory',
                     'monolog.logger.mautic',
                 ],

--- a/app/bundles/InstallBundle/Config/config.php
+++ b/app/bundles/InstallBundle/Config/config.php
@@ -121,6 +121,20 @@ return [
                     'priority' => 2,
                 ],
             ],
+            'mautic.install.service' => [
+                'class'     => 'Mautic\InstallBundle\Install\InstallService',
+                'arguments' => [
+                    'mautic.configurator',
+                    'mautic.helper.core_parameters',
+                    'mautic.helper.cache',
+                    'mautic.helper.paths',
+                    'doctrine.orm.entity_manager',
+                    'translator',
+                    'kernel',
+                    'security.encoder_factory',
+                    'monolog.logger.mautic',
+                ],
+            ],
         ],
     ],
 ];

--- a/app/bundles/InstallBundle/Config/config.php
+++ b/app/bundles/InstallBundle/Config/config.php
@@ -125,7 +125,6 @@ return [
                 'class'     => 'Mautic\InstallBundle\Install\InstallService',
                 'arguments' => [
                     'mautic.configurator',
-                    'mautic.helper.core_parameters',
                     'mautic.helper.cache',
                     'mautic.helper.paths',
                     'doctrine.orm.entity_manager',
@@ -133,7 +132,6 @@ return [
                     'kernel',
                     'validator',
                     'security.encoder_factory',
-                    'monolog.logger.mautic',
                 ],
             ],
         ],

--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -70,7 +70,7 @@ class CheckStep implements StepInterface
         $this->configIsWritable = $configurator->isFileWritable();
         $this->kernelRoot       = $kernelRoot;
         if (!empty($request)) {
-            $this->site_url         = $request->getSchemeAndHttpHost().$request->getBasePath();
+            $this->site_url     = $request->getSchemeAndHttpHost().$request->getBasePath();
         }
         $this->openSSLCipher    = $openSSLCipher;
     }

--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -22,50 +22,35 @@ class CheckStep implements StepInterface
 {
     /**
      * Flag if the configuration file is writable.
-     *
-     * @var bool
      */
     private $configIsWritable;
 
     /**
      * Path to the kernel root.
-     *
-     * @var string
      */
     private $kernelRoot;
 
-    /**
-     * @var OpenSSLCipher
-     */
     private $openSSLCipher;
 
     /**
      * Absolute path to cache directory.
      * Required in step.
-     *
-     * @var string
      */
     public $cache_path = '%kernel.root_dir%/../var/cache';
 
     /**
      * Absolute path to log directory.
      * Required in step.
-     *
-     * @var string
      */
     public $log_path = '%kernel.root_dir%/../var/logs';
 
     /**
      * Set the domain URL for use in getting the absolute URL for cli/cronjob generated URLs.
-     *
-     * @var string
      */
     public $site_url;
 
     /**
      * Recommended minimum memory limit for Mautic.
-     *
-     * @var string
      */
     public static $memory_limit = '512M';
 
@@ -84,7 +69,9 @@ class CheckStep implements StepInterface
 
         $this->configIsWritable = $configurator->isFileWritable();
         $this->kernelRoot       = $kernelRoot;
-        $this->site_url         = $request->getSchemeAndHttpHost().$request->getBasePath();
+        if (!empty($request)) {
+            $this->site_url         = $request->getSchemeAndHttpHost().$request->getBasePath();
+        }
         $this->openSSLCipher    = $openSSLCipher;
     }
 

--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -57,6 +57,8 @@ class CheckStep implements StepInterface
 
     /**
      * Set the domain URL for use in getting the absolute URL for cli/cronjob generated URLs.
+     *
+     * @var string
      */
     public $site_url;
 

--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -22,25 +22,36 @@ class CheckStep implements StepInterface
 {
     /**
      * Flag if the configuration file is writable.
+     *
+     * @var bool
      */
     private $configIsWritable;
 
     /**
      * Path to the kernel root.
+     *
+     * @var string
      */
     private $kernelRoot;
 
+    /**
+     * @var OpenSSLCipher
+     */
     private $openSSLCipher;
 
     /**
      * Absolute path to cache directory.
      * Required in step.
+     *
+     * @var string
      */
     public $cache_path = '%kernel.root_dir%/../var/cache';
 
     /**
      * Absolute path to log directory.
      * Required in step.
+     *
+     * @var string
      */
     public $log_path = '%kernel.root_dir%/../var/logs';
 
@@ -51,6 +62,8 @@ class CheckStep implements StepInterface
 
     /**
      * Recommended minimum memory limit for Mautic.
+     *
+     * @var string
      */
     public static $memory_limit = '512M';
 

--- a/app/bundles/InstallBundle/Controller/InstallController.php
+++ b/app/bundles/InstallBundle/Controller/InstallController.php
@@ -25,11 +25,6 @@ use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 
 class InstallController extends CommonController
 {
-    const CHECK_STEP    = 0;
-    const DOCTRINE_STEP = 1;
-    const USER_STEP     = 2;
-    const EMAIL_STEP    = 3;
-
     private $configurator;
 
     private $installer;
@@ -76,8 +71,8 @@ class InstallController extends CommonController
             return $this->redirect($this->generateUrl('mautic_installer_step', ['index' => 1]));
         }
 
-        /** @var \Mautic\CoreBundle\Configurator\Step\StepInterface|array $step */
-        $step   = $this->configurator->getStep($index)[0];
+        /** @var \Mautic\CoreBundle\Configurator\Step\StepInterface $step */
+        $step   = $this->configurator->getStep($index);
         $action = $this->generateUrl('mautic_installer_step', ['index' => $index]);
 
         $form = $this->createForm($step->getFormType(), $step, ['action' => $action]);
@@ -93,11 +88,11 @@ class InstallController extends CommonController
                 $formData = $form->getData();
 
                 switch ($index) {
-                    case self::CHECK_STEP:
+                    case InstallService::CHECK_STEP:
                         $complete = true;
 
                         break;
-                    case self::DOCTRINE_STEP:
+                    case InstallService::DOCTRINE_STEP:
                         // password field does not retain configured defaults
                         if (empty($formData->password) && !empty($params['db_password'])) {
                             $formData->password = $params['db_password'];
@@ -117,7 +112,7 @@ class InstallController extends CommonController
                         }
                         break;
 
-                    case self::USER_STEP:
+                    case InstallService::USER_STEP:
                         $adminParam = (array) $formData;
                         $messages   = $this->installer->createAdminUserStep($adminParam);
 
@@ -132,7 +127,7 @@ class InstallController extends CommonController
                         }
                         break;
 
-                    case self::EMAIL_STEP:
+                    case InstallService::EMAIL_STEP:
                         $emailParam = (array) $formData;
                         $messages   = $this->installer->setupEmailStep($step, $emailParam);
                         if (is_bool($messages)) {
@@ -145,7 +140,7 @@ class InstallController extends CommonController
             }
         } elseif (!empty($subIndex)) {
             switch ($index) {
-                case self::DOCTRINE_STEP:
+                case InstallService::DOCTRINE_STEP:
                     $dbParams = (array) $step;
 
                     switch ((int) $subIndex) {

--- a/app/bundles/InstallBundle/Controller/InstallController.php
+++ b/app/bundles/InstallBundle/Controller/InstallController.php
@@ -124,7 +124,8 @@ class InstallController extends CommonController
                         break;
 
                     case self::USER_STEP:
-                        $messages = $this->installer->createAdminUserStep($formData);
+                        $adminParam = (array) $formData;
+                        $messages   = $this->installer->createAdminUserStep($adminParam);
 
                         if (is_bool($messages) && $messages === true) {
                             // Store the data to repopulate the form
@@ -138,7 +139,8 @@ class InstallController extends CommonController
                         break;
 
                     case self::EMAIL_STEP:
-                        $messages = $this->installer->saveConfiguration($formData, $step);
+                        $emailParam = (array) $formData;
+                        $messages   = $this->installer->setupEmailStep($step, $emailParam);
                         if (is_bool($messages)) {
                             $complete = $messages;
                         } elseif (is_array($messages) && !empty($messages)) {

--- a/app/bundles/InstallBundle/Controller/InstallController.php
+++ b/app/bundles/InstallBundle/Controller/InstallController.php
@@ -30,18 +30,12 @@ class InstallController extends CommonController
     const USER_STEP     = 2;
     const EMAIL_STEP    = 3;
 
-    /**
-     * @var Configurator
-     */
     private $configurator;
 
-    /**
-     * @var InstallService
-     */
     private $installer;
 
     /**
-     * @param FilterControllerEvent $event
+     * Initialize controller.
      */
     public function initialize(FilterControllerEvent $event)
     {
@@ -111,7 +105,7 @@ class InstallController extends CommonController
                         $dbParams = (array) $formData;
 
                         $messages = $this->installer->createDatabaseStep($step, $dbParams);
-                        if (is_bool($messages) && $messages === true) {
+                        if (is_bool($messages) && true === $messages) {
                             // XXX Regression: we used to also get this if database created but configuration not saved
                             $schemaHelper             = new SchemaHelper($dbParams);
                             $formData->server_version = $schemaHelper->getServerVersion();
@@ -127,7 +121,7 @@ class InstallController extends CommonController
                         $adminParam = (array) $formData;
                         $messages   = $this->installer->createAdminUserStep($adminParam);
 
-                        if (is_bool($messages) && $messages === true) {
+                        if (is_bool($messages) && true === $messages) {
                             // Store the data to repopulate the form
                             unset($formData->password);
                             $session->set('mautic.installer.user', $formData);
@@ -158,7 +152,7 @@ class InstallController extends CommonController
                         case 1:
                             $messages = $this->installer->createSchemaStep($dbParams);
 
-                            if (is_bool($messages) && $messages === true) {
+                            if (is_bool($messages) && true === $messages) {
                                 return $this->redirect($this->generateUrl('mautic_installer_step', ['index' => 1.2]));
                             } elseif (is_array($messages) && !empty($messages)) {
                                 $this->handleInstallerErrors($form, $messages);
@@ -168,7 +162,7 @@ class InstallController extends CommonController
                         case 2:
                             $messages = $this->installer->createFixturesStep($this->container);
 
-                            if (is_bool($messages) && $messages === true) {
+                            if (is_bool($messages) && true === $messages) {
                                 $complete = true;
                             } elseif (is_array($messages) && !empty($messages)) {
                                 $this->handleInstallerErrors($form, $messages);
@@ -298,8 +292,7 @@ class InstallController extends CommonController
     }
 
     /**
-     * @param Form  $form
-     * @param array $messages
+     * Handle installer errors.
      */
     private function handleInstallerErrors(Form $form, array $messages)
     {

--- a/app/bundles/InstallBundle/Controller/InstallController.php
+++ b/app/bundles/InstallBundle/Controller/InstallController.php
@@ -150,7 +150,7 @@ class InstallController extends CommonController
         } elseif (!empty($subIndex)) {
             switch ($index) {
                 case self::DOCTRINE_STEP:
-                    $dbParams     = (array) $step;
+                    $dbParams = (array) $step;
 
                     switch ((int) $subIndex) {
                         case 1:

--- a/app/bundles/InstallBundle/Controller/InstallController.php
+++ b/app/bundles/InstallBundle/Controller/InstallController.php
@@ -11,22 +11,12 @@
 
 namespace Mautic\InstallBundle\Controller;
 
-use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
-use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\DBAL\DBALException;
-use Doctrine\ORM\OptimisticLockException;
-use Doctrine\ORM\ORMException;
 use Mautic\CoreBundle\Configurator\Configurator;
-use Mautic\CoreBundle\Configurator\Step\StepInterface;
 use Mautic\CoreBundle\Controller\CommonController;
-use Mautic\CoreBundle\Helper\CacheHelper;
-use Mautic\CoreBundle\Helper\EncryptionHelper;
 use Mautic\InstallBundle\Helper\SchemaHelper;
-use Mautic\UserBundle\Entity\User;
-use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Console\Output\BufferedOutput;
+use Mautic\InstallBundle\Install\InstallService;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -45,9 +35,18 @@ class InstallController extends CommonController
      */
     private $configurator;
 
+    /**
+     * @var InstallService
+     */
+    private $installer;
+
+    /**
+     * @param FilterControllerEvent $event
+     */
     public function initialize(FilterControllerEvent $event)
     {
         $this->configurator = $this->container->get('mautic.configurator');
+        $this->installer    = $this->container->get('mautic.install.service');
     }
 
     /**
@@ -63,7 +62,7 @@ class InstallController extends CommonController
     {
         // We're going to assume a bit here; if the config file exists already and DB info is provided, assume the app
         // is installed and redirect
-        if ($this->checkIfInstalled()) {
+        if ($this->installer->checkIfInstalled()) {
             return $this->redirect($this->generateUrl('mautic_dashboard_index'));
         }
 
@@ -72,11 +71,6 @@ class InstallController extends CommonController
         }
 
         $params = $this->configurator->getParameters();
-        $step   = $this->configurator->getStep($index)[0];
-        $action = $this->generateUrl('mautic_installer_step', ['index' => $index]);
-
-        $form = $this->createForm($step->getFormType(), $step, ['action' => $action]);
-        $tmpl = $this->request->isXmlHttpRequest() ? $this->request->get('tmpl', 'index') : 'index';
 
         $session        = $this->get('session');
         $completedSteps = $session->get('mautic.installer.completedsteps', []);
@@ -87,6 +81,13 @@ class InstallController extends CommonController
 
             return $this->redirect($this->generateUrl('mautic_installer_step', ['index' => 1]));
         }
+
+        /** @var \Mautic\CoreBundle\Configurator\Step\StepInterface|array $step */
+        $step   = $this->configurator->getStep($index)[0];
+        $action = $this->generateUrl('mautic_installer_step', ['index' => $index]);
+
+        $form = $this->createForm($step->getFormType(), $step, ['action' => $action]);
+        $tmpl = $this->request->isXmlHttpRequest() ? $this->request->get('tmpl', 'index') : 'index';
 
         // Note if this step is complete
         $complete = false;
@@ -108,53 +109,41 @@ class InstallController extends CommonController
                             $formData->password = $params['db_password'];
                         }
                         $dbParams = (array) $formData;
-                        $this->validateDatabaseParams($form, $dbParams);
-                        if (!$form->getErrors(true)->count()) {
-                            // Check if connection works and/or create database if applicable
-                            $schemaHelper = new SchemaHelper($dbParams);
 
-                            try {
-                                $schemaHelper->testConnection();
+                        $messages = $this->installer->createDatabaseStep($step, $dbParams);
+                        if (is_bool($messages) && $messages === true) {
+                            // XXX Regression: we used to also get this if database created but configuration not saved
+                            $schemaHelper             = new SchemaHelper($dbParams);
+                            $formData->server_version = $schemaHelper->getServerVersion();
 
-                                if ($schemaHelper->createDatabase()) {
-                                    $formData->server_version = $schemaHelper->getServerVersion();
-                                    if ($this->saveConfiguration($formData, $step)) {
-                                        // Refresh to install schema with new connection information in the container
-                                        return $this->redirect($this->generateUrl('mautic_installer_step', ['index' => 1.1]));
-                                    }
-
-                                    $this->addFlash('mautic.installer.error.writing.configuration', [], 'error');
-                                } else {
-                                    $this->addFlash('mautic.installer.error.creating.database', ['%name%' => $dbParams['name']], 'error');
-                                }
-                            } catch (\Exception $exception) {
-                                $this->addFlash('mautic.installer.error.connecting.database', ['%exception%' => $exception->getMessage()], 'error');
-                            }
+                            // Refresh to install schema with new connection information in the container
+                            return $this->redirect($this->generateUrl('mautic_installer_step', ['index' => 1.1]));
+                        } elseif (is_array($messages) && !empty($messages)) {
+                            $this->handleInstallerErrors($form, $messages);
                         }
                         break;
 
                     case self::USER_STEP:
-                        try {
-                            $this->createAdminUserStep($formData);
+                        $messages = $this->installer->createAdminUserStep($formData);
 
+                        if (is_bool($messages) && $messages === true) {
                             // Store the data to repopulate the form
                             unset($formData->password);
                             $session->set('mautic.installer.user', $formData);
 
                             $complete = true;
-                        } catch (\Exception $exception) {
-                            $this->addFlash('mautic.installer.error.creating.user', ['%exception%' => $exception->getMessage()], 'error');
+                        } elseif (is_array($messages) && !empty($messages)) {
+                            $this->handleInstallerErrors($form, $messages);
                         }
-
                         break;
 
                     case self::EMAIL_STEP:
-                        if (!$this->saveConfiguration($formData, $step)) {
-                            $this->addFlash('mautic.installer.error.writing.configuration', [], 'error');
-                        } else {
-                            $complete = true;
+                        $messages = $this->installer->saveConfiguration($formData, $step);
+                        if (is_bool($messages)) {
+                            $complete = $messages;
+                        } elseif (is_array($messages) && !empty($messages)) {
+                            $this->handleInstallerErrors($form, $messages);
                         }
-
                         break;
                 }
             }
@@ -162,29 +151,25 @@ class InstallController extends CommonController
             switch ($index) {
                 case self::DOCTRINE_STEP:
                     $dbParams     = (array) $step;
-                    $schemaHelper = new SchemaHelper($dbParams);
-
-                    $schemaHelper->setEntityManager($this->get('doctrine.orm.entity_manager'));
 
                     switch ((int) $subIndex) {
                         case 1:
-                            try {
-                                if (!$schemaHelper->installSchema()) {
-                                    $this->addFlash('mautic.installer.error.no.metadata', [], 'error');
-                                } else {
-                                    return $this->redirect($this->generateUrl('mautic_installer_step', ['index' => 1.2]));
-                                }
-                            } catch (\Exception $exception) {
-                                $this->addFlash('mautic.installer.error.installing.data', ['%exception%' => $exception->getMessage(), 'error']);
+                            $messages = $this->installer->createSchemaStep($dbParams);
+
+                            if (is_bool($messages) && $messages === true) {
+                                return $this->redirect($this->generateUrl('mautic_installer_step', ['index' => 1.2]));
+                            } elseif (is_array($messages) && !empty($messages)) {
+                                $this->handleInstallerErrors($form, $messages);
                             }
 
                             return $this->redirect($this->generateUrl('mautic_installer_step', ['index' => 1]));
                         case 2:
-                            try {
-                                $this->installDatabaseFixtures();
+                            $messages = $this->installer->createFixturesStep($this->container);
+
+                            if (is_bool($messages) && $messages === true) {
                                 $complete = true;
-                            } catch (\Exception $exception) {
-                                $this->addFlash('mautic.installer.error.adding.fixtures', ['%exception%' => $exception->getMessage()], 'error');
+                            } elseif (is_array($messages) && !empty($messages)) {
+                                $this->handleInstallerErrors($form, $messages);
 
                                 return $this->redirect($this->generateUrl('mautic_installer_step', ['index' => 1]));
                             }
@@ -204,14 +189,11 @@ class InstallController extends CommonController
 
                 return $this->redirect($this->generateUrl('mautic_installer_step', ['index' => (int) $index]));
             } else {
-                // Merge final things into the config, wipe the container, and we're done!
-                $finalConfigVars = [
-                    'secret_key' => EncryptionHelper::generateKey(),
-                    'site_url'   => $this->request->getSchemeAndHttpHost().$this->request->getBasePath(),
-                ];
+                $siteUrl  = $this->request->getSchemeAndHttpHost().$this->request->getBaseUrl();
+                $messages = $this->installer->createFinalConfigStep($siteUrl);
 
-                if (!$this->saveConfiguration($finalConfigVars, null)) {
-                    $this->addFlash('mautic.installer.error.writing.configuration', [], 'error');
+                if (is_array($messages) && !empty($messages)) {
+                    $this->handleInstallerErrors($form, $messages);
                 }
 
                 return $this->postActionRedirect(
@@ -272,7 +254,7 @@ class InstallController extends CommonController
         $session = $this->get('session');
 
         // We're going to assume a bit here; if the config file exists already and DB info is provided, assume the app is installed and redirect
-        if ($this->checkIfInstalled()) {
+        if ($this->installer->checkIfInstalled()) {
             if (!$session->has('mautic.installer.completedsteps')) {
                 // Arrived here by directly browsing to URL so redirect to the dashboard
 
@@ -287,14 +269,7 @@ class InstallController extends CommonController
         $session->remove('mautic.installer.completedsteps');
         $session->remove('mautic.installer.user');
 
-        // Add database migrations up to this point since this is a fresh install (must be done at this point
-        // after the cache has been rebuilt
-        $input  = new ArgvInput(['console', 'doctrine:migrations:version', '--add', '--all', '--no-interaction']);
-        $output = new BufferedOutput();
-
-        $application = new Application($this->container->get('kernel'));
-        $application->setAutoExit(false);
-        $application->run($input, $output);
+        $this->installer->finalMigrationStep();
 
         $welcomeUrl = $this->generateUrl('mautic_dashboard_index');
 
@@ -321,147 +296,23 @@ class InstallController extends CommonController
     }
 
     /**
-     * Checks if the application has been installed and redirects if so.
-     *
-     * @return bool
+     * @param Form  $form
+     * @param array $messages
      */
-    private function checkIfInstalled()
+    private function handleInstallerErrors(Form $form, array $messages)
     {
-        // If the config file doesn't even exist, no point in checking further
-        $localConfigFile = $this->get('mautic.helper.paths')->getSystemPath('local_config');
-        if (!file_exists($localConfigFile)) {
-            return false;
-        }
-
-        /** @var Configurator $configurator */
-        $params = $this->configurator->getParameters();
-
-        // if db_driver and mailer_from_name are present then it is assumed all the steps of the installation have been
-        // performed; manually deleting these values or deleting the config file will be required to re-enter
-        // installation.
-        if (empty($params['db_driver']) || empty($params['mailer_from_name'])) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Installs data fixtures for the application.
-     */
-    private function installDatabaseFixtures()
-    {
-        $entityManager = $this->get('doctrine.orm.entity_manager');
-        $paths         = [dirname(__DIR__).'/InstallFixtures/ORM'];
-        $loader        = new ContainerAwareLoader($this->container);
-
-        foreach ($paths as $path) {
-            if (is_dir($path)) {
-                $loader->loadFromDirectory($path);
+        foreach ($messages as $type => $message) {
+            switch ($type) {
+                case 'warning':
+                case 'error':
+                case 'notice':
+                    $this->addFlash($message, [], $type);
+                    break;
+                default:
+                    // If type not a flash type, assume form field error
+                    $form[$type]->addError(new FormError($message));
+                    break;
             }
         }
-
-        $fixtures = $loader->getFixtures();
-
-        if (!$fixtures) {
-            throw new \InvalidArgumentException(sprintf('Could not find any fixtures to load in: %s', "\n\n- ".implode("\n- ", $paths)));
-        }
-
-        $purger = new ORMPurger($entityManager);
-        $purger->setPurgeMode(ORMPurger::PURGE_MODE_DELETE);
-        $executor = new ORMExecutor($entityManager, $purger);
-        $executor->execute($fixtures, true);
-    }
-
-    /**
-     * Create the administrator user.
-     *
-     * @param array $data
-     *
-     * @throws ORMException
-     * @throws OptimisticLockException
-     */
-    private function createAdminUserStep($data)
-    {
-        $entityManager = $this->get('doctrine.orm.entity_manager');
-
-        //ensure the username and email are unique
-        try {
-            $existingUser = $entityManager->getRepository('MauticUserBundle:User')->find(1);
-        } catch (\Exception $e) {
-            $existingUser = null;
-        }
-
-        if (null != $existingUser) {
-            $user = $existingUser;
-        } else {
-            $user = new User();
-        }
-
-        /** @var PasswordEncoderInterface $encoder */
-        $encoder = $this->get('security.encoder_factory')->getEncoder($user);
-
-        $user->setFirstName($data->firstname);
-        $user->setLastName($data->lastname);
-        $user->setUsername($data->username);
-        $user->setEmail($data->email);
-        $user->setPassword($encoder->encodePassword($data->password, $user->getSalt()));
-        $user->setRole($entityManager->getReference('MauticUserBundle:Role', 1));
-
-        $entityManager->persist($user);
-        $entityManager->flush();
-    }
-
-    /**
-     * @param $form
-     * @param $dbParams
-     */
-    protected function validateDatabaseParams($form, $dbParams)
-    {
-        $translator = $this->get('translator');
-
-        $required = [
-            'host',
-            'name',
-            'user',
-        ];
-
-        foreach ($required as $r) {
-            if (empty($dbParams[$r])) {
-                $form[$r]->addError(new FormError($translator->trans('mautic.core.value.required', [], 'validators')));
-            }
-        }
-
-        if ((int) $dbParams['port'] <= 0) {
-            $form['port']->addError(new FormError($translator->trans('mautic.install.database.port.invalid', [], 'validators')));
-        }
-    }
-
-    /**
-     * @param array|StepInterface $params
-     * @param null                $step
-     * @param bool                $clearCache
-     *
-     * @return bool
-     */
-    protected function saveConfiguration($params, $step = null)
-    {
-        if (null !== $step) {
-            $params = $step->update($params);
-        }
-
-        $this->configurator->mergeParameters($params);
-
-        try {
-            $this->configurator->write();
-        } catch (\RuntimeException $exception) {
-            return false;
-        }
-
-        /** @var CacheHelper $cacheHelper */
-        $cacheHelper = $this->get('mautic.helper.cache');
-        $cacheHelper->refreshConfig();
-
-        return true;
     }
 }

--- a/app/bundles/InstallBundle/Controller/InstallController.php
+++ b/app/bundles/InstallBundle/Controller/InstallController.php
@@ -72,7 +72,7 @@ class InstallController extends CommonController
         }
 
         /** @var \Mautic\CoreBundle\Configurator\Step\StepInterface $step */
-        $step   = $this->configurator->getStep($index);
+        $step   = $this->configurator->getStep($index)[0];
         $action = $this->generateUrl('mautic_installer_step', ['index' => $index]);
 
         $form = $this->createForm($step->getFormType(), $step, ['action' => $action]);

--- a/app/bundles/InstallBundle/Install/InstallService.php
+++ b/app/bundles/InstallBundle/Install/InstallService.php
@@ -244,9 +244,8 @@ class InstallService
         }
 
         if ($clearCache) {
-            $this->cacheHelper->clearContainerFile(false);
+            $this->cacheHelper->refreshConfig();
         }
-        $this->cacheHelper->refreshConfig();
 
         return $messages;
     }

--- a/app/bundles/InstallBundle/Install/InstallService.php
+++ b/app/bundles/InstallBundle/Install/InstallService.php
@@ -37,6 +37,11 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  */
 class InstallService
 {
+    const CHECK_STEP    = 0;
+    const DOCTRINE_STEP = 1;
+    const USER_STEP     = 2;
+    const EMAIL_STEP    = 3;
+
     private $configurator;
 
     private $cacheHelper;
@@ -80,7 +85,7 @@ class InstallService
      *
      * @param int $index The step number to retrieve
      *
-     * @return int|StepInterface the valid
+     * @return bool|StepInterface the valid step given installation status
      *
      * @throws \InvalidArgumentException
      */
@@ -99,11 +104,13 @@ class InstallService
         $params = $this->configurator->getParameters();
 
         // Check to ensure the installer is in the right place
-        if ((empty($params) || empty($params['db_driver'])) && $index > 1) {
-            return 1;
+        if ((empty($params)
+                || !isset($params['db_driver'])
+                || empty($params['db_driver'])) && $index > 1) {
+            return $this->configurator->getStep(self::DOCTRINE_STEP);
         }
 
-        return $this->configurator->getStep($index)[0];
+        return $this->configurator->getStep($index);
     }
 
     /**
@@ -113,7 +120,7 @@ class InstallService
      */
     private function localConfig()
     {
-        return $this->pathsHelper->getSystemPath('local_config');
+        return $this->pathsHelper->getSystemPath('local_config', false);
     }
 
     /**

--- a/app/bundles/InstallBundle/Install/InstallService.php
+++ b/app/bundles/InstallBundle/Install/InstallService.php
@@ -110,7 +110,7 @@ class InstallService
             return $this->configurator->getStep(self::DOCTRINE_STEP);
         }
 
-        return $this->configurator->getStep($index);
+        return $this->configurator->getStep($index)[0];
     }
 
     /**

--- a/app/bundles/InstallBundle/Install/InstallService.php
+++ b/app/bundles/InstallBundle/Install/InstallService.php
@@ -1,0 +1,604 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\InstallBundle\Install;
+
+use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\ORM\EntityManager;
+use Mautic\CoreBundle\Configurator\Configurator;
+use Mautic\CoreBundle\Configurator\Step\StepInterface;
+use Mautic\CoreBundle\Helper\CacheHelper;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\EncryptionHelper;
+use Mautic\CoreBundle\Helper\PathsHelper;
+use Mautic\InstallBundle\Helper\SchemaHelper;
+use Mautic\UserBundle\Entity\User;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Security\Core\Encoder\EncoderFactory;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Class InstallService.
+ */
+class InstallService
+{
+    /**
+     * @var Configurator
+     */
+    private $configurator;
+
+    /**
+     * @var CoreParametersHelper
+     */
+    private $coreParametersHelper;
+
+    /**
+     * @var CacheHelper
+     */
+    private $cacheHelper;
+
+    /**
+     * @var PathsHelper
+     */
+    protected $pathsHelper;
+
+    /**
+     * @var EntityManager
+     */
+    private $entityManager;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var KernelInterface
+     */
+    private $kernel;
+    /**
+     * @var EncoderFactory
+     */
+    private $encoder;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * InstallService constructor.
+     *
+     * @param Configurator         $configurator
+     * @param CoreParametersHelper $coreParametersHelper
+     * @param CacheHelper          $cacheHelper
+     * @param PathsHelper          $pathsHelper
+     * @param EntityManager        $entityManager
+     * @param TranslatorInterface  $translator
+     * @param KernelInterface      $kernel
+     * @param EncoderFactory       $encoder
+     * @param LoggerInterface      $logger
+     */
+    public function __construct(Configurator $configurator,
+                                CoreParametersHelper $coreParametersHelper,
+                                CacheHelper $cacheHelper,
+                                PathsHelper $pathsHelper,
+                                EntityManager $entityManager,
+                                TranslatorInterface $translator,
+                                KernelInterface $kernel,
+                                EncoderFactory $encoder,
+                                LoggerInterface $logger)
+    {
+        $this->configurator             = $configurator;
+        $this->coreParametersHelper     = $coreParametersHelper;
+        $this->cacheHelper              = $cacheHelper;
+        $this->pathsHelper              = $pathsHelper;
+        $this->entityManager            = $entityManager;
+        $this->translator               = $translator;
+        $this->kernel                   = $kernel;
+        $this->encoder                  = $encoder;
+        $this->logger                   = $logger;
+    }
+
+    /**
+     * Get step object for given index or appropriate step index.
+     *
+     * @param int $index The step number to retrieve
+     *
+     * @return int|StepInterface the valid
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function getStep($index = 0)
+    {
+        // We're going to assume a bit here; if the config file exists already and DB info is provided, assume the app
+        // is installed and redirect
+        if ($this->checkIfInstalled()) {
+            return true;
+        }
+
+        if (($pos = strpos($index, '.')) !== false) {
+            $index = (int) substr($index, 0, $pos);
+        }
+
+        $params = $this->configurator->getParameters();
+
+        // Check to ensure the installer is in the right place
+        if ((empty($params) || empty($params['db_driver'])) && $index > 1) {
+            return 1;
+        }
+
+        return $this->configurator->getStep($index)[0];
+    }
+
+    /**
+     * Get local config file location.
+     *
+     * @return string
+     */
+    private function localConfig()
+    {
+        return $this->pathsHelper->getSystemPath('local_config');
+    }
+
+    /**
+     * Get local config parameters.
+     *
+     * @return array
+     */
+    public function localConfigParameters()
+    {
+        $localConfigFile = $this->localConfig();
+
+        if (file_exists($localConfigFile)) {
+            /** @var array $parameters */
+            include $localConfigFile;
+            $localParameters = (isset($parameters) && is_array($parameters)) ? $parameters : [];
+        } else {
+            $localParameters = [];
+        }
+
+        return $localParameters;
+    }
+
+    /**
+     * Checks if the application has been installed and redirects if so.
+     *
+     * @return bool
+     */
+    public function checkIfInstalled()
+    {
+        // If the config file doesn't even exist, no point in checking further
+        $localConfigFile = $this->localConfig();
+        if (!file_exists($localConfigFile)) {
+            return false;
+        }
+
+        /** @var \Mautic\CoreBundle\Configurator\Configurator $configurator */
+        $params = $this->configurator->getParameters();
+
+        // if db_driver and mailer_from_name are present then it is assumed all the steps of the installation have been
+        // performed; manually deleting these values or deleting the config file will be required to re-enter
+        // installation.
+        if (empty($params['db_driver']) || empty($params['mailer_from_name'])) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Translation messages array.
+     *
+     * @param array $messages
+     *
+     * @return array
+     */
+    private function translateMessage($messages)
+    {
+        $translator = $this->translator;
+
+        if (is_array($messages) && !empty($messages)) {
+            foreach ($messages as $key => $value) {
+                $messages[$key] = $translator->trans($value);
+            }
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Checks for step's requirements.
+     *
+     * @param null|StepInterface $step
+     *
+     * @return array
+     */
+    public function checkRequirements($step)
+    {
+        $messages = $step->checkRequirements();
+
+        return $this->translateMessage($messages);
+    }
+
+    /**
+     * Checks for step's optional settings.
+     *
+     * @param null|StepInterface $step
+     *
+     * @return array
+     */
+    public function checkOptionalSettings($step)
+    {
+        $messages = $step->checkOptionalSettings();
+
+        return $this->translateMessage($messages);
+    }
+
+    /**
+     * @param array|StepInterface $params
+     * @param null|StepInterface  $step
+     * @param bool                $clearCache
+     *
+     * @return bool
+     */
+    public function saveConfiguration($params, $step = null, $clearCache = false)
+    {
+        $translator = $this->translator;
+
+        if (null !== $step) {
+            $params = $step->update($params);
+        }
+
+        $this->configurator->mergeParameters($params);
+
+        $messages = false;
+
+        try {
+            $this->configurator->write();
+            $messages = true;
+        } catch (\RuntimeException $exception) {
+            $messages = [];
+            $messages['error'] = $translator->trans(
+                'mautic.installer.error.writing.configuration',
+                [],
+                'flashes');
+        }
+
+        if ($clearCache) {
+            $this->cacheHelper->clearContainerFile(false);
+        }
+        $this->cacheHelper->refreshConfig();
+
+        return $messages;
+    }
+
+    /**
+     * @param array $dbParams
+     *
+     * @return array|bool
+     */
+    public function validateDatabaseParams($dbParams)
+    {
+        $translator = $this->translator;
+
+        $required = [
+            'host',
+            'name',
+            'user',
+        ];
+
+        $messages = [];
+        foreach ($required as $r) {
+            if (empty($dbParams[$r])) {
+                $messages[$r] = $translator->trans(
+                    'mautic.core.value.required',
+                    [],
+                    'validators'
+                );
+            }
+        }
+
+        if ((int) $dbParams['port'] <= 0) {
+            $messages['port'] = $translator->trans(
+                'mautic.install.database.port.invalid',
+                [],
+                'validators'
+            );
+        }
+
+        return empty($messages) ? true : $messages;
+    }
+
+    /**
+     * Create the database.
+     *
+     * @param null|StepInterface $step
+     * @param array              $dbParams
+     *
+     * @return array|bool
+     */
+    public function createDatabaseStep($step, $dbParams)
+    {
+        $translator = $this->translator;
+
+        $messages = $this->validateDatabaseParams($dbParams);
+
+        if (is_bool($messages) && $messages === true) {
+            // Check if connection works and/or create database if applicable
+            $schemaHelper = new SchemaHelper($dbParams);
+
+            try {
+                $schemaHelper->testConnection();
+
+                if ($schemaHelper->createDatabase()) {
+                    $messages = $this->saveConfiguration($dbParams, $step, true);
+                    if (is_bool($messages)) {
+                        return $messages;
+                    }
+
+                    $messages['error'] = $translator->trans(
+                        'mautic.installer.error.writing.configuration',
+                        [],
+                        'flashes');
+                } else {
+                    $messages['error'] = $translator->trans(
+                        'mautic.installer.error.creating.database',
+                        ['%name%' => $dbParams['name']],
+                        'flashes');
+                }
+            } catch (\Exception $exception) {
+                $messages['error'] = $translator->trans(
+                    'mautic.installer.error.connecting.database',
+                    ['%exception%' => $exception->getMessage()],
+                    'flashes');
+            }
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Create the database schema.
+     *
+     * @param array $dbParams
+     *
+     * @return array|bool
+     */
+    public function createSchemaStep($dbParams)
+    {
+        $translator   = $this->translator;
+        $schemaHelper = new SchemaHelper($dbParams);
+        $schemaHelper->setEntityManager($this->entityManager);
+
+        $messages = [];
+        try {
+            if (!$schemaHelper->installSchema()) {
+                $messages['error'] = $translator->trans(
+                    'mautic.installer.error.no.metadata',
+                    [],
+                    'flashes');
+            } else {
+                $messages = true;
+            }
+        } catch (\Exception $exception) {
+            $messages['error'] = $translator->trans(
+                'mautic.installer.error.installing.data',
+                ['%exception%' => $exception->getMessage()],
+                'flashes');
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Load the database fixtures in the database.
+     *
+     * @param ContainerInterface $container
+     *
+     * @return array|bool
+     */
+    public function createFixturesStep(ContainerInterface $container)
+    {
+        $translator = $this->translator;
+
+        $messages = [];
+        try {
+            $this->installDatabaseFixtures($container);
+            $messages = true;
+        } catch (\Exception $exception) {
+            $messages['error'] = $translator->trans(
+                'mautic.installer.error.adding.fixtures',
+                ['%exception%' => $exception->getMessage()],
+                'flashes');
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Installs data fixtures for the application.
+     *
+     * @param ContainerInterface $container
+     *
+     * @return bool boolean true on success
+     */
+    public function installDatabaseFixtures(ContainerInterface $container)
+    {
+        $entityManager = $this->entityManager;
+        $paths         = [dirname(__DIR__).'/InstallFixtures/ORM'];
+        $loader        = new ContainerAwareLoader($container);
+
+        foreach ($paths as $path) {
+            if (is_dir($path)) {
+                $loader->loadFromDirectory($path);
+            }
+        }
+
+        $fixtures = $loader->getFixtures();
+
+        if (!$fixtures) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Could not find any fixtures to load in: %s',
+                    "\n\n- ".implode("\n- ", $paths)
+                )
+            );
+        }
+
+        $purger = new ORMPurger($entityManager);
+        $purger->setPurgeMode(ORMPurger::PURGE_MODE_DELETE);
+        $executor = new ORMExecutor($entityManager, $purger);
+        $executor->execute($fixtures, true);
+
+        return true;
+    }
+
+    /**
+     * Create the administrator user.
+     *
+     * @param array $data
+     *
+     * @return array|bool
+     *
+     * @throws ORMException
+     * @throws OptimisticLockException
+     */
+    public function createAdminUserStep($data)
+    {
+        $entityManager = $this->entityManager;
+
+        //ensure the username and email are unique
+        try {
+            $existingUser = $entityManager->getRepository('MauticUserBundle:User')->find(1);
+        } catch (\Exception $e) {
+            $existingUser = null;
+        }
+
+        if (null != $existingUser) {
+            $user = $existingUser;
+        } else {
+            $user = new User();
+        }
+
+        $required = [
+            'firstname',
+            'lastname',
+            'username',
+            'email',
+            'password',
+        ];
+
+        $translator = $this->translator;
+
+        $messages = [];
+        foreach ($required as $r) {
+            if (empty($data[$r])) {
+                $messages[$r] = $translator->trans(
+                    'mautic.core.value.required',
+                    [],
+                    'validators'
+                );
+            }
+        }
+
+        if (!empty($messages)) {
+            return $messages;
+        }
+
+        $encoder = $this->encoder->getEncoder($user);
+
+        $user->setFirstName($data['firstname']);
+        $user->setLastName($data['lastname']);
+        $user->setUsername($data['username']);
+        $user->setEmail($data['email']);
+        $user->setPassword($encoder->encodePassword($data['password'], $user->getSalt()));
+
+        $adminRole = null;
+        try {
+            $adminRole = $entityManager->getReference('MauticUserBundle:Role', 1);
+        } catch (\Exception $exception) {
+            $messages['error'] = $translator->trans(
+                'mautic.installer.error.getting.role',
+                ['%exception%' => $exception->getMessage()],
+                'flashes'
+            );
+        }
+
+        if (!empty($adminRole)) {
+            $user->setRole($adminRole);
+
+            try {
+                $entityManager->persist($user);
+                $entityManager->flush();
+            } catch (\Exception $exception) {
+                $messages['error'] = $translator->trans(
+                    'mautic.installer.error.creating.user',
+                    ['%exception%' => $exception->getMessage()],
+                    'flashes'
+                );
+            }
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Create the final configuration.
+     *
+     * @param string $siteUrl
+     *
+     * @return array|bool
+     */
+    public function createFinalConfigStep($siteUrl)
+    {
+        // Merge final things into the config, wipe the container, and we're done!
+        $finalConfigVars = [
+            'secret_key' => EncryptionHelper::generateKey(),
+            'site_url'   => $siteUrl,
+        ];
+
+        $messages = $this->saveConfiguration($finalConfigVars, null, true);
+        if (is_bool($messages)) {
+            return $messages;
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Final migration step for install.
+     *
+     * @return bool
+     *
+     * @throws \Exception
+     */
+    public function finalMigrationStep()
+    {
+        // Add database migrations up to this point since this is a fresh install (must be done at this point
+        // after the cache has been rebuilt
+        $input  = new ArgvInput(['console', 'doctrine:migrations:version', '--add', '--all', '--no-interaction']);
+        $output = new BufferedOutput();
+
+        $application = new Application($this->kernel);
+        $application->setAutoExit(false);
+        $application->run($input, $output);
+
+        return true;
+    }
+}

--- a/app/bundles/InstallBundle/Install/InstallService.php
+++ b/app/bundles/InstallBundle/Install/InstallService.php
@@ -127,8 +127,11 @@ class InstallService
 
         if (file_exists($localConfigFile)) {
             /** @var array $parameters */
+            $parameters = false;
+
+            // Load local config to override parameters
             include $localConfigFile;
-            $localParameters = (isset($parameters) && is_array($parameters)) ? $parameters : [];
+            $localParameters = (is_array($parameters)) ? $parameters : [];
         } else {
             $localParameters = [];
         }

--- a/app/bundles/InstallBundle/Tests/Command/InstallCommandTest.php
+++ b/app/bundles/InstallBundle/Tests/Command/InstallCommandTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\InstallBundle\Tests\Command;
+
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\InstallBundle\Command\InstallCommand;
+use Mautic\InstallBundle\Install\InstallService;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class InstallCommandTest extends \PHPUnit\Framework\TestCase
+{
+    private $coreParametersHelper;
+    private $dispatcher;
+    private $container;
+    private $transport;
+    private $application;
+    private $installer;
+
+    private $command;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->dispatcher           = $this->createMock(EventDispatcherInterface::class);
+        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+        $this->container            = $this->createMock(Container::class);
+        $this->transport            = $this->createMock(\Swift_Transport::class);
+        $this->application          = $this->createMock(Application::class);
+        $this->installer            = $this->createMock(InstallService::class);
+
+        $this->application->method('getHelperSet')
+            ->willReturn($this->createMock(HelperSet::class));
+
+        $inputDefinition = $this->createMock(InputDefinition::class);
+
+        $this->application->method('getDefinition')
+            ->willReturn($inputDefinition);
+
+        $inputDefinition->method('getOptions')
+            ->willReturn([]);
+
+        $this->command = new InstallCommand();
+        $this->command->setContainer($this->container);
+        $this->command->setApplication($this->application);
+
+        $this->container->method('get')
+            ->withConsecutive(
+                ['mautic.install.service']
+            )->willReturnOnConsecutiveCalls(
+                $this->installer
+            );
+    }
+
+    public function testCommandWhenSiteInstalled()
+    {
+        $this->installer->method('checkIfInstalled')
+            ->willReturnOnConsecutiveCalls(true);
+
+        $input  = new ArrayInput([
+            'site_url'          => 'localhost',
+        ]);
+        $output = new BufferedOutput();
+        $this->command->run($input, $output);
+
+        $this->assertSame('Mautic already installed'.PHP_EOL, $output->fetch());
+    }
+
+    public function testCommandWhenSiteNotInstalled()
+    {
+        $this->installer->method('checkIfInstalled')
+            ->willReturnOnConsecutiveCalls(false);
+
+        $input  = new ArrayInput([
+            'site_url'          => 'localhost',
+            '--admin_firstname' => 'Admin',
+            '--admin_lastname'  => 'Mautic',
+            '--admin_username'  => 'admin',
+            '--admin_email'     => 'admin@example.com',
+            '--admin_password'  => 'password',
+        ]);
+        $output = new BufferedOutput();
+        $this->command->run($input, $output);
+
+        $this->assertContains('Install complete'.PHP_EOL, $output->fetch());
+    }
+}

--- a/app/bundles/InstallBundle/Tests/Controller/InstallControllerTest.php
+++ b/app/bundles/InstallBundle/Tests/Controller/InstallControllerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\InstallBundle\Tests\Controller;
+
+use Mautic\CoreBundle\Factory\ModelFactory;
+use Mautic\CoreBundle\Helper\PathsHelper;
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
+use Mautic\InstallBundle\Controller\InstallController;
+use Mautic\InstallBundle\Install\InstallService;
+use Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactory;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\Router;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class InstallControllerTest extends \PHPUnit\Framework\TestCase
+{
+    private $translatorMock;
+    private $sessionMock;
+    private $modelFactoryMock;
+    private $containerMock;
+    private $routerMock;
+    private $flashBagMock;
+    private $controller;
+    private $corePermissionsMock;
+    private $pathsHelper;
+    private $formFactoryMock;
+    private $formMock;
+    private $templatingMock;
+
+    private $configurator;
+    private $installer;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->translatorMock       = $this->createMock(TranslatorInterface::class);
+        $this->sessionMock          = $this->createMock(Session::class);
+        $this->modelFactoryMock     = $this->createMock(ModelFactory::class);
+        $this->containerMock        = $this->createMock(Container::class);
+        $this->routerMock           = $this->createMock(Router::class);
+        $this->flashBagMock         = $this->createMock(FlashBagInterface::class);
+        $this->corePermissionsMock  = $this->createMock(CorePermissions::class);
+        $this->pathsHelper          = $this->createMock(PathsHelper::class);
+        $this->formFactoryMock      = $this->createMock(FormFactory::class);
+        $this->formMock             = $this->createMock(Form::class);
+        $this->templatingMock       = $this->createMock(DelegatingEngine::class);
+
+        $this->configurator         = $this->createMock(Form::class);
+        $this->installer            = $this->createMock(InstallService::class);
+
+        $this->controller           = new InstallController();
+        $this->controller->setContainer($this->containerMock);
+        $this->controller->setTranslator($this->translatorMock);
+        $this->sessionMock->method('getFlashBag')->willReturn($this->flashBagMock);
+        $this->controller->setRequest(new Request());
+
+        $this->containerMock->method('get')
+            ->withConsecutive(
+                ['mautic.configurator'],
+                ['mautic.install.service'],
+                ['router'],
+                ['session'],
+                ['mautic.helper.paths']
+            )->willReturnOnConsecutiveCalls(
+                $this->configurator,
+                $this->installer,
+                $this->routerMock,
+                $this->sessionMock,
+                $this->pathsHelper
+            );
+
+        $event = $this->createMock(FilterControllerEvent::class);
+        $this->controller->initialize($event);
+    }
+
+    public function testStepActionWhenInstalled()
+    {
+        $this->installer->expects($this->once())
+            ->method('checkIfInstalled')
+            ->willReturn(
+                true
+            );
+
+        $this->routerMock->expects($this->once())
+            ->method('generate')
+            ->with('mautic_dashboard_index', [], UrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willReturn('http://localhost/');
+
+        $response = $this->controller->stepAction(InstallService::CHECK_STEP);
+        $this->assertEquals(302, $response->getStatusCode());
+    }
+}

--- a/app/bundles/InstallBundle/Tests/Install/InstallServiceTest.php
+++ b/app/bundles/InstallBundle/Tests/Install/InstallServiceTest.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\InstallBundle\Tests\Install;
+
+use Doctrine\ORM\EntityManager;
+use Mautic\CoreBundle\Configurator\Configurator;
+use Mautic\CoreBundle\Configurator\Step\StepInterface;
+use Mautic\CoreBundle\Helper\CacheHelper;
+use Mautic\CoreBundle\Helper\EncryptionHelper;
+use Mautic\CoreBundle\Helper\PathsHelper;
+use Mautic\InstallBundle\Configurator\Step\CheckStep;
+use Mautic\InstallBundle\Configurator\Step\DoctrineStep;
+use Mautic\InstallBundle\Configurator\Step\EmailStep;
+use Mautic\InstallBundle\Helper\SchemaHelper;
+use Mautic\InstallBundle\Install\InstallService;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Security\Core\Encoder\EncoderFactory;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class InstallServiceTest extends \PHPUnit\Framework\TestCase
+{
+    private $configurator;
+
+    private $cacheHelper;
+    private $pathsHelper;
+    private $entityManager;
+    private $translator;
+    private $kernel;
+    private $validator;
+    private $encoder;
+
+    private $installer;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator         = $this->createMock(Configurator::class);
+        $this->cacheHelper          = $this->createMock(CacheHelper::class);
+        $this->pathsHelper          = $this->createMock(PathsHelper::class);
+        $this->entityManager        = $this->createMock(EntityManager::class);
+        $this->translator           = $this->createMock(TranslatorInterface::class);
+        $this->kernel               = $this->createMock(KernelInterface::class);
+        $this->validator            = $this->createMock(ValidatorInterface::class);
+        $this->encoder              = $this->createMock(EncoderFactory::class);
+
+        $this->installer = new InstallService(
+            $this->configurator,
+            $this->cacheHelper,
+            $this->pathsHelper,
+            $this->entityManager,
+            $this->translator,
+            $this->kernel,
+            $this->validator,
+            $this->encoder
+        );
+    }
+
+    public function testCheckIfInstalledWhenNoLocalConfig(): void
+    {
+        $this->pathsHelper->expects($this->once())
+            ->method('getSystemPath')
+            ->with('local_config', false)
+            ->willReturn(
+                null
+            );
+
+        $this->assertFalse($this->installer->checkIfInstalled());
+    }
+
+    public function testGetStepWhenNoLocalConfig(): void
+    {
+        $this->pathsHelper->expects($this->once())
+            ->method('getSystemPath')
+            ->with('local_config', false)
+            ->willReturn(
+                null
+            );
+
+        $this->configurator->expects($this->once())
+            ->method('getParameters')
+            ->willReturn(
+                []
+            );
+
+        $index = 0;
+        $step  = $this->createMock(StepInterface::class);
+
+        $this->configurator->expects($this->once())
+            ->method('getStep')
+            ->with($index)
+            ->willReturn($step);
+
+        $this->assertEquals($step, $this->installer->getStep($index));
+    }
+
+    public function testGetStepWhenDbDriverSet(): void
+    {
+        $this->pathsHelper->expects($this->once())
+            ->method('getSystemPath')
+            ->with('local_config', false)
+            ->willReturn(
+                null
+            );
+
+        $this->configurator->expects($this->once())
+            ->method('getParameters')
+            ->willReturn(
+                ['db_driver' => 'test']
+            );
+
+        $index = 0;
+        $step  = $this->createMock(StepInterface::class);
+
+        $this->configurator->expects($this->once())
+            ->method('getStep')
+            ->with($index)
+            ->willReturn($step);
+
+        $this->assertEquals($step, $this->installer->getStep($index));
+    }
+
+    public function testCheckRequirements(): void
+    {
+        $step     = $this->createMock(StepInterface::class);
+        $messages = ['dummy' => 'test'];
+
+        $step->expects($this->once())
+            ->method('checkRequirements')
+            ->willReturn($messages);
+
+        $this->translator->expects($this->once())
+            ->method('trans')
+            ->with('test', [], null, null)
+            ->willReturn('test');
+
+        $this->assertEquals($messages, $this->installer->checkRequirements($step));
+    }
+
+    public function testCheckOptionalSettings(): void
+    {
+        $step     = $this->createMock(StepInterface::class);
+        $messages = ['dummy' => 'test'];
+
+        $step->expects($this->once())
+            ->method('checkOptionalSettings')
+            ->willReturn($messages);
+
+        $this->translator->expects($this->once())
+            ->method('trans')
+            ->with('test', [], null, null)
+            ->willReturn('test');
+
+        $this->assertEquals($messages, $this->installer->checkOptionalSettings($step));
+    }
+
+    public function testSaveConfigurationWhenNoCacheClear(): void
+    {
+        $params     = [];
+        $step       = $this->createMock(StepInterface::class);
+        $clearCache = false;
+
+        $messages = true;
+
+        $step->expects($this->once())
+            ->method('update')
+            ->with($step)
+            ->willReturn($params);
+
+        $this->configurator->expects($this->once())
+            ->method('write');
+
+        $this->configurator->expects($this->once())
+            ->method('mergeParameters')
+            ->with($params)
+            ->willReturn($messages);
+
+        $this->assertEquals($messages, $this->installer->saveConfiguration($params, $step, $clearCache));
+    }
+
+    public function testSaveConfigurationWhenCacheClear(): void
+    {
+        $params     = [];
+        $step       = $this->createMock(StepInterface::class);
+        $clearCache = true;
+
+        $messages = true;
+
+        $step->expects($this->once())
+            ->method('update')
+            ->with($step)
+            ->willReturn($params);
+
+        $this->configurator->expects($this->once())
+            ->method('mergeParameters')
+            ->with($params)
+            ->willReturn($messages);
+
+        $this->configurator->expects($this->once())
+            ->method('write');
+
+        $this->cacheHelper->expects($this->once())
+            ->method('refreshConfig');
+
+        $this->assertEquals($messages, $this->installer->saveConfiguration($params, $step, $clearCache));
+    }
+
+    public function testValidateDatabaseParamsWhenNoRequired(): void
+    {
+        $dbParams = [];
+        $messages = [
+            'driver' => null,
+            'host'   => null,
+            'port'   => null,
+            'name'   => null,
+            'user'   => null,
+        ];
+
+        $this->assertEquals($messages, $this->installer->validateDatabaseParams($dbParams));
+    }
+
+    public function testValidateDatabaseParamsWhenPortNotValid(): void
+    {
+        $dbParams = [
+            'driver' => 'mysql',
+            'host'   => 'localhost',
+            'port'   => '-1',
+            'name'   => 'mautic',
+            'user'   => 'mautic',
+        ];
+        $messages = [
+            'port' => null,
+        ];
+
+        $this->assertEquals($messages, $this->installer->validateDatabaseParams($dbParams));
+    }
+
+    public function testValidateDatabaseParamsWhenAllValid(): void
+    {
+        $dbParams = [
+            'driver' => 'mysql',
+            'host'   => 'localhost',
+            'port'   => '3306',
+            'name'   => 'mautic',
+            'user'   => 'mautic',
+        ];
+
+        $this->assertEquals(true, $this->installer->validateDatabaseParams($dbParams));
+    }
+}

--- a/app/bundles/InstallBundle/Tests/Install/InstallServiceTest.php
+++ b/app/bundles/InstallBundle/Tests/Install/InstallServiceTest.php
@@ -101,7 +101,7 @@ class InstallServiceTest extends \PHPUnit\Framework\TestCase
         $this->configurator->expects($this->once())
             ->method('getStep')
             ->with($index)
-            ->willReturn($step);
+            ->willReturn([$step]);
 
         $this->assertEquals($step, $this->installer->getStep($index));
     }
@@ -127,7 +127,7 @@ class InstallServiceTest extends \PHPUnit\Framework\TestCase
         $this->configurator->expects($this->once())
             ->method('getStep')
             ->with($index)
-            ->willReturn($step);
+            ->willReturn([$step]);
 
         $this->assertEquals($step, $this->installer->getStep($index));
     }

--- a/app/bundles/InstallBundle/Translations/en_US/flashes.ini
+++ b/app/bundles/InstallBundle/Translations/en_US/flashes.ini
@@ -2,6 +2,7 @@ mautic.installer.error.adding.fields="An error occurred while attempting to popu
 mautic.installer.error.adding.fixtures="An error occurred while attempting to add default data: %exception%"
 mautic.installer.error.connecting.database="An error occured while attempting to connect to the database: %exception%"
 mautic.installer.error.creating.database="The database, %name%, could not be found or created due to permissions restrictions. Please manually create the database then try again."
+mautic.installer.error.getting.role="An error occurred while attempting to get the admin role: %exception%"
 mautic.installer.error.creating.user="An error occurred while attempting to create the admin user: %exception%"
 mautic.installer.error.database.exists="The database you've specified already exists and contains Mautic data."
 mautic.installer.error.installing.data="An error occurred while attempting to install the data: %exception%"


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | mautic/developer-documentation#122
| Issues addressed (#s or URLs) | Resolves #7389
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Feature to allow command line install of Mautic. The objective is to migrate all the install process of `InstallController` to a service called `InstallService` and add an `InstallCommand` called by `php app/console mautic:install` that would leverage the new service.

Might also be useful to export each install steps into a different service / command in case one would only want to execute specific steps (something like `mautic:install:database`, `mautic:install:admin`, etc...).

This feature was funded by @Monogramm

#### Steps to test this PR:
Two things will need to be tested with this PR: 
1. the new install command(s)
2. the regular install wizard

Mautic install:
1. Load up this PR and user composer to install deps: #7395
```bash
git clone --branch feature/install-command git@github.com:Monogramm/mautic.git mautic_install
cd mautic_install
composer install
```
2. Create an initial `local.php` config file with the database parameters. You can also define the mailer properties and admin properties in `local.php` with the same syntax expected by the command line options (do `php bin/console mautic:install --help` for the list of options)
```php
<?php
// Example local.php to test install (to adapt of course)
$parameters = array(
	// Do not set db_driver and mailer_from_name as they are used to assume Mautic is installed
	'db_host' => 'localhost',
	'db_table_prefix' => null,
	'db_port' => 3306,
	'db_name' => 'mautic',
	'db_user' => 'mautic',
	'db_password' => 'mautic',
	'db_backup_tables' => true,
	'db_backup_prefix' => 'bak_',
	'admin_email' => 'admin@yopmail.com',
	'admin_password' => 'mautic',
	'mailer_transport' => null,
	'mailer_host' => null,
	'mailer_port' => null,
	'mailer_user' => null,
	'mailer_password' => null,
	'mailer_api_key' => null,
	'mailer_encryption' => null,
	'mailer_auth_mode' => null,
);

```
3. Execute `php bin/console mautic:install http://your-mautic-domain.com` (see [documentation](https://github.com/mautic/developer-documentation/pull/122/files#diff-860e3ce2541f17effc8aebd6b8cf606bR55))
```
Mautic Install
==============

Parsing options and arguments...
0 - Checking installation requirements...
Missing optional settings:
  - [0] It is recommended to secure your installation with an SSL certificate (https). Starting February 2020 Google Chrome will stop sending third-party cookies in cross-site requests unless the cookies are secure. Tracking will stop working for Mautic instances running on HTTP. Use HTTPS.
  - [1] The <strong>memory_limit</strong> setting in your PHP configuration is lower than the suggested minimum limit of %min_memory_limit%. Mautic can have performance issues with large datasets without sufficient memory.
Ready to Install!
1 - Creating database...
1.1 - Creating schema...
1.2 - Loading fixtures...
2 - Creating admin user...
3 - Email configuration and final steps...

================
Install complete
================

```
4. Check install worked properly and the install wizard is not triggered
5. Execute `php bin/console mautic:install` again and verify that nothing happens:
```
> php bin/console mautic:install http://your-mautic-domain.com

Mautic already installed
```

Mautic wizard:
1. Load up this PR: #7395
2. Go to your Mautic address and execute install wizard
3. Check install worked properly and the install wizard is not triggered anymore

#### List deprecations along with the new alternative:
None

#### List backwards compatibility breaks:
None (?)
