### PR TITLE
Fix contactgrid inline accessdenied

### DIFF
--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -763,8 +763,8 @@ class CampaignController extends AbstractStandardFormController
                                 'objectId'   => $entity->getId(),
                                 'page'       => $this->get('session')->get('mautic.campaign.contact.page', 1),
                                 'ignoreAjax' => true,
-                            ],[
-                                '_forwarded' => true
+                            ], [
+                                '_forwarded' => true,
                             ]
                         )->getContent(),
                     ]

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -763,6 +763,8 @@ class CampaignController extends AbstractStandardFormController
                                 'objectId'   => $entity->getId(),
                                 'page'       => $this->get('session')->get('mautic.campaign.contact.page', 1),
                                 'ignoreAjax' => true,
+                            ],[
+                                '_forwarded' => true
                             ]
                         )->getContent(),
                     ]

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -765,6 +765,7 @@ class CampaignController extends AbstractStandardFormController
                                 'ignoreAjax' => true,
                             ], [
                                 '_forwarded' => true,
+                                'ignoreAjax' => true,
                             ]
                         )->getContent(),
                     ]

--- a/app/bundles/ChannelBundle/Controller/MessageController.php
+++ b/app/bundles/ChannelBundle/Controller/MessageController.php
@@ -141,6 +141,7 @@ class MessageController extends AbstractStandardFormController
                             'channel'    => 'all',
                         ], [
                             '_forwarded' => true,
+                            'ignoreAjax' => true,
                         ]
                     )->getContent(),
                 ];
@@ -164,6 +165,7 @@ class MessageController extends AbstractStandardFormController
                                 'channel'    => $channel->getChannel(),
                             ], [
                                 '_forwarded' => true,
+                                'ignoreAjax' => true,
                             ]
                         )->getContent();
                     }

--- a/app/bundles/ChannelBundle/Controller/MessageController.php
+++ b/app/bundles/ChannelBundle/Controller/MessageController.php
@@ -139,6 +139,8 @@ class MessageController extends AbstractStandardFormController
                             'page'       => $this->get('session')->get('mautic.'.$this->getSessionBase('all').'.contact.page', 1),
                             'ignoreAjax' => true,
                             'channel'    => 'all',
+                        ],[
+                            '_forwarded' => true
                         ]
                     )->getContent(),
                 ];
@@ -160,6 +162,8 @@ class MessageController extends AbstractStandardFormController
                                 ),
                                 'ignoreAjax' => true,
                                 'channel'    => $channel->getChannel(),
+                            ],[
+                                '_forwarded' => true
                             ]
                         )->getContent();
                     }

--- a/app/bundles/ChannelBundle/Controller/MessageController.php
+++ b/app/bundles/ChannelBundle/Controller/MessageController.php
@@ -139,8 +139,8 @@ class MessageController extends AbstractStandardFormController
                             'page'       => $this->get('session')->get('mautic.'.$this->getSessionBase('all').'.contact.page', 1),
                             'ignoreAjax' => true,
                             'channel'    => 'all',
-                        ],[
-                            '_forwarded' => true
+                        ], [
+                            '_forwarded' => true,
                         ]
                     )->getContent(),
                 ];
@@ -162,8 +162,8 @@ class MessageController extends AbstractStandardFormController
                                 ),
                                 'ignoreAjax' => true,
                                 'channel'    => $channel->getChannel(),
-                            ],[
-                                '_forwarded' => true
+                            ], [
+                                '_forwarded' => true,
                             ]
                         )->getContent();
                     }

--- a/app/bundles/CoreBundle/Controller/ExceptionController.php
+++ b/app/bundles/CoreBundle/Controller/ExceptionController.php
@@ -95,7 +95,7 @@ class ExceptionController extends CommonController
 
             if (!$exception instanceof FatalThrowableError && $request->get('_forwarded', false)) {
                 $inline = true;
-            }else{
+            } else {
                 $inline = false;
             }
 

