### PR TITLE
Fix tracking of lead that have non trackable IP

### DIFF
--- a/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerTest.php
@@ -191,7 +191,7 @@ class ContactTrackerTest extends \PHPUnit_Framework_TestCase
     {
         $contactTracker = $this->getContactTracker();
 
-        $this->ipLookupHelperMock->expects($this->once())
+        $this->ipLookupHelperMock->expects($this->exactly(2))
             ->method('getIpAddress')
             ->willReturn(new IpAddress());
 
@@ -222,7 +222,7 @@ class ContactTrackerTest extends \PHPUnit_Framework_TestCase
     {
         $contactTracker = $this->getContactTracker();
 
-        $this->ipLookupHelperMock->expects($this->once())
+        $this->ipLookupHelperMock->expects($this->exactly(2))
             ->method('getIpAddress')
             ->willReturn(new IpAddress());
 

--- a/app/bundles/LeadBundle/Tracker/ContactTracker.php
+++ b/app/bundles/LeadBundle/Tracker/ContactTracker.php
@@ -276,6 +276,12 @@ class ContactTracker
     {
         $lead = null;
 
+        // Return null for leads that are from a non-trackable IP, prevent anonymous lead with a non-trackable IP to be tracked
+        $ip = $this->ipLookupHelper->getIpAddress();
+        if ($ip && !$ip->isTrackable()) {
+            return $lead;
+        }
+
         // Is there a device being tracked?
         if ($trackedDevice = $this->deviceTracker->getTrackedDevice()) {
             $lead = $trackedDevice->getLead();


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7765
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Lead already identified by cookie pass through the **List of IPs to not track contacts with** configuration and are tracked.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make a web page with tracking script
2. Make a report on **Pages: Page hits** with this columns
![Screenshot_2019-08-20 Edit Report - Tracking Mautic](https://user-images.githubusercontent.com/27768270/63330090-7bd7cf00-c333-11e9-899c-3106551ece46.png)

3. Go to the web page on private navigation
4. See that anonymous contact is registred in your instance with your IP and see that one line is added to the report
5. Place your IP in **List of IPs to not track contacts with** in configuration of Mautic
6. Refresh the web page with tracking script, a second line is added to the report

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7805)
2. Repeat step above
3. When you refresh web page for the second time no line is added
