### PR TITLE
Unable to open file for reading #8034

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -957,9 +957,18 @@ class MailHelper
             $matches = [];
             if (preg_match_all('/<img.+?src=[\"\'](.+?)[\"\'].*?>/i', $content, $matches)) {
                 $replaces = [];
+                $tokens = $this->getGlobalTokens();
                 foreach ($matches[1] as $match) {
                     if (strpos($match, 'cid:') === false) {
-                        $replaces[$match] = $this->message->embed(\Swift_Image::fromPath($match));
+                        if (preg_match('/\{[^\}]+\}/i', $match)) {
+                            if (!count($tokens))
+                                continue;
+                            else 
+                                $matched = strtr($match, $tokens);
+                        } else {
+                            $matched = $match;
+                        }
+                        $replaces[$match] = $this->message->embed(\Swift_Image::fromPath($matched));
                     }
                 }
                 $content = strtr($content, $replaces);


### PR DESCRIPTION
closes #8034
Checking the image source if it has tokens then the tokens will be replaced to the matched values sent in the sendToCotact api call


[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | #8034 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
Send Email to contact using api fails when embed image option is enabled and the image source has tokens in the url. while the images being embedded before the processing of the token parameters

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. set Mautic to embed images 
2. set Mail template code to include tokens in the image src attribute
3. send email to contact from the API 
4. error from SwiftImage "Unable to open file for reading"

#### Steps to test this PR:
1. set Mautic to embed images 
2. set Mail template code to include tokens in the image src attribute
3. send email to contact from the API 
4. if all goes right, the email will be sent without errors