--- a/app/bundles/CoreBundle/Controller/ExceptionController.php
+++ b/app/bundles/CoreBundle/Controller/ExceptionController.php
@@ -102,14 +102,14 @@ class ExceptionController extends CommonController
             return $this->delegateView(
                 [
                     'viewParameters' => [
-                        'baseTemplate'   => $inline?null:$baseTemplate,
+                        'baseTemplate'   => $inline ? null : $baseTemplate,
                         'status_code'    => $code,
                         'status_text'    => $statusText,
                         'exception'      => $exception,
                         'logger'         => $logger,
                         'currentContent' => $currentContent,
                         'isPublicPage'   => $anonymous,
-                        'inline'         => $inline
+                        'inline'         => $inline,
                     ],
                     'contentTemplate' => $template,
                     'passthroughVars' => [

--- a/app/bundles/CoreBundle/Controller/ExceptionController.php
+++ b/app/bundles/CoreBundle/Controller/ExceptionController.php
@@ -93,16 +93,23 @@ class ExceptionController extends CommonController
             $url      = $request->getRequestUri();
             $urlParts = parse_url($url);
 
+            if (!$exception instanceof FatalThrowableError && $request->get('_forwarded', false)) {
+                $inline = true;
+            }else{
+                $inline = false;
+            }
+
             return $this->delegateView(
                 [
                     'viewParameters' => [
-                        'baseTemplate'   => $baseTemplate,
+                        'baseTemplate'   => $inline?null:$baseTemplate,
                         'status_code'    => $code,
                         'status_text'    => $statusText,
                         'exception'      => $exception,
                         'logger'         => $logger,
                         'currentContent' => $currentContent,
                         'isPublicPage'   => $anonymous,
+                        'inline'         => $inline
                     ],
                     'contentTemplate' => $template,
                     'passthroughVars' => [

--- a/app/bundles/CoreBundle/Controller/ExceptionController.php
+++ b/app/bundles/CoreBundle/Controller/ExceptionController.php
@@ -44,7 +44,7 @@ class ExceptionController extends CommonController
             if (
                 (strpos($request->getUri(), '/oauth') !== false && strpos($request->getUri(), 'authorize') === false) ||
                 strpos($request->getUri(), '/api') !== false ||
-                (!defined('MAUTIC_AJAX_VIEW') && strpos($request->server->get('HTTP_ACCEPT', ''), 'application/json') !== false)
+                (!defined('MAUTIC_AJAX_VIEW') && strpos($request->server->get('HTTP_ACCEPT', ''), 'application/json') !== false && !$request->get('_forwarded', false))
             ) {
                 $message   = ('dev' === MAUTIC_ENV) ? $exception->getMessage() : $this->get('translator')->trans('mautic.core.error.generic', ['%code%' => $code]);
                 $dataArray = [

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -430,8 +430,8 @@ class EmailController extends FormController
                             'objectId'   => $email->getId(),
                             'page'       => $this->get('session')->get('mautic.email.contact.page', 1),
                             'ignoreAjax' => true,
-                        ],[
-                            '_forwarded' => true
+                        ], [
+                            '_forwarded' => true,
                         ]
                     )->getContent(),
                     'dateRangeForm' => $dateRangeForm->createView(),

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -432,6 +432,7 @@ class EmailController extends FormController
                             'ignoreAjax' => true,
                         ], [
                             '_forwarded' => true,
+                            'ignoreAjax' => true,
                         ]
                     )->getContent(),
                     'dateRangeForm' => $dateRangeForm->createView(),

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -430,6 +430,8 @@ class EmailController extends FormController
                             'objectId'   => $email->getId(),
                             'page'       => $this->get('session')->get('mautic.email.contact.page', 1),
                             'ignoreAjax' => true,
+                        ],[
+                            '_forwarded' => true
                         ]
                     )->getContent(),
                     'dateRangeForm' => $dateRangeForm->createView(),

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -805,6 +805,8 @@ class ListController extends FormController
                         'page'       => $this->get('session')->get('mautic.segment.contact.page', 1),
                         'ignoreAjax' => true,
                         'filters'    => $filters,
+                    ],[
+                        '_forwarded' => true
                     ]
                 )->getContent(),
             ],

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -807,6 +807,7 @@ class ListController extends FormController
                         'filters'    => $filters,
                     ], [
                         '_forwarded' => true,
+                        'ignoreAjax' => true,
                     ]
                 )->getContent(),
             ],

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -805,8 +805,8 @@ class ListController extends FormController
                         'page'       => $this->get('session')->get('mautic.segment.contact.page', 1),
                         'ignoreAjax' => true,
                         'filters'    => $filters,
-                    ],[
-                        '_forwarded' => true
+                    ], [
+                        '_forwarded' => true,
                     ]
                 )->getContent(),
             ],

--- a/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
@@ -236,6 +236,7 @@ class MobileNotificationController extends FormController
                         'ignoreAjax' => true,
                     ], [
                         '_forwarded' => true,
+                        'ignoreAjax' => true,
                     ]
                 )->getContent(),
                 'dateRangeForm' => $dateRangeForm->createView(),

