### PR TITLE
Adds support for defining Sparkpost's campaign ID

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
@@ -500,9 +500,7 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
     }
 
     /**
-     * Extract and build a campaign ID from the metadata sample
-     *
-     * @param array $metadataSet
+     * Extract and build a campaign ID from the metadata sample.
      *
      * @return string
      */
@@ -512,13 +510,9 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
 
         if (!empty($metadataSet['utmTags']['utmCampaign'])) {
             $id = $metadataSet['utmTags']['utmCampaign'];
-        }
-
-        elseif (!empty($metadataSet['emailId']) && !empty($metadataSet['emailName'])) {
+        } elseif (!empty($metadataSet['emailId']) && !empty($metadataSet['emailName'])) {
             $id = $metadataSet['emailId'].':'.$metadataSet['emailName'];
-        }
-
-        elseif (!empty($metadataSet['emailId'])) {
+        } elseif (!empty($metadataSet['emailId'])) {
             $id = $metadataSet['emailId'];
         }
 

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
@@ -175,6 +175,7 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
         $this->message = $message;
         $metadata      = $this->getMetadata();
         $mauticTokens  = $mergeVars = $mergeVarPlaceholders = [];
+        $campaignId    = '';
 
         // Sparkpost uses {{ name }} for tokens so Mautic's need to be converted; although using their {{{ }}} syntax to prevent HTML escaping
         if (!empty($metadata)) {
@@ -187,6 +188,8 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
                 $mergeVars[$token]            = strtoupper(preg_replace('/[^a-z0-9]+/i', '', $token));
                 $mergeVarPlaceholders[$token] = '{{{ '.$mergeVars[$token].' }}}';
             }
+
+            $campaignId = $this->extractCampaignId($metadataSet);
         }
 
         $message = $this->messageToArray($mauticTokens, $mergeVarPlaceholders, true);
@@ -291,10 +294,11 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
         }
 
         $sparkPostMessage = [
-            'content'    => $content,
-            'recipients' => $recipients,
-            'inline_css' => $inlineCss,
-            'tags'       => $tags,
+            'content'     => $content,
+            'recipients'  => $recipients,
+            'inline_css'  => $inlineCss,
+            'tags'        => $tags,
+            'campaign_id' => $campaignId,
         ];
 
         if (!empty($message['attachments'])) {
@@ -501,5 +505,26 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
     public function ping()
     {
         return true;
+    }
+
+    /**
+     * @return string
+     */
+    private function extractCampaignId(array $metadataSet)
+    {
+        // Extract and build a campaign ID from the metadata sample
+        if (!empty($metadataSet['utmTags']['utmCampaign'])) {
+            return $metadataSet['utmTags']['utmCampaign'];
+        }
+
+        if (!empty($metadataSet['emailId']) && !empty($metadataSet['emailName'])) {
+            return $metadataSet['emailId'].':'.$metadataSet['emailName'];
+        }
+
+        if (!empty($metadataSet['emailId'])) {
+            return $metadataSet['emailId'];
+        }
+
+        return '';
     }
 }

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
@@ -500,31 +500,36 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
     }
 
     /**
+     * Extract and build a campaign ID from the metadata sample
+     *
+     * @param array $metadataSet
+     *
+     * @return string
+     */
+    private function extractCampaignId(array $metadataSet)
+    {
+        $id = '';
+
+        if (!empty($metadataSet['utmTags']['utmCampaign'])) {
+            $id = $metadataSet['utmTags']['utmCampaign'];
+        }
+
+        elseif (!empty($metadataSet['emailId']) && !empty($metadataSet['emailName'])) {
+            $id = $metadataSet['emailId'].':'.$metadataSet['emailName'];
+        }
+
+        elseif (!empty($metadataSet['emailId'])) {
+            $id = $metadataSet['emailId'];
+        }
+
+        return substr($id, 0, 64);
+    }
+
+    /**
      * @return bool
      */
     public function ping()
     {
         return true;
-    }
-
-    /**
-     * @return string
-     */
-    private function extractCampaignId(array $metadataSet)
-    {
-        // Extract and build a campaign ID from the metadata sample
-        if (!empty($metadataSet['utmTags']['utmCampaign'])) {
-            return $metadataSet['utmTags']['utmCampaign'];
-        }
-
-        if (!empty($metadataSet['emailId']) && !empty($metadataSet['emailName'])) {
-            return $metadataSet['emailId'].':'.$metadataSet['emailName'];
-        }
-
-        if (!empty($metadataSet['emailId'])) {
-            return $metadataSet['emailId'];
-        }
-
-        return '';
     }
 }

