### PR TITLE
Make the unusedip command run on master

### DIFF
--- a/app/bundles/CoreBundle/Entity/IpAddressRepository.php
+++ b/app/bundles/CoreBundle/Entity/IpAddressRepository.php
@@ -51,57 +51,55 @@ class IpAddressRepository extends CommonRepository
             DELETE {$prefix}ip_addresses FROM {$prefix}ip_addresses
             JOIN (
                 SELECT {$prefix}ip_addresses.id FROM {$prefix}ip_addresses
-                    LEFT JOIN {$prefix}asset_downloads 
-                      ON {$prefix}asset_downloads.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}campaign_lead_event_log 
-                      ON {$prefix}campaign_lead_event_log.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}email_stats 
+                    LEFT JOIN {$prefix}asset_downloads
+                      ON {$prefix}asset_downloads.ip_id = {$prefix}ip_addresses.id
+                    LEFT JOIN {$prefix}campaign_lead_event_log
+                      ON {$prefix}campaign_lead_event_log.ip_id = {$prefix}ip_addresses.id
+                    LEFT JOIN {$prefix}email_stats
                       ON {$prefix}email_stats.ip_id = {$prefix}ip_addresses.id
-                    LEFT JOIN {$prefix}email_stats_devices 
+                    LEFT JOIN {$prefix}email_stats_devices
                       ON {$prefix}email_stats_devices.ip_id = {$prefix}ip_addresses.id
-                    LEFT JOIN {$prefix}form_submissions 
-                      ON {$prefix}form_submissions.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}lead_ips_xref 
-                      ON {$prefix}lead_ips_xref.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}lead_points_change_log 
+                    LEFT JOIN {$prefix}form_submissions
+                      ON {$prefix}form_submissions.ip_id = {$prefix}ip_addresses.id
+                    LEFT JOIN {$prefix}lead_ips_xref
+                      ON {$prefix}lead_ips_xref.ip_id = {$prefix}ip_addresses.id
+                    LEFT JOIN {$prefix}lead_points_change_log
                       ON {$prefix}lead_points_change_log.ip_id = {$prefix}ip_addresses.id
-                    LEFT JOIN {$prefix}page_hits 
+                    LEFT JOIN {$prefix}page_hits
                       ON {$prefix}page_hits.ip_id = {$prefix}ip_addresses.id
-                    LEFT JOIN {$prefix}point_lead_action_log 
-                      ON {$prefix}point_lead_action_log.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}point_lead_event_log 
-                      ON {$prefix}point_lead_event_log.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}push_notification_stats 
-                      ON {$prefix}push_notification_stats.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}sms_message_stats 
-                      ON {$prefix}sms_message_stats.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}stage_lead_action_log 
-                      ON {$prefix}stage_lead_action_log.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}video_hits 
-                      ON {$prefix}video_hits.ip_id = {$prefix}ip_addresses.id 
-                   WHERE {$prefix}asset_downloads.id IS NULL 
-                     AND {$prefix}campaign_lead_event_log.id IS NULL 
-                     AND {$prefix}email_stats.id IS NULL 
-                     AND {$prefix}email_stats_devices.id IS NULL 
-                     AND {$prefix}form_submissions.id IS NULL 
-                     AND {$prefix}lead_ips_xref.lead_id IS NULL 
-                     AND {$prefix}lead_points_change_log.id IS NULL 
-                     AND {$prefix}page_hits.id IS NULL 
-                     AND {$prefix}point_lead_action_log.point_id IS NULL 
-                     AND {$prefix}point_lead_event_log.event_id IS NULL 
-                     AND {$prefix}push_notification_stats.id IS NULL 
-                     AND {$prefix}sms_message_stats.id IS NULL 
-                     AND {$prefix}stage_lead_action_log.stage_id IS NULL 
-                     AND {$prefix}video_hits.id IS NULL 
+                    LEFT JOIN {$prefix}point_lead_action_log
+                      ON {$prefix}point_lead_action_log.ip_id = {$prefix}ip_addresses.id
+                    LEFT JOIN {$prefix}point_lead_event_log
+                      ON {$prefix}point_lead_event_log.ip_id = {$prefix}ip_addresses.id
+                    LEFT JOIN {$prefix}push_notification_stats
+                      ON {$prefix}push_notification_stats.ip_id = {$prefix}ip_addresses.id
+                    LEFT JOIN {$prefix}sms_message_stats
+                      ON {$prefix}sms_message_stats.ip_id = {$prefix}ip_addresses.id
+                    LEFT JOIN {$prefix}stage_lead_action_log
+                      ON {$prefix}stage_lead_action_log.ip_id = {$prefix}ip_addresses.id
+                    LEFT JOIN {$prefix}video_hits
+                      ON {$prefix}video_hits.ip_id = {$prefix}ip_addresses.id
+                   WHERE {$prefix}asset_downloads.id IS NULL
+                     AND {$prefix}campaign_lead_event_log.id IS NULL
+                     AND {$prefix}email_stats.id IS NULL
+                     AND {$prefix}email_stats_devices.id IS NULL
+                     AND {$prefix}form_submissions.id IS NULL
+                     AND {$prefix}lead_ips_xref.lead_id IS NULL
+                     AND {$prefix}lead_points_change_log.id IS NULL
+                     AND {$prefix}page_hits.id IS NULL
+                     AND {$prefix}point_lead_action_log.point_id IS NULL
+                     AND {$prefix}point_lead_event_log.event_id IS NULL
+                     AND {$prefix}push_notification_stats.id IS NULL
+                     AND {$prefix}sms_message_stats.id IS NULL
+                     AND {$prefix}stage_lead_action_log.stage_id IS NULL
+                     AND {$prefix}video_hits.id IS NULL
                    LIMIT :limit
                 ) sq
             ON {$prefix}ip_addresses.id = sq.id;
 SQL;
         $params = [':limit' => (int) $limit];
         $types  = [':limit' => \PDO::PARAM_INT];
-        $stmt   = $this->_em->getConnection()->executeQuery($sql, $params, $types);
-
-        $deletedCount = $stmt->rowCount();
+        $deletedCount = $this->_em->getConnection()->executeUpdate($sql, $params, $types);
 
         return $deletedCount;
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | yes
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When running the mautic:unusedips:delete command with a master/slave setup, the command is run against the slave instead of the master, which means it cannot actually delete any IPs

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. setup a master/slave Mautic installation
2. run the command

#### Steps to test this PR:
1. setup a master/slave Mautic installation
2. Load up [this PR](https://mautibox.com)
2. run the command

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
