### PR TITLE
Webhook fail notification by e-mail

### DIFF
--- a/app/bundles/WebhookBundle/Config/config.php
+++ b/app/bundles/WebhookBundle/Config/config.php
@@ -66,6 +66,16 @@ return [
                 ],
                 'alias' => 'campaignevent_sendwebhook',
             ],
+            'mautic.webhook.notificator.webhookkillnotificator' => [
+                'class'     => \Mautic\WebhookBundle\Notificator\WebhookKillNotificator::class,
+                'arguments' => [
+                    'translator',
+                    'router',
+                    'mautic.core.model.notification',
+                    'doctrine.orm.entity_manager',
+                    'mautic.helper.mailer',
+                ],
+            ],
         ],
         'events' => [
             'mautic.webhook.config.subscriber' => [
@@ -76,8 +86,7 @@ return [
                 'arguments' => [
                     'mautic.helper.ip_lookup',
                     'mautic.core.model.auditlog',
-                    'mautic.core.model.notification',
-                    'doctrine.orm.entity_manager',
+                    'mautic.webhook.notificator.webhookkillnotificator',
                 ],
             ],
             'mautic.webhook.stats.subscriber' => [
@@ -117,7 +126,7 @@ return [
         'webhook_start'         => 0, // deprecated, should be 0 by default
         'webhook_limit'         => 10, // How many entities can be sent in one webhook
         'webhook_log_max'       => 1000, // How many recent logs to keep
-        'webhook_disable_limit' => 2, // How many times the webhook response can fail until the webhook will be unpublished
+        'webhook_disable_limit' => 100, // How many times the webhook response can fail until the webhook will be unpublished
         'webhook_timeout'       => 15, // How long the CURL request can wait for response before Mautic hangs up. In seconds
         'queue_mode'            => 'immediate_process', // Trigger the webhook immediately or queue it for faster response times
         'events_orderby_dir'    => \Doctrine\Common\Collections\Criteria::ASC, // Order the queued events chronologically or the other way around

--- a/app/bundles/WebhookBundle/Config/config.php
+++ b/app/bundles/WebhookBundle/Config/config.php
@@ -76,6 +76,8 @@ return [
                 'arguments' => [
                     'mautic.helper.ip_lookup',
                     'mautic.core.model.auditlog',
+                    'mautic.core.model.notification',
+                    'doctrine.orm.entity_manager',
                 ],
             ],
             'mautic.webhook.stats.subscriber' => [
@@ -97,7 +99,7 @@ return [
                 'arguments' => [
                     'mautic.helper.core_parameters',
                     'jms_serializer',
-                    'mautic.core.model.notification',
+                    'event_dispatcher',
                 ],
             ],
         ],
@@ -115,7 +117,7 @@ return [
         'webhook_start'         => 0, // deprecated, should be 0 by default
         'webhook_limit'         => 10, // How many entities can be sent in one webhook
         'webhook_log_max'       => 1000, // How many recent logs to keep
-        'webhook_disable_limit' => 100, // How many times the webhook response can fail until the webhook will be unpublished
+        'webhook_disable_limit' => 2, // How many times the webhook response can fail until the webhook will be unpublished
         'webhook_timeout'       => 15, // How long the CURL request can wait for response before Mautic hangs up. In seconds
         'queue_mode'            => 'immediate_process', // Trigger the webhook immediately or queue it for faster response times
         'events_orderby_dir'    => \Doctrine\Common\Collections\Criteria::ASC, // Order the queued events chronologically or the other way around

--- a/app/bundles/WebhookBundle/Event/WebhookEvent.php
+++ b/app/bundles/WebhookBundle/Event/WebhookEvent.php
@@ -20,13 +20,29 @@ use Mautic\WebhookBundle\Entity\Webhook;
 class WebhookEvent extends CommonEvent
 {
     /**
+     * @var Webhook
+     */
+    protected $entity;
+
+    /**
+     * @var bool
+     */
+    protected $isNew = false;
+
+    /**
+     * @var string
+     */
+    private $reason = '';
+
+    /**
      * @param Webhook $webhook
      * @param bool    $isNew
      */
-    public function __construct(Webhook &$webhook, $isNew = false)
+    public function __construct(Webhook &$webhook, $isNew = false, $reason = '')
     {
         $this->entity = &$webhook;
         $this->isNew  = $isNew;
+        $this->reason = $reason;
     }
 
     /**
@@ -47,5 +63,21 @@ class WebhookEvent extends CommonEvent
     public function setWebhook(Webhook $webhook)
     {
         $this->entity = $webhook;
+    }
+
+    /**
+     * @param $reason
+     */
+    public function setReason($reason)
+    {
+        $this->reason = $reason;
+    }
+
+    /**
+     * @return string
+     */
+    public function getReason(): string
+    {
+        return $this->reason;
     }
 }

--- a/app/bundles/WebhookBundle/Event/WebhookEvent.php
+++ b/app/bundles/WebhookBundle/Event/WebhookEvent.php
@@ -76,7 +76,7 @@ class WebhookEvent extends CommonEvent
     /**
      * @return string
      */
-    public function getReason(): string
+    public function getReason()
     {
         return $this->reason;
     }

--- a/app/bundles/WebhookBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/WebhookBundle/EventListener/WebhookSubscriber.php
@@ -48,16 +48,9 @@ class WebhookSubscriber extends CommonSubscriber
         AuditLogModel $auditLogModel,
         WebhookKillNotificator $webhookKillNotificator
     ) {
-<<<<<<< HEAD
-        $this->ipLookupHelper    = $ipLookupHelper;
-        $this->auditLogModel     = $auditLogModel;
-        $this->notificationModel = $notificationModel;
-        $this->entityManager     = $entityManager;
-=======
         $this->ipLookupHelper         = $ipLookupHelper;
         $this->auditLogModel          = $auditLogModel;
         $this->webhookKillNotificator = $webhookKillNotificator;
->>>>>>> 946c956a45... Add webhook kill notificator service with added e-mail sender
     }
 
     /**
@@ -120,30 +113,6 @@ class WebhookSubscriber extends CommonSubscriber
      */
     public function onWebhookKill(WebhookEvent $event)
     {
-<<<<<<< HEAD
-        $webhook = $event->getWebhook();
-        $reason  = $event->getReason();
-
-        $this->notificationModel->addNotification(
-            $this->translator->trans(
-                'mautic.webhook.stopped.details',
-                [
-                    '%reason%'  => $this->translator->trans($reason),
-                    '%webhook%' => '<a href="'.$this->router->generate(
-                            'mautic_webhook_action',
-                            ['objectAction' => 'view', 'objectId' => $webhook->getId()]
-                        ).'" data-toggle="ajax">'.$webhook->getName().'</a>',
-                ]
-            ),
-            'error',
-            false,
-            $this->translator->trans('mautic.webhook.stopped'),
-            null,
-            null,
-            $this->entityManager->getReference('MauticUserBundle:User', $webhook->getCreatedBy())
-        );
-=======
         $this->webhookKillNotificator->send($event->getWebhook(), $event->getReason());
->>>>>>> 946c956a45... Add webhook kill notificator service with added e-mail sender
     }
 }

--- a/app/bundles/WebhookBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/WebhookBundle/EventListener/WebhookSubscriber.php
@@ -11,13 +11,12 @@
 
 namespace Mautic\WebhookBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\EventListener\CommonSubscriber;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
-use Mautic\CoreBundle\Model\NotificationModel;
 use Mautic\WebhookBundle\Event\WebhookEvent;
-use Mautic\WebhookBundle\WebhookEvents as WebhookEvents;
+use Mautic\WebhookBundle\Notificator\WebhookKillNotificator;
+use Mautic\WebhookBundle\WebhookEvents;
 
 /**
  * Class WebhookSubscriber.
@@ -35,31 +34,30 @@ class WebhookSubscriber extends CommonSubscriber
     protected $auditLogModel;
 
     /**
-     * @var NotificationModel
+     * @var WebhookKillNotificator
      */
-    private $notificationModel;
+    private $webhookKillNotificator;
 
     /**
-     * @var EntityManager
-     */
-    private $entityManager;
-
-    /**
-     * @param IpLookupHelper    $ipLookupHelper
-     * @param AuditLogModel     $auditLogModel
-     * @param NotificationModel $notificationModel
-     * @param EntityManager     $entityManager
+     * @param IpLookupHelper         $ipLookupHelper
+     * @param AuditLogModel          $auditLogModel
+     * @param WebhookKillNotificator $webhookKillNotificator
      */
     public function __construct(
         IpLookupHelper $ipLookupHelper,
         AuditLogModel $auditLogModel,
-        NotificationModel $notificationModel,
-        EntityManager $entityManager
+        WebhookKillNotificator $webhookKillNotificator
     ) {
+<<<<<<< HEAD
         $this->ipLookupHelper    = $ipLookupHelper;
         $this->auditLogModel     = $auditLogModel;
         $this->notificationModel = $notificationModel;
         $this->entityManager     = $entityManager;
+=======
+        $this->ipLookupHelper         = $ipLookupHelper;
+        $this->auditLogModel          = $auditLogModel;
+        $this->webhookKillNotificator = $webhookKillNotificator;
+>>>>>>> 946c956a45... Add webhook kill notificator service with added e-mail sender
     }
 
     /**
@@ -122,6 +120,7 @@ class WebhookSubscriber extends CommonSubscriber
      */
     public function onWebhookKill(WebhookEvent $event)
     {
+<<<<<<< HEAD
         $webhook = $event->getWebhook();
         $reason  = $event->getReason();
 
@@ -143,5 +142,8 @@ class WebhookSubscriber extends CommonSubscriber
             null,
             $this->entityManager->getReference('MauticUserBundle:User', $webhook->getCreatedBy())
         );
+=======
+        $this->webhookKillNotificator->send($event->getWebhook(), $event->getReason());
+>>>>>>> 946c956a45... Add webhook kill notificator service with added e-mail sender
     }
 }

--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -97,6 +97,11 @@ class WebhookModel extends FormModel
     protected $serializer;
 
     /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
      * Queued events default order by dir
      * Possible values: ['ASC', 'DESC'].
      *

--- a/app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
+++ b/app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+* @copyright   2019 Mautic, Inc. All rights reserved
+* @author      Mautic, Inc.
+*
+* @link        https://mautic.com
+*
+* @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+*/
+
+namespace Mautic\WebhookBundle\Notificator;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMException;
+use Mautic\CoreBundle\Model\NotificationModel;
+use Mautic\EmailBundle\Helper\MailHelper;
+use Mautic\UserBundle\Entity\User;
+use Mautic\WebhookBundle\Entity\Webhook;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\Translation\DataCollectorTranslator;
+
+class WebhookKillNotificator
+{
+    /**
+     * @var DataCollectorTranslator
+     */
+    private $translator;
+
+    /**
+     * @var Router
+     */
+    private $router;
+
+    /**
+     * @var NotificationModel
+     */
+    private $notificationModel;
+
+    /**
+     * @var EntityManager
+     */
+    private $entityManager;
+
+    /**
+     * @var MailHelper
+     */
+    private $mailer;
+
+    /**
+     * @param DataCollectorTranslator $translator
+     * @param Router                  $router
+     * @param NotificationModel       $notificationModel
+     * @param EntityManager           $entityManager
+     * @param MailHelper              $mailer
+     */
+    public function __construct(
+        DataCollectorTranslator $translator,
+        Router $router,
+        NotificationModel $notificationModel,
+        EntityManager $entityManager,
+        MailHelper $mailer
+    ) {
+        $this->translator        = $translator;
+        $this->router            = $router;
+        $this->notificationModel = $notificationModel;
+        $this->entityManager     = $entityManager;
+        $this->mailer            = $mailer;
+    }
+
+    /**
+     * @param Webhook $webhook
+     * @param string  $reason  Translatable key
+     */
+    public function send(Webhook $webhook, $reason)
+    {
+        $subject = $this->translator->trans('mautic.webhook.stopped');
+        $reason  = $this->translator->trans($reason);
+        $htmlUrl = '<a href="'.$this->router->generate(
+                'mautic_webhook_action',
+                ['objectAction' => 'view', 'objectId' => $webhook->getId()]
+            ).'" data-toggle="ajax">'.$webhook->getName().'</a>';
+
+        $details = $this->translator->trans(
+            'mautic.webhook.stopped.details',
+            [
+                '%reason%'  => $reason,
+                '%webhook%' => $htmlUrl,
+            ]
+        );
+
+        $this->sendMauticNotification($webhook, $subject, $details);
+        $this->sendMailNotification($webhook, $subject, $details);
+    }
+
+    /**
+     * @param Webhook $webhook
+     * @param string  $subject
+     * @param string  $details
+     *
+     * @throws ORMException
+     */
+    private function sendMauticNotification(Webhook $webhook, $subject, $details)
+    {
+        $owner      = $this->entityManager->getReference('MauticUserBundle:User', $webhook->getCreatedBy());
+        /** @var User $user */
+        $user = $owner;
+
+        if ($modifiedBy = $webhook->getModifiedBy()) {
+            $modifiedBy = $this->entityManager->getReference('MauticUserBundle:User', $modifiedBy);
+
+            if ($modifiedBy !== $owner) {
+                $user = $modifiedBy;
+            }
+        }
+
+        $this->notificationModel->addNotification(
+            $details,
+            'error',
+            false,
+            $subject,
+            null,
+            null,
+            $user
+        );
+    }
+
+    /**
+     * @param Webhook $webhook
+     * @param string  $subject
+     * @param string  $details
+     *
+     * @throws ORMException
+     */
+    private function sendMailNotification(Webhook $webhook, $subject, $details)
+    {
+        $mailer = $this->mailer;
+
+        /** @var User $owner */
+        $owner = $this->entityManager->getReference('MauticUserBundle:User', $webhook->getCreatedBy());
+
+        $mailer->setTo($owner->getEmail());
+
+        if ($modifiedBy = $webhook->getModifiedBy()) {
+            $modifiedBy = $this->entityManager->getReference('MauticUserBundle:User', $webhook->getModifiedBy());
+
+            if ($modifiedBy !== $owner) {
+                $mailer->setTo($modifiedBy->getEmail());
+                $mailer->setCC($owner);
+            }
+        }
+
+        $mailer->setSubject($subject);
+        $mailer->setBody($details);
+        $mailer->send(true);
+    }
+}

--- a/app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
+++ b/app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
@@ -93,13 +93,11 @@ class WebhookKillNotificator
         /** @var User $owner */
         $owner = $toUser = $this->entityManager->getReference('MauticUserBundle:User', $webhook->getCreatedBy());
 
-        if (null !== $webhook->getModifiedBy() && $modifiedBy = $webhook->getModifiedBy()) {
-            $modifiedBy = $this->entityManager->getReference('MauticUserBundle:User', $modifiedBy);
+        if (null !== $webhook->getModifiedBy() && $webhook->getCreatedBy() !== $webhook->getModifiedBy()) {
+            $modifiedBy = $this->entityManager->getReference('MauticUserBundle:User', $webhook->getModifiedBy());
 
-            if ($modifiedBy !== $owner) {
-                $toUser   = $modifiedBy; // Send notification to modifier
-                $ccToUser = $owner; // And cc e-mail to owner
-            }
+            $toUser   = $modifiedBy; // Send notification to modifier
+            $ccToUser = $owner; // And cc e-mail to owner
         }
 
         // Send notification

--- a/app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
+++ b/app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
@@ -93,7 +93,7 @@ class WebhookKillNotificator
         /** @var User $owner */
         $owner = $toUser = $this->entityManager->getReference('MauticUserBundle:User', $webhook->getCreatedBy());
 
-        if ($modifiedBy = $webhook->getModifiedBy()) {
+        if (null !== $webhook->getModifiedBy() && $modifiedBy = $webhook->getModifiedBy()) {
             $modifiedBy = $this->entityManager->getReference('MauticUserBundle:User', $modifiedBy);
 
             if ($modifiedBy !== $owner) {

--- a/app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
+++ b/app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
@@ -89,31 +89,19 @@ class WebhookKillNotificator
             ]
         );
 
-        $this->sendMauticNotification($webhook, $subject, $details);
-        $this->sendMailNotification($webhook, $subject, $details);
-    }
-
-    /**
-     * @param Webhook $webhook
-     * @param string  $subject
-     * @param string  $details
-     *
-     * @throws ORMException
-     */
-    private function sendMauticNotification(Webhook $webhook, $subject, $details)
-    {
-        $owner      = $this->entityManager->getReference('MauticUserBundle:User', $webhook->getCreatedBy());
-        /** @var User $user */
-        $user = $owner;
+        /** @var User $owner */
+        $owner = $toUser = $this->entityManager->getReference('MauticUserBundle:User', $webhook->getCreatedBy());
 
         if ($modifiedBy = $webhook->getModifiedBy()) {
             $modifiedBy = $this->entityManager->getReference('MauticUserBundle:User', $modifiedBy);
 
             if ($modifiedBy !== $owner) {
-                $user = $modifiedBy;
+                $toUser = $modifiedBy; // Send notification to modifier
+                $ccToUser = $owner; // And cc e-mail to owner
             }
         }
 
+        // Send notification
         $this->notificationModel->addNotification(
             $details,
             'error',
@@ -121,33 +109,16 @@ class WebhookKillNotificator
             $subject,
             null,
             null,
-            $user
+            $toUser
         );
-    }
 
-    /**
-     * @param Webhook $webhook
-     * @param string  $subject
-     * @param string  $details
-     *
-     * @throws ORMException
-     */
-    private function sendMailNotification(Webhook $webhook, $subject, $details)
-    {
+        // Send e-mail
         $mailer = $this->mailer;
 
-        /** @var User $owner */
-        $owner = $this->entityManager->getReference('MauticUserBundle:User', $webhook->getCreatedBy());
+        $mailer->setTo($toUser->getEmail());
 
-        $mailer->setTo($owner->getEmail());
-
-        if ($modifiedBy = $webhook->getModifiedBy()) {
-            $modifiedBy = $this->entityManager->getReference('MauticUserBundle:User', $webhook->getModifiedBy());
-
-            if ($modifiedBy !== $owner) {
-                $mailer->setTo($modifiedBy->getEmail());
-                $mailer->setCC($owner);
-            }
+        if (isset($ccToUser)) {
+            $mailer->setCc($ccToUser->getEmail());
         }
 
         $mailer->setSubject($subject);

--- a/app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
+++ b/app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
@@ -17,6 +17,7 @@ use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\UserBundle\Entity\User;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class WebhookKillNotificator
@@ -47,11 +48,11 @@ class WebhookKillNotificator
     private $mailer;
 
     /**
-     * @param TranslatorInterface     $translator
-     * @param Router                  $router
-     * @param NotificationModel       $notificationModel
-     * @param EntityManager           $entityManager
-     * @param MailHelper              $mailer
+     * @param TranslatorInterface $translator
+     * @param Router              $router
+     * @param NotificationModel   $notificationModel
+     * @param EntityManager       $entityManager
+     * @param MailHelper          $mailer
      */
     public function __construct(
         TranslatorInterface $translator,
@@ -77,7 +78,8 @@ class WebhookKillNotificator
         $reason  = $this->translator->trans($reason);
         $htmlUrl = '<a href="'.$this->router->generate(
                 'mautic_webhook_action',
-                ['objectAction' => 'view', 'objectId' => $webhook->getId()]
+                ['objectAction' => 'view', 'objectId' => $webhook->getId()],
+                UrlGeneratorInterface::ABSOLUTE_URL
             ).'" data-toggle="ajax">'.$webhook->getName().'</a>';
 
         $details = $this->translator->trans(

--- a/app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
+++ b/app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
@@ -17,12 +17,12 @@ use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\UserBundle\Entity\User;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
-use Symfony\Component\Translation\DataCollectorTranslator;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class WebhookKillNotificator
 {
     /**
-     * @var DataCollectorTranslator
+     * @var TranslatorInterface
      */
     private $translator;
 
@@ -47,14 +47,14 @@ class WebhookKillNotificator
     private $mailer;
 
     /**
-     * @param DataCollectorTranslator $translator
+     * @param TranslatorInterface     $translator
      * @param Router                  $router
      * @param NotificationModel       $notificationModel
      * @param EntityManager           $entityManager
      * @param MailHelper              $mailer
      */
     public function __construct(
-        DataCollectorTranslator $translator,
+        TranslatorInterface $translator,
         Router $router,
         NotificationModel $notificationModel,
         EntityManager $entityManager,

--- a/app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
+++ b/app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
@@ -12,7 +12,6 @@
 namespace Mautic\WebhookBundle\Notificator;
 
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\ORMException;
 use Mautic\CoreBundle\Model\NotificationModel;
 use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\UserBundle\Entity\User;
@@ -96,7 +95,7 @@ class WebhookKillNotificator
             $modifiedBy = $this->entityManager->getReference('MauticUserBundle:User', $modifiedBy);
 
             if ($modifiedBy !== $owner) {
-                $toUser = $modifiedBy; // Send notification to modifier
+                $toUser   = $modifiedBy; // Send notification to modifier
                 $ccToUser = $owner; // And cc e-mail to owner
             }
         }

--- a/app/bundles/WebhookBundle/Tests/EventListener/WebhookSubscriberTest.php
+++ b/app/bundles/WebhookBundle/Tests/EventListener/WebhookSubscriberTest.php
@@ -9,7 +9,7 @@
 * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
 */
 
-namespace Mautic\WebhookBundle\Tests\EvenzListener;
+namespace Mautic\WebhookBundle\Tests\EventListener;
 
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;

--- a/app/bundles/WebhookBundle/Tests/EvenzListener/WebhookSubscriberTest.php
+++ b/app/bundles/WebhookBundle/Tests/EvenzListener/WebhookSubscriberTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+* @copyright   2019 Mautic, Inc. All rights reserved
+* @author      Mautic, Inc.
+*
+* @link        https://mautic.com
+*
+* @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+*/
+
+namespace Mautic\WebhookBundle\Tests\EvenzListener;
+
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\WebhookBundle\Event\WebhookEvent;
+use Mautic\WebhookBundle\EventListener\WebhookSubscriber;
+use Mautic\WebhookBundle\Notificator\WebhookKillNotificator;
+use Mautic\WebhookBundle\WebhookEvents;
+
+class WebhookSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    private $ipLookupHelper;
+    private $auditLogModel;
+    private $webhookKillNotificator;
+
+    protected function setUp()
+    {
+        $this->ipLookupHelper = $this->createMock(IpLookupHelper::class);
+        $this->auditLogModel = $this->createMock(AuditLogModel::class);
+        $this->webhookKillNotificator = $this->createMock(WebhookKillNotificator::class);
+    }
+
+    public function testGetSubscribedEvents()
+    {
+        $this->assertSame(
+            [
+                WebhookEvents::WEBHOOK_POST_SAVE   => ['onWebhookSave', 0],
+                WebhookEvents::WEBHOOK_POST_DELETE => ['onWebhookDelete', 0],
+                WebhookEvents::WEBHOOK_KILL        => ['onWebhookKill', 0],
+            ],
+            WebhookSubscriber::getSubscribedEvents()
+        );
+    }
+
+    public function testOnWebhookKill()
+    {
+
+    }
+}

--- a/app/bundles/WebhookBundle/Tests/EvenzListener/WebhookSubscriberTest.php
+++ b/app/bundles/WebhookBundle/Tests/EvenzListener/WebhookSubscriberTest.php
@@ -13,6 +13,7 @@ namespace Mautic\WebhookBundle\Tests\EvenzListener;
 
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\WebhookBundle\Entity\Webhook;
 use Mautic\WebhookBundle\Event\WebhookEvent;
 use Mautic\WebhookBundle\EventListener\WebhookSubscriber;
 use Mautic\WebhookBundle\Notificator\WebhookKillNotificator;
@@ -26,8 +27,8 @@ class WebhookSubscriberTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->ipLookupHelper = $this->createMock(IpLookupHelper::class);
-        $this->auditLogModel = $this->createMock(AuditLogModel::class);
+        $this->ipLookupHelper         = $this->createMock(IpLookupHelper::class);
+        $this->auditLogModel          = $this->createMock(AuditLogModel::class);
         $this->webhookKillNotificator = $this->createMock(WebhookKillNotificator::class);
     }
 
@@ -45,6 +46,25 @@ class WebhookSubscriberTest extends \PHPUnit_Framework_TestCase
 
     public function testOnWebhookKill()
     {
+        $webhookMock = $this->createMock(Webhook::class);
+        $reason      = 'reason';
 
+        $eventMock = $this->createMock(WebhookEvent::class);
+        $eventMock
+            ->expects($this->once())
+            ->method('getWebhook')
+            ->willReturn($webhookMock);
+        $eventMock
+            ->expects($this->once())
+            ->method('getReason')
+            ->willReturn($reason);
+
+        $this->webhookKillNotificator
+            ->expects($this->once())
+            ->method('send')
+            ->with($webhookMock, $reason);
+
+        $subscriber = new WebhookSubscriber($this->ipLookupHelper, $this->auditLogModel, $this->webhookKillNotificator);
+        $subscriber->onWebhookKill($eventMock);
     }
 }

--- a/app/bundles/WebhookBundle/Tests/Model/WebhookModelTest.php
+++ b/app/bundles/WebhookBundle/Tests/Model/WebhookModelTest.php
@@ -14,27 +14,27 @@ namespace Mautic\WebhookBundle\Tests\Model;
 use Doctrine\ORM\EntityManager;
 use JMS\Serializer\Serializer;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Model\NotificationModel;
 use Mautic\WebhookBundle\Entity\Event;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Mautic\WebhookBundle\Entity\WebhookQueue;
 use Mautic\WebhookBundle\Entity\WebhookQueueRepository;
 use Mautic\WebhookBundle\Model\WebhookModel;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class WebhookModelTest extends \PHPUnit_Framework_TestCase
 {
     private $parametersHelperMock;
     private $serializerMock;
-    private $notificationModelMock;
     private $entityManagerMock;
+    private $eventDispatcherMock;
     private $model;
 
     protected function setUp()
     {
         $this->parametersHelperMock  = $this->createMock(CoreParametersHelper::class);
         $this->serializerMock        = $this->createMock(Serializer::class);
-        $this->notificationModelMock = $this->createMock(NotificationModel::class);
         $this->entityManagerMock     = $this->createMock(EntityManager::class);
+        $this->eventDispatcherMock   = $this->createMock(EventDispatcher::class);
         $this->model                 = $this->initModel();
     }
 
@@ -140,7 +140,7 @@ class WebhookModelTest extends \PHPUnit_Framework_TestCase
         $model = new WebhookModel(
             $this->parametersHelperMock,
             $this->serializerMock,
-            $this->notificationModelMock
+            $this->eventDispatcherMock
         );
 
         $model->setEntityManager($this->entityManagerMock);

--- a/app/bundles/WebhookBundle/Tests/Model/WebhookModelTest.php
+++ b/app/bundles/WebhookBundle/Tests/Model/WebhookModelTest.php
@@ -18,7 +18,9 @@ use Mautic\WebhookBundle\Entity\Event;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Mautic\WebhookBundle\Entity\WebhookQueue;
 use Mautic\WebhookBundle\Entity\WebhookQueueRepository;
+use Mautic\WebhookBundle\Event\WebhookEvent;
 use Mautic\WebhookBundle\Model\WebhookModel;
+use Mautic\WebhookBundle\WebhookEvents;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class WebhookModelTest extends \PHPUnit_Framework_TestCase

--- a/app/bundles/WebhookBundle/Tests/Model/WebhookModelTest.php
+++ b/app/bundles/WebhookBundle/Tests/Model/WebhookModelTest.php
@@ -18,9 +18,7 @@ use Mautic\WebhookBundle\Entity\Event;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Mautic\WebhookBundle\Entity\WebhookQueue;
 use Mautic\WebhookBundle\Entity\WebhookQueueRepository;
-use Mautic\WebhookBundle\Event\WebhookEvent;
 use Mautic\WebhookBundle\Model\WebhookModel;
-use Mautic\WebhookBundle\WebhookEvents;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class WebhookModelTest extends \PHPUnit_Framework_TestCase

--- a/app/bundles/WebhookBundle/Tests/Notificator/WebhookKillNotificatorTest.php
+++ b/app/bundles/WebhookBundle/Tests/Notificator/WebhookKillNotificatorTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Translation\DataCollectorTranslator;
 
 class WebhookKillNotificatorTest extends \PHPUnit_Framework_TestCase
 {
-    public function testSend()
+    public function testSendToOwner()
     {
         $subject        = 'subject';
         $reason         = 'reason';

--- a/app/bundles/WebhookBundle/Tests/Notificator/WebhookKillNotificatorTest.php
+++ b/app/bundles/WebhookBundle/Tests/Notificator/WebhookKillNotificatorTest.php
@@ -18,7 +18,7 @@ use Mautic\UserBundle\Entity\User;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Mautic\WebhookBundle\Notificator\WebhookKillNotificator;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
-use Symfony\Component\Translation\DataCollectorTranslator;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class WebhookKillNotificatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -35,7 +35,7 @@ class WebhookKillNotificatorTest extends \PHPUnit_Framework_TestCase
         $ownerEmail     = 'toEmail';
         $modifiedBy     = null;
 
-        $translatorMock = $this->createMock(DataCollectorTranslator::class);
+        $translatorMock = $this->createMock(TranslatorInterface::class);
         $translatorMock
             ->expects($this->at(0))
             ->method('trans')
@@ -144,7 +144,7 @@ class WebhookKillNotificatorTest extends \PHPUnit_Framework_TestCase
         $modifier       = $this->createMock(User::class);
         $modifierEmail  = 'modifierEmail';
 
-        $translatorMock = $this->createMock(DataCollectorTranslator::class);
+        $translatorMock = $this->createMock(TranslatorInterface::class);
         $translatorMock
             ->expects($this->at(0))
             ->method('trans')

--- a/app/bundles/WebhookBundle/Tests/Notificator/WebhookKillNotificatorTest.php
+++ b/app/bundles/WebhookBundle/Tests/Notificator/WebhookKillNotificatorTest.php
@@ -193,7 +193,7 @@ class WebhookKillNotificatorTest extends \PHPUnit_Framework_TestCase
             ->method('getCreatedBy')
             ->willReturn($createdBy);
         $webhook
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getModifiedBy')
             ->willReturn($modifiedBy);
 

--- a/app/bundles/WebhookBundle/Tests/Notificator/WebhookKillNotificatorTest.php
+++ b/app/bundles/WebhookBundle/Tests/Notificator/WebhookKillNotificatorTest.php
@@ -189,11 +189,11 @@ class WebhookKillNotificatorTest extends \PHPUnit_Framework_TestCase
             ->willReturn($details);
 
         $webhook
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getCreatedBy')
             ->willReturn($createdBy);
         $webhook
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(3))
             ->method('getModifiedBy')
             ->willReturn($modifiedBy);
 

--- a/app/bundles/WebhookBundle/Tests/Notificator/WebhookKillNotificatorTest.php
+++ b/app/bundles/WebhookBundle/Tests/Notificator/WebhookKillNotificatorTest.php
@@ -18,6 +18,7 @@ use Mautic\UserBundle\Entity\User;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Mautic\WebhookBundle\Notificator\WebhookKillNotificator;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class WebhookKillNotificatorTest extends \PHPUnit_Framework_TestCase
@@ -61,7 +62,8 @@ class WebhookKillNotificatorTest extends \PHPUnit_Framework_TestCase
             ->method('generate')
             ->with(
                 'mautic_webhook_action',
-                ['objectAction' => 'view', 'objectId' => $webhookId]
+                ['objectAction' => 'view', 'objectId' => $webhookId],
+                UrlGeneratorInterface::ABSOLUTE_URL
             )
             ->willReturn($generatedRoute);
 
@@ -170,7 +172,8 @@ class WebhookKillNotificatorTest extends \PHPUnit_Framework_TestCase
             ->method('generate')
             ->with(
                 'mautic_webhook_action',
-                ['objectAction' => 'view', 'objectId' => $webhookId]
+                ['objectAction' => 'view', 'objectId' => $webhookId],
+                UrlGeneratorInterface::ABSOLUTE_URL
             )
             ->willReturn($generatedRoute);
 

--- a/app/bundles/WebhookBundle/Tests/Notificator/WebhookKillNotificatorTest.php
+++ b/app/bundles/WebhookBundle/Tests/Notificator/WebhookKillNotificatorTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+* @copyright   2019 Mautic, Inc. All rights reserved
+* @author      Mautic, Inc.
+*
+* @link        https://mautic.com
+*
+* @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+*/
+
+namespace Mautic\WebhookBundle\Tests\Notificator;
+
+use Doctrine\ORM\EntityManager;
+use Mautic\CoreBundle\Model\NotificationModel;
+use Mautic\EmailBundle\Helper\MailHelper;
+use Mautic\UserBundle\Entity\User;
+use Mautic\WebhookBundle\Entity\Webhook;
+use Mautic\WebhookBundle\Notificator\WebhookKillNotificator;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\Translation\DataCollectorTranslator;
+
+class WebhookKillNotificatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSend()
+    {
+        $subject        = 'subject';
+        $reason         = 'reason';
+        $webhookId      = 1;
+        $webhookName    = 'Webhook name';
+        $generatedRoute = 'generatedRoute';
+        $details        = 'details';
+        $createdBy      = 'createdBy';
+        $modifiedBy     = null;
+        $toUser         = $this->createMock(User::class);
+        $toEmail        = 'toEmail';
+
+        $translatorMock = $this->createMock(DataCollectorTranslator::class);
+        $translatorMock
+            ->expects($this->at(0))
+            ->method('trans')
+            ->with('mautic.webhook.stopped')
+            ->willReturn($subject);
+        $translatorMock
+            ->expects($this->at(1))
+            ->method('trans')
+            ->with($reason)
+            ->willReturn($reason);
+
+        $webhook = $this->createMock(Webhook::class);
+        $webhook->expects($this->once())
+            ->method('getId')
+            ->willReturn($webhookId);
+        $webhook->expects($this->once())
+            ->method('getName')
+            ->willReturn($webhookName);
+
+        $routerMock = $this->createMock(Router::class);
+        $routerMock
+            ->expects($this->once())
+            ->method('generate')
+            ->with(
+                'mautic_webhook_action',
+                ['objectAction' => 'view', 'objectId' => $webhookId]
+            )
+            ->willReturn($generatedRoute);
+
+        $htmlUrl = '<a href="'.$generatedRoute.'" data-toggle="ajax">'.$webhookName.'</a>';
+
+        $translatorMock
+            ->expects($this->at(2))
+            ->method('trans')
+            ->with(
+                'mautic.webhook.stopped.details',
+                ['%reason%'  => $reason, '%webhook%' => $htmlUrl]
+            )
+            ->willReturn($details);
+
+        $webhook
+            ->expects($this->once())
+            ->method('getCreatedBy')
+            ->willReturn($createdBy);
+        $webhook
+            ->expects($this->once())
+            ->method('getModifiedBy')
+            ->willReturn($modifiedBy);
+
+        $entityManagerMock = $this->createMock(EntityManager::class);
+        $entityManagerMock
+            ->expects($this->once())
+            ->method('getReference')
+            ->with('MauticUserBundle:User', $createdBy)
+            ->willReturn($toUser);
+
+        $notificationModelMock = $this->createMock(NotificationModel::class);
+        $notificationModelMock
+            ->expects($this->once())
+            ->method('addNotification')
+            ->with(
+                $details,
+                'error',
+                false,
+                $subject,
+                null,
+                false,
+                $toUser
+            );
+
+        $toUser
+            ->expects($this->once())
+            ->method('getEmail')
+            ->willReturn($toEmail);
+
+        $mailHelperMock = $this->createMock(MailHelper::class);
+        $mailHelperMock
+            ->expects($this->once())
+            ->method('setTo')
+            ->with($toEmail);
+        $mailHelperMock
+            ->expects($this->once())
+            ->method('setSubject')
+            ->with($subject);
+        $mailHelperMock
+            ->expects($this->once())
+            ->method('setBody')
+            ->with($details);
+
+        $webhookKillNotificator = new WebhookKillNotificator($translatorMock, $routerMock, $notificationModelMock, $entityManagerMock, $mailHelperMock);
+        $webhookKillNotificator->send($webhook, $reason);
+    }
+}

--- a/app/bundles/WebhookBundle/WebhookEvents.php
+++ b/app/bundles/WebhookBundle/WebhookEvents.php
@@ -54,6 +54,15 @@ final class WebhookEvents
     const WEBHOOK_POST_DELETE = 'mautic.webhook_post_delete';
 
     /**
+     * The mautic.webhook_kill event is thrown when target is not available.
+     *
+     * The event listener receives a Mautic\WebhookBundle\Event\WebhookEvent instance.
+     *
+     * @var string
+     */
+    const WEBHOOK_KILL = 'mautic.webhook_kill';
+
+    /**
      * The mautic.webhook_queue_on_add event is thrown as the queue entity is created, before it is persisted to the database.
      *
      * The event listener receives a Mautic\WebhookBundle\Event\WebhookQueueEvent instance.


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Y
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Mautic user  needs to be notified about failing webhook by e-mail.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create webhook targeting to not existing url connected to edit contact event.
2. Temporarily decrease value `webhook_disable_limit` to `1` in `app/bundles/WebhookBundle/Config/config.php`
3. Edit and save contact.
4. Webhook is unpublished, notification send, but no e-mail received.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Publish webhook.
3. Same as reproduction steps, but you will receive e-mail.
4. Test e-mail link redirection on Mautic app side