### PR TITLE
Add new cache bundle

### DIFF
--- a/app/bundles/CacheBundle/Cache/Adapter/FilesystemTagAwareAdapter.php
+++ b/app/bundles/CacheBundle/Cache/Adapter/FilesystemTagAwareAdapter.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc. Jan Kozak <galvani78@gmail.com>
+ *
+ * @link        http://mautic.com
+ * @created     12.9.18
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CacheBundle\Cache\Adapter;
+
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+
+class FilesystemTagAwareAdapter extends TagAwareAdapter
+{
+    public function __construct($prefix, $lifetime)
+    {
+        $prefix = 'app_cache_'.$prefix;
+
+        parent::__construct(
+            new \Symfony\Component\Cache\Adapter\FilesystemAdapter($prefix, $lifetime),
+            new \Symfony\Component\Cache\Adapter\FilesystemAdapter($prefix.'_tags')
+        );
+    }
+}

--- a/app/bundles/CacheBundle/Cache/Adapter/MemcachedTagAwareAdapter.php
+++ b/app/bundles/CacheBundle/Cache/Adapter/MemcachedTagAwareAdapter.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc. Jan Kozak <galvani78@gmail.com>
+ *
+ * @link        http://mautic.com
+ * @created     12.9.18
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CacheBundle\Cache\Adapter;
+
+use Mautic\CacheBundle\Exceptions\InvalidArgumentException;
+use Symfony\Component\Cache\Adapter\MemcachedAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+
+class MemcachedTagAwareAdapter extends TagAwareAdapter
+{
+    public function __construct($servers, $namespace, $lifetime)
+    {
+        if (!isset($servers['servers'])) {
+            throw new InvalidArgumentException('Invalid memcached configuration. No servers specified.');
+        }
+
+        $options = array_key_exists('options', $servers) ? $servers['options'] : [];
+
+        $client = MemcachedAdapter::createConnection($servers['servers'], $options);
+
+        parent::__construct(
+            new MemcachedAdapter($client, $namespace, $lifetime),
+            new MemcachedAdapter($client, $namespace, $lifetime)
+        );
+    }
+}

--- a/app/bundles/CacheBundle/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/app/bundles/CacheBundle/Cache/Adapter/RedisTagAwareAdapter.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc. Jan Kozak <galvani78@gmail.com>
+ *
+ * @link        http://mautic.com
+ * @created     12.9.18
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CacheBundle\Cache\Adapter;
+
+use Mautic\CacheBundle\Exceptions\InvalidArgumentException;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+
+class RedisTagAwareAdapter extends TagAwareAdapter
+{
+    public function __construct($servers, $namespace, $lifetime)
+    {
+        if (!isset($servers['dsn'])) {
+            throw new InvalidArgumentException('Invalid redis configuration. No server specified.');
+        }
+
+        $options = array_key_exists('options', $servers) ? $servers['options'] : [];
+
+        $client = new \Predis\Client([$servers['dsn']], $options);
+
+        parent::__construct(
+            new RedisAdapter($client, $namespace, $lifetime),
+            new RedisAdapter($client, $namespace.'.tags.', $lifetime)
+        );
+    }
+}

