### PR TITLE
Fix campaign update form field values

### DIFF
--- a/app/bundles/FormBundle/Assets/js/form.js
+++ b/app/bundles/FormBundle/Assets/js/form.js
@@ -149,7 +149,7 @@ Mautic.updateFormFieldValues = function (field) {
             .attr('value', valueFieldAttrs['value']);
         mQuery.each(options[fieldValue], function(key, optionVal) {
             var option = mQuery("<option></option>")
-                .attr('value', optionVal)
+                .attr('value', key)
                 .text(optionVal);
             newValueField.append(option);
         });


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
JS function Mautic.updateFormFieldValues sets label as value. This causes validation error when select is generated by JS.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create campaign with Form field value condition
2. Choose form with select field
3. Set field (select type), operator and value
4. Click update
5. Update failed: "This value is not valid"

Note: If you click again then the update is successful because the select values are generated by PHP script, not JS.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat steps to reproduce bug
