### PR TITLE
Add CreatedDate to Salesforce integration

### DIFF
--- a/app/bundles/PluginBundle/Assets/js/plugin.js
+++ b/app/bundles/PluginBundle/Assets/js/plugin.js
@@ -8,7 +8,7 @@ Mautic.matchedFields = function (index, object, integration) {
     var integrationField = mQuery('#integration_details_featureSettings_'+object+'Fields_i_' + index).attr('data-value');
     var mauticField = mQuery('#integration_details_featureSettings_'+object+'Fields_m_' + index + ' option:selected').val();
 
-    if(mQuery('.btn-arrow' + index).parent().attr('data-force-setuped') != 1) {
+    if(mQuery('.btn-arrow' + index).parent().attr('data-force-direction') != 1) {
         if (mQuery.inArray(mauticField, compoundMauticFields) >= 0) {
             mQuery('.btn-arrow' + index).removeClass('active');
             mQuery('#integration_details_featureSettings_' + object + 'Fields_update_mautic' + index + '_0').attr('checked', 'checked');

--- a/app/bundles/PluginBundle/Assets/js/plugin.js
+++ b/app/bundles/PluginBundle/Assets/js/plugin.js
@@ -8,15 +8,19 @@ Mautic.matchedFields = function (index, object, integration) {
     var integrationField = mQuery('#integration_details_featureSettings_'+object+'Fields_i_' + index).attr('data-value');
     var mauticField = mQuery('#integration_details_featureSettings_'+object+'Fields_m_' + index + ' option:selected').val();
 
-    if (mQuery.inArray(mauticField, compoundMauticFields) >= 0) {
-        mQuery('.btn-arrow' + index).removeClass('active');
-        mQuery('#integration_details_featureSettings_'+object+'Fields_update_mautic'+ index +'_0').attr('checked', 'checked');
-        mQuery('input[name="integration_details[featureSettings]['+object+'Fields][update_mautic' + index + ']"]').prop('disabled', true).trigger("chosen:updated");
-        mQuery('.btn-arrow' + index).addClass('disabled');
-    } else {
-        mQuery('input[name="integration_details[featureSettings]['+object+'Fields][update_mautic' + index + ']"]').prop('disabled', false).trigger("chosen:updated");
-        mQuery('.btn-arrow' + index).removeClass('disabled');
+    if(mQuery('.btn-arrow' + index).parent().attr('data-force-setuped') != 1) {
+        if (mQuery.inArray(mauticField, compoundMauticFields) >= 0) {
+            mQuery('.btn-arrow' + index).removeClass('active');
+            mQuery('#integration_details_featureSettings_' + object + 'Fields_update_mautic' + index + '_0').attr('checked', 'checked');
+            mQuery('input[name="integration_details[featureSettings][' + object + 'Fields][update_mautic' + index + ']"]').prop('disabled', true).trigger("chosen:updated");
+            mQuery('.btn-arrow' + index).addClass('disabled');
+        }
+        else {
+            mQuery('input[name="integration_details[featureSettings][' + object + 'Fields][update_mautic' + index + ']"]').prop('disabled', false).trigger("chosen:updated");
+            mQuery('.btn-arrow' + index).removeClass('disabled');
+        }
     }
+
     if (object == 'lead') {
         var updateMauticField = mQuery('input[name="integration_details[featureSettings]['+object+'Fields][update_mautic' + index + ']"]:checked').val();
     } else {

--- a/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
+++ b/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
@@ -152,6 +152,18 @@ trait FieldsTypeTrait
                         if ($fieldObject) {
                             $updateName .= '_'.$fieldObject;
                         }
+
+                        $disabled = (isset($fieldData[$fieldsName][$field])) ? $options['integration_object']->isCompoundMauticField($fieldData[$fieldsName][$field]) : false;
+                        $data = isset($fieldData[$updateName][$field]) ? (int) $fieldData[$updateName][$field] : 1;
+
+                        $forceSetuped = false;
+                        // Force to use just one way for certainly fields
+                        if (isset($fields[$field]['update_mautic'])) {
+                            $data = (bool) $fields[$field]['update_mautic'];
+                            $disabled = true;
+                            $forceSetuped = true;
+                        }
+
                         $form->add(
                             $updateName.$index,
                             'button_group',
@@ -161,12 +173,13 @@ trait FieldsTypeTrait
                                     '<btn class="btn-nospin fa fa-arrow-circle-right"></btn>',
                                 ],
                                 'label'       => false,
-                                'data'        => isset($fieldData[$updateName][$field]) ? (int) $fieldData[$updateName][$field] : 1,
+                                'data'        => $data,
                                 'empty_value' => false,
                                 'attr'        => [
                                     'data-toggle' => 'tooltip',
                                     'title'       => 'mautic.plugin.direction.data.update',
-                                    'disabled'    => (isset($fieldData[$fieldsName][$field])) ? $options['integration_object']->isCompoundMauticField($fieldData[$fieldsName][$field]) : false,
+                                    'disabled'    => $disabled,
+                                    'forceSetuped'=> $forceSetuped,
                                 ],
                             ]
                         );

--- a/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
+++ b/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
@@ -153,15 +153,15 @@ trait FieldsTypeTrait
                             $updateName .= '_'.$fieldObject;
                         }
 
+                        $forceDirection = false;
                         $disabled = (isset($fieldData[$fieldsName][$field])) ? $options['integration_object']->isCompoundMauticField($fieldData[$fieldsName][$field]) : false;
                         $data = isset($fieldData[$updateName][$field]) ? (int) $fieldData[$updateName][$field] : 1;
 
-                        $forceSetuped = false;
                         // Force to use just one way for certainly fields
                         if (isset($fields[$field]['update_mautic'])) {
                             $data = (bool) $fields[$field]['update_mautic'];
                             $disabled = true;
-                            $forceSetuped = true;
+                            $forceDirection = true;
                         }
 
                         $form->add(
@@ -176,10 +176,10 @@ trait FieldsTypeTrait
                                 'data'        => $data,
                                 'empty_value' => false,
                                 'attr'        => [
-                                    'data-toggle' => 'tooltip',
-                                    'title'       => 'mautic.plugin.direction.data.update',
-                                    'disabled'    => $disabled,
-                                    'forceSetuped'=> $forceSetuped,
+                                    'data-toggle'   => 'tooltip',
+                                    'title'         => 'mautic.plugin.direction.data.update',
+                                    'disabled'      => $disabled,
+                                    'forceDirection'=> $forceDirection,
                                 ],
                             ]
                         );

--- a/app/bundles/PluginBundle/Views/FormTheme/Integration/fields_row.html.php
+++ b/app/bundles/PluginBundle/Views/FormTheme/Integration/fields_row.html.php
@@ -81,7 +81,7 @@ $indexCount = 1;
                 <div class="row">
                     <div class="form-group col-xs-12 ">
                         <div class="choice-wrapper">
-                            <div class="btn-group btn-block" data-toggle="buttons" <?php if ($child->vars['attr']['forceSetuped']) : echo 'data-force-setuped="1"'; endif; ?>>
+                            <div class="btn-group btn-block" data-toggle="buttons" <?php if ($child->vars['attr']['forceDirection']) : echo 'data-force-direction="1"'; endif; ?>>
                                 <?php $checked = $child->vars['value'] === '0'; ?>
                                 <label class="btn-arrow<?php echo $indexCount; ?> btn btn-default<?php if ($checked): echo ' active'; endif; ?> <?php if ($child->vars['attr']['disabled']) : echo 'disabled'; endif; ?>">
                                     <input type="radio"

--- a/app/bundles/PluginBundle/Views/FormTheme/Integration/fields_row.html.php
+++ b/app/bundles/PluginBundle/Views/FormTheme/Integration/fields_row.html.php
@@ -81,7 +81,7 @@ $indexCount = 1;
                 <div class="row">
                     <div class="form-group col-xs-12 ">
                         <div class="choice-wrapper">
-                            <div class="btn-group btn-block" data-toggle="buttons">
+                            <div class="btn-group btn-block" data-toggle="buttons" <?php if ($child->vars['attr']['forceSetuped']) : echo 'data-force-setuped="1"'; endif; ?>>
                                 <?php $checked = $child->vars['value'] === '0'; ?>
                                 <label class="btn-arrow<?php echo $indexCount; ?> btn btn-default<?php if ($checked): echo ' active'; endif; ?> <?php if ($child->vars['attr']['disabled']) : echo 'disabled'; endif; ?>">
                                     <input type="radio"

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -275,7 +275,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
         $isRequired = function (array $field, $object) {
             return
-                ($field['type'] !== 'boolean' && empty($field['nillable']) && !in_array($field['name'], ['Status', 'Id'])) ||
+                ($field['type'] !== 'boolean' && empty($field['nillable']) && !in_array($field['name'], ['Status', 'Id', 'CreatedDate'])) ||
                 ($object == 'Lead' && in_array($field['name'], ['Company'])) ||
                 (in_array($object, ['Lead', 'Contact']) && 'Email' === $field['name']);
         };

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -295,7 +295,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
                     $sfObject = trim($sfObject);
                     // Check the cache first
-                    $settings['cache_suffix'] = $cacheSuffix = '3.'.$sfObject;
+                    $settings['cache_suffix'] = $cacheSuffix = '.'.$sfObject;
                     if ($fields = parent::getAvailableLeadFields($settings)) {
                         if (('company' === $sfObject && isset($fields['Id'])) || isset($fields['Id__'.$sfObject])) {
                             $salesFields[$sfObject] = $fields;

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -294,9 +294,8 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     }
 
                     $sfObject = trim($sfObject);
-
                     // Check the cache first
-                    $settings['cache_suffix'] = $cacheSuffix = '.'.$sfObject;
+                    $settings['cache_suffix'] = $cacheSuffix = '3.'.$sfObject;
                     if ($fields = parent::getAvailableLeadFields($settings)) {
                         if (('company' === $sfObject && isset($fields['Id'])) || isset($fields['Id__'.$sfObject])) {
                             $salesFields[$sfObject] = $fields;
@@ -310,7 +309,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                             $fields = $this->getApiHelper()->getLeadFields($sfObject);
                             if (!empty($fields['fields'])) {
                                 foreach ($fields['fields'] as $fieldInfo) {
-                                    if ((!$fieldInfo['updateable'] && (!$fieldInfo['calculated'] && $fieldInfo['name'] != 'Id') && $fieldInfo['name'] != 'IsDeleted')
+                                    if ((!$fieldInfo['updateable'] && (!$fieldInfo['calculated'] && !in_array($fieldInfo['name'], ['Id', 'IsDeleted', 'CreatedDate'])))
                                         || !isset($fieldInfo['name'])
                                         || (in_array(
                                                 $fieldInfo['type'],
@@ -339,6 +338,11 @@ class SalesforceIntegration extends CrmAbstractIntegration
                                             'group'       => $sfObject,
                                             'optionLabel' => $fieldInfo['label'],
                                         ];
+
+                                        // CreateDate can be updatable just in Mautic
+                                        if (in_array($fieldInfo['name'], ['CreatedDate'])) {
+                                            $salesFields[$sfObject][$fieldInfo['name'].'__'.$sfObject]['update_mautic'] = 1;
+                                        }
                                     } else {
                                         $salesFields[$sfObject][$fieldInfo['name']] = [
                                             'type'     => $type,


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR added support for sync CreatedDate from Salesforce to Mautic.
This fieldcannot be update on Salesforce, then this field have to just one way (to Mautic sync). 
This PR added option to force direction for any field. For this example we use it for CreatedDate

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Setup Salesforce https://www.mautic.org/docs/en/plugins/salesforce.html
3. Find Created Date in field list and setup mapping to any custom date field

![image](https://user-images.githubusercontent.com/462477/55883881-5f6a9f80-5ba7-11e9-8d96-9423bdb0ae54.png)

5. Call `php app/console mautic:integration:fetchleads --integration=Salesforce` 
6. Check If Created date was synced to Mautic 