--- a/app/bundles/CacheBundle/Cache/CacheProvider.php
+++ b/app/bundles/CacheBundle/Cache/CacheProvider.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc. Jan Kozak <galvani78@gmail.com>
+ *
+ * @link        http://mautic.com
+ * @created     12.9.18
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CacheBundle\Cache;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+use Symfony\Component\Cache\CacheItem;
+use Symfony\Component\Cache\PruneableInterface;
+use Symfony\Component\Cache\Simple\Psr6Cache;
+
+/**
+ * Class CacheProvider provides caching mechanism using adapters, it provides both PSR-6 and PSR-16.
+ */
+final class CacheProvider implements TagAwareAdapterInterface
+{
+    /**
+     * @var TagAwareAdapterInterface
+     */
+    private $adapter;
+
+    /**
+     * @var Psr6Cache
+     */
+    private $psr16;
+
+    /**
+     * @param TagAwareAdapterInterface $adapter
+     */
+    public function setCacheAdapter(TagAwareAdapterInterface $adapter)
+    {
+        $this->adapter = $adapter;
+
+        if ($this->adapter instanceof PruneableInterface) {
+            $this->adapter->prune();
+        }
+    }
+
+    /**
+     * @return TagAwareAdapterInterface
+     */
+    public function getCacheAdapter()
+    {
+        return $this->adapter;
+    }
+
+    /**
+     * @return Psr6Cache
+     */
+    public function getSimpleCache()
+    {
+        if (is_null($this->psr16)) {
+            $this->psr16 = new Psr6Cache($this->getCacheAdapter());
+        }
+
+        return $this->psr16;
+    }
+
+    /**
+     * @param $key
+     *
+     * @return CacheItem
+     *
+     * @throws InvalidArgumentException
+     */
+    public function getItem($key)
+    {
+        return $this->getCacheAdapter()->getItem($key);
+    }
+
+    /**
+     * @param array $keys
+     *
+     * @return CacheItem[]|\Traversable
+     *
+     * @throws InvalidArgumentException
+     */
+    public function getItems(array $keys = [])
+    {
+        return $this->getCacheAdapter()->getItems($keys);
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return bool
+     *
+     * @throws InvalidArgumentException
+     */
+    public function hasItem($key)
+    {
+        return $this->getCacheAdapter()->hasItem($key);
+    }
+
+    /**
+     * @return bool
+     */
+    public function clear()
+    {
+        return $this->getCacheAdapter()->clear();
+    }
+
+    public function deleteItem($key)
+    {
+        return $this->getCacheAdapter()->deleteItem($key);
+    }
+
+    /**
+     * Removes multiple items from the pool.
+     *
+     * @param string[] $keys
+     *                       An array of keys that should be removed from the pool
+     *
+     * @throws invalidArgumentException
+     *                                  If any of the keys in $keys are not a legal value a \Psr\Cache\InvalidArgumentException
+     *                                  MUST be thrown
+     *
+     * @return bool
+     *              True if the items were successfully removed. False if there was an error.
+     */
+    public function deleteItems(array $keys)
+    {
+        return $this->getCacheAdapter()->deleteItems($keys);
+    }
+
+    /**
+     * Persists a cache item immediately.
+     *
+     * @param cacheItemInterface $item
+     *                                 The cache item to save
+     *
+     * @return bool
+     *              True if the item was successfully persisted. False if there was an error.
+     */
+    public function save(CacheItemInterface $item)
+    {
+        return $this->getCacheAdapter()->save($item);
+    }
+
+    /**
+     * Sets a cache item to be persisted later.
+     *
+     * @param cacheItemInterface $item
+     *                                 The cache item to save
+     *
+     * @return bool
+     *              False if the item could not be queued or if a commit was attempted and failed. True otherwise.
+     */
+    public function saveDeferred(CacheItemInterface $item)
+    {
+        return $this->getCacheAdapter()->saveDeferred($item);
+    }
+
+    /**
+     * Persists any deferred cache items.
+     *
+     * @return bool
+     *              True if all not-yet-saved items were successfully saved or there were none. False otherwise.
+     */
+    public function commit()
+    {
+        return $this->getCacheAdapter()->commit();
+    }
+
+    /**
+     * Invalidates cached items using tags.
+     *
+     * @param string[] $tags An array of tags to invalidate
+     *
+     * @return bool True on success
+     *
+     * @throws InvalidArgumentException When $tags is not valid
+     */
+    public function invalidateTags(array $tags)
+    {
+        return $this->getCacheAdapter()->invalidateTags($tags);
+    }
+}

--- a/app/bundles/CacheBundle/Command/ClearCacheCommand.php
+++ b/app/bundles/CacheBundle/Command/ClearCacheCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CacheBundle\Command;
+
+use Mautic\CacheBundle\Cache\CacheProvider;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * CLI Command to clear the application cache.
+ */
+class ClearCacheCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('mautic:cache:clear')
+            ->setDescription('Clears Mautic\'s cache');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var CacheProvider $cacheProvider */
+        $cacheProvider = $this->getContainer()->get('mautic.cache.provider');
+        $options       = $input->getOptions();
+
+        return $cacheProvider->clear();
+    }
+}

