### PR TITLE
Fix "Problems parsing request as json" error in Sparkpost

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
         "stack/builder": "^1.0",
         "piwik/device-detector": "~3.7.0",
         "php-http/guzzle6-adapter": "^1.1",
-        "sparkpost/sparkpost": "~2.0.3",
+        "sparkpost/sparkpost": "~2.1.0",
         "doctrine/data-fixtures": "1.2.1",
         "sonata-project/exporter": "^1.7",
         "lightsaml/sp-bundle": "~1.0.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e09408d23624dfd3451cee6e23c5815b",
+    "content-hash": "9fa10f1a8516228ce9a896d43954951f",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -8909,12 +8909,12 @@
             "version": "1.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/facebook/php-webdriver.git",
+                "url": "https://github.com/php-webdriver/php-webdriver-archive.git",
                 "reference": "86b5ca2f67173c9d34340845dd690149c886a605"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/86b5ca2f67173c9d34340845dd690149c886a605",
+                "url": "https://api.github.com/repos/php-webdriver/php-webdriver-archive/zipball/86b5ca2f67173c9d34340845dd690149c886a605",
                 "reference": "86b5ca2f67173c9d34340845dd690149c886a605",
                 "shasum": ""
             },
@@ -10507,7 +10507,7 @@
                 }
             ],
             "description": "This bundle generates code for you",
-            "abandoned": true,
+            "abandoned": "symfony/maker-bundle",
             "time": "2017-12-07T15:36:41+00:00"
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -5210,35 +5210,38 @@
         },
         {
             "name": "sparkpost/sparkpost",
-            "version": "2.0.3",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SparkPost/php-sparkpost.git",
-                "reference": "34dcd9b35098ffb7565c4e6a51c84c2c38a07a0f"
+                "reference": "0c45993ee9d68d47acbd04b241c8b24b8667f937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SparkPost/php-sparkpost/zipball/34dcd9b35098ffb7565c4e6a51c84c2c38a07a0f",
-                "reference": "34dcd9b35098ffb7565c4e6a51c84c2c38a07a0f",
+                "url": "https://api.github.com/repos/SparkPost/php-sparkpost/zipball/0c45993ee9d68d47acbd04b241c8b24b8667f937",
+                "reference": "0c45993ee9d68d47acbd04b241c8b24b8667f937",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
+                "php": "^5.6 || ^7.0",
                 "php-http/client-implementation": "^1.0",
                 "php-http/discovery": "^1.0",
                 "php-http/httplug": "^1.0",
                 "php-http/message": "^1.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "^1.11",
+                "friendsofphp/php-cs-fixer": "^1.11",
                 "mockery/mockery": "^0.9.4",
-                "php-http/guzzle6-adapter": "^1.0"
+                "nyholm/nsa": "^1.0",
+                "php-http/guzzle6-adapter": "^1.0",
+                "phpunit/phpcov": "2.*",
+                "phpunit/phpunit": "^4.8 || ^5.4",
+                "satooshi/php-coveralls": "dev-master"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "SparkPost\\": "lib/SparkPost/",
-                    "SparkPost\\Test\\TestUtils\\": "test/unit/TestUtils/"
+                    "SparkPost\\": "lib/SparkPost"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -5251,7 +5254,7 @@
                 }
             ],
             "description": "Client library for interfacing with the SparkPost API.",
-            "time": "2016-07-29T05:08:27+00:00"
+            "time": "2017-01-10T14:29:09+00:00"
         },
         {
             "name": "stack/builder",


### PR DESCRIPTION

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

We had a couple of "Problems parsing request as json"  email sending errors when we tried to send certain emails. We were unable to reproduce them later, but the issue exists.
See https://github.com/SparkPost/php-sparkpost/issues/141

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. I wasn't able to reproduce the bug.
The issue is happening on Sparkpost's side. I've found a similar bug in their GitHub, so this PR basically updates `sparkpost/sparkpost` package to the latest version. The "Problems parsing request as json" is fixed in the 2.1.0 version of that package.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. I wasn't able to reproduce it, so for testing we only need to make sure this updated package doesn't break BC.
3. Obtain an API key from Sparkpost (this is free) and setup your Mautic instance to use Sparkpost as your email service.
4. Try to send couple of emails. We need to make sure that emails are sent and the are no email/Sparkpost related errors in the logs.