--- a/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportTest.php
@@ -187,6 +187,102 @@ class SparkpostTransportTest extends \PHPUnit\Framework\TestCase
         $this->sparkpostTransport->send($this->message);
     }
 
+    public function testCampaignIdFromUtmTagInPayload()
+    {
+        $metadata = [
+            'name'        => 'Joe Smith',
+            'leadId'      => '1',
+            'emailId'     => 20,
+            'emailName'   => 'Campaign Test Email',
+            'hashId'      => '5c92a91788e39848445285',
+            'hashIdState' => true,
+            'source'      =>
+                [
+                    'email',
+                    20,
+                ],
+            'tokens'      =>
+                [
+                    '{dynamiccontent="Dynamic Content 1"}' => 'Default Dynamic Content',
+                    '{unsubscribe_text}'                   => '<a href="http://website/email/unsubscribe/5c92a91788e39848445285">Unsubscribe</a> to no longer receive emails from us.',
+                    '{unsubscribe_url}'                    => 'http://website/email/unsubscribe/5c92a91788e39848445285',
+                    '{webview_text}'                       => '<a href="http://website/email/view/5c92a91788e39848445285">Having trouble reading this email? Click here.</a>',
+                    '{webview_url}'                        => 'http://website/email/view/5c92a91788e39848445285',
+                    '{signature}'                          => 'Best regards, Company',
+                    '{subject}'                            => 'Campaign Test',
+                    '{tracking_pixel}'                     => 'http://website/email/5c92a91788e39848445285.gif',
+                ],
+            'utmTags'     =>
+                [
+                    'utmSource'   => null,
+                    'utmMedium'   => null,
+                    'utmCampaign' => 'Campaign Test',
+                    'utmContent'  => null,
+                ],
+        ];
+
+        $message = new MauticMessage();
+        $message->addMetadata('test@test.com', $metadata);
+        $message->addTo('test@test.com');
+        $message->setFrom('someone@somewhere.com');
+        $message->setSubject('Test Email');
+        $message->setBody('Hello');
+
+        $sparkpost = new SparkpostTransport('abc123', $this->translator, $this->transportCallback, $this->sparkpostFactory, $this->logger);
+
+        $message = $sparkpost->getSparkPostMessage($message);
+
+        $this->assertEquals($message['campaign_id'], 'Campaign Test');
+    }
+
+    public function testCampaignIdFromEmailNameInPayload()
+    {
+        $metadata = [
+            'name'        => 'Joe Smith',
+            'leadId'      => '1',
+            'emailId'     => 20,
+            'emailName'   => 'Campaign Test Email',
+            'hashId'      => '5c92a91788e39848445285',
+            'hashIdState' => true,
+            'source'      =>
+                [
+                    'email',
+                    20,
+                ],
+            'tokens'      =>
+                [
+                    '{dynamiccontent="Dynamic Content 1"}' => 'Default Dynamic Content',
+                    '{unsubscribe_text}'                   => '<a href="http://website/email/unsubscribe/5c92a91788e39848445285">Unsubscribe</a> to no longer receive emails from us.',
+                    '{unsubscribe_url}'                    => 'http://website/email/unsubscribe/5c92a91788e39848445285',
+                    '{webview_text}'                       => '<a href="http://website/email/view/5c92a91788e39848445285">Having trouble reading this email? Click here.</a>',
+                    '{webview_url}'                        => 'http://website/email/view/5c92a91788e39848445285',
+                    '{signature}'                          => 'Best regards, Company',
+                    '{subject}'                            => 'Campaign Test',
+                    '{tracking_pixel}'                     => 'http://website/email/5c92a91788e39848445285.gif',
+                ],
+            'utmTags'     =>
+                [
+                    'utmSource'   => null,
+                    'utmMedium'   => null,
+                    'utmCampaign' => null,
+                    'utmContent'  => null,
+                ],
+        ];
+
+        $message = new MauticMessage();
+        $message->addMetadata('test@test.com', $metadata);
+        $message->addTo('test@test.com');
+        $message->setFrom('someone@somewhere.com');
+        $message->setSubject('Test Email');
+        $message->setBody('Hello');
+
+        $sparkpost = new SparkpostTransport('abc123', $this->translator, $this->transportCallback, $this->sparkpostFactory, $this->logger);
+
+        $message = $sparkpost->getSparkPostMessage($message);
+
+        $this->assertEquals($message['campaign_id'], '20:Campaign Test Email');
+    }
+
     private function getRequestWithPayload()
     {
         $json = <<<JSON

--- a/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/SparkpostTransportTest.php
@@ -196,13 +196,11 @@ class SparkpostTransportTest extends \PHPUnit\Framework\TestCase
             'emailName'   => 'Campaign Test Email',
             'hashId'      => '5c92a91788e39848445285',
             'hashIdState' => true,
-            'source'      =>
-                [
+            'source'      => [
                     'email',
                     20,
                 ],
-            'tokens'      =>
-                [
+            'tokens'      => [
                     '{dynamiccontent="Dynamic Content 1"}' => 'Default Dynamic Content',
                     '{unsubscribe_text}'                   => '<a href="http://website/email/unsubscribe/5c92a91788e39848445285">Unsubscribe</a> to no longer receive emails from us.',
                     '{unsubscribe_url}'                    => 'http://website/email/unsubscribe/5c92a91788e39848445285',
@@ -212,8 +210,7 @@ class SparkpostTransportTest extends \PHPUnit\Framework\TestCase
                     '{subject}'                            => 'Campaign Test',
                     '{tracking_pixel}'                     => 'http://website/email/5c92a91788e39848445285.gif',
                 ],
-            'utmTags'     =>
-                [
+            'utmTags'     => [
                     'utmSource'   => null,
                     'utmMedium'   => null,
                     'utmCampaign' => 'Campaign Test',
@@ -244,13 +241,11 @@ class SparkpostTransportTest extends \PHPUnit\Framework\TestCase
             'emailName'   => 'Campaign Test Email',
             'hashId'      => '5c92a91788e39848445285',
             'hashIdState' => true,
-            'source'      =>
-                [
+            'source'      => [
                     'email',
                     20,
                 ],
-            'tokens'      =>
-                [
+            'tokens'      => [
                     '{dynamiccontent="Dynamic Content 1"}' => 'Default Dynamic Content',
                     '{unsubscribe_text}'                   => '<a href="http://website/email/unsubscribe/5c92a91788e39848445285">Unsubscribe</a> to no longer receive emails from us.',
                     '{unsubscribe_url}'                    => 'http://website/email/unsubscribe/5c92a91788e39848445285',
@@ -260,8 +255,7 @@ class SparkpostTransportTest extends \PHPUnit\Framework\TestCase
                     '{subject}'                            => 'Campaign Test',
                     '{tracking_pixel}'                     => 'http://website/email/5c92a91788e39848445285.gif',
                 ],
-            'utmTags'     =>
-                [
+            'utmTags'     => [
                     'utmSource'   => null,
                     'utmMedium'   => null,
                     'utmCampaign' => null,


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | y
| Automated tests included? |Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This simply adds campaign_id to the Sparkpost API so that Mautic emails can be identified through Sparkpost's UI. 

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Configure Mautic to send through sparkpost
2. Create a new broadcast email and set something for the UTM tag Campaign Name
3. Send the broadcast
4. Login to Sparkpost and look at Reports -> Summary. Change the Group By to Campaign and you should see the defined campaign listed.
5. Repeat but leave UTM tag empty and the Campaign should be the ID and and name of the email instead.
