### PR TITLE
Correct cache handling for zero counts (Fix #7003)

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -401,11 +401,11 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             $queued  = $this->cacheStorageHelper->get(sprintf('%s|%s|%s', 'email', $entity->getId(), 'queued'));
             $pending = $this->cacheStorageHelper->get(sprintf('%s|%s|%s', 'email', $entity->getId(), 'pending'));
 
-            if ($queued) {
+            if ($queued !== false) {
                 $entity->setQueuedCount($queued);
             }
 
-            if ($pending) {
+            if ($pending !== false) {
                 $entity->setPendingCount($pending);
             }
         }
@@ -977,7 +977,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             $countWithMaxMin
         );
 
-        if ($storeToCache && !empty($total)) {
+        if ($storeToCache) {
             if ($countOnly && $countWithMaxMin) {
                 $toStore = $total['count'];
             } elseif ($countOnly) {
@@ -1006,10 +1006,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         }
 
         $queued = (int) $this->messageQueueModel->getQueuedChannelCount('email', $ids);
-
-        if ($queued) {
-            $this->cacheStorageHelper->set(sprintf('%s|%s|%s', 'email', $email->getId(), 'queued'), $queued);
-        }
+        $this->cacheStorageHelper->set(sprintf('%s|%s|%s', 'email', $email->getId(), 'queued'), $queued);
 
         return $queued;
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #7003
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The cache handling in EmailModel for queued and pending counts was leaving stale cache entries when there was a previous non-zero value in cache.  This PR ensures that zero counts are cached the same way as non-zero counts, and that they aren't ignored when retrieved.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a segment email
2. See the pending badge
3. Send the email
4. Go back on the list of email and see that the pending badge is still showed even if it has been sent.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Same as above, except the badge goes away as expected

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
