### PR TITLE
404 Images in Email Webview when 'Convert embed images to Base64' is ON #7037

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -203,10 +203,10 @@ class MailHelper
      * @var array
      */
     protected $body = [
-        'content'           => '',
-        'embedMap'          => [],
-        'contentType'       => 'text/html',
-        'charset'           => null,
+        'content'     => '',
+        'embedMap'    => [],
+        'contentType' => 'text/html',
+        'charset'     => null,
     ];
 
     /**
@@ -681,10 +681,10 @@ class MailHelper
             $this->plainText           = '';
             $this->plainTextSet        = false;
             $this->body                = [
-                'content'           => '',
-                'embedMap'          => [],
-                'contentType'       => 'text/html',
-                'charset'           => null,
+                'content'     => '',
+                'embedMap'    => [],
+                'contentType' => 'text/html',
+                'charset'     => null,
             ];
         }
     }
@@ -984,10 +984,10 @@ class MailHelper
         $this->contentHash = md5($content.$this->plainText);
 
         $this->body = [
-            'content'           => $content,
-            'embedMap'          => $this->body['embedMap'],
-            'contentType'       => $contentType,
-            'charset'           => $charset,
+            'content'     => $content,
+            'embedMap'    => $this->body['embedMap'],
+            'contentType' => $contentType,
+            'charset'     => $charset,
         ];
     }
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | #7037
| BC breaks? | No
| Deprecations? | No

#### Description:
When using the `Convert embed images to Base64` feature, images with url as `src` are embedded in email using `cid` attachments.
The persisted version of the email `{webview_url}` can't show those images as it references the non existing (in the web view context) `cid's`.

#### Steps to reproduce the bug:
see in #7037

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. use steps from #7037
3. Make sure the webview shows the image properly

#### Solution
Save a map of the replaces made by the base64 feature, and revert those replace when persisting the email.