### PR TITLE
Fix relative dates gt

### DIFF
--- a/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionFactory.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionFactory.php
@@ -76,7 +76,7 @@ class DateOptionFactory
             return new DateDefault($this->dateDecorator, $originalValue);
         }
 
-        switch ($timeframe) {
+        switch (strtolower($timeframe)) {
             case 'birthday':
             case 'anniversary':
                 return new DateAnniversary($this->dateDecorator, $dateOptionParameters);

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateRelativeInterval.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateRelativeInterval.php
@@ -111,6 +111,9 @@ class DateRelativeInterval implements FilterDecoratorInterface
         if ($operator === 'like' || $operator === 'notLike') {
             $format .= '%';
         }
+        if ($operator === 'gt') { //    This assures that gt does work correctly
+            $format .= ' 23:59:59';
+        }
 
         return $date->toLocalString($format);
     }

--- a/app/bundles/LeadBundle/Tests/DataFixtures/ORM/Data/leads.yml
+++ b/app/bundles/LeadBundle/Tests/DataFixtures/ORM/Data/leads.yml
@@ -1,0 +1,38 @@
+Mautic\LeadBundle\Entity\Lead:
+  contact1:
+    firstname: '<firstName()>'
+    lastname: '<lastName()>'
+    is_published: 1
+    date_added: '<dateTimeBetween("-1 days 00:00:00","-1 days 23:59:59")>'
+    email: '<email()>'
+  contact2:
+    firstname: '<firstName()>'
+    lastname: '<lastName()>'
+    is_published: 1
+    date_added: '<dateTimeBetween("-2 days 00:00:00","-2 days 23:59:59")>'
+    email: '<email()>'
+  contact3:
+    firstname: '<firstName()>'
+    lastname: '<lastName()>'
+    is_published: 1
+    date_added: '<dateTimeBetween("-3 days 00:00:00","-3 days 23:59:59")>'
+    email: '<email()>'
+  contact4:
+    firstname: '<firstName()>'
+    lastname: '<lastName()>'
+    is_published: 1
+    date_added: '<dateTimeBetween("-4 days 00:00:00","-4 days 23:59:59")>'
+    email: '<email()>'
+  contact5:
+    firstname: '<firstName()>'
+    lastname: '<lastName()>'
+    is_published: 1
+    date_added: '<dateTimeBetween("-5 days 00:00:00","-5 days 23:59:59")>'
+    email: '<email()>'
+  contact6:
+    firstname: '<firstName()>'
+    lastname: '<lastName()>'
+    is_published: 1
+    date_added: '<dateTimeBetween("-6 days 00:00:00","-6 days 23:59:59")>'
+    email: '<email()>'
+

--- a/app/bundles/LeadBundle/Tests/DataFixtures/ORM/Data/roles.yml
+++ b/app/bundles/LeadBundle/Tests/DataFixtures/ORM/Data/roles.yml
@@ -1,0 +1,6 @@
+Mautic\UserBundle\Entity\Role:
+  role1:
+    is_published: 1
+    name: 'Test Role'
+    description: '<sentence(20)>'
+    is_admin: 1

--- a/app/bundles/LeadBundle/Tests/DataFixtures/ORM/Data/users.yml
+++ b/app/bundles/LeadBundle/Tests/DataFixtures/ORM/Data/users.yml
@@ -1,0 +1,10 @@
+Mautic\UserBundle\Entity\User:
+  user1:
+    role: '@role1'
+    is_published: 1
+    username: 'test2'
+    password: 'dxul9wuermx9l'
+    first_name: '<firstName("female")>'
+    last_name: '<lastName()>'
+    email: '<email()>'
+

--- a/app/bundles/LeadBundle/Tests/DataFixtures/Traits/FixtureObjectsTrait.php
+++ b/app/bundles/LeadBundle/Tests/DataFixtures/Traits/FixtureObjectsTrait.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * @copyright   2019 Mautic Inc. All rights reserved
  * @author      Mautic, Inc.
@@ -38,7 +36,7 @@ trait FixtureObjectsTrait
      *
      * @param mixed[] $objects
      */
-    public function setFixtureObjects(array $objects): void
+    public function setFixtureObjects(array $objects)
     {
         foreach ($objects as $key => $object) {
             $this->objects[get_class($object)][$key] = $object;
@@ -53,7 +51,7 @@ trait FixtureObjectsTrait
      *
      * @throws FixtureNotFoundException
      */
-    public function getFixturesByEntityClassName(string $type): array
+    public function getFixturesByEntityClassName($type)
     {
         if (!isset($this->objects[$type])) {
             throw new FixtureNotFoundException('No fixtures of type '.$type.' defined');
@@ -70,7 +68,7 @@ trait FixtureObjectsTrait
      *
      * @throws FixtureNotFoundException
      */
-    public function getFixtureByEntityClassNameAndIndex(string $type, int $index): CommonEntity
+    public function getFixtureByEntityClassNameAndIndex($type, $index)
     {
         $fixtures = $this->getFixturesByEntityClassName($type);
 
@@ -90,7 +88,7 @@ trait FixtureObjectsTrait
      *
      * @throws FixtureNotFoundException
      */
-    public function getFixtureById(string $id): UniqueEntityInterface
+    public function getFixtureById($id)
     {
         if (!isset($this->entityMap[$id])) {
             throw new FixtureNotFoundException('No fixture with id "'.$id.'"" defined');
@@ -102,7 +100,7 @@ trait FixtureObjectsTrait
     /**
      * @return mixed[]
      */
-    public function getFixturesInUnloadableOrder(): array
+    public function getFixturesInUnloadableOrder()
     {
         $entities = [];
 
@@ -118,11 +116,11 @@ trait FixtureObjectsTrait
     /**
      * @return string
      */
-    private function getFixturesDirectory(): string
+    private function getFixturesDirectory()
     {
         /** @var KernelInterface $kernel */
         $kernel               = $this->getContainer()->get('kernel');
-        echo $pluginDirectory = $kernel->getRootDir().'/bundles/LeadBundle/Tests/DataFixtures/ORM/Data';
+        $pluginDirectory = $kernel->getRootDir().'/bundles/LeadBundle/Tests/DataFixtures/ORM/Data';
 
         if (!is_dir($pluginDirectory)) {
             throw new NotFoundException('Resource not found.');

--- a/app/bundles/LeadBundle/Tests/DataFixtures/Traits/FixtureObjectsTrait.php
+++ b/app/bundles/LeadBundle/Tests/DataFixtures/Traits/FixtureObjectsTrait.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2019 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        http://mautic.com
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\DataFixtures\Traits;
+
+use Mautic\CoreBundle\Entity\CommonEntity;
+use MauticPlugin\CustomObjectsBundle\Tests\Functional\Exception\FixtureNotFoundException;
+use MauticPlugin\CustomObjectsBundle\Entity\UniqueEntityInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use MauticPlugin\CustomObjectsBundle\Exception\NotFoundException;
+
+/**
+ * Trait FixtureObjectsTrait implements Liip fixtures with Alice and offers helper methods for handling them.
+ */
+trait FixtureObjectsTrait
+{
+    /**
+     * @var mixed[]
+     */
+    private $objects = [];
+
+    /**
+     * @var string[]
+     */
+    private $entityMap = [];
+
+    /**
+     * The result of loadFixtureFiles should be passed here to initialize the thread.
+     *
+     * @param mixed[] $objects
+     */
+    public function setFixtureObjects(array $objects): void
+    {
+        foreach ($objects as $key => $object) {
+            $this->objects[get_class($object)][$key] = $object;
+            $this->entityMap[$key]                   = get_class($object);
+        }
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return mixed[]
+     *
+     * @throws FixtureNotFoundException
+     */
+    public function getFixturesByEntityClassName(string $type): array
+    {
+        if (!isset($this->objects[$type])) {
+            throw new FixtureNotFoundException('No fixtures of type '.$type.' defined');
+        }
+
+        return $this->objects[$type];
+    }
+
+    /**
+     * @param string $type
+     * @param int    $index
+     *
+     * @return CommonEntity
+     *
+     * @throws FixtureNotFoundException
+     */
+    public function getFixtureByEntityClassNameAndIndex(string $type, int $index): CommonEntity
+    {
+        $fixtures = $this->getFixturesByEntityClassName($type);
+
+        $fixtures = array_values($fixtures);
+
+        if (!isset($fixtures[$index])) {
+            throw new FixtureNotFoundException('No index "'.$index.'" defined of '.$type.'\'s');
+        }
+
+        return $fixtures[$index];
+    }
+
+    /**
+     * @param string $id key specified in fixtures
+     *
+     * @return UniqueEntityInterface
+     *
+     * @throws FixtureNotFoundException
+     */
+    public function getFixtureById(string $id): UniqueEntityInterface
+    {
+        if (!isset($this->entityMap[$id])) {
+            throw new FixtureNotFoundException('No fixture with id "'.$id.'"" defined');
+        }
+
+        return $this->objects[$this->entityMap[$id]][$id];
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getFixturesInUnloadableOrder(): array
+    {
+        $entities = [];
+
+        $orderedKeys = $this->entityMap;
+        array_reverse($orderedKeys, true);
+        foreach ($orderedKeys as $key => $type) {
+            $entities[$key] = $this->objects[$type][$key];
+        }
+
+        return $entities;
+    }
+
+    /**
+     * @return string
+     */
+    private function getFixturesDirectory(): string
+    {
+        /** @var KernelInterface $kernel */
+        $kernel          = $this->getContainer()->get('kernel');
+        echo $pluginDirectory = $kernel->getRootDir() . '/bundles/LeadBundle/Tests/DataFixtures/ORM/Data';
+
+        if (!is_dir($pluginDirectory)) {
+            throw new NotFoundException('Resource not found.');
+        }
+
+        return $pluginDirectory;
+    }
+}

--- a/app/bundles/LeadBundle/Tests/DataFixtures/Traits/FixtureObjectsTrait.php
+++ b/app/bundles/LeadBundle/Tests/DataFixtures/Traits/FixtureObjectsTrait.php
@@ -120,7 +120,7 @@ trait FixtureObjectsTrait
     {
         /** @var KernelInterface $kernel */
         $kernel               = $this->getContainer()->get('kernel');
-        $pluginDirectory = $kernel->getRootDir().'/bundles/LeadBundle/Tests/DataFixtures/ORM/Data';
+        $pluginDirectory      = $kernel->getRootDir().'/bundles/LeadBundle/Tests/DataFixtures/ORM/Data';
 
         if (!is_dir($pluginDirectory)) {
             throw new NotFoundException('Resource not found.');

--- a/app/bundles/LeadBundle/Tests/DataFixtures/Traits/FixtureObjectsTrait.php
+++ b/app/bundles/LeadBundle/Tests/DataFixtures/Traits/FixtureObjectsTrait.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Tests\DataFixtures\Traits;
 
 use Mautic\CoreBundle\Entity\CommonEntity;
-use MauticPlugin\CustomObjectsBundle\Tests\Functional\Exception\FixtureNotFoundException;
 use MauticPlugin\CustomObjectsBundle\Entity\UniqueEntityInterface;
-use Symfony\Component\HttpKernel\KernelInterface;
 use MauticPlugin\CustomObjectsBundle\Exception\NotFoundException;
+use MauticPlugin\CustomObjectsBundle\Tests\Functional\Exception\FixtureNotFoundException;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * Trait FixtureObjectsTrait implements Liip fixtures with Alice and offers helper methods for handling them.
@@ -121,8 +121,8 @@ trait FixtureObjectsTrait
     private function getFixturesDirectory(): string
     {
         /** @var KernelInterface $kernel */
-        $kernel          = $this->getContainer()->get('kernel');
-        echo $pluginDirectory = $kernel->getRootDir() . '/bundles/LeadBundle/Tests/DataFixtures/ORM/Data';
+        $kernel               = $this->getContainer()->get('kernel');
+        echo $pluginDirectory = $kernel->getRootDir().'/bundles/LeadBundle/Tests/DataFixtures/ORM/Data';
 
         if (!is_dir($pluginDirectory)) {
             throw new NotFoundException('Resource not found.');

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
@@ -137,7 +137,7 @@ class RelativeDateFunctionalTest extends MauticWebTestCase
         $this->setFixtureObjects($objects);
 
         /** @var Register $connection */
-        $connection            = $this->em->getConnection();
+        $connection = $this->em->getConnection();
 
         /** @var ContactSegmentFilterFactory $filterFactory */
         $filterFactory = $this->getContainer()->get('mautic.lead.model.lead_segment_filter_factory');

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
@@ -130,7 +130,7 @@ class RelativeDateFunctionalTest extends WebTestCase
     public function testRelativeOperators()
     {
         /** @var EntityManager $entityManager */
-        $entityManager       = $this->getContainer()->get('doctrine.orm.entity_manager');
+        $entityManager       = $this->getContainer()->get('doctrine.orm.default_entity_manager');
         $this->entityManager = $entityManager;
         $this->postFixtureSetup();
 
@@ -144,7 +144,7 @@ class RelativeDateFunctionalTest extends WebTestCase
         $this->setFixtureObjects($objects);
 
         /** @var Registr $connection */
-        $connection            = $this->em->getConnection();
+        $connection            = $this->entityManager->getConnection();
 
         /** @var ContactSegmentFilterFactory $filterFactory */
         $filterFactory = $this->getContainer()->get('mautic.lead.model.lead_segment_filter_factory');

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Test\MauticWebTestCase;
@@ -19,9 +20,6 @@ use Mautic\LeadBundle\Tests\DataFixtures\Traits\FixtureObjectsTrait;
 class RelativeDateFunctionalTest extends MauticWebTestCase
 {
     use FixtureObjectsTrait;
-
-    /** @var EntityManager */
-    private $entityManager;
 
     public function testSegmentCountIsCorrectForToday()
     {
@@ -136,7 +134,7 @@ class RelativeDateFunctionalTest extends MauticWebTestCase
 
         $this->setFixtureObjects($objects);
 
-        /** @var Register $connection */
+        /** @var Connection $connection */
         $connection = $this->em->getConnection();
 
         /** @var ContactSegmentFilterFactory $filterFactory */

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
@@ -3,7 +3,6 @@
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Test\MauticWebTestCase;
 use Mautic\LeadBundle\Entity\Lead;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
@@ -3,8 +3,8 @@
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date;
 
 use Doctrine\ORM\EntityManager;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Mautic\CoreBundle\Helper\InputHelper;
+use Mautic\CoreBundle\Test\MauticWebTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
@@ -16,7 +16,7 @@ use Mautic\LeadBundle\Tests\DataFixtures\Traits\FixtureObjectsTrait;
 /**
  * Class RelativeDateFunctionalTest.
  */
-class RelativeDateFunctionalTest extends WebTestCase
+class RelativeDateFunctionalTest extends MauticWebTestCase
 {
     use FixtureObjectsTrait;
 
@@ -127,28 +127,17 @@ class RelativeDateFunctionalTest extends WebTestCase
         $this->checkSegmentResult($name, $lead);
     }
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        /** @var EntityManager $entityManager */
-        $entityManager       = $this->getContainer()->get('doctrine.orm.entity_manager');
-        $this->entityManager = $entityManager;
-    }
-
-        public function testRelativeOperators()
+    public function testRelativeOperators()
     {
         $fixturesDirectory = $this->getFixturesDirectory();
         $objects           = $this->loadFixtureFiles([
-            $fixturesDirectory.'/roles.yml',
-            $fixturesDirectory.'/users.yml',
             $fixturesDirectory.'/leads.yml',
         ], false, null, 'doctrine'); //,ORMPurger::PURGE_MODE_DELETE);
 
         $this->setFixtureObjects($objects);
 
-        /** @var Registr $connection */
-        $connection            = $this->entityManager->getConnection();
+        /** @var Register $connection */
+        $connection            = $this->em->getConnection();
 
         /** @var ContactSegmentFilterFactory $filterFactory */
         $filterFactory = $this->getContainer()->get('mautic.lead.model.lead_segment_filter_factory');
@@ -251,14 +240,13 @@ class RelativeDateFunctionalTest extends WebTestCase
         $this->em->getConnection()->query(sprintf("DELETE FROM %sleads WHERE lastname = 'Date';", MAUTIC_TABLE_PREFIX));
     }
 
-    protected function unloadFixtures(): void
+    protected function unloadFixtures()
     {
         foreach ($this->getFixturesInUnloadableOrder() as $entity) {
-            $this->entityManager->remove($entity);
+            $entity = $this->em->merge($entity);
+            $this->em->remove($entity);
         }
 
-        $this->entityManager->flush();
-
-        parent::tearDown();
+        $this->em->flush();
     }
 }

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
@@ -132,7 +132,7 @@ class RelativeDateFunctionalTest extends MauticWebTestCase
         $fixturesDirectory = $this->getFixturesDirectory();
         $objects           = $this->loadFixtureFiles([
             $fixturesDirectory.'/leads.yml',
-        ], false, null, 'doctrine'); //,ORMPurger::PURGE_MODE_DELETE);
+        ], false, null, 'doctrine');
 
         $this->setFixtureObjects($objects);
 

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
@@ -127,13 +127,17 @@ class RelativeDateFunctionalTest extends WebTestCase
         $this->checkSegmentResult($name, $lead);
     }
 
-    public function testRelativeOperators()
+    protected function setUp(): void
     {
-        /** @var EntityManager $entityManager */
-        $entityManager       = $this->getContainer()->get('doctrine.orm.default_entity_manager');
-        $this->entityManager = $entityManager;
-        $this->postFixtureSetup();
+        parent::setUp();
 
+        /** @var EntityManager $entityManager */
+        $entityManager       = $this->getContainer()->get('doctrine.orm.entity_manager');
+        $this->entityManager = $entityManager;
+    }
+
+        public function testRelativeOperators()
+    {
         $fixturesDirectory = $this->getFixturesDirectory();
         $objects           = $this->loadFixtureFiles([
             $fixturesDirectory.'/roles.yml',

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Mautic\CoreBundle\Helper\InputHelper;
@@ -145,7 +144,7 @@ class RelativeDateFunctionalTest extends WebTestCase
         $this->setFixtureObjects($objects);
 
         /** @var Registr $connection */
-        $connection            = $entityManager->getConnection();
+        $connection            = $this->em->getConnection();
 
         /** @var ContactSegmentFilterFactory $filterFactory */
         $filterFactory = $this->getContainer()->get('mautic.lead.model.lead_segment_filter_factory');
@@ -172,7 +171,7 @@ class RelativeDateFunctionalTest extends WebTestCase
 
         foreach ($filterValues as $filterValue) {
             $queryBuilder = new QueryBuilder($connection);
-            $queryBuilder->select('l.id, l.date_added')->from(MAUTIC_TABLE_PREFIX.'leads','l');
+            $queryBuilder->select('l.id, l.date_added')->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
 
             $crateArguments['operator'] = $filterValue[1];
             $crateArguments['filter']   = $filterValue[2];
@@ -185,7 +184,6 @@ class RelativeDateFunctionalTest extends WebTestCase
         }
         $this->unloadFixtures();
     }
-
 
     /**
      * @param string $name

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -261,7 +261,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
      *
      * @return array|mixed
      *
-     * @throws \Psr\Cache\InvalidArgumentException
+     * @throws \Exception
      */
     public function getAvailableLeadFields($settings = [])
     {
@@ -402,8 +402,6 @@ class SalesforceIntegration extends CrmAbstractIntegration
      * @param array $params
      *
      * @return array
-     *
-     * @throws ApiErrorException
      */
     public function amendLeadDataBeforeMauticPopulate($data, $object, $params = [])
     {
@@ -414,8 +412,6 @@ class SalesforceIntegration extends CrmAbstractIntegration
         $detachClass           = null;
         $mauticObjectReference = null;
         $integrationMapping    = [];
-
-        $DNCUpdates = [];
 
         if (isset($data['records']) and $object !== 'Activity') {
             foreach ($data['records'] as $record) {
@@ -472,6 +468,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                             $entity                = $this->getMauticLead($dataObject, true, null, null, $object);
                             $mauticObjectReference = 'lead';
                             $detachClass           = Lead::class;
+
                             break;
                         case 'Account':
                             $entity                = $this->getMauticCompany($dataObject, 'Account');
@@ -499,15 +496,6 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
                     if (method_exists($entity, 'isNewlyCreated') && $entity->isNewlyCreated()) {
                         ++$created;
-                        if (isset($record['HasOptedOutOfEmail'])) {
-                            $DNCUpdates[$object][$entity->getEmail()] = [
-                                'integration_entity_id' => $record['Id'],
-                                'internal_entity_id'    => $entity->getId(),
-                                'email'                 => $entity->getEmail(),
-                                'is_new'                => true,
-                                'opted_out'             => $record['HasOptedOutOfEmail'],
-                            ];
-                        }
                     } else {
                         ++$updated;
                     }
@@ -528,10 +516,6 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 // Persist integration entities
                 $this->buildIntegrationEntities($integrationMapping, $object, $mauticObjectReference, $params);
                 $this->em->clear($detachClass);
-            }
-
-            foreach ($DNCUpdates as $objectName=>$sfEntity) {
-                $this->pushLeadDoNotContactByDate('email', $sfEntity, $objectName, $params);
             }
 
             unset($data['records']);
@@ -1109,8 +1093,6 @@ class SalesforceIntegration extends CrmAbstractIntegration
      * @param array $params
      *
      * @return mixed
-     *
-     * @throws ApiErrorException
      */
     public function pushLeads($params = [])
     {
@@ -1367,7 +1349,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
     /**
      * @param $campaignId
      *
-     * @throws \Psr\Cache\InvalidArgumentException
+     * @throws \Exception
      */
     public function getCampaignMembers($campaignId)
     {
@@ -1503,14 +1485,11 @@ class SalesforceIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param Lead   $lead
-     * @param int    $campaignId
-     * @param string $status
-     * @param null   $personIds
+     * @param Lead $lead
+     * @param      $campaignId
+     * @param      $status
      *
-     * @return bool
-     *
-     * @throws ApiErrorException
+     * @return array
      */
     public function pushLeadToCampaign(Lead $lead, $campaignId, $status = '', $personIds = null)
     {
@@ -2606,6 +2585,8 @@ class SalesforceIntegration extends CrmAbstractIntegration
     /**
      * @param array $fields
      *
+     * @return array
+     *
      * @deprecated 2.6.0 to be removed in 3.0
      */
     public function amendToSfFields($fields)
@@ -2635,9 +2616,6 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     if (strpos($sfField, '-'.$object) !== false) {
                         $fields[] = str_replace('-'.$object, '', $sfField);
                     }
-                }
-                if (!in_array('HasOptedOutOfEmail', $fields)) {
-                    $fields[] = 'HasOptedOutOfEmail';
                 }
         }
 
@@ -2670,15 +2648,14 @@ class SalesforceIntegration extends CrmAbstractIntegration
      * @param string $sfObject
      * @param array  $sfIds
      *
-     * @return int|void
+     * @return int
      *
      * @throws ApiErrorException
      */
     public function pushLeadDoNotContactByDate($channel, &$sfRecords, $sfObject, $params = [])
     {
-        $filters            = [];
-        $leadIds            = [];
-        $DNCCreatedContacts = [];
+        $filters = [];
+        $leadIds = [];
 
         if (empty($sfRecords) || !isset($sfRecords['mauticContactIsContactableByEmail']) && !$this->updateDncByDate()) {
             return;
@@ -2691,20 +2668,11 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
             $leadIds[$record['internal_entity_id']]    = $record['integration_entity_id'];
             $leadEmails[$record['internal_entity_id']] = $record['email'];
-
-            if (isset($record['opted_out']) && $record['opted_out'] && isset($record['is_new']) && $record['is_new']) {
-                $DNCCreatedContacts[] = $record['internal_entity_id'];
-            }
         }
 
         $sfFieldString = "'".implode("','", $leadIds)."'";
 
         $historySF = $this->getDncHistory($sfObject, $sfFieldString);
-
-        if (count($DNCCreatedContacts)) {
-            $this->updateMauticDNC($DNCCreatedContacts, true);
-        }
-
         //if there is no records of when it was modified in SF then just exit
         if (empty($historySF['records'])) {
             return;
@@ -2745,21 +2713,17 @@ class SalesforceIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param int|int[] $leadId
-     * @param bool      $newDncValue
+     * @param $leadId
+     * @param $newDncValue
      */
     private function updateMauticDNC($leadId, $newDncValue)
     {
-        $leadIds = is_array($leadId) ? $leadId : [$leadId];
+        $lead = $this->leadModel->getEntity($leadId);
 
-        foreach ($leadIds as $leadId) {
-            $lead = $this->leadModel->getEntity($leadId);
-
-            if ($newDncValue == true) {
-                $this->leadModel->addDncForLead($lead, 'email', 'Set by Salesforce', DoNotContact::MANUAL, true, false, true);
-            } elseif ($newDncValue == false) {
-                $this->leadModel->removeDncForLead($lead, 'email', true);
-            }
+        if ($newDncValue == true) {
+            $this->leadModel->addDncForLead($lead, 'email', 'Set by Salesforce', DoNotContact::MANUAL, true, false, true);
+        } elseif ($newDncValue == false) {
+            $this->leadModel->removeDncForLead($lead, 'email', true);
         }
     }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| BC breaks? | Y
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Operators **gte** and **gt** behave the same for *relative* date parameters. 

### Summary of the issue:
Customer tried “Date Last Active, Less than, -3 days” and “Less than or equal, -3 days”, and got the same results.

When Rowland tested in his own account, he said there was a Contact who was last active 3 days ago and they were not added to the Segment using the filter `Date last active` `less than or equal to` `-3 day`
It should include that Contact.
So is the `less than or equal to` filter acting the same as `less than` in regards to DATES?  
Also, how does time of day factor in? 
When you click into that filter to write in `-3 day` the time option does appear

### Expected Results:
When using the `less than` filter with `-3 day` I would expect all Contacts who were last active 4+ days ago to fill the Segment

When using the `less than or equal to` filter with `-3 day` I would expect all Contacts who were last active 3+ days ago to fill the Segment.

### Actual Results:
The same number of Contacts fill both Segments, but more importantly, the `less than or equal to` filter appears to be the same as the `less than` filter, as Contacts who were last active 3 days ago do not filter into the `less than or equal to` Segment, even though they should.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create 4 leads with date *value*, one from 24hrs ago and every of them +24hrs (2019-01-01,2019-01-02...today)
2. Create segment with *value* and set **gt** 2 day ago
3. Create segment with *value* and set **gte** 2 day ago
4. Run them and checj; they have same number of leads, it should be 2

#### Steps to test this PR:
1. Load up this PR
2. Rerun segments and verify the amount differ. It should be 1 and 2.

#### List backwards compatibility breaks:

This changes the behaviour of segments. 

