### PR TITLE
Prevent PHP notice in configuration

### DIFF
--- a/app/bundles/PageBundle/Form/Type/ConfigTrackingPageType.php
+++ b/app/bundles/PageBundle/Form/Type/ConfigTrackingPageType.php
@@ -58,7 +58,7 @@ class ConfigTrackingPageType extends AbstractType
             'yesno_button_group',
             [
                 'label' => 'mautic.page.config.form.track_contact_by_ip',
-                'data'  => (bool) $options['data']['track_contact_by_ip'],
+                'data'  => isset($options['data']['track_contact_by_ip']) ? (bool) $options['data']['track_contact_by_ip'] : false,
                 'attr'  => [
                     'tooltip'      => 'mautic.page.config.form.track_contact_by_ip.tooltip',
                     'data-show-on' => '{"config_trackingconfig_anonymize_ip_1":"checked"}',


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This simply prevents a PHP notice when track_contact_by_ip is not defined (same code used in other places such as track_by_tracking_url and track_by_fingerprint). Code review should suffice. 

