### PR TITLE
Fix report empty expression

### DIFF
--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -428,11 +428,13 @@ final class MauticReportBuilder implements ReportBuilderInterface
                         );
                         break;
                     case 'empty':
-                        $groupExpr->add(
-                            $expr->isNull($filter['column'])
+                        $expression = $queryBuilder->expr()->orX(
+                            $queryBuilder->expr()->isNull($filter['column']),
+                            $queryBuilder->expr()->eq($filter['column'], $expr->literal(''))
                         );
+
                         $groupExpr->add(
-                            $expr->eq($filter['column'], $expr->literal(''))
+                            $expression
                         );
                         break;
                     default:
@@ -503,7 +505,6 @@ final class MauticReportBuilder implements ReportBuilderInterface
         if ($groupExpr->count()) {
             $groups[] = $groupExpr;
         }
-
         if (count($groups) === 1) {
             // Only one andX expression
             $filterExpr = $groups[0];


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7737
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Report empty expression return wrong condition: 

- (column IS NULL AND column != '')

We expected

- (columns IS NULL OR column !='')

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create contact without email
2. Create contact report with filter empty email 
![image](https://user-images.githubusercontent.com/462477/62229309-b21ed000-b3bf-11e9-9fdd-c12c7aa502e8.png)
2. See no results. We expected results

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps
3. Empty filter should  return results
