### PR TITLE
Disable image resize in FileManager

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/scripts/filemanager.config.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/ckeditor/filemanager/scripts/filemanager.config.js
@@ -70,7 +70,7 @@
             "svg"
         ],
             "resize": {
-            "enabled":true,
+            "enabled":false,
                 "maxWidth": 1280,
                 "maxHeight": 1024
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Images uploaded via FileManager are resized to max. 1280 x 1024 px

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Open builder
2. Click on a text slot, then click on insert image icon
3. Click browse to open FileManager
4. In FileManager, click upload
5. Upload picture bigger than 1280 x 1024 px
6. Uploaded picture has been resized to max. 1280 x 1024 px

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Same as steps to reproduce
3. Uploaded picture should have original dimensions

