### PR TITLE
Default value overwrites on contact merge fix

### DIFF
--- a/app/bundles/LeadBundle/Deduplicate/ContactMerger.php
+++ b/app/bundles/LeadBundle/Deduplicate/ContactMerger.php
@@ -200,7 +200,13 @@ class ContactMerger
 
             try {
                 $defaultValue = ArrayHelper::getValue('default_value', $winner->getField($field));
-                $newValue     = MergeValueHelper::getMergeValue($newestFields[$field], $oldestFields[$field], $winner->getFieldValue($field), $defaultValue);
+                $newValue     = MergeValueHelper::getMergeValue(
+                    $newestFields[$field],
+                    $oldestFields[$field],
+                    $winner->getFieldValue($field),
+                    $defaultValue,
+                    $newest->isAnonymous()
+                );
                 $winner->addUpdatedField($field, $newValue);
 
                 $fromValue = empty($oldestFields[$field]) ? 'empty' : $oldestFields[$field];

--- a/app/bundles/LeadBundle/Deduplicate/ContactMerger.php
+++ b/app/bundles/LeadBundle/Deduplicate/ContactMerger.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\LeadBundle\Deduplicate;
 
+use Mautic\CoreBundle\Helper\ArrayHelper;
 use Mautic\LeadBundle\Deduplicate\Exception\SameContactException;
 use Mautic\LeadBundle\Deduplicate\Exception\ValueNotMergeableException;
 use Mautic\LeadBundle\Deduplicate\Helper\MergeValueHelper;
@@ -198,13 +199,14 @@ class ContactMerger
             }
 
             try {
-                $newValue = MergeValueHelper::getMergeValue($newestFields[$field], $oldestFields[$field], $winner->getFieldValue($field));
+                $defaultValue = ArrayHelper::getValue('default_value', $winner->getField($field));
+                $newValue     = MergeValueHelper::getMergeValue($newestFields[$field], $oldestFields[$field], $winner->getFieldValue($field), $defaultValue);
                 $winner->addUpdatedField($field, $newValue);
 
                 $fromValue = empty($oldestFields[$field]) ? 'empty' : $oldestFields[$field];
-                $this->logger->debug("CONTACT: Updated $field from $fromValue to $newValue for {$winner->getId()}");
+                $this->logger->debug("CONTACT: Updated {$field} from {$fromValue} to {$newValue} for {$winner->getId()}");
             } catch (ValueNotMergeableException $exception) {
-                $this->logger->info("CONTACT: $field is not mergeable for {$winner->getId()} - ".$exception->getMessage());
+                $this->logger->info("CONTACT: {$field} is not mergeable for {$winner->getId()} - {$exception->getMessage()}");
             }
         }
 

--- a/app/bundles/LeadBundle/Deduplicate/Helper/MergeValueHelper.php
+++ b/app/bundles/LeadBundle/Deduplicate/Helper/MergeValueHelper.php
@@ -36,7 +36,7 @@ class MergeValueHelper
             throw new ValueNotMergeableException($newerValue, $olderValue);
         }
 