--- a/app/bundles/CacheBundle/Config/config.php
+++ b/app/bundles/CacheBundle/Config/config.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+return [
+    'routes'   => [
+        'main'   => [],
+        'public' => [],
+        'api'    => [],
+    ],
+    'menu'     => [],
+    'services' => [
+        'events'    => [
+            'mautic.cache.clear_cache_subscriber' => [
+                'class'     => \Mautic\CacheBundle\EventListener\CacheClearSubscriber::class,
+                'tags'      => ['kernel.cache_clearer'],
+                'arguments' => [
+                    'mautic.cache.provider',
+                    'monolog.logger.mautic',
+                ],
+            ],
+        ],
+        'forms'     => [],
+        'helpers'   => [],
+        'menus'     => [],
+        'other'     => [
+            'mautic.cache.provider'           => [
+                'class'     => \Mautic\CacheBundle\Cache\CacheProvider::class,
+                'arguments' => [
+                ],
+            ],
+            'mautic.cache.adapter.filesystem' => [
+                'class'     => \Mautic\CacheBundle\Cache\Adapter\FilesystemTagAwareAdapter::class,
+                'arguments' => [
+                    '%mautic.cache_prefix%',
+                    '%mautic.cache_lifetime%',
+                ],
+                'tag'       => 'mautic.cache.adapter',
+            ],
+            'mautic.cache.adapter.memcached'  => [
+                'class'     => \Mautic\CacheBundle\Cache\Adapter\MemcachedTagAwareAdapter::class,
+                'arguments' => [
+                    '%mautic.cache_adapter_memcached%',
+                    '%mautic.cache_prefix%',
+                    '%mautic.cache_lifetime%',
+                ],
+                'tag'       => 'mautic.cache.adapter',
+            ],
+            'mautic.cache.adapter.redis'      => [
+                'class'     => \Mautic\CacheBundle\Cache\Adapter\RedisTagAwareAdapter::class,
+                'arguments' => [
+                    '%mautic.cache_adapter_redis%',
+                    '%mautic.cache_prefix%',
+                    '%mautic.cache_lifetime%',
+                ],
+                'tag'       => 'mautic.cache.adapter',
+            ],
+        ],
+        'models'    => [],
+        'validator' => [],
+    ],
+
+    'parameters' => [
+        'cache_adapter'           => 'mautic.cache.adapter.filesystem',
+        'cache_prefix'            => getenv('DB_NAME') ?: '%mautic.db_name%',
+        'cache_lifetime'          => 86400,
+        'cache_adapter_memcached' => [
+            'servers' => ['memcached://localhost'],
+            'options' => [
+                'compression'          => true,
+                'libketama_compatible' => true,
+                'serializer'           => 'igbinary',
+            ],
+        ],
+        'cache_adapter_redis'     => [
+            'dsn'     => 'redis://localhost',
+            'options' => [
+                'lazy'           => false,
+                'persistent'     => 0,
+                'persistent_id'  => null,
+                'timeout'        => 30,
+                'read_timeout'   => 0,
+                'retry_interval' => 0,
+            ],
+        ],
+    ],
+];

--- a/app/bundles/CacheBundle/DependencyInjection/Compiler/AppCachePass.php
+++ b/app/bundles/CacheBundle/DependencyInjection/Compiler/AppCachePass.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CacheBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Cache\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Class IntegrationPass.
+ */
+class AppCachePass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $selectedAdapter = $container->getParameter('mautic.cache_adapter');
+
+        foreach ($container->findTaggedServiceIds('mautic.cache.adapter') as $id => $tags) {
+            $definition             = $container->findDefinition($id);
+            $availableAdapters[$id] = $definition;
+        }
+
+        if (!isset($availableAdapters[$selectedAdapter])) {
+            throw new InvalidArgumentException('Requested cache adapter "'.$selectedAdapter.'" is not available');
+        }
+
+        $cacheServiceDefinition = $container->findDefinition('mautic.cache.provider');
+        $cacheServiceDefinition->addArgument($selectedAdapter);
+        $cacheServiceDefinition->addMethodCall('setCacheAdapter', [new Reference($selectedAdapter)]);
+    }
+}

