### PR TITLE
Fix Salesforce boolean sync and fix warning

### DIFF
--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -429,7 +429,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
                 foreach ($record as $key => $item) {
                     if (is_bool($item)) {
-                        $dataObject[$key.$newName] = (int)$item;
+                        $dataObject[$key.$newName] = (int) $item;
                     } else {
                         $dataObject[$key.$newName] = $item;
                     }

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -428,7 +428,11 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 }
 
                 foreach ($record as $key => $item) {
-                    $dataObject[$key.$newName] = $item;
+                    if (is_bool($item)) {
+                        $dataObject[$key.$newName] = (int)$item;
+                    } else {
+                        $dataObject[$key.$newName] = $item;
+                    }
                 }
 
                 if (isset($dataObject) && $dataObject) {
@@ -724,8 +728,8 @@ class SalesforceIntegration extends CrmAbstractIntegration
             if ($this->isAuthorized()) {
                 $existingPersons = $this->getApiHelper()->getPerson(
                     [
-                        'Lead'    => $mappedData['Lead']['create'],
-                        'Contact' => $mappedData['Contact']['create'],
+                        'Lead'    => isset($mappedData['Lead']['create']) ? $mappedData['Lead']['create'] : null,
+                        'Contact' => isset($mappedData['Contact']['create']) ? $mappedData['Contact']['create'] : null,
                     ]
                 );
 
@@ -766,7 +770,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                         }
                     }
 
-                    if ('Lead' === $object && !$personFound) {
+                    if ('Lead' === $object && !$personFound && isset($mappedData[$object]['create'])) {
                         $personData                         = $this->getApiHelper()->createLead($mappedData[$object]['create']);
                         $people[$object][$personData['Id']] = $personData['Id'];
                         $personFound                        = true;


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Boolean field is not synchronized properly.

Fix some warning like:
```
[2019-06-11 11:54:48] mautic.NOTICE: PHP Notice - Undefined index: create - in file /plugins/MauticCrmBundle/Integration/SalesforceIntegration.php - at line 717 [] []
[2019-06-11 11:54:49] mautic.NOTICE: PHP Notice - Undefined index: create - in file /plugins/MauticCrmBundle/Integration/SalesforceIntegration.php - at line 760 [] []
[2019-06-11 11:54:49] mautic.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Type error: Argument 1 passed to MauticPlugin\MauticCrmBundle\Api\SalesforceApi::createLead() must be of the type array, null given, called in /plugins/MauticCrmBundle/Integration/SalesforceIntegration.php on line 760" at /plugins/MauticCrmBundle/Api/SalesforceApi.php line 185 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Type error: Argument 1 passed to MauticPlugin\\MauticCrmBundle\\Api\\SalesforceApi::createLead() must be of the type array, null given, called in /plugins/MauticCrmBundle/Integration/SalesforceIntegration.php on line 760 at /plugins/MauticCrmBundle/Api/SalesforceApi.php:185)"} []
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Install and configure Salesforce
2. Map boolean field for Contact
3. Set one Salesforce boolean value to **true**
4. Launch command to sync `php app/console mautic:integration:fetchleads --time-interval=180minutes --integration=Salesforce`
5. Set Salesforce boolean value to **false**
6. Relaunch sync
7. Value of this boolean field is stuck on **true** on Mautic side.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7643)
2. Repeat step above
3. On the second sync, value is now **false** on Mautic side.
