### PR TITLE
Fix issue with tooltip getting frozen in campaign UI and fix issue where campaign events were rescheduled in UTC rather than the configured hour

### DIFF
--- a/app/bundles/CampaignBundle/Assets/js/campaign.js
+++ b/app/bundles/CampaignBundle/Assets/js/campaign.js
@@ -48,7 +48,7 @@ Mautic.campaignOnLoad = function (container, response) {
             var thisSelect = mQuery(event.target).attr('id');
             Mautic.campaignBuilderUpdateEventListTooltips(thisSelect, false);
 
-            mQuery('#'+thisSelect+'_chosen .chosen-search input').on('keydown.toolip', function () {
+            mQuery('#'+thisSelect+'_chosen .chosen-search input').on('keydown.tooltip', function () {
                 // Destroy tooltips that are filtered out
                 Mautic.campaignBuilderUpdateEventListTooltips(thisSelect, true);
             }).on('keyup.tooltip', function() {
@@ -64,7 +64,7 @@ Mautic.campaignOnLoad = function (container, response) {
             var thisSelect = mQuery(event.target).attr('id');
             Mautic.campaignBuilderUpdateEventListTooltips(thisSelect, true);
 
-            mQuery('#'+thisSelect+'_chosen .chosen-search input').off('keyup.toolip')
+            mQuery('#'+thisSelect+'_chosen .chosen-search input').off('keyup.tooltip')
                 .off('keydown.tooltip');
         });
 

--- a/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
@@ -394,7 +394,7 @@ class EventExecutioner
 
             $this->logger->debug(
                 'CAMPAIGN: Event ID# '.$event->getId().
-                ' to be executed on '.$executionDate->format('Y-m-d H:i:s')
+                ' to be executed on '.$executionDate->format('Y-m-d H:i:s e')
             );
 
             // Check if we need to schedule this if it is not an inactivity check

--- a/app/bundles/CampaignBundle/Executioner/InactiveExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/InactiveExecutioner.php
@@ -352,7 +352,7 @@ class InactiveExecutioner implements ExecutionerInterface
 
             $this->logger->debug(
                 'CAMPAIGN: Event ID# '.$event->getId().
-                ' to be executed on '.$eventExecutionDate->format('Y-m-d H:i:s')
+                ' to be executed on '.$eventExecutionDate->format('Y-m-d H:i:s e')
             );
 
             if ($this->scheduler->shouldSchedule($eventExecutionDate, $executionDate)) {

--- a/app/bundles/CampaignBundle/Executioner/KickoffExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/KickoffExecutioner.php
@@ -217,8 +217,8 @@ class KickoffExecutioner implements ExecutionerInterface
                     $executionDate = $this->scheduler->getExecutionDateTime($event, $now);
                     $this->logger->debug(
                         'CAMPAIGN: Event ID# '.$event->getId().
-                        ' to be executed on '.$executionDate->format('Y-m-d H:i:s').
-                        ' compared to '.$now->format('Y-m-d H:i:s')
+                        ' to be executed on '.$executionDate->format('Y-m-d H:i:s e').
+                        ' compared to '.$now->format('Y-m-d H:i:s e')
                     );
 
                     // Adjust the hour based on contact timezone if applicable

--- a/app/bundles/CampaignBundle/Executioner/RealTimeExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/RealTimeExecutioner.php
@@ -210,7 +210,7 @@ class RealTimeExecutioner
             $executionDate = $this->scheduler->getExecutionDateTime($child, $now);
             $this->logger->debug(
                 'CAMPAIGN: Event ID# '.$child->getId().
-                ' to be executed on '.$executionDate->format('Y-m-d H:i:s')
+                ' to be executed on '.$executionDate->format('Y-m-d H:i:s e')
             );
 
             if ($this->scheduler->shouldSchedule($executionDate, $now)) {

--- a/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
@@ -346,8 +346,8 @@ class ScheduledExecutioner implements ExecutionerInterface
             $executionDate = $this->scheduler->validateExecutionDateTime($log, $now);
             $this->logger->debug(
                 'CAMPAIGN: Log ID #'.$log->getID().
-                ' to be executed on '.$executionDate->format('Y-m-d H:i:s').
-                ' compared to '.$now->format('Y-m-d H:i:s')
+                ' to be executed on '.$executionDate->format('Y-m-d H:i:s e').
+                ' compared to '.$now->format('Y-m-d H:i:s e')
             );
 
             if ($this->scheduler->shouldSchedule($executionDate, $now)) {

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -138,14 +138,21 @@ class Interval implements ScheduleModeInterface
 
         // Get the difference between now and the date we're supposed to be executing
         $compareFromDateTime = $compareFromDateTime ? clone $compareFromDateTime : new \DateTime('now');
-        $compareFromDateTime->setTimezone($this->getDefaultTimezone());
-
-        $diff    = $compareFromDateTime->diff($executionDate);
-        $diff->f = 0; // we don't care about microseconds
+        $diff                = $compareFromDateTime->diff($executionDate);
+        $diff->f             = 0; // we don't care about microseconds
 
         /** @var Lead $contact */
         foreach ($contacts as $contact) {
-            $groupExecutionDate = $this->getGroupExecutionDateTime($event->getId(), $contact, $diff, $compareFromDateTime, $hour, $startTime, $endTime, $daysOfWeek);
+            $groupExecutionDate = $this->getGroupExecutionDateTime(
+                $event->getId(),
+                $contact,
+                $diff,
+                $compareFromDateTime,
+                $hour,
+                $startTime,
+                $endTime,
+                $daysOfWeek
+            );
             if (!isset($groupedExecutionDates[$groupExecutionDate->getTimestamp()])) {
                 $groupedExecutionDates[$groupExecutionDate->getTimestamp()] = new GroupExecutionDateDAO($groupExecutionDate);
             }
@@ -202,16 +209,46 @@ class Interval implements ScheduleModeInterface
         \DateTime $endTime = null,
         array $daysOfWeek = []
     ) {
+        $this->logger->debug(
+            sprintf('CAMPAIGN: Comparing calculated executed time for event ID %s and contact ID %s with %s', $eventId, $contact->getId(), $compareFromDateTime->format('Y-m-d H:i:s e'))
+        );
+
         if ($hour) {
+            $this->logger->debug(
+                sprintf('CAMPAIGN: Scheduling event ID %s for contact ID %s based on hour of %s', $eventId, $contact->getId(), $hour->format('H:i e'))
+            );
             $groupDateTime = $this->getExecutionDateTimeFromHour($contact, $hour, $diff, $eventId, $compareFromDateTime);
         } elseif ($startTime && $endTime) {
+            $this->logger->debug(
+                sprintf(
+                    'CAMPAIGN: Scheduling event ID %s for contact ID %s based on hour range of %s to %s',
+                    $eventId,
+                    $contact->getId(),
+                    $startTime->format('H:i e'),
+                    $endTime->format('H:i e')
+                )
+            );
+
             $groupDateTime = $this->getExecutionDateTimeBetweenHours($contact, $startTime, $endTime, $diff, $eventId, $compareFromDateTime);
         } else {
+            $this->logger->debug(
+                sprintf('CAMPAIGN: Scheduling event ID %s for contact ID %s without hour restrictions.', $eventId, $contact->getId())
+            );
+
             $groupDateTime = clone $compareFromDateTime;
             $groupDateTime->add($diff);
         }
 
         if ($daysOfWeek) {
+            $this->logger->debug(
+                sprintf(
+                    'CAMPAIGN: Scheduling event ID %s for contact ID %s based on DOW restrictions of %s',
+                    $eventId,
+                    $contact->getId(),
+                    implode(',', $daysOfWeek)
+                )
+            );
+
             // Schedule for the next day of the week if applicable
             while (!in_array((int) $groupDateTime->format('w'), $daysOfWeek)) {
                 $groupDateTime->modify('+1 day');
@@ -262,6 +299,7 @@ class Interval implements ScheduleModeInterface
         }
 
         $groupExecutionDate = clone $compareFromDateTime;
+        $groupExecutionDate->setTimezone($this->getDefaultTimezone());
         $groupExecutionDate->add($diff);
 
         $groupExecutionDate->setTime($groupHour->format('H'), $groupHour->format('i'));
@@ -323,6 +361,7 @@ class Interval implements ScheduleModeInterface
 
         if (!isset($groupExecutionDate)) {
             $groupExecutionDate = clone $compareFromDateTime;
+            $groupExecutionDate->setTimezone($this->getDefaultTimezone());
             $groupExecutionDate->add($diff);
         }
 

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -48,7 +48,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
             ->willReturn('America/Los_Angeles');
         $contacts = new ArrayCollection([$contact1]);
 
-        $grouped    = $interval->groupContactsByDate($event, $contacts, new \DateTime('2018-10-18 07:00:00', new \DateTimeZone('America/Los_Angeles')));
+        $grouped    = $interval->groupContactsByDate($event, $contacts, new \DateTime('2018-10-18 14:00:00', new \DateTimeZone('UTC')));
         $firstGroup = reset($grouped);
 
         $executionDate = $firstGroup->getExecutionDate();
@@ -83,7 +83,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
             ->willReturn('America/Los_Angeles');
         $contacts = new ArrayCollection([$contact1]);
 
-        $grouped    = $interval->groupContactsByDate($event, $contacts, new \DateTime('2018-10-18 10:00:00', new \DateTimeZone('America/Los_Angeles')));
+        $grouped    = $interval->groupContactsByDate($event, $contacts, new \DateTime('2018-10-18 16:00:00', new \DateTimeZone('UTC')));
         $firstGroup = reset($grouped);
 
         $executionDate = $firstGroup->getExecutionDate();
@@ -118,7 +118,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
             ->willReturn('America/New_York');
         $contacts = new ArrayCollection([$contact1]);
 
-        $grouped       = $interval->groupContactsByDate($event, $contacts, new \DateTime('2018-10-18 6:00:00', new \DateTimeZone('America/Los_Angeles')));
+        $grouped       = $interval->groupContactsByDate($event, $contacts, new \DateTime('2018-10-18 14:00:00', new \DateTimeZone('UTC')));
         $firstGroup    = reset($grouped);
         $executionDate = $firstGroup->getExecutionDate();
 
@@ -152,7 +152,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
         $contacts = new ArrayCollection([$contact1]);
 
         $interval               = $this->getInterval();
-        $scheduledExecutionDate = new \DateTime('2018-10-18 07:00', new \DateTimeZone('America/New_York'));
+        $scheduledExecutionDate = new \DateTime('2018-10-18 12:00', new \DateTimeZone('UTC'));
         $grouped                = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
 
         $firstGroup    = reset($grouped);
@@ -187,7 +187,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
         $contacts = new ArrayCollection([$contact1]);
 
         $interval               = $this->getInterval();
-        $scheduledExecutionDate = new \DateTime('2018-10-18 11:00', new \DateTimeZone('America/New_York'));
+        $scheduledExecutionDate = new \DateTime('2018-10-18 16:00', new \DateTimeZone('UTC'));
         $grouped                = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
 
         $firstGroup    = reset($grouped);
@@ -222,7 +222,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
         $contacts = new ArrayCollection([$contact1]);
 
         $interval               = $this->getInterval();
-        $scheduledExecutionDate = new \DateTime('2018-10-18 21:00', new \DateTimeZone('America/New_York'));
+        $scheduledExecutionDate = new \DateTime('2018-10-19 02:00', new \DateTimeZone('UTC'));
         $grouped                = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
 
         $firstGroup    = reset($grouped);
@@ -238,7 +238,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
             ->willReturn(1);
 
         // Thursday/4
-        $scheduledExecutionDate = new \DateTime('2018-10-18 10:00:00', new \DateTimeZone('America/New_York'));
+        $scheduledExecutionDate = new \DateTime('2018-10-18 15:00:00', new \DateTimeZone('UTC'));
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
@@ -262,7 +262,8 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
         $firstGroup    = reset($grouped);
         $executionDate = $firstGroup->getExecutionDate();
 
-        $this->assertEquals('2018-10-20 10:00', $executionDate->format('Y-m-d H:i'));
+        $executionDate->setTimezone(new \DateTimeZone('UTC'));
+        $this->assertEquals('2018-10-20 15:00', $executionDate->format('Y-m-d H:i'));
     }
 
     public function testNotRescheduledDueDayOfWeekRestriction()
@@ -272,7 +273,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
             ->willReturn(1);
 
         // Thursday/4
-        $scheduledExecutionDate = new \DateTime('2018-10-18 10:00:00', new \DateTimeZone('America/New_York'));
+        $scheduledExecutionDate = new \DateTime('2018-10-18 15:00:00', new \DateTimeZone('UTC'));
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
@@ -295,7 +296,8 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
         $firstGroup    = reset($grouped);
         $executionDate = $firstGroup->getExecutionDate();
 
-        $this->assertEquals('2018-10-18 10:00', $executionDate->format('Y-m-d H:i'));
+        $executionDate->setTimezone(new \DateTimeZone('UTC'));
+        $this->assertEquals('2018-10-18 15:00', $executionDate->format('Y-m-d H:i'));
     }
 
     public function testRescheduledDueToSpecificHourAndDayOfWeekRestrictions()
@@ -305,7 +307,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
             ->willReturn(1);
 
         // Thursday/4
-        $scheduledExecutionDate = new \DateTime('2018-10-18 10:00:00', new \DateTimeZone('America/New_York'));
+        $scheduledExecutionDate = new \DateTime('2018-10-18 15:00:00', new \DateTimeZone('UTC'));
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
@@ -342,7 +344,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
             ->willReturn(1);
 
         // Thursday/4
-        $scheduledExecutionDate = new \DateTime('2018-10-18 10:00:00', new \DateTimeZone('America/New_York'));
+        $scheduledExecutionDate = new \DateTime('2018-10-18 15:00:00', new \DateTimeZone('UTC'));
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
@@ -379,7 +381,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
             ->willReturn(1);
 
         // Thursday/4
-        $scheduledExecutionDate = new \DateTime('2018-10-18 9:00:00', new \DateTimeZone('America/New_York'));
+        $scheduledExecutionDate = new \DateTime('2018-10-18 14:00:00', new \DateTimeZone('UTC'));
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
@@ -416,7 +418,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
             ->willReturn(1);
 
         // Thursday/4
-        $scheduledExecutionDate = new \DateTime('2018-10-18 11:00:00', new \DateTimeZone('America/New_York'));
+        $scheduledExecutionDate = new \DateTime('2018-10-18 16:00:00', new \DateTimeZone('UTC'));
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
@@ -453,7 +455,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
             ->willReturn(1);
 
         // Thursday/4
-        $scheduledExecutionDate = new \DateTime('2018-10-18 10:00:00', new \DateTimeZone('America/New_York'));
+        $scheduledExecutionDate = new \DateTime('2018-10-18 15:00:00', new \DateTimeZone('UTC'));
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
@@ -490,7 +492,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
             ->willReturn(1);
 
         // Thursday/4
-        $scheduledExecutionDate = new \DateTime('2018-10-18 08:00:00', new \DateTimeZone('America/New_York'));
+        $scheduledExecutionDate = new \DateTime('2018-10-18 13:00:00', new \DateTimeZone('UTC'));
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
@@ -527,7 +529,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
             ->willReturn(1);
 
         // Thursday/4
-        $scheduledExecutionDate = new \DateTime('2018-10-18 21:00:00', new \DateTimeZone('America/New_York'));
+        $scheduledExecutionDate = new \DateTime('2018-10-19 02:00:00', new \DateTimeZone('UTC'));
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -183,7 +183,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
         $contact1->method('getId')
             ->willReturn(1);
         $contact1->method('getTimezone')
-            ->willReturn('America/New_York');
+            ->willReturn('Etc/GMT+5');
         $contacts = new ArrayCollection([$contact1]);
 
         $interval               = $this->getInterval();
@@ -436,7 +436,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
         $contact1->method('getId')
             ->willReturn(1);
         $contact1->method('getTimezone')
-            ->willReturn('America/New_York');
+            ->willReturn('Etc/GMT+5');
         $contacts = new ArrayCollection([$contact1]);
 
         $interval = $this->getInterval();
@@ -473,7 +473,7 @@ class IntervalTest extends \PHPUnit_Framework_TestCase
         $contact1->method('getId')
             ->willReturn(1);
         $contact1->method('getTimezone')
-            ->willReturn('America/New_York');
+            ->willReturn('Etc/GMT+5');
         $contacts = new ArrayCollection([$contact1]);
 
         $interval = $this->getInterval();


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When an event had interval hour ranges and event is rescheduled, the rescheduled event would have UTC hours instead of the configured hour. This resolves that. 

It also resolves an annoying UI bug where tooltips got stuck because of a mis-spelled jQuery event suffix.

The original tests falsely passed because it fed a date\time that was already in the local timezone where the code calling those methods were feeding it UTC dates.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
To reproduce the UI bug:
1. Create a new campaign and add a source then add a new action.
2. Instead of using the mouse to select the action from the dropdown, start tying to filter then hit enter.
3. Notice the tooltip that is now frozen in the UI and the only way to get rid of it is to refresh the browser.

For the timezone bug:
* Extremely tricky which took manipulating the database just right to simulate without waiting days. 
* Run the fixed unit tests