--- a/app/bundles/CacheBundle/EventListener/CacheClearSubscriber.php
+++ b/app/bundles/CacheBundle/EventListener/CacheClearSubscriber.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CacheBundle\EventListener;
+
+use Mautic\CacheBundle\Cache\CacheProvider;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
+
+/**
+ * Class CampaignSubscriber.
+ */
+class CacheClearSubscriber implements CacheClearerInterface
+{
+    /**
+     * @var CacheProvider
+     */
+    private $cacheProvider;
+    /**
+     * @var
+     */
+    private $logger;
+
+    /**
+     * CacheClearSubscriber constructor.
+     *
+     * @param AdapterInterface $cacheProvider
+     * @param LoggerInterface  $logger
+     */
+    public function __construct(AdapterInterface $cacheProvider, LoggerInterface $logger)
+    {
+        $this->cacheProvider = $cacheProvider;
+        $this->logger        = $logger;
+    }
+
+    /**
+     * @param string $cacheDir
+     *
+     * @throws \Exception
+     */
+    public function clear($cacheDir)
+    {
+        try {
+            $reflect = new \ReflectionClass($this->cacheProvider->getCacheAdapter());
+            $adapter = $reflect->getShortName();
+        } catch (\ReflectionException $e) {
+            $adapter = 'unknown';
+        }
+
+        try {
+            if (!$this->cacheProvider->clear()) {
+                $this->logger->emergency('Failed to clear Mautic cache.', ['adapter' => $adapter]);
+                throw new \Exception('Failed to clear '.$adapter);
+            }
+        } catch (\PDOException $e) {
+        }
+    }
+}

--- a/app/bundles/CacheBundle/Exceptions/InvalidArgumentException.php
+++ b/app/bundles/CacheBundle/Exceptions/InvalidArgumentException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc. Jan Kozak <galvani78@gmail.com>
+ *
+ * @link        http://mautic.com
+ * @created     7.11.18
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CacheBundle\Exceptions;
+
+class InvalidArgumentException extends \Symfony\Component\Cache\Exception\InvalidArgumentException
+{
+}

--- a/app/bundles/CacheBundle/MauticCacheBundle.php
+++ b/app/bundles/CacheBundle/MauticCacheBundle.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CacheBundle;
+
+use Mautic\CacheBundle\DependencyInjection\Compiler\AppCachePass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class MauticCacheBundle extends Bundle
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new AppCachePass());
+    }
+}

