### PR TITLE
Fix field merge condition for merging contacts

### DIFF
--- a/app/bundles/LeadBundle/Deduplicate/ContactMerger.php
+++ b/app/bundles/LeadBundle/Deduplicate/ContactMerger.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\LeadBundle\Deduplicate;
 
+use Mautic\CoreBundle\Helper\ArrayHelper;
 use Mautic\LeadBundle\Deduplicate\Exception\SameContactException;
 use Mautic\LeadBundle\Deduplicate\Exception\ValueNotMergeableException;
 use Mautic\LeadBundle\Deduplicate\Helper\MergeValueHelper;
@@ -198,13 +199,26 @@ class ContactMerger
             }
 
             try {
-                $newValue = MergeValueHelper::getMergeValue($newestFields[$field], $oldestFields[$field], $winner->getFieldValue($field));
+                $fromValue    = empty($oldestFields[$field]) ? 'empty' : $oldestFields[$field];
+                $fieldDetails = $winner->getField($field);
+
+                if ($fieldDetails === false) {
+                    throw new ValueNotMergeableException($fromValue, false);
+                }
+
+                $defaultValue = ArrayHelper::getValue('default_value', $fieldDetails);
+                $newValue     = MergeValueHelper::getMergeValue(
+                    $newestFields[$field],
+                    $oldestFields[$field],
+                    $winner->getFieldValue($field),
+                    $defaultValue,
+                    $newest->isAnonymous()
+                );
                 $winner->addUpdatedField($field, $newValue);
 
-                $fromValue = empty($oldestFields[$field]) ? 'empty' : $oldestFields[$field];
-                $this->logger->debug("CONTACT: Updated $field from $fromValue to $newValue for {$winner->getId()}");
+                $this->logger->debug("CONTACT: Updated {$field} from {$fromValue} to {$newValue} for {$winner->getId()}");
             } catch (ValueNotMergeableException $exception) {
-                $this->logger->info("CONTACT: $field is not mergeable for {$winner->getId()} - ".$exception->getMessage());
+                $this->logger->info("CONTACT: {$field} is not mergeable for {$winner->getId()} - {$exception->getMessage()}");
             }
         }
 

--- a/app/bundles/LeadBundle/Deduplicate/Helper/MergeValueHelper.php
+++ b/app/bundles/LeadBundle/Deduplicate/Helper/MergeValueHelper.php
@@ -18,13 +18,15 @@ class MergeValueHelper
     /**
      * @param mixed $newerValue
      * @param mixed $olderValue
-     * @param null  $currentValue
+     * @param mixed $currentValue
+     * @param mixed $defaultValue
+     * @param bool  $newIsAnonymous
      *
      * @return mixed
      *
      * @throws ValueNotMergeableException
      */
