### PR TITLE
Fix hidden bar If allow hide is disabled

### DIFF
--- a/plugins/MauticFocusBundle/Views/Builder/generate.js.php
+++ b/plugins/MauticFocusBundle/Views/Builder/generate.js.php
@@ -96,11 +96,16 @@ switch ($style) {
             // Register click events for toggling bar, closing windows, etc
             registerClickEvents: function () {
                 <?php if ($style == 'bar'): ?>
+                var isTop = Focus.hasClass(Focus.iframeFocus, 'mf-bar-top');
+                Focus.setDefaultBarPosition(isTop);
+
                 var collapser = document.getElementsByClassName('mf-bar-collapser-<?php echo $focus['id']; ?>');
 
-                collapser[0].addEventListener('click', function () {
-                    Focus.toggleBarCollapse(collapser[0], false);
-                });
+                if (collapser[0]) {
+                    collapser[0].addEventListener('click', function () {
+                        Focus.toggleBarCollapse(collapser[0], false);
+                    });
+                }
 
                 <?php else: ?>
                 var closer = Focus.iframeDoc.getElementsByClassName('mf-<?php echo $style; ?>-close');
@@ -147,7 +152,13 @@ switch ($style) {
                 }
                 <?php endif; ?>
             },
-
+            setDefaultBarPosition: function (isTop) {
+                if (isTop) {
+                    Focus.iframe.style.marginTop = 0;
+                }else {
+                    Focus.iframe.style.marginBottom = 0;
+                }
+            },
             toggleBarCollapse: function (collapser, useCookie) {
                 var svg = collapser.getElementsByTagName('svg');
                 var g = svg[0].getElementsByTagName('g');
@@ -178,12 +189,7 @@ switch ($style) {
                 var isTop = Focus.hasClass(Focus.iframeFocus, 'mf-bar-top');
                 if ((!isTop && newDirection == 90) || (isTop && newDirection == -90)) {
                     // Open it up
-                    if (isTop) {
-                        Focus.iframe.style.marginTop = 0;
-                    } else {
-                        Focus.iframe.style.marginBottom = 0;
-                    }
-
+                    Focus.setDefaultBarPosition(isTop);
                     Focus.removeClass(collapser, 'mf-bar-collapsed');
                     Focus.enableIframeResizer();
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

We noticed Focus bar type not display If option Allow to hide is disabled. 
This PR fixed it. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Create a focus item
2. Set Display a notice
3. Set "bar" as style
4. Here, disable the "Allow to hide" option
5. Set colors and enter text if you want.
6. Save your focus.
7. Create a landing page with the focus token in it. Or insert the focus script on a site.
8. See that the focus is a blank bar.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps to reproduce
3. Check If works for both states of Allow to hide option

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
