### PR TITLE
Fix autofilling when using multiple autofill fields

### DIFF
--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -233,10 +233,20 @@ class FormFieldHelper extends AbstractFormFieldHelper
                 foreach ($value as $val) {
                     $val = $this->sanitizeValue($val);
                     if (preg_match(
+                        '/<input(.*?)id="mauticform_checkboxgrp_checkbox_'.$alias.'_(.*?)"(.*?)value="'.$val.'"(.*?)\/>/i',
+                        $formHtml,
+                        $match
+                    )) {
+                        // For multiple checkbox groups
+                        $replace = '<input'.$match[1].'id="mauticform_checkboxgrp_checkbox_'.$alias.'_'.$match[2].'"'.$match[3].'value="'.$val.'"'
+                            .$match[4].' checked />';
+                        $formHtml = str_replace($match[0], $replace, $formHtml);
+                    } elseif (preg_match(
                         '/<input(.*?)id="mauticform_checkboxgrp_checkbox(.*?)"(.*?)value="'.$val.'"(.*?)\/>/i',
                         $formHtml,
                         $match
                     )) {
+                        // For one checkbox group
                         $replace = '<input'.$match[1].'id="mauticform_checkboxgrp_checkbox'.$match[2].'"'.$match[3].'value="'.$val.'"'
                             .$match[4].' checked />';
                         $formHtml = str_replace($match[0], $replace, $formHtml);

--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -233,11 +233,11 @@ class FormFieldHelper extends AbstractFormFieldHelper
                 foreach ($value as $val) {
                     $val = $this->sanitizeValue($val);
                     if (preg_match(
-                        '/<input(.*?)id="mauticform_checkboxgrp_checkbox(.*?)"(.*?)value="'.$val.'"(.*?)\/>/i',
+                        '/<input(.*?)id="mauticform_checkboxgrp_checkbox_'.$alias.'(.*?)"(.*?)value="'.$val.'"(.*?)\/>/i',
                         $formHtml,
                         $match
                     )) {
-                        $replace = '<input'.$match[1].'id="mauticform_checkboxgrp_checkbox'.$match[2].'"'.$match[3].'value="'.$val.'"'
+                        $replace = '<input'.$match[1].'id="mauticform_checkboxgrp_checkbox_'.$alias.$match[2].'"'.$match[3].'value="'.$val.'"'
                             .$match[4].' checked />';
                         $formHtml = str_replace($match[0], $replace, $formHtml);
                     }

--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -233,12 +233,12 @@ class FormFieldHelper extends AbstractFormFieldHelper
                 foreach ($value as $val) {
                     $val = $this->sanitizeValue($val);
                     if (preg_match(
-                        '/<input(.*?)id="mauticform_checkboxgrp_checkbox_'.$alias.'_(.*?)"(.*?)value="'.$val.'"(.*?)\/>/i',
+                        '/<input(.*?)id="mauticform_checkboxgrp_checkbox_'.$alias.'_(\d{2})"(.*?)value="'.$val.'"(.*?)\/>/i',
                         $formHtml,
                         $match
                     )) {
                         // For multiple checkbox groups
-                        $replace = '<input'.$match[1].'id="mauticform_checkboxgrp_checkbox_'.$alias.'_'.$match[2].'"'.$match[3].'value="'.$val.'"'
+                        $replace = '<input'.$match[1].'id="mauticform_checkboxgrp_checkbox'.$alias.'_'.$match[2].'"'.$match[3].'value="'.$val.'"'
                             .$match[4].' checked />';
                         $formHtml = str_replace($match[0], $replace, $formHtml);
                     } elseif (preg_match(

--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -233,11 +233,11 @@ class FormFieldHelper extends AbstractFormFieldHelper
                 foreach ($value as $val) {
                     $val = $this->sanitizeValue($val);
                     if (preg_match(
-                        '/<input(.*?)id="mauticform_checkboxgrp_checkbox_'.$alias.'(.*?)"(.*?)value="'.$val.'"(.*?)\/>/i',
+                        '/<input(.*?)id="mauticform_checkboxgrp_checkbox(.*?)"(.*?)value="'.$val.'"(.*?)\/>/i',
                         $formHtml,
                         $match
                     )) {
-                        $replace = '<input'.$match[1].'id="mauticform_checkboxgrp_checkbox_'.$alias.$match[2].'"'.$match[3].'value="'.$val.'"'
+                        $replace = '<input'.$match[1].'id="mauticform_checkboxgrp_checkbox'.$match[2].'"'.$match[3].'value="'.$val.'"'
                             .$match[4].' checked />';
                         $formHtml = str_replace($match[0], $replace, $formHtml);
                     }

--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -238,7 +238,7 @@ class FormFieldHelper extends AbstractFormFieldHelper
                         $match
                     )) {
                         // For multiple checkbox groups
-                        $replace = '<input'.$match[1].'id="mauticform_checkboxgrp_checkbox'.$alias.'_'.$match[2].'"'.$match[3].'value="'.$val.'"'
+                        $replace = '<input'.$match[1].'id="mauticform_checkboxgrp_checkbox_'.$alias.'_'.$match[2].'"'.$match[3].'value="'.$val.'"'
                             .$match[4].' checked />';
                         $formHtml = str_replace($match[0], $replace, $formHtml);
                     } elseif (preg_match(

--- a/app/bundles/FormBundle/Tests/Helper/FormFieldHelperTest.php
+++ b/app/bundles/FormBundle/Tests/Helper/FormFieldHelperTest.php
@@ -38,6 +38,17 @@ class FormFieldHelperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider multiGroupFieldProvider
+     */
+    public function testPopulateMultiGroupFields($field, $value, $formHtml, $expectedValue, $message)
+    {
+        $field->setAlias('test');
+        $this->fixture->populateField($field, $value, 'mautic', $formHtml);
+
+        $this->assertEquals($expectedValue, $formHtml, $message);
+    }
+
+    /**
      * @return array
      */
     public function fieldProvider()
@@ -98,6 +109,22 @@ class FormFieldHelperTest extends \PHPUnit_Framework_TestCase
                 '<select id="mauticform_input_mautic_select"><option value="myvalue">My Value</option></select>',
                 '<select id="mauticform_input_mautic_select"><option value="myvalue" selected="selected">My Value</option></select>',
                 'Select lists should have their values set appropriately via GET.',
+            ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function multiGroupFieldProvider()
+    {
+        return [
+            [
+                $this->getField('Multi checkbox groups', 'checkboxgrp'),
+                'myvalue|alsomyvalue',
+                '<input id="mauticform_checkboxgrp_checkbox_test_00" value="myvalue"/><input id="mauticform_checkboxgrp_checkbox_test_01" value="notmyvalue"/>',
+                '<input id="mauticform_checkboxgrp_checkbox_test_00" value="myvalue" checked /><input id="mauticform_checkboxgrp_checkbox_test_01" value="notmyvalue"/>',
+                'Multi-value multi checkbox groups should have their values set appropriately via GET.',
             ],
         ];
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: When using multiple checkbox groups or selects, only first one is autofilled.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create multiple Boolean or Select custom fields
2. Create form with checkbox groups mapping to those custom fields, using "Use assigned contact/company field's list choices. = Yes" in the Properties Tab
3. Add form to a landing page, then submit form with at least one of those checkboxes checked
4. Refresh landing page that the form is on 

#### Steps to test this PR:
1. Load up this PR
2. Use reproduction steps
