### PR TITLE
Add manually_removed filter into campaign segment condition

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -249,10 +249,12 @@ class LeadListRepository extends CommonRepository
             ->where(
                 $q->expr()->andX(
                     $q->expr()->in('x.leadlist_id', $ids),
-                    $q->expr()->eq('l.id', ':leadId')
+                    $q->expr()->eq('l.id', ':leadId'),
+                    $q->expr()->eq('x.manually_removed', ':false')
                 )
             )
-            ->setParameter('leadId', $lead->getId());
+            ->setParameter('leadId', $lead->getId())
+            ->setParameter('false', false, 'boolean');
 
         return  (bool) $q->execute()->fetchColumn();
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL |
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #7862
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When you use a campaign filter of "is in segment", the test erroneously returns true for contacts who USED to be in the segment but who have been removed. They are not in the segment, so the test should return false regardless of whether they were in it before or not.

This PR adds `manually_removed` filter into campaign segment conditions. Then contact manually (interface or import) marked as DNC will be segmentable.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create a lead and set it as DNC
3. Create a segment with this filter
4. Run commandes and see the contact in the segment

Additional test instructions from further down in the thread:

Create two segments, segA and segB
Create two contacts con1 and con2
Add con1 and con2 to both segments segA and segB (I use the preferences on each contact to do this, saving between each operation)
Remove con2 from segB
Create a campaign which uses segA as the source. Add a condition "is member of segB".
On the true leg, add an action to modify contact tags, to add a tag 'ISINSEGB'.
On the false leg, add an action to modify contact tags, to add a tag 'ISNOTINSEGB'
Publish the campaign