### PR TITLE
Fix report scheduling form in specific report config

### DIFF
--- a/app/bundles/ReportBundle/Form/Type/TableOrderType.php
+++ b/app/bundles/ReportBundle/Form/Type/TableOrderType.php
@@ -48,7 +48,7 @@ class TableOrderType extends AbstractType
             'empty_value' => false,
             'required'    => false,
             'attr'        => [
-                'class' => 'form-control filter-columns',
+                'class' => 'form-control',
             ],
         ]);
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The report scheduler form was broken for specific report configuration and was showing following JS error in JS console:
```
libraries.js?v2b3872fa:345 Uncaught TypeError: Cannot read property 'nodeType' of undefined
    at Function.jQuery.acceptData [as accepts] (libraries.js?v2b3872fa:345)
    at Data.key (libraries.js?v2b3872fa:346)
    at Data.get (libraries.js?v2b3872fa:350)
    at Data.access (libraries.js?v2b3872fa:350)
    at Function._data (libraries.js?v2b3872fa:355)
    at Object.Mautic.destroyChosen (app.js?v2b3872fa:103)
    at Object.Mautic.updateReportFilterValueInput (app.js?v2b3872fa:658)
    at HTMLSelectElement.<anonymous> (app.js?v2b3872fa:646)
    at Function.each (libraries.js?v2b3872fa:149)
    at jQuery.fn.init.each (libraries.js?v2b3872fa:139)
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create new report with data source of **Contact Point Log**
2. Select column **Point Change Date**
3. Select order by **Point Change Date**
4. Apply the report. Notice the JS error in dev tools.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Refresh the report edit page again. The error is gone and the schedule form shows correct fields for different sending time units.
3. Click around to ensure this did not break anything else. The order by select box should update for different data sources.