### PR TITLE
Fix overwrite custom field value with default value during redirection

### DIFF
--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -122,8 +122,6 @@ class ContactRequestHelper
      */
     public function getContactFromQuery(array $queryFields = [])
     {
-        $this->trackedContact = $this->contactTracker->getContact();
-
         unset($queryFields['page_url']); // This is set now automatically by PageModel
         $this->queryFields    = $queryFields;
 
@@ -132,6 +130,7 @@ class ContactRequestHelper
             $this->trackedContact = $foundContact;
             $this->contactTracker->setTrackedContact($this->trackedContact);
         } catch (ContactNotFoundException $exception) {
+            $this->trackedContact = $this->contactTracker->getContact();
         }
 
         if (!$this->trackedContact) {

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -172,6 +172,7 @@ class ContactRequestHelper
 
         $this->setEmailFromClickthroughIdentification($clickthrough);
 
+        $foundContact = null;
         /* @var Lead $foundContact */
         if (!empty($this->queryFields)) {
             list($foundContact, $this->publiclyUpdatableFieldValues) = $this->leadModel->checkForDuplicateContact(
@@ -182,7 +183,9 @@ class ContactRequestHelper
             );
             if (is_null($this->trackedContact) or $foundContact->getId() !== $this->trackedContact->getId()) {
                 // A contact was found by a publicly updatable field
-                return $foundContact;
+                if (!$foundContact->isNew()) {
+                    return $foundContact;
+                }
             }
         }
 
@@ -248,7 +251,7 @@ class ContactRequestHelper
             throw new ContactNotFoundException();
         }
 
-        if (!$this->trackedContact->isAnonymous() || empty($this->queryFields['fingerprint'])) {
+        if (($this->trackedContact && !$this->trackedContact->isAnonymous()) || (empty($this->queryFields['fingerprint']))) {
             // We already know who this is or fingerprint is not available so just use tracked lead
             throw new ContactNotFoundException();
         }

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -130,6 +130,9 @@ class ContactRequestHelper
             $this->trackedContact = $foundContact;
             $this->contactTracker->setTrackedContact($this->trackedContact);
         } catch (ContactNotFoundException $exception) {
+        }
+
+        if (!$this->trackedContact) {
             $this->trackedContact = $this->contactTracker->getContact();
         }
 

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -172,7 +172,6 @@ class ContactRequestHelper
 
         $this->setEmailFromClickthroughIdentification($clickthrough);
 
-        $foundContact = null;
         /* @var Lead $foundContact */
         if (!empty($this->queryFields)) {
             list($foundContact, $this->publiclyUpdatableFieldValues) = $this->leadModel->checkForDuplicateContact(


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Noticed issue with contact field default value. 
If Mautic create contact and already have contact in url (ct), Mautic create new anonymouse contact first and then merge it with founded contact.
This make mess, because If our founded contact already exist and we modified custom field, then during the merge method, these two contact are merged and value is overwritten to default value.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create custom field with default value
2. Create contact (default values is filled)
3. Change default value
4. Create email with anchor link to http://mautic.org
5. Send email to contact
6. Copy redirect link from email
7. Open this link in incognito window
8. See value of custom field was set to default value (what we don't expect)


#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps
3. See If value of custom field is not overwrite to default value