### PR TITLE
Intl infinite loop fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -134,6 +134,10 @@
         {
             "type": "git",
             "url": "https://github.com/mautic/BazingaOAuthServerBundle.git"
+        },
+        {
+            "type": "git",
+            "url": "https://github.com/mautic/intl.git"
         }
     ],
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -6541,11 +6541,11 @@
         },
         {
             "name": "symfony/intl",
-            "version": "v2.8.50",
+            "version": "v2.8.51",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mautic/intl.git",
-                "reference": "7c332001c3c3557c136eba4908f642dca41769de"
+                "reference": "236c4eb3d12813f766d6b52d23b5677bf0a9840f"
             },
             "require": {
                 "php": ">=5.3.9",
@@ -6606,7 +6606,7 @@
                 "l10n",
                 "localization"
             ],
-            "time": "2018-11-11T11:11:22+00:00"
+            "time": "2019-04-25T07:50:25+00:00"
         },
         {
             "name": "symfony/monolog-bridge",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d865a55c8f4f76edea7f41ffb0d5223f",
+    "content-hash": "76ca1f3e88950d50351be721720c3e0a",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -827,7 +827,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2017-09-29T14:39:10+00:00"
+            "time": "2017-10-12T17:23:29+00:00"
         },
         {
             "name": "doctrine/doctrine-fixtures-bundle",
@@ -2731,7 +2731,7 @@
                     "homepage": "http://github.com/knplabs/Gaufrette/contributors"
                 },
                 {
-                    "name": "KNPLabs Team",
+                    "name": "KnpLabs Team",
                     "homepage": "http://knplabs.com"
                 }
             ],
@@ -3145,7 +3145,7 @@
                 "geolocation",
                 "maxmind"
             ],
-            "time": "2017-01-19T23:49:38+00:00"
+            "time": "2017-10-27T19:15:33+00:00"
         },
         {
             "name": "maxmind/web-service-common",
@@ -6541,17 +6541,11 @@
         },
         {
             "name": "symfony/intl",
-            "version": "v2.8.34",
+            "version": "v2.8.50",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/intl.git",
-                "reference": "847da8b0460d6119e571982037093df43aed9b21"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/intl/zipball/847da8b0460d6119e571982037093df43aed9b21",
-                "reference": "847da8b0460d6119e571982037093df43aed9b21",
-                "shasum": ""
+                "url": "https://github.com/mautic/intl.git",
+                "reference": "7c332001c3c3557c136eba4908f642dca41769de"
             },
             "require": {
                 "php": ">=5.3.9",
@@ -6581,7 +6575,6 @@
                     "/Tests/"
                 ]
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -6613,7 +6606,7 @@
                 "l10n",
                 "localization"
             ],
-            "time": "2018-01-03T07:36:31+00:00"
+            "time": "2018-11-11T11:11:22+00:00"
         },
         {
             "name": "symfony/monolog-bridge",
@@ -7755,7 +7748,7 @@
             ],
             "description": "Symfony SwiftmailerBundle",
             "homepage": "http://symfony.com",
-            "time": "2017-07-22T07:18:13+00:00"
+            "time": "2017-10-19T01:06:41+00:00"
         },
         {
             "name": "symfony/templating",
@@ -9009,7 +9002,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-04-12T18:52:22+00:00"
+            "time": "2017-10-19T19:58:43+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -9273,6 +9266,7 @@
                 "testing",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2016-12-02T14:39:14+00:00"
         },
         {
@@ -9663,6 +9657,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2017-06-30T09:13:00+00:00"
         },
         {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7408
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The [symfony/intl:2.8](https://github.com/symfony/intl/tree/2.8) has a bug that cause an infinite loop on some PHP versions. Since version 2.8 that Mautic uses is in the "security fixes only" mode and we cannot upgrade to 3.4 without BC breaks we forked the intl package, [fixed the issue](https://github.com/mautic/intl/pull/1) and tell Composer to use our fork instead of the original.

I can see that the `\Symfony\Component\Intl\Locale` class contains the fix and when I run 

`$ composer show symfony/intl -v`

I can see

`source   : [git] https://github.com/mautic/intl.git 236c4eb3d12813f766d6b52d23b5677bf0a9840f`

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. I don't quite know when it happens. I asked in the issue but did not get any answer. But guys in the issue provided info about what needs to change to fix the issue and several Mauticans confirmed.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com) or run `composer install` on your local Mautic.
