### PR TITLE
Prevent destroyChosen call function on null

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -983,7 +983,9 @@ Mautic.activateChosenSelect = function(el, ignoreGlobal, jQueryVariant) {
  * @param el
  */
 Mautic.destroyChosen = function(el) {
-    var eventObject = mQuery._data(el.get(0), 'events');
+    if(el.get(0)) {
+        var eventObject = mQuery._data(el.get(0), 'events');
+    }
 
     // Check if object has chosen event
     if (eventObject !== undefined && eventObject['chosen:activate'] !== undefined) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a report
2. Choose **Emails Sent** as "Data Source"
3. In data tab **Add Filter**
4. Choose filter **Bounced** or another bool type
5. Then try change to another non bool filter
6. You should see rrror in console: `TypeError: owner is undefined`

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com) 
2. Without Mautibox require `php app/console mautic:assets:generate`
3. Repeat all steps to reproduce, should work properly