--- a/app/bundles/CacheBundle/README.md
+++ b/app/bundles/CacheBundle/README.md
@@ -1,0 +1,163 @@
+# mautic-cache-plugin
+
+Enables PSR-6 and PSR-16 caching. Check: [Symfony Cache Component](https://symfony.com/doc/3.4/components/cache.html)
+
+## Installation
+
+Install this plugin as submodule into plugins directory.
+
+## Namespace versus tag
+
+This bundle introduces tags to cache. All its adapters are fully tag
+aware which makes the use of namespace obsolete for daily use.
+
+Previously if you wanted to keep control on cache section and did not want to hold
+the index of all keys to clear you would have to use namespace.
+
+Disadvantage of this approach is a new adapter being created for each namespace.
+
+[Symfony 3.4 Cache](https://symfony.com/doc/3.4/components/cache.html) uses tag-aware adapters. If you want to clear all records related to your bundle
+or component you just need to tag them.
+
+```php
+    /** @var CacheProvider $cache */
+    $cache = $this->get('mautic.cache.provider');
+
+    /** @var CacheItemInterface $item */
+    $item = $cache->getItem('test_tagged_Item');
+    $item->set('yesa!!!');
+    $item->tag(['firstTag', 'secondTag']);
+    $item->expiresAfter(20000);
+```
+
+All you need to do now is to clear all tagged items:
+
+```
+$cache->invalidateTags(['firstTag']);
+```
+
+### Pools clearing
+
+Removing Cache Items¶
+
+Cache Pools include methods to delete a cache item, some of them or all of them.
+The most common is `Psr\\Cache\\CacheItemPoolInterface::deleteItem`, which deletes the cache item identified by the given key.
+
+```
+$isDeleted = $cache->deleteItem('user_'.$userId);
+```
+
+Use the Psr\\Cache\\CacheItemPoolInterface::deleteItems method to delete several cache items simultaneously (it returns true only if all the items have been deleted, even when any or some of them don't exist):
+
+## Configuration
+
+Plugin comes preconfigured to utilize filesystem caching.
+
+These are the default settings:
+```
+'cache_adapter'        => 'mautic.cache.adapter.filesystem',
+'cache_prefix'         => 'app',
+'cache_lifetime'       => 86400
+```
+
+
+They can be overridden in **local.php** like this:
+
+```
+'cache_adapter' => 'mautic.cache.adapter.redis',
+'cache_prefix' => 'app_cache',
+'cache_lifetime' => 86400,
+```
+
+
+## Delivered adapters
+ * mautic.cache.adapter.filesystem
+ * mautic.cache.adapter.memcached
+```
+ 'memcached' => [
+         'servers' => ['memcached://localhost'],
+         'options' => [
+             'compression'          => true,
+             'libketama_compatible' => true,
+             'serializer'           => 'igbinary',
+         ],
+     ],
+```
+ * mautic.cache.adapter.redis
+ Redis configuration in **local.php**:
+ ```
+ 'redis' => [
+         'dsn' => 'redis://localhost',
+         'options' => [
+             'lazy' => false,
+             'persistent' => 0,
+             'persistent_id' => null,
+             'timeout' => 30,
+             'read_timeout' => 0,
+             'retry_interval' => 0,
+         ]
+     ],
+```
+
+In order to use another adapter just set it up as a service
+
+## Clearing the cache
+
+The cache is cleared when **cache:clear** command is run. The cache can be cleared by running
+
+```bash
+app/console  mautic:cache:clear
+```
+
+## Features auto pruning on adapter initialization
+
+## Usage
+
+### PSR-6
+
+```php
+    /** @var CacheProvider $cache */
+    $cache = $this->get('mautic.cache.provider');
+
+    /** @var CacheItemInterface $item */
+    $item = $cache->getItem('test_tagged_Item');
+    $item->set('yesa!!!');
+    $item->tag(['firstTag', 'secondTag']);
+    $item->expiresAfter(20000);
+
+    $cache->save($item);
+
+    $item = $cache->getItem('test_nottagged_Item2');
+    $item->tag(['firstTag']);
+    $cache->save($item);
+
+    $item = $cache->getItem('test_nottagged_Item3');
+    $item->tag(['secondTag']);
+    $cache->save($item);
+
+    $cache->commit();
+
+    var_dump($cache->getItem('test_nottagged_Item2')->isHit());
+    var_dump($cache->getItem('test_nottagged_Item3')->isHit());
+
+    $cache->invalidateTags(['firstTag']);
+
+    var_dump($cache->getItem('test_nottagged_Item2')->isHit());
+    var_dump($cache->getItem('test_nottagged_Item3')->isHit());
+
+    $cache->commit();
+```
+
+### PSR-16
+
+```php
+        /** @var CacheProvider $cache */
+        $cache = $this->get('mautic.cache.provider');
+
+
+        $simpleCache = $cache->getSimpleCache();
+        $test = $simpleCache->get('test_value');
+
+        var_dump($test);
+```
+

--- a/app/bundles/CacheBundle/README.md
+++ b/app/bundles/CacheBundle/README.md
@@ -2,10 +2,6 @@
 
 Enables PSR-6 and PSR-16 caching. Check: [Symfony Cache Component](https://symfony.com/doc/3.4/components/cache.html)
 
-## Installation
-
-Install this plugin as submodule into plugins directory.
-
 ## Namespace versus tag
 
 This bundle introduces tags to cache. All its adapters are fully tag

--- a/app/bundles/CacheBundle/Tests/Cache/CacheProviderTest.php
+++ b/app/bundles/CacheBundle/Tests/Cache/CacheProviderTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc. Jan Kozak <galvani78@gmail.com>
+ *
+ * @link        http://mautic.com
+ * @created     10.10.18
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CacheBundle\Tests;
+
+use Mautic\CacheBundle\Cache\Adapter\FilesystemTagAwareAdapter;
+use Mautic\CacheBundle\Cache\CacheProvider;
+use Symfony\Component\Cache\Simple\Psr6Cache;
+
+class CacheProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CacheProvider
+     */
+    private $cacheProvider;
+
+    private $adapter;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->adapter       = $this->createMock(FilesystemTagAwareAdapter::class);
+        $this->cacheProvider = new CacheProvider();
+    }
+
+    public function testProviderAndSimpleCache()
+    {
+        $this->cacheProvider->setCacheAdapter($this->adapter);
+        $this->assertEquals($this->cacheProvider->getCacheAdapter(), $this->adapter);
+        $simleCache = $this->cacheProvider->getSimpleCache();
+        $this->assertInstanceOf(Psr6Cache::class, $simleCache);
+    }
+}

--- a/app/bundles/CacheBundle/Tests/EventListener/CacheClearSubscriberTest.php
+++ b/app/bundles/CacheBundle/Tests/EventListener/CacheClearSubscriberTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc. Jan Kozak <galvani78@gmail.com>
+ *
+ * @link        http://mautic.com
+ * @created     10.10.18
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CacheBundle\Tests\EventListener;
+
+use Mautic\CacheBundle\Cache\Adapter\FilesystemTagAwareAdapter;
+use Mautic\CacheBundle\EventListener\CacheClearSubscriber;
+use Monolog\Logger;
+
+class CacheClearSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var
+     */
+    private $adapter;
+
+    /**
+     * @var string
+     */
+    private $random;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->random  = sha1((string) time());
+        $this->adapter = $this->getMockBuilder(FilesystemTagAwareAdapter::class)
+                              ->disableOriginalConstructor()
+                              ->setMethods(['clear', 'getCacheAdapter', 'commit'])
+                              ->getMock();
+        $this->adapter->method('clear')->willReturn($this->random);
+        $this->adapter->method('commit')->willReturn(null);
+    }
+
+    public function testClear()
+    {
+        $this->adapter->expects($this->once())->method('clear')->willReturn($this->random);
+        $subscriber = new CacheClearSubscriber($this->adapter, new Logger('test'));
+        $subscriber->clear('aaa');
+    }
+}

