### PR TITLE
Fix token link in code mode editor

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/froala/plugins/token.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/froala/plugins/token.js
@@ -94,6 +94,7 @@
                     var normalizedValue = val.replace(new RegExp('"', 'g'), "'");
                     var newOption = '<li role="presentation"><a class="fr-command" tabIndex="-1" role="option"' +
                         ' data-cmd="token" data-param1="' + normalizedValue + '" title="' + title + '">' + title + badge + '</a></li>';
+                    options.push(newOption);
                 }
 
                 mQuery('button[data-cmd="token"]').next().find('ul').html(options.join(''));

--- a/app/bundles/CoreBundle/Assets/js/libraries/froala/plugins/token.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/froala/plugins/token.js
@@ -91,8 +91,9 @@
                                                                 str.replace(/_BADGE_/,'dwc') : '';
                     var title = tokens[val];
                     if (title.length>24) title = title.substr(0, 24) + '...';
-                    var newOption = '<li role="presentation"><a class="fr-command" tabIndex="-1" role="option" data-cmd="token" data-param1="' + encodeURI(val) + '" title="' + title + '">' + title + badge + '</a></li>';
-                    options.push(newOption);
+                    var normalizedValue = val.replace(new RegExp('"', 'g'), "'");
+                    var newOption = '<li role="presentation"><a class="fr-command" tabIndex="-1" role="option"' +
+                        ' data-cmd="token" data-param1="' + normalizedValue + '" title="' + title + '">' + title + badge + '</a></li>';
                 }
 
                 mQuery('button[data-cmd="token"]').next().find('ul').html(options.join(''));

--- a/app/bundles/CoreBundle/Assets/js/libraries/froala/plugins/token.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/froala/plugins/token.js
@@ -91,7 +91,7 @@
                                                                 str.replace(/_BADGE_/,'dwc') : '';
                     var title = tokens[val];
                     if (title.length>24) title = title.substr(0, 24) + '...';
-                    var newOption = '<li role="presentation"><a class="fr-command" tabIndex="-1" role="option" data-cmd="token" data-param1="' + val + '" title="' + title + '">' + title + badge + '</a></li>';
+                    var newOption = '<li role="presentation"><a class="fr-command" tabIndex="-1" role="option" data-cmd="token" data-param1="' + encodeURI(val) + '" title="' + title + '">' + title + badge + '</a></li>';
                     options.push(newOption);
                 }
 

--- a/app/bundles/CoreBundle/Assets/js/libraries/froala/plugins/token.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/froala/plugins/token.js
@@ -52,12 +52,12 @@
                     if (k.match(/assetlink=/i) && v.match(/a:/)){
                         delete tokens[k];
                         var nv = v.replace('a:', '');
-                        k = '<a title=\'Asset Link\' href=\'' + k + '\'>' + nv + '</a>';
+                        k = '<a title="Asset Link" href="' + k + '">' + nv + '</a>';
                         tokens[k] = nv;
                     } else if (k.match(/pagelink=/i) && v.match(/a:/)){
                         delete tokens[k];
                         nv = v.replace('a:', '');
-                        k = '<a title=\'Page Link\' href=\'' + k + '\'>' + nv + '</a>';
+                        k = '<a title="Page Link" href=""' + k + '">' + nv + '</a>';
                         tokens[k] = nv;
                     } else if (k.match(/dwc=/i)){
                         var tn = k.substr(5, k.length - 6);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7917
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixed bug in code mode editor. 
If you use CTRL + SPACE BAR for token drop down and want use Assets or Page link, code mode editor generate: 

`<a title='Asset Link' href='{assetlink=1}'>foto_1.jpg</a>`

After save this is cleaning to 

`<a title='Asset Link'>foto_1.jpg</a>`

Because it's not valid HTML. 

This PR add reguler format of link

`<a title="Asset Link" href="{assetlink=1}">foto_1.jpg</a>`

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create an asset
2. Create an email in code mode
3. Edit the email to insert the asset link via control + space shortcut
4. Use the Apply button in the editor to validate change
5. See that the link vanish and the token doesn't work.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps, and see If your link work properly 
