### PR TITLE
Fix integration modal closing in Safari

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/9.modals.js
+++ b/app/bundles/CoreBundle/Assets/js/9.modals.js
@@ -406,7 +406,7 @@ Mautic.showModal = function(target) {
                 }
 
                 if (mQuery(modal).attr('data-modal-moved')) {
-                    mQuery('[data-modal-placeholder').replaceWith(mQuery(modal));
+                    mQuery('[data-modal-placeholder]').replaceWith(mQuery(modal));
                     mQuery(modal).attr('data-modal-moved', undefined);
                 }
             });


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
While trying to close integration config modal, Safari produces error and modal won't close.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Open plugin page
2. Click integration icon
3. Try to close modal

#### Steps to test this PR:
1. Same as reproduction steps
