### PR TITLE
Fixed sending scheduled reports through Sparkpost & Momentum

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1025,7 +1025,7 @@ class MailHelper
                 $address[$item] = $name;
 
                 return $address;
-            }, array());
+            }, []);
         }
 
         $this->checkBatchMaxRecipients(count($addresses));

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1015,9 +1015,17 @@ class MailHelper
      */
     public function setTo($addresses, $name = null)
     {
+        $name = $this->cleanName($name);
+
         if (!is_array($addresses)) {
-            $name      = $this->cleanName($name);
             $addresses = [$addresses => $name];
+        } elseif (array_keys($addresses)[0] === 0) {
+            // We need an array of $email => $name pairs
+            $addresses = array_reduce($addresses, function ($address, $item) use ($name) {
+                $address[$item] = $name;
+
+                return $address;
+            }, array());
         }
 
         $this->checkBatchMaxRecipients(count($addresses));

--- a/app/bundles/EmailBundle/Swiftmailer/Momentum/DTO/TransmissionDTO/RecipientDTO.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Momentum/DTO/TransmissionDTO/RecipientDTO.php
@@ -127,7 +127,6 @@ final class RecipientDTO implements \JsonSerializable
             // `substitution_data` is required but Sparkpost will return the following error with empty arrays:
             // field 'substitution_data' is of type 'json_array', but needs to be of type 'json_object'
             $json['substitution_data'] = new \stdClass();
-
         } else {
             $json['substitution_data'] = $this->substitutionData;
         }

--- a/app/bundles/EmailBundle/Swiftmailer/Momentum/DTO/TransmissionDTO/RecipientDTO.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Momentum/DTO/TransmissionDTO/RecipientDTO.php
@@ -122,9 +122,16 @@ final class RecipientDTO implements \JsonSerializable
         if (count($this->metadata) !== 0) {
             $json['metadata'] = $this->metadata;
         }
-        if (count($this->substitutionData) !== 0) {
+
+        if (count($this->substitutionData) === 0) {
+            // `substitution_data` is required but Sparkpost will return the following error with empty arrays:
+            // field 'substitution_data' is of type 'json_array', but needs to be of type 'json_object'
+            $json['substitution_data'] = new \stdClass();
+
+        } else {
             $json['substitution_data'] = $this->substitutionData;
         }
+
         if ($this->returnPath !== null) {
             $json['return_path'] = $this->returnPath;
         }

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
@@ -201,10 +201,14 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
                 $recipient['metadata'] = $metadata[$to['email']];
             }
 
-            // Apparently Sparkpost doesn't like empty substitution_data or metadata
+            // Sparkpost requires substitution_data which can be byspassed by using MailHelper::setTo() rather than a Lead via MailHelper::setLead()
+            // Without it, Sparkpost returns the error: "field 'substitution_data' is required"
+            // But, it can't be an empty array or Sparkpost will return error: field 'substitution_data' is of type 'json_array', but needs to be of type 'json_object'
             if (empty($recipient['substitution_data'])) {
-                unset($recipient['substitution_data']);
+                $recipient['substitution_data'] = new \stdClass();
             }
+
+            // Sparkpost doesn't like empty metadata
             if (empty($recipient['metadata'])) {
                 unset($recipient['metadata']);
             }

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -674,4 +674,34 @@ class MailHelperTest extends \PHPUnit_Framework_TestCase
 
         return $mockFactory;
     }
+
+    public function testArrayOfAddressesAreRemappedIntoEmailToNameKeyValuePair()
+    {
+        $mockFactory = $this->getMockBuilder(MauticFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockFactory->method('getParameter')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['mailer_return_path', false, null],
+                        ['mailer_spool_type', false, 'memory'],
+                    ]
+                )
+            );
+
+        $swiftMailer = new \Swift_Mailer(new SmtpTransport());
+
+        $mailer = new MailHelper($mockFactory, $swiftMailer, ['nobody@nowhere.com' => 'No Body']);
+
+        $mailer->setTo(['sombody@somewhere.com', 'sombodyelse@somewhere.com'], 'test');
+
+        $this->assertEquals(
+            [
+                'sombody@somewhere.com'     => 'test',
+                'sombodyelse@somewhere.com' => 'test',
+            ],
+            $mailer->message->getTo()
+        );
+    }
 }

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/Momentum/Service/SwiftMessageServiceTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/Momentum/Service/SwiftMessageServiceTest.php
@@ -72,40 +72,46 @@ class SwiftMessageServiceTest extends \PHPUnit_Framework_TestCase
                         "email":"to1@test.local",
                         "name":"To1 test",
                         "header_to":"to1@test.local"
