### PR TITLE
Page titles containing text like " Curso: ABC"

### DIFF
--- a/app/bundles/CoreBundle/Helper/Serializer.php
+++ b/app/bundles/CoreBundle/Helper/Serializer.php
@@ -28,7 +28,7 @@ class Serializer
      */
     public static function decode($serializedString, array $options = ['allowed_classes' => false])
     {
-        if (stripos($serializedString, 'o:') !== false) {
+        if (preg_match("/o\:(\d+)\:/gi", $serializedString)) {
             throw new \InvalidArgumentException(sprintf('The string %s contains an object.', $serializedString));
         }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | No
| Related developer documentation PR URL | No
| Issues addressed (#s or URLs) | 
| BC breaks? | No
| Deprecations? | No

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: It was causing me some problems, so I changed it to use preg_match and check only if the string begins with "o:"

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. If a website title tracked has words like "Curso: ABC" it is not possible to view a contact 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
