### PR TITLE
Correct pref center lp form child

### DIFF
--- a/app/bundles/CoreBundle/Views/Slots/channelfrequency.html.php
+++ b/app/bundles/CoreBundle/Views/Slots/channelfrequency.html.php
@@ -24,7 +24,7 @@ $channelNumber = 0;
                     <input type="hidden" id="<?php echo $channel->value; ?>"
                            name="lead_contact_frequency_rules[lead_channels][subscribed_channels][<?php echo $key; ?>]"
                            value="">
-                    <input type="checkbox" id="<?php echo $channel->value; ?>
+                    <input type="checkbox" id="<?php echo $channel->value; ?>"
                            name="lead_contact_frequency_rules[lead_channels][subscribed_channels][<?php echo $key; ?>]"
                            onclick="togglePreferredChannel(this.value);"
                            value="<?php echo $view->escape($channel->value); ?>" <?php echo $checked; ?>>

--- a/app/bundles/CoreBundle/Views/Slots/channelfrequency.html.php
+++ b/app/bundles/CoreBundle/Views/Slots/channelfrequency.html.php
@@ -11,7 +11,7 @@
 
 $channelNumber = 0;
 ?>
-<?php if (isset($form)) : ?>
+<?php if (isset($form['lead_channels'])) : ?>
 <table class="table table-striped">
     <?php foreach ($form['lead_channels']['subscribed_channels']->vars['choices'] as $key=>$channel):
         $contactMe   = isset($leadChannels[$channel->value]);
@@ -24,7 +24,7 @@ $channelNumber = 0;
                     <input type="hidden" id="<?php echo $channel->value; ?>"
                            name="lead_contact_frequency_rules[lead_channels][subscribed_channels][<?php echo $key; ?>]"
                            value="">
-                    <input type="checkbox" id="<?php echo $channel->value; ?>"
+                    <input type="checkbox" id="<?php echo $channel->value; ?>
                            name="lead_contact_frequency_rules[lead_channels][subscribed_channels][<?php echo $key; ?>]"
                            onclick="togglePreferredChannel(this.value);"
                            value="<?php echo $view->escape($channel->value); ?>" <?php echo $checked; ?>>

--- a/app/bundles/CoreBundle/Views/Slots/preferredchannel.html.php
+++ b/app/bundles/CoreBundle/Views/Slots/preferredchannel.html.php
@@ -10,7 +10,7 @@
  */
 
 ?>
-<?php if (isset($form)) : ?>
+<?php if (isset($form['lead_channels'])) : ?>
     <?php if ($showContactPreferredChannels):?>
         <div class="preferred_channel text-left"><?php echo $view['form']->row($form['lead_channels']['preferred_channel']); ?></div>
         <?php

--- a/app/bundles/CoreBundle/Views/Slots/saveprefsbutton.html.php
+++ b/app/bundles/CoreBundle/Views/Slots/saveprefsbutton.html.php
@@ -27,7 +27,7 @@ if (isset($form)) {
     <div style="clear:both"></div>
 <?php
 if (isset($form)) {
-    unset($form['subscribed_channels'], $form['buttons']['save'], $form['buttons']['cancel']);
+    unset($form['lead_channels']['subscribed_channels'], $form['buttons']['save'], $form['buttons']['cancel']);
     if (!$showContactCategories) {
         unset($form['global_categories']);
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | N
| BC breaks? | /
| Deprecations? | /

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR was suppose to fix the same issue for our Mautic fork as what https://github.com/mautic/mautic/pull/7006 did. So there is not much left after the merge of both. I can see from the code changes that there is still the bug with the `subscribed_channels` field.

There was a change in some of the preference center what looks like 2 years ago that caused a trouble with rendering of the preference center field order. The "Save preferences" button was rendered first although the user wanted it last. This happened because the code that was suppose to handle the fields was not called at all and then the `$form->end()`that is called after the button dumped all the fields that weren't handled manually.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a Preference Center page
2. Add the Save Preferences slot below the Subscribed channels slot
3. Ensure Show Contact's Preferences is enabled in Configuration --> Email Settings
4. Send an email (either Segment email or Template email through a campaign) to a contact
5. Click Unsubscribe link

- The button is above the Subscribed channels field.

#### Steps to test this PR:
- Maybe even a code review would suffice. As there are not many changes left after the merge.

1. Refresh the Preference center page. The fields are in the correct order as you configured it on the landing page.
2. Test that all field values stick when you save the form.
