### PR TITLE
Fix the periodic check for tracking pixel presence

### DIFF
--- a/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
@@ -298,7 +298,8 @@ document.addEventListener('mauticPageEventDelivered', function(e) {
 * Check if a DOM tracking pixel is present
 */
 MauticJS.checkForTrackingPixel = function() {
-    if (!/in/.test(document.readyState)) {
+    if (document.readyState != 'complete') {
+        // Periodically call self until the DOM is completely loaded
         setTimeout(function(){MauticJS.checkForTrackingPixel()}, 9)
     } else {
         // Only fetch once a tracking pixel has been loaded

--- a/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
@@ -298,7 +298,7 @@ document.addEventListener('mauticPageEventDelivered', function(e) {
 * Check if a DOM tracking pixel is present
 */
 MauticJS.checkForTrackingPixel = function() {
-    if (document.readyState != 'complete') {
+    if (document.readyState !== 'complete') {
         // Periodically call self until the DOM is completely loaded
         setTimeout(function(){MauticJS.checkForTrackingPixel()}, 9)
     } else {


### PR DESCRIPTION
closes #7852
| Q  | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| Automated tests included? | no
| Related user documentation PR URL | -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | #7852
| BC breaks? | no
| Deprecations? | no

#### Description:

As [laid out in detail in #7852](https://github.com/mautic/mautic/issues/7852), the current algorithm to detect when the Mautic tracking pixel is loaded is most likely broken.

This PR reverses the broken condition, makes it a little bit more obvious for developers to recognize and ads an explaining comment to the conditional body.

#### Steps to reproduce the bug:
1. Include the Mautic script into an already fully loaded website.
2. Wait for Mautic to dispatch a `mauticPageEventDelivered` event. This should never be the case as the algorithm runs into the described behavior.

#### Steps to test this PR:
Same as "steps to reproduce the bug", but the event should be dispatched.
