### PR TITLE
Contacts able to submit Form without adding data in required fields

### DIFF
--- a/app/bundles/FormBundle/Entity/Field.php
+++ b/app/bundles/FormBundle/Entity/Field.php
@@ -876,9 +876,8 @@ class Field
             return false;
         }
 
-        if ($this->showWhenValueExists === false && !$this->isRequired()) {
+        if ($this->showWhenValueExists === false) {
             // Hide the field if there is the value condition and if we already know the value for this field
-            // If the field is required then we always show it
             if ($submissions) {
                 foreach ($submissions as $submission) {
                     if (!empty($submission[$this->alias]) && !$this->isAutoFill) {

--- a/app/bundles/FormBundle/Entity/Field.php
+++ b/app/bundles/FormBundle/Entity/Field.php
@@ -876,8 +876,9 @@ class Field
             return false;
         }
 
-        if ($this->showWhenValueExists === false) {
+        if ($this->showWhenValueExists === false && !$this->isRequired()) {
             // Hide the field if there is the value condition and if we already know the value for this field
+            // If the field is required then we always show it
             if ($submissions) {
                 foreach ($submissions as $submission) {
                     if (!empty($submission[$this->alias]) && !$this->isAutoFill) {

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -277,10 +277,6 @@ class SubmissionModel extends CommonFormModel
             }
 
             if ($value === '' && $f->isRequired()) {
-                //field is required, but hidden from form because of 'ShowWhenValueExists'
-                if ($f->getShowWhenValueExists() === false && !isset($post[$alias])) {
-                    continue;
-                }
 
                 //somehow the user got passed the JS validation
                 $msg = $f->getValidationMessage();

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -277,7 +277,6 @@ class SubmissionModel extends CommonFormModel
             }
 
             if ($value === '' && $f->isRequired()) {
-
                 //somehow the user got passed the JS validation
                 $msg = $f->getValidationMessage();
                 if (empty($msg)) {

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -406,7 +406,6 @@ class SubmissionModel extends CommonFormModel
         $trackedDevice = $this->deviceTrackingService->getTrackedDevice();
         $trackingId    = ($trackedDevice === null ? null : $trackedDevice->getTrackingId());
 
-
         //set tracking ID for stats purposes to determine unique hits
         $submission->setTrackingId($trackingId)
             ->setLead($lead);

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -277,6 +277,7 @@ class SubmissionModel extends CommonFormModel
             }
 
             if ($value === '' && $f->isRequired()) {
+
                 //somehow the user got passed the JS validation
                 $msg = $f->getValidationMessage();
                 if (empty($msg)) {

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -277,6 +277,10 @@ class SubmissionModel extends CommonFormModel
             }
 
             if ($value === '' && $f->isRequired()) {
+                //field is required, but hidden from form because of 'ShowWhenValueExists'
+                if ($f->getShowWhenValueExists() === false && !isset($post[$alias])) {
+                    continue;
+                }
 
                 //somehow the user got passed the JS validation
                 $msg = $f->getValidationMessage();

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -380,19 +380,7 @@ class SubmissionModel extends CommonFormModel
         // @deprecated - BC support; to be removed in 3.0 - be sure to remove the validator option from addSubmitAction as well
         $this->validateActionCallbacks($submissionEvent, $validationErrors, $alias);
 
-        // Create/update lead
-        $lead = null;
-        if (!empty($leadFieldMatches)) {
-            $this->createLeadFromSubmit($form, $leadFieldMatches, $leadFields);
-        }
-
         $lead          = $this->leadModel->getCurrentLead();
-        $trackedDevice = $this->deviceTrackingService->getTrackedDevice();
-        $trackingId    = ($trackedDevice === null ? null : $trackedDevice->getTrackingId());
-
-        //set tracking ID for stats purposes to determine unique hits
-        $submission->setTrackingId($trackingId)
-            ->setLead($lead);
 
         // Remove validation errors if the field is not visible
         if ($lead && $form->usesProgressiveProfiling()) {
@@ -409,6 +397,19 @@ class SubmissionModel extends CommonFormModel
         if (!empty($validationErrors)) {
             return ['errors' => $validationErrors];
         }
+
+        // Create/update lead
+        if (!empty($leadFieldMatches)) {
+            $lead = $this->createLeadFromSubmit($form, $leadFieldMatches, $leadFields);
+        }
+
+        $trackedDevice = $this->deviceTrackingService->getTrackedDevice();
+        $trackingId    = ($trackedDevice === null ? null : $trackedDevice->getTrackingId());
+
+
+        //set tracking ID for stats purposes to determine unique hits
+        $submission->setTrackingId($trackingId)
+            ->setLead($lead);
 
         /*
          * Process File upload and save the result to the entity


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL |
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/pull/7570
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Contacts with missing required fields get saved when using Mautic forms.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form with email and a couple of other required fields and add it to a landing page. 
2. Go to developer console of your browser and disable Javascript. This is an important step, we have to disable Javascript to emulate spambots and disable Javascript validation.
3. Open a new browser window in incognito (private) mode.
4. Go to the landing page you created on step 1, fill in some required fields but not all. E.g. fill in email but don't fill first or last name.
5. Submit the form.
6. Go to the contacts page of your Mautic instance.
7. A contact with missing required fields will be created.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat steps 1-6 (inclusive) from "Steps to reproduce".
3. No contact will be created.