### PR TITLE
Fix company search from list view

### DIFF
--- a/app/bundles/LeadBundle/Views/Company/list.html.php
+++ b/app/bundles/LeadBundle/Views/Company/list.html.php
@@ -153,7 +153,7 @@ if ($tmpl == 'index') {
                             'mautic_contact_index',
                             [
                                 'search' => $view['translator']->trans('mautic.lead.lead.searchcommand.company').':"'
-                                    .$view->escape($fields['core']['companyname']['value']).'"',
+                                    .$fields['core']['companyname']['value'].'"',
                             ]
                         ); ?>" data-toggle="ajax"<?php echo ($leadCounts[$item->getId()] == 0) ? 'disabled=disabled' : ''; ?>>
                             <?php echo $view['translator']->transChoice(


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixed company search from company list view due already escaped value no need escape in template.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create company with ' symbol in the company name
2. Add contact to company
3. Go to Companies  and click to view contacts in list view

![image](https://user-images.githubusercontent.com/462477/62382023-060aef80-b54d-11e9-991b-e0d16e32808e.png)

4. No contacts in results


#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps to reproduce
3. Should see one contact after click to view contacts
