### PR TITLE
Add query to apply MySQL defaults to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ By contributing to this project, you accept and agree to the [Contributors Agree
 	- recommended: `openssl`, `opcache` / `apcu` / `memcached`
 	- recommended for development: `xdebug`
 3. Recommended memory limit: minimally 256 MB for testing, 512 MB and more for production.
-4. Disabling `ONLY_FULL_GROUP_BY` on the mySQL server.
+4. Recommended MySQL defaults can be set by running the queries `SET GLOBAL innodb_default_row_format=DYNAMIC; SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));`
 
 ## Installation
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |  #5328 #6471
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
sql_mode does not include "ONLY_FULL_GROUP_BY" by default in stock MySQL, but it causes various problems in Mautic if enabled as Mautic is not compatible with that strict convention. innodb_default_row_format is "dynamic" by default in MySQL 5.7+ but there is no downside to setting this early with ~5.6 as it allows a smoother upgrade path, performance benefits, and reduced index limitations. We could set these (at the session level) during installation/migration/plugin-update automatically in the future and remove the need to explain this.