### PR TITLE
[BUGFIX] Reintroduce support for Apache < 2.4

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -97,21 +97,31 @@
     </IfModule>
 </IfModule>
 
-# Denie access via HTTP requests to all PHP files.
-<Files "*.php">
-    Require all denied
-</Files>
+# Apache 2.4+
+<IfModule authz_core_module>
+    # Denie access via HTTP requests to all PHP files.
+    <FilesMatch "\.php">
+        Require all denied
+    </FilesMatch>
 
-# Except those whitelisted bellow.
-<Files "index.php">
-    Require all granted
-</Files>
-<Files "index_dev.php">
-    Require all granted
-</Files>
-<Files "filemanager.php">
-    Require all granted
-</Files>
-<Files "upgrade.php">
-    Require all granted
-</Files>
+    # Except those whitelisted bellow.
+    <FilesMatch "(index|index_dev|filemanager|upgrade)\.php">
+        Require all granted
+    </FilesMatch>
+</IfModule>
+
+# Fallback for Apache < 2.4
+<IfModule !authz_core_module>
+    # Denie access via HTTP requests to all PHP files.
+    <FilesMatch "\.php">
+        Order deny,allow
+        Deny from all
+    </FilesMatch>
+
+    # Except those whitelisted bellow.
+    <FilesMatch "(index|index_dev|filemanager|upgrade)\.php">
+        Order allow,deny
+        Allow from all
+    </FilesMatch>
+</IfModule>
+

--- a/.htaccess
+++ b/.htaccess
@@ -100,12 +100,12 @@
 # Apache 2.4+
 <IfModule authz_core_module>
     # Denie access via HTTP requests to all PHP files.
-    <FilesMatch "\.php">
+    <FilesMatch "\.php$">
         Require all denied
     </FilesMatch>
 
     # Except those whitelisted bellow.
-    <FilesMatch "(index|index_dev|filemanager|upgrade)\.php">
+    <FilesMatch "^(index|index_dev|filemanager|upgrade)\.php$">
         Require all granted
     </FilesMatch>
 </IfModule>
@@ -113,13 +113,13 @@
 # Fallback for Apache < 2.4
 <IfModule !authz_core_module>
     # Denie access via HTTP requests to all PHP files.
-    <FilesMatch "\.php">
+    <FilesMatch "\.php$">
         Order deny,allow
         Deny from all
     </FilesMatch>
 
     # Except those whitelisted bellow.
-    <FilesMatch "(index|index_dev|filemanager|upgrade)\.php">
+    <FilesMatch "^(index|index_dev|filemanager|upgrade)\.php$">
         Order allow,deny
         Allow from all
     </FilesMatch>

--- a/.htaccess
+++ b/.htaccess
@@ -99,7 +99,7 @@
 
 # Apache 2.4+
 <IfModule authz_core_module>
-    # Denie access via HTTP requests to all PHP files.
+    # Deny access via HTTP requests to all PHP files.
     <FilesMatch "\.php$">
         Require all denied
     </FilesMatch>
@@ -112,7 +112,7 @@
 
 # Fallback for Apache < 2.4
 <IfModule !authz_core_module>
-    # Denie access via HTTP requests to all PHP files.
+    # Deny access via HTTP requests to all PHP files.
     <FilesMatch "\.php$">
         Order deny,allow
         Deny from all


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  X
| New feature? | - 
| Automated tests included? | -
| Related user documentation PR URL | -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | #7975
| BC breaks? |  -
| Deprecations? | - 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
New .htaccess syntax breaks Mautic on an Apache v2.2.
This PR resolves #7975 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run Mautic v.2.15.3 on an Apache v2.2
2. Open Mautic in a Web-Browser
