### PR TITLE
Date condition on company field

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -309,13 +309,14 @@ class LeadFieldRepository extends CommonRepository
      */
     public function compareDateValue($lead, $field, $value)
     {
-        $q = $this->_em->getConnection()->createQueryBuilder();
+        $q        = $this->_em->getConnection()->createQueryBuilder();
+        $property = $this->getPropertyByField($field, $q);
         $q->select('l.id')
             ->from(MAUTIC_TABLE_PREFIX.'leads', 'l')
             ->where(
                 $q->expr()->andX(
                     $q->expr()->eq('l.id', ':lead'),
-                    $q->expr()->eq('l.'.$field, ':value')
+                    $q->expr()->eq($property, ':value')
                 )
             )
             ->setParameter('lead', (int) $lead)

--- a/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
@@ -13,8 +13,8 @@ namespace Mautic\LeadBundle\Tests\Entity;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Portability\Statement;
-use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
+use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Mautic\LeadBundle\Entity\LeadFieldRepository;
@@ -56,7 +56,7 @@ class LeadFieldRepositoryTest extends \PHPUnit_Framework_TestCase
         $statementAlias   = $this->createMock(Statement::class);
         $statementCompare = $this->createMock(Statement::class);
         $exprCompare      = $this->createMock(ExpressionBuilder::class);
-        
+
         $this->entityManager->method('getConnection')->willReturn($this->connection);
         $builderAlias->method('expr')->willReturn(new ExpressionBuilder($this->connection));
         $builderCompare->method('expr')->willReturn($exprCompare);
@@ -149,7 +149,7 @@ class LeadFieldRepositoryTest extends \PHPUnit_Framework_TestCase
         $statementAlias   = $this->createMock(Statement::class);
         $statementCompare = $this->createMock(Statement::class);
         $exprCompare      = $this->createMock(ExpressionBuilder::class);
-        
+
         $this->entityManager->method('getConnection')->willReturn($this->connection);
         $builderAlias->method('expr')->willReturn(new ExpressionBuilder($this->connection));
         $builderCompare->method('expr')->willReturn($exprCompare);

--- a/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
@@ -18,14 +18,24 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Mautic\LeadBundle\Entity\LeadFieldRepository;
+use PHPUnit\Framework\MockObject\MockObject;
 
-class LeadFieldRepositoryTest extends \PHPUnit_Framework_TestCase
+class LeadFieldRepositoryTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var MockObject|EntityManager
+     */
     private $entityManager;
+
+    /**
+     * @var MockObject|ClassMetadata
+     */
     private $classMetadata;
+
+    /**
+     * @var MockObject|Connection
+     */
     private $connection;
-    private $dbalBuilder;
-    private $statement;
 
     /**
      * @var LeadFieldRepository
@@ -41,8 +51,6 @@ class LeadFieldRepositoryTest extends \PHPUnit_Framework_TestCase
         $this->entityManager = $this->createMock(EntityManager::class);
         $this->classMetadata = $this->createMock(ClassMetadata::class);
         $this->connection    = $this->createMock(Connection::class);
-        $this->dbalBuilder   = $this->createMock(QueryBuilder::class);
-        $this->statement     = $this->createMock(Statement::class);
         $this->repository    = new LeadFieldRepository($this->entityManager, $this->classMetadata);
     }
 

--- a/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
@@ -1,0 +1,241 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Entity;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Portability\Statement;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Mautic\LeadBundle\Entity\LeadFieldRepository;
+
+class LeadFieldRepositoryTest extends \PHPUnit_Framework_TestCase
+{
+    private $entityManager;
+    private $classMetadata;
+    private $connection;
+    private $dbalBuilder;
+    private $statement;
+
+    /**
+     * @var LeadFieldRepository
+     */
+    private $repository;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
+
+        $this->entityManager = $this->createMock(EntityManager::class);
+        $this->classMetadata = $this->createMock(ClassMetadata::class);
+        $this->connection    = $this->createMock(Connection::class);
+        $this->dbalBuilder   = $this->createMock(QueryBuilder::class);
+        $this->statement     = $this->createMock(Statement::class);
+        $this->repository    = new LeadFieldRepository($this->entityManager, $this->classMetadata);
+    }
+
+    public function testCompareDateValueForContactField()
+    {
+        $contactId        = 12;
+        $fieldAlias       = 'date_field';
+        $value            = '2019-04-30';
+        $builderAlias     = $this->createMock(QueryBuilder::class);
+        $builderCompare   = $this->createMock(QueryBuilder::class);
+        $statementAlias   = $this->createMock(Statement::class);
+        $statementCompare = $this->createMock(Statement::class);
+        $exprCompare      = $this->createMock(ExpressionBuilder::class);
+        
+        $this->entityManager->method('getConnection')->willReturn($this->connection);
+        $builderAlias->method('expr')->willReturn(new ExpressionBuilder($this->connection));
+        $builderCompare->method('expr')->willReturn($exprCompare);
+
+        $this->connection->expects($this->exactly(2))
+            ->method('createQueryBuilder')
+            ->will($this->onConsecutiveCalls($builderCompare, $builderAlias));
+
+        $builderAlias->expects($this->once())
+            ->method('select')
+            ->with('f.alias, f.is_unique_identifer as is_unique, f.type, f.object')
+            ->willReturnSelf();
+
+        $builderAlias->expects($this->once())
+            ->method('from')
+            ->with(MAUTIC_TABLE_PREFIX.'lead_fields', 'f')
+            ->willReturnSelf();
+
+        $builderAlias->expects($this->once())
+            ->method('where')
+            ->willReturnSelf();
+
+        $builderAlias->expects($this->once())
+            ->method('setParameter')
+            ->with('object', 'company')
+            ->willReturnSelf();
+
+        $builderAlias->expects($this->once())
+            ->method('orderBy')
+            ->with('f.field_order', 'ASC')
+            ->willReturnSelf();
+
+        $builderAlias->expects($this->once())
+            ->method('execute')
+            ->willReturn($statementAlias);
+
+        // No company column found. Therefore it's a contact field.
+        $statementAlias->expects($this->once())
+            ->method('fetchAll')
+            ->willReturn([]);
+
+        $exprCompare->expects($this->exactly(2))
+            ->method('eq')
+            ->withConsecutive(
+                ['l.id', ':lead'],
+                ['l.date_field', ':value'] // See? It's a contact column.
+            );
+
+        $builderCompare->expects($this->once())
+            ->method('select')
+            ->with('l.id')
+            ->willReturnSelf();
+
+        $builderCompare->expects($this->once())
+            ->method('from')
+            ->with(MAUTIC_TABLE_PREFIX.'leads', 'l')
+            ->willReturnSelf();
+
+        $builderCompare->expects($this->once())
+            ->method('where')
+            ->willReturnSelf();
+
+        $builderCompare->expects($this->exactly(2))
+            ->method('setParameter')
+            ->withConsecutive(
+                ['lead', $contactId],
+                ['value', $value]
+            )
+            ->willReturnSelf();
+
+        $builderCompare->expects($this->once())
+            ->method('execute')
+            ->willReturn($statementCompare);
+
+        // No contact ID was found by the value so the result should be false.
+        $statementCompare->expects($this->once())
+            ->method('fetch')
+            ->willReturn([]);
+
+        $this->assertFalse($this->repository->compareDateValue($contactId, $fieldAlias, $value));
+    }
+
+    public function testCompareDateValueForCompanyField()
+    {
+        $contactId        = 12;
+        $fieldAlias       = 'date_field';
+        $value            = '2019-04-30';
+        $builderAlias     = $this->createMock(QueryBuilder::class);
+        $builderCompare   = $this->createMock(QueryBuilder::class);
+        $statementAlias   = $this->createMock(Statement::class);
+        $statementCompare = $this->createMock(Statement::class);
+        $exprCompare      = $this->createMock(ExpressionBuilder::class);
+        
+        $this->entityManager->method('getConnection')->willReturn($this->connection);
+        $builderAlias->method('expr')->willReturn(new ExpressionBuilder($this->connection));
+        $builderCompare->method('expr')->willReturn($exprCompare);
+
+        $this->connection->expects($this->exactly(2))
+            ->method('createQueryBuilder')
+            ->will($this->onConsecutiveCalls($builderCompare, $builderAlias));
+
+        $builderAlias->expects($this->once())
+            ->method('select')
+            ->with('f.alias, f.is_unique_identifer as is_unique, f.type, f.object')
+            ->willReturnSelf();
+
+        $builderAlias->expects($this->once())
+            ->method('from')
+            ->with(MAUTIC_TABLE_PREFIX.'lead_fields', 'f')
+            ->willReturnSelf();
+
+        $builderAlias->expects($this->once())
+            ->method('where')
+            ->willReturnSelf();
+
+        $builderAlias->expects($this->once())
+            ->method('setParameter')
+            ->with('object', 'company')
+            ->willReturnSelf();
+
+        $builderAlias->expects($this->once())
+            ->method('orderBy')
+            ->with('f.field_order', 'ASC')
+            ->willReturnSelf();
+
+        $builderAlias->expects($this->once())
+            ->method('execute')
+            ->willReturn($statementAlias);
+
+        // A company column found. Therefore it's a company field.
+        $statementAlias->expects($this->once())
+            ->method('fetchAll')
+            ->willReturn([['alias' => $fieldAlias]]);
+
+        $exprCompare->expects($this->exactly(2))
+            ->method('eq')
+            ->withConsecutive(
+                ['l.id', ':lead'],
+                ['company.date_field', ':value'] // See? It's a company column.
+            );
+
+        $builderCompare->expects($this->exactly(2))
+            ->method('leftJoin')
+            ->withConsecutive(
+                ['l', MAUTIC_TABLE_PREFIX.'companies_leads', 'companies_lead', 'l.id = companies_lead.lead_id'],
+                ['companies_lead', MAUTIC_TABLE_PREFIX.'companies', 'company', 'companies_lead.company_id = company.id']
+            );
+
+        $builderCompare->expects($this->once())
+            ->method('select')
+            ->with('l.id')
+            ->willReturnSelf();
+
+        $builderCompare->expects($this->once())
+            ->method('from')
+            ->with(MAUTIC_TABLE_PREFIX.'leads', 'l')
+            ->willReturnSelf();
+
+        $builderCompare->expects($this->once())
+            ->method('where')
+            ->willReturnSelf();
+
+        $builderCompare->expects($this->exactly(2))
+            ->method('setParameter')
+            ->withConsecutive(
+                ['lead', $contactId],
+                ['value', $value]
+            )
+            ->willReturnSelf();
+
+        $builderCompare->expects($this->once())
+            ->method('execute')
+            ->willReturn($statementCompare);
+
+        // A contact ID was found by the value so the result should be true.
+        $statementCompare->expects($this->once())
+            ->method('fetch')
+            ->willReturn(['id' => 456]);
+
+        $this->assertTrue($this->repository->compareDateValue($contactId, $fieldAlias, $value));
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Campaign conditions with date fields and date operators did not work on company fields. This PR fixes that.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a custom field (Data type = Date) on the company object
2. Add a date (5 days ago) in that field to the record for a contact's Primary Company
3. Create a campaign with a contact linked to that company in the Contact Source segment
4. Add a condition for Contact field value
--Execute immediately
--Select the company date field
--Operator = date; Value = custom, # = 5, day(s)
5. Add an action on the yes path to trigger immediately
6. Publish the campaign

The contact will go to the false (red) route of the campaign.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Clone the campaign so you could run it again.
3. The contact will go to the true (green) campaign path.