### PR TITLE
bad error handling on scheduled email events causing email blast!

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1481,7 +1481,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         $this->sendModel->finalFlush();
 
         // Get the errors to return
-        $errorMessages  = array_merge($errors, $this->sendModel->getErrors());
+        $errorMessages  = $errors + $this->sendModel->getErrors();
         $failedContacts = $this->sendModel->getFailedContacts();
 
         // Get sent counts to update email stats


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | No
| Deprecations? | No

#### Description:

When errors occur during email sending in scheduled events, the lead ids that had errors get "disappeared" causing the error handler to not find them, causing the entire `mautic:campaigns:trigger->triggerCampaign` flow to end without persisting the data.
This causes emails to be sent over and over again as the event log is never marked as handled even though mails are sent!

This bug caused mautic to sends hundreds of transnational emails per client! I think we should think of a feature to add to mautic to add rate limiting, so even if this scenario happens again, at least the leads won't get blasted with emails...

#### Steps to reproduce the bug:
1. Create a campaign with a __transactional__ email step that is scheduled (ie for 1 minute later)
2. Make sure that emails can't be sent (ie set bad credentials to the email transport)
3. trigger the campign with a user
4. execute the `mautic:campaigns:trigger` command and make sure the email was scheduled
5. wait until the email should be sent
6. execute the `mautic:campaigns:trigger` command - you should see a similar output:

```bash
Triggering events for campaign 1
Triggering events for newly added contacts
1 total events(s) to be processed in batches of 100 contacts
 1/1 [============================] 100%


3 total events were executed
0 total events were scheduled

Triggering scheduled events
1 total events(s) to be processed in batches of 100 contacts
 1/1 [============================] 100%
 1/1 [============================] 100%

Triggering events for campaign 2
```

Notice that instead of continuing, it skipped to the next campaign.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. follow same steps to reproduce and notice that the full log is shown
