### PR TITLE
Duplicated leads are created by Salesforce sync 

### DIFF
--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -370,7 +370,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
      *
      * @return Lead
      */
-    public function getMauticLead($data, $persist = true, $socialCache = null, $identifiers = null, $object = null, $skipValidation = array())
+    public function getMauticLead($data, $persist = true, $socialCache = null, $identifiers = null, $object = null, $skipValidation = [])
     {
         if (is_object($data)) {
             // Convert to array in all levels
@@ -440,7 +440,6 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
         }
 
         $leadModel->setFieldValues($lead, $matchedFields, false, false);
-
 
         foreach ($skipValidation as $field) {
             // We need to set them again

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -367,7 +367,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
      * @param array|null  $socialCache
      * @param mixed||null $identifiers
      * @param string|null $object
-     * @param array       $preserve    List of fields we don't want to be sanitized
+     * @param array       $preserve List of fields we don't want to be sanitized
      *
      * @return Lead
      */
@@ -445,7 +445,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
         foreach ($preserve as $field) {
             // We need to set values for those fields again
             // to prevent modification by RequestTrait::cleanField method
-            // called from LeadModel::setFieldValues. This creates duplicated leads.
+            // called from LeadModel::setFieldValues
             if (isset($matchedFields[$field])) {
                 $lead->$field = $matchedFields[$field];
             }

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -367,7 +367,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
      * @param array|null  $socialCache
      * @param mixed||null $identifiers
      * @param string|null $object
-     * @param array       $preserve List of fields we don't want to be sanitized
+     * @param array       $preserve    List of fields we don't want to be sanitized
      *
      * @return Lead
      */
@@ -445,7 +445,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
         foreach ($preserve as $field) {
             // We need to set values for those fields again
             // to prevent modification by RequestTrait::cleanField method
-            // called from LeadModel::setFieldValues
+            // called from LeadModel::setFieldValues. This creates duplicated leads.
             if (isset($matchedFields[$field])) {
                 $lead->$field = $matchedFields[$field];
             }

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -370,7 +370,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
      *
      * @return Lead
      */
-    public function getMauticLead($data, $persist = true, $socialCache = null, $identifiers = null, $object = null)
+    public function getMauticLead($data, $persist = true, $socialCache = null, $identifiers = null, $object = null, $skipValidation = array())
     {
         if (is_object($data)) {
             // Convert to array in all levels
@@ -440,6 +440,16 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
         }
 
         $leadModel->setFieldValues($lead, $matchedFields, false, false);
+
+
+        foreach ($skipValidation as $field) {
+            // We need to set them again
+            // to prevent modification by LeadModel::setFieldValues method
+            if (isset($matchedFields[$field])) {
+                $lead->$field = $matchedFields[$field];
+            }
+        }
+
         if (!empty($socialCache)) {
             // Update the social cache
             $leadSocialCache = $lead->getSocialCache();

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -370,7 +370,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
      *
      * @return Lead
      */
-    public function getMauticLead($data, $persist = true, $socialCache = null, $identifiers = null, $object = null, $skipValidation = array())
+    public function getMauticLead($data, $persist = true, $socialCache = null, $identifiers = null, $object = null)
     {
         if (is_object($data)) {
             // Convert to array in all levels
@@ -440,16 +440,6 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
         }
 
         $leadModel->setFieldValues($lead, $matchedFields, false, false);
-
-
-        foreach ($skipValidation as $field) {
-            // We need to set them again
-            // to prevent modification by LeadModel::setFieldValues method
-            if (isset($matchedFields[$field])) {
-                $lead->$field = $matchedFields[$field];
-            }
-        }
-
         if (!empty($socialCache)) {
             // Update the social cache
             $leadSocialCache = $lead->getSocialCache();

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -367,10 +367,11 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
      * @param array|null  $socialCache
      * @param mixed||null $identifiers
      * @param string|null $object
+     * @param array       $preserve List of fields we don't want to be sanitized
      *
      * @return Lead
      */
-    public function getMauticLead($data, $persist = true, $socialCache = null, $identifiers = null, $object = null, $skipValidation = [])
+    public function getMauticLead($data, $persist = true, $socialCache = null, $identifiers = null, $object = null, $preserve = [])
     {
         if (is_object($data)) {
             // Convert to array in all levels
@@ -441,9 +442,10 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
 
         $leadModel->setFieldValues($lead, $matchedFields, false, false);
 
-        foreach ($skipValidation as $field) {
-            // We need to set them again
-            // to prevent modification by LeadModel::setFieldValues method
+        foreach ($preserve as $field) {
+            // We need to set values for those fields again
+            // to prevent modification by RequestTrait::cleanField method
+            // called from LeadModel::setFieldValues
             if (isset($matchedFields[$field])) {
                 $lead->$field = $matchedFields[$field];
             }

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -367,11 +367,10 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
      * @param array|null  $socialCache
      * @param mixed||null $identifiers
      * @param string|null $object
-     * @param array       $preserve List of fields we don't want to be sanitized
      *
      * @return Lead
      */
-    public function getMauticLead($data, $persist = true, $socialCache = null, $identifiers = null, $object = null, $preserve = [])
+    public function getMauticLead($data, $persist = true, $socialCache = null, $identifiers = null, $object = null, $skipValidation = [])
     {
         if (is_object($data)) {
             // Convert to array in all levels
@@ -442,10 +441,9 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
 
         $leadModel->setFieldValues($lead, $matchedFields, false, false);
 
-        foreach ($preserve as $field) {
-            // We need to set values for those fields again
-            // to prevent modification by RequestTrait::cleanField method
-            // called from LeadModel::setFieldValues
+        foreach ($skipValidation as $field) {
+            // We need to set them again
+            // to prevent modification by LeadModel::setFieldValues method
             if (isset($matchedFields[$field])) {
                 $lead->$field = $matchedFields[$field];
             }

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -370,7 +370,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
      *
      * @return Lead
      */
-    public function getMauticLead($data, $persist = true, $socialCache = null, $identifiers = null, $object = null, $skipValidation = [])
+    public function getMauticLead($data, $persist = true, $socialCache = null, $identifiers = null, $object = null, $skipValidation = array())
     {
         if (is_object($data)) {
             // Convert to array in all levels
@@ -440,6 +440,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
         }
 
         $leadModel->setFieldValues($lead, $matchedFields, false, false);
+
 
         foreach ($skipValidation as $field) {
             // We need to set them again

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -451,7 +451,6 @@ class SalesforceIntegration extends CrmAbstractIntegration
                             } elseif (!empty($dataObject['Owner__Contact']['Email'])) {
                                 $dataObject['owner_email'] = $dataObject['Owner__Contact']['Email'];
                             }
-
                             $entity                = $this->getMauticLead($dataObject, true, null, null, $object, ['email']);
                             $mauticObjectReference = 'lead';
                             $detachClass           = Lead::class;

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -11,6 +11,7 @@
 
 namespace MauticPlugin\MauticCrmBundle\Integration;
 
+use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
@@ -451,7 +452,14 @@ class SalesforceIntegration extends CrmAbstractIntegration
                             } elseif (!empty($dataObject['Owner__Contact']['Email'])) {
                                 $dataObject['owner_email'] = $dataObject['Owner__Contact']['Email'];
                             }
-                            $entity                = $this->getMauticLead($dataObject, true, null, null, $object, $params);
+
+                            if (isset($dataObject['Email__Lead'])) {
+                                // Sanitize email to make sure we match it
+                                // correctly against mautic_leads emails
+                                $dataObject['Email__Lead'] = InputHelper::email($dataObject['Email__Lead']);
+                            }
+
+                            $entity                = $this->getMauticLead($dataObject, true, null, null, $object);
                             $mauticObjectReference = 'lead';
                             $detachClass           = Lead::class;
 

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -435,6 +435,12 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     $entity = false;
                     switch ($object) {
                         case 'Contact':
+                            if (isset($dataObject['Email__Contact'])) {
+                                // Sanitize email to make sure we match it
+                                // correctly against mautic emails
+                                $dataObject['Email__Contact'] = InputHelper::email($dataObject['Email__Contact']);
+                            }
+
                             //get company from account id and assign company name
                             if (isset($dataObject['AccountId__'.$object])) {
                                 $companyName = $this->getCompanyName($dataObject['AccountId__'.$object], 'Name');

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -452,9 +452,6 @@ class SalesforceIntegration extends CrmAbstractIntegration
                                 $dataObject['owner_email'] = $dataObject['Owner__Contact']['Email'];
                             }
 
-                            if (isset($dataObject['Email__Lead']) && ($dataObject['Email__Lead'] == 'blast.market@gmail.com')) {
-                                $dataObject['Email__Lead'] = 'https://sjdhkjsdnmwnewe.comksjdfds.com';
-                            }
                             $entity                = $this->getMauticLead($dataObject, true, null, null, $object, ['email']);
                             $mauticObjectReference = 'lead';
                             $detachClass           = Lead::class;

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -451,11 +451,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                             } elseif (!empty($dataObject['Owner__Contact']['Email'])) {
                                 $dataObject['owner_email'] = $dataObject['Owner__Contact']['Email'];
                             }
-
-                            if (isset($dataObject['Email__Lead']) && ($dataObject['Email__Lead'] == 'blast.market@gmail.com')) {
-                                $dataObject['Email__Lead'] = 'https://sjdhkjsdnmwnewe.comksjdfds.com';
-                            }
-                            $entity                = $this->getMauticLead($dataObject, true, null, null, $object, ['email']);
+                            $entity                = $this->getMauticLead($dataObject, true, null, null, $object, $params);
                             $mauticObjectReference = 'lead';
                             $detachClass           = Lead::class;
 

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -451,6 +451,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                             } elseif (!empty($dataObject['Owner__Contact']['Email'])) {
                                 $dataObject['owner_email'] = $dataObject['Owner__Contact']['Email'];
                             }
+
                             $entity                = $this->getMauticLead($dataObject, true, null, null, $object, ['email']);
                             $mauticObjectReference = 'lead';
                             $detachClass           = Lead::class;

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -451,7 +451,11 @@ class SalesforceIntegration extends CrmAbstractIntegration
                             } elseif (!empty($dataObject['Owner__Contact']['Email'])) {
                                 $dataObject['owner_email'] = $dataObject['Owner__Contact']['Email'];
                             }
-                            $entity                = $this->getMauticLead($dataObject, true, null, null, $object, $params);
+
+                            if (isset($dataObject['Email__Lead']) && ($dataObject['Email__Lead'] == 'blast.market@gmail.com')) {
+                                $dataObject['Email__Lead'] = 'https://sjdhkjsdnmwnewe.comksjdfds.com';
+                            }
+                            $entity                = $this->getMauticLead($dataObject, true, null, null, $object, ['email']);
                             $mauticObjectReference = 'lead';
                             $detachClass           = Lead::class;
 

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -452,6 +452,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
                                 $dataObject['owner_email'] = $dataObject['Owner__Contact']['Email'];
                             }
 
+                            if (isset($dataObject['Email__Lead']) && ($dataObject['Email__Lead'] == 'blast.market@gmail.com')) {
+                                $dataObject['Email__Lead'] = 'https://sjdhkjsdnmwnewe.comksjdfds.com';
+                            }
                             $entity                = $this->getMauticLead($dataObject, true, null, null, $object, ['email']);
                             $mauticObjectReference = 'lead';
                             $detachClass           = Lead::class;


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? |
| Automated tests included? |
| Related user documentation PR URL |
| Related developer documentation PR URL |
| Issues addressed (#s or URLs) | 
| BC breaks? |
| Deprecations? |

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Duplicated leads are created when fetching contacts from Salesforce.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a contact in Salesforce that has invalid email. E.g. `https://www.abcde.com/` Salesforce doesn't allow to do this from their web interface. We can simulate this by "hacking" the source code.
2. Run `php app/console mautic:integration:fetchleads --integration=Salesforce --time-interval="29 days"` from the console.
3. Go to `mautic_leads` table and observe duplicated leads with the same email.

#### Steps to test this PR:
1. Repeat steps 1,2 from "Steps to reproduce".
2. Go to `mautic_leads` table. No duplicated leads should be created.