### PR TITLE
Bug fix on CommonRepository

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -1636,6 +1636,7 @@ class CommonRepository extends EntityRepository
                                 $whereClause = $query->expr()->{$clause['expr']}($column, ':'.$param);
                                 $query->setParameter($param, $clause['val']);
                             }
+                            break;
                         default:
                             if (method_exists($query->expr(), $clause['expr'])) {
                                 if (in_array($clause['expr'], $columnValue)) {


### PR DESCRIPTION
When you try use `in` or `notIn` code also rund `default` block in the `swith:case`