### PR TITLE
show label instead of value for select/selectmulti fields in contact detail page

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -351,9 +351,12 @@ class LeadController extends FormController
         $dnc             = $this->getDoctrine()->getManager()->getRepository('MauticLeadBundle:DoNotContact')->getEntriesByLeadAndChannel($lead, 'email');
         $integrationRepo = $this->get('doctrine.orm.entity_manager')->getRepository('MauticPluginBundle:IntegrationEntity');
 
+        $fieldRepository = $this->getDoctrine()->getManager()->getRepository('MauticLeadBundle:LeadField');
+
         return $this->delegateView(
             [
                 'viewParameters' => [
+                    'fieldRepository'   => $fieldRepository,
                     'lead'              => $lead,
                     'avatarPanelState'  => $this->request->cookies->get('mautic_lead_avatar_panel', 'expanded'),
                     'fields'            => $fields,

--- a/app/bundles/LeadBundle/Helper/CustomFieldHelper.php
+++ b/app/bundles/LeadBundle/Helper/CustomFieldHelper.php
@@ -11,6 +11,8 @@
 
 namespace Mautic\LeadBundle\Helper;
 
+use Doctrine\ORM\EntityRepository;
+
 /**
  * Helper class custom field operations.
  */
@@ -44,6 +46,49 @@ class CustomFieldHelper
             }
         }
 
+        return $value;
+    }
+
+    /**
+     * Return property label instead of value for select and selectmultiple fields.
+     *
+     * @param EntityRepository $repository
+     * @param string $alias
+     * @param mixed  $value
+     *
+     * @return mixed
+     */
+    public static function fixSelectFieldValue(EntityRepository $repository, $alias, $value)
+    {
+        if (!is_null($value)) {
+            $customField = $repository->findOneByAlias($alias);
+            $customFieldProperties = $customField->getProperties()['list'];
+            if ( is_array($value) ) {
+                for( $i=0;$i<count($value);$i++ ) {
+                    $value[$i] = self::searchFieldValue($customFieldProperties,$alias,$value[$i]);
+                }
+            }else{
+                $value = self::searchFieldValue($customFieldProperties,$alias,$value);
+            }
+        }
+        return $value;
+    }
+
+    /**
+     * Search for the Lead field value in LeadField properties.
+     *
+     * @param EntityRepository $fieldProperties
+     * @param string $alias
+     * @param mixed  $value
+     *
+     * @return string
+     */
+    public static function searchFieldValue($fieldProperties, $alias, $value)
+    {
+        $propertyIndex = array_search($value,array_column($fieldProperties, 'value'));
+        if ( $propertyIndex !== false ) {
+            $value = $fieldProperties[$propertyIndex]['label'];
+        }
         return $value;
     }
 }

--- a/app/bundles/LeadBundle/Views/Lead/lead.html.php
+++ b/app/bundles/LeadBundle/Views/Lead/lead.html.php
@@ -223,8 +223,13 @@ $view['slots']->set(
                                                     <img class="mr-sm" src="<?php echo $flag; ?>" alt="" style="max-height: 24px;"/>
                                                     <span class="mt-1"><?php echo $view->escape($field['value']); ?>
                                                     <?php else: ?>
-                                                        <?php if (is_array($field['value']) && 'multiselect' === $field['type']): ?>
-                                                            <?php echo implode(', ', $field['value']); ?>
+                                                        <?php if (count(explode('|',$field['value']) > 0) && 'multiselect' === $field['type']): ?>
+                                                            <?php 
+                                                                $valueArray = explode('|',$field['value']);
+                                                                echo implode(', ', \Mautic\LeadBundle\Helper\CustomFieldHelper::fixSelectFieldValue($fieldRepository,$field['alias'],$valueArray));
+                                                            ?>
+                                                        <?php elseif (is_string($field['value']) && 'select' === $field['type']): ?>
+                                                            <?php echo \Mautic\LeadBundle\Helper\CustomFieldHelper::fixSelectFieldValue($fieldRepository,$field['alias'],$field['value']); ?>
                                                         <?php elseif (is_string($field['value']) && 'url' === $field['type']): ?>
                                                             <a href="<?php echo $view->escape($field['value']); ?>" target="_blank">
                                                                 <?php echo $field['value']; ?>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? |No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: #3664

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Set contact data for select/selectmulti field.
2.  On contact detail page, the field shows the value instead of label.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
