### PR TITLE
Never catch all exceptions

### DIFF
--- a/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
@@ -282,24 +282,27 @@ class TriggerCampaignCommand extends ModeratedCommand
         if ($id) {
             /** @var \Mautic\CampaignBundle\Entity\Campaign $campaign */
             if ($campaign = $this->campaignRepository->getEntity($id)) {
-                $this->triggerCampaign($campaign);
+                $success = $this->triggerCampaign($campaign);
             } else {
                 $output->writeln('<error>'.$this->translator->trans('mautic.campaign.rebuild.not_found', ['%id%' => $id]).'</error>');
+                $success = false;
             }
 
             $this->completeRun();
 
-            return 0;
+            return $success ? 0 : 1;
         }
 
         // All published campaigns
         /** @var \Doctrine\ORM\Internal\Hydration\IterableResult $campaigns */
         $campaigns = $this->campaignRepository->getEntities(['iterator_mode' => true]);
+        $success   = true;
 
         while (($next = $campaigns->next()) !== false) {
             // Key is ID and not 0
             $campaign = reset($next);
-            $this->triggerCampaign($campaign);
+            // Order matters here, we want to trigger each campaign regardless of earlier errors
+            $success = $this->triggerCampaign($campaign) && $success;
             if ($this->limiter->hasCampaignLimit()) {
                 $this->limiter->resetCampaignLimitRemaining();
             }
@@ -307,7 +310,7 @@ class TriggerCampaignCommand extends ModeratedCommand
 
         $this->completeRun();
 
-        return 0;
+        return $success ? 0 : 1;
     }
 
     /**
@@ -333,6 +336,8 @@ class TriggerCampaignCommand extends ModeratedCommand
     /**
      * @param Campaign $campaign
      *
+     * @return bool
+     *
      * @throws \Exception
      */
     private function triggerCampaign(Campaign $campaign)
@@ -346,6 +351,7 @@ class TriggerCampaignCommand extends ModeratedCommand
         }
 
         $this->campaign = $campaign;
+        $success        = true;
 
         try {
             $this->output->writeln('<info>'.$this->translator->trans('mautic.campaign.trigger.triggering', ['%id%' => $campaign->getId()]).'</info>');
@@ -373,14 +379,21 @@ class TriggerCampaignCommand extends ModeratedCommand
                 $this->executeInactive();
             }
         } catch (\Exception $exception) {
+            if ('prod' !== MAUTIC_ENV) {
+                // Throw the exception for dev/test mode
+                throw $exception;
+            }
+
             $this->logger->error('CAMPAIGN: '.$exception->getMessage());
-            throw $exception;
+            $success = false;
         }
 
         // Don't detach in tests since this command will be ran multiple times in the same process
         if ('test' !== MAUTIC_ENV) {
             $this->campaignRepository->detachEntity($campaign);
         }
+
+        return $success;
     }
 
     /**

--- a/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
@@ -373,12 +373,8 @@ class TriggerCampaignCommand extends ModeratedCommand
                 $this->executeInactive();
             }
         } catch (\Exception $exception) {
-            if ('prod' !== MAUTIC_ENV) {
-                // Throw the exception for dev/test mode
-                throw $exception;
-            }
-
             $this->logger->error('CAMPAIGN: '.$exception->getMessage());
+            throw $exception;
         }
 
         // Don't detach in tests since this command will be ran multiple times in the same process

--- a/app/bundles/CampaignBundle/Command/UpdateLeadCampaignsCommand.php
+++ b/app/bundles/CampaignBundle/Command/UpdateLeadCampaignsCommand.php
@@ -232,12 +232,8 @@ class UpdateLeadCampaignsCommand extends ModeratedCommand
 
             $this->membershipBuilder->build($campaign, $this->contactLimiter, $this->runLimit, ($this->quiet) ? null : $this->output);
         } catch (\Exception $exception) {
-            if ('prod' !== MAUTIC_ENV) {
-                // Throw the exception for dev/test mode
-                throw $exception;
-            }
-
             $this->logger->error('CAMPAIGN: '.$exception->getMessage());
+            throw $exception;
         }
 
         // Don't detach in tests since this command will be ran multiple times in the same process

--- a/app/bundles/CampaignBundle/Command/UpdateLeadCampaignsCommand.php
+++ b/app/bundles/CampaignBundle/Command/UpdateLeadCampaignsCommand.php
@@ -223,7 +223,7 @@ class UpdateLeadCampaignsCommand extends ModeratedCommand
     private function updateCampaign(Campaign $campaign)
     {
         if (!$campaign->isPublished()) {
-            return;
+            return true;
         }
 
         $success = true;


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

In two places in the code we catch all types of exceptions, and silently continue the execution when they happen. This means that the campaigns:trigger cron can exit with a zero exit code even though exceptions occured. Needless to say this is not a good idea, so this merge requests makes sure to (re)throw those exceptions.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run Mautic on a larger scale I guess?

#### Steps to test this PR:
? 
I believe the code change should speak for itself.