### PR TITLE
Option for custom popup name for loadNewWindow method

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -343,8 +343,13 @@ var Mautic = {
         if (options.windowUrl) {
             Mautic.startModalLoadingBar();
 
+            var popupName = 'mauticpopup';
+            if (options.popupName) {
+                popupName = options.popupName;
+            }
+
             setTimeout(function () {
-                var opener = window.open(options.windowUrl, 'mauticpopup', 'height=600,width=1100');
+                var opener = window.open(options.windowUrl, popupName, 'height=600,width=1100');
 
                 if (!opener || opener.closed || typeof opener.closed == 'undefined') {
                     alert(mauticLang.popupBlockerMessage);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR added option to loadNewWindow to customize popupname. 
This allow call another window from already opened window (for example create/edit email from campaign action)

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Just code review and test if current window are fired for example in campaign send email action