### PR TITLE
Fix unsubscribe form

### DIFF
--- a/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
+++ b/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
@@ -176,6 +176,6 @@ JS;
     </div>
 
     <?php
-    unset($form['lead_channels']['subscribed_channels']);
+    unset($form['lead_channels']);
     echo $view['form']->end($form); ?>
 </div>

--- a/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
+++ b/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
@@ -9,7 +9,6 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 /** @var \Symfony\Component\Form\Form $form */
-
 $leadId           = $lead->getId();
 $leadName         = $lead->getPrimaryIdentifier();
 $channelNumber    = 0;

--- a/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
+++ b/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
@@ -127,6 +127,7 @@ JS;
                     <hr />
                     <div id="preferred_channel" class="text-left"><?php echo $view['form']->row($leadChannelsForm['preferred_channel']); ?></div>
                 <?php
+                    unset($form['lead_channels']['preferred_channel']);
                 else:
                     unset($form['lead_channels']['preferred_channel']);
                 endif; ?>
@@ -176,6 +177,6 @@ JS;
     </div>
 
     <?php
-    unset($form['lead_channels']);
+    unset($form['lead_channels']['subscribed_channels']);
     echo $view['form']->end($form); ?>
 </div>

--- a/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
+++ b/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
@@ -8,6 +8,8 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
+/** @var \Symfony\Component\Form\Form $form */
+
 $leadId           = $lead->getId();
 $leadName         = $lead->getPrimaryIdentifier();
 $channelNumber    = 0;
@@ -177,7 +179,6 @@ JS;
     </div>
 
     <?php
-    unset($form['lead_channels']['preferred_channel']);
-    unset($form['lead_channels']['subscribed_channels']);
+    unset($form['lead_channels']);  // We do not want to render anything else but the CSRF token
     echo $view['form']->end($form); ?>
 </div>