-                     }
+                     },
+                     "substitution_data": {}
                   },
                   {
                      "address":{
                         "email":"to2@test.local",
                         "name":"To2 test",
                         "header_to":"to2@test.local"
-                     }
+                     },
+                     "substitution_data": {}
                   },
                   {
                      "address":{
                         "email":"cc1@test.local",
                         "name":"CC1 test",
                         "header_to":"cc1@test.local"
-                     }
+                     },
+                     "substitution_data": {}
                   },
                   {
                      "address":{
                         "email":"cc2@test.local",
                         "name":"CC2 test",
                         "header_to":"cc2@test.local"
-                     }
+                     },
+                     "substitution_data": {}
                   },
                   {
                      "address":{
                         "email":"bcc1@test.local",
                         "name":"BCC1 test"
-                     }
+                     },
+                     "substitution_data": {}
                   },
                   {
                      "address":{
                         "email":"bcc2@test.local",
                         "name":"BCC2 test"
-                     }
+                     },
+                     "substitution_data": {}
                   }
                ],
                "content":{
@@ -208,26 +214,30 @@ class SwiftMessageServiceTest extends \PHPUnit_Framework_TestCase
                         "email":"cc1@test.local",
                         "name":"CC1 test",
                         "header_to":"cc1@test.local"
-                     }
+                     },
+                     "substitution_data": {}
                   },
                   {
                      "address":{
                         "email":"cc2@test.local",
                         "name":"CC2 test",
                         "header_to":"cc2@test.local"
-                     }
+                     },
+                     "substitution_data": {}
                   },
                   {
                      "address":{
                         "email":"bcc1@test.local",
                         "name":"BCC1 test"
-                     }
+                     },
+                     "substitution_data": {}
                   },
                   {
                      "address":{
                         "email":"bcc2@test.local",
                         "name":"BCC2 test"
-                     }
+                     },
+                     "substitution_data": {}
                   }
                ],
                "content":{
@@ -344,26 +354,30 @@ class SwiftMessageServiceTest extends \PHPUnit_Framework_TestCase
                         "email":"cc1@test.local",
                         "name":"CC1 test",
                         "header_to":"cc1@test.local"
-                     }
+                     },
+                     "substitution_data": {}
                   },
                   {
                      "address":{
                         "email":"cc2@test.local",
                         "name":"CC2 test",
                         "header_to":"cc2@test.local"
-                     }
+                     },
+                     "substitution_data": {}
                   },
                   {
                      "address":{
                         "email":"bcc1@test.local",
                         "name":"BCC1 test"
-                     }
+                     },
+                     "substitution_data": {}
                   },
                   {
                      "address":{
                         "email":"bcc2@test.local",
                         "name":"BCC2 test"
-                     }
+                     },
+                     "substitution_data": {}
                   }
                ],
                "content":{


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Sending reports through Sparkpost failed because sparkpost requires `substitution_data` which is not sent when we use a mailer's `setTo()` directly (compared to using setLead() which most of Mautic uses). This fixes that by setting an empty object for `substitution_data`. It's assumed this also affects Momentum since it is the hosted version of Sparkpost so fixed it there as well. 

This also fixes some inconsistencies with how `to` emails are formatted when using the `setTo` method using an array of just email addresses. Swiftmailer handles this internally but it caused odd error logging in the MailHelper. (i.e `(send); 0, 1, test1@test.com, test2@test.com`).
 
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Configure Mautic to send through Sparkpost
2. Create/edit a report and schedule it to be sent daily
3. Go the table `report_schedulers` in the database and manually edit the `schedule_date` for the report to be in the past
4. Run the command `php app/console mautic:reports:scheduler --report=ID` changing ID to your report's ID
5. Notice that the report is not sent and there is a mail error in the log that `field 'substitution_data' is required`

#### Steps to test this PR:
1. Repeat the above and the report will be sent
