### PR TITLE
"Do not contact" property doesn't work during import

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1512,8 +1512,7 @@ class LeadModel extends FormModel
                 $lead->addUpdatedField('email', $data[$fields['email']]);
                 if ($doNotEmail) {
                     $this->addDncForLead($lead, 'email', $reason, DNC::MANUAL);
-                }
-                else {
+                } else {
                     $this->removeDncForLead($lead, 'email', true);
                 }
             }

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1501,18 +1501,24 @@ class LeadModel extends FormModel
         unset($fieldData['stage']);
 
         // Set unsubscribe status
-        if (!empty($fields['doNotEmail']) && !empty($data[$fields['doNotEmail']]) && (!empty($fields['email']) && !empty($data[$fields['email']]))) {
-            $doNotEmail = filter_var($data[$fields['doNotEmail']], FILTER_VALIDATE_BOOLEAN);
-            if ($doNotEmail) {
+        if (!empty($fields['doNotEmail']) && isset($data[$fields['doNotEmail']]) && (!empty($fields['email']) && !empty($data[$fields['email']]))) {
+            $doNotEmail = filter_var($data[$fields['doNotEmail']], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+            if (null !== $doNotEmail) {
                 $reason = $this->translator->trans('mautic.lead.import.by.user', [
                     '%user%' => $this->userHelper->getUser()->getUsername(),
                 ]);
 
                 // The email must be set for successful unsubscribtion
                 $lead->addUpdatedField('email', $data[$fields['email']]);
-                $this->addDncForLead($lead, 'email', $reason, DNC::MANUAL);
+                if ($doNotEmail) {
+                    $this->addDncForLead($lead, 'email', $reason, DNC::MANUAL);
+                }
+                else {
+                    $this->removeDncForLead($lead, 'email', true);
+                }
             }
         }
+
         unset($fieldData['doNotEmail']);
 
         if (!empty($fields['ownerusername']) && !empty($data[$fields['ownerusername']])) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |
| New feature? | Y
| Automated tests included? |
| Related user documentation PR URL |
| Related developer documentation PR URL |
| Issues addressed (#s or URLs) |
| BC breaks? |
| Deprecations? |

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When attempting to remove the DNC designation via .csv from Contacts who were manually marked as DNC with either the value 0, No or False, the Do Not Contact designation is not removed.

Contacts manually Marked DNC or Email Bounced cannot be updated via .csv, which means this cannot be done in bulk, which is a big need

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Manually mark a Contact as DNC or make the Contact designated as Email Bounced
2. Create a .csv with that Contact's email address, and another column with DNC with the value or either 0 or No or False.
3. Nothing happens

#### Steps to test this PR:
1. Manually mark a Contact as DNC or make the Contact designated as Email Bounced
2. Create a .csv with that Contact's email address, and another column with DNC with the value or either 0 or No or False. 
3. Contact should have DNC or Email Bounced designation removed