### PR TITLE
Fix PHP warning that save large data to logs

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
@@ -341,7 +341,11 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
      */
     public function getBatchRecipientCount(\Swift_Message $message, $toBeAdded = 1, $type = 'to')
     {
-        return count($message->getTo()) + count($message->getCc()) + count($message->getBcc()) + $toBeAdded;
+        return
+            count($message->getTo())
+            + (!empty($message->getCc()) ? count($message->getCc()) : 0)
+            + (!empty($message->getBcc()) ? count($message->getBcc()) : 0)
+            + $toBeAdded;
     }
 
     /**


### PR DESCRIPTION
In my log files I see many Warnings like this:
```
PHP Warning - count(): Parameter must be an array or an object that implements Countable - in file /var/www/html/mautic/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
```
Because of there many leads each message take many disk space

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
