### PR TITLE
Fix contactgrid required permission

### DIFF
--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -127,10 +127,17 @@ class CampaignController extends AbstractStandardFormController
      */
     public function contactsAction($objectId, $page = 1)
     {
+        $model  = $this->getModel($this->getModelName());
+        $entity = $model->getEntity($objectId);
+
+        if (!$this->checkActionPermission('view', $entity)) {
+            return $this->accessDenied();
+        }
+
         return $this->generateContactsGrid(
             $objectId,
             $page,
-            'campaign:campaigns:view',
+            'lead:leads:viewown',
             'campaign',
             'campaign_leads',
             null,

--- a/app/bundles/ChannelBundle/Controller/MessageController.php
+++ b/app/bundles/ChannelBundle/Controller/MessageController.php
@@ -276,6 +276,13 @@ class MessageController extends AbstractStandardFormController
      */
     public function contactsAction($objectId, $channel, $page = 1)
     {
+        $model  = $this->getModel($this->getModelName());
+        $entity = $model->getEntity($objectId);
+
+        if (!$this->checkActionPermission('view', $entity)) {
+            return $this->accessDenied();
+        }
+
         $filter = [];
         if ('all' !== $channel) {
             $returnUrl = $this->generateUrl(
@@ -303,7 +310,7 @@ class MessageController extends AbstractStandardFormController
         return $this->generateContactsGrid(
             $objectId,
             $page,
-            'channel:messages:view',
+            'lead:leads:viewown',
             'message.'.$channel,
             'campaign_lead_event_log',
             $channel,

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1632,7 +1632,6 @@ class EmailController extends FormController
             return $this->accessDenied();
         }
 
-
         return $this->generateContactsGrid(
             $objectId,
             $page,

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1596,7 +1596,7 @@ class EmailController extends FormController
     public function contactsAction($objectId, $page = 1)
     {
         /** @var \Mautic\EmailBundle\Model\EmailModel $model */
-        $model    = $this->getModel('email');        
+        $model    = $this->getModel('email');
 
         /** @var \Mautic\EmailBundle\Entity\Email $email */
         $email = $model->getEntity($objectId);

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1600,7 +1600,7 @@ class EmailController extends FormController
 
         /** @var \Mautic\EmailBundle\Entity\Email $email */
         $email = $model->getEntity($objectId);
-           
+
         if ($email === null) {
             //set the return URL
             $returnUrl = $this->generateUrl('mautic_email_index', ['page' => $page]);

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -824,9 +824,9 @@ class ListController extends FormController
      */
     public function contactsAction($objectId, $page = 1)
     {
-         /** @var \Mautic\LeadBundle\Model\ListModel $model */
+        /** @var \Mautic\LeadBundle\Model\ListModel $model */
         $model    = $this->getModel('lead.list');
-        
+
         /** @var \Mautic\LeadBundle\Entity\LeadList $list */
         $list = $model->getEntity($objectId);
 
@@ -858,8 +858,6 @@ class ListController extends FormController
         ) {
             return $this->accessDenied();
         }
-
-
 
         $manuallyRemoved = 0;
         $listFilters     = ['manually_removed' => $manuallyRemoved];

--- a/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
@@ -767,7 +767,7 @@ class MobileNotificationController extends FormController
       
         /** @var \Mautic\NotificationBundle\Entity\Notification $notification */
         $notification = $model->getEntity($objectId);
-      
+
         if ($notification === null) {
             //set the return URL
             $returnUrl = $this->generateUrl('mautic_mobile_notification_index', ['page' => $page]);

--- a/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
@@ -764,7 +764,7 @@ class MobileNotificationController extends FormController
     {
         /** @var \Mautic\NotificationBundle\Model\NotificationModel $model */
         $model    = $this->getModel('notification');
-      
+
         /** @var \Mautic\NotificationBundle\Entity\Notification $notification */
         $notification = $model->getEntity($objectId);
       
@@ -798,7 +798,6 @@ class MobileNotificationController extends FormController
         ) {
             return $this->accessDenied();
         }
-
 
         return $this->generateContactsGrid(
             $objectId,

--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -761,10 +761,10 @@ class NotificationController extends FormController
     public function contactsAction($objectId, $page = 1)
     {
         /** @var \Mautic\NotificationBundle\Model\NotificationModel $model */
-        $model    = $this->getModel('notification');        
+        $model    = $this->getModel('notification');
 
         /** @var \Mautic\NotificationBundle\Entity\Notification $notification */
-        $notification = $model->getEntity($objectId);        
+        $notification = $model->getEntity($objectId);
 
         if ($notification === null) {
             //set the return URL
@@ -796,7 +796,6 @@ class NotificationController extends FormController
         ) {
             return $this->accessDenied();
         }
-
 
         return $this->generateContactsGrid(
             $objectId,

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -736,10 +736,10 @@ class SmsController extends FormController
     public function contactsAction($objectId, $page = 1)
     {
         /** @var \Mautic\SmsBundle\Model\SmsModel $model */
-        $model    = $this->getModel('sms');        
+        $model    = $this->getModel('sms');
 
         /** @var \Mautic\SmsBundle\Entity\Sms $sms */
-        $sms = $model->getEntity($objectId);        
+        $sms = $model->getEntity($objectId);
 
         if ($sms === null) {
             //set the return URL

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -770,7 +770,6 @@ class SmsController extends FormController
             return $this->accessDenied();
         }
 
-
         return $this->generateContactsGrid(
             $objectId,
             $page,

--- a/plugins/MauticSocialBundle/Controller/MonitoringController.php
+++ b/plugins/MauticSocialBundle/Controller/MonitoringController.php
@@ -638,10 +638,14 @@ class MonitoringController extends FormController
      */
     public function contactsAction($objectId, $page = 1)
     {
+        if (!$this->get('mautic.security')->isGranted('plugin:mauticSocial:monitoring:view')) {
+            return $this->accessDenied();
+        }
+        
         return $this->generateContactsGrid(
             $objectId,
             $page,
-            'plugin:mauticSocial:monitoring:view',
+            'lead:leads:viewown',
             'social',
             'monitoring_leads',
             null, // @todo - implement when individual social channels are supported by the plugin

--- a/plugins/MauticSocialBundle/Controller/MonitoringController.php
+++ b/plugins/MauticSocialBundle/Controller/MonitoringController.php
@@ -641,7 +641,7 @@ class MonitoringController extends FormController
         if (!$this->get('mautic.security')->isGranted('plugin:mauticSocial:monitoring:view')) {
             return $this->accessDenied();
         }
-        
+
         return $this->generateContactsGrid(
             $objectId,
             $page,


### PR DESCRIPTION
closes #7551

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| Automated tests included? | no
| Related user documentation PR URL | -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | 
https://github.com/mautic/mautic/issues/7551
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The contactsAction (contactgrid) can be invoked by the viewAction via forwarding or in many cases it can be invoked directly by url. 
The contactgrid  checks for permission passed by the contactsAction method. Previously the contactsAction passed a permission that was usually required to view the current object. While checking the view permission is appropriate because the contactsAction can be invoked via direct url, the contactGrid shows leads, therefore it should rather check for permission for view leads.

_There remains an inherent question regarding contact grids. There is a separate permission for viewing own and other users' contacts. The contactgrid currently  does not respect this differentiation and lists all contact that are associated with the currenlty viewed entity (list, email, etc.)

It's hard to address this question, because the contactgrid did not list all contacts but only those that the current user has permission to view (`lead:leads:viewown`, `lead:leads:viewother`) then the segment I create could be added to contacts I can't see or emails could be sent to contacts I can't see without `lead:leads:viewother` permission.

The behaviour of the entity (list, email, etc.) should be changed accordingly. Shortly: If I don't have permission to view other users' contacts, the segment I create should not be added to users that are not owner by me if I don't have `lead:leads:viewother` permission._

_Note that this PR doesn not address this question_


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a role without the `lead:lists:viewother` permission 
2. Add a user with that role
3. With that user create a segment
4. Add contacts to the segment
5. You won't be able to see what contacts are in your own segment.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
