### PR TITLE
Fix convert all email images to embed type

### DIFF
--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -197,7 +197,7 @@ class EmailSendEvent extends CommonEvent
     public function setContent($content)
     {
         if ($this->helper !== null) {
-            $this->helper->setBody($content, 'text/html', null, true, true);
+            $this->helper->setBody($content, 'text/html', null);
         } else {
             $this->content = $content;
         }

--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -197,7 +197,7 @@ class EmailSendEvent extends CommonEvent
     public function setContent($content)
     {
         if ($this->helper !== null) {
-            $this->helper->setBody($content, 'text/html', null);
+            $this->helper->setBody($content, 'text/html', null, true);
         } else {
             $this->content = $content;
         }

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -416,6 +416,7 @@ class MailHelper
                     self::searchReplaceTokens($search, $replace, $this->message);
                 }
             }
+
             // Attach assets
             if (!empty($this->assets)) {
                 /** @var \Mautic\AssetBundle\Entity\Asset $asset */
@@ -977,7 +978,7 @@ class MailHelper
     }
 
     /**
-     * @param $content
+     * @param string $content
      *
      * @return string
      */

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -416,7 +416,6 @@ class MailHelper
                     self::searchReplaceTokens($search, $replace, $this->message);
                 }
             }
-
             // Attach assets
             if (!empty($this->assets)) {
                 /** @var \Mautic\AssetBundle\Entity\Asset $asset */
@@ -435,6 +434,11 @@ class MailHelper
             try {
                 if (!$this->transport->isStarted()) {
                     $this->transportStartTime = time();
+                }
+
+                if ($this->factory->getParameter('mailer_convert_embed_images')) {
+                    $convertedContent = $this->convertEmbedImages($this->message->getBody());
+                    $this->message->setBody($convertedContent);
                 }
 
                 $this->mailer->send($this->message, $failures);
@@ -953,19 +957,6 @@ class MailHelper
      */
     public function setBody($content, $contentType = 'text/html', $charset = null, $ignoreTrackingPixel = false, $ignoreEmbedImageConversion = false)
     {
-        if (!$ignoreEmbedImageConversion && $this->factory->getParameter('mailer_convert_embed_images')) {
-            $matches = [];
-            if (preg_match_all('/<img.+?src=[\"\'](.+?)[\"\'].*?>/i', $content, $matches)) {
-                $replaces = [];
-                foreach ($matches[1] as $match) {
-                    if (strpos($match, 'cid:') === false) {
-                        $replaces[$match] = $this->message->embed(\Swift_Image::fromPath($match));
-                    }
-                }
-                $content = strtr($content, $replaces);
-            }
-        }
-
         if (!$ignoreTrackingPixel && $this->factory->getParameter('mailer_append_tracking_pixel')) {
             // Append tracking pixel
             $trackingImg = '<img height="1" width="1" src="{tracking_pixel}" alt="" />';
@@ -984,6 +975,27 @@ class MailHelper
             'contentType' => $contentType,
             'charset'     => $charset,
         ];
+    }
+
+    /**
+     * @param $content
+     *
+     * @return string
+     */
+    private function convertEmbedImages($content)
+    {
+        $matches = [];
+        if (preg_match_all('/<img.+?src=[\"\'](.+?)[\"\'].*?>/i', $content, $matches)) {
+            $replaces = [];
+            foreach ($matches[1] as $match) {
+                if (strpos($match, 'cid:') === false) {
+                    $replaces[$match] = $this->message->embed(\Swift_Image::fromPath($match));
+                }
+            }
+            $content = strtr($content, $replaces);
+        }
+
+        return $content;
     }
 
     /**

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -953,9 +953,8 @@ class MailHelper
      * @param string $contentType
      * @param null   $charset
      * @param bool   $ignoreTrackingPixel
-     * @param bool   $ignoreEmbedImageConversion
      */
-    public function setBody($content, $contentType = 'text/html', $charset = null, $ignoreTrackingPixel = false, $ignoreEmbedImageConversion = false)
+    public function setBody($content, $contentType = 'text/html', $charset = null, $ignoreTrackingPixel = false)
     {
         if (!$ignoreTrackingPixel && $this->factory->getParameter('mailer_append_tracking_pixel')) {
             // Append tracking pixel


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR improve convert images to embed mode, If this option is enabled.

This fix allow convert images generate by plugin. For example 
https://github.com/mtcextendee/mautic-barcode-generator-bundle

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create email and insert image
2. Enable mailer_convert_embed_images from configuration
3. Install https://github.com/mtcextendee/mautic-barcode-generator-bundle and insert {barcode=id} to email
4. Send email
5. See first image was embed and second image from token don't embed

#### Steps to test this PR:
1. Repeat all steps
2. See If both images are converted
