### PR TITLE
Fix dynamic content slot duplication errors inside builder

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -522,7 +522,7 @@ Mautic.sendBuilderContentToTextarea = function(callback, keepBuilderContent) {
         // prevent from being able to close builder
         console.error(error);
     }
-}
+};
 
 Mautic.sanitizeHtmlAndStoreToTextarea = function(html) {
     var cleanHtml = Mautic.sanitizeHtmlBeforeSave(html);
@@ -1232,7 +1232,15 @@ Mautic.initSlotListeners = function() {
                 focus.remove();
             });
             cloneLink.click(function(e) {
-                slot.clone().insertAfter(slot);
+                if (type == 'dynamicContent') {
+                    var maxId = Mautic.getDynamicContentMaxId();
+
+                    slot.clone().attr('data-param-dec-id', maxId + 1).insertAfter(slot);
+                    Mautic.createNewDynamicContentItem(parent.mQuery);
+                } else {
+                    slot.clone().insertAfter(slot);
+                }
+
                 Mautic.initSlots(slot.closest('[data-slot-container="1"]'));
             });
 
@@ -1469,10 +1477,8 @@ Mautic.initSlotListeners = function() {
             });
         } else if (type === 'dynamicContent') {
             if (slot.html().match(/__dynamicContent__/)) {
-                var decs = mQuery('[data-slot="dynamicContent"]');
-                var ids = mQuery.map(decs, function(e){return mQuery(e).attr('data-param-dec-id');})
-                var maxId = Math.max.apply(Math, ids);
-                if (isNaN(maxId) || Number.NEGATIVE_INFINITY == maxId) maxId = 0;
+                var maxId = Mautic.getDynamicContentMaxId();
+
                 slot.attr('data-param-dec-id', maxId + 1);
                 slot.html('Dynamic Content');
                 Mautic.createNewDynamicContentItem(parent.mQuery);
@@ -1979,6 +1985,15 @@ Mautic.getPredefinedLinks = function(callback) {
         }
         return callback(linkList);
     });
+};
+
+Mautic.getDynamicContentMaxId = function() {
+    var decs = mQuery('[data-slot="dynamicContent"]');
+    var ids = mQuery.map(decs, function(e){return mQuery(e).attr('data-param-dec-id');});
+    var maxId = Math.max.apply(Math, ids);
+    if (isNaN(maxId) || Number.NEGATIVE_INFINITY === maxId) maxId = 0;
+
+    return maxId;
 };
 
 // Init inside the builder's iframe


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
In the builder when you clone a dynamic content slot, this slot is duplicated with the same identifier.
This produces bugs like when you edit one, the second is also modified or when you delete one the second is no more editable.

Warning: no more errors when duplicated but content is not duplicated, it's reset by default.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make a new mail
2. Open the builder
3. Create a dynamic content slot and put a content
4. Duplicate this slot
5. Edit the new slot
6. See that the first slot is also modified

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7536)
2. Repeat step above
3. The first slot is no more modified
