### PR TITLE
Prevent an exception when a contact is deleted between the time logs …

### DIFF
--- a/app/bundles/CampaignBundle/Executioner/ContactFinder/ScheduledContactFinder.php
+++ b/app/bundles/CampaignBundle/Executioner/ContactFinder/ScheduledContactFinder.php
@@ -63,9 +63,14 @@ class ScheduledContactFinder
 
         $contacts = $this->leadRepository->getContactCollection($contactIds);
 
-        foreach ($logs as $log) {
+        foreach ($logs as $key => $log) {
             $contactId = $log->getLead()->getId();
-            $contact   = $contacts->get($contactId);
+            if (!$contact = $contacts->get($contactId)) {
+                // the contact must have been deleted mid execution so remove this log from memory
+                $logs->remove($key);
+
+                continue;
+            }
 
             $log->setLead($contact);
         }

--- a/app/bundles/CampaignBundle/Tests/Executioner/ContactFinder/ScheduledContactFinderTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ContactFinder/ScheduledContactFinderTest.php
@@ -94,6 +94,58 @@ class ScheduledContactFinderTest extends \PHPUnit_Framework_TestCase
         $this->getContactFinder()->hydrateContacts($logs);
     }
 
+    public function testHydratedLeadsFromRepositoryWithMissingLeadResultsLogBeingRemoved()
+    {
+        $lead1 = $this->getMockBuilder(Lead::class)
+            ->getMock();
+        $lead1->expects($this->exactly(2))
+            ->method('getId')
+            ->willReturn(1);
+
+        $lead2 = $this->getMockBuilder(Lead::class)
+            ->getMock();
+        $lead2->expects($this->exactly(2))
+            ->method('getId')
+            ->willReturn(2);
+
+        $log1 = $this->getMockBuilder(LeadEventLog::class)
+            ->getMock();
+        $log1->expects($this->exactly(2))
+            ->method('getLead')
+            ->willReturn($lead1);
+        $log1->expects($this->once())
+            ->method('setLead');
+
+        $log2 = $this->getMockBuilder(LeadEventLog::class)
+            ->getMock();
+        $log2->expects($this->exactly(2))
+            ->method('getLead')
+            ->willReturn($lead2);
+        $log2->expects($this->never())
+            ->method('setLead');
+
+        $logs = new ArrayCollection(
+            [
+                1 => $log1,
+                2 => $log2,
+            ]
+        );
+
+        $contacs = new ArrayCollection(
+            [
+                1 => $lead1,
+            ]
+        );
+
+        $this->leadRepository->expects($this->once())
+            ->method('getContactCollection')
+            ->willReturn($contacs);
+
+        $this->getContactFinder()->hydrateContacts($logs);
+
+        $this->assertCount(1, $logs);
+    }
+
     public function testNoContactsFoundExceptionIsThrownIfEntitiesAreNotFound()
     {
         $this->leadRepository->expects($this->never())


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? | y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
An exception will be thrown if a contact is deleted between the time event logs to be executed are loaded into memory and the time contacts are hydrated with custom field values due to signature mismatches. This PR simply handles that gracefully. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Very tricky. Code review should suffice. 

#### Steps to test this PR:
1. Run the new unit test
