### PR TITLE
Fix clone campaign with form source

### DIFF
--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -585,7 +585,7 @@ class Campaign extends FormEntity
      */
     public function addForm(Form $form)
     {
-        $this->forms[] = $form;
+        $this->forms[$form->getId()] = $form;
 
         $this->changes['forms']['added'][$form->getId()] = $form->getName();
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7127
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Clone campaing with form source return 500 error. This PR fixed it

### Steps to reproduce
1. Create a new campaign such as in the screenshot below

![image](https://user-images.githubusercontent.com/23435414/51070735-d95abd80-1678-11e9-94e8-5cd16d778f72.png)


2. Clone the campaign
3. Save the clone

The campaign is saved but an error page is shown 

![image](https://user-images.githubusercontent.com/23435414/51070758-1921a500-1679-11e9-96c3-9d84d611d1b5.png)

Go back to the clone and see the campaign builder :

![image](https://user-images.githubusercontent.com/23435414/51070774-4ec68e00-1679-11e9-9527-8f0c08b2eaf6.png)

 
### Log errors

```
[2019-01-12 14:36:24] mautic.CRITICAL: Uncaught PHP Exception Doctrine\DBAL\Exception\UniqueConstraintViolationException: "An exception occurred while executing 'INSERT INTO campaign_form_xref (campaign_id, form_id) VALUES (?, ?)' with params [15, 10]:  SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '15-10' for key 'PRIMARY'" at /var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php line 66 {"exception":"[object] (Doctrine\\DBAL\\Exception\\UniqueConstraintViolationException(code: 0): An exception occurred while executing 'INSERT INTO campaign_form_xref (campaign_id, form_id) VALUES (?, ?)' with params [15, 10]:\n\nSQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '15-10' for key 'PRIMARY' at /var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:66, Doctrine\\DBAL\\Driver\\PDOException(code: 23000): SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '15-10' for key 'PRIMARY' at /var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:107, PDOException(code: 23000): SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '15-10' for key 'PRIMARY' at /var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:105)"} []
```


#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps, and see If there is  not error
