### PR TITLE
Fixed infinite recursion in Search string helper

### DIFF
--- a/app/bundles/CoreBundle/Helper/SearchStringHelper.php
+++ b/app/bundles/CoreBundle/Helper/SearchStringHelper.php
@@ -214,7 +214,7 @@ class SearchStringHelper
                         //does group have a negative?
                         if (strpos($string, '!') === 0) {
                             $filters->{$baseName}[$keyCount]->not = 1;
-                            $string = substr($string, 1);
+                            $string                               = substr($string, 1);
                         }
 
                         //remove wrapping grouping chars

--- a/app/bundles/CoreBundle/Helper/SearchStringHelper.php
+++ b/app/bundles/CoreBundle/Helper/SearchStringHelper.php
@@ -211,6 +211,12 @@ class SearchStringHelper
                     if ($c === $this->closingChars[$key] && $openingCount === $closingCount) {
                         //found the matching character (accounts for nesting)
 
+                        //does group have a negative?
+                        if (strpos($string, '!') === 0) {
+                            $filters->{$baseName}[$keyCount]->not = 1;
+                            $string = substr($string, 1);
+                        }
+
                         //remove wrapping grouping chars
                         if (0 === strpos($string, $char) && substr($string, -1) === $c) {
                             $string = substr($string, 1, -1);

--- a/app/bundles/CoreBundle/Helper/SearchStringHelper.php
+++ b/app/bundles/CoreBundle/Helper/SearchStringHelper.php
@@ -173,7 +173,7 @@ class SearchStringHelper
                 //the string is a command
                 $command = trim(substr($string, 0, -1));
                 //does this have a negative?
-                if (0 === strpos($string, '!')) {
+                if (0 === strpos($command, '!')) {
                     $filters->{$baseName}[$keyCount]->not = 1;
                     $command                              = substr($command, 1);
                 }

--- a/app/bundles/CoreBundle/Helper/SearchStringHelper.php
+++ b/app/bundles/CoreBundle/Helper/SearchStringHelper.php
@@ -212,7 +212,7 @@ class SearchStringHelper
                         //found the matching character (accounts for nesting)
 
                         //does group have a negative?
-                        if (strpos($string, '!') === 0) {
+                        if (0 === strpos($string, '!')) {
                             $filters->{$baseName}[$keyCount]->not = 1;
                             $string                               = substr($string, 1);
                         }

--- a/app/bundles/CoreBundle/Helper/SearchStringHelper.php
+++ b/app/bundles/CoreBundle/Helper/SearchStringHelper.php
@@ -173,7 +173,7 @@ class SearchStringHelper
                 //the string is a command
                 $command = trim(substr($string, 0, -1));
                 //does this have a negative?
-                if (0 === strpos($command, '!')) {
+                if (0 === strpos($string, '!')) {
                     $filters->{$baseName}[$keyCount]->not = 1;
                     $command                              = substr($command, 1);
                 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

#### Description:
Filter by contacts has bug with infinite recursion if filter has negative group

#### Steps to reproduce the bug:
1. Go to "contacts" page
2. Type in filter: "email:!(bla_bla_%)"

#### Steps to test this PR:
1. Same like reproduce

