### PR TITLE
Add contact ID only if contact exists

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -169,6 +169,8 @@ class PublicController extends CommonFormController
         }
         $contentTemplate = $this->factory->getHelper('theme')->checkForTwigTemplate(':'.$template.':message.html.php');
         if (!empty($stat)) {
+            $successSessionName = 'mautic.email.prefscenter.success';
+
             if ($lead = $stat->getLead()) {
                 // Set the lead as current lead
                 $leadModel->setCurrentLead($lead);
@@ -177,9 +179,11 @@ class PublicController extends CommonFormController
                 if ($lead->getPreferredLocale()) {
                     $translator->setLocale($lead->getPreferredLocale());
                 }
-            }
 
-            $successSessionName = 'mautic.email.prefscenter.success.'.$lead->getId();
+                // Add contact ID to the session name in case more contacts
+                // share the same session/device and the contact is known.
+                $successSessionName .= ".{$lead->getId()}";
+            }
 
             if (!$this->get('mautic.helper.core_parameters')->getParameter('show_contact_preferences')) {
                 $message = $this->getUnsubscribeMessage($idHash, $model, $stat, $translator);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Ensure the contact exist during unsubscribe action before asking for his ID. Fixing error

```
Call to a member function getId() on null" at app/bundles/EmailBundle/Controller/PublicController.php line 183
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Sent an email with unsubscribe link to a contact.
2. Delete that contact.
3. Click on the unsubscribe link - 500 error page

#### Steps to test this PR:
1. Click on the unsubscribe page again - shows successful unsubscription.