-        $isDefaultValue = $defaultValue && $newerValue === $defaultValue;
+        $isDefaultValue = null !== $defaultValue && $newerValue === $defaultValue;
 
         if (self::isNotEmpty($newerValue) && !($newIsAnonymous && $isDefaultValue)) {
             return $newerValue;

--- a/app/bundles/LeadBundle/Deduplicate/Helper/MergeValueHelper.php
+++ b/app/bundles/LeadBundle/Deduplicate/Helper/MergeValueHelper.php
@@ -18,13 +18,14 @@ class MergeValueHelper
     /**
      * @param mixed $newerValue
      * @param mixed $olderValue
-     * @param null  $currentValue
+     * @param mixed $currentValue
+     * @param mixed $defaultValue
      *
      * @return mixed
      *
      * @throws ValueNotMergeableException
      */
-    public static function getMergeValue($newerValue, $olderValue, $currentValue = null)
+    public static function getMergeValue($newerValue, $olderValue, $currentValue = null, $defaultValue = null)
     {
         if ($newerValue === $olderValue) {
             throw new ValueNotMergeableException($newerValue, $olderValue);
@@ -34,7 +35,7 @@ class MergeValueHelper
             throw new ValueNotMergeableException($newerValue, $olderValue);
         }
 
-        if (self::isNotEmpty($newerValue)) {
+        if (self::isNotEmpty($newerValue) && $newerValue !== $defaultValue) {
             return $newerValue;
         }
 

--- a/app/bundles/LeadBundle/Deduplicate/Helper/MergeValueHelper.php
+++ b/app/bundles/LeadBundle/Deduplicate/Helper/MergeValueHelper.php
@@ -20,12 +20,13 @@ class MergeValueHelper
      * @param mixed $olderValue
      * @param mixed $currentValue
      * @param mixed $defaultValue
+     * @param bool  $newIsAnonymous
      *
      * @return mixed
      *
      * @throws ValueNotMergeableException
      */
-    public static function getMergeValue($newerValue, $olderValue, $currentValue = null, $defaultValue = null)
+    public static function getMergeValue($newerValue, $olderValue, $currentValue = null, $defaultValue = null, $newIsAnonymous = false)
     {
         if ($newerValue === $olderValue) {
             throw new ValueNotMergeableException($newerValue, $olderValue);
@@ -35,7 +36,9 @@ class MergeValueHelper
             throw new ValueNotMergeableException($newerValue, $olderValue);
         }
 
-        if (self::isNotEmpty($newerValue) && $newerValue !== $defaultValue) {
+        $isDefaultValue = $defaultValue && $newerValue === $defaultValue;
+
+        if (self::isNotEmpty($newerValue) && !($newIsAnonymous && $isDefaultValue)) {
             return $newerValue;
         }
 

--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -359,7 +359,7 @@ trait CustomFieldRepositoryTrait
         if (empty($this->customFieldList)) {
             //Get the list of custom fields
             $fq = $this->getEntityManager()->getConnection()->createQueryBuilder();
-            $fq->select('f.id, f.label, f.alias, f.type, f.field_group as "group", f.object, f.is_fixed, f.properties')
+            $fq->select('f.id, f.label, f.alias, f.type, f.field_group as "group", f.object, f.is_fixed, f.properties, f.default_value')
                 ->from(MAUTIC_TABLE_PREFIX.'lead_fields', 'f')
                 ->where('f.is_published = :published')
                 ->andWhere($fq->expr()->eq('object', ':object'))

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -448,6 +448,7 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
                 'id'      => 1,
                 'email'   => 'winner@test.com',
                 'consent' => 'Yes',
+                'boolean' => 1,
             ]);
 
         $loser->expects($this->once())
@@ -456,6 +457,7 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
                 'id'      => 2,
                 'email'   => null,
                 'consent' => 'No',
+                'boolean' => 0,
             ]);
 
         $winner->method('getDateModified')->willReturn($winnerDateModified);
@@ -464,14 +466,14 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
         $loser->method('getId')->willReturn(2);
         $loser->method('isAnonymous')->willReturn(true);
 
-        $winner->expects($this->exactly(2))
+        $winner->expects($this->exactly(3))
             ->method('getFieldValue')
-            ->withConsecutive(['email'], ['consent'])
-            ->will($this->onConsecutiveCalls('winner@test.com', 'Yes'));
+            ->withConsecutive(['email'], ['consent'], ['boolean'])
+            ->will($this->onConsecutiveCalls('winner@test.com', 'Yes', 1));
 
-        $winner->expects($this->exactly(2))
+        $winner->expects($this->exactly(3))
             ->method('getField')
-            ->withConsecutive(['email'], ['consent'])
+            ->withConsecutive(['email'], ['consent'], ['boolean'])
             ->will($this->onConsecutiveCalls([
                 'id'            => 22,
                 'label'         => 'Email',
@@ -490,13 +492,23 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
                 'object'        => 'lead',
                 'is_fixed'      => true,
                 'default_value' => 'No',
+            ],  [
+                'id'            => 45,
+                'label'         => 'Boolean Field',
+                'alias'         => 'boolean',
+                'type'          => 'boolean',
+                'group'         => 'core',
+                'object'        => 'lead',
+                'is_fixed'      => true,
+                'default_value' => 0,
             ]));
 
-        $winner->expects($this->exactly(2))
+        $winner->expects($this->exactly(3))
             ->method('addUpdatedField')
             ->withConsecutive(
                 ['email', 'winner@test.com'],
-                ['consent', 'Yes']
+                ['consent', 'Yes'],
+                ['boolean', 1]
             );
 
         $merger->mergeFieldData($winner, $loser);

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -462,6 +462,7 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
         $winner->method('getId')->willReturn(1);
         $loser->method('getDateModified')->willReturn($loserDateModified);
         $loser->method('getId')->willReturn(2);
+        $loser->method('isAnonymous')->willReturn(true);
 
         $winner->expects($this->exactly(2))
             ->method('getFieldValue')

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -491,7 +491,6 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
                 'default_value' => 'No',
             ]));
 
