### PR TITLE
Add path to cookie when focus is engaged

### DIFF
--- a/plugins/MauticFocusBundle/Views/Builder/generate.js.php
+++ b/plugins/MauticFocusBundle/Views/Builder/generate.js.php
@@ -660,7 +660,7 @@ switch ($style) {
                     if (Focus.debug)
                         console.log('Visitor converted');
 
-                    Focus.cookies.setItem('mautic_focus_<?php echo $focus['id']; ?>', -1, Infinity);
+                    Focus.cookies.setItem('mautic_focus_<?php echo $focus['id']; ?>', -1, Infinity, '/');
                 } else if (Focus.debug) {
                     console.log('Visitor converted but ignoreConverted not enabled');
                 }


### PR DESCRIPTION
closes https://github.com/mautic/mautic/issues/5956

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5956
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Issue with cookie and path If focus should stop display after conversion.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create focus with Emphasize a link
2. Set to stop engaging after a conversion
3. Put it two pages
- domain.tld/first/test.html
- domain.tld/second/test.html 
3. Open first page, click to the link - focus should not load on page reload
4. Go to second page, focus should display - expected hidden popup, because contact was already engaged

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7507)
2. Repeat all steps, see If focus not fired on both pages