### PR TITLE
Fixing "PHP Notice - Undefined variable: submissions"

### DIFF
--- a/app/bundles/FormBundle/Views/Builder/form.html.php
+++ b/app/bundles/FormBundle/Views/Builder/form.html.php
@@ -37,6 +37,14 @@ if (!isset($style)) {
 if (!isset($isAjax)) {
     $isAjax = true;
 }
+
+if (!isset($submissions)) {
+    $submissions = null;
+}
+
+if (!isset($lead)) {
+    $lead = null;
+}
 ?>
 
 <?php echo $style; ?>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? |/
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7135
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR fixes a PHP notice about undefined variable. More details in the linked issue.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
0. Ensure you have a Mautic form created.
1. Create a new focus item
2. In the builder select that you want to collect data
3. Select a form to show.
4. Check the logs. The notice will be recorded there. Or in case you use index_dev.php, it will display the notice in the UI.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat the steps. No notice will show up.
3. The focus item still works in the builder and in the page for the contacts.