### PR TITLE
Upgrade dynamic content form types for Symfony 3

### DIFF
--- a/app/bundles/DynamicContentBundle/Config/config.php
+++ b/app/bundles/DynamicContentBundle/Config/config.php
@@ -102,11 +102,9 @@ return [
                     'translator',
                     'mautic.lead.model.lead',
                 ],
-                'alias' => 'dwc',
             ],
             'mautic.form.type.dwc_entry_filters' => [
                 'class'     => 'Mautic\DynamicContentBundle\Form\Type\DwcEntryFiltersType',
-                'alias'     => 'dwc_entry_filters',
                 'arguments' => [
                     'translator',
                 ],
@@ -121,18 +119,15 @@ return [
                 'arguments' => [
                     'router',
                 ],
-                'alias' => 'dwcsend_list',
             ],
             'mautic.form.type.dwcdecision_list' => [
                 'class'     => 'Mautic\DynamicContentBundle\Form\Type\DynamicContentDecisionType',
                 'arguments' => [
                     'router',
                 ],
-                'alias' => 'dwcdecision_list',
             ],
             'mautic.form.type.dwc_list' => [
                 'class' => 'Mautic\DynamicContentBundle\Form\Type\DynamicContentListType',
-                'alias' => 'dwc_list',
             ],
         ],
         'models' => [
@@ -150,6 +145,7 @@ return [
                     'mautic.campaign.model.event',
                     'event_dispatcher',
                 ],
-            ], ],
+            ],
+        ],
     ],
 ];

--- a/app/bundles/DynamicContentBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/CampaignSubscriber.php
@@ -18,6 +18,8 @@ use Mautic\CoreBundle\Event\TokenReplacementEvent;
 use Mautic\CoreBundle\EventListener\CommonSubscriber;
 use Mautic\DynamicContentBundle\DynamicContentEvents;
 use Mautic\DynamicContentBundle\Entity\DynamicContent;
+use Mautic\DynamicContentBundle\Form\Type\DynamicContentDecisionType;
+use Mautic\DynamicContentBundle\Form\Type\DynamicContentSendType;
 use Mautic\DynamicContentBundle\Model\DynamicContentModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -75,7 +77,7 @@ class CampaignSubscriber extends CommonSubscriber
                 'label'                  => 'mautic.dynamicContent.campaign.send_dwc',
                 'description'            => 'mautic.dynamicContent.campaign.send_dwc.tooltip',
                 'eventName'              => DynamicContentEvents::ON_CAMPAIGN_TRIGGER_ACTION,
-                'formType'               => 'dwcsend_list',
+                'formType'               => DynamicContentSendType::class,
                 'formTypeOptions'        => ['update_select' => 'campaignevent_properties_dynamicContent'],
                 'formTheme'              => 'MauticDynamicContentBundle:FormTheme\DynamicContentPushList',
                 'timelineTemplate'       => 'MauticDynamicContentBundle:SubscribedEvents\Timeline:index.html.php',
@@ -101,7 +103,7 @@ class CampaignSubscriber extends CommonSubscriber
                 'label'           => 'mautic.dynamicContent.campaign.decision_dwc',
                 'description'     => 'mautic.dynamicContent.campaign.decision_dwc.tooltip',
                 'eventName'       => DynamicContentEvents::ON_CAMPAIGN_TRIGGER_DECISION,
-                'formType'        => 'dwcdecision_list',
+                'formType'        => DynamicContentDecisionType::class,
                 'formTypeOptions' => ['update_select' => 'campaignevent_properties_dynamicContent'],
                 'formTheme'       => 'MauticDynamicContentBundle:FormTheme\DynamicContentDecisionList',
                 'channel'         => 'dynamicContent',

