### PR TITLE
Fix for #7775 - small typo

### DIFF
--- a/themes/skyline/html/email.html.twig
+++ b/themes/skyline/html/email.html.twig
@@ -135,7 +135,7 @@
                 <tr>
                     <td valign="top" data-slot-container="1">
                         <div data-slot="text">
-                            <h3 style="text-align:center;">Enjoy 50% of your next purchase!</h3>
+                            <h3 style="text-align:center;">Enjoy 50% off your next purchase!</h3>
                             <br>
 
                             <table style="margin: 0 auto;" cellspacing="0" cellpadding="8" width="250">

--- a/themes/skyline/html/page.html.twig
+++ b/themes/skyline/html/page.html.twig
@@ -34,7 +34,7 @@
                 <tr>
                     <td valign="top" data-slot-container="1">
                         <div data-slot="text">
-                            <h3 style="text-align:center;">Enjoy 50% of your next purchase!</h3>
+                            <h3 style="text-align:center;">Enjoy 50% off your next purchase!</h3>
                             <br>
 
                             <table style="margin: 0 auto;" cellspacing="0" cellpadding="8" width="250">


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #7775 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fixes small typo in theme landing page and email

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Open landing page or email using landing page and notice it offers 50% of, instead of off

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Open landing page or email with skyline template and notice it now says 50% off