--- a/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
@@ -234,8 +234,8 @@ class MobileNotificationController extends FormController
                         'objectId'   => $notification->getId(),
                         'page'       => $this->get('session')->get('mautic.mobile_notification.contact.page', 1),
                         'ignoreAjax' => true,
-                    ],[
-                        '_forwarded' => true
+                    ], [
+                        '_forwarded' => true,
                     ]
                 )->getContent(),
                 'dateRangeForm' => $dateRangeForm->createView(),

--- a/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
@@ -234,6 +234,8 @@ class MobileNotificationController extends FormController
                         'objectId'   => $notification->getId(),
                         'page'       => $this->get('session')->get('mautic.mobile_notification.contact.page', 1),
                         'ignoreAjax' => true,
+                    ],[
+                        '_forwarded' => true
                     ]
                 )->getContent(),
                 'dateRangeForm' => $dateRangeForm->createView(),

--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -238,8 +238,8 @@ class NotificationController extends FormController
                         'objectId'   => $notification->getId(),
                         'page'       => $this->get('session')->get('mautic.notification.contact.page', 1),
                         'ignoreAjax' => true,
-                    ],[
-                        '_forwarded' => true
+                    ], [
+                        '_forwarded' => true,
                     ]
                 )->getContent(),
                 'dateRangeForm' => $dateRangeForm->createView(),

--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -240,6 +240,7 @@ class NotificationController extends FormController
                         'ignoreAjax' => true,
                     ], [
                         '_forwarded' => true,
+                        'ignoreAjax' => true,
                     ]
                 )->getContent(),
                 'dateRangeForm' => $dateRangeForm->createView(),

--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -238,6 +238,8 @@ class NotificationController extends FormController
                         'objectId'   => $notification->getId(),
                         'page'       => $this->get('session')->get('mautic.notification.contact.page', 1),
                         'ignoreAjax' => true,
+                    ],[
+                        '_forwarded' => true
                     ]
                 )->getContent(),
                 'dateRangeForm' => $dateRangeForm->createView(),

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -225,8 +225,8 @@ class SmsController extends FormController
                         'objectId'   => $sms->getId(),
                         'page'       => $this->get('session')->get('mautic.sms.contact.page', 1),
                         'ignoreAjax' => true,
-                    ],[
-                        '_forwarded' => true
+                    ], [
+                        '_forwarded' => true,
                     ]
                 )->getContent(),
                 'dateRangeForm' => $dateRangeForm->createView(),

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -225,6 +225,8 @@ class SmsController extends FormController
                         'objectId'   => $sms->getId(),
                         'page'       => $this->get('session')->get('mautic.sms.contact.page', 1),
                         'ignoreAjax' => true,
+                    ],[
+                        '_forwarded' => true
                     ]
                 )->getContent(),
                 'dateRangeForm' => $dateRangeForm->createView(),

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -227,6 +227,7 @@ class SmsController extends FormController
                         'ignoreAjax' => true,
                     ], [
                         '_forwarded' => true,
+                        'ignoreAjax' => true,
                     ]
                 )->getContent(),
                 'dateRangeForm' => $dateRangeForm->createView(),

--- a/plugins/MauticSocialBundle/Controller/MonitoringController.php
+++ b/plugins/MauticSocialBundle/Controller/MonitoringController.php
@@ -474,6 +474,8 @@ class MonitoringController extends FormController
                             'objectId'   => $monitoringEntity->getId(),
                             'page'       => $page,
                             'ignoreAjax' => true,
+                        ], [
+                            '_forwarded' => true,
                         ]
                     )->getContent(),
                     'dateRangeForm' => $dateRangeForm->createView(),

--- a/plugins/MauticSocialBundle/Controller/MonitoringController.php
+++ b/plugins/MauticSocialBundle/Controller/MonitoringController.php
@@ -476,6 +476,7 @@ class MonitoringController extends FormController
                             'ignoreAjax' => true,
                         ], [
                             '_forwarded' => true,
+                            'ignoreAjax' => true,
                         ]
                     )->getContent(),
                     'dateRangeForm' => $dateRangeForm->createView(),


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| Automated tests included? | no
| Related user documentation PR URL | -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | 
https://github.com/mautic/mautic/issues/7551
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When a user had a role without the proper permission to see the contact grid the program throws an "access denied". But the contact grid is not a full page, but a partial view (forwarded) and the "access denied" controller method renders the error message as a full html page. This breaks the original page.

This patch solves this problem by making the the "access denied" view >inline<


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create role for a user with no segment permissions
2. Create a new segment with that user
3. Open the segment for view