--- a/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
+++ b/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
@@ -8,9 +8,11 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
-$leadId        = $lead->getId();
-$leadName      = $lead->getPrimaryIdentifier();
-$channelNumber = 0;
+$leadId           = $lead->getId();
+$leadName         = $lead->getPrimaryIdentifier();
+$channelNumber    = 0;
+$leadChannelsForm = $form['lead_channels'];
+
 $js            = <<<'JS'
 function togglePreferredChannel(channel){
        var status = document.getElementById(channel).checked;
@@ -45,8 +47,7 @@ JS;
                         echo $view['translator']->trans('mautic.lead.message.preferences.descr'); ?></small>
                 </div>
                 <table class="table table-striped">
-                    <?php if ($showContactFrequency):?>
-                    <?php foreach ($form['lead_channels']['subscribed_channels']->vars['choices'] as $key => $channel):
+                    <?php foreach ($leadChannelsForm['subscribed_channels']->vars['choices'] as $channel):
                         $contactMe   = isset($leadChannels[$channel->value]);
                         $checked     = $contactMe ? 'checked' : '';
                         $channelName = strtolower($view['channel']->getChannelLabel($channel->value));
@@ -90,70 +91,90 @@ JS;
                                         <?php echo $view['form']->widget($form['lead_channels']['contact_pause_end_date_'.$channel->value]); ?>
                                     </div>
                                     <?php
-                                else:
-                                    unset($form['lead_channels']['contact_pause_start_date_'.$channel->value]);
-                                    unset($form['lead_channels']['contact_pause_end_date_'.$channel->value]);
-                                endif; ?>
-                            </div>
-                        </td>
-                    </tr>
+                                    if ($showContactFrequency):?>
+                                        <div class="col-md-6">
+                                            <label class="text-muted"><?php echo $view['translator']->trans($leadChannelsForm['frequency_number_'.$channel->value]->vars['label']); ?></label>
+                                            <?php echo $view['form']->widget($leadChannelsForm['frequency_number_'.$channel->value]); ?>
+                                            <?php echo $view['form']->label($leadChannelsForm['frequency_time_'.$channel->value]); ?>
+                                            <?php echo $view['form']->widget($leadChannelsForm['frequency_time_'.$channel->value]); ?>
+                                        </div>
+                                    <?php else:
+                                        unset($form['lead_channels']['frequency_time_'.$channel->value]);
+                                        unset($form['lead_channels']['frequency_number_'.$channel->value]);
+                                    endif; ?>
+                                    <?php if ($showContactPauseDates):?>
+                                        <div class="col-md-6">
+                                            <label class="text-muted"><?php echo $view['translator']->trans('mautic.lead.frequency.dates.label'); ?></label>
+                                            <?php echo $view['form']->widget($leadChannelsForm['contact_pause_start_date_'.$channel->value]); ?>
+                                            <?php echo $view['form']->label($leadChannelsForm['contact_pause_end_date_'.$channel->value]); ?>
+                                            <?php echo $view['form']->widget($leadChannelsForm['contact_pause_end_date_'.$channel->value]); ?>
+                                        </div>
+                                    <?php
+                                    else:
+                                        unset($form['lead_channels']['contact_pause_start_date_'.$channel->value]);
+                                        unset($form['lead_channels']['contact_pause_end_date_'.$channel->value]);
+                                    endif;
+
+                                    ?>
+                                </div>
+                            </td>
+                        </tr>
                     <?php endforeach; ?>
-                    <?php endif; ?>
                 </table>
+
                 <?php if ($showContactPreferredChannels):?>
-                <hr />
-                <div id="preferred_channel" class="text-left"><?php echo $view['form']->row($form['lead_channels']['preferred_channel']); ?></div>
+                    <hr />
+                    <div id="preferred_channel" class="text-left"><?php echo $view['form']->row($leadChannelsForm['preferred_channel']); ?></div>
                 <?php
                 else:
-                    unset($form['lead_channels']['preferred_channel']);
+                    unset($form['preferred_channel']);
                 endif; ?>
-                <?php if ($showContactSegments && count($form['lead_lists'])):?>
-                <hr />
-                <div id="contact-segments"> <div class="text-left"><?php echo  $view['form']->label($form['lead_lists']); ?></div>
-                    <?php
-                    foreach ($form['lead_lists'] as $key=>$leadList) {
-                        ?>
-                        <div id="segment-<?php echo $key; ?>" class="text-left">
-                            <?php echo $view['form']->widget($leadList); ?>
-                            <?php echo $view['form']->label($leadList); ?>
-                        </div>
-                    <?php
-                    }
 
-                    unset($form['lead_lists']);
-                    ?>
-                </div>
-                    <?php
+                <?php if ($showContactSegments && count($form['lead_lists'])):?>
+                    <hr />
+                    <div id="contact-segments"> <div class="text-left"><?php echo  $view['form']->label($form['lead_lists']); ?></div>
+                        <?php
+                        $segmentNumber = count($form['lead_lists']->vars['choices']);
+                        for ($i = ($segmentNumber - 1); $i >= 0; --$i): ?>
+                            <div id="segment-<?php echo $i; ?>" class="text-left">
+                                <?php echo $view['form']->widget($form['lead_lists'][$i]); ?>
+                                <?php echo $view['form']->label($form['lead_lists'][$i]); ?>
+                            </div>
+                        <?php
+                        endfor;
+                        unset($form['lead_lists']);
+                        ?>
+                    </div>
+                <?php
                 else:
                     unset($form['lead_lists']);
                 endif; ?>
                 <?php if ($showContactCategories && count($form['global_categories'])):?>
-                <hr />
-                <div id="global-categories" class="text-left">
-                    <div><?php echo  $view['form']->label($form['global_categories']); ?></div>
-                    <?php $categoryNumber = count($form['global_categories']->vars['choices']);
-                    for ($i = ($categoryNumber - 1); $i >= 0; --$i): ?>
-                        <div id="category-<?php echo $i; ?>" class="text-left">
-                            <?php echo $view['form']->widget($form['global_categories'][$i]); ?>
-                            <?php echo $view['form']->label($form['global_categories'][$i]); ?>
-                        </div>
-                    <?php
-                    endfor;
-                    unset($form['global_categories']);
-                    ?>
-                </div>
+                    <hr />
+                    <div id="global-categories" class="text-left">
+                        <div><?php echo  $view['form']->label($form['global_categories']); ?></div>
+                        <?php $categoryNumber = count($form['global_categories']->vars['choices']);
+                        for ($i = ($categoryNumber - 1); $i >= 0; --$i): ?>
+                            <div id="category-<?php echo $i; ?>" class="text-left">
+                                <?php echo $view['form']->widget($form['global_categories'][$i]); ?>
+                                <?php echo $view['form']->label($form['global_categories'][$i]); ?>
+                            </div>
+                        <?php
+                        endfor;
+                        ?>
+                    </div>
                 <?php
-                else:
-                    unset($form['global_categories']);
                 endif;
+                unset($form['global_categories']);
                 ?>
             </div>
             <div class="panel-footer text-left">
-                <?php echo $view['form']->row($form['buttons']['save']); unset($form['buttons']['cancel']); ?></div>
+                <?php echo $view['form']->row($form['buttons']['save']); unset($form['buttons']['cancel']) ?>
+            </div>
         </div>
     </div>
 
     <?php
-    unset($form['lead_channels']);
+    unset($form['lead_channels']['subscribed_channels']);
     echo $view['form']->end($form); ?>
 </div>

--- a/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
+++ b/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
@@ -12,25 +12,22 @@
 $leadId           = $lead->getId();
 $leadName         = $lead->getPrimaryIdentifier();
 $channelNumber    = 0;
-$leadChannelsForm = $form['lead_channels'];
-
-$js            = <<<'JS'
-function togglePreferredChannel(channel){
-       var status = document.getElementById(channel).checked;
-       var formPrefix = 'lead_contact_frequency_rules_lead_channels_';
-       if(status)
-           {
-                document.getElementById(formPrefix + 'frequency_number_' + channel).disabled = false;
-                document.getElementById(formPrefix + 'frequency_time_' + channel).disabled = false;
-                document.getElementById(formPrefix + 'contact_pause_start_date_' + channel).disabled = false;
-                document.getElementById(formPrefix + 'contact_pause_end_date_' + channel).disabled = false;
-            } else {
-                document.getElementById(formPrefix + 'frequency_number_' + channel).disabled = true;
-                document.getElementById(formPrefix + 'frequency_time_' + channel).disabled = true;
-                document.getElementById(formPrefix + 'contact_pause_start_date_' + channel).disabled = true;
-                document.getElementById(formPrefix + 'contact_pause_end_date_' + channel).disabled = true;
-            }
-        }
+$js               = <<<'JS'
+function togglePreferredChannel(channel) {
+    var status = document.getElementById(channel).checked;
+    var formPrefix = 'lead_contact_frequency_rules_lead_channels_';
+    if (status) {
+        document.getElementById(formPrefix + 'frequency_number_' + channel).disabled = false;
+        document.getElementById(formPrefix + 'frequency_time_' + channel).disabled = false;
+        document.getElementById(formPrefix + 'contact_pause_start_date_' + channel).disabled = false;
+        document.getElementById(formPrefix + 'contact_pause_end_date_' + channel).disabled = false;
+    } else {
+        document.getElementById(formPrefix + 'frequency_number_' + channel).disabled = true;
+        document.getElementById(formPrefix + 'frequency_time_' + channel).disabled = true;
+        document.getElementById(formPrefix + 'contact_pause_start_date_' + channel).disabled = true;
+        document.getElementById(formPrefix + 'contact_pause_end_date_' + channel).disabled = true;
+    }
+}
 JS;
 
 ?>
@@ -49,7 +46,8 @@ JS;
                         echo $view['translator']->trans('mautic.lead.message.preferences.descr'); ?></small>
                 </div>
                 <table class="table table-striped">
-                    <?php foreach ($leadChannelsForm['subscribed_channels']->vars['choices'] as $channel):
+                    <?php if ($showContactFrequency):?>
+                    <?php foreach ($form['lead_channels']['subscribed_channels']->vars['choices'] as $key => $channel):
                         $contactMe   = isset($leadChannels[$channel->value]);
                         $checked     = $contactMe ? 'checked' : '';
                         $channelName = strtolower($view['channel']->getChannelLabel($channel->value));
@@ -93,40 +91,20 @@ JS;
                                         <?php echo $view['form']->widget($form['lead_channels']['contact_pause_end_date_'.$channel->value]); ?>
                                     </div>
                                     <?php
-                                    if ($showContactFrequency):?>
-                                        <div class="col-md-6">
-                                            <label class="text-muted"><?php echo $view['translator']->trans($leadChannelsForm['frequency_number_'.$channel->value]->vars['label']); ?></label>
-                                            <?php echo $view['form']->widget($leadChannelsForm['frequency_number_'.$channel->value]); ?>
-                                            <?php echo $view['form']->label($leadChannelsForm['frequency_time_'.$channel->value]); ?>
-                                            <?php echo $view['form']->widget($leadChannelsForm['frequency_time_'.$channel->value]); ?>
-                                        </div>
-                                    <?php else:
-                                        unset($form['lead_channels']['frequency_time_'.$channel->value]);
-                                        unset($form['lead_channels']['frequency_number_'.$channel->value]);
-                                    endif; ?>
-                                    <?php if ($showContactPauseDates):?>
-                                        <div class="col-md-6">
-                                            <label class="text-muted"><?php echo $view['translator']->trans('mautic.lead.frequency.dates.label'); ?></label>
-                                            <?php echo $view['form']->widget($leadChannelsForm['contact_pause_start_date_'.$channel->value]); ?>
-                                            <?php echo $view['form']->label($leadChannelsForm['contact_pause_end_date_'.$channel->value]); ?>
-                                            <?php echo $view['form']->widget($leadChannelsForm['contact_pause_end_date_'.$channel->value]); ?>
-                                        </div>
-                                    <?php
-                                    else:
-                                        unset($form['lead_channels']['contact_pause_start_date_'.$channel->value]);
-                                        unset($form['lead_channels']['contact_pause_end_date_'.$channel->value]);
-                                    endif;
-
-                                    ?>
-                                </div>
-                            </td>
-                        </tr>
+                                else:
+                                    unset($form['lead_channels']['contact_pause_start_date_'.$channel->value]);
+                                    unset($form['lead_channels']['contact_pause_end_date_'.$channel->value]);
+                                endif; ?>
+                            </div>
+                        </td>
+                    </tr>
                     <?php endforeach; ?>
+                    <?php endif; ?>
                 </table>
 
                 <?php if ($showContactPreferredChannels):?>
-                    <hr />
-                    <div id="preferred_channel" class="text-left"><?php echo $view['form']->row($leadChannelsForm['preferred_channel']); ?></div>
+                <hr />
+                <div id="preferred_channel" class="text-left"><?php echo $view['form']->row($form['lead_channels']['preferred_channel']); ?></div>
                 <?php
                     unset($form['lead_channels']['preferred_channel']);
                 else:
@@ -172,12 +150,12 @@ JS;
                 ?>
             </div>
             <div class="panel-footer text-left">
-                <?php echo $view['form']->row($form['buttons']['save']); unset($form['buttons']['cancel']) ?>
+                <?php echo $view['form']->row($form['buttons']['save']); unset($form['buttons']['cancel']); ?>
             </div>
         </div>
     </div>
 
     <?php
-    unset($form['lead_channels']);  // We do not want to render anything else but the CSRF token
+    unset($form['lead_channels']);
     echo $view['form']->end($form); ?>
 </div>

--- a/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
+++ b/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
@@ -16,17 +16,18 @@ $leadChannelsForm = $form['lead_channels'];
 $js            = <<<'JS'
 function togglePreferredChannel(channel){
        var status = document.getElementById(channel).checked;
+       var formPrefix = 'lead_contact_frequency_rules_lead_channels_';
        if(status)
            {
-                document.getElementById('lead_contact_frequency_rules_frequency_number_' + channel).disabled = false;
-                document.getElementById('lead_contact_frequency_rules_frequency_time_' + channel).disabled = false;
-                document.getElementById('lead_contact_frequency_rules_contact_pause_start_date_' + channel).disabled = false;
-                document.getElementById('lead_contact_frequency_rules_contact_pause_end_date_' + channel).disabled = false;
+                document.getElementById(formPrefix + 'frequency_number_' + channel).disabled = false;
+                document.getElementById(formPrefix + 'frequency_time_' + channel).disabled = false;
+                document.getElementById(formPrefix + 'contact_pause_start_date_' + channel).disabled = false;
+                document.getElementById(formPrefix + 'contact_pause_end_date_' + channel).disabled = false;
             } else {
-                document.getElementById('lead_contact_frequency_rules_frequency_number_' + channel).disabled = true;
-                document.getElementById('lead_contact_frequency_rules_frequency_time_' + channel).disabled = true;
-                document.getElementById('lead_contact_frequency_rules_contact_pause_start_date_' + channel).disabled = true;
-                document.getElementById('lead_contact_frequency_rules_contact_pause_end_date_' + channel).disabled = true;
+                document.getElementById(formPrefix + 'frequency_number_' + channel).disabled = true;
+                document.getElementById(formPrefix + 'frequency_time_' + channel).disabled = true;
+                document.getElementById(formPrefix + 'contact_pause_start_date_' + channel).disabled = true;
+                document.getElementById(formPrefix + 'contact_pause_end_date_' + channel).disabled = true;
             }
         }
 JS;

--- a/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
+++ b/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
@@ -179,6 +179,5 @@ JS;
     <?php
     unset($form['lead_channels']['preferred_channel']);
     unset($form['lead_channels']['subscribed_channels']);
-    var_dump($form['lead_channels']);
     echo $view['form']->end($form); ?>
 </div>

--- a/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
+++ b/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
@@ -127,7 +127,7 @@ JS;
                     <div id="preferred_channel" class="text-left"><?php echo $view['form']->row($leadChannelsForm['preferred_channel']); ?></div>
                 <?php
                 else:
-                    unset($form['preferred_channel']);
+                    unset($form['lead_channels']['preferred_channel']);
                 endif; ?>
 
                 <?php if ($showContactSegments && count($form['lead_lists'])):?>

--- a/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
+++ b/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
@@ -177,6 +177,8 @@ JS;
     </div>
 
     <?php
+    unset($form['lead_channels']['preferred_channel']);
     unset($form['lead_channels']['subscribed_channels']);
+    var_dump($form['lead_channels']);
     echo $view['form']->end($form); ?>
 </div>

--- a/app/bundles/LeadBundle/Form/Type/ContactFrequencyType.php
+++ b/app/bundles/LeadBundle/Form/Type/ContactFrequencyType.php
@@ -39,10 +39,9 @@ class ContactFrequencyType extends AbstractType
                 'lead_channels',
                 ContactChannelsType::class,
                 [
-                    'label'       => false,
-                    'channels'    => $options['channels'],
-                    'data'        => $options['data']['lead_channels'],
-                    'public_view' => $options['public_view'],
+                    'label'    => false,
+                    'channels' => $options['channels'],
+                    'data'     => $options['data']['lead_channels'],
                 ]
             );
         }
