### PR TITLE
Prevent an issue with installation and Mautibox for installations in subdirectories

### DIFF
--- a/app/bundles/CoreBundle/EventListener/RouterSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/RouterSubscriber.php
@@ -95,7 +95,14 @@ class RouterSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if ('dev' === MAUTIC_ENV) {
+        $originalContext = $this->router->getContext();
+        if ($originalContext->getBaseUrl() && !$this->baseUrl) {
+            // Likely in installation where the request parameters passed into this listener are not set yet so just use the original context
+            return;
+        }
+
+        // Append index_dev.php for installations at the root level
+        if ('dev' === MAUTIC_ENV && strpos($this->baseUrl, 'index_dev.php') === false) {
             $this->baseUrl = $this->baseUrl.'/index_dev.php';
         }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

https://github.com/mautic/mautic/pull/7193 introduced an issue with installations under subdirectories which caused the subdirectory to be removed from the URL. This fixes that by solving for two cases. 

1. During installation, site_url is not yet defined which causes Symfony to pass in empty values for the router context parameters. This caused Mautic to redirect to a URL without the subdirectory when you clicked to continue the installation. 
2. Some URLs in Mautic would be generated without the subdirectory such as https://github.com/mautic/mautic/pull/7193/files#r275331511

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Test installation with Mautic within a subdirectory. Notice that step two will cause you to go to a 404 or the root domain. 
#### Steps to test this PR:
1. Test installation with Mautic at the root and within a subdirectory. Then test again for both scenarios in dev environment (index_dev.php). All should work. 
3. Retest the steps in https://github.com/mautic/mautic/pull/7193.
