### PR TITLE
Fix sql syntax error in query build

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -112,9 +112,8 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
             ->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
 
         if (is_array($value)) {
-            $q->where(
-                $q->expr()->in($col, $value)
-            );
+            $q->where($col.' IN (:value)')
+                ->setParameter('value', $value);
         } else {
             $q->where("$col = :search")
                 ->setParameter('search', $value);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | No
| Related developer documentation PR URL | No
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7177
| BC breaks? | No
| Deprecations? | No


[//]: # ( Required: )
#### Description:
Fix the query build for the leads sync. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. You need to have a GoToWebinar plugin sync to test this.
2. Try to sync leads with Citrix plugin (GoToWebinar): the sync fails because of missing quotes around the emails in the query.


#### Steps to test this PR:
1. Load up this PR 
2. Try to sync leads: No sql syntax problem, the sync works.