### PR TITLE
Fix SugarCRM records not syncing - #7112 and #7138

### DIFF
--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -42,8 +42,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
     protected $doNotContactModel;
 
     /**
-     * Holds a list of IntegrationEntities which are saved later in 
-     * fetchLeads process
+     * Holds a list of IntegrationEntities which are saved later in fetchLeads process.
      *
      * @var array
      */
@@ -1927,22 +1926,21 @@ class SugarcrmIntegration extends CrmAbstractIntegration
      * Hold a list of Integration Entitity records to be saved later
      * If a NEW Integration Entity record is provided, it is saved/flushed immediately.
      * 
-     * This is needed because the `getLeads` and `getContacts` functions create 
+     * This is needed because the `getLeads` and `getContacts` functions create
      * IntegrationEntity records (in the `amendLeadDataBeforeMauticPopulate` function). The
-     * `pushLeads` function calls the repo's `findLeadsToUpdate` function which filters based on 
+     * `pushLeads` function calls the repo's `findLeadsToUpdate` function which filters based on
      * the IE's last_sync_date. We need to not flush the IE record until after that function has
-     * been called. 
-     * So this function helps to hold on to them until a reasonable time
+     * been called.
+     * So this function helps to hold on to them until a reasonable time.
      *
      * @param array $entities
-     * @return void
      */
     protected function delaySaveIntegrationEntities(array $entities)
     {
-        foreach($entities as $entity){
-            if($entity->getId()){
+        foreach ($entities as $entity) {
+            if ($entity->getId()) {
                 $this->IntegrationEntitiesToSave[$entity->getId()] = $entity;
-            }else{
+            } else {
                 $this->em->getRepository('MauticPluginBundle:IntegrationEntity')->saveEntity($entity);
             }
         }

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -1921,7 +1921,6 @@ class SugarcrmIntegration extends CrmAbstractIntegration
         return $convertedString;
     }
 
-    
     /**
      * Hold a list of Integration Entitity records to be saved later
      * If a NEW Integration Entity record is provided, it is saved/flushed immediately.

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -1925,7 +1925,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
     /**
      * Hold a list of Integration Entitity records to be saved later
      * If a NEW Integration Entity record is provided, it is saved/flushed immediately.
-     * 
+     *
      * This is needed because the `getLeads` and `getContacts` functions create
      * IntegrationEntity records (in the `amendLeadDataBeforeMauticPopulate` function). The
      * `pushLeads` function calls the repo's `findLeadsToUpdate` function which filters based on


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | n/a
| Related developer documentation PR URL | n/a
| Issues addressed (#s or URLs) | #7112 #7138 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The current code prevents records from being being synced to CRM if the corresponding record has updates both in Mautic and CRM within the given Time Interval.

For example, if the interval is 15 minutes and the record was updated in both systems within the 15 minutes, then the changes will not be completely synced. 

This PR fixes that by delaying the save of the IntegrationEntity records until a more reasonable time.

Please see my comment in #7112 for a full explanation. 
tldr; The `getLeads` function sets the IntegrationEntity's 'last_sync_date' to Now. The `pushLeads` function only pushes Leads where the `date_modified` is GREATER than the `last_sync_date` - this is obviously never going to happen when the last_sync_date is only milliseconds ago. 
We need to wait to set the last_sync_date until later in the `pushLeads` process. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Set up the Mautic/SugarCRM connector and map fields. Be sure that you have at least some fields going each direction. 
2. Create a Lead in Mautic
3. Run the `fetchleads` (or `synccontacts`) command : `mautic:integration:fetchleads --integration=Sugarcrm`
    This should create the Lead in CRM.
    You should have an Integration record under the Mautic Contact:
    ![Screen Shot](https://user-images.githubusercontent.com/3300497/56056312-6a493f80-5d21-11e9-8a4e-0962f80216c2.png)

4. Modify the record in CRM. Change one of the 'sync to Mautic fields'
5. Modify the record in Mautic. Change one of the 'sync to CRM fields'
6. Run the `fetchleads` command again. 

Expected: The records are in sync. The CRM changes are reflected in Mautic and the Mautic changes in CRM. 

Actual : The records are not in sync. The CRM changes ARE reflected in Mautic, but the Mautic changes are NOT reflected in CRM. 

#### Steps to test this PR:
1. Load up this PR
2. Repeat steps above. You should receive the Expected results.

#### List deprecations along with the new alternative:
1. n/a

#### List backwards compatibility breaks:
1. n/a
