### PR TITLE
Pass empty args to AssetModel#getLookupResults

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/ListType.php
+++ b/app/bundles/LeadBundle/Form/Type/ListType.php
@@ -107,7 +107,8 @@ class ListType extends AbstractType
         }
         ksort($this->emailChoices);
 
-        $assets = $assetModel->getLookupResults('asset');
+        // Get assets without 'filter' or 'limit'
+        $assets = $assetModel->getLookupResults('asset', null, 0);
         foreach ($assets as $asset) {
             $this->assetChoices[$asset['language']][$asset['id']] = $asset['title'];
         }


### PR DESCRIPTION

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | n
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #7910 
| BC breaks? | N
| Deprecations? | N

#### Description:

This prevents the AssetRepository from applying the default limit of
10 results to the QueryBuilder in getAssetList.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Having more than 10 assets 
2. Create a Segment
3. Add an "Asset Download" filter to the segment
4. Count no more than 10 assets available in dropdown

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Follow steps above, seeing more than 10 assets in step **4**.

