### PR TITLE
Fix multi select sync for Hubspot

### DIFF
--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -432,6 +432,10 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
                 return;
             }
 
+            if (isset($fieldsToUpdateInMautic[0])) {
+                $fieldsToUpdateInMautic = array_flip($fieldsToUpdateInMautic);
+            }
+
             $fieldsToUpdateInMautic = array_intersect_key($leadFields, $fieldsToUpdateInMautic);
             $matchedFields          = array_intersect_key($matchedFields, array_flip($fieldsToUpdateInMautic));
             if ((isset($config['updateBlanks']) && isset($config['updateBlanks'][0]) && $config['updateBlanks'][0] == 'updateBlanks')) {

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -432,10 +432,6 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
                 return;
             }
 
-            if (isset($fieldsToUpdateInMautic[0])) {
-                $fieldsToUpdateInMautic = array_flip($fieldsToUpdateInMautic);
-            }
-
             $fieldsToUpdateInMautic = array_intersect_key($leadFields, $fieldsToUpdateInMautic);
             $matchedFields          = array_intersect_key($matchedFields, array_flip($fieldsToUpdateInMautic));
             if ((isset($config['updateBlanks']) && isset($config['updateBlanks'][0]) && $config['updateBlanks'][0] == 'updateBlanks')) {

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -215,6 +215,30 @@ class HubspotIntegration extends CrmAbstractIntegration
     }
 
     /**
+     * @param       $fieldsToUpdate
+     * @param array $objects
+     *
+     * @return array
+     */
+    protected function cleanPriorityFields($fieldsToUpdate, $objects = null)
+    {
+        if (null === $objects) {
+            $objects = ['Leads', 'Contacts'];
+        }
+
+        if (isset($fieldsToUpdate['leadFields'])) {
+            // Pass in the whole config
+            $fields = $fieldsToUpdate;
+        } else {
+            $fields = array_flip($fieldsToUpdate);
+        }
+
+        $fieldsToUpdate = $this->prepareFieldsForSync($fields, $fieldsToUpdate, $objects);
+
+        return $fieldsToUpdate;
+    }
+
+    /**
      * Format the lead data to the structure that HubSpot requires for the createOrUpdate request.
      *
      * @param array $leadData All the lead fields mapped

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -228,7 +228,7 @@ class HubspotIntegration extends CrmAbstractIntegration
 
         if (isset($fieldsToUpdate['leadFields'])) {
             // Pass in the whole config
-            $fields = $fieldsToUpdate;
+            $fields = $fieldsToUpdate['leadFields'];
         } else {
             $fields = array_flip($fieldsToUpdate);
         }

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -301,7 +301,8 @@ class HubspotIntegration extends CrmAbstractIntegration
             return [];
         }
         foreach ($data['properties'] as $key => $field) {
-            $fieldsValues[$key] = $field['value'];
+            $value              = str_replace(';', '|', $field['value']);
+            $fieldsValues[$key] = $value;
         }
         if ($object == 'Lead' && !isset($fieldsValues['email'])) {
             foreach ($data['identity-profiles'][0]['identities'] as $identifiedProfile) {
@@ -538,7 +539,6 @@ class HubspotIntegration extends CrmAbstractIntegration
                 'feature_settings' => ['objects' => $config['objects']],
             ]
         );
-
         $this->amendLeadDataBeforePush($mappedData);
 
         if (empty($mappedData)) {
@@ -571,5 +571,17 @@ class HubspotIntegration extends CrmAbstractIntegration
         }
 
         return false;
+    }
+
+    /**
+     * Amend mapped lead data before pushing to CRM.
+     *
+     * @param $mappedData
+     */
+    public function amendLeadDataBeforePush(&$mappedData)
+    {
+        foreach ($mappedData as &$data) {
+            $data = str_replace('|', ';', $data);
+        }
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fix for both way sync multi select field for Hubspot integration


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1 Create a custom multiple field in Mautic
2 Create a custom multiple field in Hubspot with the same exact choices as in Mautic
3 Create a contact in Mautic with at least 2 choices in the multiple field and push it in Hubspot with a form
4 See that in Hubspot the multiple field is empty
5 Create a contact in Hubspot and synchronize it with cron to Mautic.
6 See that in Mautic the multiple field is empty

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Should works properly

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
