### PR TITLE
Use lead:leads as permissions for companies to match CompanyController

### DIFF
--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -132,7 +132,8 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
      */
     public function getPermissionBase()
     {
-        return 'company:companies';
+        // We are using lead:leads in the CompanyController so this should match to prevent a BC break
+        return 'lead:leads';
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If using a restricted role with the API, companies will fail with a 500 error `Permission class not found for company in permissions classes`. This is because in the CompanyModel, the permission base is set to company:companies but that permission class does not exist. We use `lead:leads` elsewhere in Mautic (i.e. CompanyController). Ideally, we'd add new company permissions. But it'd be a BC break since we use lead:leads already elsewhere in Mautic for companies. So for now, we'll keep existing permissions and just fix the modal so that companies work as long as the user has access to leads/contacts. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new Role that is _not_ an admin. Give the role full access to contacts.
2. Using the API, make a GET request to /api/companies and notice the 500 response

#### Steps to test this PR:
1. Repeat and you should get a list of companies

