### PR TITLE
Command to delete orphaned ip duplicates

### DIFF
--- a/app/bundles/CoreBundle/Command/DuplicateIpDeleteCommand.php
+++ b/app/bundles/CoreBundle/Command/DuplicateIpDeleteCommand.php
@@ -41,12 +41,12 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $em = $this->getContainer()->get('doctrine')->getEntityManager();
-        $ipAddressRepository = $em->getRepository('MauticCoreBundle:IpAddress');
+        $em             = $this->getContainer()->get('doctrine')->getEntityManager();
+        $ipAddressRepo  = $em->getRepository('MauticCoreBundle:IpAddress');
 
-        $deletedRows = $ipAddressRepository->deleteDuplicateIpAddresses();
+        $deletedRows = $ipAddressRepo->deleteDuplicateIpAddresses();
 
-        $output->writeln(sprintf('<info>%s duplicate IP adreeses has been deleted</info>', $deletedRows)); //TODO add translation?
+        $output->writeln(sprintf("\n\n<info>%s duplicate IP addresses has been deleted</info>", $deletedRows));
 
         return 0;
     }

--- a/app/bundles/CoreBundle/Command/DuplicateIpDeleteCommand.php
+++ b/app/bundles/CoreBundle/Command/DuplicateIpDeleteCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * CLI Command to delete duplicate IP addresses.
+ */
+class DuplicateIpDeleteCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('mautic:duplicateip:delete')
+            ->setDescription('Deletes duplicate IP addresses that are not used in any other table')
+            ->setHelp(
+                <<<'EOT'
+                The <info>%command.name%</info> command is used to delete duplicate IP addresses that are not used in any other table.
+
+<info>php %command.full_name%</info>
+EOT
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $em = $this->getContainer()->get('doctrine')->getEntityManager();
+        $ipAddressRepository = $em->getRepository('MauticCoreBundle:IpAddress');
+
+        $deletedRows = $ipAddressRepository->deleteDuplicateIpAddresses();
+
+        $output->writeln(sprintf('<info>%s duplicate IP adreeses has been deleted</info>', $deletedRows)); //TODO add translation?
+
+        return 0;
+    }
+}

--- a/app/bundles/CoreBundle/Command/DuplicateIpDeleteCommand.php
+++ b/app/bundles/CoreBundle/Command/DuplicateIpDeleteCommand.php
@@ -11,10 +11,10 @@
 
 namespace Mautic\CoreBundle\Command;
 
