### PR TITLE
Fix date handling

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -812,7 +812,11 @@ class LeadListRepository extends CommonRepository
             if ($details['type'] === 'datetime' || $details['type'] === 'date') {
                 $relativeDateStrings = $this->getRelativeDateStrings();
                 // Check if the column type is a date/time stamp
-                $isTimestamp = ($details['type'] === 'datetime' || $columnType instanceof UTCDateTimeType);
+                $isTimestamp = (
+                    $details['type'] === 'date' ||
+                    $details['type'] === 'datetime' ||
+                    $columnType instanceof UTCDateTimeType ||
+                    $columnType instanceof DateType);
                 $getDate     = function (&$string) use ($isTimestamp, $relativeDateStrings, &$details, &$func) {
                     $key             = array_search($string, $relativeDateStrings);
                     $dtHelper        = new DateTimeHelper('midnight today', null, 'local');
@@ -971,16 +975,16 @@ class LeadListRepository extends CommonRepository
                         $dateTime = $date->format('Y-m-d H:i:s');
                         $dtHelper->setDateTime($dateTime, null);
 
+                        $modifier   = $string;
                         $isRelative = true;
                     }
 
                     if ($isRelative) {
                         if ($requiresBetween) {
                             $startWith = ($isTimestamp) ? $dtHelper->toUtcString('Y-m-d H:i:s') : $dtHelper->toUtcString('Y-m-d');
-
                             $dtHelper->modify($modifier);
                             $endWith = ($isTimestamp) ? $dtHelper->toUtcString('Y-m-d H:i:s') : $dtHelper->toUtcString('Y-m-d');
-
+                            //
                             // Use a between statement
                             $func              = ($func == 'neq') ? 'notBetween' : 'between';
                             $details['filter'] = [$startWith, $endWith];

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -984,7 +984,6 @@ class LeadListRepository extends CommonRepository
                             $startWith = ($isTimestamp) ? $dtHelper->toUtcString('Y-m-d H:i:s') : $dtHelper->toUtcString('Y-m-d');
                             $dtHelper->modify($modifier);
                             $endWith = ($isTimestamp) ? $dtHelper->toUtcString('Y-m-d H:i:s') : $dtHelper->toUtcString('Y-m-d');
-                            //
                             // Use a between statement
                             $func              = ($func == 'neq') ? 'notBetween' : 'between';
                             $details['filter'] = [$startWith, $endWith];

--- a/app/bundles/LeadBundle/Tests/Entity/LeadListRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadListRepositoryTest.php
@@ -128,9 +128,9 @@ class LeadListRepositoryTest extends AbstractMauticTestCase
 
         $field = new LeadField();
         $field->setName('renewal_date')
-              ->setAlias('renewal_date')
-              ->setType('date')
-              ->setObject('lead');
+            ->setAlias('renewal_date')
+            ->setType('date')
+            ->setObject('lead');
 
         $fieldModel->saveEntity($field);
 

--- a/app/bundles/LeadBundle/Tests/Entity/LeadListRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadListRepositoryTest.php
@@ -124,15 +124,15 @@ class LeadListRepositoryTest extends AbstractMauticTestCase
 
         $this->container = $this->client->getContainer();
         $this->em        = $this->container->get('doctrine')->getManager();
-        //$fieldModel = $this->container->get('mautic.lead.model.field');
+        $fieldModel      = $this->container->get('mautic.lead.model.field');
 
-        //        $field = new LeadField();
-        //        $field->setName('renewal_date')
-        //              ->setAlias('renewal_date')
-        //              ->setType('date')
-        //              ->setObject('lead');
-        //
-        //        $fieldModel->saveEntity($field);
+        $field = new LeadField();
+        $field->setName('renewal_date')
+              ->setAlias('renewal_date')
+              ->setType('date')
+              ->setObject('lead');
+
+        $fieldModel->saveEntity($field);
 
         // array $filters, array &$parameters, QueryBuilder $q, QueryBuilder $parameterQ = null, $listId = null, $not = false
         $expr = $reflectedMethod->invokeArgs($mockRepository, [$filters, &$parameters, $qb]);
@@ -140,11 +140,6 @@ class LeadListRepositoryTest extends AbstractMauticTestCase
         //$fieldModel->deleteEntity($field);
 
         $string = (string) $expr;
-    }
-
-    public function setUp()
-    {
-        parent::setUp();
     }
 
     public function testExcludeSegmentFilterWithFiltersAppendNotExistsSubQuery()
@@ -366,9 +361,9 @@ class LeadListRepositoryTest extends AbstractMauticTestCase
     {
         defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
         $mockRepository = $this->getMockBuilder(LeadListRepository::class)
-                               ->disableOriginalConstructor()
-                               ->setMethods(['getEntityManager', 'getRelativeDateStrings'])
-                               ->getMock();
+           ->disableOriginalConstructor()
+           ->setMethods(['getEntityManager', 'getRelativeDateStrings'])
+           ->getMock();
 
         $mockConnection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()

--- a/app/bundles/LeadBundle/Tests/Entity/LeadListRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadListRepositoryTest.php
@@ -18,14 +18,11 @@ use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\MySqlSchemaManager;
-use Doctrine\DBAL\Types\DateType;
 use Doctrine\DBAL\Types\TextType;
 use Doctrine\ORM\EntityManager;
-use Mautic\CoreBundle\Test\AbstractMauticTestCase;
-use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadListRepository;
 
-class LeadListRepositoryTest extends AbstractMauticTestCase
+class LeadListRepositoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testIncludeSegmentFilterWithFiltersAppendInOrGroups()
     {
@@ -95,51 +92,6 @@ class LeadListRepositoryTest extends AbstractMauticTestCase
         // Segment filters combined by OR to keep consistent behavior with the use of leadlist_id IN (1,2,3)
         $found = preg_match_all('/OR \(EXISTS \(SELECT null FROM '.MAUTIC_TABLE_PREFIX.'lead_lists_leads/', $string, $matches);
         $this->assertEquals(1, $found, $string);
-    }
-
-    public function testCustomFieldDateFilterRelativeMonths()
-    {
-        return $this->markTestSkipped('Not yet written');   // @todo it does act differently on test
-
-        list($mockRepository, $reflectedMethod, $connection) = $this->getReflectedGenerateSegmentExpressionMethod(true);
-
-        $parameters = [];
-        $qb         = $connection->createQueryBuilder();
-        $filters    =
-            [
-                [
-                    'glue'     => 'and',
-                    'operator' => '=',
-                    'field'    => 'renewal_date',
-                    'object'   => 'lead',
-                    'type'     => 'date',
-                    'display'  => null,
-                    'filter'   => '-11 months',
-                ],
-            ];
-
-        $this->client = static::createClient([], $this->clientServer);
-        $this->client->disableReboot();
-        $this->client->followRedirects(true);
-
-        $this->container = $this->client->getContainer();
-        $this->em        = $this->container->get('doctrine')->getManager();
-        $fieldModel      = $this->container->get('mautic.lead.model.field');
-
-        $field = new LeadField();
-        $field->setName('renewal_date')
-            ->setAlias('renewal_date')
-            ->setType('date')
-            ->setObject('lead');
-
-        $fieldModel->saveEntity($field);
-
-        // array $filters, array &$parameters, QueryBuilder $q, QueryBuilder $parameterQ = null, $listId = null, $not = false
-        $expr = $reflectedMethod->invokeArgs($mockRepository, [$filters, &$parameters, $qb]);
-
-        //$fieldModel->deleteEntity($field);
-
-        $string = (string) $expr;
     }
 
     public function testExcludeSegmentFilterWithFiltersAppendNotExistsSubQuery()
@@ -361,9 +313,9 @@ class LeadListRepositoryTest extends AbstractMauticTestCase
     {
         defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
         $mockRepository = $this->getMockBuilder(LeadListRepository::class)
-           ->disableOriginalConstructor()
-           ->setMethods(['getEntityManager', 'getRelativeDateStrings'])
-           ->getMock();
+            ->disableOriginalConstructor()
+            ->setMethods(['getEntityManager'])
+            ->getMock();
 
         $mockConnection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
@@ -398,15 +350,10 @@ class LeadListRepositoryTest extends AbstractMauticTestCase
                             $name = 'email';
                     }
 
-                    $column            = new Column($name, $mockType);
-                    $mockType          = $this->getMockBuilder(DateType::class)
-                                              ->disableOriginalConstructor()
-                                              ->getMock();
-                    $customFieldColumn = new Column('renewal_date', $mockType);
+                    $column = new Column($name, $mockType);
 
                     return [
-                        $name          => $column,
-                        'renewal_date' => $customFieldColumn,
+                        $name => $column,
                     ];
                 }
             );
@@ -487,9 +434,7 @@ class LeadListRepositoryTest extends AbstractMauticTestCase
                 }
             );
 
