### PR TITLE
Dashboard bundle deprecation refactoring

### DIFF
--- a/app/bundles/DashboardBundle/Config/config.php
+++ b/app/bundles/DashboardBundle/Config/config.php
@@ -53,18 +53,10 @@ return [
         'forms' => [
             'mautic.dashboard.form.type.widget' => [
                 'class'     => 'Mautic\DashboardBundle\Form\Type\WidgetType',
-                'arguments' => 'mautic.factory',
-                'alias'     => 'widget',
-            ],
-            'mautic.dashboard.form.uplload' => [
-                'class'     => 'Mautic\DashboardBundle\Form\Type\UploadType',
-                'arguments' => 'mautic.factory',
-                'alias'     => 'dashboard_upload',
-            ],
-            'mautic.dashboard.form.filter' => [
-                'class'     => 'Mautic\DashboardBundle\Form\Type\FilterType',
-                'arguments' => 'mautic.factory',
-                'alias'     => 'dashboard_filter',
+                'arguments' => [
+                    'event_dispatcher',
+                    'mautic.security',
+                ],
             ],
         ],
         'models' => [

--- a/app/bundles/DashboardBundle/Controller/AjaxController.php
+++ b/app/bundles/DashboardBundle/Controller/AjaxController.php
@@ -13,6 +13,7 @@ namespace Mautic\DashboardBundle\Controller;
 
 use Mautic\CoreBundle\Controller\AjaxController as CommonAjaxController;
 use Mautic\DashboardBundle\Entity\Widget;
+use Mautic\DashboardBundle\Form\Type\WidgetType;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -58,9 +59,9 @@ class AjaxController extends CommonAjaxController
         }
 
         $widget   = new Widget();
-        $form     = $this->get('form.factory')->create('widget', $widget);
+        $form     = $this->get('form.factory')->create(WidgetType::class, $widget);
         $formHtml = $this->render('MauticDashboardBundle::Widget\\form.html.php',
-            ['form' => $form->bind($data)->createView()]
+            ['form' => $form->submit($data)->createView()]
         )->getContent();
 
         $dataArray['formHtml'] = $formHtml;

--- a/app/bundles/DashboardBundle/Controller/DashboardController.php
+++ b/app/bundles/DashboardBundle/Controller/DashboardController.php
@@ -11,9 +11,10 @@
 
 namespace Mautic\DashboardBundle\Controller;
 
-use Mautic\CoreBundle\Controller\FormController;
+use Mautic\CoreBundle\Controller\AbstractFormController;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\DashboardBundle\Entity\Widget;
+use Mautic\DashboardBundle\Form\Type\UploadType;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -21,7 +22,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 /**
  * Class DashboardController.
  */
-class DashboardController extends FormController
+class DashboardController extends AbstractFormController
 {
     /**
      * Generates the default view.
@@ -427,7 +428,7 @@ class DashboardController extends FormController
         ];
 
         $action = $this->generateUrl('mautic_dashboard_action', ['objectAction' => 'import']);
-        $form   = $this->get('form.factory')->create('dashboard_upload', [], ['action' => $action]);
+        $form   = $this->get('form.factory')->create(UploadType::class, [], ['action' => $action]);
 
         if ($this->request->getMethod() == 'POST') {
             if (isset($form) && !$cancelled = $this->isFormCancelled($form)) {

--- a/app/bundles/DashboardBundle/Form/Type/UploadType.php
+++ b/app/bundles/DashboardBundle/Form/Type/UploadType.php
@@ -12,6 +12,8 @@
 namespace Mautic\DashboardBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -25,19 +27,22 @@ class UploadType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('file', 'file', [
-            'label' => 'mautic.lead.import.file',
-            'attr'  => [
-                'accept' => '.json',
-                'class'  => 'form-control',
-            ],
-        ]);
-        $constraints = [
-            new \Symfony\Component\Validator\Constraints\NotBlank(
-                ['message' => 'mautic.core.value.required']
-            ),
-        ];
-        $builder->add('start', 'submit', [
+        $builder->add(
+            'file',
+            FileType::class,
+            [
+                'label' => 'mautic.lead.import.file',
+                'attr'  => [
+                    'accept' => '.json',
+                    'class'  => 'form-control',
+                ],
+            ]
+        );
+
+        $builder->add(
+            'start',
+            SubmitType::class,
+            [
             'attr' => [
                 'class'   => 'btn btn-primary',
                 'icon'    => 'fa fa-upload',
@@ -53,7 +58,7 @@ class UploadType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'dashboard_upload';
     }

--- a/app/bundles/DashboardBundle/Form/Type/WidgetType.php
+++ b/app/bundles/DashboardBundle/Form/Type/WidgetType.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\DashboardBundle\Form\Type;
 
+use Mautic\CoreBundle\Form\Type\FormButtonsType;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\DashboardBundle\DashboardEvents;
 use Mautic\DashboardBundle\Event\WidgetFormEvent;
@@ -18,6 +19,9 @@ use Mautic\DashboardBundle\Event\WidgetTypeListEvent;
 use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -53,56 +57,72 @@ class WidgetType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', 'text', [
-            'label'      => 'mautic.dashboard.widget.form.name',
-            'label_attr' => ['class' => 'control-label'],
-            'attr'       => ['class' => 'form-control'],
-            'required'   => false,
-        ]);
+        $builder->add(
+            'name',
+            TextType::class,
+            [
+                'label'      => 'mautic.dashboard.widget.form.name',
+                'label_attr' => ['class' => 'control-label'],
+                'attr'       => ['class' => 'form-control'],
+                'required'   => false,
+            ]
+        );
 
-        $event      = new WidgetTypeListEvent();
+        $event = new WidgetTypeListEvent();
         $event->setSecurity($this->security);
         $this->dispatcher->dispatch(DashboardEvents::DASHBOARD_ON_MODULE_LIST_GENERATE, $event);
 
-        $builder->add('type', 'choice', [
-            'label'       => 'mautic.dashboard.widget.form.type',
-            'choices'     => $event->getTypes(),
-            'label_attr'  => ['class' => 'control-label'],
-            'empty_value' => 'mautic.core.select',
-            'attr'        => [
-                'class'    => 'form-control',
-                'onchange' => 'Mautic.updateWidgetForm(this)',
-            ],
-        ]);
+        $builder->add(
+            'type',
+            ChoiceType::class,
+            [
+                'label'       => 'mautic.dashboard.widget.form.type',
+                'choices'     => $event->getTypes(),
+                'label_attr'  => ['class' => 'control-label'],
+                'empty_value' => 'mautic.core.select',
+                'attr'        => [
+                    'class'    => 'form-control',
+                    'onchange' => 'Mautic.updateWidgetForm(this)',
+                ],
+            ]
+        );
 
-        $builder->add('width', 'choice', [
-            'label'   => 'mautic.dashboard.widget.form.width',
-            'choices' => [
-                '25'  => '25%',
-                '50'  => '50%',
-                '75'  => '75%',
-                '100' => '100%',
-            ],
-            'empty_data' => '100',
-            'label_attr' => ['class' => 'control-label'],
-            'attr'       => ['class' => 'form-control'],
-            'required'   => false,
-        ]);
+        $builder->add(
+            'width',
+            ChoiceType::class,
+            [
+                'label'   => 'mautic.dashboard.widget.form.width',
+                'choices' => [
+                    '25'  => '25%',
+                    '50'  => '50%',
+                    '75'  => '75%',
+                    '100' => '100%',
+                ],
+                'empty_data'        => '100',
+                'label_attr'        => ['class' => 'control-label'],
+                'attr'              => ['class' => 'form-control'],
+                'required'          => false,
+            ]
+        );
 
-        $builder->add('height', 'choice', [
-            'label'   => 'mautic.dashboard.widget.form.height',
-            'choices' => [
-                '215' => '215px',
-                '330' => '330px',
-                '445' => '445px',
-                '560' => '560px',
-                '675' => '675px',
-            ],
-            'empty_data' => '330',
-            'label_attr' => ['class' => 'control-label'],
-            'attr'       => ['class' => 'form-control'],
-            'required'   => false,
-        ]);
+        $builder->add(
+            'height',
+            ChoiceType::class,
+            [
+                'label'   => 'mautic.dashboard.widget.form.height',
+                'choices' => [
+                    '215' => '215px',
+                    '330' => '330px',
+                    '445' => '445px',
+                    '560' => '560px',
+                    '675' => '675px',
+                ],
+                'empty_data'        => '330',
+                'label_attr'        => ['class' => 'control-label'],
+                'attr'              => ['class' => 'form-control'],
+                'required'          => false,
+            ]
+        );
 
         // function to add a form for specific widget type dynamically
         $func = function (FormEvent $e) {
@@ -137,14 +157,22 @@ class WidgetType extends AbstractType
             }
         };
 
-        $builder->add('id', 'hidden', [
-            'mapped' => false,
-        ]);
+        $builder->add(
+            'id',
+            HiddenType::class,
+            [
+                'mapped' => false,
+            ]
+        );
 
-        $builder->add('buttons', 'form_buttons', [
-            'apply_text' => false,
-            'save_text'  => 'mautic.core.form.save',
-        ]);
+        $builder->add(
+            'buttons',
+            FormButtonsType::class,
+            [
+                'apply_text' => false,
+                'save_text'  => 'mautic.core.form.save',
+            ]
+        );
 
         if (!empty($options['action'])) {
             $builder->setAction($options['action']);
@@ -152,13 +180,13 @@ class WidgetType extends AbstractType
 
         // Register the function above as EventListener on PreSet and PreBind
         $builder->addEventListener(FormEvents::PRE_SET_DATA, $func);
-        $builder->addEventListener(FormEvents::PRE_BIND, $func);
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, $func);
     }
 
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'widget';
     }

--- a/app/bundles/DashboardBundle/Model/DashboardModel.php
+++ b/app/bundles/DashboardBundle/Model/DashboardModel.php
@@ -19,6 +19,7 @@ use Mautic\CoreBundle\Model\FormModel;
 use Mautic\DashboardBundle\DashboardEvents;
 use Mautic\DashboardBundle\Entity\Widget;
 use Mautic\DashboardBundle\Event\WidgetDetailEvent;
+use Mautic\DashboardBundle\Form\Type\WidgetType;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -299,7 +300,7 @@ class DashboardModel extends FormModel
             $options['action'] = $action;
         }
 
-        return $formFactory->create('widget', $entity, $options);
+        return $formFactory->create(WidgetType::class, $entity, $options);
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7993
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR upgrades DashboardBundle Symfony Form types to work with Symfony 3.

[//]: # ( As applicable: )
#### Steps to test this PR:
1. On Dashboard try : 
- to add widget
- to export dashboard
- to import dashboard