### PR TITLE
Fix form boolean mapping

### DIFF
--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -51,7 +51,9 @@ trait RequestTrait
                                 break;
                             } catch (\InvalidArgumentException $exception) {
                             }
-                            $params[$name] = $data;
+
+                            // If not manually handled cast to int because Symfony form processing take false as empty
+                            $params[$name] = (int) $data;
                         }
                         break;
                     case 'choice':


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Form submission don't set boolean mapped field when value = 0 for new contact.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a custom boolean field
2. Create a form
3. Add a radio group field with value 1 and 0, and map it to your custom field
4. Add an email field
5. Go to form and submit it with a new email and radio value = 0
6. Go to the new created lead, see that boolean field is not set

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7782)
2. Repeat step above
3. Boolean field is now correctly set
