### PR TITLE
Bugfix - Postfix delivery reports being ignored

### DIFF
--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/DsnParser.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/DsnParser.php
@@ -460,7 +460,7 @@ class DsnParser
                      * sample 2:
                      * Diagnostic-Code: SMTP; 550 sorry, that recipient doesn't exist (#5.7.1)
                      */
-                    elseif (preg_match("/(?:alias|account|recipient|address|email|mailbox|user).*(?:n't|not) exist/is", $diagnosisCode)) {
+                    elseif (preg_match("/(?:alias|account|recipient|address|email|mailbox|user).*(?:n't|not).*exist/is", $diagnosisCode)) {
                         $result['rule_cat'] = Category::UNKNOWN;
                         $result['rule_no']  = '0205';
                     }

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/DsnParserTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/DsnParserTest.php
@@ -45,7 +45,7 @@ DSN;
         $this->assertEquals(Type::HARD, $bounce->getType());
         $this->assertTrue($bounce->isFinal());
     }
-    
+
     /**
      * @testdox Test a Postfix BouncedEmail is returned from a dsn report
      *
@@ -73,7 +73,7 @@ DSN;
         $this->assertEquals(Category::UNKNOWN, $bounce->getRuleCategory());
         $this->assertEquals(Type::HARD, $bounce->getType());
         $this->assertTrue($bounce->isFinal());
-    }    
+    }
 
     /**
      * @testdox Test that an exception is thrown if a bounce cannot be found in a dsn report

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/DsnParserTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/DsnParserTest.php
@@ -45,6 +45,35 @@ DSN;
         $this->assertEquals(Type::HARD, $bounce->getType());
         $this->assertTrue($bounce->isFinal());
     }
+    
+    /**
+     * @testdox Test a Postfix BouncedEmail is returned from a dsn report
+     *
+     * @covers  \Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\DsnParser::getBounce()
+     * @covers  \Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\DsnParser::parse()
+     */
+    public function testPostfixBouncedEmailIsReturnedFromParsedDsnReport()
+    {
+        $message            = new Message();
+        $message->dsnReport = <<<'DSN'
+Final-Recipient: rfc822; aaaaaaaaaaaaa@yoursite.com
+Original-Recipient: rfc822;aaaaaaaaaaaaa@yoursite.com
+Action: failed
+Status: 5.1.1
+Remote-MTA: dns; mail-server.yoursite.com
+Diagnostic-Code: smtp; 550 5.1.1 <aaaaaaaaaaaaa@yoursite.com> User doesn't
+    exist: aaaaaaaaaaaaa@yoursite.com
+DSN;
+
+        $parser = new DsnParser();
+        $bounce = $parser->getBounce($message);
+
+        $this->assertInstanceOf(BouncedEmail::class, $bounce);
+        $this->assertEquals('aaaaaaaaaaaaa@yoursite.com', $bounce->getContactEmail());
+        $this->assertEquals(Category::UNKNOWN, $bounce->getRuleCategory());
+        $this->assertEquals(Type::HARD, $bounce->getType());
+        $this->assertTrue($bounce->isFinal());
+    }    
 
     /**
      * @testdox Test that an exception is thrown if a bounce cannot be found in a dsn report


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | [#4106](https://github.com/mautic/mautic/issues/4106) (maybe)
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Sometimes if email username or domain is too long the MTA (Postfix) adds a line break and some spaces in the `Diagnostic-Code` header of bounce delivery report message. This line break splits the phrase "User doesn't exist".
 
In this cases, Mautic couldn't parse the *Delivery Report* and bounce mails was being ignored by `php app/console mautic:email:fetch`.

**Delivery Report Exemples**

DR with short email username (aaaa@yoursite.com):

```text
Reporting-MTA: dns; mail-server.yoursite.com
X-Mail-Service-Queue-ID: F3DA482657
X-Mail-Service-Sender: rfc822; contact+bounce_5cbe4f53b4520176148124@yoursite.com
Arrival-Date: Mon, 22 Apr 2019 23:31:41 +0000 (UTC)

Final-Recipient: rfc822; aaaa@yoursite.com
Original-Recipient: rfc822;aaaa@yoursite.com
Action: failed
Status: 5.1.1
Remote-MTA: dns; mail-server.yoursite.com
Diagnostic-Code: smtp; 550 5.1.1 <aaaa@yoursite.com> User doesn't exist:
    aaaa@yoursite.com
```

DR with long email username (aaaaaaaaaaaaa@yoursite.com):

```text
Reporting-MTA: dns; mail-server.yoursite.com
X-Mail-Service-Queue-ID: A851482656
X-Mail-Service-Sender: rfc822; contact+bounce_5cbe4e6b2982b488364102@yoursite.com
Arrival-Date: Mon, 22 Apr 2019 23:29:49 +0000 (UTC)

Final-Recipient: rfc822; aaaaaaaaaaaaa@yoursite.com
Original-Recipient: rfc822;aaaaaaaaaaaaa@yoursite.com
Action: failed
Status: 5.1.1
Remote-MTA: dns; mail-server.yoursite.com
Diagnostic-Code: smtp; 550 5.1.1 <aaaaaaaaaaaaa@yoursite.com> User doesn't
    exist: aaaaaaaaaaaaa@yoursite.com
```

| Q   | A
| --- | ---
| Mautic version | 2.15.1
| PHP version | PHP 7.2.17
| MTA Server | Postfix 3.1.0
| POP3/IMAP Server | Dovecot 2.2.22

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Install and Configure a Mail Server with Postfix and Dovecot
2. Manually adds a contact with inexistent email like aaaaaaaaaaaaa@yoursite.com and named Bob
3. Configure your SMTP on `Service to send mail through`
2. Configure your IMAP on `Monitored Inbox Settings`
3. Create a email channel and send it to Bob contact
4. Run `php app/console mautic:email:fetch`

Now you will have a read bouce mail in your INBOX. 