### PR TITLE
Fix access_token expired after 1 hour for Go To plugins

### DIFF
--- a/plugins/MauticCitrixBundle/Api/CitrixApi.php
+++ b/plugins/MauticCitrixBundle/Api/CitrixApi.php
@@ -53,7 +53,7 @@ class CitrixApi
         );
         $status  = $request->code;
 
-        // Try refresh access_token with refresh_token (ttps://goto-developer.logmeininc.com/how-use-refresh-tokens)
+        // Try refresh access_token with refresh_token (https://goto-developer.logmeininc.com/how-use-refresh-tokens)
         if ($refreshToken && $this->isInvalidTokenFromReponse($request)) {
             $error = $this->integration->authCallback(['use_refresh_token' => true]);
             if (!$error) {

--- a/plugins/MauticCitrixBundle/Api/CitrixApi.php
+++ b/plugins/MauticCitrixBundle/Api/CitrixApi.php
@@ -61,14 +61,13 @@ class CitrixApi
         );
         $status  = $request->code;
         $message = '';
-        $this->integration->mergeApiKeysAfterRefresh();
+
         // Try refresh access_token with refresh_token (https://goto-developer.logmeininc.com/how-use-refresh-tokens)
         if ($refreshToken && $this->isInvalidTokenFromReponse($request)) {
             $error = $this->integration->authCallback(['use_refresh_token' => true]);
             if (!$error) {
                 // keys changes, load new integration object
-                $request = $this->_request($operation, $settings, $route, false);
-                $status  = $request->code;
+                return $this->_request($operation, $settings, $route, false);
             }
         }
 

--- a/plugins/MauticCitrixBundle/Api/CitrixApi.php
+++ b/plugins/MauticCitrixBundle/Api/CitrixApi.php
@@ -8,8 +8,16 @@ use MauticPlugin\MauticCitrixBundle\Integration\CitrixAbstractIntegration;
 
 class CitrixApi
 {
+    /**
+     * @var CitrixAbstractIntegration
+     */
     protected $integration;
 
+    /**
+     * CitrixApi constructor.
+     *
+     * @param CitrixAbstractIntegration $integration
+     */
     public function __construct(CitrixAbstractIntegration $integration)
     {
         $this->integration = $integration;
@@ -53,11 +61,12 @@ class CitrixApi
         );
         $status  = $request->code;
         $message = '';
-
+        $this->integration->mergeApiKeysAfterRefresh();
         // Try refresh access_token with refresh_token (https://goto-developer.logmeininc.com/how-use-refresh-tokens)
         if ($refreshToken && $this->isInvalidTokenFromReponse($request)) {
             $error = $this->integration->authCallback(['use_refresh_token' => true]);
             if (!$error) {
+                // keys changes, load new integration object
                 $request = $this->_request($operation, $settings, $route, false);
                 $status  = $request->code;
             }

--- a/plugins/MauticCitrixBundle/Api/CitrixApi.php
+++ b/plugins/MauticCitrixBundle/Api/CitrixApi.php
@@ -52,6 +52,7 @@ class CitrixApi
             $requestSettings
         );
         $status  = $request->code;
+        $message = '';
 
         // Try refresh access_token with refresh_token (https://goto-developer.logmeininc.com/how-use-refresh-tokens)
         if ($refreshToken && $this->isInvalidTokenFromReponse($request)) {

--- a/plugins/MauticCitrixBundle/Integration/CitrixAbstractIntegration.php
+++ b/plugins/MauticCitrixBundle/Integration/CitrixAbstractIntegration.php
@@ -45,6 +45,17 @@ abstract class CitrixAbstractIntegration extends AbstractIntegration
     }
 
     /**
+     * Refresh tokens.
+     */
+    public function getRefreshTokenKeys()
+    {
+        return [
+            'refresh_token',
+            'expires_in',
+        ];
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @return string

--- a/plugins/MauticCitrixBundle/Integration/CitrixAbstractIntegration.php
+++ b/plugins/MauticCitrixBundle/Integration/CitrixAbstractIntegration.php
@@ -173,4 +173,16 @@ abstract class CitrixAbstractIntegration extends AbstractIntegration
 
         return $keys['organizer_key'];
     }
+
+    public function mergeApiKeysAfterRefresh()
+    {
+        if (!$this->session) {
+            return;
+        }
+
+        $tokenResponse = $this->session->get($this->getName().'_tokenResponse', []);
+        if (!empty($tokenResponse)) {
+            $this->mergeApiKeys($tokenResponse);
+        }
+    }
 }

--- a/plugins/MauticCitrixBundle/Integration/CitrixAbstractIntegration.php
+++ b/plugins/MauticCitrixBundle/Integration/CitrixAbstractIntegration.php
@@ -171,8 +171,6 @@ abstract class CitrixAbstractIntegration extends AbstractIntegration
     {
         $keys = $this->getKeys();
 
-        if (isset($keys['organizer_key'])) {
-            return $keys['organizer_key'];
-        }
+        return $keys['organizer_key'];
     }
 }

--- a/plugins/MauticCitrixBundle/Integration/CitrixAbstractIntegration.php
+++ b/plugins/MauticCitrixBundle/Integration/CitrixAbstractIntegration.php
@@ -171,6 +171,8 @@ abstract class CitrixAbstractIntegration extends AbstractIntegration
     {
         $keys = $this->getKeys();
 
-        return $keys['organizer_key'];
+        if (isset($keys['organizer_key'])) {
+            return $keys['organizer_key'];
+        }
     }
 }

--- a/plugins/MauticCitrixBundle/Integration/CitrixAbstractIntegration.php
+++ b/plugins/MauticCitrixBundle/Integration/CitrixAbstractIntegration.php
@@ -173,16 +173,4 @@ abstract class CitrixAbstractIntegration extends AbstractIntegration
 
         return $keys['organizer_key'];
     }
-
-    public function mergeApiKeysAfterRefresh()
-    {
-        if (!$this->session) {
-            return;
-        }
-
-        $tokenResponse = $this->session->get($this->getName().'_tokenResponse', []);
-        if (!empty($tokenResponse)) {
-            $this->mergeApiKeys($tokenResponse);
-        }
-    }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
2.15.2 add new Adapt GoTo plugin for oauth2 authentication https://github.com/mautic/mautic/pull/7380
But according to the documentation https://goto-developer.logmeininc.com/how-use-refresh-tokens access_token expire every one hour.
This PR try identify If access_token is invalid and then try refresh it (docs above)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup GOTO plugin (webinar for example)
2. Authorize, and try use it one hour later. If you are on dev enviroment, you should see error in logs

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7531)
2. Repeat all steps. You access token should refresh after one hour

