### PR TITLE
Fix use groupByFormula while build select columns in report

### DIFF
--- a/app/bundles/FormBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/ReportSubscriber.php
@@ -87,6 +87,7 @@ class ReportSubscriber extends CommonSubscriber
                 $submissionPrefix.'date_submitted' => [
                     'label'          => 'mautic.form.report.submit.date_submitted',
                     'type'           => 'datetime',
+                    'formula'        => $submissionPrefix.'date_submitted',
                     'groupByFormula' => 'DATE('.$submissionPrefix.'date_submitted)',
                 ],
                 $submissionPrefix.'referer' => [

--- a/app/bundles/FormBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/ReportSubscriber.php
@@ -87,7 +87,6 @@ class ReportSubscriber extends CommonSubscriber
                 $submissionPrefix.'date_submitted' => [
                     'label'          => 'mautic.form.report.submit.date_submitted',
                     'type'           => 'datetime',
-                    'formula'        => $submissionPrefix.'date_submitted',
                     'groupByFormula' => 'DATE('.$submissionPrefix.'date_submitted)',
                 ],
                 $submissionPrefix.'referer' => [

--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -295,8 +295,9 @@ final class MauticReportBuilder implements ReportBuilderInterface
 
         // Build SELECT clause
         if (!$selectOptions = $event->getSelectColumns()) {
-            $fields         = $this->entity->getColumns();
-            $groupByColumns = $queryBuilder->getQueryPart('groupBy');
+            $fields             = $this->entity->getColumns();
+            $groupByColumns     = $queryBuilder->getQueryPart('groupBy');
+            $groupByColumnsKeys = array_flip($groupByColumns);
 
             foreach ($fields as $field) {
                 if (isset($options['columns'][$field])) {
@@ -306,7 +307,7 @@ final class MauticReportBuilder implements ReportBuilderInterface
                         $selectText = $this->buildCaseSelect($fieldOptions['channelData']);
                     } else {
                         // If there is a group by, and this field has groupByFormula
-                        if (isset($groupByColumns) && isset($fieldOptions['groupByFormula'])) {
+                        if (isset($fieldOptions['groupByFormula']) && isset($groupByColumnsKeys[$fieldOptions['groupByFormula']])) {
                             $selectText = $fieldOptions['groupByFormula'];
                         } elseif (isset($fieldOptions['formula'])) {
                             $selectText = $fieldOptions['formula'];

--- a/app/bundles/ReportBundle/Views/Report/details.html.php
+++ b/app/bundles/ReportBundle/Views/Report/details.html.php
@@ -169,7 +169,7 @@ if ($tmpl == 'index') {
 <div class="report-content">
     <?php $view['slots']->output('_content'); ?>
 </div>
-<?php if (!empty($debug)): ?>
+<?php if (!empty($debug) && isset($debug['count_query'])): ?>
 <div class="well">
     <h4>Debug: <?php echo $debug['query_time']; ?></h4>
     <div><?php echo $debug['count_query']; ?></div>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
We noticed error during the build report query.
This happend If groupByFormula definition exists. But this definition expect apply just if we're using group by this column. Without groupBy definition, we use standard column   statement.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Create a form > make submissions
2. Create a form submission report > add submission date column
3. Export in CSV or XLSX and see that the date is including time with always 10 pm UTC.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps, and see date in correct way
3. Just If we add this column to groupBy column, then will apply groupByFormula statement.
