### PR TITLE
Fix relative date segment filter and add support for datetime relative filter

### DIFF
--- a/app/bundles/CoreBundle/Helper/DateTimeHelper.php
+++ b/app/bundles/CoreBundle/Helper/DateTimeHelper.php
@@ -44,12 +44,18 @@ class DateTimeHelper
     private $datetime;
 
     /**
+     * @var string
+     */
+    private $localTimezone;
+
+    /**
      * @param \DateTimeInterface|string $string
      * @param string                    $fromFormat Format the string is in
      * @param string                    $timezone   Timezone the string is in
      */
     public function __construct($string = '', $fromFormat = 'Y-m-d H:i:s', $timezone = 'UTC')
     {
+        $this->localTimezone = ArrayHelper::getValue('default_timezone', (new ParamsLoaderHelper())->getParameters(), date_default_timezone_get());
         $this->setDateTime($string, $fromFormat, $timezone);
     }
 
@@ -63,16 +69,15 @@ class DateTimeHelper
     public function setDateTime($datetime = '', $fromFormat = 'Y-m-d H:i:s', $timezone = 'local')
     {
         if ($timezone == 'local') {
-            $timezone = date_default_timezone_get();
+            $timezone = $this->localTimezone;
         } elseif (empty($timezone)) {
             $timezone = 'UTC';
         }
 
         $this->format   = (empty($fromFormat)) ? 'Y-m-d H:i:s' : $fromFormat;
         $this->timezone = $timezone;
-
-        $this->utc   = new \DateTimeZone('UTC');
-        $this->local = new \DateTimeZone($timezone);
+        $this->utc      = new \DateTimeZone('UTC');
+        $this->local    = new \DateTimeZone($this->localTimezone);
 
         if ($datetime instanceof \DateTimeInterface) {
             $this->datetime = $datetime;

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateRelativeInterval.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateRelativeInterval.php
@@ -103,7 +103,7 @@ class DateRelativeInterval implements FilterDecoratorInterface
      */
     public function getParameterValue(ContactSegmentFilterCrate $contactSegmentFilterCrate)
     {
-        $date     = $this->dateOptionParameters->getDefaultDate();
+        $date = $this->dateOptionParameters->getDefaultDate();
         $date->modify($this->originalValue);
 
         $operator = $this->getOperator($contactSegmentFilterCrate);

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateRelativeInterval.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateRelativeInterval.php
@@ -104,6 +104,8 @@ class DateRelativeInterval implements FilterDecoratorInterface
     public function getParameterValue(ContactSegmentFilterCrate $contactSegmentFilterCrate)
     {
         $date     = $this->dateOptionParameters->getDefaultDate();
+        $date->modify($this->originalValue);
+
         $operator = $this->getOperator($contactSegmentFilterCrate);
         $format   = 'Y-m-d';
 
@@ -111,7 +113,6 @@ class DateRelativeInterval implements FilterDecoratorInterface
         if ($contactSegmentFilterCrate->hasTimeParts() && in_array($contactSegmentFilterCrate->getOperator(), ['!gt', 'gt', 'gte', '!lt', 'lt', 'lte'])) {
             $format   = 'Y-m-d H:i:s';
         }
-        $date->modify($this->originalValue);
 
         if ($operator === 'like' || $operator === 'notLike') {
             $format .= '%';

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateRelativeInterval.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateRelativeInterval.php
@@ -103,11 +103,16 @@ class DateRelativeInterval implements FilterDecoratorInterface
      */
     public function getParameterValue(ContactSegmentFilterCrate $contactSegmentFilterCrate)
     {
-        $date = $this->dateOptionParameters->getDefaultDate();
-        $date->modify($this->originalValue);
-
+        $date     = $this->dateOptionParameters->getDefaultDate();
         $operator = $this->getOperator($contactSegmentFilterCrate);
         $format   = 'Y-m-d';
+
+        // set now datetime for relative dates like -8 hours, -24 minutes with gt/lt types of operator
+        if ($contactSegmentFilterCrate->hasTimeParts() && in_array($contactSegmentFilterCrate->getOperator(), ['!gt', 'gt', 'gte', '!lt', 'lt', 'lte'])) {
+            $format   = 'Y-m-d H:i:s';
+        }
+        $date->modify($this->originalValue);
+
         if ($operator === 'like' || $operator === 'notLike') {
             $format .= '%';
         }

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/TimezoneResolver.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/TimezoneResolver.php
@@ -45,7 +45,7 @@ class TimezoneResolver
          *
          * Later we use toLocalString() method - it gives us midnight in UTC for first condition and midnight in local timezone for second option.
          */
-        $timezone = $hasTimePart ? 'UTC' : $this->coreParametersHelper->getParameter('default_timezone', 'UTC');
+        $timezone = 'UTC';
 
         $date = new \DateTime('midnight today', new \DateTimeZone($timezone));
 

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/TimezoneResolver.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/TimezoneResolver.php
@@ -45,9 +45,14 @@ class TimezoneResolver
          *
          * Later we use toLocalString() method - it gives us midnight in UTC for first condition and midnight in local timezone for second option.
          */
-        $timezone = 'UTC';
+        $timezone = $hasTimePart ? 'UTC' : $this->coreParametersHelper->getParameter('default_timezone', 'UTC');
 
-        $date = new \DateTime('midnight today', new \DateTimeZone($timezone));
+        $time = 'midnight today';
+        if ($hasTimePart) {
+            $time = 'now';
+        }
+
+        $date = new \DateTime($time, new \DateTimeZone($timezone));
 
         return new DateTimeHelper($date, null, $timezone);
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7967
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR is ongoing solution to relative date segment filter issue.
This PR require before testing merge this https://github.com/mautic/mautic/pull/7752
This PR continue on un-resolving issue write by core member team @anton-vlasenko  https://github.com/mautic/mautic/issues/7967
This PR also include support for datetime in segment filter resolved in already closed  https://github.com/mautic/mautic/pull/7122

Solution is easy:

Before DateTimeHelper.php load localTimezone from server date_default_timezone_get
After load from local.php

https://github.com/mautic/mautic/pull/8044/files#diff-36ed844b46ee77f22d7c9a23897b4053R58


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
Apply this fix first https://github.com/mautic/mautic/pull/7752
1. Setup local timezone on server to UTC
2. Setup timezone in Mautic configuration or in local.php to Paris
3. Create two custom field date and datetime format
4. Then create segment filter with both fields and relative dates
- equal = 2 days
- greater/equal 2 days

![image](https://user-images.githubusercontent.com/462477/67850869-8bc91780-fb09-11e9-8339-aed1400a7835.png) 

5. Run segment rebuild
6. Check sql query in  logs on your dev enviroment (or in Mautibox logs)
7. If today is 30. 10. 2019, you should see

`SELECT count(leadIdPrimary) count, max(leadIdPrimary) maxId, min(leadIdPrimary) minId FROM (SELECT DISTINCT orp.lead_id as leadIdPrimary, orp.lead_id as id, orp.leadlist_id FROM lead_lists_leads orp LEFT JOIN (SELECT l.id FROM leads l WHERE ((l.custom_date LIKE '2019-10-31%') AND (l.custom_date_time LIKE '2019-11-01%')) OR ((l.custom_date >= '2019-10-31') AND (l.custom_date_time >= '2019-11-01'))) members ON members.id=orp.lead_id WHERE (orp.leadlist_id = 9) AND (members.id IS NULL) AND (orp.manually_added = '0')) sss`

#### Steps to test this PR:
1. Apply this PR and don't forget apply https://github.com/mautic/mautic/pull/7752
2. Run segment:rebuild 
3. You should see now

`SELECT count(leadIdPrimary) count, max(leadIdPrimary) maxId, min(leadIdPrimary) minId FROM (SELECT DISTINCT orp.lead_id as leadIdPrimary, orp.lead_id as id, orp.leadlist_id FROM lead_lists_leads orp LEFT JOIN (SELECT l.id FROM leads l WHERE ((l.custom_date LIKE '2019-11-01%') AND (l.custom_date_time LIKE '2019-11-01%')) OR ((l.custom_date >= '2019-11-01') AND (l.custom_date_time >= '2019-11-01 11:48:12'))) members ON members.id=orp.lead_id WHERE (orp.leadlist_id = 9) AND (members.id IS NULL) AND (orp.manually_added = '0')) sss`

- l.custom_date LIKE '2019-11-01%' - ✔️ 
- l.custom_date_time LIKE '2019-11-01%' - ✔️ 
- l.custom_date >= '2019-11-01' - ✔️ 
- l.custom_date_time >= '2019-11-01 11:48:12' ✔️ 

This is what we expect


#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
