### PR TITLE
Fix relative date support to anniversary

### DIFF
--- a/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionFactory.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionFactory.php
@@ -79,6 +79,10 @@ class DateOptionFactory
         switch ($timeframe) {
             case 'birthday':
             case 'anniversary':
+            case $timeframe && (
+                    false !== strpos($timeframe, 'anniversary') ||
+                    false !== strpos($timeframe, 'birthday')
+                ):
                 return new DateAnniversary($this->dateDecorator, $dateOptionParameters);
             case 'today':
                 return new DateDayToday($this->dateDecorator, $dateOptionParameters);

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateAnniversary.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateAnniversary.php
@@ -86,9 +86,15 @@ class DateAnniversary implements FilterDecoratorInterface
      */
     public function getParameterValue(ContactSegmentFilterCrate $contactSegmentFilterCrate)
     {
-        $dateTimeHelper = $this->dateOptionParameters->getDefaultDate();
+        $date           = $this->dateOptionParameters->getDefaultDate();
+        $filter         =  $contactSegmentFilterCrate->getFilter();
+        $relativeFilter =  trim(str_replace(['anniversary', 'birthday'], '', $filter));
 
-        return $dateTimeHelper->toLocalString('%-m-d');
+        if ($relativeFilter) {
+            $date->modify($relativeFilter);
+        }
+
+        return $date->toLocalString('%-m-d');
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/DateOptionFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/DateOptionFactoryTest.php
@@ -45,7 +45,7 @@ class DateOptionFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(DateAnniversary::class, $filterDecorator);
 
-        $filterName = 'birthday';
+        $filterName = 'anniversary';
 
         $filterDecorator = $this->getFilterDecorator($filterName);
 

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateAnniversaryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateAnniversaryTest.php
@@ -67,4 +67,34 @@ class DateAnniversaryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('%-03-02', $filterDecorator->getParameterValue($contactSegmentFilterCrate));
     }
+
+    /**
+     * @covers \Mautic\LeadBundle\Segment\Decorator\Date\Other\DateAnniversary::getParameterValue
+     */
+    public function testGetParameterValueWithRelativeDate()
+    {
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
+
+        $date = new DateTimeHelper('2018-03-02', null, 'local');
+
+        $timezoneResolver->method('getDefaultDate')
+            ->with()
+            ->willReturn($date);
+
+        $filter        = [
+            'operator' => '=',
+        ];
+        $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
+
+        $filter        = [
+            'filter'   => 'birthday +2days',
+        ];
+        $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
+
+        $filterDecorator = new DateAnniversary($dateDecorator, $dateOptionParameters);
+
+        $this->assertEquals('%-03-04', $filterDecorator->getParameterValue($contactSegmentFilterCrate));
+    }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | ✅ 
| New feature? | N
| Automated tests included? | ✅ 
| Related user documentation PR URL | https://github.com/mautic/documentation/pull/299
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR re-add support relative dates to anniversary added with https://github.com/mautic/mautic/pull/6993 but broken by https://github.com/mautic/mautic/pull/7244

I added TU.

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7853)
2. Create date contact custom field
3. Setup this field with date to anniversary with -7 days
For example: If today is 11. 12. 2018 setup this field for 4. 12. 2010
4. Create segment with this custom field filter and add equals and value of filter: anniversary -7 days
5. Your contact should be added to segment
6. If you change contacts custom field value to 3. 12. 2010, contact should be removed from segment.