-
         $winner->expects($this->exactly(2))
             ->method('addUpdatedField')
             ->withConsecutive(

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -492,7 +492,7 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
                 'object'        => 'lead',
                 'is_fixed'      => true,
                 'default_value' => 'No',
-            ],  [
+            ], [
                 'id'            => 45,
                 'label'         => 'Boolean Field',
                 'alias'         => 'boolean',

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -53,25 +53,11 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->leadModel = $this->getMockBuilder(LeadModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->leadRepo = $this->getMockBuilder(LeadRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->mergeRecordRepo = $this->getMockBuilder(MergeRecordRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->dispatcher = $this->getMockBuilder(EventDispatcher::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->logger = $this->getMockBuilder(Logger::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->leadModel       = $this->createMock(LeadModel::class);
+        $this->leadRepo        = $this->createMock(LeadRepository::class);
+        $this->mergeRecordRepo = $this->createMock(MergeRecordRepository::class);
+        $this->dispatcher      = $this->createMock(EventDispatcher::class);
+        $this->logger          = $this->createMock(Logger::class);
 
         $this->leadModel->method('getRepository')->willReturn($this->leadRepo);
     }
@@ -183,6 +169,21 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
             ->with('email')
             ->willReturn('winner@test.com');
 
+        $winner->expects($this->once())
+            ->method('getField')
+            ->with('email')
+            ->willReturn([
+                'value'         => 'winner@test.com',
+                'id'            => 22,
+                'label'         => 'Email',
+                'alias'         => 'email',
+                'type'          => 'email',
+                'group'         => 'core',
+                'object'        => 'lead',
+                'is_fixed'      => true,
+                'default_value' => null,
+            ]);
+
         $winner->expects($this->exactly(3))
             ->method('getId')
             ->willReturn(1);
@@ -233,6 +234,22 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
         $winner->expects($this->exactly(2))
             ->method('getDateModified')
             ->willReturn($winnerDateModified);
+
+        $winner->expects($this->once())
+            ->method('getField')
+            ->with('email')
+            ->willReturn([
+                'value'         => 'winner@test.com',
+                'id'            => 22,
+                'label'         => 'Email',
+                'alias'         => 'email',
+                'type'          => 'email',
+                'group'         => 'core',
+                'object'        => 'lead',
+                'is_fixed'      => true,
+                'default_value' => null,
+            ]);
+
         $winner->expects($this->once())
             ->method('getFieldValue')
             ->with('email')
@@ -290,6 +307,22 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
         $winner->expects($this->exactly(2))
             ->method('getDateModified')
             ->willReturn($winnerDateModified);
+
+        $winner->expects($this->once())
+            ->method('getField')
+            ->with('email')
+            ->willReturn([
+                'value'         => 'winner@test.com',
+                'id'            => 22,
+                'label'         => 'Email',
+                'alias'         => 'email',
+                'type'          => 'email',
+                'group'         => 'core',
+                'object'        => 'lead',
+                'is_fixed'      => true,
+                'default_value' => null,
+            ]);
+
         $winner->expects($this->once())
             ->method('getFieldValue')
             ->with('email')
@@ -355,6 +388,22 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
         $winner->expects($this->once())
             ->method('getDateAdded')
             ->willReturn($winnerDateModified);
+
+        $winner->expects($this->once())
+            ->method('getField')
+            ->with('email')
+            ->willReturn([
+                'value'         => 'winner@test.com',
+                'id'            => 22,
+                'label'         => 'Email',
+                'alias'         => 'email',
+                'type'          => 'email',
+                'group'         => 'core',
+                'object'        => 'lead',
+                'is_fixed'      => true,
+                'default_value' => null,
+            ]);
+
         $winner->expects($this->once())
             ->method('getFieldValue')
             ->with('email')
@@ -375,6 +424,80 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
         // addUpdatedField should never be called as they aren't different values
         $winner->expects($this->never())
             ->method('addUpdatedField');
+
+        $merger->mergeFieldData($winner, $loser);
+    }
+
+    /**
+     * Scenario: A contact clicks on a tracked email link that goes to a tracked page.
+     * The browser must contain no Mautic cookies. A new contact is created with only default values.
+     * If default values from the new contact overwrite the values of the original contact then data are lost.
+     */
+    public function testMergeFieldDataWithDefaultValues()
+    {
+        $winner = $this->createMock(Lead::class);
+        $loser  = $this->createMock(Lead::class);
+        $merger = $this->getMerger();
+
+        $winnerDateModified = new \DateTime('-30 minutes');
+        $loserDateModified  = new \DateTime();
+
+        $winner->expects($this->once())
+            ->method('getProfileFields')
+            ->willReturn([
+                'id'      => 1,
+                'email'   => 'winner@test.com',
+                'consent' => 'Yes',
+            ]);
+
+        $loser->expects($this->once())
+            ->method('getProfileFields')
+            ->willReturn([
+                'id'      => 2,
+                'email'   => null,
+                'consent' => 'No',
+            ]);
+
+        $winner->method('getDateModified')->willReturn($winnerDateModified);
+        $winner->method('getId')->willReturn(1);
+        $loser->method('getDateModified')->willReturn($loserDateModified);
+        $loser->method('getId')->willReturn(2);
+
+        $winner->expects($this->exactly(2))
+            ->method('getFieldValue')
+            ->withConsecutive(['email'], ['consent'])
+            ->will($this->onConsecutiveCalls('winner@test.com', 'Yes'));
+
+        $winner->expects($this->exactly(2))
+            ->method('getField')
+            ->withConsecutive(['email'], ['consent'])
+            ->will($this->onConsecutiveCalls([
+                'id'            => 22,
+                'label'         => 'Email',
+                'alias'         => 'email',
+                'type'          => 'email',
+                'group'         => 'core',
+                'object'        => 'lead',
+                'is_fixed'      => true,
+                'default_value' => null,
+            ], [
+                'id'            => 44,
+                'label'         => 'Email Consent',
+                'alias'         => 'consent',
+                'type'          => 'select',
+                'group'         => 'core',
+                'object'        => 'lead',
+                'is_fixed'      => true,
+                'default_value' => 'No',
+            ]));
+
+
+        $winner->expects($this->exactly(2))
+            ->method('addUpdatedField')
+            ->withConsecutive(
+                ['email', 'winner@test.com'],
+                ['consent', 'Yes']
+            );
 
         $merger->mergeFieldData($winner, $loser);
     }
@@ -506,6 +629,22 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
             ->method('getFieldValue')
             ->with('email')
             ->willReturn('winner@test.com');
+
+        $winner->expects($this->once())
+            ->method('getField')
+            ->with('email')
+            ->willReturn([
+                'value'         => 'winner@test.com',
+                'id'            => 22,
+                'label'         => 'Email',
+                'alias'         => 'email',
+                'type'          => 'email',
+                'group'         => 'core',
+                'object'        => 'lead',
+                'is_fixed'      => true,
+                'default_value' => null,
+            ]);
+
         $winner->expects($this->once())
             ->method('addUpdatedField')
             ->with('email', 'loser@test.com');

--- a/app/bundles/LeadBundle/Tests/Deduplicate/Helper/MergeValueHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/Helper/MergeValueHelperTest.php
@@ -91,4 +91,17 @@ class MergeValueHelperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('bbb', $value);
     }
+
+    public function testGetMergeValueWhenNewerValueIsNotNullAndDefaultValueIsZero()
+    {
+        $newerValue     = 0;
+        $olderValue     = 1;
+        $winnerValue    = 1;
+        $defaultValue   = 0;
+        $newIsAnonymous = true;
+
+        $value = MergeValueHelper::getMergeValue($newerValue, $olderValue, $winnerValue, $defaultValue, $newIsAnonymous);
+
+        $this->assertSame($winnerValue, $value);
+    }
 }

--- a/app/bundles/LeadBundle/Tests/Deduplicate/Helper/MergeValueHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/Helper/MergeValueHelperTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Deduplicate\Helper;
+
+use Mautic\LeadBundle\Deduplicate\Exception\ValueNotMergeableException;
+use Mautic\LeadBundle\Deduplicate\Helper\MergeValueHelper;
+
+class MergeValueHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetMergeValueWhenNewAndOldValuesAreIdentical()
+    {
+        $newerValue     = 'bbb';
+        $olderValue     = 'bbb';
+        $winnerValue    = null;
+        $defaultValue   = null;
+        $newIsAnonymous = false;
+
+        $this->expectException(ValueNotMergeableException::class);
+        MergeValueHelper::getMergeValue($newerValue, $olderValue, $winnerValue, $defaultValue, $newIsAnonymous);
+    }
+
+    public function testGetMergeValueWhenNewAndWinnerValuesAreIdentical()
+    {
+        $newerValue     = 'bbb';
+        $olderValue     = 'aaa';
+        $winnerValue    = 'bbb';
+        $defaultValue   = null;
+        $newIsAnonymous = false;
+
+        $this->expectException(ValueNotMergeableException::class);
+        MergeValueHelper::getMergeValue($newerValue, $olderValue, $winnerValue, $defaultValue, $newIsAnonymous);
+    }
+
+    public function testGetMergeValueWhenNewerValueIsNotNull()
+    {
+        $newerValue     = 'aaa';
+        $olderValue     = 'bbb';
+        $winnerValue    = 'bbb';
+        $defaultValue   = null;
+        $newIsAnonymous = false;
+
+        $value = MergeValueHelper::getMergeValue($newerValue, $olderValue, $winnerValue, $defaultValue, $newIsAnonymous);
+
+        $this->assertSame('aaa', $value);
+    }
+
+    public function testGetMergeValueWhenNewerValueIsNotNullAndSameAsDefaultValueForAnonymousContact()
+    {
+        $newerValue     = 'aaa';
+        $olderValue     = 'bbb';
+        $winnerValue    = 'bbb';
+        $defaultValue   = 'aaa';
+        $newIsAnonymous = true;
+
+        $value = MergeValueHelper::getMergeValue($newerValue, $olderValue, $winnerValue, $defaultValue, $newIsAnonymous);
+
+        $this->assertSame('bbb', $value);
+    }
+
+    public function testGetMergeValueWhenNewerValueIsNotNullAndSameAsDefaultValueForIdentifiedContact()
+    {
+        $newerValue     = 'aaa';
+        $olderValue     = 'bbb';
+        $winnerValue    = 'bbb';
+        $defaultValue   = 'aaa';
+        $newIsAnonymous = false;
+
+        $value = MergeValueHelper::getMergeValue($newerValue, $olderValue, $winnerValue, $defaultValue, $newIsAnonymous);
+
+        $this->assertSame('aaa', $value);
+    }
+
+    public function testGetMergeValueWhenNewerValueIsNull()
+    {
+        $newerValue     = null;
+        $olderValue     = 'bbb';
+        $winnerValue    = 'bbb';
+        $defaultValue   = null;
+        $newIsAnonymous = false;
+
+        $value = MergeValueHelper::getMergeValue($newerValue, $olderValue, $winnerValue, $defaultValue, $newIsAnonymous);
+
+        $this->assertSame('bbb', $value);
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | ~~maybe https://github.com/mautic/mautic/issues/7558 and https://github.com/mautic/mautic/issues/7559~~
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

A contact clicks on a tracked email link that goes to a tracked page. The browser must contain no Mautic cookies. A new contact is created with only default values. If default values from the new contact overwrite the values of the original contact then data are lost. This PR ensures that a default value from newer contact won't overwrite the original value in the older contact.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
Step 1: Create a Custom Field called Email Consent with Select Data Type, with Yes and No labels and values and default value of No
Step 2: Create a Contact from within Mautic with a First Name, Last Name, Email and Email Consent set to Yes.
Step 3. Send an Email to the new Contact with a link to a Mautic-tracked page. Does not matter if a landing page or a page tracked by the tracking script. Just ensure that you are opening the tracked link in a fresh incognito window (no Mautic cookies) and if you test on local then add `index_dev.php` to the tracking URL. Otherwise it won't track the page it as localhost is excluded from tracked IPs.
Step 4. Refresh the contact edit/detail page. The value is set to No.


#### Steps to test this PR:
1. Edit the contact and set the value to Yes again.
2. Open the tracking URL in a fresh incognito window.
3. Refresh the contact edit/detail page. The value is still set to Yes.