-        $mockRepository->method('getRelativeDateStrings')->willReturn([]);
         $reflectedMockRepository = new \ReflectionObject($mockRepository);
-
         $method                  = $reflectedMockRepository->getMethod('generateSegmentExpression');
         $method->setAccessible(true);
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | None 
| BC breaks? | N
| Deprecations? | N 

### Description 

> I'm checking some Segments for a customer and I think there may be a bug in the `date based + text filters/relative dates` feature:
(https://github.com/mautic/documentation/pull/262/files#diff-44081953730b38fc2f796040f927f316R53).

> This feature works when trying to find a Contact who was identified 11 months ago by adding this as a filter for a Segment:

> Date Identified equals -11 months

> However, when using a Custom Field with Date as the Data Type, Contacts who meet this criteria are not getting filtered in.  This feature does work, however, when using Date/Time as the Data Type with a Custom Field.

### Steps to reproduce the bug and test this PR

1. Create custom field of type date
2. Update this field at contact to 11 month ago, today that would be 2018-02-18
3. Create a segment with filter
![image](https://user-images.githubusercontent.com/556426/51413648-e6434980-1b6f-11e9-8548-fc5168d7b69f.png)
4. Run the segment and check whether the contact got into the segment
5. Checkout this PR
6. Re-run the segment and verify it got there

> You may run app/console `mautic:segments:check-builder --env-dev -v -i[segment-id]`
> Check logs afterwards, you should see `like 'yyyy-mm-dd%'` like query

7. We should probably verify that other date related queries are ok, I am not sure how much it is covered by tests.
