### PR TITLE
fix: Has valid email address campaign condition always results true

### DIFF
--- a/app/bundles/EmailBundle/EventListener/CampaignConditionSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignConditionSubscriber.php
@@ -74,11 +74,7 @@ class CampaignConditionSubscriber implements EventSubscriberInterface
         try {
             $this->validator->validate($event->getLead()->getEmail());
         } catch (InvalidEmailException $exception) {
-            return $event->setResult(
-                [
-                    'timeline' => $exception->getMessage(),
-                ]
-            );
+            return $event->setResult(false);
         }
 
         return $event->setResult(true);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| Automated tests included? | -
| Related user documentation PR URL | -
| Related developer documentation PR URL |  -
| Issues addressed (#s or URLs) |  -
| BC breaks? |  -
| Deprecations? |  -

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
fixes https://github.com/mautic/mautic/issues/7904 as proposed there.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
described here: https://github.com/mautic/mautic/issues/7904

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create a campaign that uses a `has valid email address` condition on contacts without email address

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
