### PR TITLE
Several fixes to export reports

### DIFF
--- a/app/bundles/ReportBundle/Crate/ReportDataResult.php
+++ b/app/bundles/ReportBundle/Crate/ReportDataResult.php
@@ -96,7 +96,14 @@ class ReportDataResult
         $row = $this->data[0];
         foreach ($row as $k => $v) {
             $dataColumn      = $data['dataColumns'][$k];
-            $this->headers[] = $data['columns'][$dataColumn]['label'];
+            $label           = $data['columns'][$dataColumn]['label'];
+
+            // Aggregated column
+            if (isset($data['aggregatorColumns'][$k])) {
+                $this->headers[] = str_replace($dataColumn, $label, $k);
+            } else {
+                $this->headers[] = $data['columns'][$dataColumn]['label'];
+            }
         }
     }
 

--- a/app/bundles/ReportBundle/Model/ExcelExporter.php
+++ b/app/bundles/ReportBundle/Model/ExcelExporter.php
@@ -12,6 +12,7 @@
 namespace Mautic\ReportBundle\Model;
 
 use Mautic\CoreBundle\Templating\Helper\FormatterHelper;
+use Mautic\ReportBundle\Crate\ReportDataResult;
 
 /**
  * Class CsvExporter.
@@ -52,20 +53,17 @@ class ExcelExporter
 
             $header = [];
 
+            $reportDataResult = new ReportDataResult($reportData);
             //build the data rows
-            foreach ($reportData['data'] as $count => $data) {
+            foreach ($reportDataResult->getData() as $count=>$data) {
                 $row = [];
                 foreach ($data as $k => $v) {
-                    if ($count === 0) {
-                        //set the header
-                        $header[] = $k;
-                    }
-                    $row[] = htmlspecialchars_decode($this->formatterHelper->_($v, $reportData['columns'][$reportData['dataColumns'][$k]]['type'], true), ENT_QUOTES);
+                    $type       = $reportDataResult->getType($k);
+                    $row[]      = htmlspecialchars_decode($this->formatterHelper->_($v, $type, true), ENT_QUOTES);
                 }
-
                 if ($count === 0) {
                     //write the column names row
-                    $objPHPExcel->getActiveSheet()->fromArray($header);
+                    $objPHPExcel->getActiveSheet()->fromArray($reportDataResult->getHeaders());
                 }
                 //write the row
                 $rowCount = $count + 2;

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -470,13 +470,14 @@ class ReportModel extends FormModel
                 $content = $this->templatingHelper->getTemplating()->renderResponse(
                     'MauticReportBundle:Report:export.html.php',
                     [
-                        'data'      => $reportData['data'],
-                        'columns'   => $reportData['columns'],
-                        'pageTitle' => $name,
-                        'graphs'    => $reportData['graphs'],
-                        'report'    => $report,
-                        'dateFrom'  => $reportData['dateFrom'],
-                        'dateTo'    => $reportData['dateTo'],
+                        'reportData' => $reportData,
+                        'data'       => $reportData['data'],
+                        'columns'    => $reportData['columns'],
+                        'pageTitle'  => $name,
+                        'graphs'     => $reportData['graphs'],
+                        'report'     => $report,
+                        'dateFrom'   => $reportData['dateFrom'],
+                        'dateTo'     => $reportData['dateTo'],
                     ]
                 )->getContent();
 

--- a/app/bundles/ReportBundle/Views/Report/details_data.html.php
+++ b/app/bundles/ReportBundle/Views/Report/details_data.html.php
@@ -85,8 +85,8 @@ $graphContent = $view->render(
                                     $columnName = isset($columns[$aggregator['column']]['alias']) ? $columns[$aggregator['column']]['label'] : '';
                                     echo $view->render('MauticCoreBundle:Helper:tableheader.html.php', [
                                         'sessionVar' => 'report.'.$report->getId(),
-                                        'orderBy'    => $aggregator['function'],
                                         'text'       => $aggregator['function'].' '.$columnName,
+                                        'orderBy'    => '`'.$aggregator['function'].' '.$aggregator['column'].'`',
                                         'dataToggle' => '',
                                         'target'     => '.report-content',
                                     ]);

--- a/app/bundles/ReportBundle/Views/Report/export.html.php
+++ b/app/bundles/ReportBundle/Views/Report/export.html.php
@@ -8,6 +8,9 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
+
+use Mautic\ReportBundle\Crate\ReportDataResult;
+
 $view->extend('MauticCoreBundle:Default:slim.html.php');
 $view['slots']->set('pageTitle', $pageTitle);
 $view['slots']->set('headerTitle', $report->getName());
@@ -17,7 +20,7 @@ $showGraphsAboveTable = (!empty($report->getSettings()['showGraphsAboveTable']) 
 $dataCount            = count($data);
 $columnOrder          = $report->getColumns();
 $graphOrder           = $report->getGraphs();
-$startCount           = 1;
+$reportDataResult     = new ReportDataResult($reportData);
 ?>
 
 <div class="pa-md">
@@ -34,42 +37,43 @@ $startCount           = 1;
             'graphOrder' => $graphOrder,
             'graphs'     => $graphs,
             'report'     => $report,
-        ]);
+        ]
+    );
     ?>
 <?php endif; ?>
 
 
-<?php if (!empty($columnOrder)):?>
-<table class="table table-hover table-striped table-bordered report-list" id="reportTable">
-    <thead>
-    <tr>
-        <th class="col-report-count"></th>
-        <?php foreach ($columnOrder as $key): ?>
-            <th class="col-report-<?php echo $columns[$key]['type']; ?>"><?php echo $columns[$key]['label']; ?></th>
-        <?php endforeach; ?>
-    </tr>
-    </thead>
-    <tbody>
-    <?php if ($dataCount): ?>
-        <?php foreach ($data as $row): ?>
-            <tr>
-                <td><?php echo $startCount; ?></td>
-                <?php foreach ($columnOrder as $key): ?>
-                    <td><?php echo $view['formatter']->_($row[$columns[$key]['alias']], $columns[$key]['type']); ?></td>
-                <?php endforeach; ?>
-            </tr>
-            <?php ++$startCount; ?>
-        <?php endforeach; ?>
-    <?php else: ?>
+<?php if (!empty($columnOrder)): ?>
+    <table class="table table-hover table-striped table-bordered report-list" id="reportTable">
+        <thead>
         <tr>
-            <td>&nbsp;</td>
-            <?php foreach ($columnOrder as $key): ?>
-                <td>&nbsp;</td>
+            <th class="col-report-count"></th>
+
+            <?php foreach ($reportDataResult->getHeaders() as $header):?>
+                <th><?php echo $header; ?></th>
             <?php endforeach; ?>
         </tr>
-    <?php endif; ?>
-    </tbody>
-</table>
+        </thead>
+        <tbody>
+        <?php if ($dataCount): ?>
+            <?php foreach ($reportDataResult->getData() as $count => $data):?>
+                <tr>
+                    <td><?php echo $count + 1; ?></td>
+                    <?php foreach ($data as $k => $v): ?>
+                        <td><?php echo $view['formatter']->_($v, $reportDataResult->getType($k)); ?></td>
+                    <?php endforeach; ?>
+                </tr>
+            <?php endforeach; ?>
+        <?php else: ?>
+            <tr>
+                <td>&nbsp;</td>
+                <?php foreach ($columnOrder as $key): ?>
+                    <td>&nbsp;</td>
+                <?php endforeach; ?>
+            </tr>
+        <?php endif; ?>
+        </tbody>
+    </table>
 <?php endif; ?>
 
 <?php if (empty($showGraphsAboveTable)): ?>
@@ -79,6 +83,7 @@ $startCount           = 1;
             'graphOrder' => $graphOrder,
             'graphs'     => $graphs,
             'report'     => $report,
-        ]);
+        ]
+    );
     ?>
 <?php endif; ?>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
While I worked on https://github.com/mautic/mautic/pull/7871/files I noticed few inconsistent issues with export results. The main issue was with regular columns and aggregated columns.



[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create basic report. For example page hits with URL, date_hit and COUNT date_hit. You should see basic report

![image](https://user-images.githubusercontent.com/462477/64683033-c952e200-d482-11e9-96a0-4f5ba2f20373.png)

2. Export to CSV - shoud works OK
3. Export to HTML - should see just two columns

![image](https://user-images.githubusercontent.com/462477/64683351-64e45280-d483-11e9-9443-f0e7c1b0d3a6.png)

4. Export to excel - should see wrong export

![image](https://user-images.githubusercontent.com/462477/64683184-11720480-d483-11e9-8e48-e534ce190d8e.png)

5. Try also order report by Count date_hit column - should return nothing or 500 error (check logs)

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps to reproduce. Should works good