### PR TITLE
Fix clone campaign with segment/form sources

### DIFF
--- a/app/bundles/CampaignBundle/Controller/SourceController.php
+++ b/app/bundles/CampaignBundle/Controller/SourceController.php
@@ -131,7 +131,7 @@ class SourceController extends CommonFormController
     {
         $session         = $this->get('session');
         $method          = $this->request->getMethod();
-        $selectedSources = $session->get('mautic.campaign.'.$objectId.'.leadsources.modified', []);
+        $modifiedSources = $selectedSources = $session->get('mautic.campaign.'.$objectId.'.leadsources.modified', []);
         if ($method == 'POST') {
             $source     = $this->request->request->get('campaign_leadsource');
             $sourceType = $source['sourceType'];


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixed ugly issue If using  both sources of campaign - segments and form.


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create campaign with segment source and form source (yes Mautic support it)
![image](https://user-images.githubusercontent.com/462477/66486649-53ef2700-eaab-11e9-8347-f1c01da9f3fc.png)
2. Clone campaign (don't save)
3. Open campaign builder
4. Edit segment source and change segment
5. Then try apply
6. See your form source was removed 
![image](https://user-images.githubusercontent.com/462477/66486796-90bb1e00-eaab-11e9-84e5-2aa0f17953ff.png)
 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps and see if both sources (segments/forms) are update properly
