### PR TITLE
Make manipulator available

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -17,6 +17,7 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\LeadBundle\Controller\FrequencyRuleTrait;
 use Mautic\LeadBundle\Controller\LeadDetailsTrait;
+use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\DoNotContact as DoNotContactModel;
@@ -24,7 +25,6 @@ use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
-use Mautic\LeadBundle\DataObject\LeadManipulator;
 
 /**
  * Class LeadApiController.

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -24,6 +24,7 @@ use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Mautic\LeadBundle\DataObject\LeadManipulator;
 
 /**
  * Class LeadApiController.
@@ -565,6 +566,15 @@ class LeadApiController extends CommonApiController
             // new endpoints will leverage getNewEntity in order to return the correct status codes
             $entity = $this->model->checkForDuplicateContact($this->entityRequestParameters, $entity);
         }
+
+        $manipulatorObject = $this->inBatchMode ? 'api-batch' : 'api-single';
+
+        $entity->setManipulator(new LeadManipulator(
+            'lead',
+            $manipulatorObject,
+            null,
+            $this->get('mautic.helper.user')->getUser()->getName()
+        ));
 
         if (isset($parameters['companies'])) {
             $this->model->modifyCompanies($entity, $parameters['companies']);

--- a/app/bundles/LeadBundle/DataObject/LeadManipulator.php
+++ b/app/bundles/LeadBundle/DataObject/LeadManipulator.php
@@ -43,7 +43,7 @@ class LeadManipulator
     /**
      * @param ?string $bundleName
      * @param ?string $objectName
-     * @param ?int $objectId
+     * @param ?int    $objectId
      * @param ?string $objectDescription
      */
     public function __construct($bundleName = null, $objectName = null, $objectId = null, $objectDescription = null)

--- a/app/bundles/LeadBundle/DataObject/LeadManipulator.php
+++ b/app/bundles/LeadBundle/DataObject/LeadManipulator.php
@@ -11,9 +11,6 @@
 
 namespace Mautic\LeadBundle\DataObject;
 
-/**
- * Class LeadManipulator.
- */
 class LeadManipulator
 {
     /**
@@ -37,12 +34,17 @@ class LeadManipulator
     private $objectDescription;
 
     /**
-     * LeadManipulator constructor.
+     * If true then the manipulator was logged and should not be logged for the second time.
      *
-     * @param null $bundleName
-     * @param null $objectName
-     * @param null $objectId
-     * @param null $objectDescription
+     * @var bool
+     */
+    private $logged = false;
+
+    /**
+     * @param ?string $bundleName
+     * @param ?string $objectName
+     * @param ?int $objectId
+     * @param ?string $objectDescription
      */
     public function __construct($bundleName = null, $objectName = null, $objectId = null, $objectDescription = null)
     {
@@ -53,7 +55,7 @@ class LeadManipulator
     }
 
     /**
-     * @return string
+     * @return ?string
      */
     public function getBundleName()
     {
@@ -61,7 +63,7 @@ class LeadManipulator
     }
 
     /**
-     * @return string
+     * @return ?string
      */
     public function getObjectName()
     {
@@ -69,15 +71,36 @@ class LeadManipulator
     }
 
     /**
-     * @return int
+     * @return ?int
      */
     public function getObjectId()
     {
         return $this->objectId;
     }
 
+    /**
+     * @return ?string
+     */
     public function getObjectDescription()
     {
         return $this->objectDescription;
+    }
+
+    /**
+     * Check if the manipulator was logged already or not.
+     *
+     * @return bool
+     */
+    public function wasLogged()
+    {
+        return $this->logged;
+    }
+
+    /**
+     * Set manipulator as logged so it wouldn't be logged for the second time in the same request.
+     */
+    public function setAsLogged()
+    {
+        $this->logged = true;
     }
 }

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -2347,7 +2347,7 @@ class LeadModel extends FormModel
         if ($lead->isNewlyCreated() || $lead->wasAnonymous()) {
             // Only store an entry once for created and once for identified, not every time the lead is saved
             $manipulator = $lead->getManipulator();
-            if (null !== $manipulator) {
+            if (null !== $manipulator && !$manipulator->wasLogged()) {
                 $manipulationLog = new LeadEventLog();
                 $manipulationLog->setLead($lead)
                     ->setBundle($manipulator->getBundleName())
@@ -2362,6 +2362,7 @@ class LeadModel extends FormModel
                 $manipulationLog->setProperties(['object_description' => $description]);
 
                 $lead->addEventLog($manipulationLog);
+                $manipulator->setAsLogged();
             }
         }
     }

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -2362,7 +2362,6 @@ class LeadModel extends FormModel
                 $manipulationLog->setProperties(['object_description' => $description]);
 
                 $lead->addEventLog($manipulationLog);