+use Doctrine\DBAL\DBALException;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Doctrine\DBAL\DBALException;
 
 /**
  * CLI Command to delete duplicate IP addresses.
@@ -27,10 +27,10 @@ class DuplicateIpDeleteCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this->setName('mautic:duplicateip:delete')
-            ->setDescription('Deletes duplicate IP addresses that are not used in any other table')
+            ->setDescription('Deletes duplicate IP addresses that are not used in any other database table')
             ->setHelp(
                 <<<'EOT'
-                The <info>%command.name%</info> command is used to delete duplicate IP addresses that are not used in any other table.
+                The <info>%command.name%</info> command is used to delete duplicate IP addresses that are not used in any other database table.
 
 <info>php %command.full_name%</info>
 EOT
@@ -47,10 +47,9 @@ EOT
 
         try {
             $deletedRows = $ipAddressRepo->deleteDuplicateIpAddresses();
-            $output->writeln(sprintf("<info>%s duplicate IP addresses has been deleted</info>", $deletedRows));
-
+            $output->writeln(sprintf('<info>%s duplicate IP addresses has been deleted</info>', $deletedRows));
         } catch (DBALException $e) {
-            $output->writeln(sprintf("<error>Deletion of duplicate IP addresses failed because of database error: %s</error>", $e->getMessage()));
+            $output->writeln(sprintf('<error>Deletion of duplicate IP addresses failed because of database error: %s</error>', $e->getMessage()));
 
             return 1;
         }

--- a/app/bundles/CoreBundle/Entity/IpAddressRepository.php
+++ b/app/bundles/CoreBundle/Entity/IpAddressRepository.php
@@ -33,4 +33,47 @@ class IpAddressRepository extends CommonRepository
 
         return (int) $results['unique'];
     }
+
+    /**
+     * Deletes duplicate IP addresses that are not being used in any other table
+     *
+     * @return int
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function deleteDuplicateIpAddresses()
+    {
+
+        $prefix = MAUTIC_TABLE_PREFIX;
+
+        $sql = <<<SQL
+            DELETE {$prefix}ip_addresses FROM {$prefix}ip_addresses 
+                LEFT JOIN {$prefix}asset_downloads ON {$prefix}asset_downloads.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}campaign_lead_event_log ON {$prefix}campaign_lead_event_log.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}email_stats ON {$prefix}email_stats.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}email_stats_devices ON {$prefix}email_stats_devices.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}form_submissions ON {$prefix}form_submissions.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}lead_ips_xref ON {$prefix}lead_ips_xref.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}lead_points_change_log ON {$prefix}lead_points_change_log.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}page_hits ON {$prefix}page_hits.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}point_lead_action_log ON {$prefix}point_lead_action_log.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}point_lead_event_log ON {$prefix}point_lead_event_log.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}push_notification_stats ON {$prefix}push_notification_stats.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}sms_message_stats ON {$prefix}sms_message_stats.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}stage_lead_action_log ON {$prefix}stage_lead_action_log.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}video_hits ON {$prefix}video_hits.ip_id = {$prefix}ip_addresses.id 
+	            WHERE {$prefix}asset_downloads.id IS NULL 
+	            AND {$prefix}campaign_lead_event_log.id IS NULL 
+	            AND {$prefix}email_stats.id IS NULL 
+	            AND {$prefix}email_stats_devices.id IS NULL 
+	            AND {$prefix}form_submissions.id IS NULL AND {$prefix}lead_ips_xref.lead_id IS NULL AND {$prefix}lead_points_change_log.id IS NULL 
+	            AND {$prefix}page_hits.id IS NULL AND {$prefix}point_lead_action_log.point_id IS NULL AND {$prefix}point_lead_event_log.event_id IS NULL AND {$prefix}push_notification_stats.id IS NULL 
+	            AND {$prefix}sms_message_stats.id IS NULL AND {$prefix}stage_lead_action_log.stage_id IS NULL AND {$prefix}video_hits.id IS NULL AND {$prefix}ip_addresses.id < 10000000;
+SQL;
+        $stmt = $this->_em->getConnection()->prepare($sql);
+        $stmt->execute();
+
+        $deletedCount = $stmt->rowCount();
+
+        return $deletedCount;
+    }
 }

--- a/app/bundles/CoreBundle/Entity/IpAddressRepository.php
+++ b/app/bundles/CoreBundle/Entity/IpAddressRepository.php
@@ -35,14 +35,14 @@ class IpAddressRepository extends CommonRepository
     }
 
     /**
-     * Deletes duplicate IP addresses that are not being used in any other table
+     * Deletes duplicate IP addresses that are not being used in any other table.
      *
-     * @return int
+     * @return int  Number of deleted rows
+     *
      * @throws \Doctrine\DBAL\DBALException
      */
     public function deleteDuplicateIpAddresses()
     {
-
         $prefix = MAUTIC_TABLE_PREFIX;
 
         $sql = <<<SQL
@@ -65,12 +65,18 @@ class IpAddressRepository extends CommonRepository
 	            AND {$prefix}campaign_lead_event_log.id IS NULL 
 	            AND {$prefix}email_stats.id IS NULL 
 	            AND {$prefix}email_stats_devices.id IS NULL 
-	            AND {$prefix}form_submissions.id IS NULL AND {$prefix}lead_ips_xref.lead_id IS NULL AND {$prefix}lead_points_change_log.id IS NULL 
-	            AND {$prefix}page_hits.id IS NULL AND {$prefix}point_lead_action_log.point_id IS NULL AND {$prefix}point_lead_event_log.event_id IS NULL AND {$prefix}push_notification_stats.id IS NULL 
-	            AND {$prefix}sms_message_stats.id IS NULL AND {$prefix}stage_lead_action_log.stage_id IS NULL AND {$prefix}video_hits.id IS NULL AND {$prefix}ip_addresses.id < 10000000;
+	            AND {$prefix}form_submissions.id IS NULL 
+	            AND {$prefix}lead_ips_xref.lead_id IS NULL 
+	            AND {$prefix}lead_points_change_log.id IS NULL 
+	            AND {$prefix}page_hits.id IS NULL 
+	            AND {$prefix}point_lead_action_log.point_id IS NULL 
+	            AND {$prefix}point_lead_event_log.event_id IS NULL 
+	            AND {$prefix}push_notification_stats.id IS NULL 
+	            AND {$prefix}sms_message_stats.id IS NULL 
+	            AND {$prefix}stage_lead_action_log.stage_id IS NULL 
+	            AND {$prefix}video_hits.id IS NULL;
 SQL;
-        $stmt = $this->_em->getConnection()->prepare($sql);
-        $stmt->execute();
+        $stmt = $this->_em->getConnection()->executeQuery($sql);
 
         $deletedCount = $stmt->rowCount();
 

--- a/app/bundles/CoreBundle/Entity/IpAddressRepository.php
+++ b/app/bundles/CoreBundle/Entity/IpAddressRepository.php
@@ -47,34 +47,48 @@ class IpAddressRepository extends CommonRepository
 
         $sql = <<<SQL
             DELETE {$prefix}ip_addresses FROM {$prefix}ip_addresses 
-                LEFT JOIN {$prefix}asset_downloads ON {$prefix}asset_downloads.ip_id = {$prefix}ip_addresses.id 
-                LEFT JOIN {$prefix}campaign_lead_event_log ON {$prefix}campaign_lead_event_log.ip_id = {$prefix}ip_addresses.id 
-                LEFT JOIN {$prefix}email_stats ON {$prefix}email_stats.ip_id = {$prefix}ip_addresses.id
-                LEFT JOIN {$prefix}email_stats_devices ON {$prefix}email_stats_devices.ip_id = {$prefix}ip_addresses.id
-                LEFT JOIN {$prefix}form_submissions ON {$prefix}form_submissions.ip_id = {$prefix}ip_addresses.id 
-                LEFT JOIN {$prefix}lead_ips_xref ON {$prefix}lead_ips_xref.ip_id = {$prefix}ip_addresses.id 
-                LEFT JOIN {$prefix}lead_points_change_log ON {$prefix}lead_points_change_log.ip_id = {$prefix}ip_addresses.id
-                LEFT JOIN {$prefix}page_hits ON {$prefix}page_hits.ip_id = {$prefix}ip_addresses.id
-                LEFT JOIN {$prefix}point_lead_action_log ON {$prefix}point_lead_action_log.ip_id = {$prefix}ip_addresses.id 
-                LEFT JOIN {$prefix}point_lead_event_log ON {$prefix}point_lead_event_log.ip_id = {$prefix}ip_addresses.id 
-                LEFT JOIN {$prefix}push_notification_stats ON {$prefix}push_notification_stats.ip_id = {$prefix}ip_addresses.id 
-                LEFT JOIN {$prefix}sms_message_stats ON {$prefix}sms_message_stats.ip_id = {$prefix}ip_addresses.id 
-                LEFT JOIN {$prefix}stage_lead_action_log ON {$prefix}stage_lead_action_log.ip_id = {$prefix}ip_addresses.id 
-                LEFT JOIN {$prefix}video_hits ON {$prefix}video_hits.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}asset_downloads 
+                  ON {$prefix}asset_downloads.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}campaign_lead_event_log 
+                  ON {$prefix}campaign_lead_event_log.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}email_stats 
+                  ON {$prefix}email_stats.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}email_stats_devices 
+                  ON {$prefix}email_stats_devices.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}form_submissions 
+                  ON {$prefix}form_submissions.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}lead_ips_xref 
+                  ON {$prefix}lead_ips_xref.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}lead_points_change_log 
+                  ON {$prefix}lead_points_change_log.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}page_hits 
+                  ON {$prefix}page_hits.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}point_lead_action_log 
+                  ON {$prefix}point_lead_action_log.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}point_lead_event_log 
+                  ON {$prefix}point_lead_event_log.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}push_notification_stats 
+                  ON {$prefix}push_notification_stats.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}sms_message_stats 
+                  ON {$prefix}sms_message_stats.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}stage_lead_action_log 
+                  ON {$prefix}stage_lead_action_log.ip_id = {$prefix}ip_addresses.id 
+                LEFT JOIN {$prefix}video_hits 
+                  ON {$prefix}video_hits.ip_id = {$prefix}ip_addresses.id 
 	            WHERE {$prefix}asset_downloads.id IS NULL 
