### PR TITLE
Fix Sugar/Suite CRM sync for email addresses with an uppercase char

### DIFF
--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -1451,7 +1451,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
      *
      * @return array The first element is made up of records that exist in Mautic, but which no longer have a match in CRM.
      *               We therefore assume that they've been deleted in CRM and will mark them as deleted in the pushLeads function (~line 1320).
-     *               The second element contains Ids of records that were explicitly marked as deleted in CRM. ATM, nothing is done with this data.             
+     *               The second element contains Ids of records that were explicitly marked as deleted in CRM. ATM, nothing is done with this data.
      */
     public function getObjectDataToUpdate($checkEmailsInSugar, &$mauticData, $availableFields, $contactSugarFields, $leadSugarFields, $object = 'Leads')
     {

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -1449,7 +1449,10 @@ class SugarcrmIntegration extends CrmAbstractIntegration
      * @param $leadSugarFields
      * @param string $object
      *
-     * @return mixed
+     * @return array The first element is made up of records that exist in Mautic, but which no longer have a match in CRM.
+     *                   We therefore assume that they've been deleted in CRM and will mark them as deleted in the pushLeads function (~line 1320)
+     *               The second element contains Ids of records that were explicitly marked as deleted in CRM. ATM, nothing is done with this data
+     *               
      */
     public function getObjectDataToUpdate($checkEmailsInSugar, &$mauticData, $availableFields, $contactSugarFields, $leadSugarFields, $object = 'Leads')
     {
@@ -1497,7 +1500,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                 $key             = mb_strtolower($email);
                 $leadOwnerEmails = [];
                 foreach ($checkEmailsInSugar as $emailKey => $mauticRecord) {
-                    if ($email == $emailKey) {
+                    if ($key == $emailKey) {
                         $isConverted = (isset($sugarLeadRecord['contact_id'])
                             && $sugarLeadRecord['contact_id'] != null
                             && $sugarLeadRecord['contact_id'] != '');

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -1450,8 +1450,8 @@ class SugarcrmIntegration extends CrmAbstractIntegration
      * @param string $object
      *
      * @return array The first element is made up of records that exist in Mautic, but which no longer have a match in CRM.
-     *                   We therefore assume that they've been deleted in CRM and will mark them as deleted in the pushLeads function (~line 1320)
-     *               The second element contains Ids of records that were explicitly marked as deleted in CRM. ATM, nothing is done with this data
+     *               We therefore assume that they've been deleted in CRM and will mark them as deleted in the pushLeads function (~line 1320).
+     *               The second element contains Ids of records that were explicitly marked as deleted in CRM. ATM, nothing is done with this data.
      *               
      */
     public function getObjectDataToUpdate($checkEmailsInSugar, &$mauticData, $availableFields, $contactSugarFields, $leadSugarFields, $object = 'Leads')

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -1451,8 +1451,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
      *
      * @return array The first element is made up of records that exist in Mautic, but which no longer have a match in CRM.
      *               We therefore assume that they've been deleted in CRM and will mark them as deleted in the pushLeads function (~line 1320).
-     *               The second element contains Ids of records that were explicitly marked as deleted in CRM. ATM, nothing is done with this data.
-     *               
+     *               The second element contains Ids of records that were explicitly marked as deleted in CRM. ATM, nothing is done with this data.             
      */
     public function getObjectDataToUpdate($checkEmailsInSugar, &$mauticData, $availableFields, $contactSugarFields, $leadSugarFields, $object = 'Leads')
     {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | n/a
| Related developer documentation PR URL | n/a
| Issues addressed (#s or URLs) | #7138 #6140
| BC breaks? | No
| Deprecations? | No

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Currently the code will not properly keep  Mautic and Sugar/SuiteCRM in sync when a Lead's email address has any uppercase characters. 

Within the `SugarcrmIntegration::pushLeads` function, a `$checkEmailsInSugar` array is created. Its keys are forced to be lowercase:
```php
//line 1297
$checkEmailsInSugar[$object][mb_strtolower($lead['email'])] = $lead;
```
Later, this is compared to a list of CRM records. However, the CRM records are NOT normalized to lowercase. If the system does not find a match, then it marks the IntegrationEntity relationship as deleted

```php
//line 1497
foreach ($sugarLeadRecords as $sugarLeadRecord) {
    if ((isset($sugarLeadRecord) && $sugarLeadRecord)) {
        $email           = $sugarLeadRecord['email1'];
        $key             = mb_strtolower($email);
        $leadOwnerEmails = [];
        foreach ($checkEmailsInSugar as $emailKey => $mauticRecord) {
            if ($email == $emailKey) {     <------
```

The fix was simple, I just changed `$email` to `$key`.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Configure the SugarCRM plugin. Be sure to have at least one field pointing from Mautic to CRM
2. Create a Lead in Mautic - it should have uppercase characters in the email address
3. Run the `mautic:integration:synccontacts -i Sugarcrm` (or `fetchleads` (they are synonymous)) command
    This should create the Lead in CRM. 
5. Now, edit your Mautic->CRM field in Mautic. 
6. Run the command again. 

**Expected**: The field updates in CRM
**Actual** : The field does not update. Additionally, the `integration_entity` record has changed from 'lead' to 'lead-deleted'

#### Steps to test this PR:
1. Repeat steps above after installing PR. 

#### List deprecations along with the new alternative:
1. n/a


#### List backwards compatibility breaks:
1. n/a