--- a/app/bundles/CoreBundle/Helper/CacheStorageHelper.php
+++ b/app/bundles/CoreBundle/Helper/CacheStorageHelper.php
@@ -17,6 +17,8 @@ use Symfony\Component\Cache\Adapter\PdoAdapter;
 
 /**
  * Class CacheStorageHelper.
+ *
+ * @deprecated This helper is deprecated in favor of CacheBundle
  */
 class CacheStorageHelper
 {
@@ -110,10 +112,13 @@ class CacheStorageHelper
     }
 
     /**
-     * @param $name
-     * @param $data
+     * @param      $name
+     * @param      $data
+     * @param null $expiration
      *
      * @return bool
+     *
+     * @throws \Psr\Cache\InvalidArgumentException
      */
     public function set($name, $data, $expiration = null)
     {
@@ -132,7 +137,7 @@ class CacheStorageHelper
 
         $cacheItem->set($data);
 
-        $this->cacheAdaptor->save($cacheItem);
+        return $this->cacheAdaptor->save($cacheItem);
     }
 
     /**
@@ -140,6 +145,8 @@ class CacheStorageHelper
      * @param int $maxAge @deprecated 2.6.0 to be removed in 3.0; set expiration when using set()
      *
      * @return bool|mixed
+     *
+     * @throws \Psr\Cache\InvalidArgumentException
      */
     public function get($name, $maxAge = null)
     {
@@ -207,8 +214,7 @@ class CacheStorageHelper
     }
 
     /**
-     * @param $namespace
-     * @param $defaultExpiration
+     * Creates adapter.
      */
     protected function setCacheAdaptor()
     {

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
         "symfony/property-access": "~2.8",
         "symfony/dom-crawler": "~2.8",
         "symfony/browser-kit": "~2.8",
-        "symfony/cache": "~3.1",
-
+        "symfony/cache": "~3.4",
+	    "symfony/serializer": "~2.8",
         "symfony/asset": "~2.7",
         "symfony/class-loader": "~2.1",
         "symfony/dependency-injection": "~2.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "76ca1f3e88950d50351be721720c3e0a",
+    "content-hash": "75e3a9b72f0fbc0e6a0c8bf9e49d3adb",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -5474,16 +5474,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v3.4.4",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "8dee9ec2c9824c3f4039960d679a6689ee1cbdc1"
+                "reference": "380b8395b43f60e7d26a32f84f80c0a7ba93e7c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/8dee9ec2c9824c3f4039960d679a6689ee1cbdc1",
-                "reference": "8dee9ec2c9824c3f4039960d679a6689ee1cbdc1",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/380b8395b43f60e7d26a32f84f80c0a7ba93e7c5",
+                "reference": "380b8395b43f60e7d26a32f84f80c0a7ba93e7c5",
                 "shasum": ""
             },
             "require": {
@@ -5540,7 +5540,7 @@
                 "caching",
                 "psr6"
             ],
