### PR TITLE
Allow plaintext-only by suppressing empty text/html

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1416,7 +1416,11 @@ class MailHelper
         // Convert short codes to emoji
         $customHtml = EmojiHelper::toEmoji($customHtml, 'short');
 
-        $this->setBody($customHtml, 'text/html', null, $ignoreTrackingPixel);
+        // Only set text/html part if there actually is something. Otherwise plaintext-only is not be possible,
+        // there would be an empty text/htlm part.
+        if (!empty($email->getContent())) {
+            $this->setBody($customHtml, 'text/html', null, $ignoreTrackingPixel);
+        }
 
         // Reset attachments
         $this->assets = $this->attachedAssets = [];


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? |  X
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #4593 #7703 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
Sending plaintext-only emails was not possible because Mautic always added a text/html part to the message, even if the html-code was entirely left empty in the builder. This PR proposes to skip adding an empty html part, and allowing text/plain only.

Take note, that plaintext only email won't have a tracking pixel, so opens aren't as easily detectable as before.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Send an email with empty html code (using Code Mode !) and filled-in Plain Text version
2. See that you receive an apparently empty email because the text/plain part is not shown.
3. Examine the email raw code and note that there is an empty text/plain part (apart from a possible tracking pixel) in addition to the text/plain part.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. See the email showing the text/plain part, and no "blocked image" alert if applicable
3. Check the email code to see that there is only one text/plain part.

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
