### PR TITLE
Ensure that the "Lead Channels" label won't show up

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/ContactFrequencyType.php
+++ b/app/bundles/LeadBundle/Form/Type/ContactFrequencyType.php
@@ -51,6 +51,7 @@ class ContactFrequencyType extends AbstractType
                 'lead_channels',
                 ContactChannelsType::class,
                 [
+                    'label'       => false,
                     'channels'    => $options['channels'],
                     'data'        => $options['data']['lead_channels'],
                     'public_view' => $options['public_view'],


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The preference center landing pages in some cases show label "Lead channels" bellow the "Save preferences" button. Like this:

![Screenshot 2019-04-30 at 10 14 47](https://user-images.githubusercontent.com/1235442/56948575-cfc66a00-6b30-11e9-9c50-6f0f8237f37d.png)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. As I was not very successful in reproducing it I will just say code review is sufficient.

#### Steps to test this PR:
0. Code review is sufficient as it's very simple change and it make sense that a "field" containing other fields should not have a label.
1. But if you want to ensure that the preference center still works then load up [this PR](https://mautibox.com) and test.
