### PR TITLE
Some admin menu items are visible for user with not permissions

### DIFF
--- a/app/bundles/CoreBundle/Menu/MenuHelper.php
+++ b/app/bundles/CoreBundle/Menu/MenuHelper.php
@@ -325,6 +325,10 @@ class MenuHelper
     {
         switch ($accessLevel) {
             case 'admin':
+                if (!$this->security->isAdmin()) {
+                    return false;
+                }
+            return $this->security->isAdmin();
                 return $this->security->isAdmin();
             default:
                 return $this->security->isGranted($accessLevel, 'MATCH_ONE');

--- a/app/bundles/CoreBundle/Menu/MenuHelper.php
+++ b/app/bundles/CoreBundle/Menu/MenuHelper.php
@@ -325,10 +325,7 @@ class MenuHelper
     {
         switch ($accessLevel) {
             case 'admin':
-                if (!$this->security->isAdmin()) {
-                    return false;
-                }
-                return $this->security->isAdmin();
+                return (bool) $this->security->isAdmin();
             default:
                 return $this->security->isGranted($accessLevel, 'MATCH_ONE');
         }

--- a/app/bundles/CoreBundle/Menu/MenuHelper.php
+++ b/app/bundles/CoreBundle/Menu/MenuHelper.php
@@ -328,7 +328,6 @@ class MenuHelper
                 if (!$this->security->isAdmin()) {
                     return false;
                 }
-            return $this->security->isAdmin();
                 return $this->security->isAdmin();
             default:
                 return $this->security->isGranted($accessLevel, 'MATCH_ONE');


### PR DESCRIPTION
handleAccessCheck function return integer 0. but handleChecks function check for boolean value.

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| Automated tests included? | no
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. log in with user that have a rol with only "own" mail permissions
2. there are some UI links that the user should not see. and if you click in a 403 forbidden is trigged.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
