### PR TITLE
Fix zoho contact sync

### DIFF
--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -138,7 +138,15 @@ class ZohoIntegration extends CrmAbstractIntegration
                     $fl = [$fl];
                 }
                 foreach ($fl as $field) {
-                    $fieldsValues[$row['no'] - 1][$this->getFieldKey($field['val'])] = $field['content'];
+                    // Fix boolean comparison
+                    $value = $field['content'];
+                    if ($field['content'] === 'true') {
+                        $value = true;
+                    } elseif ($field['content'] === 'false') {
+                        $value = false;
+                    }
+
+                    $fieldsValues[$row['no'] - 1][$this->getFieldKey($field['val'])] = $value;
                 }
             }
         }
@@ -994,7 +1002,7 @@ class ZohoIntegration extends CrmAbstractIntegration
 
         // convert ignored contacts
         foreach ($isContact as $email => $lead) {
-            $integrationId         = $integrationEntityRepo->getIntegrationsEntityId(
+            $integrationId = $integrationEntityRepo->getIntegrationsEntityId(
                 'Zoho',
                 'Leads',
                 'lead',
@@ -1296,7 +1304,7 @@ class ZohoIntegration extends CrmAbstractIntegration
     {
         $parsedData = [];
 
-        if (!empty($data['response']['result'][$object])) {
+        if (!empty($data['response']['result'][$object]) && isset($data['response']['result'][$object]['row']['FL'])) {
             $records = $data['response']['result'][$object]['row']['FL'];
             foreach ($fields as $key => $field) {
                 foreach ($records as $record) {

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -138,7 +138,7 @@ class ZohoIntegration extends CrmAbstractIntegration
                     $fl = [$fl];
                 }
                 foreach ($fl as $field) {
-                    $fieldsValues[$row['no'] - 1][$field['val']] = $field['content'];
+                    $fieldsValues[$row['no'] - 1][$this->getFieldKey($field['val'])] = $field['content'];
                 }
             }
         }
@@ -201,7 +201,7 @@ class ZohoIntegration extends CrmAbstractIntegration
                                 // Match that data with mapped lead fields
                                 $fieldsToUpdateInMautic = $this->getPriorityFieldsForMautic($config, $object, 'mautic_company');
                                 if (!empty($fieldsToUpdateInMautic)) {
-                                    $fieldsToUpdateInMautic = array_intersect_key($config['companyFields'], array_flip($fieldsToUpdateInMautic));
+                                    $fieldsToUpdateInMautic = array_intersect_key($config['companyFields'], $fieldsToUpdateInMautic);
                                     $newMatchedFields       = array_intersect_key($matchedFields, array_flip($fieldsToUpdateInMautic));
                                 } else {
                                     $newMatchedFields = $matchedFields;
@@ -232,7 +232,7 @@ class ZohoIntegration extends CrmAbstractIntegration
                                     $isModified = true;
                                 }
                             } else {
-                                $entity = $this->getMauticCompany($entityData, 'company');
+                                $entity = $this->getMauticCompany($entityData, 'Accounts');
                             }
                             if ($entity) {
                                 $result[] = $entity->getName();
@@ -258,12 +258,12 @@ class ZohoIntegration extends CrmAbstractIntegration
                             if (count($integrationId)) { // lead exists, then update
                                 /** @var Lead $entity */
                                 $entity        = $this->leadModel->getEntity($integrationId[0]['internal_entity_id']);
-                                $matchedFields = $this->populateMauticLeadData($entityData, $config, $object);
+                                $matchedFields = $this->populateMauticLeadData($entityData, $config);
 
                                 // Match that data with mapped lead fields
                                 $fieldsToUpdateInMautic = $this->getPriorityFieldsForMautic($config, $object, 'mautic');
                                 if (!empty($fieldsToUpdateInMautic)) {
-                                    $fieldsToUpdateInMautic = array_intersect_key($config['leadFields'], array_flip($fieldsToUpdateInMautic));
+                                    $fieldsToUpdateInMautic = array_intersect_key($config['leadFields'], $fieldsToUpdateInMautic);
                                     $newMatchedFields       = array_intersect_key($matchedFields, array_flip($fieldsToUpdateInMautic));
                                 } else {
                                     $newMatchedFields = $matchedFields;
@@ -290,28 +290,28 @@ class ZohoIntegration extends CrmAbstractIntegration
                                 }
                             } else {
                                 /** @var Lead $entity */
-                                $entity = $this->getMauticLead($entityData);
+                                $entity = $this->getMauticLead($entityData, true, null, null, $object);
                             }
 
                             if ($entity) {
                                 $result[] = $entity->getEmail();
-                            }
 
-                            // Associate lead company
-                            if (!empty($entityData['Company'])
-                                && $entityData['Company'] !== $this->translator->trans(
-                                    'mautic.integration.form.lead.unknown'
-                                )
-                            ) {
-                                $company = IdentifyCompanyHelper::identifyLeadsCompany(
-                                    ['company' => $entityData['Company']],
-                                    null,
-                                    $this->companyModel
-                                );
+                                // Associate lead company
+                                if (!empty($entityData['Company'])
+                                    && $entityData['Company'] !== $this->translator->trans(
+                                        'mautic.integration.form.lead.unknown'
+                                    )
+                                ) {
+                                    $company = IdentifyCompanyHelper::identifyLeadsCompany(
+                                        ['company' => $entityData['Company']],
+                                        null,
+                                        $this->companyModel
+                                    );
 
-                                if (!empty($company[2])) {
-                                    $syncLead = $this->companyModel->addLeadToCompany($company[2], $entity);
-                                    $this->em->detach($company[2]);
+                                    if (!empty($company[2])) {
+                                        $syncLead = $this->companyModel->addLeadToCompany($company[2], $entity);
+                                        $this->em->detach($company[2]);
+                                    }
                                 }
                             }
 
@@ -334,12 +334,12 @@ class ZohoIntegration extends CrmAbstractIntegration
                             if (count($integrationId)) { // contact exists, then update
                                 /** @var Lead $entity */
                                 $entity        = $this->leadModel->getEntity($integrationId[0]['internal_entity_id']);
-                                $matchedFields = $this->populateMauticLeadData($entityData, $config, $object);
+                                $matchedFields = $this->populateMauticLeadData($entityData, $config);
 
                                 // Match that data with mapped lead fields
                                 $fieldsToUpdateInMautic = $this->getPriorityFieldsForMautic($config, $object, 'mautic');
                                 if (!empty($fieldsToUpdateInMautic)) {
-                                    $fieldsToUpdateInMautic = array_intersect_key($config['leadFields'], array_flip($fieldsToUpdateInMautic));
+                                    $fieldsToUpdateInMautic = array_intersect_key($config['leadFields'], $fieldsToUpdateInMautic);
                                     $newMatchedFields       = array_intersect_key($matchedFields, array_flip($fieldsToUpdateInMautic));
                                 } else {
                                     $newMatchedFields = $matchedFields;
@@ -366,11 +366,29 @@ class ZohoIntegration extends CrmAbstractIntegration
                                 }
                             } else {
                                 /** @var Lead $entity */
-                                $entity = $this->getMauticLead($entityData);
+                                $entity = $this->getMauticLead($entityData, true, null, null, $object);
                             }
 
                             if ($entity) {
                                 $result[] = $entity->getEmail();
+
+                                // Associate lead company
+                                if (!empty($entityData['AccountName'])
+                                    && $entityData['AccountName'] !== $this->translator->trans(
+                                        'mautic.integration.form.lead.unknown'
+                                    )
+                                ) {
+                                    $company = IdentifyCompanyHelper::identifyLeadsCompany(
+                                        ['company' => $entityData['AccountName']],
+                                        null,
+                                        $this->companyModel
+                                    );
+
+                                    if (!empty($company[2])) {
+                                        $syncLead = $this->companyModel->addLeadToCompany($company[2], $entity);
+                                        $this->em->detach($company[2]);
+                                    }
+                                }
                             }
 
                             $mauticObjectReference = 'lead';
@@ -575,37 +593,6 @@ class ZohoIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * {@inheritdoc}
-     *
-     * @param array $data
-     * @param array $config
-     * @param null  $object
-     *
-     * @return array
-     */
-    public function populateMauticLeadData($data, $config = [], $object = 'Leads')
-    {
-        // Match that data with mapped lead fields
-        $aFields       = $this->getAvailableLeadFields($config);
-        $matchedFields = [];
-
-        $fieldsName = ('company' === $object) ? 'companyFields' : 'leadFields';
-
-        if (isset($aFields[$object])) {
-            $aFields = $aFields[$object];
-        }
-        foreach ($aFields as $k => $v) {
-            foreach ($data as $dk => $dv) {
-                if ($dk === $v['dv']) {
-                    $matchedFields[$config[$fieldsName][$k]] = $dv;
-                }
-            }
-        }
-
-        return $matchedFields;
-    }
-
-    /**
      * @param Form|FormBuilder $builder
      * @param array            $data
      * @param string           $formArea
@@ -805,7 +792,7 @@ class ZohoIntegration extends CrmAbstractIntegration
                                 $optgroup['FL'] = [$optgroup['FL']];
                             }
                             foreach ($optgroup['FL'] as $field) {
-                                if (!(bool) $field['isreadonly'] || in_array($field['type'], ['Lookup', 'OwnerLookup', 'Boolean'], true)) {
+                                if (!(bool) $field['isreadonly'] || in_array($field['type'], ['OwnerLookup'], true)) {
                                     continue;
                                 }
 
@@ -988,9 +975,16 @@ class ZohoIntegration extends CrmAbstractIntegration
                     if (isset($isContact[$key])) {
                         $isContact[$key] = $lead; // lead-converted
                     } else {
+                        $integrationId = $integrationEntityRepo->getIntegrationsEntityId(
+                            'Zoho',
+                            'Leads',
+                            'lead',
+                            $lead['internal_entity_id']
+                        );
+
                         $lead['integration_entity'] = 'Leads';
                         $leadsToUpdateInZ[$key]     = $lead;
-                        $integrationEntity          = $this->em->getReference('MauticPluginBundle:IntegrationEntity', $lead['id']);
+                        $integrationEntity          = $this->em->getReference('MauticPluginBundle:IntegrationEntity', $integrationId[0]['id']);
                         $integrationEntities[]      = $integrationEntity->setLastSyncDate(new \DateTime());
                     }
                 }
@@ -1000,9 +994,6 @@ class ZohoIntegration extends CrmAbstractIntegration
 
         // convert ignored contacts
         foreach ($isContact as $email => $lead) {
-            // do not call update
-            $integrationEntity     = $this->em->getReference('MauticPluginBundle:IntegrationEntity', $lead['id']);
-            $integrationEntities[] = $integrationEntity->setLastSyncDate(new \DateTime());
             $integrationId         = $integrationEntityRepo->getIntegrationsEntityId(
                 'Zoho',
                 'Leads',
@@ -1011,7 +1002,9 @@ class ZohoIntegration extends CrmAbstractIntegration
             );
             if (count($integrationId)) { // lead exists, then update
                 $integrationEntity     = $this->em->getReference('MauticPluginBundle:IntegrationEntity', $integrationId[0]['id']);
-                $integrationEntities[] = $integrationEntity->setInternalEntity('lead-converted');
+                $integrationEntity->setLastSyncDate(new \DateTime());
+                $integrationEntity->setInternalEntity('lead-converted');
+                $integrationEntities[] = $integrationEntity;
                 unset($leadsToUpdateInZ[$email]);
             }
         }
@@ -1287,7 +1280,7 @@ class ZohoIntegration extends CrmAbstractIntegration
         $availableFields = $this->getAvailableLeadFields(['feature_settings' => ['objects' => ['Leads', 'Contacts']]]);
         $selectColumns   = implode(',', array_keys($availableFields[$object]));
         $records         = $this->getApiHelper()->getSearchRecords($selectColumns, $seachColumn, $searchValue, $object);
-        $parsedRecords   = $this->parseZohoRecord($records, array_merge($availableFields[$object], ['LEADID' => ['dv'=>'LEADID']]));
+        $parsedRecords   = $this->parseZohoRecord($records, array_merge($availableFields[$object], ['LEADID' => ['dv'=>'LEADID']]), $object);
 
         return $parsedRecords;
     }
@@ -1344,5 +1337,66 @@ class ZohoIntegration extends CrmAbstractIntegration
         $failed   = $this->consumeResponse($response, $object, true);
         $counter -= $failed;
         $errorCounter += $failed;
+    }
+
+    /**
+     * @param       $fieldsToUpdate
+     * @param array $objects
+     *
+     * @return array
+     */
+    protected function cleanPriorityFields($fieldsToUpdate, $objects = null)
+    {
+        if (null === $objects) {
+            $objects = ['Leads', 'Contacts'];
+        }
+
+        if (isset($fieldsToUpdate['leadFields'])) {
+            // Pass in the whole config
+            $fields = $fieldsToUpdate;
+        } else {
+            $fields = array_flip($fieldsToUpdate);
+        }
+
+        $fieldsToUpdate = $this->prepareFieldsForSync($fields, $fieldsToUpdate, $objects);
+
+        return $fieldsToUpdate;
+    }
+
+    /**
+     * @param array $fields
+     * @param array $keys
+     * @param mixed $object
+     *
+     * @return array
+     */
+    public function prepareFieldsForSync($fields, $keys, $object = null)
+    {
+        $leadFields = [];
+        if (null === $object) {
+            $object = 'Leads';
+        }
+
+        $objects = (!is_array($object)) ? [$object] : $object;
+        if (is_string($object) && 'Accounts' === $object) {
+            return isset($fields['companyFields']) ? $fields['companyFields'] : $fields;
+        }
+
+        if (isset($fields['leadFields'])) {
+            $fields = $fields['leadFields'];
+            $keys   = array_keys($fields);
+        }
+
+        foreach ($objects as $obj) {
+            if (!isset($leadFields[$obj])) {
+                $leadFields[$obj] = [];
+            }
+
+            foreach ($keys as $key) {
+                $leadFields[$obj][$key] = $fields[$key];
+            }
+        }
+
+        return (is_array($object)) ? $leadFields : $leadFields[$object];
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | Y
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Add boolean field to Zoho sync.
Add company mapping to contact.
Fix sync for Contact.
Fix some warning like:
```
[2019-05-28 09:26:34] mautic.NOTICE: Doctrine\ORM\EntityNotFoundException: Entity of type 'Mautic\PluginBundle\Entity\IntegrationEntity' for IDs id(66) was not found (uncaught exception) at /vendor/doctrine/orm/lib/Doctrine/ORM/EntityNotFoundException.php line 47 while running console command `mautic:integration:fetchleads` [] []
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Install and configure Zoho
2. Map Company field, Lead field and Contact field
3. See that there is no Boolean in mapping
3. Launch command to sync `php app/console mautic:integration:fetchleads --time-interval=180minutes --integration=Zoho`
4. See that Zoho contact haves no company inside Mautic
5. See that there is some warning inside log.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7644)
2. Repeat step above
3. Everything works as expected
