### PR TITLE
Watch out for failures to parse webhooks

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
@@ -178,8 +178,13 @@ class AmazonTransport extends \Swift_SmtpTransport implements CallbackTransportI
 
                     $this->logger->debug("Unsubscribe email '".$complainedRecipient['emailAddress']."'");
                 }
+
+                return;
             }
         }
+
+        $this->logger->warn("Received SES webhook of type '$payload[Type]' but couldn't understand payload");
+        $this->logger->debug('SES webhook payload: '.json_encode($payload));
     }
 
     /**


### PR DESCRIPTION
#### Description

Log useful messages just in case anything goes wrong with parsing of the webhook payload.  In theory this should never happen, but defensive programming just in
case is usually a good idea.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Enable debugging if possible
3. Send an invalid payload to the webhook endpoint

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | n/a
| Related developer documentation PR URL | n/a 
| Issues addressed (#s or URLs) | n/a
| BC breaks? | none
| Deprecations? | none