### PR TITLE
Campaign decisions after contact removed

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -211,7 +211,12 @@ class LeadRepository extends CommonRepository
         $q = $this->getSlaveConnection($limiter)->createQueryBuilder();
         $q->select('l.lead_id, l.date_added')
             ->from(MAUTIC_TABLE_PREFIX.'campaign_leads', 'l')
-            ->where($q->expr()->eq('l.campaign_id', ':campaignId'))
+            ->where(
+                $q->expr()->andX(
+                    $q->expr()->eq( 'l.campaign_id', ':campaignId'),
+                    $q->expr()->eq('l.manually_removed', 0)
+                )
+            )
             // Order by ID so we can query by greater than X contact ID when batching
             ->orderBy('l.lead_id')
             ->setMaxResults($limiter->getBatchLimit())
@@ -291,7 +296,12 @@ class LeadRepository extends CommonRepository
             $q = $this->getSlaveConnection()->createQueryBuilder();
             $q->select('count(*)')
                 ->from(MAUTIC_TABLE_PREFIX.'campaign_leads', 'l')
-                ->where($q->expr()->eq('l.campaign_id', ':campaignId'))
+                ->where(
+                    $q->expr()->andX(
+                        $q->expr()->eq( 'l.campaign_id', ':campaignId'),
+                        $q->expr()->eq('l.manually_removed', 0)
+                    )
+                )
                 // Order by ID so we can query by greater than X contact ID when batching
                 ->orderBy('l.lead_id')
                 ->setParameter('campaignId', (int) $campaignId);

--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -213,7 +213,7 @@ class LeadRepository extends CommonRepository
             ->from(MAUTIC_TABLE_PREFIX.'campaign_leads', 'l')
             ->where(
                 $q->expr()->andX(
-                    $q->expr()->eq( 'l.campaign_id', ':campaignId'),
+                    $q->expr()->eq('l.campaign_id', ':campaignId'),
                     $q->expr()->eq('l.manually_removed', 0)
                 )
             )
@@ -298,7 +298,7 @@ class LeadRepository extends CommonRepository
                 ->from(MAUTIC_TABLE_PREFIX.'campaign_leads', 'l')
                 ->where(
                     $q->expr()->andX(
-                        $q->expr()->eq( 'l.campaign_id', ':campaignId'),
+                        $q->expr()->eq('l.campaign_id', ':campaignId'),
                         $q->expr()->eq('l.manually_removed', 0)
                     )
                 )

--- a/app/bundles/CampaignBundle/Tests/Command/ValidateEventCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/ValidateEventCommandTest.php
@@ -11,7 +11,6 @@
 
 namespace Mautic\CampaignBundle\Tests\Command;
 
-
 class ValidateEventCommandTest extends AbstractCampaignCommand
 {
     public function testEventsAreExecutedForInactiveEventWithSingleContact()
@@ -61,7 +60,6 @@ class ValidateEventCommandTest extends AbstractCampaignCommand
         $this->assertCount(3, $byEvent[7]); // inactive event executed
         $this->assertCount(0, $byEvent[10]); // the positive path should be 0
     }
-
 
     public function testContactsRemovedFromTheCampaignAreNotExecutedForInactiveEvents()
     {

--- a/app/bundles/CampaignBundle/Tests/Command/ValidateEventCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/ValidateEventCommandTest.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\CampaignBundle\Tests\Command;
 
+
 class ValidateEventCommandTest extends AbstractCampaignCommand
 {
     public function testEventsAreExecutedForInactiveEventWithSingleContact()
@@ -58,6 +59,38 @@ class ValidateEventCommandTest extends AbstractCampaignCommand
         $byEvent = $this->getCampaignEventLogs([3, 7, 10]);
         $this->assertCount(3, $byEvent[3]); // decision recorded
         $this->assertCount(3, $byEvent[7]); // inactive event executed
+        $this->assertCount(0, $byEvent[10]); // the positive path should be 0
+    }
+
+
+    public function testContactsRemovedFromTheCampaignAreNotExecutedForInactiveEvents()
+    {
+        $this->runCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-ids' => '1,2,3']);
+
+        // Wait 20 seconds then execute the campaign again to send scheduled events
+        sleep(20);
+        $this->runCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-ids' => '1,2,3']);
+
+        // No open email decisions should be recorded yet
+        $byEvent = $this->getCampaignEventLogs([3]);
+        $this->assertCount(0, $byEvent[3]);
+
+        // Wait 20 seconds to go beyond the inaction timeframe
+        sleep(20);
+
+        // Remove a contact from the campaign
+        $this->db->createQueryBuilder()->update(MAUTIC_TABLE_PREFIX.'campaign_leads')
+            ->set('manually_removed', 1)
+            ->where('lead_id = 1')
+            ->execute();
+
+        // Now they should be inactive
+        $this->runCommand('mautic:campaigns:validate', ['--decision-id' => 3, '--contact-ids' => '1,2,3']);
+
+        // Only two contacts should have been considered inactive because one was marked as manually removed
+        $byEvent = $this->getCampaignEventLogs([3, 7, 10]);
+        $this->assertCount(2, $byEvent[3]); // decision recorded
+        $this->assertCount(2, $byEvent[7]); // inactive event executed
         $this->assertCount(0, $byEvent[10]); // the positive path should be 0
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/6407
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Turns out we've had a bug for a long time that would execute events associated with the inactive path of a decision even if the contact had since been removed from the campaign. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a segment based on a filter
2. Create a campaign using that segment as a source, send an email, connect an opens email decision, then connect a second send email to the right/red/inactive anchor of the decision. Set a wait time of 2 minutes
3. If you don't already have contacts in the segment, modify/create a contact that matches the segments filter.
4. Wait till the campaign sends the first email but DO NOT open the email
5. Immediately update the contact so that they no longer match the filters in which they should be removed from the segment and campaign
6. Wait until 2 minutes have passed and notice that the contact will get the second email even though they are removed from the campaign

#### Steps to test this PR:
1. Repeat and the contact will not receive the second email after being removed from the campaign