--- a/app/bundles/DynamicContentBundle/Form/Type/DwcEntryFiltersType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DwcEntryFiltersType.php
@@ -54,10 +54,11 @@ class DwcEntryFiltersType extends AbstractType
             [
                 'label'   => false,
                 'choices' => [
-                    'and' => 'mautic.lead.list.form.glue.and',
-                    'or'  => 'mautic.lead.list.form.glue.or',
+                    'mautic.lead.list.form.glue.and' => 'and',
+                    'mautic.lead.list.form.glue.or'  => 'or',
                 ],
-                'attr' => [
+                'choices_as_values' => true,
+                'attr'              => [
                     'class'    => 'form-control not-chosen glue-select',
                     'onchange' => 'Mautic.updateFilterPositioning(this)',
                 ],

--- a/app/bundles/DynamicContentBundle/Form/Type/DwcEntryFiltersType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DwcEntryFiltersType.php
@@ -119,7 +119,7 @@ class DwcEntryFiltersType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'dwc_entry_filters';
     }

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentDecisionType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentDecisionType.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\DynamicContentBundle\Form\Type;
 
+use Doctrine\DBAL\Types\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
@@ -23,7 +24,7 @@ class DynamicContentDecisionType extends DynamicContentSendType
     {
         $builder->add(
             'dwc_slot_name',
-            'text',
+            TextType::class,
             [
                 'label'      => 'mautic.dynamicContent.send.slot_name',
                 'label_attr' => ['class' => 'control-label'],

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentDecisionType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentDecisionType.php
@@ -11,7 +11,7 @@
 
 namespace Mautic\DynamicContentBundle\Form\Type;
 
-use Doctrine\DBAL\Types\TextType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentDecisionType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentDecisionType.php
@@ -42,7 +42,7 @@ class DynamicContentDecisionType extends DynamicContentSendType
 
         $builder->add(
             'dynamicContent',
-            'dwc_list',
+            DynamicContentListType::class,
             [
                 'label'      => 'mautic.dynamicContent.send.selectDynamicContents.default',
                 'label_attr' => ['class' => 'control-label'],
@@ -64,7 +64,7 @@ class DynamicContentDecisionType extends DynamicContentSendType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'dwcdecision_list';
     }

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentListType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentListType.php
@@ -66,7 +66,7 @@ class DynamicContentListType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'dwc_list';
     }

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentSendType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentSendType.php
@@ -13,7 +13,7 @@ namespace Mautic\DynamicContentBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
@@ -45,7 +45,7 @@ class DynamicContentSendType extends AbstractType
     {
         $builder->add(
             'dynamicContent',
-            'dwc_list',
+            DynamicContentListType::class,
             [
                 'label'      => 'mautic.dynamicContent.send.selectDynamicContents',
                 'label_attr' => ['class' => 'control-label'],
@@ -118,15 +118,15 @@ class DynamicContentSendType extends AbstractType
         }
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setOptional(['update_select']);
+        $resolver->setDefined(['update_select']);
     }
 
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'dwcsend_list';
     }

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentSendType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentSendType.php
@@ -12,6 +12,7 @@
 namespace Mautic\DynamicContentBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\RouterInterface;
@@ -75,7 +76,7 @@ class DynamicContentSendType extends AbstractType
 
             $builder->add(
                 'newDynamicContentButton',
-                'button',
+                ButtonType::class,
                 [
                     'label' => 'mautic.dynamicContent.send.new.dynamicContent',
                     'attr'  => [
@@ -104,7 +105,7 @@ class DynamicContentSendType extends AbstractType
 
             $builder->add(
                 'editDynamicContentButton',
-                'button',
+                ButtonType::class,
                 [
                     'label' => 'mautic.dynamicContent.send.edit.dynamicContent',
                     'attr'  => [

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
@@ -14,16 +14,26 @@ namespace Mautic\DynamicContentBundle\Form\Type;
 use DeviceDetector\Parser\Device\DeviceParserAbstract as DeviceParser;
 use DeviceDetector\Parser\OperatingSystem;
 use Doctrine\ORM\EntityManager;
+use Mautic\CategoryBundle\Form\Type\CategoryType;
 use Mautic\CoreBundle\Form\DataTransformer\EmojiToShortTransformer;
 use Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
+use Mautic\CoreBundle\Form\Type\FormButtonsType;
+use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
 use Mautic\DynamicContentBundle\Entity\DynamicContent;
+use Mautic\EmailBundle\Form\Type\EmailUtmTagsType;
 use Mautic\LeadBundle\Form\DataTransformer\FieldFilterTransformer;
 use Mautic\LeadBundle\Helper\FormFieldHelper;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Model\ListModel;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\LocaleType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -101,7 +111,7 @@ class DynamicContentType extends AbstractType
 
         $builder->add(
             'name',
-            'text',
+            TextType::class,
             [
                 'label'      => 'mautic.dynamicContent.form.internal.name',
                 'label_attr' => ['class' => 'control-label'],
@@ -111,7 +121,7 @@ class DynamicContentType extends AbstractType
 
         $builder->add(
             'slotName',
-            'text',
+            TextType::class,
             [
                 'label'      => 'mautic.dynamicContent.send.slot_name',
                 'label_attr' => ['class' => 'control-label'],
@@ -126,7 +136,7 @@ class DynamicContentType extends AbstractType
         $builder->add(
             $builder->create(
                 'description',
-                'textarea',
+                TextareaType::class,
                 [
                     'label'      => 'mautic.dynamicContent.description',
                     'label_attr' => ['class' => 'control-label'],
@@ -140,7 +150,7 @@ class DynamicContentType extends AbstractType
 
         $builder->add(
             'isCampaignBased',
-            'yesno_button_group',
+            YesNoButtonGroupType::class,
             [
                 'label' => 'mautic.dwc.form.is_campaign_based',
                 'data'  => (bool) $options['data']->isCampaignBased(),
@@ -153,7 +163,7 @@ class DynamicContentType extends AbstractType
 
         $builder->add(
             'language',
-            'locale',
+            LocaleType::class,
             [
                 'label'      => 'mautic.core.language',
                 'label_attr' => ['class' => 'control-label'],
@@ -166,7 +176,7 @@ class DynamicContentType extends AbstractType
 
         $builder->add(
             'publishUp',
-            'datetime',
+            DateTimeType::class,
             [
                 'widget'     => 'single_text',
                 'label'      => 'mautic.core.form.publishup',
@@ -182,7 +192,7 @@ class DynamicContentType extends AbstractType
 
         $builder->add(
             'publishDown',
-            'datetime',
+            DateTimeType::class,
             [
                 'widget'     => 'single_text',
                 'label'      => 'mautic.core.form.publishdown',
@@ -198,7 +208,7 @@ class DynamicContentType extends AbstractType
 
         $builder->add(
             'content',
-            'textarea',
+            TextareaType::class,
             [
                 'label'      => 'mautic.dynamicContent.form.content',
                 'label_attr' => ['class' => 'control-label'],
@@ -214,7 +224,7 @@ class DynamicContentType extends AbstractType
         );
         $builder->add(
             'utmTags',
-            'utm_tags',
+            EmailUtmTagsType::class,
             [
                 'label'      => 'mautic.email.utm_tags',
                 'label_attr' => ['class' => 'control-label'],
@@ -249,20 +259,20 @@ class DynamicContentType extends AbstractType
 
         $builder->add(
             'category',
-            'category',
+            CategoryType::class,
             ['bundle' => 'dynamicContent']
         );
 
         if (!empty($options['update_select'])) {
             $builder->add(
                 'buttons',
-                'form_buttons',
+                FormButtonsType::class,
                 ['apply_text' => false]
             );
 
             $builder->add(
                 'updateSelect',
-                'hidden',
+                HiddenType::class,
                 [
                     'data'   => $options['update_select'],
                     'mapped' => false,
@@ -271,7 +281,7 @@ class DynamicContentType extends AbstractType
         } else {
             $builder->add(
                 'buttons',
-                'form_buttons'
+                FormButtonsType::class
             );
         }
 
@@ -279,10 +289,10 @@ class DynamicContentType extends AbstractType
         $builder->add(
             $builder->create(
                 'filters',
-                'collection',
+                CollectionType::class,
                 [
-                    'type'    => DwcEntryFiltersType::class,
-                    'options' => [
+                    'type'          => DwcEntryFiltersType::class,
+                    'entry_options' => [
                         'countries'    => $this->countryChoices,
                         'regions'      => $this->regionChoices,
                         'timezones'    => $this->timezoneChoices,

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
@@ -14,7 +14,6 @@ namespace Mautic\DynamicContentBundle\Form\Type;
 use DeviceDetector\Parser\Device\DeviceParserAbstract as DeviceParser;
 use DeviceDetector\Parser\OperatingSystem;
 use Doctrine\ORM\EntityManager;
-use Mautic\CategoryBundle\Form\Type\CategoryType;
 use Mautic\CoreBundle\Form\DataTransformer\EmojiToShortTransformer;
 use Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
@@ -259,7 +258,7 @@ class DynamicContentType extends AbstractType
 
         $builder->add(
             'category',
-            CategoryType::class,
+            'category',
             ['bundle' => 'dynamicContent']
         );
 

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
@@ -230,7 +230,7 @@ class DynamicContentType extends AbstractType
         $builder->add(
             $builder->create(
                 'translationParent',
-                'dwc_list',
+                DynamicContentListType::class,
                 [
                     'label'      => 'mautic.core.form.translation_parent',
                     'label_attr' => ['class' => 'control-label'],
@@ -360,7 +360,7 @@ class DynamicContentType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'dwc';
     }

--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -23,6 +23,7 @@ use Mautic\DynamicContentBundle\Entity\DynamicContent;
 use Mautic\DynamicContentBundle\Entity\DynamicContentRepository;
 use Mautic\DynamicContentBundle\Entity\Stat;
 use Mautic\DynamicContentBundle\Event\DynamicContentEvent;
+use Mautic\DynamicContentBundle\Form\Type\DynamicContentType;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
@@ -116,7 +117,7 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface
             $options['action'] = $action;
         }
 
-        return $formFactory->create('dwc', $entity, $options);
+        return $formFactory->create(DynamicContentType::class, $entity, $options);
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7996
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR upgrades the Symfony Form types to work with Symfony 3.
This is specific to the Components > Dynamic Content (web & campaign based dynamic content)

Things to test:
1) Creating dynamic content
2) Creating a campaign with "request dynamic content" and "return dynamic dynamic" conditions/actions, ensuring the lists of dynamic content (to select) work correctly. 
3) 