-    public static function getMergeValue($newerValue, $olderValue, $currentValue = null)
+    public static function getMergeValue($newerValue, $olderValue, $currentValue = null, $defaultValue = null, $newIsAnonymous = false)
     {
         if ($newerValue === $olderValue) {
             throw new ValueNotMergeableException($newerValue, $olderValue);
@@ -34,7 +36,9 @@ class MergeValueHelper
             throw new ValueNotMergeableException($newerValue, $olderValue);
         }
 
-        if (self::isNotEmpty($newerValue)) {
+        $isDefaultValue = null !== $defaultValue && $newerValue === $defaultValue;
+
+        if (self::isNotEmpty($newerValue) && !($newIsAnonymous && $isDefaultValue)) {
             return $newerValue;
         }
 

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -183,6 +183,21 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
             ->with('email')
             ->willReturn('winner@test.com');
 
+        $winner->expects($this->once())
+            ->method('getField')
+            ->with('email')
+            ->willReturn([
+                'value'         => 'winner@test.com',
+                'id'            => 22,
+                'label'         => 'Email',
+                'alias'         => 'email',
+                'type'          => 'email',
+                'group'         => 'core',
+                'object'        => 'lead',
+                'is_fixed'      => true,
+                'default_value' => null,
+            ]);
+
         $winner->expects($this->exactly(3))
             ->method('getId')
             ->willReturn(1);
@@ -233,6 +248,22 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
         $winner->expects($this->exactly(2))
             ->method('getDateModified')
             ->willReturn($winnerDateModified);
+
+        $winner->expects($this->once())
+            ->method('getField')
+            ->with('email')
+            ->willReturn([
+                'value'         => 'winner@test.com',
+                'id'            => 22,
+                'label'         => 'Email',
+                'alias'         => 'email',
+                'type'          => 'email',
+                'group'         => 'core',
+                'object'        => 'lead',
+                'is_fixed'      => true,
+                'default_value' => null,
+            ]);
+
         $winner->expects($this->once())
             ->method('getFieldValue')
             ->with('email')
@@ -290,6 +321,22 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
         $winner->expects($this->exactly(2))
             ->method('getDateModified')
             ->willReturn($winnerDateModified);
+
+        $winner->expects($this->once())
+            ->method('getField')
+            ->with('email')
+            ->willReturn([
+                'value'         => 'winner@test.com',
+                'id'            => 22,
+                'label'         => 'Email',
+                'alias'         => 'email',
+                'type'          => 'email',
+                'group'         => 'core',
+                'object'        => 'lead',
+                'is_fixed'      => true,
+                'default_value' => null,
+            ]);
+
         $winner->expects($this->once())
             ->method('getFieldValue')
             ->with('email')
@@ -355,6 +402,22 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
         $winner->expects($this->once())
             ->method('getDateAdded')
             ->willReturn($winnerDateModified);
+
+        $winner->expects($this->once())
+            ->method('getField')
+            ->with('email')
+            ->willReturn([
+                'value'         => 'winner@test.com',
+                'id'            => 22,
+                'label'         => 'Email',
+                'alias'         => 'email',
+                'type'          => 'email',
+                'group'         => 'core',
+                'object'        => 'lead',
+                'is_fixed'      => true,
+                'default_value' => null,
+            ]);
+
         $winner->expects($this->once())
             ->method('getFieldValue')
             ->with('email')
@@ -506,6 +569,22 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
             ->method('getFieldValue')
             ->with('email')
             ->willReturn('winner@test.com');
+
+        $winner->expects($this->once())
+            ->method('getField')
+            ->with('email')
+            ->willReturn([
+                'value'         => 'winner@test.com',
+                'id'            => 22,
+                'label'         => 'Email',
+                'alias'         => 'email',
+                'type'          => 'email',
+                'group'         => 'core',
+                'object'        => 'lead',
+                'is_fixed'      => true,
+                'default_value' => null,
+            ]);
+
         $winner->expects($this->once())
             ->method('addUpdatedField')
             ->with('email', 'loser@test.com');

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -12,6 +12,7 @@
 namespace Mautic\LeadBundle\Tests\Deduplicate;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Mautic\CampaignBundle\Executioner\Scheduler\Mode\DateTime;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\LeadBundle\Deduplicate\ContactMerger;
 use Mautic\LeadBundle\Deduplicate\Exception\SameContactException;
@@ -531,6 +532,45 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
             ->with($winner, [], null, false);
 
         $this->getMerger()->merge($winner, $loser);
+    }
+
+    public function testMergeFieldWithEmptyFieldData()
+    {
+        $loser = $this->createMock(Lead::class);
+        $winner = $this->createMock(Lead::class);
+
+        $loser->expects($this->exactly(2))
+            ->method('getDateModified')
+            ->willReturn(new \DateTime('-10 minutes'));
+
+        $winner->expects($this->exactly(2))
+            ->method('getDateModified')
+            ->willReturn(new \DateTime());
+
+        $winner->expects($this->exactly(4))
+            ->method('getId')
+            ->willReturn(1);
+
+        $loser->expects($this->exactly(1))
+            ->method('getId')
+            ->willReturn(2);
+
+        $winner->expects($this->once())
+            ->method('getProfileFields')
+            ->willReturn([
+                'email'  => 'winner@test.com',
+            ]);
+
+        $winner->expects($this->once())
+            ->method('getField')
+            ->with('email')
+            ->willReturn(false);
+
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with('CONTACT: email is not mergeable for 1 - ');
+
+        $this->getMerger()->mergeFieldData($winner, $loser);
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -12,7 +12,6 @@
 namespace Mautic\LeadBundle\Tests\Deduplicate;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Mautic\CampaignBundle\Executioner\Scheduler\Mode\DateTime;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\LeadBundle\Deduplicate\ContactMerger;
 use Mautic\LeadBundle\Deduplicate\Exception\SameContactException;
@@ -536,7 +535,7 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
 
     public function testMergeFieldWithEmptyFieldData()
     {
-        $loser = $this->createMock(Lead::class);
+        $loser  = $this->createMock(Lead::class);
         $winner = $this->createMock(Lead::class);
 
         $loser->expects($this->exactly(2))
@@ -551,7 +550,7 @@ class ContactMergerTest extends \PHPUnit_Framework_TestCase
             ->method('getId')
             ->willReturn(1);
 
-        $loser->expects($this->exactly(1))
+        $loser->expects($this->once())
             ->method('getId')
             ->willReturn(2);
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
There is a bug probably when merging contacts and code expects array and gets false from \Mautic\LeadBundle\Entity\CustomFieldEntityTrait::getField().

When merging to community I discovered many differences between community and cloud code, so this became enhancement and sinc.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. We don't know, but reported by our customer and fixed by this.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Test contact merge

