### PR TITLE
Report not showing properly clicks for multiple emails

### DIFF
--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -376,8 +376,8 @@ class ReportSubscriber extends CommonSubscriber
 
                     if ($event->hasFilter('e.id')) {
                         $filterParam = $event->createParameterName();
-                        $qbcut->andWhere("cut2.channel_id = :{$filterParam}");
-                        $qb->setParameter($filterParam, $event->getFilterValue('e.id'), \PDO::PARAM_INT);
+                        $qbcut->andWhere($qb->expr()->in('cut2.channel_id', ":{$filterParam}"));
+                        $qb->setParameter($filterParam, $event->getFilterValues('e.id'), Connection::PARAM_INT_ARRAY);
                     }
 
                     $qb->leftJoin(

--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -385,6 +385,31 @@ class Report extends FormEntity implements SchedulerInterface
     }
 
     /**
+     * Get filter values from a specific filter.
+     *
+     * @param string $column
+     *
+     * @return array
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function getFilterValues($column)
+    {
+        $values = [];
+        foreach ($this->getFilters() as $field) {
+            if ($column === $field['column']) {
+                $values[] = $field['value'];
+            }
+        }
+
+        if (empty($values)) {
+            throw new \UnexpectedValueException("Column {$column} doesn't have any filter.");
+        }
+
+        return $values;
+    }
+
+    /**
      * @return mixed
      */
     public function getDescription()

--- a/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
@@ -448,6 +448,20 @@ class ReportGeneratorEvent extends AbstractReportEvent
     }
 
     /**
+     * Get filter values from a specific filter.
+     *
+     * @param string $column
+     *
+     * @return array
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function getFilterValues($column)
+    {
+        return $this->getReport()->getFilterValues($column);
+    }
+
+    /**
      * Check if the report has a groupBy columns selected.
      *
      *

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -689,6 +689,9 @@ class ReportModel extends FormModel
             $params             = $query->getParameters();
 
             foreach ($params as $name => $param) {
+                if (is_array($param)) {
+                    $param = implode("','", $param);
+                }
                 $debugData['query'] = str_replace(":$name", "'$param'", $debugData['query']);
             }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? |N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Reports for Emails sent data source based on more than one email are showing clicks only for the first email. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a report using Emails sent datasource
2. Create two filters for Email ID with OR condition
3. Clicks are displayed only for the first email

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create a report using Emails sent datasource
3. Create two filters for Email ID with OR condition
4. Clicks are displayed for both emails

