### PR TITLE
bugfix: Handle SES bounces without a DSN

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
@@ -154,8 +154,9 @@ class AmazonTransport extends \Swift_SmtpTransport implements CallbackTransportI
                 // Get bounced recipients in an array
                 $bouncedRecipients = $message['bounce']['bouncedRecipients'];
                 foreach ($bouncedRecipients as $bouncedRecipient) {
-                    $this->transportCallback->addFailureByAddress($bouncedRecipient['emailAddress'], $bouncedRecipient['diagnosticCode'], DoNotContact::BOUNCED, $emailId);
-                    $this->logger->debug("Mark email '".$bouncedRecipient['emailAddress']."' as bounced, reason: ".$bouncedRecipient['diagnosticCode']);
+                        $bounceCode = array_key_exists('diagnosticCode', $bouncedRecipient) ? $bouncedRecipient['diagnosticCode'] : 'unknown';
+                        $this->transportCallback->addFailureByAddress($bouncedRecipient['emailAddress'], $bounceCode, DoNotContact::BOUNCED, $emailId);
+                        $this->logger->debug("Mark email '".$bouncedRecipient['emailAddress']."' as bounced, reason: ".$bounceCode);
                 }
 
                 return;

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
@@ -116,11 +116,11 @@ class AmazonTransport extends \Swift_SmtpTransport implements CallbackTransportI
             throw new HttpException(400, "Key 'Type' not found in payload ");
         }
 
-        if ($payload['Type'] == 'SubscriptionConfirmation') {
+        if ('SubscriptionConfirmation' == $payload['Type']) {
             // Confirm Amazon SNS subscription by calling back the SubscribeURL from the playload
             try {
                 $response = $this->httpClient->get($payload['SubscribeURL']);
-                if ($response->code == 200) {
+                if (200 == $response->code) {
                     $this->logger->info('Callback to SubscribeURL from Amazon SNS successfully');
 
                     return;
@@ -136,16 +136,16 @@ class AmazonTransport extends \Swift_SmtpTransport implements CallbackTransportI
             return;
         }
 
-        if ($payload['Type'] == 'Notification') {
+        if ('Notification' == $payload['Type']) {
             $message = json_decode($payload['Message'], true);
 
             // only deal with hard bounces
-            if ($message['notificationType'] == 'Bounce' && $message['bounce']['bounceType'] == 'Permanent') {
+            if ('Bounce' == $message['notificationType'] && 'Permanent' == $message['bounce']['bounceType']) {
                 $emailId = null;
 
                 if (isset($message['mail']['headers'])) {
                     foreach ($message['mail']['headers'] as $header) {
-                        if ($header['name'] === 'X-EMAIL-ID') {
+                        if ('X-EMAIL-ID' === $header['name']) {
                             $emailId = $header['value'];
                         }
                     }
@@ -154,16 +154,16 @@ class AmazonTransport extends \Swift_SmtpTransport implements CallbackTransportI
                 // Get bounced recipients in an array
                 $bouncedRecipients = $message['bounce']['bouncedRecipients'];
                 foreach ($bouncedRecipients as $bouncedRecipient) {
-                        $bounceCode = array_key_exists('diagnosticCode', $bouncedRecipient) ? $bouncedRecipient['diagnosticCode'] : 'unknown';
-                        $this->transportCallback->addFailureByAddress($bouncedRecipient['emailAddress'], $bounceCode, DoNotContact::BOUNCED, $emailId);
-                        $this->logger->debug("Mark email '".$bouncedRecipient['emailAddress']."' as bounced, reason: ".$bounceCode);
+                    $bounceCode = array_key_exists('diagnosticCode', $bouncedRecipient) ? $bouncedRecipient['diagnosticCode'] : 'unknown';
+                    $this->transportCallback->addFailureByAddress($bouncedRecipient['emailAddress'], $bounceCode, DoNotContact::BOUNCED, $emailId);
+                    $this->logger->debug("Mark email '".$bouncedRecipient['emailAddress']."' as bounced, reason: ".$bounceCode);
                 }
 
                 return;
             }
 
             // unsubscribe customer that complain about spam at their mail provider
-            if ($message['notificationType'] == 'Complaint') {
+            if ('Complaint' == $message['notificationType']) {
                 foreach ($message['complaint']['complainedRecipients'] as $complainedRecipient) {
                     $reason = null;
                     if (isset($message['complaint']['complaintFeedbackType'])) {
@@ -181,7 +181,7 @@ class AmazonTransport extends \Swift_SmtpTransport implements CallbackTransportI
                         }
                     }
 
-                    if ($reason == null) {
+                    if (null == $reason) {
                         $reason = $this->translator->trans('mautic.email.complaint.reason.unknown');
                     }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  Y
| New feature? |  N
| Automated tests included? | N
| Related user documentation PR URL |
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #4632
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When receiving a bounce notification from SES, the current code assumes that it includes a DSN... which may not be present (as documented on https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html).

Without this patch the following occurs:
[2019-09-16 13:51:01] mautic.NOTICE: PHP Notice - Undefined index:
diagnosticCode - in file
/var/www/mautic/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
- at line 147 ...

This fixes it.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Configure mautic to use SES for delivery
2. Send an email to an address that bounces and where the receiving MTA doesn't send a DSN back
3. Get the exception above ^
