### PR TITLE
fix deleteCookie expire parameter

### DIFF
--- a/app/bundles/CoreBundle/Helper/CookieHelper.php
+++ b/app/bundles/CoreBundle/Helper/CookieHelper.php
@@ -98,6 +98,6 @@ class CookieHelper
      */
     public function deleteCookie($name, $path = null, $domain = null, $secure = null, $httponly = null)
     {
-        $this->setCookie($name, '', time() - 3600, $path, $domain, $secure, $httponly);
+        $this->setCookie($name, '', -86400, $path, $domain, $secure, $httponly);
     }
 }


### PR DESCRIPTION
The setCookie function expects a relative expirational date in seconds and does the math (time() + X) on itself.
The deleteCookie function should not pass "time() - 3600", but a negative number and let setCookie do the math

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
