### PR TITLE
M3: Refactor Deprecations - ApiBundle #7985

### DIFF
--- a/app/bundles/ApiBundle/Config/config.php
+++ b/app/bundles/ApiBundle/Config/config.php
@@ -126,9 +126,9 @@ return [
             'mautic.form.type.apiclients' => [
                 'class'     => 'Mautic\ApiBundle\Form\Type\ClientType',
                 'arguments' => [
+                    'service_container',
                     'translator',
                     'validator',
-                    'request',
                     'router',
                     'session',
                 ],

--- a/app/bundles/ApiBundle/Config/config.php
+++ b/app/bundles/ApiBundle/Config/config.php
@@ -126,7 +126,7 @@ return [
             'mautic.form.type.apiclients' => [
                 'class'     => 'Mautic\ApiBundle\Form\Type\ClientType',
                 'arguments' => [
-                    'service_container',
+                    'request_stack',
                     'translator',
                     'validator',
                     'router',

--- a/app/bundles/ApiBundle/Config/config.php
+++ b/app/bundles/ApiBundle/Config/config.php
@@ -132,11 +132,9 @@ return [
                     'router',
                     'session',
                 ],
-                'alias'     => 'client',
             ],
             'mautic.form.type.apiconfig' => [
                 'class' => 'Mautic\ApiBundle\Form\Type\ConfigType',
-                'alias' => 'apiconfig',
             ],
         ],
         'other' => [
@@ -176,7 +174,6 @@ return [
             'mautic.validator.oauthcallback' => [
                 'class' => 'Mautic\ApiBundle\Form\Validator\Constraints\OAuthCallbackValidator',
                 'tag'   => 'validator.constraint_validator',
-                'alias' => 'oauth_callback',
             ],
         ],
         'models' => [

--- a/app/bundles/ApiBundle/Config/config.php
+++ b/app/bundles/ApiBundle/Config/config.php
@@ -125,7 +125,13 @@ return [
         'forms' => [
             'mautic.form.type.apiclients' => [
                 'class'     => 'Mautic\ApiBundle\Form\Type\ClientType',
-                'arguments' => 'mautic.factory',
+                'arguments' => [
+                    'translator',
+                    'validator',
+                    'request',
+                    'router',
+                    'session',
+                ],
                 'alias'     => 'client',
             ],
             'mautic.form.type.apiconfig' => [

--- a/app/bundles/ApiBundle/Controller/ClientController.php
+++ b/app/bundles/ApiBundle/Controller/ClientController.php
@@ -206,7 +206,7 @@ class ClientController extends FormController
 
         //get the user form factory
         $action = $this->generateUrl('mautic_client_action', ['objectAction' => 'new']);
-        $form   = $model->createForm($client, $this->get('form.factory'), $action);
+        $form   = $model->createForm(get_class($client), $this->get('form.factory'), $action);
 
         //remove the client id and secret fields as they'll be auto generated
         $form->remove('randomId');
@@ -322,7 +322,7 @@ class ClientController extends FormController
         }
 
         $action = $this->generateUrl('mautic_client_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-        $form   = $model->createForm($client, $this->get('form.factory'), $action);
+        $form   = $model->createForm(get_class($client), $this->get('form.factory'), $action);
 
         // remove api_mode field
         $form->remove('api_mode');

--- a/app/bundles/ApiBundle/Controller/ClientController.php
+++ b/app/bundles/ApiBundle/Controller/ClientController.php
@@ -206,7 +206,7 @@ class ClientController extends FormController
 
         //get the user form factory
         $action = $this->generateUrl('mautic_client_action', ['objectAction' => 'new']);
-        $form   = $model->createForm(get_class($client), $this->get('form.factory'), $action);
+        $form   = $model->createForm($client, $this->get('form.factory'), $action);
 
         //remove the client id and secret fields as they'll be auto generated
         $form->remove('randomId');
@@ -322,7 +322,7 @@ class ClientController extends FormController
         }
 
         $action = $this->generateUrl('mautic_client_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-        $form   = $model->createForm(get_class($client), $this->get('form.factory'), $action);
+        $form   = $model->createForm($client, $this->get('form.factory'), $action);
 
         // remove api_mode field
         $form->remove('api_mode');

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -22,7 +22,6 @@ use Mautic\ApiBundle\Serializer\Exclusion\PublishDetailsExclusionStrategy;
 use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CoreBundle\Controller\FormErrorMessagesTrait;
 use Mautic\CoreBundle\Controller\MauticController;
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Form\RequestTrait;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
@@ -101,11 +100,6 @@ class CommonApiController extends FOSRestController implements MauticController
      * @var array
      */
     protected $extraGetEntitiesArguments = [];
-
-    /**
-     * @var MauticFactory
-     */
-    protected $factory;
 
     /**
      * @var bool
@@ -655,14 +649,6 @@ class CommonApiController extends FOSRestController implements MauticController
     public function setDispatcher(EventDispatcherInterface $dispatcher)
     {
         $this->dispatcher = $dispatcher;
-    }
-
-    /**
-     * @param MauticFactory $factory
-     */
-    public function setFactory(MauticFactory $factory)
-    {
-        $this->factory = $factory;
     }
 
     /**

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -22,6 +22,7 @@ use Mautic\ApiBundle\Serializer\Exclusion\PublishDetailsExclusionStrategy;
 use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CoreBundle\Controller\FormErrorMessagesTrait;
 use Mautic\CoreBundle\Controller\MauticController;
+use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Form\RequestTrait;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
@@ -100,6 +101,11 @@ class CommonApiController extends FOSRestController implements MauticController
      * @var array
      */
     protected $extraGetEntitiesArguments = [];
+
+    /**
+     * @var MauticFactory
+     */
+    protected $factory;
 
     /**
      * @var bool
@@ -649,6 +655,14 @@ class CommonApiController extends FOSRestController implements MauticController
     public function setDispatcher(EventDispatcherInterface $dispatcher)
     {
         $this->dispatcher = $dispatcher;
+    }
+
+    /**
+     * @param MauticFactory $factory
+     */
+    public function setFactory(MauticFactory $factory)
+    {
+        $this->factory = $factory;
     }
 
     /**

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -755,7 +755,7 @@ class CommonApiController extends FOSRestController implements MauticController
     protected function createEntityForm($entity)
     {
         return $this->model->createForm(
-            $entity,
+            get_class($entity),
             $this->get('form.factory'),
             null,
             array_merge(

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -769,7 +769,7 @@ class CommonApiController extends FOSRestController implements MauticController
     protected function createEntityForm($entity)
     {
         return $this->model->createForm(
-            get_class($entity),
+            $entity,
             $this->get('form.factory'),
             null,
             array_merge(

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -1230,13 +1230,6 @@ class CommonApiController extends FOSRestController implements MauticController
                 'errors' => [
                     $error,
                 ],
-                // @deprecated 2.6.0 to be removed in 3.0
-                'error' => [
-                    'message' => $this->get('translator')->trans($msg, [], 'flashes')
-                        .' (`error` is deprecated as of 2.6.0 and will be removed in 3.0. Use the `errors` array instead.)',
-                    'code'    => $code,
-                    'details' => $details,
-                ],
             ],
             $code
         );

--- a/app/bundles/ApiBundle/DependencyInjection/Compiler/OAuthPass.php
+++ b/app/bundles/ApiBundle/DependencyInjection/Compiler/OAuthPass.php
@@ -28,21 +28,7 @@ class OAuthPass implements CompilerPassInterface
         if ($container->hasDefinition('bazinga.oauth.security.authentication.provider')) {
             //Add a addMethodCall to set factory
             $container->getDefinition('bazinga.oauth.security.authentication.provider')->addMethodCall(
-                'setFactory', [new Reference('mautic.factory')]
-            );
-        }
-
-        if ($container->hasDefinition('bazinga.oauth.security.authentication.listener')) {
-            //Add a addMethodCall to set factory
-            $container->getDefinition('bazinga.oauth.security.authentication.listener')->addMethodCall(
-                'setFactory', [new Reference('mautic.factory')]
-            );
-        }
-
-        if ($container->hasDefinition('fos_oauth_server.security.authentication.listener')) {
-            //Add a addMethodCall to set factory
-            $container->getDefinition('fos_oauth_server.security.authentication.listener')->addMethodCall(
-                'setFactory', [new Reference('mautic.factory')]
+                'setTranslator', [new Reference('translator')]
             );
         }
     }

--- a/app/bundles/ApiBundle/EventListener/ApiSubscriber.php
+++ b/app/bundles/ApiBundle/EventListener/ApiSubscriber.php
@@ -150,9 +150,6 @@ class ApiSubscriber extends CommonSubscriber
                                         'type'    => $type,
                                     ],
                                 ],
-                                // @deprecated 2.6.0 to be removed in 3.0
-                                'error'             => $data['error'],
-                                'error_description' => $message.' (`error` and `error_description` are deprecated as of 2.6.0 and will be removed in 3.0. Use the `errors` array instead.)',
                             ],
                             $statusCode
                         );

--- a/app/bundles/ApiBundle/Form/Type/ClientType.php
+++ b/app/bundles/ApiBundle/Form/Type/ClientType.php
@@ -23,7 +23,7 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\ValidatorInterface;
@@ -283,7 +283,7 @@ class ClientType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $dataClass = ($this->apiMode == 'oauth2') ? 'Mautic\ApiBundle\Entity\oAuth2\Client' : 'Mautic\ApiBundle\Entity\oAuth1\Consumer';
         $resolver->setDefaults(
@@ -296,7 +296,7 @@ class ClientType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'client';
     }

--- a/app/bundles/ApiBundle/Form/Type/ClientType.php
+++ b/app/bundles/ApiBundle/Form/Type/ClientType.php
@@ -17,6 +17,8 @@ use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvent;
@@ -89,7 +91,7 @@ class ClientType extends AbstractType
         if (!$options['data']->getId()) {
             $builder->add(
                 'api_mode',
-                'choice',
+                ChoiceType::class,
                 [
                     'mapped'     => false,
                     'label'      => 'mautic.api.client.form.auth_protocol',
@@ -111,7 +113,7 @@ class ClientType extends AbstractType
 
         $builder->add(
             'name',
-            'text',
+            TextType::class,
             [
                 'label'      => 'mautic.core.name',
                 'label_attr' => ['class' => 'control-label'],
@@ -124,7 +126,7 @@ class ClientType extends AbstractType
             $builder->add(
                 $builder->create(
                     'redirectUris',
-                    'text',
+                    TextType::class,
                     [
                         'label'      => 'mautic.api.client.redirecturis',
                         'label_attr' => ['class' => 'control-label'],
@@ -139,7 +141,7 @@ class ClientType extends AbstractType
 
             $builder->add(
                 'publicId',
-                'text',
+                TextType::class,
                 [
                     'label'      => 'mautic.api.client.form.clientid',
                     'label_attr' => ['class' => 'control-label'],
@@ -153,7 +155,7 @@ class ClientType extends AbstractType
 
             $builder->add(
                 'secret',
-                'text',
+                TextType::class,
                 [
                     'label'      => 'mautic.api.client.form.clientsecret',
                     'label_attr' => ['class' => 'control-label'],
@@ -199,7 +201,7 @@ class ClientType extends AbstractType
             $builder->add(
                 $builder->create(
                     'callback',
-                    'text',
+                    TextType::class,
                     [
                         'label'      => 'mautic.api.client.form.callback',
                         'label_attr' => ['class' => 'control-label'],
@@ -214,7 +216,7 @@ class ClientType extends AbstractType
 
             $builder->add(
                 'consumerKey',
-                'text',
+                TextType::class,
                 [
                     'label'      => 'mautic.api.client.form.consumerkey',
                     'label_attr' => ['class' => 'control-label'],
@@ -231,7 +233,7 @@ class ClientType extends AbstractType
 
             $builder->add(
                 'consumerSecret',
-                'text',
+                TextType::class,
                 [
                     'label'      => 'mautic.api.client.form.consumersecret',
                     'label_attr' => ['class' => 'control-label'],

--- a/app/bundles/ApiBundle/Form/Type/ClientType.php
+++ b/app/bundles/ApiBundle/Form/Type/ClientType.php
@@ -12,7 +12,6 @@
 namespace Mautic\ApiBundle\Form\Type;
 
 use Mautic\ApiBundle\Form\Validator\Constraints\OAuthCallback;
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Form\DataTransformer as Transformers;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
@@ -22,7 +21,12 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\ValidatorInterface;
 
 /**
  * Class ClientType.
@@ -45,19 +49,33 @@ class ClientType extends AbstractType
     private $apiMode;
 
     /**
-     * @var \Symfony\Bundle\FrameworkBundle\Routing\Router
+     * @var \Symfony\Component\Routing\RouterInterface
      */
     private $router;
 
     /**
-     * @param MauticFactory $factory
+     * Constructor.
+     *
+     * @param TranslatorInterface $translator
+     * @param ValidatorInterface  $validator
+     * @param Request             $request
+     * @param Session             $session
+     * @param RouterInterface     $router
      */
-    public function __construct(MauticFactory $factory)
-    {
-        $this->translator = $factory->getTranslator();
-        $this->validator  = $factory->getValidator();
-        $this->apiMode    = $factory->getRequest()->get('api_mode', $factory->getSession()->get('mautic.client.filter.api_mode', 'oauth1a'));
-        $this->router     = $factory->getRouter();
+    public function __construct(
+        TranslatorInterface $translator,
+        ValidatorInterface $validator,
+        Request $request,
+        Session $session,
+        RouterInterface $router
+    ) {
+        $this->translator = $translator;
+        $this->validator  = $validator;
+        $this->apiMode    = $request->get(
+            'api_mode',
+            $session->get('mautic.client.filter.api_mode', 'oauth1a')
+        );
+        $this->router     = $router;
     }
 
     /**

--- a/app/bundles/ApiBundle/Form/Type/ClientType.php
+++ b/app/bundles/ApiBundle/Form/Type/ClientType.php
@@ -16,12 +16,12 @@ use Mautic\CoreBundle\Form\DataTransformer as Transformers;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\RouterInterface;
@@ -56,14 +56,14 @@ class ClientType extends AbstractType
     /**
      * Constructor.
      *
-     * @param ContainerInterface $container
-     * @param TranslatorInterface       $translator
-     * @param ValidatorInterface        $validator
-     * @param Session                   $session
-     * @param RouterInterface           $router
+     * @param RequestStack        $requestStack
+     * @param TranslatorInterface $translator
+     * @param ValidatorInterface  $validator
+     * @param Session             $session
+     * @param RouterInterface     $router
      */
     public function __construct(
-        ContainerInterface $container,
+        RequestStack $requestStack,
         TranslatorInterface $translator,
         ValidatorInterface $validator,
         Session $session,
@@ -71,7 +71,7 @@ class ClientType extends AbstractType
     ) {
         $this->translator = $translator;
         $this->validator  = $validator;
-        $this->apiMode    = $container->get('request')->get(
+        $this->apiMode    = $requestStack->getCurrentRequest()->get(
             'api_mode',
             $session->get('mautic.client.filter.api_mode', 'oauth1a')
         );

--- a/app/bundles/ApiBundle/Form/Type/ClientType.php
+++ b/app/bundles/ApiBundle/Form/Type/ClientType.php
@@ -101,12 +101,13 @@ class ClientType extends AbstractType
                         'onchange' => 'Mautic.refreshApiClientForm(\''.$this->router->generate('mautic_client_action', ['objectAction' => 'new']).'\', this)',
                     ],
                     'choices' => [
-                        'oauth1a' => 'OAuth 1.0a',
-                        'oauth2'  => 'OAuth 2',
+                        'OAuth 1.0a' => 'oauth1a',
+                        'OAuth 2'    => 'oauth2',
                     ],
-                    'required'    => false,
-                    'empty_value' => false,
-                    'data'        => $this->apiMode,
+                    'choices_as_values' => true,
+                    'required'          => false,
+                    'empty_value'       => false,
+                    'data'              => $this->apiMode,
                 ]
             );
         }

--- a/app/bundles/ApiBundle/Form/Type/ClientType.php
+++ b/app/bundles/ApiBundle/Form/Type/ClientType.php
@@ -16,12 +16,12 @@ use Mautic\CoreBundle\Form\DataTransformer as Transformers;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\RouterInterface;
@@ -56,22 +56,22 @@ class ClientType extends AbstractType
     /**
      * Constructor.
      *
-     * @param TranslatorInterface $translator
-     * @param ValidatorInterface  $validator
-     * @param Request             $request
-     * @param Session             $session
-     * @param RouterInterface     $router
+     * @param ContainerInterface $container
+     * @param TranslatorInterface       $translator
+     * @param ValidatorInterface        $validator
+     * @param Session                   $session
+     * @param RouterInterface           $router
      */
     public function __construct(
+        ContainerInterface $container,
         TranslatorInterface $translator,
         ValidatorInterface $validator,
-        Request $request,
         Session $session,
         RouterInterface $router
     ) {
         $this->translator = $translator;
         $this->validator  = $validator;
-        $this->apiMode    = $request->get(
+        $this->apiMode    = $container->get('request')->get(
             'api_mode',
             $session->get('mautic.client.filter.api_mode', 'oauth1a')
         );

--- a/app/bundles/ApiBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ApiBundle/Form/Type/ConfigType.php
@@ -13,6 +13,7 @@ namespace Mautic\ApiBundle\Form\Type;
 
 use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
@@ -53,7 +54,7 @@ class ConfigType extends AbstractType
 
         $builder->add(
             'api_oauth2_access_token_lifetime',
-            'number',
+            NumberType::class,
             [
                 'label' => 'mautic.api.config.form.api.oauth2_access_token_lifetime',
                 'attr'  => [
@@ -73,7 +74,7 @@ class ConfigType extends AbstractType
 
         $builder->add(
             'api_oauth2_refresh_token_lifetime',
-            'number',
+            NumberType::class,
             [
                 'label' => 'mautic.api.config.form.api.oauth2_refresh_token_lifetime',
                 'attr'  => [
@@ -93,7 +94,7 @@ class ConfigType extends AbstractType
 
         $builder->add(
           'api_rate_limiter_limit',
-          'number',
+          NumberType::class,
           [
             'label' => 'mautic.api.config.form.api.rate_limiter_limit',
             'attr'  => [

--- a/app/bundles/ApiBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ApiBundle/Form/Type/ConfigType.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\ApiBundle\Form\Type;
 
+use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -29,7 +30,7 @@ class ConfigType extends AbstractType
     {
         $builder->add(
             'api_enabled',
-            'yesno_button_group',
+            YesNoButtonGroupType::class,
             [
                 'label' => 'mautic.api.config.form.api.enabled',
                 'data'  => (bool) $options['data']['api_enabled'],
@@ -41,7 +42,7 @@ class ConfigType extends AbstractType
 
         $builder->add(
             'api_enable_basic_auth',
-            'yesno_button_group',
+            YesNoButtonGroupType::class,
             [
                 'label' => 'mautic.api.config.form.api.basic_auth_enabled',
                 'data'  => (bool) $options['data']['api_enable_basic_auth'],

--- a/app/bundles/ApiBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ApiBundle/Form/Type/ConfigType.php
@@ -115,7 +115,7 @@ class ConfigType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'apiconfig';
     }

--- a/app/bundles/ApiBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ApiBundle/Form/Type/ConfigType.php
@@ -11,7 +11,6 @@
 
 namespace Mautic\ApiBundle\Form\Type;
 
-use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -30,7 +29,7 @@ class ConfigType extends AbstractType
     {
         $builder->add(
             'api_enabled',
-            YesNoButtonGroupType::class,
+            'yesno_button_group',
             [
                 'label' => 'mautic.api.config.form.api.enabled',
                 'data'  => (bool) $options['data']['api_enabled'],
@@ -42,7 +41,7 @@ class ConfigType extends AbstractType
 
         $builder->add(
             'api_enable_basic_auth',
-            YesNoButtonGroupType::class,
+            'yesno_button_group',
             [
                 'label' => 'mautic.api.config.form.api.basic_auth_enabled',
                 'data'  => (bool) $options['data']['api_enable_basic_auth'],

--- a/app/bundles/ApiBundle/Security/OAuth1/Authentication/Provider/OAuthProvider.php
+++ b/app/bundles/ApiBundle/Security/OAuth1/Authentication/Provider/OAuthProvider.php
@@ -12,9 +12,9 @@
 namespace Mautic\ApiBundle\Security\OAuth1\Authentication\Provider;
 
 use Bazinga\OAuthServerBundle\Security\Authentification\Token\OAuthToken;
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class OAuthProvider.
@@ -22,16 +22,16 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 class OAuthProvider extends \Bazinga\OAuthServerBundle\Security\Authentification\Provider\OAuthProvider
 {
     /**
-     * @var MauticFactory
+     * @var \Symfony\Bundle\FrameworkBundle\Translation\Translator
      */
-    private $factory;
+    private $translator;
 
     /**
-     * @param MauticFactory $factory
+     * @param TranslatorInterface $translator
      */
-    public function setFactory(MauticFactory $factory)
+    public function setTranslator(TranslatorInterface $translator)
     {
-        $this->factory = $factory;
+        $this->translator = $translator;
     }
 
     /**
@@ -42,8 +42,6 @@ class OAuthProvider extends \Bazinga\OAuthServerBundle\Security\Authentification
         if (!$this->supports($token)) {
             return null;
         }
-
-        $translator = $this->factory->getTranslator();
 
         $requestParameters = $token->getRequestParameters();
         $requestMethod     = $token->getRequestMethod();
@@ -66,7 +64,7 @@ class OAuthProvider extends \Bazinga\OAuthServerBundle\Security\Authentification
             return $token;
         }
 
-        throw new AuthenticationException($translator->trans('mautic.api.oauth.auth.failed'));
+        throw new AuthenticationException($this->translator->trans('mautic.api.oauth.auth.failed'));
     }
 
     /**

--- a/app/bundles/ApiBundle/Security/OAuth1/Firewall/OAuthListener.php
+++ b/app/bundles/ApiBundle/Security/OAuth1/Firewall/OAuthListener.php
@@ -12,7 +12,6 @@
 namespace Mautic\ApiBundle\Security\OAuth1\Firewall;
 
 use Bazinga\OAuthServerBundle\Security\Authentification\Token\OAuthToken;
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -24,19 +23,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  */
 class OAuthListener extends \Bazinga\OAuthServerBundle\Security\Firewall\OAuthListener
 {
-    /**
-     * @var MauticFactory
-     */
-    private $factory;
-
-    /**
-     * @param MauticFactory $factory
-     */
-    public function setFactory(MauticFactory $factory)
-    {
-        $this->factory = $factory;
-    }
-
     /**
      * @author William DURAND <william.durand1@gmail.com>
      *

--- a/app/bundles/ApiBundle/Security/OAuth2/Firewall/OAuthListener.php
+++ b/app/bundles/ApiBundle/Security/OAuth2/Firewall/OAuthListener.php
@@ -11,7 +11,6 @@
 
 namespace Mautic\ApiBundle\Security\OAuth2\Firewall;
 
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 /**
@@ -19,19 +18,6 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  */
 class OAuthListener extends \FOS\OAuthServerBundle\Security\Firewall\OAuthListener
 {
-    /**
-     * @var MauticFactory
-     */
-    private $factory;
-
-    /**
-     * @param MauticFactory $factory
-     */
-    public function setFactory(MauticFactory $factory)
-    {
-        $this->factory = $factory;
-    }
-
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
PR for https://github.com/mautic/mautic/issues/7985

- [x]  Remove uses of MauticFactory
- [x] Search for and remove/refactor M2 @deprecated code if simple otherwise, create a new issue with details to be prioritized
- [x] https://github.com/symfony/symfony/blob/3.0/UPGRADE-3.0.md#form

ApiBundle/Form/Validator/Constraints/OAuthCallbackValidator.php
- [ ] Nr. 350 line 52: Calling deprecated method Symfony\Component\Validator\ConstraintValidator->buildViolation() - NOTE: This one is confusing because all though it is marked deprecated in the code, the Symfony 3.0 upgrade doc says to use it????

ApiBundle/Form/Type/ClientType.php
- [x] Nr. 351 line 267: Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface
- [x] Nr. 352 line 267: Overriding deprecated method Mautic\ApiBundle\Form\Type\ClientType->setDefaultOptions()
- [x] Nr. 353 line 280: Overriding deprecated method Mautic\ApiBundle\Form\Type\ClientType->getName()

ApiBundle/Form/Type/ConfigType.php
- [x] Nr. 354 line 117: Overriding deprecated method Mautic\ApiBundle\Form\Type\ConfigType->getName()