### PR TITLE
Ensure the root URL field will always show up

### DIFF
--- a/app/bundles/CoreBundle/Views/FormTheme/Config/_config_coreconfig_widget.html.php
+++ b/app/bundles/CoreBundle/Views/FormTheme/Config/_config_coreconfig_widget.html.php
@@ -13,7 +13,7 @@ $fieldKeys = array_keys($fields);
 $template  = '<div class="col-md-6">{content}</div>';
 ?>
 
-<?php if (count(array_intersect($fieldKeys, ['site_url', 'update_stability', 'cache_path', 'log_path', 'theme', 'image_path']))): ?>
+<?php if (count(array_intersect($fieldKeys, ['site_url', 'webroot', 'update_stability', 'cache_path', 'log_path', 'theme', 'image_path']))): ?>
 <div class="panel panel-primary">
     <div class="panel-heading">
         <h3 class="panel-title"><?php echo $view['translator']->trans('mautic.core.config.header.general'); ?></h3>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The `webroot` field is missing from the condition. It doesn't cause any trouble normally. But we select which fields to show to our users and so we need to be precise otherwise the whole field section won't show up.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Very hard to do without hacking Mautic.

#### Steps to test this PR:
0. A code review should suffice.
1. Load up [this PR](https://mautibox.com)
2. Go to Settings > Configuration page
3. Verify, that General settings block with Mautic's root URL field is present