### PR TITLE
Altered froala image plugin to allow imageOutputSize to function on i…

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -1459,7 +1459,8 @@ Mautic.initSlotListeners = function() {
             var froalaOptions = mQuery.extend({}, Mautic.basicFroalaOptions, {
                     linkList: [], // TODO push here the list of tokens from Mautic.getPredefinedLinks
                     imageEditButtons: ['imageReplace', 'imageAlign', 'imageAlt', 'imageSize', '|', 'imageLink', 'linkOpen', 'linkEdit', 'linkRemove'],
-                    useClasses: false
+                    useClasses: false,
+                    imageOutputSize: true
                 }
             );
             image.froalaEditor(froalaOptions);

--- a/app/bundles/CoreBundle/Assets/js/libraries/froala/plugins/image.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/froala/plugins/image.js
@@ -1870,8 +1870,8 @@
       if (editor.opts.imageOutputSize) {
         var imgs;
 
-        editor.events.on('html.beforeGet', function () {
-          imgs = editor.el.querySelectorAll('img')
+        editor.events.on(editor.el.tagName == 'IMG' ? 'image.loaded image.resizeEnd' : 'html.beforeGet', function () {
+          imgs = editor.el.tagName == 'IMG' ? [editor.el] : editor.el.querySelectorAll('img')
           for (var i = 0; i < imgs.length; i++) {
             var width = imgs[i].style.width || $(imgs[i]).width();
             var height = imgs[i].style.height || $(imgs[i]).height();


### PR DESCRIPTION
…mage slots to fix displaying in Outlook

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | #2791
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
#6845 was merged to fix issue with images displaying incorrectly in Outlook, but only fixed it for Text slots in the email builder. This PR applies the same change to Image slots.

It also contains changes to the froala image plugin, as in its current state the imageOutputSize option has no effect on editors instantiated on img tags.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create an email.
2. Add an Image slot and select an image.
3. Save the email.
4. Preview the email.
5. Inspect the HTML source and the image doesn't have the width and height attributes.

#### Steps to test this PR:
1. Create an email
2. Add an Image slot and select an image.
3. Save the email.
4. Preview the email.
5. Inspect the HTML source and the image has the width and height attributes set.
