### PR TITLE
Improve pending contacts queries.

### DIFF
--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -423,15 +423,14 @@ class CampaignRepository extends CommonRepository
             ->where(
                 $sq->expr()->andX(
                     $sq->expr()->eq('e.lead_id', 'cl.lead_id'),
-                    $sq->expr()->eq('e.campaign_id', ':campaignId'),
+                    $sq->expr()->eq('e.campaign_id', (int) $campaignId),
                     $sq->expr()->eq('e.rotation', 'cl.rotation')
                 )
             );
 
         $q->andWhere(
             sprintf('NOT EXISTS (%s)', $sq->getSQL())
-        )
-            ->setParameter('campaignId', (int) $campaignId);
+        );
 
         if ($limiter->hasCampaignLimit() && $limiter->getCampaignLimitRemaining() < $limiter->getBatchLimit()) {
             $q->setMaxResults($limiter->getCampaignLimitRemaining());

--- a/app/bundles/CampaignBundle/Entity/ContactLimiterTrait.php
+++ b/app/bundles/CampaignBundle/Entity/ContactLimiterTrait.php
@@ -30,7 +30,7 @@ trait ContactLimiterTrait
             $qb->andWhere(
                 $qb->expr()->eq("$alias.lead_id", ':contactId')
             )
-                ->setParameter('contactId', $contactId, \PDO::PARAM_INT);
+                ->setParameter('contactId', $contactId, \Doctrine\DBAL\ParameterType::INTEGER);
         } elseif ($contactIds = $contactLimiter->getContactIdList()) {
             $qb->andWhere(
                 $qb->expr()->in("$alias.lead_id", ':contactIds')
@@ -40,26 +40,26 @@ trait ContactLimiterTrait
             $qb->andWhere(
                 "$alias.lead_id BETWEEN :minContactId AND :maxContactId"
             )
-                ->setParameter('minContactId', $minContactId, \PDO::PARAM_INT)
-                ->setParameter('maxContactId', $maxContactId, \PDO::PARAM_INT);
+                ->setParameter('minContactId', $minContactId, \Doctrine\DBAL\ParameterType::INTEGER)
+                ->setParameter('maxContactId', $maxContactId, \Doctrine\DBAL\ParameterType::INTEGER);
         } elseif ($minContactId) {
             $qb->andWhere(
                 $qb->expr()->gte("$alias.lead_id", ':minContactId')
             )
-                ->setParameter('minContactId', $minContactId, \PDO::PARAM_INT);
+                ->setParameter('minContactId', $minContactId, \Doctrine\DBAL\ParameterType::INTEGER);
         } elseif ($maxContactId) {
             $qb->andWhere(
                 $qb->expr()->lte("$alias.lead_id", ':maxContactId')
             )
-                ->setParameter('maxContactId', $maxContactId, \PDO::PARAM_INT);
+                ->setParameter('maxContactId', $maxContactId, \Doctrine\DBAL\ParameterType::INTEGER);
         }
 
         if ($threadId = $contactLimiter->getThreadId()) {
             if ($maxThreads = $contactLimiter->getMaxThreads()) {
                 if ($threadId <= $maxThreads) {
                     $qb->andWhere("MOD(($alias.lead_id + :threadShift), :maxThreads) = 0")
-                        ->setParameter('threadShift', $threadId - 1, \PDO::PARAM_INT)
-                        ->setParameter('maxThreads', $maxThreads, \PDO::PARAM_INT);
+                        ->setParameter('threadShift', $threadId - 1, \Doctrine\DBAL\ParameterType::INTEGER)
+                        ->setParameter('maxThreads', $maxThreads, \Doctrine\DBAL\ParameterType::INTEGER);
                 }
             }
         }
@@ -81,7 +81,7 @@ trait ContactLimiterTrait
             $qb->andWhere(
                 $qb->expr()->eq("IDENTITY($alias.lead)", ':contact')
             )
-                ->setParameter('contact', $contactId, \PDO::PARAM_INT);
+                ->setParameter('contact', $contactId, \Doctrine\DBAL\ParameterType::INTEGER);
         } elseif ($contactIds = $contactLimiter->getContactIdList()) {
             $qb->andWhere(
                 $qb->expr()->in("IDENTITY($alias.lead)", ':contactIds')
@@ -91,25 +91,25 @@ trait ContactLimiterTrait
             $qb->andWhere(
                 "IDENTITY($alias.lead) BETWEEN :minContactId AND :maxContactId"
             )
-                ->setParameter('minContactId', $minContactId, \PDO::PARAM_INT)
-                ->setParameter('maxContactId', $maxContactId, \PDO::PARAM_INT);
+                ->setParameter('minContactId', $minContactId, \Doctrine\DBAL\ParameterType::INTEGER)
+                ->setParameter('maxContactId', $maxContactId, \Doctrine\DBAL\ParameterType::INTEGER);
         } elseif ($minContactId) {
             $qb->andWhere(
                 $qb->expr()->gte("IDENTITY($alias.lead)", ':minContactId')
             )
-                ->setParameter('minContactId', $minContactId, \PDO::PARAM_INT);
+                ->setParameter('minContactId', $minContactId, \Doctrine\DBAL\ParameterType::INTEGER);
         } elseif ($maxContactId) {
             $qb->andWhere(
                 $qb->expr()->lte("IDENTITY($alias.lead)", ':maxContactId')
             )
-                ->setParameter('maxContactId', $maxContactId, \PDO::PARAM_INT);
+                ->setParameter('maxContactId', $maxContactId, \Doctrine\DBAL\ParameterType::INTEGER);
         }
 
         if ($threadId = $contactLimiter->getThreadId()) {
             if ($maxThreads = $contactLimiter->getMaxThreads()) {
                 $qb->andWhere("MOD((IDENTITY($alias.lead) + :threadShift), :maxThreads) = 0")
-                    ->setParameter('threadShift', $threadId - 1, \PDO::PARAM_INT)
-                    ->setParameter('maxThreads', $maxThreads, \PDO::PARAM_INT);
+                    ->setParameter('threadShift', $threadId - 1, \Doctrine\DBAL\ParameterType::INTEGER)
+                    ->setParameter('maxThreads', $maxThreads, \Doctrine\DBAL\ParameterType::INTEGER);
             }
         }
 

--- a/app/bundles/CampaignBundle/Entity/ContactLimiterTrait.php
+++ b/app/bundles/CampaignBundle/Entity/ContactLimiterTrait.php
@@ -30,7 +30,7 @@ trait ContactLimiterTrait
             $qb->andWhere(
                 $qb->expr()->eq("$alias.lead_id", ':contactId')
             )
-                ->setParameter('contactId', $contactId);
+                ->setParameter('contactId', $contactId, \PDO::PARAM_INT);
         } elseif ($contactIds = $contactLimiter->getContactIdList()) {
             $qb->andWhere(
                 $qb->expr()->in("$alias.lead_id", ':contactIds')
@@ -40,26 +40,26 @@ trait ContactLimiterTrait
             $qb->andWhere(
                 "$alias.lead_id BETWEEN :minContactId AND :maxContactId"
             )
-                ->setParameter('minContactId', $minContactId)
-                ->setParameter('maxContactId', $maxContactId);
+                ->setParameter('minContactId', $minContactId, \PDO::PARAM_INT)
+                ->setParameter('maxContactId', $maxContactId, \PDO::PARAM_INT);
         } elseif ($minContactId) {
             $qb->andWhere(
                 $qb->expr()->gte("$alias.lead_id", ':minContactId')
             )
-                ->setParameter('minContactId', $minContactId);
+                ->setParameter('minContactId', $minContactId, \PDO::PARAM_INT);
         } elseif ($maxContactId) {
             $qb->andWhere(
                 $qb->expr()->lte("$alias.lead_id", ':maxContactId')
             )
-                ->setParameter('maxContactId', $maxContactId);
+                ->setParameter('maxContactId', $maxContactId, \PDO::PARAM_INT);
         }
 
         if ($threadId = $contactLimiter->getThreadId()) {
             if ($maxThreads = $contactLimiter->getMaxThreads()) {
                 if ($threadId <= $maxThreads) {
                     $qb->andWhere("MOD(($alias.lead_id + :threadShift), :maxThreads) = 0")
-                        ->setParameter('threadShift', $threadId - 1)
-                        ->setParameter('maxThreads', $maxThreads);
+                        ->setParameter('threadShift', $threadId - 1, \PDO::PARAM_INT)
+                        ->setParameter('maxThreads', $maxThreads, \PDO::PARAM_INT);
                 }
             }
         }
@@ -81,7 +81,7 @@ trait ContactLimiterTrait
             $qb->andWhere(
                 $qb->expr()->eq("IDENTITY($alias.lead)", ':contact')
             )
-                ->setParameter('contact', $contactId);
+                ->setParameter('contact', $contactId, \PDO::PARAM_INT);
         } elseif ($contactIds = $contactLimiter->getContactIdList()) {
             $qb->andWhere(
                 $qb->expr()->in("IDENTITY($alias.lead)", ':contactIds')
@@ -91,25 +91,25 @@ trait ContactLimiterTrait
             $qb->andWhere(
                 "IDENTITY($alias.lead) BETWEEN :minContactId AND :maxContactId"
             )
-                ->setParameter('minContactId', $minContactId)
-                ->setParameter('maxContactId', $maxContactId);
+                ->setParameter('minContactId', $minContactId, \PDO::PARAM_INT)
+                ->setParameter('maxContactId', $maxContactId, \PDO::PARAM_INT);
         } elseif ($minContactId) {
             $qb->andWhere(
                 $qb->expr()->gte("IDENTITY($alias.lead)", ':minContactId')
             )
-                ->setParameter('minContactId', $minContactId);
+                ->setParameter('minContactId', $minContactId, \PDO::PARAM_INT);
         } elseif ($maxContactId) {
             $qb->andWhere(
                 $qb->expr()->lte("IDENTITY($alias.lead)", ':maxContactId')
             )
-                ->setParameter('maxContactId', $maxContactId);
+                ->setParameter('maxContactId', $maxContactId, \PDO::PARAM_INT);
         }
 
         if ($threadId = $contactLimiter->getThreadId()) {
             if ($maxThreads = $contactLimiter->getMaxThreads()) {
                 $qb->andWhere("MOD((IDENTITY($alias.lead) + :threadShift), :maxThreads) = 0")
-                    ->setParameter('threadShift', $threadId - 1)
-                    ->setParameter('maxThreads', $maxThreads);
+                    ->setParameter('threadShift', $threadId - 1, \PDO::PARAM_INT)
+                    ->setParameter('maxThreads', $maxThreads, \PDO::PARAM_INT);
             }
         }
 

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -477,7 +477,7 @@ class LeadEventLogRepository extends CommonRepository
             ->from(MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'l')
             ->join('l', MAUTIC_TABLE_PREFIX.'campaigns', 'c', 'l.campaign_id = c.id')
             ->where($expr)
-            ->setParameter('campaignId', $campaignId)
+            ->setParameter('campaignId', (int) $campaignId)
             ->setParameter('now', $now->format('Y-m-d H:i:s'))
             ->setParameter('true', true, \PDO::PARAM_BOOL)
             ->groupBy('l.event_id')


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Automated tests included? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Required: )
#### Description:
The query to find new kickoff events to run will treat the campaign ID as a string, making MySQL 5.6 (possibly others) perform a range scan instead of using the correct index. This makes sure that the campaign ID is treated as an integer for this query.

When fixing this, I found a few other queries similarly enclosing quotes around integers and fixed those as well.

Example:
```
SELECT cl.lead_id FROM campaign_leads cl WHERE (cl.campaign_id = 43) AND (cl.manually_removed = 0) AND (cl.lead_id >= '281027000') AND (NOT EXISTS (SELECT null FROM campaign_lead_event_log e WHERE (e.lead_id = cl.lead_id) AND (e.campaign_id = '43') AND (e.rotation = cl.rotation))) ORDER BY cl.lead_id ASC LIMIT 100
```
Where the '43' should just be 43.

The code change makes this:
![Screen Shot 2019-08-30 at 10 35 03 AM](https://user-images.githubusercontent.com/302215/64030067-dc28f680-cb13-11e9-8dd7-dd992421ec43.png)
turn into this:
![Screen Shot 2019-08-30 at 10 35 10 AM](https://user-images.githubusercontent.com/302215/64030090-e1864100-cb13-11e9-8444-6bf09986045f.png)

#### Steps to test this PR:
1. Unit tests should be sufficient.
