### PR TITLE
Correct grammar for mautic:unusedip:delete <info>

### DIFF
--- a/app/bundles/CoreBundle/Command/ModeratedCommand.php
+++ b/app/bundles/CoreBundle/Command/ModeratedCommand.php
@@ -51,7 +51,7 @@ abstract class ModeratedCommand extends ContainerAwareCommand
                 '--timeout',
                 '-t',
                 InputOption::VALUE_REQUIRED,
-                'If getmypid() is disabled on this system, lock files will be used. This option will assume the process is dead afer the specified number of seconds and will execute anyway. This is disabled by default.',
+                'If getmypid() is disabled on this system, lock files will be used. This option will assume the process is dead after the specified number of seconds and will execute anyway. This is disabled by default.',
                 false
             )
             ->addOption(

--- a/app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php
+++ b/app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php
@@ -58,7 +58,7 @@ EOT
         try {
             $limit       = $input->getOption('limit');
             $deletedRows = $ipAddressRepo->deleteUnusedIpAddresses($limit);
-            $output->writeln(sprintf('<info>%s unused IP addresses has been deleted</info>', $deletedRows));
+            $output->writeln(sprintf('<info>%s unused IP addresses have been deleted</info>', $deletedRows));
         } catch (DBALException $e) {
             $output->writeln(sprintf('<error>Deletion of unused IP addresses failed because of database error: %s</error>', $e->getMessage()));
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y (typo)

[//]: # ( Required: )
#### Description:

- [x] corrects grammar for `mautic:unusedip:delete` 
- [x] corrects spelling for `--timeout` in `CoreBundle/Command/ModeratedCommand.php`


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run `console mautic:unusedip:delete -l 2`
2. Output
```console
$ console mautic:unusedip:delete -l 2
2 unused IP addresses has been deleted
```

Spelling of `afer` 

```console
$ console mautic:segments:update -h
Usage:
  mautic:segments:update [options]

Options:
  -t, --timeout=TIMEOUT              ... the process is dead afer the specified number of seconds and will execute anyway. This is disabled by default. [default: false]
```

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. repeat above

```console
$ console mautic:unusedip:delete -l 2
2 unused IP addresses have been deleted
```

Ideally one would use an automagic pluralising function, but the singular IP is the exception to the normal output.  Even zero works.

```console
$ console mautic:unusedip:delete
0 unused IP addresses have been deleted
```

Spelling of `afer` => `after`

```console
$ console mautic:segments:update -h
Usage:
  mautic:segments:update [options]

Options:
  -t, --timeout=TIMEOUT              ... the process is dead after the specified number of seconds and will execute anyway. This is disabled by default. [default: false]
```
