### PR TITLE
Contact timeline timezone fix

### DIFF
--- a/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
@@ -170,12 +170,6 @@ class DateHelper extends Helper
             return '';
         }
 
-        if ($datetime instanceof \DateTime) {
-            // Fix time shift with timezone conversion into string representation
-            $timezone  = ($datetime->getTimezone()->getName() === 'UTC') ? 'utc' : $timezone;
-            $datetime  = $datetime->format($fromFormat);
-        }
-
         $this->helper->setDateTime($datetime, $fromFormat, $timezone);
 
         $textDate = $this->helper->getTextDate();

--- a/app/bundles/CoreBundle/Tests/unit/Templating/Helper/DateHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Templating/Helper/DateHelperTest.php
@@ -11,8 +11,8 @@
 
 namespace Mautic\CoreBundle\Tests\Helper;
 
-use Symfony\Component\Translation\TranslatorInterface;
 use Mautic\CoreBundle\Templating\Helper\DateHelper;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class DateHelperTest extends \PHPUnit_Framework_TestCase
 {

--- a/app/bundles/CoreBundle/Tests/unit/Templating/Helper/DateHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Templating/Helper/DateHelperTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Tests\Helper;
+
+use Symfony\Component\Translation\TranslatorInterface;
+use Mautic\CoreBundle\Templating\Helper\DateHelper;
+
+class DateHelperTest extends \PHPUnit_Framework_TestCase
+{
+    private $translator;
+
+    /**
+     * @var DateHelper
+     */
+    private $helper;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->translator = $this->createMock(TranslatorInterface::class);
+        $this->helper     = new DateHelper(
+            'F j, Y g:i a T',
+            'D, M d',
+            'F j, Y',
+            'g:i a',
+            $this->translator
+        );
+    }
+
+    public function testToTextWithPragueTimezone()
+    {
+        $dateTime = new \DateTime('2016-01-27 13:30:00', new \DateTimeZone('UTC'));
+
+        $this->assertSame('January 27, 2016 2:30 pm', $this->helper->toText($dateTime, 'Europe/Prague', 'Y-m-d H:i:s', true));
+    }
+
+    public function testToTextWithUtcTimezone()
+    {
+        $dateTime = new \DateTime('2017-11-20 15:45:00', new \DateTimeZone('UTC'));
+
+        $this->assertSame('November 20, 2017 3:45 pm', $this->helper->toText($dateTime, 'UTC', 'Y-m-d H:i:s', true));
+    }
+}

--- a/app/bundles/CoreBundle/Tests/unit/Templating/Helper/DateHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/unit/Templating/Helper/DateHelperTest.php
@@ -39,9 +39,10 @@ class DateHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testToTextWithPragueTimezone()
     {
-        $dateTime = new \DateTime('2016-01-27 13:30:00', new \DateTimeZone('UTC'));
+        $dateTime    = new \DateTime('2016-01-27 13:30:00', new \DateTimeZone('UTC'));
+        $regexForDst = '/^January 27, 2016 [1,2]:30 pm$/';
 
-        $this->assertSame('January 27, 2016 2:30 pm', $this->helper->toText($dateTime, 'Europe/Prague', 'Y-m-d H:i:s', true));
+        $this->assertRegExp($regexForDst, $this->helper->toText($dateTime, 'Europe/Prague', 'Y-m-d H:i:s', true));
     }
 
     public function testToTextWithUtcTimezone()


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR reverts PR https://github.com/mautic/mautic/pull/6850 which seemed to fix the same problem it is now causing. Plus I've added unit tests to ensure it works as it should.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
0. Configure different timezone than UTC for your Mautic user.
1. Create a new contact. 
2. Check the history. It looks like this:
![Screenshot 2019-04-15 at 15 29 50](https://user-images.githubusercontent.com/1235442/56136568-56a50f80-5f93-11e9-87cd-4ca5af84b3e2.png)
Note that I've created the contact at 2:11 pm Prague time. So it wrote into the database time in UTC which is 12:11 pm. So it shows some dates in UTC and one in the correct timezone of the user.\

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Refresh the contact detail page. All events should show in the correct timezone:
![Screenshot 2019-04-15 at 15 32 19](https://user-images.githubusercontent.com/1235442/56136781-b8fe1000-5f93-11e9-9cb2-9ea176eb4f3a.png)
