### PR TITLE
Fix contact's token zero value

### DIFF
--- a/app/bundles/LeadBundle/Helper/TokenHelper.php
+++ b/app/bundles/LeadBundle/Helper/TokenHelper.php
@@ -103,7 +103,7 @@ class TokenHelper
             $value = $lead['companies'][0][$alias];
         }
 
-        if ($value) {
+        if ($value !== '') {
             switch ($defaultValue) {
                 case 'true':
                     $value = urlencode($value);
@@ -135,7 +135,7 @@ class TokenHelper
         if (in_array($defaultValue, ['true', 'date', 'time', 'datetime'])) {
             return $value;
         } else {
-            return $value ?: $defaultValue;
+            return $value !== '' ? $value : $defaultValue;
         }
     }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7638
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Noticed number contact type with 0 value was evaluated as empty string. This PR bring type comparison

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Create a number custom field
2. Set value of this field to zero in one contact
3. Put your contact in a segment
4. Create a segment email for this segment
5. In the builder add the token of the custom field in any text bloc:
![image](https://user-images.githubusercontent.com/462477/60014514-7a668f00-9681-11e9-8b19-f462a1afd366.png)
6. Send the email
7. Open the email, the value of the token is empty
8. Test again with any value in the custom field, you will see it in an email.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Test againg  nad see 0 in your email