@@ -111,8 +110,8 @@ class ContactFrequencyType extends AbstractType
         $resolver->setRequired(['channels']);
         $resolver->setDefaults(
             [
-                'public_view'               => false,
-                'preference_center_only'    => false,
+                'public_view'            => false,
+                'preference_center_only' => false,
             ]
         );
     }

--- a/app/bundles/LeadBundle/Views/Lead/frequency.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/frequency.html.php
@@ -10,7 +10,7 @@
  */
 ?>
 
-    <?php echo $view['form']->start($form); ?>
+<?php echo $view['form']->start($form); ?>
 <ul class="nav nav-tabs">
     <li class="active"><a data-toggle="tab" href="#channels"><?php echo $view['translator']->trans('mautic.lead.contact.channels'); ?></a></li>
     <li><a data-toggle="tab" href="#categories"><?php echo $view['translator']->trans('mautic.lead.preferred.categories'); ?></a></li>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )
#### Summary of the issue:

In testing, I got an "Oh dear" error page when clicking unsubscribe. This only happened when there was no preference center page attached to an email, and "Show contact preference settings" was set to Yes. Other preference options were set to Yes.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Set "Show contact preference settings" to yes
2. Create new template or segment email, with no Preference Center page
3. Send email to contact (through campaign/form or segment)
4. Click unsubscribe

#### Expected Results:

Default preference center page should appear (with styling from default theme)

#### Actual Results:

"Oh, dear" page appears

#### Steps to test this PR:

1. Load up this PR
2. Verify above is fixed
3. Verify preferences are stored