### PR TITLE
Fix broken URL for Contributor Agreement, change plurals to singular.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Installing from source is only recommended if you are comfortable using the comm
 
 ## Requirements
 
-#### Contributors Agreement 
+#### Contributor Agreement 
 
-By contributing to this project, you accept and agree to the [Contributors Agreement](https://www.mautic.org/contributors-agreement) in its entirety.
+By contributing to this project, you accept and agree to the [Contributor Agreement](https://www.mautic.org/contributor-agreement) in its entirety.
 
 #### Development / Build process requirements
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | YES

[//]: # ( Required: )
#### Description:

Fixed broken URL for Contributor Agreement in README.md to https://www.mautic.org/contributor-agreement. Modified previous instances of plural use of 'contributors' to 'contributor', as is found on Mautic website for Contributor Agreement.