### PR TITLE
Fix of campaign reschedule loop

### DIFF
--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -339,7 +339,8 @@ class CampaignSubscriber implements EventSubscriberInterface
             foreach ($stats as $contactId => $sentCount) {
                 /** @var LeadEventLog $log */
                 $log = $event->findLogByContactId($contactId);
-                $event->fail(
+                // Pass with a note to the UI because no use retrying
+                $event->passWithError(
                     $log,
                     $this->translator->trans('mautic.email.contact_already_received_marketing_email', ['%contact%' => $credentialArray[$log->getId()]['primaryIdentifier']])
                 );


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6971, https://github.com/mautic/mautic/issues/6625, https://github.com/mautic/mautic/issues/7226
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

We found a never ending loop that was creating massive amount of user notifications. When a contact is added to a campaign with the Send (marketing) Email event and the marketing email was sent to this contact previously then it the event will fail with error: `Last execution error: John Doe has already received this marketing email.`. The problem is that the event was rescheduled for another 30 minutes. And so this generated new notifications for the same contact and the same campaign event every 30 minutes.

The solution is to just send the error once without rescheduling.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a campaign that has 2 events to send the same marketing email. The second event will have delay of 3 minutes (for example)
2. Trigger the campaign for 1 contact. It will send the email properly. 
3. Wait 3 minutes and trigger the campaign again.
4. You should see the error message in the contact detail page in his history and the email should be scheduled for another 30 minutes.

You will see the notification created for every 30 minutes if you will test that long.

#### Steps to test this PR:
1. Checkout this branch.
2. Wait another 30 minutes or clone the campaign and test from the beginning.
3. The scheduled email should disappear.

Only 1 notification should be created.
