### PR TITLE
Exclude upgrade.php from build process

### DIFF
--- a/build/excludefiles.txt
+++ b/build/excludefiles.txt
@@ -10,6 +10,7 @@ app/phpunit.xml.dist
 build/*
 bin/*
 codeception.yml
+upgrade.php
 composer.json
 composer.lock
 deleted_files.txt

--- a/build/excludefiles.txt
+++ b/build/excludefiles.txt
@@ -10,7 +10,6 @@ app/phpunit.xml.dist
 build/*
 bin/*
 codeception.yml
-upgrade.php
 composer.json
 composer.lock
 deleted_files.txt
@@ -23,6 +22,7 @@ package.json
 package-lock.json
 README.md
 tests/*
+upgrade.php
 vendor/babdev/*
 vendor/liip/*
 vendor/sensio/generator-bundle/*


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic-inc/mautic-security/issues/53
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
We noticed upgrade.php was part of release build. This PR exclude it

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. run **php build/package_release.php**
2. See build/packages/ both zip contains upgrade.php

#### Steps to test this PR:
1. Repeat test and see zip files without upgrade.php file
