### PR TITLE
Fix number/boolean form field campaign condition

### DIFF
--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -12,7 +12,6 @@
 namespace Mautic\FormBundle\Entity;
 
 use Doctrine\DBAL\Query\QueryBuilder;
-use Doctrine\ORM\Query;
 use Mautic\CoreBundle\Entity\CommonRepository;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Entity\TimelineTrait;
@@ -424,16 +423,17 @@ class SubmissionRepository extends CommonRepository
     /**
      * Compare a form result value with defined value for defined lead.
      *
-     * @param int    $lead         ID
-     * @param int    $form         ID
-     * @param string $formAlias
-     * @param int    $field        alias
-     * @param string $value        to compare with
-     * @param string $operatorExpr for WHERE clause
+     * @param int         $lead         ID
+     * @param int         $form         ID
+     * @param string      $formAlias
+     * @param int         $field        alias
+     * @param string      $value        to compare with
+     * @param string      $operatorExpr for WHERE clause
+     * @param string|null $type
      *
      * @return bool
      */
-    public function compareValue($lead, $form, $formAlias, $field, $value, $operatorExpr)
+    public function compareValue($lead, $form, $formAlias, $field, $value, $operatorExpr, $type = null)
     {
         // Modify operator
         switch ($operatorExpr) {
@@ -459,13 +459,22 @@ class SubmissionRepository extends CommonRepository
             ->where(
                 $q->expr()->andX(
                     $q->expr()->eq('s.lead_id', ':lead'),
-                    $q->expr()->eq('s.form_id', ':form'),
-                    $q->expr()->$operatorExpr('r.'.$field, ':value')
+                    $q->expr()->eq('s.form_id', ':form')
                 )
             )
             ->setParameter('lead', (int) $lead)
-            ->setParameter('form', (int) $form)
+            ->setParameter('form', (int) $form);
+
+        switch ($type) {
+            case 'boolean':
+            case 'number':
+            $q->andWhere($q->expr()->$operatorExpr('r.'.$field, $value));
+                break;
+            default:
+        $q->andWhere($q->expr()->$operatorExpr('r.'.$field, ':value'))
             ->setParameter('value', $value);
+                break;
+        }
 
         $result = $q->execute()->fetch();
 

--- a/app/bundles/FormBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/CampaignSubscriber.php
@@ -125,13 +125,16 @@ class CampaignSubscriber implements EventSubscriberInterface
             return $event->setResult(false);
         }
 
+        $field = $this->formModel->findFormFieldByAlias($form, $event->getConfig()['field']);
+
         $result = $this->formSubmissionModel->getRepository()->compareValue(
             $lead->getId(),
             $form->getId(),
             $form->getAlias(),
             $event->getConfig()['field'],
             $event->getConfig()['value'],
-            $operators[$event->getConfig()['operator']]['expr']
+            $operators[$event->getConfig()['operator']]['expr'],
+            $field ? $field->getType() : null
         );
 
         $event->setChannel('form', $form->getId());

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -1122,4 +1122,21 @@ class FormModel extends CommonFormModel
             $formField->setProperties($formFieldProps);
         }
     }
+
+    /**
+     * @param Form   $form
+     * @param string $fieldAlias
+     *
+     * @return Field|null
+     */
+    public function findFormFieldByAlias(Form $form, $fieldAlias)
+    {
+        foreach ($form->getFields() as $field) {
+            if ($field->getAlias() === $fieldAlias) {
+                return $field;
+            }
+        }
+
+        return null;
+    }
 }

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -1124,7 +1124,6 @@ class FormModel extends CommonFormModel
     }
 
     /**
-     * @param Form   $form
      * @param string $fieldAlias
      *
      * @return Field|null


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Number and boolean condition from form results are processed as string equal function. This return not correctly results. For example it considers 15 smaller than 3,  it's because 1 comes before 3 alphabetical

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create form with number field type. 
2. Submit that form with value 3 in number field
3. Create campaign with Form field condition number form field > 15
4. Run campaign and see your contact passed (expect false)

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps
3. See correct condition results
