### PR TITLE
Added identical comparison for boolean for email dynamic content

### DIFF
--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -122,10 +122,18 @@ trait MatchFilterForLeadTrait
 
             switch ($data['operator']) {
                 case '=':
-                    $groups[$groupNum] = $leadVal == $filterVal;
+                    if ($data['type'] === 'boolean') {
+                        $groups[$groupNum] = $leadVal === $filterVal;
+                    } else {
+                        $groups[$groupNum] = $leadVal == $filterVal;
+                    }
                     break;
                 case '!=':
-                    $groups[$groupNum] = $leadVal != $filterVal;
+                    if ($data['type'] === 'boolean') {
+                        $groups[$groupNum] = $leadVal !== $filterVal;
+                    } else {
+                        $groups[$groupNum] = $leadVal != $filterVal;
+                    }
                     break;
                 case 'gt':
                     $groups[$groupNum] = $leadVal > $filterVal;


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7451
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This fix for issue https://github.com/mautic/mautic/issues/7451
Email dynamic content compare bool type of filter and value in wrong way.

Before: **Not set custom bool field not equal 0** - return false
After: Return true (**"not set" is not equal to 0**)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a boolean custom field leave the default value to blank
2. Create an email with a dynamic content using the filter not equal to No
![image](https://user-images.githubusercontent.com/49391402/56424819-21116680-62b2-11e9-862e-e402130a697b.png)
3. Send the email to the contact, he will receive the default variant and not the one with the filter

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps
3. "not set" custom field  with condition not equal to No should return true)
