### PR TITLE
Use tls 1.2 since Salesforce disabled 1.1 https://help.salesforce.com/articleView?id=000321556&type=1&mode=1

### DIFF
--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -26,7 +26,7 @@ class SalesforceApi extends CrmApi
         parent::__construct($integration);
 
         $this->requestSettings['curl_options'] = [
-            CURLOPT_SSLVERSION => defined('CURL_SSLVERSION_TLSv1_1') ? CURL_SSLVERSION_TLSv1_1 : 5,
+            CURLOPT_SSLVERSION => defined('CURL_SSLVERSION_TLSv1_2') ? CURL_SSLVERSION_TLSv1_2 : 6,
         ];
     }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Salesforce is disabling tls 1.1 which it seems we are forcing our integration to use. https://help.salesforce.com/articleView?id=000321556&type=1&mode=1

[//]: # ( As applicable: )

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Setup the salesforce integration and after authenticating, ensure that there is no error message and the fields show up on the contact mapping tab. 
