### PR TITLE
Better logging of exceptions

### DIFF
--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -653,7 +653,7 @@ class CampaignModel extends CommonFormModel
 
             return true;
         } catch (\Exception $exception) {
-            $this->logger->log('error', $exception->getMessage());
+            $this->logger->log('error', $exception->getMessage(), ['exception' => $exception]);
 
             return false;
         }

--- a/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
+++ b/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
@@ -419,11 +419,6 @@ namespace Mautic\CoreBundle\ErrorHandler {
          */
         protected function log($logLevel, $message, $context = [], $debugTrace = null)
         {
-            if ('dev' !== self::$environment) {
-                // Don't clutter the logs
-                $context = [];
-            }
-
             $message = strip_tags($message);
             if ($this->logger) {
                 if (LogLevel::DEBUG === $logLevel) {
@@ -434,7 +429,7 @@ namespace Mautic\CoreBundle\ErrorHandler {
                     if ($this->debugLogger) {
                         if ($debugTrace) {
                             // Just a snippet
-                            $context['trace'] = array_slice($debugTrace, 1, 5);
+                            $context['trace'] = array_slice($debugTrace, 0, 50);
                         }
                         $this->debugLogger->log($logLevel, $message, $context);
                     }

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1631,6 +1631,7 @@ class MailHelper
     protected function logError($error, $context = null)
     {
         if ($error instanceof \Exception) {
+            $exceptionContext = ['exception' => $error];
             $errorMessage = $error->getMessage();
             $error        = ('dev' === MAUTIC_ENV) ? (string) $error : $errorMessage;
 
@@ -1639,6 +1640,7 @@ class MailHelper
 
             $this->fatal = true;
         } else {
+            $exceptionContext = [];
             $errorMessage = trim($error);
         }
 
@@ -1659,7 +1661,7 @@ class MailHelper
 
         $this->logger->clear();
 
-        $this->factory->getLogger()->log('error', '[MAIL ERROR] '.$error);
+        $this->factory->getLogger()->log('error', '[MAIL ERROR] '.$error, $exceptionContext);
     }
 
     /**

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1632,8 +1632,8 @@ class MailHelper
     {
         if ($error instanceof \Exception) {
             $exceptionContext = ['exception' => $error];
-            $errorMessage = $error->getMessage();
-            $error        = ('dev' === MAUTIC_ENV) ? (string) $error : $errorMessage;
+            $errorMessage     = $error->getMessage();
+            $error            = ('dev' === MAUTIC_ENV) ? (string) $error : $errorMessage;
 
             // Clean up the error message
             $errorMessage = trim(preg_replace('/(.*?)Log data:(.*)$/is', '$1', $errorMessage));
@@ -1641,7 +1641,7 @@ class MailHelper
             $this->fatal = true;
         } else {
             $exceptionContext = [];
-            $errorMessage = trim($error);
+            $errorMessage     = trim($error);
         }
 
         $logDump = $this->logger->dump();


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |
| New feature? | Y
| Automated tests included? |
| Related user documentation PR URL |
| Related developer documentation PR URL |
| Issues addressed (#s or URLs) |
| BC breaks? |
| Deprecations? |

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When curl throws an exception mautic logs it as-is. Without attaching details. The exception report without specific information is useless:

```Operation timed out after 15001 milliseconds with 0 bytes received```
```Could not resolve host: examplehost.com```

There is no information about where are these comming from. Is it about webhooks? URL shortener? Email send? What was the url we were trying to contact? Etc.
We need to catch the exception, decorate it with all the available metadata and throw it again. Ideally with a stacktrace too.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to logs and search for logs like "Operation timed out after".
2. Such logs contain no information about where the error has happened. 

#### Steps to test this PR:
1. It's difficult to test this PR, because we need to get the same errors like the ones in the description and check if they contain stacktrace. But the issue is that we don't know why  and where are they happening, because we are unable to get stactkrace from the logs. 