### PR TITLE
Fix default console timezone

### DIFF
--- a/app/console
+++ b/app/console
@@ -2,7 +2,9 @@
 <?php
 
 // Fix for hosts that do not have date.timezone set
-date_default_timezone_set('UTC');
+if (empty(ini_get('date.timezone'))) {
+    date_default_timezone_set('UTC');
+}
 
 // if you don't want to setup permissions the proper way, just uncomment the following PHP line
 // read http://symfony.com/doc/current/book/installation.html#configuration-and-setup for more information


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Console timezone is always set to UTC no matter if `date.timezone` in your php.ini is set.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Check value of `date.timezone` in your php.ini and set it if not:
Ex: `date.timezone = Europe/Paris`
2. Edit Mautic command file like: mautic:segments:update
`app\bundles\LeadBundle\Command\UpdateLeadListsCommand.php`
3. Add dump `DateTime()`
![console-timezone](https://user-images.githubusercontent.com/27768270/59665599-82bb5780-91b3-11e9-89e8-1410a417c1c3.PNG)
4. Launch command: `php app/console m:s:u`
5. Console result:
```
object(DateTime)#1279 (3) {
  ["date"]=>
  string(26) "2019-06-18 08:28:08.000000"
  ["timezone_type"]=>
  int(3)
  ["timezone"]=>
  string(3) "UTC"
}
```
6. Wrong timezone


#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7617)
2. Launch command: `php app/console m:s:u`
3. Console result:
```
object(DateTime)#1279 (3) {
  ["date"]=>
  string(26) "2019-06-18 10:29:40.000000"
  ["timezone_type"]=>
  int(3)
  ["timezone"]=>
  string(12) "Europe/Paris"
}
```
4. Good timezone

