### PR TITLE
Add SES/SNS bounces to email graph

### DIFF
--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -296,6 +296,9 @@ class CampaignSubscriber implements EventSubscriberInterface
             'email_type'     => $type,
             'return_errors'  => true,
             'dnc_as_error'   => true,
+            'customHeaders' => [
+                'X-EMAIL-ID' => $emailId,
+            ],
         ];
 
         // Determine if this email is transactional/marketing

--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -296,7 +296,7 @@ class CampaignSubscriber implements EventSubscriberInterface
             'email_type'     => $type,
             'return_errors'  => true,
             'dnc_as_error'   => true,
-            'customHeaders' => [
+            'customHeaders'  => [
                 'X-EMAIL-ID' => $emailId,
             ],
         ];

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1054,6 +1054,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             'allowResends'  => false,
             'customHeaders' => [
                 'Precedence' => 'Bulk',
+                'X-EMAIL-ID' => $email->getId(),
             ],
         ];
 

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
@@ -143,9 +143,11 @@ class AmazonTransport extends \Swift_SmtpTransport implements CallbackTransportI
             if ($message['notificationType'] == 'Bounce' && $message['bounce']['bounceType'] == 'Permanent') {
                 $emailId = null;
 
-                foreach ($message['mail']['headers'] as $header) {
-                    if ($header['name'] === 'X-EMAIL-ID') {
-                        $emailId = $header['value'];
+                if (isset($message['mail']['headers'])) {
+                    foreach ($message['mail']['headers'] as $header) {
+                        if ($header['name'] === 'X-EMAIL-ID') {
+                            $emailId = $header['value'];
+                        }
                     }
                 }
 

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
@@ -141,10 +141,18 @@ class AmazonTransport extends \Swift_SmtpTransport implements CallbackTransportI
 
             // only deal with hard bounces
             if ($message['notificationType'] == 'Bounce' && $message['bounce']['bounceType'] == 'Permanent') {
+                $emailId = null;
+
+                foreach ($message['mail']['headers'] as $header) {
+                    if ($header['name'] === 'X-EMAIL-ID') {
+                        $emailId = $header['value'];
+                    }
+                }
+
                 // Get bounced recipients in an array
                 $bouncedRecipients = $message['bounce']['bouncedRecipients'];
                 foreach ($bouncedRecipients as $bouncedRecipient) {
-                    $this->transportCallback->addFailureByAddress($bouncedRecipient['emailAddress'], $bouncedRecipient['diagnosticCode']);
+                    $this->transportCallback->addFailureByAddress($bouncedRecipient['emailAddress'], $bouncedRecipient['diagnosticCode'], DoNotContact::BOUNCED, $emailId);
                     $this->logger->debug("Mark email '".$bouncedRecipient['emailAddress']."' as bounced, reason: ".$bouncedRecipient['diagnosticCode']);
                 }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  Yes
| New feature? | No 
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |  https://github.com/mautic/mautic/issues/3655
| BC breaks? |  No
| Deprecations? |  No

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The main cause of the problem is that SES is not sending the email id in the bounce information so a bounce cannot be attributed to a specific email, what  is done is this PR is that custom header `X-EMAIL-ID` is added when sending an email so later when bounce happens email id can be retrieved and attributed to bounce record.

Disclaimer: sponsored by maatoo.io