### PR TITLE
Fixed adding or removing contacts to campaigns when they are added or removed to/from segments

### DIFF
--- a/app/bundles/ApiBundle/Tests/Form/Type/ClientTypeTest.php
+++ b/app/bundles/ApiBundle/Tests/Form/Type/ClientTypeTest.php
@@ -76,13 +76,13 @@ class ClientTypeTest extends TestCase
     protected function setUp(): void
     {
         $this->requestStack = $this->createMock(RequestStack::class);
-        $this->translator = $this->createMock(TranslatorInterface::class);
-        $this->validator = $this->createMock(ValidatorInterface::class);
-        $this->session = $this->createMock(Session::class);
-        $this->router = $this->createMock(RouterInterface::class);
-        $this->builder = $this->createMock(FormBuilderInterface::class);
-        $this->request = $this->createMock(Request::class);
-        $this->consumer = new Consumer();
+        $this->translator   = $this->createMock(TranslatorInterface::class);
+        $this->validator    = $this->createMock(ValidatorInterface::class);
+        $this->session      = $this->createMock(Session::class);
+        $this->router       = $this->createMock(RouterInterface::class);
+        $this->builder      = $this->createMock(FormBuilderInterface::class);
+        $this->request      = $this->createMock(Request::class);
+        $this->consumer     = new Consumer();
 
         $this->requestStack->expects($this->once())
             ->method('getCurrentRequest')
@@ -104,14 +104,14 @@ class ClientTypeTest extends TestCase
     public function testThatBuildFormCallsEventSubscribers(): void
     {
         $options = [
-            'data' => $this->consumer
+            'data' => $this->consumer,
         ];
 
         $this->builder->expects($this->any())
             ->method('create')
             ->willReturnSelf();
 
-        $cleanSubscriber = new CleanFormSubscriber([]);
+        $cleanSubscriber    = new CleanFormSubscriber([]);
         $formExitSubscriber = new FormExitSubscriber('api.client', $options);
 
         $this->builder->expects($this->exactly(2))

--- a/app/bundles/ApiBundle/Tests/Form/Type/ClientTypeTest.php
+++ b/app/bundles/ApiBundle/Tests/Form/Type/ClientTypeTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-namespace Mautic\ApiBundle\Tests\Helper;
+namespace Mautic\ApiBundle\Tests\Form\Type;
 
 use Mautic\ApiBundle\Entity\oAuth1\Consumer;
 use Mautic\ApiBundle\Form\Type\ClientType;

--- a/app/bundles/ApiBundle/Tests/Form/Type/ClientTypeTest.php
+++ b/app/bundles/ApiBundle/Tests/Form/Type/ClientTypeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2021 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\ApiBundle\Tests\Helper;
+
+use Mautic\ApiBundle\Form\Type\ClientType;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class ClientTypeTest extends TestCase
+{
+    /**
+     * @var ClientType
+     */
+    private $clientType;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var ValidatorInterface
+     */
+    private $validator;
+
+    /**
+     * @var Session
+     */
+    private $session;
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var FormBuilderInterface
+     */
+    private $builder;
+
+    protected function setUp(): void
+    {
+        $this->requestStack = $this->createMock(RequestStack::class);
+        $this->translator = $this->createMock(TranslatorInterface::class);
+        $this->validator = $this->createMock(ValidatorInterface::class);
+        $this->session = $this->createMock(Session::class);
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->builder = $this->createMock(FormBuilderInterface::class);
+
+        $this->clientType = new ClientType(
+            $this->requestStack,
+            $this->translator,
+            $this->validator,
+            $this->session,
+            $this->router
+        );
+    }
+
+    public function testThatBuildFormCallsEventSubscribers(): void
+    {
+        $this->clientType->buildForm($this->builder, []);
+    }
+}

--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -132,7 +132,6 @@ return [
                     'translator',
                     'doctrine.orm.entity_manager',
                     'router',
-                    'mautic.security',
                 ],
             ],
             'mautic.campaign.calendarbundle.subscriber' => [

--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -133,7 +133,7 @@ class CampaignRepository extends CommonRepository
      *
      * @return array
      */
-    public function getPublishedCampaignsByLeadLists($leadLists, $viewOther = false)
+    public function getPublishedCampaignsByLeadLists($leadLists)
     {
         if (!is_array($leadLists)) {
             $leadLists = [(int) $leadLists];
@@ -153,11 +153,6 @@ class CampaignRepository extends CommonRepository
         $q->andWhere(
             $q->expr()->in('ll.leadlist_id', $leadLists)
         );
-
-        if (!$viewOther) {
-            $q->andWhere($q->expr()->eq('c.created_by', ':id'))
-                ->setParameter('id', $this->currentUser->getId());
-        }
 
         $results = $q->execute()->fetchAll();
 

--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -204,10 +204,7 @@ class LeadSubscriber implements EventSubscriberInterface
         $action = $event->wasAdded() ? 'added' : 'removed';
 
         //get campaigns for the list
-        $listCampaigns = $this->campaignModel->getRepository()->getPublishedCampaignsByLeadLists(
-            $list->getId(),
-            $this->security->isGranted('campaign:campaigns:viewother')
-        );
+        $listCampaigns = $this->campaignModel->getRepository()->getPublishedCampaignsByLeadLists($list->getId());
 
         $leadLists     = $this->leadModel->getLists($lead, true);
         $leadListIds   = array_keys($leadLists);

--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -82,11 +82,6 @@ class LeadSubscriber implements EventSubscriberInterface
     private $router;
 
     /**
-     * @var CorePermissions
-     */
-    private $security;
-
-    /**
      * @var LeadListRepository
      */
     private $segmentRepository;
@@ -108,8 +103,7 @@ class LeadSubscriber implements EventSubscriberInterface
         LeadModel $leadModel,
         TranslatorInterface $translator,
         EntityManager $entityManager,
-        RouterInterface $router,
-        CorePermissions $security
+        RouterInterface $router
     ) {
         $this->membershipManager         = $membershipManager;
         $this->eventCollector            = $eventCollector;
@@ -118,7 +112,6 @@ class LeadSubscriber implements EventSubscriberInterface
         $this->translator                = $translator;
         $this->entityManager             = $entityManager;
         $this->router                    = $router;
-        $this->security                  = $security;
         $this->segmentRepository         = $entityManager->getRepository(LeadList::class);
         $this->contactEventLogRepository = $entityManager->getRepository(LeadEventLog::class);
         $this->contactRepository         = $entityManager->getRepository(CampaignLead::class);

--- a/app/bundles/CampaignBundle/Tests/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/LeadSubscriberTest.php
@@ -13,7 +13,6 @@ use Mautic\CampaignBundle\EventCollector\EventCollector;
 use Mautic\CampaignBundle\EventListener\LeadSubscriber;
 use Mautic\CampaignBundle\Membership\MembershipManager;
 use Mautic\CampaignBundle\Model\CampaignModel;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\LeadListRepository;
@@ -95,8 +94,7 @@ class LeadSubscriberTest extends \PHPUnit\Framework\TestCase
             $this->createMock(LeadModel::class),
             $this->createMock(Translator::class),
             $this->makeBatchEntityManagerMock(),
-            $this->createMock(Router::class),
-            $this->createMock(CorePermissions::class)
+            $this->createMock(Router::class)
         );
 
         $leadSubscriber->onLeadListBatchChange($event);
@@ -128,8 +126,7 @@ class LeadSubscriberTest extends \PHPUnit\Framework\TestCase
             $this->createMock(LeadModel::class),
             $this->createMock(Translator::class),
             $this->makeBatchEntityManagerMock(),
-            $this->createMock(Router::class),
-            $this->createMock(CorePermissions::class)
+            $this->createMock(Router::class)
         );
 
         $leadSubscriber->onLeadListBatchChange($event);
@@ -171,8 +168,7 @@ class LeadSubscriberTest extends \PHPUnit\Framework\TestCase
             $leadModel,
             $this->createMock(Translator::class),
             $this->makeSingleEntityManagerMock(),
-            $this->createMock(Router::class),
-            $this->createMock(CorePermissions::class)
+            $this->createMock(Router::class)
         );
 
         $leadSubscriber->onLeadListChange($event);
@@ -214,8 +210,7 @@ class LeadSubscriberTest extends \PHPUnit\Framework\TestCase
             $leadModel,
             $this->createMock(Translator::class),
             $this->makeSingleEntityManagerMock(),
-            $this->createMock(Router::class),
-            $this->createMock(CorePermissions::class)
+            $this->createMock(Router::class)
         );
 
         $leadSubscriber->onLeadListChange($event);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
https://github.com/mautic/mautic/pull/6963 added support for "view other" campaign permissions. But it added the permission check to code that manipulated contacts' campaign membership based on segment membership. This code is mainly executed in circumstances outside a user session (cli, form submit, etc) and has no effect anyway considering the `mautic:campaign:update` command results in the same outcome (contact is added or removed). 

Finding campaigns associated with a segment for these use cases should not be restricted to whether the user has campaign access or not since those that do have access expect contacts to be added or removed from their campaign when the contact is added or removed from the segment they associated with the segment. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new segment with a filter
2. Create a new campaign with the segment as a source
3. Update a contact to match the filter
4. Run the command `php bin/console mautic:segments:update`
5. Notice the contact will be added to the segment but NOT the campaign

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
1. Create a new segment with a filter
2. Create a new campaign with the segment as a source
3. Update a contact to match the filter
5. Notice the contact will be added to the segment and the campaign
