### PR TITLE
Missing check if trackedContact is null in ContactRequestHelper

### DIFF
--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -171,7 +171,7 @@ class ContactRequestHelper
                 true,
                 true
             );
-            if ($foundContact->getId() !== $this->trackedContact->getId()) {
+            if (is_null($this->trackedContact) or $foundContact->getId() !== $this->trackedContact->getId()) {
                 // A contact was found by a publicly updatable field
                 return $foundContact;
             }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Simulate tracking ajax request from mautic user
2. Inspect network activity, you should see error 500 when loading that HTML page while logged in as Mautic user at the same browser.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Simulate tracking ajax request from mautic user
3. Inspect network activity, you shouldn't see any error
4. Ensure the DWC tracking still works for contacts.