### PR TITLE
Fix preferences center segments ordering

### DIFF
--- a/app/bundles/CoreBundle/Views/Slots/segmentlist.html.php
+++ b/app/bundles/CoreBundle/Views/Slots/segmentlist.html.php
@@ -17,14 +17,14 @@
                 <label class="control-label"><?php echo isset($label_text) ? $label_text : $view['translator']->trans('mautic.lead.form.list'); ?></label>
             </div>
             <?php
-            $segmentNumber = count($form['lead_lists']->vars['choices']);
-            for ($i = ($segmentNumber - 1); $i >= 0; --$i) : ?>
-                <div id="segment-<?php echo $i; ?>" class="text-left">
-                    <?php echo $view['form']->widget($form['lead_lists'][$i]); ?>
-                    <?php echo $view['form']->label($form['lead_lists'][$i]); ?>
+            foreach ($form['lead_lists'] as $key => $leadList) {
+                ?>
+                <div id="segment-<?php echo $key; ?>" class="text-left">
+                    <?php echo $view['form']->widget($leadList); ?>
+                    <?php echo $view['form']->label($leadList); ?>
                 </div>
                 <?php
-            endfor;
+            }
             unset($form['lead_lists']);
             ?>
         </div>

--- a/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
+++ b/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
@@ -111,14 +111,15 @@ JS;
                 <hr />
                 <div id="contact-segments"> <div class="text-left"><?php echo  $view['form']->label($form['lead_lists']); ?></div>
                     <?php
-                    $segmentNumber = count($form['lead_lists']->vars['choices']);
-                    for ($i = ($segmentNumber - 1); $i >= 0; --$i): ?>
-                        <div id="segment-<?php echo $i; ?>" class="text-left">
-                            <?php echo $view['form']->widget($form['lead_lists'][$i]); ?>
-                            <?php echo $view['form']->label($form['lead_lists'][$i]); ?>
+                    foreach ($form['lead_lists'] as $key=>$leadList) {
+                        ?>
+                        <div id="segment-<?php echo $key; ?>" class="text-left">
+                            <?php echo $view['form']->widget($leadList); ?>
+                            <?php echo $view['form']->label($leadList); ?>
                         </div>
                     <?php
-                    endfor;
+                    }
+
                     unset($form['lead_lists']);
                     ?>
                 </div>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixed wrong segment choices ordering on preferences center page.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create segments: a, b, c as Available in Preference Center 
2. Enable preferences center in Configuration > Emails and enable segments in preferences center
3. Send email to contact and click to unsubscribe link
4. You should see wrong segments order - from Z to A


#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. See segmetns ordering works properly now

![image](https://user-images.githubusercontent.com/462477/67477102-ab6bc600-f659-11e9-8404-e54dbef9c94c.png)
