### PR TITLE
Fix maintenance cleanup with gdpr option

### DIFF
--- a/app/bundles/PageBundle/EventListener/MaintenanceSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/MaintenanceSubscriber.php
@@ -91,7 +91,7 @@ class MaintenanceSubscriber extends CommonSubscriber
                     $subQb->expr()->lte('l.date_added', ':date2'),
                     $subQb->expr()->isNull('l.last_active')
                   ));
-                $qb->setParameter('date2', $event->getDate()->format('Y-m-d H:i:s'));
+                $subQb->setParameter('date2', $event->getDate()->format('Y-m-d H:i:s'));
             }
             $rows = 0;
             $loop = 0;


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? |N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Required: )
#### Description:
Command `mautic:maintenance:cleanup -g` is broken and lead to SQL error :  
```
 [Doctrine\DBAL\DBALException]                                                                                                                                                                                    
  An exception occurred while executing 'SELECT id FROM leads l WHERE (l.last_active <= :date) OR ((l.date_added <= :date2) AND (l.last_active IS NULL)) LIMIT 10000 OFFSET 0' with params ["2016-04-10 07:09:05"  
  ]:                                                                                                                                                                                                               
                                                                                                                                                                                                                   
  Value for :date2 not found in params array. Params array key should be "date2"
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
Run command `mautic:maintenance:cleanup -g`

#### Steps to test this PR:
1. Apply Patch
2. run `mautic:maintenance:cleanup -g` and see command running properly 