-            "time": "2018-01-18T22:16:57+00:00"
+            "time": "2019-04-16T09:03:16+00:00"
         },
         {
             "name": "symfony/class-loader",
@@ -6845,6 +6845,64 @@
             "time": "2018-01-30T19:27:44+00:00"
         },
         {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "82ebae02209c21113908c229e9883c419720738a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
+                "reference": "82ebae02209c21113908c229e9883c419720738a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
             "name": "symfony/polyfill-intl-icu",
             "version": "v1.7.0",
             "source": {
@@ -7641,6 +7699,71 @@
             "description": "Symfony SecurityBundle",
             "homepage": "https://symfony.com",
             "time": "2018-09-08T12:44:02+00:00"
+        },
+        {
+            "name": "symfony/serializer",
+            "version": "v2.8.50",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/serializer.git",
+                "reference": "2939e67396f7356aace05c90e5913736fcb46a20"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/2939e67396f7356aace05c90e5913736fcb46a20",
+                "reference": "2939e67396f7356aace05c90e5913736fcb46a20",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php55": "~1.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "doctrine/cache": "~1.0",
+                "symfony/config": "~2.2|~3.0.0",
+                "symfony/property-access": "~2.3|~3.0.0",
+                "symfony/yaml": "^2.0.5|~3.0.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
+                "doctrine/cache": "For using the default cached annotation reader and metadata cache.",
+                "symfony/config": "For using the XML mapping loader.",
+                "symfony/property-access": "For using the ObjectNormalizer.",
+                "symfony/yaml": "For using the default YAML mapping loader."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Serializer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Serializer Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-11-11T11:18:13+00:00"
         },
         {
             "name": "symfony/stopwatch",


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | Y
| Related developer documentation PR URL | https://github.com/mautic-inc/mautic/blob/staging.cache_bundle/app/bundles/CacheBundle/README.md
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This bundle enables the developer to use common Symfony caching mechanism with tag-aware adapters. It implements FS, Memcache and redis adapters.

#### Steps to test this PR:

1. Load up [this PR](https://github.com/mautic/mautic/pull/7522)
2. Set up an adapter as described in documentation
3. Use the cache as described in documentation
4. Verify items are created (e.g. redis records)
5. Verify items expire
5. Clear cache and verify items are purged