### PR TITLE
Implementing Datescan Date Parsing Library to Handle Multiple Formats 

### DIFF
--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -13,6 +13,7 @@ namespace Mautic\CoreBundle\Form;
 
 use Mautic\CoreBundle\Helper\InputHelper;
 use Symfony\Component\Form\Form;
+use westonwatson\Datescan\Datescan;
 
 trait RequestTrait
 {
@@ -76,19 +77,21 @@ trait RequestTrait
                             // Date placeholder was used so just ignore it to allow import of the field
                             unset($params[$name]);
                         } else {
+                            $dateTime = (new Datescan($params[$name]))->getRealDateTime();
+
                             if (false === ($timestamp = strtotime($params[$name]))) {
                                 $timestamp = null;
                             }
                             if ($timestamp) {
                                 switch ($type) {
                                     case 'datetime':
-                                        $params[$name] = (new \DateTime(date('Y-m-d H:i:s', $timestamp)))->format('Y-m-d H:i');
+                                        $params[$name] = $dateTime->format('Y-m-d H:i');
                                         break;
                                     case 'date':
-                                        $params[$name] = (new \DateTime(date('Y-m-d', $timestamp)))->format('Y-m-d');
+                                        $params[$name] = $dateTime->format('Y-m-d');
                                         break;
                                     case 'time':
-                                        $params[$name] = (new \DateTime(date('H:i:s', $timestamp)))->format('H:i:s');
+                                        $params[$name] = $dateTime->format('H:i:s');
                                         break;
                                 }
                             } else {
@@ -133,6 +136,8 @@ trait RequestTrait
             case 'datetime':
             case 'date':
             case 'time':
+                $dateTime = (new Datescan($fieldData[$leadField['alias']]))->getRealDateTime();
+
                 // Prevent zero based date placeholders
                 $dateTest = (int) str_replace(['/', '-', ' '], '', $fieldData[$leadField['alias']]);
                 if (!$dateTest) {
@@ -145,13 +150,13 @@ trait RequestTrait
                     if ($timestamp) {
                         switch ($leadField['type']) {
                             case 'datetime':
-                                $fieldData[$leadField['alias']] = (new \DateTime(date('Y-m-d H:i:s', $timestamp)))->format('Y-m-d H:i:s');
+                                $fieldData[$leadField['alias']] = $dateTime->format('Y-m-d H:i:s');
                                 break;
                             case 'date':
-                                $fieldData[$leadField['alias']] = (new \DateTime(date('Y-m-d', $timestamp)))->format('Y-m-d');
+                                $fieldData[$leadField['alias']] = $dateTime->format('Y-m-d');
                                 break;
                             case 'time':
-                                $fieldData[$leadField['alias']] = (new \DateTime(date('H:i:s', $timestamp)))->format('H:i:s');
+                                $fieldData[$leadField['alias']] = $dateTime->format('H:i:s');
                                 break;
                         }
                     }

--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,7 @@
         "sendgrid/sendgrid": "~6.0",
         "noxlogic/ratelimit-bundle": "^1.11",
         "sensio/framework-extra-bundle": "~3.0",
-        "westonwatson/datescan": "1.0.2"
+        "westonwatson/datescan": "1.0.3"
     },
     "require-dev": {
         "symfony/web-profiler-bundle": "~2.8",

--- a/composer.json
+++ b/composer.json
@@ -113,7 +113,8 @@
         "ramsey/uuid": "^3.7",
         "sendgrid/sendgrid": "~6.0",
         "noxlogic/ratelimit-bundle": "^1.11",
-        "sensio/framework-extra-bundle": "~3.0"
+        "sensio/framework-extra-bundle": "~3.0",
+        "westonwatson/datescan": "1.0.2"
     },
     "require-dev": {
         "symfony/web-profiler-bundle": "~2.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c723b01a495aa3fd913385f5ca47827e",
+    "content-hash": "27f26136863faeaf4e670d1a8aa2499a",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -8255,16 +8255,16 @@
         },
         {
             "name": "westonwatson/datescan",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/westonwatson/datescan.git",
-                "reference": "d31806483721f05d44fb2f1fb2d6ce598f5659c3"
+                "reference": "66f6f9a01c7e8a01d60b11b5c7a96c4e6cb153b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/westonwatson/datescan/zipball/d31806483721f05d44fb2f1fb2d6ce598f5659c3",
-                "reference": "d31806483721f05d44fb2f1fb2d6ce598f5659c3",
+                "url": "https://api.github.com/repos/westonwatson/datescan/zipball/66f6f9a01c7e8a01d60b11b5c7a96c4e6cb153b9",
+                "reference": "66f6f9a01c7e8a01d60b11b5c7a96c4e6cb153b9",
                 "shasum": ""
             },
             "require-dev": {
@@ -8290,7 +8290,7 @@
                 }
             ],
             "description": "Recognize and parse multiple date/time formats.",
-            "time": "2019-06-19T13:11:43+00:00"
+            "time": "2019-06-20T19:41:50+00:00"
         },
         {
             "name": "willdurand/jsonp-callback-validator",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "76ca1f3e88950d50351be721720c3e0a",
+    "content-hash": "c723b01a495aa3fd913385f5ca47827e",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -8252,6 +8252,45 @@
                 "twilio"
             ],
             "time": "2017-11-17T22:59:03+00:00"
+        },
+        {
+            "name": "westonwatson/datescan",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/westonwatson/datescan.git",
+                "reference": "d31806483721f05d44fb2f1fb2d6ce598f5659c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/westonwatson/datescan/zipball/d31806483721f05d44fb2f1fb2d6ce598f5659c3",
+                "reference": "d31806483721f05d44fb2f1fb2d6ce598f5659c3",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "5.7.27"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "": "src/"
+                },
+                "psr-4": {
+                    "westonwatson\\Datescan\\": "src/Datescan"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "westonwatson",
+                    "email": "wwatson@thedmsgrp.com"
+                }
+            ],
+            "description": "Recognize and parse multiple date/time formats.",
+            "time": "2019-06-19T13:11:43+00:00"
         },
         {
             "name": "willdurand/jsonp-callback-validator",


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | ✓
| Automated tests included? | ✓
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: 
Using external library to parse multiple date/time formats in the request trait. Instead of relying on `new DateTime()` 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Post Lead with Multiple Date Time formats.
Formats/Patterns Listed: https://github.com/westonwatson/datescan/blob/e4a3ff08b7deb8ade7db2a862d53fbe00b8c5dd8/src/Datescan/Datescan.php#L29


#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
