### PR TITLE
Missing clickthrough in the URL query

### DIFF
--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -449,7 +449,7 @@ class PublicController extends CommonFormController
         $query = $this->request->query->all();
 
         // Unset the clickthrough from the URL query
-        $ct = $query['ct'] ?? '';
+        $ct = $query['ct'] ? '';
         unset($query['ct']);
 
         // Tak on anything left to the URL

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -449,7 +449,7 @@ class PublicController extends CommonFormController
         $query = $this->request->query->all();
 
         // Unset the clickthrough from the URL query
-        $ct = $query['ct'] ? '';
+        $ct = isset($query['ct']) ? $query['ct'] : '';
         unset($query['ct']);
 
         // Tak on anything left to the URL

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -449,7 +449,7 @@ class PublicController extends CommonFormController
         $query = $this->request->query->all();
 
         // Unset the clickthrough from the URL query
-        $ct = $query['ct'];
+        $ct = $query['ct'] ?? '';
         unset($query['ct']);
 
         // Tak on anything left to the URL
@@ -461,7 +461,7 @@ class PublicController extends CommonFormController
         // If the IP address is not trackable, it means it came form a configured "do not track" IP or a "do not track" user agent
         // This prevents simulated clicks from 3rd party services such as URL shorteners from simulating clicks
         $ipAddress = $this->container->get('mautic.helper.ip_lookup')->getIpAddress();
-        if ($ipAddress->isTrackable()) {
+        if ($ct && $ipAddress->isTrackable()) {
             // Search replace lead fields in the URL
             /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
             $leadModel = $this->getModel('lead');


### PR DESCRIPTION
closes #7841
| Q  | A
| --- | ---
| Bug fix? |  X
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #7841 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:

This simple PR implements Akkufresh's fix for a PHP Notice about the Undefined index in ../app/bundles/PageBundle/Controller/PublicController.php on line 452

All fame belongs to him. Blame as well. ;)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