-	            AND {$prefix}campaign_lead_event_log.id IS NULL 
-	            AND {$prefix}email_stats.id IS NULL 
-	            AND {$prefix}email_stats_devices.id IS NULL 
-	            AND {$prefix}form_submissions.id IS NULL 
-	            AND {$prefix}lead_ips_xref.lead_id IS NULL 
-	            AND {$prefix}lead_points_change_log.id IS NULL 
-	            AND {$prefix}page_hits.id IS NULL 
-	            AND {$prefix}point_lead_action_log.point_id IS NULL 
-	            AND {$prefix}point_lead_event_log.event_id IS NULL 
-	            AND {$prefix}push_notification_stats.id IS NULL 
-	            AND {$prefix}sms_message_stats.id IS NULL 
-	            AND {$prefix}stage_lead_action_log.stage_id IS NULL 
-	            AND {$prefix}video_hits.id IS NULL;
+                  AND {$prefix}campaign_lead_event_log.id IS NULL 
+                  AND {$prefix}email_stats.id IS NULL 
+                  AND {$prefix}email_stats_devices.id IS NULL 
+                  AND {$prefix}form_submissions.id IS NULL 
+                  AND {$prefix}lead_ips_xref.lead_id IS NULL 
+                  AND {$prefix}lead_points_change_log.id IS NULL 
+                  AND {$prefix}page_hits.id IS NULL 
+                  AND {$prefix}point_lead_action_log.point_id IS NULL 
+                  AND {$prefix}point_lead_event_log.event_id IS NULL 
+                  AND {$prefix}push_notification_stats.id IS NULL 
+                  AND {$prefix}sms_message_stats.id IS NULL 
+                  AND {$prefix}stage_lead_action_log.stage_id IS NULL 
+                  AND {$prefix}video_hits.id IS NULL;
 SQL;
         $stmt = $this->_em->getConnection()->executeQuery($sql);
 

--- a/app/bundles/CoreBundle/Entity/IpAddressRepository.php
+++ b/app/bundles/CoreBundle/Entity/IpAddressRepository.php
@@ -37,7 +37,7 @@ class IpAddressRepository extends CommonRepository
     /**
      * Deletes duplicate IP addresses that are not being used in any other table.
      *
-     * @return int  Number of deleted rows
+     * @return int Number of deleted rows
      *
      * @throws \Doctrine\DBAL\DBALException
      */


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
New command mautic:duplicateip:delete that executes a delete query to remove duplicate IP addresses from the database.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Run mautic:duplicateip:delete command
3. IP Addresses from ip_addresses table without references in any other table should be deleted
