### PR TITLE
Date input type fix at preference center form

### DIFF
--- a/app/bundles/CoreBundle/Views/Slots/channelfrequency.html.php
+++ b/app/bundles/CoreBundle/Views/Slots/channelfrequency.html.php
@@ -36,7 +36,7 @@ $channelNumber = 0;
         </tr>
         <tr>
             <td>
-                <div id="frequency_<?php echo $channel->value; ?>" class="text-left">
+                <div id="frequency_<?php echo $channel->value; ?>" class="text-left row">
                     <?php
                     if ($showContactFrequency && isset($form['lead_channels']['frequency_number_'.$channel->value]) && isset($form['lead_channels']['frequency_time_'.$channel->value])):?>
                         <div class="col-md-6">
@@ -81,7 +81,7 @@ $channelNumber = 0;
     </tr>
     <tr>
         <td>
-            <div id="frequency_email" class="text-left">
+            <div id="frequency_email" class="text-left row">
                 <div class="col-xs-6">
                     <label class="text-muted label1"><?php echo $view['translator']->trans('mautic.lead.list.frequency.number'); ?></label>
                     <input type="text" class="frequency form-control">

--- a/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
+++ b/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
@@ -69,7 +69,7 @@ JS;
                     </tr>
                     <tr>
                         <td>
-                            <div id="frequency_<?php echo $channel->value; ?>" class="text-left">
+                            <div id="frequency_<?php echo $channel->value; ?>" class="text-left row">
                                 <?php
                                 if ($showContactFrequency):?>
                                     <div class="col-md-6">

--- a/app/bundles/LeadBundle/Form/Type/ContactChannelsType.php
+++ b/app/bundles/LeadBundle/Form/Type/ContactChannelsType.php
@@ -5,6 +5,7 @@ namespace Mautic\LeadBundle\Form\Type;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\LeadBundle\Entity\FrequencyRule;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -16,8 +17,6 @@ class ContactChannelsType extends AbstractType
     private $coreParametersHelper;
 
     /**
-     * ContactFrequencyType constructor.
-     *
      * @param CoreParametersHelper $coreParametersHelper
      */
     public function __construct(CoreParametersHelper $coreParametersHelper)
@@ -123,7 +122,6 @@ class ContactChannelsType extends AbstractType
                             'class'       => 'frequency-date form-control',
                         ]
                     );
-                    $type = 'datetime';
                 } else {
                     $attributes = array_merge(
                         $attr,
@@ -131,30 +129,32 @@ class ContactChannelsType extends AbstractType
                             'class' => 'form-control',
                         ]
                     );
-                    $type = 'date';
                 }
+ 
                 if (!$options['public_view'] || $showContactPauseDates) {
                     $builder->add(
                         'contact_pause_start_date_'.$channel,
-                        $type,
+                        DateType::class,
                         [
                             'widget'     => 'single_text',
-                            'label'      => false, //'mautic.lead.frequency.contact.start.date',
+                            'label'      => false,
                             'label_attr' => ['class' => 'text-muted fw-n label3'],
                             'attr'       => $attributes,
-                            'format'     => 'yyyy-MM-dd',
+                            'format'     => $options['public_view'] ? DateType::HTML5_FORMAT : 'yyyy-MM-dd',
+                            'html5'      => $options['public_view'],
                             'required'   => false,
                         ]
                     );
                     $builder->add(
                         'contact_pause_end_date_'.$channel,
-                        $type,
+                        DateType::class,
                         [
                             'widget'     => 'single_text',
                             'label'      => 'mautic.lead.frequency.contact.end.date',
                             'label_attr' => ['class' => 'frequency-label text-muted fw-n label4'],
                             'attr'       => $attributes,
-                            'format'     => 'yyyy-MM-dd',
+                            'format'     => $options['public_view'] ? DateType::HTML5_FORMAT : 'yyyy-MM-dd',
+                            'html5'      => $options['public_view'],
                             'required'   => false,
                         ]
                     );

--- a/app/bundles/LeadBundle/Form/Type/ContactChannelsType.php
+++ b/app/bundles/LeadBundle/Form/Type/ContactChannelsType.php
@@ -130,7 +130,7 @@ class ContactChannelsType extends AbstractType
                         ]
                     );
                 }
- 
+
                 if (!$options['public_view'] || $showContactPauseDates) {
                     $builder->add(
                         'contact_pause_start_date_'.$channel,


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The "Pause from" and "to" fields in the Preferences Form were plain text fields so the contacts might be confused what values and in what format to fill in. This PR fixes that and changes the input type from text to date. Modern browsers will guide contacts to fill in date in specific format.

![Screenshot 2019-04-26 at 15 04 14](https://user-images.githubusercontent.com/1235442/56810746-55979c00-6837-11e9-92e9-88868fac14db.png)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Ensure you have all the preference settings turned on in the Configuration > Email Settings.
2. Create a segment email that contain the unsubscribe link and send it to your test segment.
3. Click to the unsubscribe link in the email you've received
4. Notice the "Pause form" and "to" fields are text fields.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Refresh the preference page and the fields will be type of date so you can use the date picker to select a date.
3. Ensure the values are being saved.
4. Ensure the values will appear in the preference center on the contact detail page. This page should display normal text fields with custom datepicker that is used in the Mautic administration.
