### PR TITLE
Add possibility for batch removing DNC record

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -651,12 +651,19 @@ class LeadApiController extends CommonApiController
             unset($this->entityRequestParameters['lastActive']);
         }
 
+        // Batch DNC settings
         if (!empty($parameters['doNotContact']) && is_array($parameters['doNotContact'])) {
             foreach ($parameters['doNotContact'] as $dnc) {
                 $channel  = !empty($dnc['channel']) ? $dnc['channel'] : 'email';
                 $comments = !empty($dnc['comments']) ? $dnc['comments'] : '';
-                $reason   = !empty($dnc['reason']) ? $dnc['reason'] : DoNotContact::MANUAL;
-                $this->model->addDncForLead($entity, $channel, $comments, $reason, false);
+                $reason   = !empty($dnc['reason']) || $dnc['reason'] === 0 ? $dnc['reason'] : DoNotContact::MANUAL;
+                if ($reason === DoNotContact::IS_CONTACTABLE) {
+                    // Remove DNC record
+                    $this->model->removeDncForLead($entity, $channel, false);
+                } else {
+                    // Add DNC record
+                    $this->model->addDncForLead($entity, $channel, $comments, $reason, false);
+                }
             }
             unset($parameters['doNotContact']);
         }

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -14,6 +14,7 @@ namespace Mautic\LeadBundle\Controller\Api;
 use FOS\RestBundle\Util\Codes;
 use JMS\Serializer\SerializationContext;
 use Mautic\ApiBundle\Controller\CommonApiController;
+use Mautic\CoreBundle\Helper\ArrayHelper;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\LeadBundle\Controller\FrequencyRuleTrait;
@@ -657,8 +658,7 @@ class LeadApiController extends CommonApiController
                 $channel  = !empty($dnc['channel']) ? $dnc['channel'] : 'email';
                 $comments = !empty($dnc['comments']) ? $dnc['comments'] : '';
 
-                $reason = isset($dnc['reason']) ? (int) $dnc['reason'] : null;
-                $reason = (null !== $reason) ? $reason : DoNotContact::MANUAL;
+                $reason = (int) ArrayHelper::getValue('reason', $dnc, DoNotContact::MANUAL);
 
                 if ($reason === DoNotContact::IS_CONTACTABLE) {
                     // Remove DNC record

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -656,7 +656,10 @@ class LeadApiController extends CommonApiController
             foreach ($parameters['doNotContact'] as $dnc) {
                 $channel  = !empty($dnc['channel']) ? $dnc['channel'] : 'email';
                 $comments = !empty($dnc['comments']) ? $dnc['comments'] : '';
-                $reason   = !empty($dnc['reason']) || $dnc['reason'] === 0 ? $dnc['reason'] : DoNotContact::MANUAL;
+
+                $reason = isset($dnc['reason']) ? (int) $dnc['reason'] : null;
+                $reason = (null !== $reason) ? $reason : DoNotContact::MANUAL;
+
                 if ($reason === DoNotContact::IS_CONTACTABLE) {
                     // Remove DNC record
                     $this->model->removeDncForLead($entity, $channel, false);

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -13,6 +13,8 @@ namespace Mautic\LeadBundle\Tests\Controller\Api;
 
 use FOS\RestBundle\Util\Codes;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\DoNotContact;
+use Symfony\Component\HttpFoundation\Response;
 
 class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 {
@@ -145,5 +147,62 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($payload['firstname'], $response['contact']['fields']['all']['firstname']);
         $this->assertEquals(4, $response['contact']['points']);
         $this->assertEquals(2, count($response['contact']['tags']));
+    }
+
+    public function testBachdDncAddAndRemove()
+    {
+        // Create contact
+        $emailAddress = uniqid('', false).'@mautic.com';
+
+        $payload = [
+            'id' => 80,
+            'email'=> $emailAddress,
+        ];
+
+        $this->client->request('POST', '/api/contacts/new', $payload);
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+        $contactId      = $response['contact']['id'];
+
+        // Batch update contact with new DNC record
+        $payload = [[
+            'id' => $contactId,
+            'email'=> $emailAddress,
+            'doNotContact' => [[
+                'reason' => DoNotContact::MANUAL,
+                'comments' => 'manually',
+                'channel' => 'email',
+                'channelId' => null
+            ]]
+        ]];
+
+        $this->client->request('PUT', '/api/contacts/batch/edit', $payload);
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+
+        $this->assertSame(3, $response['contacts'][0]['doNotContact'][0]['reason']);
+
+        // Batch update contact and remove DNC record
+        $payload = [[
+            'id' => $contactId,
+            'email'=> $emailAddress,
+            'doNotContact' => [[
+                'reason' => DoNotContact::IS_CONTACTABLE,
+                'comments' => 'manually',
+                'channel' => 'email',
+                'channelId' => null
+            ]]
+        ]];
+
+        $this->client->request('PUT', '/api/contacts/batch/edit', $payload);
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+
+        $this->assertSame(null, $response['contacts'][0]['doNotContact'][0]['reason']);
+
+        // Remove contact
+        $this->client->request('DELETE', "/api/contacts/$contactId/delete");
+        $clientResponse = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
     }
 }

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -155,7 +155,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $emailAddress = uniqid('', false).'@mautic.com';
 
         $payload = [
-            'id' => 80,
+            'id'   => 80,
             'email'=> $emailAddress,
         ];
 
@@ -166,14 +166,14 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 
         // Batch update contact with new DNC record
         $payload = [[
-            'id' => $contactId,
-            'email'=> $emailAddress,
+            'id'           => $contactId,
+            'email'        => $emailAddress,
             'doNotContact' => [[
-                'reason' => DoNotContact::MANUAL,
-                'comments' => 'manually',
-                'channel' => 'email',
-                'channelId' => null
-            ]]
+                'reason'    => DoNotContact::MANUAL,
+                'comments'  => 'manually',
+                'channel'   => 'email',
+                'channelId' => null,
+            ]],
         ]];
 
         $this->client->request('PUT', '/api/contacts/batch/edit', $payload);
@@ -184,14 +184,14 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 
         // Batch update contact and remove DNC record
         $payload = [[
-            'id' => $contactId,
-            'email'=> $emailAddress,
+            'id'           => $contactId,
+            'email'        => $emailAddress,
             'doNotContact' => [[
-                'reason' => DoNotContact::IS_CONTACTABLE,
-                'comments' => 'manually',
-                'channel' => 'email',
-                'channelId' => null
-            ]]
+                'reason'    => DoNotContact::IS_CONTACTABLE,
+                'comments'  => 'manually',
+                'channel'   => 'email',
+                'channelId' => null,
+            ]],
         ]];
 
         $this->client->request('PUT', '/api/contacts/batch/edit', $payload);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | Y
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: CS requested possibility of batch removing DNC record.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Use authenticated postman for PUT request to `/api/contacts/batch/edit` with body looking like
```json
[
  {
  	"id" : 80,
    "email": "lukas@drahy.net",
    "doNotContact": [
		{
		    "reason": 0,
		    "comments": "manualy",
		    "channel": "email",
		    "channelId": null
		}
    ]
  }
]
```
2.  Your reason will be translated to 3 (MANUALLY) and new record will be added (or edited)

#### Steps to test this PR:

#### List backwards compatibility breaks:
1. If somebody makes calls to the same endpoint with reason `0`, after this update will get different result.