### PR TITLE
Contact's company field token support for Email to users campaign action

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1564,7 +1564,9 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         }
 
         $mailer            = $this->mailHelper->getMailer();
-        $lead['companies'] = $this->companyModel->getRepository()->getCompaniesByLeadId($lead['id']);
+        if (!isset($lead['companies'])) {
+            $lead['companies'] = $this->companyModel->getRepository()->getCompaniesByLeadId($lead['id']);
+        }
         $mailer->setLead($lead, true);
         $mailer->setTokens($tokens);
         $mailer->setEmail($email, false, $emailSettings[$emailId]['slots'], $assetAttachments, (!$saveStat));

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1563,7 +1563,8 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             return false;
         }
 
-        $mailer = $this->mailHelper->getMailer();
+        $mailer            = $this->mailHelper->getMailer();
+        $lead['companies'] = $this->companyModel->getRepository()->getCompaniesByLeadId($lead['id']);
         $mailer->setLead($lead, true);
         $mailer->setTokens($tokens);
         $mailer->setEmail($email, false, $emailSettings[$emailId]['slots'], $assetAttachments, (!$saveStat));


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When sending an email to users that has company field tokens, the company field tokens won't be displayed.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a company and fill the company city field
2. Create a contact with a firstname and assign this company then put this contact in a segment.
3. Create a campaign email, add tokens {contactfield=firstname} and {contactfield=companycity}
![image](https://user-images.githubusercontent.com/31535432/55876798-c765b980-5b98-11e9-825b-49df8edf15b8.png)
4. Create a campaign, add action send email to user.
5. See that when the user receive the email, the company field token is not displayed.
![image](https://user-images.githubusercontent.com/31535432/55877105-730f0980-5b99-11e9-95cb-cbabee898641.png)

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps and see If tokens are displayed
