### PR TITLE
Unsubscribed Manual segment filter

### DIFF
--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -467,6 +467,18 @@ class ListModel extends FormModel
                 'operators' => $this->getOperatorsForFieldType('bool'),
                 'object'    => 'lead',
             ],
+            'dnc_manual_email' => [
+                'label'      => $this->translator->trans('mautic.lead.list.filter.dnc_manual_email'),
+                'properties' => [
+                    'type' => 'boolean',
+                    'list' => [
+                        0 => $this->translator->trans('mautic.core.form.no'),
+                        1 => $this->translator->trans('mautic.core.form.yes'),
+                    ],
+                ],
+                'operators' => $this->getOperatorsForFieldType('bool'),
+                'object'    => 'lead',
+            ],
             'dnc_bounced_sms' => [
                 'label'      => $this->translator->trans('mautic.lead.list.filter.dnc_bounced_sms'),
                 'properties' => [

--- a/app/bundles/LeadBundle/Segment/DoNotContact/DoNotContactParts.php
+++ b/app/bundles/LeadBundle/Segment/DoNotContact/DoNotContactParts.php
@@ -48,6 +48,16 @@ class DoNotContactParts
      */
     public function getParameterType()
     {
-        return $this->type === 'bounced' ? DoNotContact::BOUNCED : DoNotContact::UNSUBSCRIBED;
+        switch ($this->type) {
+            case 'bounced':
+                return DoNotContact::BOUNCED;
+                break;
+            case 'manual':
+                return DoNotContact::MANUAL;
+                break;
+            default:
+                return DoNotContact::UNSUBSCRIBED;
+                break;
+        }
     }
 }

--- a/app/bundles/LeadBundle/Services/ContactSegmentFilterDictionary.php
+++ b/app/bundles/LeadBundle/Services/ContactSegmentFilterDictionary.php
@@ -84,6 +84,10 @@ class ContactSegmentFilterDictionary extends \ArrayIterator
             'type' => DoNotContactFilterQueryBuilder::getServiceId(),
         ];
 
+        $this->translations['dnc_manual_email'] = [
+            'type' => DoNotContactFilterQueryBuilder::getServiceId(),
+        ];
+
         $this->translations['dnc_unsubscribed_sms'] = [
             'type' => DoNotContactFilterQueryBuilder::getServiceId(),
         ];

--- a/app/bundles/LeadBundle/Translations/en_US/messages.ini
+++ b/app/bundles/LeadBundle/Translations/en_US/messages.ini
@@ -381,6 +381,7 @@ mautic.lead.list.rebuild.to_be_removed="%leads% total contact(s) to be removed i
 mautic.lead.list.filter.date_identified="Date Identified"
 mautic.lead.list.filter.dnc_bounced="Bounced - Email"
 mautic.lead.list.filter.dnc_unsubscribed="Unsubscribed - Email"
+mautic.lead.list.filter.dnc_manual_email="Unsubscribed Manual - Email"
 mautic.lead.list.filter.last_active="Date Last Active"
 mautic.lead.list.filter.date_modified="Modified date"
 mautic.lead.list.filter.campaign="Campaign Membership"


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Just new segment filter with manual unsubscribed contacts

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create segment with new filter "Unsubscribed Manual - Email"
3. Go to any contact's detail, open preferences and unsubscribe contact from email channel
4. call `php app/console mautic:segments:update`
5. See If contacts was added to segment 