-                $lead->setManipulator(null);
             }
         }
     }

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -40,6 +40,7 @@ use Mautic\LeadBundle\Entity\LeadCategory;
 use Mautic\LeadBundle\Entity\LeadEventLog;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\OperatorListTrait;
 use Mautic\LeadBundle\Entity\PointsChangeLog;
 use Mautic\LeadBundle\Entity\StagesChangeLog;
@@ -242,13 +243,12 @@ class LeadModel extends FormModel
     }
 
     /**
-     * {@inheritdoc}
-     *
-     * @return \Mautic\LeadBundle\Entity\LeadRepository
+     * @return LeadRepository
      */
     public function getRepository()
     {
-        $repo = $this->em->getRepository('MauticLeadBundle:Lead');
+        /** @var LeadRepository $repo */
+        $repo = $this->em->getRepository(Lead::class);
         $repo->setDispatcher($this->dispatcher);
 
         if (!$this->repoSetup) {

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
@@ -451,6 +451,8 @@ class LeadModelTest extends \PHPUnit\Framework\TestCase
 
     public function testManipulatorIsLoggedOnlyOnce()
     {
+        $this->mockGetLeadRepository();
+
         $contact     = $this->createMock(Lead::class);
         $manipulator = new LeadManipulator('lead', 'import', 333);
 
@@ -512,7 +514,7 @@ class LeadModelTest extends \PHPUnit\Framework\TestCase
             ->will(
                 $this->returnValueMap(
                     [
-                        ['MauticLeadBundle:Lead', $this->leadRepositoryMock],
+                        [Lead::class, $this->leadRepositoryMock],
                     ]
                 )
             );

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
@@ -12,6 +12,7 @@ use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\EmailBundle\Helper\EmailValidator;
+use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\CompanyLeadRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadEventLog;
@@ -35,7 +36,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactory;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Translation\TranslatorInterface;
-use Mautic\LeadBundle\DataObject\LeadManipulator;
 
 class LeadModelTest extends \PHPUnit\Framework\TestCase
 {
@@ -468,7 +468,7 @@ class LeadModelTest extends \PHPUnit\Framework\TestCase
 
         $contact->expects($this->once())
             ->method('addEventLog')
-            ->with($this->callback(function(LeadEventLog $leadEventLog) use ($contact) {
+            ->with($this->callback(function (LeadEventLog $leadEventLog) use ($contact) {
                 $this->assertSame($contact, $leadEventLog->getLead());
                 $this->assertSame('identified_contact', $leadEventLog->getAction());
                 $this->assertSame('lead', $leadEventLog->getBundle());


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Enhancement
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This is not changing any Mautic behaviour. I needed the information stored in the `LeadManipulator` object in a plugin. But it was deleted after save so it wouldn't be stored multiple times. With this PR the manipulator won't be deleted and so plugins can read the information in it. It will at the same time prevent that it would be saved multiple times. I created a test to ensure it works properly.

This PR also creates new source of contacts. if the contact is created via API then we'll know about it.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Ensure that the source of how the contact was created still works. Try to create a contact with a form for example, via API (this is new), via import, via UI and ensure the source in the timeline is correct.

