### PR TITLE
Reply API endpoint

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -48,6 +48,11 @@ return [
                 'controller' => 'MauticEmailBundle:Api\EmailApi:sendLead',
                 'method'     => 'POST',
             ],
+            'mautic_api_reply' => [
+                'path'       => '/emails/reply/{trackingHash}',
+                'controller' => 'MauticEmailBundle:Api\EmailApi:reply',
+                'method'     => 'POST',
+            ],
         ],
         'public' => [
             'mautic_plugin_tracker' => [

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -11,16 +11,16 @@
 
 namespace Mautic\EmailBundle\Controller\Api;
 
+use Doctrine\ORM\EntityNotFoundException;
 use Mautic\ApiBundle\Controller\CommonApiController;
 use Mautic\CoreBundle\Helper\InputHelper;
+use Mautic\CoreBundle\Helper\RandomHelper\RandomHelperInterface;
+use Mautic\EmailBundle\MonitoredEmail\Processor\Reply;
 use Mautic\LeadBundle\Controller\LeadAccessTrait;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
-/**
- * Class EmailApiController.
- */
 class EmailApiController extends CommonApiController
 {
     use LeadAccessTrait;
@@ -48,7 +48,7 @@ class EmailApiController extends CommonApiController
     /**
      * Obtains a list of emails.
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function getEntitiesAction()
     {
@@ -66,7 +66,7 @@ class EmailApiController extends CommonApiController
      *
      * @param int $id Email ID
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
@@ -105,7 +105,7 @@ class EmailApiController extends CommonApiController
      * @param int $id     Email ID
      * @param int $leadId Lead ID
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
@@ -164,5 +164,29 @@ class EmailApiController extends CommonApiController
         }
 
         return $this->notFound();
+    }
+
+    /**
+     * @param string $trackingHash
+     *
+     * @return Response
+     */
+    public function replyAction($trackingHash)
+    {
+        /** @var Reply $replyService */
+        $replyService = $this->get('mautic.message.processor.replier');
+
+        /** @var RandomHelperInterface $randomHelper */
+        $randomHelper = $this->get('mautic.helper.random');
+
+        try {
+            $replyService->createReplyByHash($trackingHash, "api-{$randomHelper->generate()}");
+        } catch (EntityNotFoundException $e) {
+            return $this->notFound($e->getMessage());
+        }
+
+        return $this->handleView(
+            $this->view(['success' => true], Response::HTTP_CREATED)
+        );
     }
 }

--- a/app/bundles/EmailBundle/Entity/EmailReply.php
+++ b/app/bundles/EmailBundle/Entity/EmailReply.php
@@ -16,9 +16,6 @@ use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Ramsey\Uuid\Uuid;
 
-/**
- * Class EmailReply.
- */
 class EmailReply
 {
     /**
@@ -85,9 +82,7 @@ class EmailReply
     }
 
     /**
-     * EmailReply constructor.
-     *
-     * @param $messageId
+     * @param string $messageId
      */
     public function __construct(Stat $stat, $messageId, \DateTime $dateReplied = null)
     {

--- a/app/bundles/EmailBundle/Entity/EmailReplyRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailReplyRepository.php
@@ -2,9 +2,9 @@
 
 namespace Mautic\EmailBundle\Entity;
 
+use Mautic\CoreBundle\Entity\CommonRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\TimelineTrait;
-use Mautic\CoreBundle\Entity\CommonRepository;
 
 /**
  * Class EmailReplyRepository.

--- a/app/bundles/EmailBundle/Entity/EmailReplyRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailReplyRepository.php
@@ -61,7 +61,7 @@ final class EmailReplyRepository extends CommonRepository implements EmailReplyR
         );
     }
 
-    private function getTableAlias(): string
+    public function getTableAlias(): string
     {
         return 'reply';
     }

--- a/app/bundles/EmailBundle/Entity/EmailReplyRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailReplyRepository.php
@@ -2,14 +2,14 @@
 
 namespace Mautic\EmailBundle\Entity;
 
-use Doctrine\ORM\EntityRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\TimelineTrait;
+use Mautic\CoreBundle\Entity\CommonRepository;
 
 /**
  * Class EmailReplyRepository.
  */
-final class EmailReplyRepository extends EntityRepository implements EmailReplyRepositoryInterface
+final class EmailReplyRepository extends CommonRepository implements EmailReplyRepositoryInterface
 {
     use TimelineTrait;
 

--- a/app/bundles/EmailBundle/Entity/Stat.php
+++ b/app/bundles/EmailBundle/Entity/Stat.php
@@ -228,8 +228,6 @@ class Stat
 
     /**
      * Prepares the metadata for API usage.
-     *
-     * @param ApiMetadataDriver $metadata
      */
     public static function loadApiMetadata(ApiMetadataDriver $metadata)
     {
@@ -297,9 +295,6 @@ class Stat
         return $this->email;
     }
 
-    /**
-     * @param Email|null $email
-     */
     public function setEmail(Email $email = null)
     {
         $this->email = $email;
@@ -361,9 +356,6 @@ class Stat
         return $this->lead;
     }
 
-    /**
-     * @param Lead|null $lead
-     */
     public function setLead(Lead $lead = null)
     {
         $this->lead = $lead;
@@ -521,9 +513,6 @@ class Stat
         return $this->tokens;
     }
 
-    /**
-     * @param array $tokens
-     */
     public function setTokens(array $tokens)
     {
         $this->tokens = $tokens;
@@ -601,8 +590,6 @@ class Stat
     }
 
     /**
-     * @param array $openDetails
-     *
      * @return Stat
      */
     public function setOpenDetails(array $openDetails)

--- a/app/bundles/EmailBundle/Entity/Stat.php
+++ b/app/bundles/EmailBundle/Entity/Stat.php
@@ -17,44 +17,42 @@ use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
 
-/**
- * Class Stat.
- */
 class Stat
 {
     /**
-     * @var int
+     * @var int|null
      */
     private $id;
 
     /**
-     * @var Email
+     * @var Email|null
      */
     private $email;
 
     /**
-     * @var \Mautic\LeadBundle\Entity\Lead
+     * @var Lead|null
      */
     private $lead;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $emailAddress;
 
     /**
-     * @var \Mautic\LeadBundle\Entity\LeadList
+     * @var LeadList|null
      */
     private $list;
 
     /**
-     * @var \Mautic\CoreBundle\Entity\IpAddress
+     * @var IpAddress|null
      */
     private $ipAddress;
 
     /**
-     * @var \DateTime
+     * @var \DateTime|null
      */
     private $dateSent;
 
@@ -74,12 +72,12 @@ class Stat
     private $viewedInBrowser = false;
 
     /**
-     * @var \DateTime
+     * @var \DateTime|null
      */
     private $dateRead;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $trackingHash;
 
@@ -89,12 +87,12 @@ class Stat
     private $retryCount = 0;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $source;
 
     /**
-     * @var int
+     * @var int|null
      */
     private $sourceId;
 
@@ -104,17 +102,17 @@ class Stat
     private $tokens = [];
 
     /**
-     * @var Copy
+     * @var Copy|null
      */
     private $storedCopy;
 
     /**
      * @var int
      */
-    private $openCount;
+    private $openCount = 0;
 
     /**
-     * @var \DateTime
+     * @var \DateTime|null
      */
     private $lastOpened;
 
@@ -231,7 +229,7 @@ class Stat
     /**
      * Prepares the metadata for API usage.
      *
-     * @param $metadata
+     * @param ApiMetadataDriver $metadata
      */
     public static function loadApiMetadata(ApiMetadataDriver $metadata)
     {
@@ -260,7 +258,7 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return \DateTime|null
      */
     public function getDateRead()
     {
@@ -268,7 +266,7 @@ class Stat
     }
 
     /**
-     * @param mixed $dateRead
+     * @param \DateTime|null $dateRead
      */
     public function setDateRead($dateRead)
     {
@@ -276,7 +274,7 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return \DateTime|null
      */
     public function getDateSent()
     {
@@ -284,7 +282,7 @@ class Stat
     }
 
     /**
-     * @param mixed $dateSent
+     * @param \DateTime|null $dateSent
      */
     public function setDateSent($dateSent)
     {
@@ -292,7 +290,7 @@ class Stat
     }
 
     /**
-     * @return Email
+     * @return Email|null
      */
     public function getEmail()
     {
@@ -300,7 +298,7 @@ class Stat
     }
 
     /**
-     * @param mixed $email
+     * @param Email|null $email
      */
     public function setEmail(Email $email = null)
     {
@@ -308,7 +306,7 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return id|null
      */
     public function getId()
     {
@@ -316,7 +314,7 @@ class Stat
     }
 
     /**
-     * @return IpAddress
+     * @return IpAddress|null
      */
     public function getIpAddress()
     {
@@ -324,7 +322,7 @@ class Stat
     }
 
     /**
-     * @param mixed $ip
+     * @param IpAddress|null $ip
      */
     public function setIpAddress(IpAddress $ip)
     {
@@ -332,7 +330,7 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return bool
      */
     public function getIsRead()
     {
@@ -340,7 +338,7 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return bool
      */
     public function isRead()
     {
@@ -348,7 +346,7 @@ class Stat
     }
 
     /**
-     * @param mixed $isRead
+     * @param bool $isRead
      */
     public function setIsRead($isRead)
     {
@@ -356,7 +354,7 @@ class Stat
     }
 
     /**
-     * @return Lead
+     * @return Lead|null
      */
     public function getLead()
     {
@@ -364,7 +362,7 @@ class Stat
     }
 
     /**
-     * @param mixed $lead
+     * @param Lead|null $lead
      */
     public function setLead(Lead $lead = null)
     {
@@ -372,7 +370,7 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getTrackingHash()
     {
@@ -380,7 +378,7 @@ class Stat
     }
 
     /**
-     * @param mixed $trackingHash
+     * @param string|null $trackingHash
      */
     public function setTrackingHash($trackingHash)
     {
@@ -388,7 +386,7 @@ class Stat
     }
 
     /**
-     * @return \Mautic\LeadBundle\Entity\LeadList
+     * @return LeadList|null
      */
     public function getList()
     {
@@ -396,7 +394,7 @@ class Stat
     }
 
     /**
-     * @param mixed $list
+     * @param LeadList|null $list
      */
     public function setList($list)
     {
@@ -404,7 +402,7 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getRetryCount()
     {
@@ -412,7 +410,7 @@ class Stat
     }
 
     /**
-     * @param mixed $retryCount
+     * @param int $retryCount
      */
     public function setRetryCount($retryCount)
     {
@@ -428,7 +426,7 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return bool
      */
     public function getIsFailed()
     {
@@ -436,7 +434,7 @@ class Stat
     }
 
     /**
-     * @param mixed $isFailed
+     * @param bool $isFailed
      */
     public function setIsFailed($isFailed)
     {
@@ -444,7 +442,7 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return bool
      */
     public function isFailed()
     {
@@ -452,7 +450,7 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getEmailAddress()
     {
@@ -460,7 +458,7 @@ class Stat
     }
 
     /**
-     * @param mixed $emailAddress
+     * @param string|null $emailAddress
      */
     public function setEmailAddress($emailAddress)
     {
@@ -468,7 +466,7 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return bool
      */
     public function getViewedInBrowser()
     {
@@ -476,7 +474,7 @@ class Stat
     }
 
     /**
-     * @param mixed $viewedInBrowser
+     * @param bool $viewedInBrowser
      */
     public function setViewedInBrowser($viewedInBrowser)
     {
@@ -484,7 +482,7 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getSource()
     {
@@ -492,7 +490,7 @@ class Stat
     }
 
     /**
-     * @param mixed $source
+     * @param string|null $source
      */
     public function setSource($source)
     {
@@ -500,7 +498,7 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return int|null
      */
     public function getSourceId()
     {
@@ -508,7 +506,7 @@ class Stat
     }
 
     /**
-     * @param mixed $sourceId
+     * @param int|null $sourceId
      */
     public function setSourceId($sourceId)
     {
@@ -516,7 +514,7 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return array
      */
     public function getTokens()
     {
@@ -524,15 +522,15 @@ class Stat
     }
 
     /**
-     * @param mixed $tokens
+     * @param array $tokens
      */
-    public function setTokens($tokens)
+    public function setTokens(array $tokens)
     {
         $this->tokens = $tokens;
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getOpenCount()
     {
@@ -540,7 +538,7 @@ class Stat
     }
 
     /**
-     * @param mixed $openCount
+     * @param int $openCount
      *
      * @return Stat
      */
@@ -552,7 +550,7 @@ class Stat
     }
 
     /**
-     * @param $details
+     * @param string $details
      */
     public function addOpenDetails($details)
     {
@@ -575,7 +573,7 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return \DateTime|null
      */
     public function getLastOpened()
     {
@@ -583,7 +581,7 @@ class Stat
     }
 
     /**
-     * @param mixed $lastOpened
+     * @param \DateTime|null $lastOpened
      *
      * @return Stat
      */
@@ -595,7 +593,7 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return array
      */
     public function getOpenDetails()
     {
@@ -603,11 +601,11 @@ class Stat
     }
 
     /**
-     * @param mixed $openDetails
+     * @param array $openDetails
      *
      * @return Stat
      */
-    public function setOpenDetails($openDetails)
+    public function setOpenDetails(array $openDetails)
     {
         $this->openDetails = $openDetails;
 
@@ -615,7 +613,7 @@ class Stat
     }
 
     /**
-     * @return Copy
+     * @return Copy|null
      */
     public function getStoredCopy()
     {

--- a/app/bundles/EmailBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/StatsSubscriber.php
@@ -16,43 +16,47 @@ use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatDevice;
+use Mautic\EmailBundle\Entity\EmailReply;
+use Mautic\EmailBundle\Entity\StatDeviceRepository;
+use MauticPlugin\MauticFocusBundle\Entity\StatRepository;
 
 class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(CorePermissions $security, EntityManager $entityManager)
     {
         parent::__construct($security, $entityManager);
-        $this->repositories[]             = $repo             = $entityManager->getRepository(StatDevice::class);
-        $devicesTable                     = $repo->getTableName();
-        $this->permissions[$devicesTable] = [
-            'stat.lead' => 'lead:leads',
-        ];
 
-        $this->repositories[]       = $repo       = $entityManager->getRepository(Stat::class);
-        $statsTable                 = $repo->getTableName();
-        $this->selects[$statsTable] =
-            [
-                'id',
-                'email_id',
-                'lead_id',
-                'list_id',
-                'ip_id',
-                'email_address',
-                'date_sent',
-                'is_read',
-                'is_failed',
-                'viewed_in_browser',
-                'date_read',
-                'tracking_hash',
-                'retry_count',
-                'source',
-                'source_id',
-                'open_count',
-                'last_opened',
-                'open_details',
-            ];
-        $this->permissions[$statsTable] = [
-            'lead' => 'lead:leads',
+        /** @var StatDeviceRepository $repo */
+        $repo                                     = $entityManager->getRepository(StatDevice::class);
+        $this->repositories[]                     = $repo;
+        $this->permissions[$repo->getTableName()] = ['stat.lead' => 'lead:leads'];
+
+        $this->addContactRestrictedRepositories([EmailReply::class]);
+
+        /** @var StatRepository $repo */
+        $repo                           = $entityManager->getRepository(Stat::class);
+        $this->repositories[]           = $repo;
+        $statsTable                     = $repo->getTableName();
+        $this->permissions[$statsTable] = ['lead' => 'lead:leads',];
+        $this->selects[$statsTable]     = [
+            'id',
+            'email_id',
+            'lead_id',
+            'list_id',
+            'ip_id',
+            'email_address',
+            'date_sent',
+            'is_read',
+            'is_failed',
+            'viewed_in_browser',
+            'date_read',
+            'tracking_hash',
+            'retry_count',
+            'source',
+            'source_id',
+            'open_count',
+            'last_opened',
+            'open_details',
         ];
     }
 }

--- a/app/bundles/EmailBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/StatsSubscriber.php
@@ -14,9 +14,9 @@ namespace Mautic\EmailBundle\EventListener;
 use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
+use Mautic\EmailBundle\Entity\EmailReply;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatDevice;
-use Mautic\EmailBundle\Entity\EmailReply;
 use Mautic\EmailBundle\Entity\StatDeviceRepository;
 use MauticPlugin\MauticFocusBundle\Entity\StatRepository;
 
@@ -37,7 +37,7 @@ class StatsSubscriber extends CommonStatsSubscriber
         $repo                           = $entityManager->getRepository(Stat::class);
         $this->repositories[]           = $repo;
         $statsTable                     = $repo->getTableName();
-        $this->permissions[$statsTable] = ['lead' => 'lead:leads',];
+        $this->permissions[$statsTable] = ['lead' => 'lead:leads'];
         $this->selects[$statsTable]     = [
             'id',
             'email_id',

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Reply.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Reply.php
@@ -174,9 +174,6 @@ class Reply implements ProcessorInterface
         return strtolower(preg_replace("/[^a-z0-9\.@]/i", '', $email));
     }
 
-    /**
-     * @param Stat $stat
-     */
     private function dispatchEvent(Stat $stat)
     {
         if ($this->dispatcher->hasListeners(EmailEvents::EMAIL_ON_REPLY)) {

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Reply.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Reply.php
@@ -129,7 +129,11 @@ class Reply implements ProcessorInterface
             throw new EntityNotFoundException("Email Stat with tracking hash {$trackingHash} was not found");
         }
 
-        $stat->isRead(true);
+        $stat->setIsRead(true);
+
+        if (null === $stat->getDateRead()) {
+            $stat->setDateRead(new \DateTime());
+        }
 
         $this->createReply($stat, $messageId);
 

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Reply.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Reply.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\EmailBundle\MonitoredEmail\Processor;
 
+use Doctrine\ORM\EntityNotFoundException;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\EmailReply;
 use Mautic\EmailBundle\Entity\Stat;
@@ -54,18 +55,10 @@ class Reply implements ProcessorInterface
     private $logger;
 
     /**
-     * @var Message
-     */
-    private $message;
-
-    /**
      * @var ContactTracker
      */
     private $contactTracker;
 
-    /**
-     * Reply constructor.
-     */
     public function __construct(
         StatRepository $statRepository,
         ContactFinder $contactFinder,
@@ -84,9 +77,7 @@ class Reply implements ProcessorInterface
 
     public function process(Message $message)
     {
-        $this->message = $message;
-
-        $this->logger->debug('MONITORED EMAIL: Processing message ID '.$this->message->id.' for a reply');
+        $this->logger->debug('MONITORED EMAIL: Processing message ID '.$message->id.' for a reply');
 
         try {
             $parser       = new Parser($message);
@@ -118,30 +109,50 @@ class Reply implements ProcessorInterface
             return;
         }
 
-        $this->createReply($stat);
-
-        if ($this->dispatcher->hasListeners(EmailEvents::EMAIL_ON_REPLY)) {
-            $this->contactTracker->setSystemContact($stat->getLead());
-
-            $event = new EmailReplyEvent($stat);
-            $this->dispatcher->dispatch(EmailEvents::EMAIL_ON_REPLY, $event);
-            unset($event);
-        }
+        $this->createReply($stat, $message->id);
+        $this->dispatchEvent($stat);
 
         $this->statRepo->clear();
         $this->leadModel->clearEntities();
     }
 
-    protected function createReply(Stat $stat)
+    /**
+     * @param string $trackingHash
+     * @param string $messageId
+     */
+    public function createReplyByHash($trackingHash, $messageId)
+    {
+        /** @var Stat|null $stat */
+        $stat = $this->statRepo->findOneBy(['trackingHash' => $trackingHash]);
+
+        if (null === $stat) {
+            throw new EntityNotFoundException("Email Stat with tracking hash {$trackingHash} was not found");
+        }
+
+        $stat->isRead(true);
+
+        $this->createReply($stat, $messageId);
+
+        $contact = $stat->getLead();
+
+        if ($contact) {
+            $this->dispatchEvent($stat);
+        }
+    }
+
+    /**
+     * @param string $messageId
+     */
+    protected function createReply(Stat $stat, $messageId)
     {
         $replies = $stat->getReplies()->filter(
-            function (EmailReply $reply) {
-                return $reply->getMessageId() === $this->message->id;
+            function (EmailReply $reply) use ($messageId) {
+                return $reply->getMessageId() === $messageId;
             }
         );
 
         if (!$replies->count()) {
-            $emailReply = new EmailReply($stat, $this->message->id);
+            $emailReply = new EmailReply($stat, $messageId);
             $stat->addReply($emailReply);
             $this->statRepo->saveEntity($stat);
         }
@@ -157,5 +168,19 @@ class Reply implements ProcessorInterface
     protected function cleanEmail($email)
     {
         return strtolower(preg_replace("/[^a-z0-9\.@]/i", '', $email));
+    }
+
+    /**
+     * @param Stat $stat
+     */
+    private function dispatchEvent(Stat $stat)
+    {
+        if ($this->dispatcher->hasListeners(EmailEvents::EMAIL_ON_REPLY)) {
+            $this->contactTracker->setTrackedContact($stat->getLead());
+
+            $event = new EmailReplyEvent($stat);
+            $this->dispatcher->dispatch(EmailEvents::EMAIL_ON_REPLY, $event);
+            unset($event);
+        }
     }
 }

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
@@ -11,7 +11,10 @@
 
 namespace Mautic\EmailBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\Util\Codes;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Entity\StatRepository;
 
 class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
 {
@@ -138,5 +141,50 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->assertSame(['lists' => []], $response);
         $this->assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+    }
+
+    public function testReplyActionIfNotFound()
+    {
+        $trackingHash = 'tracking_hash_123';
+
+        // Create new email reply.
+        $this->client->request('POST', "/api/emails/reply/{$trackingHash}");
+        $response     = $this->client->getResponse();
+        $responseData = json_decode($response->getContent(), true);
+
+        $this->assertSame(Codes::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame('Email Stat with tracking hash tracking_hash_123 was not found', $responseData['errors'][0]['message']);
+    }
+
+    public function testReplyAction()
+    {
+        $trackingHash = 'tracking_hash_123';
+
+        /** @var StatRepository $statRepository */
+        $statRepository = $this->container->get('mautic.email.repository.stat');
+
+        // Create a test email stat.
+        $stat = new Stat();
+        $stat->setTrackingHash($trackingHash);
+        $stat->setEmailAddress('john@doe.email');
+        $stat->setDateSent(new \DateTime());
+
+        $statRepository->saveEntity($stat);
+
+        // Create new email reply.
+        $this->client->request('POST', "/api/emails/reply/{$trackingHash}");
+        $response = $this->client->getResponse();
+
+        $this->assertSame(Codes::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame(['success' => true], json_decode($response->getContent(), true));
+
+        // Get the email reply that was just created from the stat API.
+        $statReplyQuery = ['where' => [['col' => 'stat_id', 'expr' => 'eq', 'val' => $stat->getId()]]];
+        $this->client->request('GET', '/api/stats/email_stat_replies', $statReplyQuery);
+        $fetchedReplyData = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertSame('1', $fetchedReplyData['total']);
+        $this->assertSame($stat->getId(), $fetchedReplyData['stats'][0]['stat_id']);
+        $this->assertRegExp('/api-[a-z0-9]*/', $fetchedReplyData['stats'][0]['message_id']);
     }
 }

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
@@ -11,10 +11,10 @@
 
 namespace Mautic\EmailBundle\Tests\Controller\Api;
 
-use FOS\RestBundle\Util\Codes;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
+use Symfony\Component\HttpFoundation\Response;
 
 class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
 {
@@ -152,7 +152,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $response     = $this->client->getResponse();
         $responseData = json_decode($response->getContent(), true);
 
-        $this->assertSame(Codes::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
         $this->assertSame('Email Stat with tracking hash tracking_hash_123 was not found', $responseData['errors'][0]['message']);
     }
 
@@ -175,7 +175,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', "/api/emails/reply/{$trackingHash}");
         $response = $this->client->getResponse();
 
-        $this->assertSame(Codes::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
         $this->assertSame(['success' => true], json_decode($response->getContent(), true));
 
         // Get the email reply that was just created from the stat API.

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
@@ -183,8 +183,20 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('GET', '/api/stats/email_stat_replies', $statReplyQuery);
         $fetchedReplyData = json_decode($this->client->getResponse()->getContent(), true);
 
+        // Check that the email reply was created correctly.
         $this->assertSame('1', $fetchedReplyData['total']);
         $this->assertSame($stat->getId(), $fetchedReplyData['stats'][0]['stat_id']);
         $this->assertRegExp('/api-[a-z0-9]*/', $fetchedReplyData['stats'][0]['message_id']);
+
+        // Get the email stat that was just updated from the stat API.
+        $statQuery = ['where' => [['col' => 'id', 'expr' => 'eq', 'val' => $stat->getId()]]];
+        $this->client->request('GET', '/api/stats/email_stats', $statQuery);
+        $fetchedStatData = json_decode($this->client->getResponse()->getContent(), true);
+
+        // Check that the email stat was updated correctly/
+        $this->assertSame('1', $fetchedStatData['total']);
+        $this->assertSame($stat->getId(), $fetchedStatData['stats'][0]['id']);
+        $this->assertSame('1', $fetchedStatData['stats'][0]['is_read']);
+        $this->assertRegExp('/\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}/', $fetchedStatData['stats'][0]['date_read']);
     }
 }

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
@@ -11,9 +11,14 @@
 
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Processor;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\EntityNotFoundException;
+use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\EmailReply;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\EmailBundle\Event\EmailReplyEvent;
 use Mautic\EmailBundle\MonitoredEmail\Message;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Reply;
 use Mautic\EmailBundle\MonitoredEmail\Search\ContactFinder;
@@ -23,11 +28,6 @@ use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Monolog\Logger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Doctrine\ORM\EntityNotFoundException;
-use Doctrine\Common\Collections\ArrayCollection;
-use Mautic\EmailBundle\Entity\EmailReply;
-use Mautic\EmailBundle\EmailEvents;
-use Mautic\EmailBundle\Event\EmailReplyEvent;
 
 class ReplyTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
@@ -11,7 +11,7 @@
 
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Processor;
 
-use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Coåmmon\Collections\ArrayCollection;
 use Doctrine\ORM\EntityNotFoundException;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\Email;
@@ -136,8 +136,16 @@ BODY;
             ->willReturn($stat);
 
         $stat->expects($this->once())
-            ->method('isRead')
+            ->method('setIsRead')
             ->with(true);
+
+        $stat->expects($this->once())
+            ->method('getDateRead')
+            ->willReturn(null);
+
+        $stat->expects($this->once())
+            ->method('setDateRead')
+            ->with($this->isInstanceOf(\DateTime::class));
 
         $stat->expects($this->any())
             ->method('getReplies')

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
@@ -11,7 +11,7 @@
 
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Processor;
 
-use Doctrine\Coåmmon\Collections\ArrayCollection;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityNotFoundException;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\Email;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
@@ -136,10 +136,6 @@ BODY;
             ->willReturn($stat);
 
         $stat->expects($this->once())
-            ->method('getIsRead')
-            ->willReturn(false);
-
-        $stat->expects($this->once())
             ->method('isRead')
             ->with(true);
 

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
@@ -36,6 +36,7 @@ class ReplyTest extends \PHPUnit\Framework\TestCase
     private $leadModel;
     private $dispatcher;
     private $logger;
+    private $contactTracker;
 
     /**
      * @var Reply
@@ -46,18 +47,20 @@ class ReplyTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->statRepo      = $this->createMock(StatRepository::class);
-        $this->contactFinder = $this->createMock(ContactFinder::class);
-        $this->leadModel     = $this->createMock(LeadModel::class);
-        $this->leadModel     = $this->createMock(LeadModel::class);
-        $this->dispatcher    = $this->createMock(EventDispatcherInterface::class);
-        $this->logger        = $this->createMock(Logger::class);
-        $this->processor     = new Reply(
+        $this->statRepo       = $this->createMock(StatRepository::class);
+        $this->contactFinder  = $this->createMock(ContactFinder::class);
+        $this->leadModel      = $this->createMock(LeadModel::class);
+        $this->leadModel      = $this->createMock(LeadModel::class);
+        $this->dispatcher     = $this->createMock(EventDispatcherInterface::class);
+        $this->logger         = $this->createMock(Logger::class);
+        $this->contactTracker = $this->createMock(ContactTracker::class);
+        $this->processor      = new Reply(
             $this->statRepo,
             $this->contactFinder,
             $this->leadModel,
             $this->dispatcher,
-            $this->logger
+            $this->logger,
+            $this->contactTracker
         );
     }
 
@@ -173,8 +176,8 @@ BODY;
             ->with(EmailEvents::EMAIL_ON_REPLY)
             ->willReturn(true);
 
-        $this->leadModel->expects($this->once())
-            ->method('setSystemCurrentLead')
+        $this->contactTracker->expects($this->once())
+            ->method('setTrackedContact')
             ->with($contact);
 
         $this->dispatcher->expects($this->once())


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/125
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR adds new `POST api/emails/reply/{trackingHash}` API endpoint that can create a record about an email reply to some specific email stat that is identified by the `trackingHash`.

#### Steps to test this PR:
1. Execute `POST api/emails/reply/{trackingHash}` while authenticated to Mautic API and use a tracking hash from one of the records in the `email_stats` table.
2. It should create a new record in the `email_stat_replies` table and mark the `email_stats` record as read if not already.
3. The `GET api/stats` endpoint now contains also `email_stat_replies` table.

