### PR TITLE
Deprecates form types no longer used in Mautic to be removed in M3

### DIFF
--- a/app/bundles/CoreBundle/Form/Type/HiddenEntityType.php
+++ b/app/bundles/CoreBundle/Form/Type/HiddenEntityType.php
@@ -18,6 +18,8 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * Class HiddenEntityType.
+ *
+ * @deprecated to be removed in 3.0
  */
 class HiddenEntityType extends AbstractType
 {

--- a/app/bundles/CoreBundle/Form/Type/SpacerType.php
+++ b/app/bundles/CoreBundle/Form/Type/SpacerType.php
@@ -19,6 +19,8 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * Class SpacerType.
+ *
+ * @deprecated to be removed in 3.0
  */
 class SpacerType extends AbstractType
 {


### PR DESCRIPTION
This simply deprecates form types no longer used in Mautic to be removed in M3.