### PR TITLE
implement periodic dummy keepalive updateStatus request when away

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/10.jquery.idletimer.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/10.jquery.idletimer.js
@@ -5,8 +5,8 @@
 
 var IdleTimer = (function($) {
     var activityHelper = {
-        _idleTimeout: 30000,	// 30 seconds
-        _awayTimeout: 600000,	// 10 minutes
+        _idleTimeout: 30000,    // 30 seconds
+        _awayTimeout: 600000,   // 10 minutes
         _idleNow: false,
         _idleTimestamp: null,
         _idleTimer: null,
@@ -18,6 +18,8 @@ var IdleTimer = (function($) {
         _onBackCallback: null,
         _debug: false,
         _lastActive: new Date().getTime(),
+        _sessionKeepAliveInterval: null,
+        _keepSessionAlive: null,
 
         _makeIdle: function () {
             var t = new Date().getTime();
@@ -45,12 +47,18 @@ var IdleTimer = (function($) {
             if (this._debug) console.log('** AWAY **');
             this._awayNow = true;
 
+            if (this._keepSessionAlive){
+                this._sessionKeepAliveInterval = setInterval(function(){
+                    activityHelper._keepSessionAlive();
+                }, this._awayTimeout);
+            }
+
             try {
                 if (this._onAwayCallback) this._onAwayCallback();
             } catch (err) {
             }
         },
-
+        
         _active: function (timer) {
             var t = new Date().getTime();
 
@@ -64,6 +72,7 @@ var IdleTimer = (function($) {
             }
 
             if (this._awayNow) {
+                clearTimeout(this._sessionKeepAliveInterval);
                 timer.setAwayTimeout(this._awayTimeout);
             }
 
@@ -142,6 +151,10 @@ var IdleTimer = (function($) {
 
                     activityHelper._onBackCallback = function() {
                         activityHelper._onStatusChange(options.statusChangeUrl, 'back');
+                    };
+
+                    activityHelper._keepSessionAlive = function() {
+                        activityHelper._onStatusChange(options.statusChangeUrl, 'keepalive');
                     };
                 }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

This PR adds session keep alive functionality for Mautic users (administrators) via `IdleTimer`

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes, sortof
| New feature? | Yes, sortof
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
https://github.com/mautic/mautic/issues/7106
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

As The https://github.com/mautic/mautic/issues/7106 issue states a user opens mautic and leaves it open for certain amount of time, next time the user gets back and wants to do somehting, the application tells the user to refresh the page, and log in again (CSFR token error)

Mautic has a nice function called `idleTimer` which tracks when a mautic user (administrator) is active: 
- after a certain amount if inactive time, it sends a request to the backend and sets the user status to `Idle`
- after even more inactive time, it sends a request to the backend and sets the user status to `Away`
- If the user gets back, it sends a request to the backend and sets the user status to `Active`

The user probably doesn't get in-app notifications while being away, and the application allows to add eventlisteners to users' status changes (Currently none is present in core mautic)

So while this funcionality sets the users status to `away` after a certain amount of time, it doesn't send a request to the server until the user gets back. If the away time is high enough, During this `away` time the backend most likely does a session data garbage collection erasing inactive sessions. (this is determined by `session.gc_maxlifetime` which is 1440 seconds by default) 
When the user gets back, the backend doesn't recognise the user as logged in.

This PR adds a feature to the `IdleTimer` so that it periodically sends a request with `keepalive` status (which the backend doesn't recognise as a valid use status) so that the session files in the backend doesn't get removed.


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. login to mautic
3. leave mautic open and untouched for more than the configured `session.gc_maxlifetime`
4. Enjoy remained logged in.

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
