### PR TITLE
M3: Refactor Deprecations - MauticCloudStorageBundle #8008

### DIFF
--- a/plugins/MauticCloudStorageBundle/Config/config.php
+++ b/plugins/MauticCloudStorageBundle/Config/config.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * @copyright   2019 Mautic Contributors. All rights reserved
+ * @copyright   2014 Mautic Contributors. All rights reserved
  * @author      Mautic
  *
  * @link        http://mautic.org
@@ -32,21 +32,12 @@ return [
         'integrations' => [
             'mautic.integration.amazons3' => [
                 'class'       => \MauticPlugin\MauticCloudStorageBundle\Integration\AmazonS3Integration::class,
-                'methodCalls' => [
-                    'setContainer' => ['@service_container'],
-                ],
             ],
             'mautic.integration.openstack' => [
                 'class'       => \MauticPlugin\MauticCloudStorageBundle\Integration\OpenStackIntegration::class,
-                'methodCalls' => [
-                    'setContainer' => ['@service_container'],
-                ],
             ],
             'mautic.integration.rackspace' => [
                 'class'       => \MauticPlugin\MauticCloudStorageBundle\Integration\RackspaceIntegration::class,
-                'methodCalls' => [
-                    'setContainer' => ['@service_container'],
-                ],
             ],
         ],
     ],

--- a/plugins/MauticCloudStorageBundle/Config/config.php
+++ b/plugins/MauticCloudStorageBundle/Config/config.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * @copyright   2014 Mautic Contributors. All rights reserved
+ * @copyright   2019 Mautic Contributors. All rights reserved
  * @author      Mautic
  *
  * @link        http://mautic.org
@@ -23,28 +23,29 @@ return [
         ],
         'forms' => [
             'mautic.form.type.cloudstorage.openstack' => [
-                'class' => 'MauticPlugin\MauticCloudStorageBundle\Form\Type\OpenStackType',
-                'alias' => 'cloudstorage_openstack',
+                'class' => \MauticPlugin\MauticCloudStorageBundle\Form\Type\OpenStackType::class,
             ],
             'mautic.form.type.cloudstorage.rackspace' => [
-                'class' => 'MauticPlugin\MauticCloudStorageBundle\Form\Type\RackspaceType',
-                'alias' => 'cloudstorage_rackspace',
+                'class' => \MauticPlugin\MauticCloudStorageBundle\Form\Type\RackspaceType::class,
             ],
         ],
         'integrations' => [
             'mautic.integration.amazons3' => [
-                'class'     => \MauticPlugin\MauticCloudStorageBundle\Integration\AmazonS3Integration::class,
-                'arguments' => [
+                'class'       => \MauticPlugin\MauticCloudStorageBundle\Integration\AmazonS3Integration::class,
+                'methodCalls' => [
+                    'setContainer' => ['@service_container'],
                 ],
             ],
             'mautic.integration.openstack' => [
-                'class'     => \MauticPlugin\MauticCloudStorageBundle\Integration\OpenStackIntegration::class,
-                'arguments' => [
+                'class'       => \MauticPlugin\MauticCloudStorageBundle\Integration\OpenStackIntegration::class,
+                'methodCalls' => [
+                    'setContainer' => ['@service_container'],
                 ],
             ],
             'mautic.integration.rackspace' => [
-                'class'     => \MauticPlugin\MauticCloudStorageBundle\Integration\RackspaceIntegration::class,
-                'arguments' => [
+                'class'       => \MauticPlugin\MauticCloudStorageBundle\Integration\RackspaceIntegration::class,
+                'methodCalls' => [
+                    'setContainer' => ['@service_container'],
                 ],
             ],
         ],

--- a/plugins/MauticCloudStorageBundle/Form/Type/OpenStackType.php
+++ b/plugins/MauticCloudStorageBundle/Form/Type/OpenStackType.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * @copyright   2014 Mautic Contributors. All rights reserved
+ * @copyright   2019 Mautic Contributors. All rights reserved
  * @author      Mautic
  *
  * @link        http://mautic.org
@@ -12,6 +12,7 @@
 namespace MauticPlugin\MauticCloudStorageBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -24,7 +25,7 @@ class OpenStackType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('serviceUrl', 'url', [
+        $builder->add('serviceUrl', UrlType::class, [
             'label'      => 'mautic.integration.OpenStack.service.url',
             'required'   => true,
             'label_attr' => ['class' => 'control-label'],
@@ -38,7 +39,7 @@ class OpenStackType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'cloudstorage_openstack';
     }

--- a/plugins/MauticCloudStorageBundle/Form/Type/OpenStackType.php
+++ b/plugins/MauticCloudStorageBundle/Form/Type/OpenStackType.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * @copyright   2019 Mautic Contributors. All rights reserved
+ * @copyright   2014 Mautic Contributors. All rights reserved
  * @author      Mautic
  *
  * @link        http://mautic.org

--- a/plugins/MauticCloudStorageBundle/Form/Type/RackspaceType.php
+++ b/plugins/MauticCloudStorageBundle/Form/Type/RackspaceType.php
@@ -28,8 +28,8 @@ class RackspaceType extends AbstractType
         $builder->add('serverLocation', ChoiceType::class, [
             'label'   => 'mautic.integration.Rackspace.server.location',
             'choices' => [
-                'mautic.integration.Rackspace.server.location.us'=>'us',
-                'mautic.integration.Rackspace.server.location.uk'=>'uk',
+                'mautic.integration.Rackspace.server.location.us' => 'us',
+                'mautic.integration.Rackspace.server.location.uk' => 'uk',
             ],
             'required'   => true,
             'label_attr' => ['class' => 'control-label'],

--- a/plugins/MauticCloudStorageBundle/Form/Type/RackspaceType.php
+++ b/plugins/MauticCloudStorageBundle/Form/Type/RackspaceType.php
@@ -28,8 +28,8 @@ class RackspaceType extends AbstractType
         $builder->add('serverLocation', ChoiceType::class, [
             'label'   => 'mautic.integration.Rackspace.server.location',
             'choices' => [
-                'us' => 'mautic.integration.Rackspace.server.location.us',
-                'uk' => 'mautic.integration.Rackspace.server.location.uk',
+                'mautic.integration.Rackspace.server.location.us'=>'us',
+                'mautic.integration.Rackspace.server.location.uk'=>'uk',
             ],
             'required'   => true,
             'label_attr' => ['class' => 'control-label'],

--- a/plugins/MauticCloudStorageBundle/Form/Type/RackspaceType.php
+++ b/plugins/MauticCloudStorageBundle/Form/Type/RackspaceType.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * @copyright   2019 Mautic Contributors. All rights reserved
+ * @copyright   2014 Mautic Contributors. All rights reserved
  * @author      Mautic
  *
  * @link        http://mautic.org
@@ -36,6 +36,7 @@ class RackspaceType extends AbstractType
             'attr'       => [
                 'class' => 'form-control',
             ],
+            'choices_as_values' => true,
         ]);
     }
 

--- a/plugins/MauticCloudStorageBundle/Form/Type/RackspaceType.php
+++ b/plugins/MauticCloudStorageBundle/Form/Type/RackspaceType.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * @copyright   2014 Mautic Contributors. All rights reserved
+ * @copyright   2019 Mautic Contributors. All rights reserved
  * @author      Mautic
  *
  * @link        http://mautic.org
@@ -12,6 +12,7 @@
 namespace MauticPlugin\MauticCloudStorageBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -24,7 +25,7 @@ class RackspaceType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('serverLocation', 'choice', [
+        $builder->add('serverLocation', ChoiceType::class, [
             'label'   => 'mautic.integration.Rackspace.server.location',
             'choices' => [
                 'us' => 'mautic.integration.Rackspace.server.location.us',
@@ -41,7 +42,7 @@ class RackspaceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'cloudstorage_rackspace';
     }

--- a/plugins/MauticCloudStorageBundle/Integration/AmazonS3Integration.php
+++ b/plugins/MauticCloudStorageBundle/Integration/AmazonS3Integration.php
@@ -88,7 +88,6 @@ class AmazonS3Integration extends CloudStorageIntegration
                         'class'   => 'form-control',
                     ],
                     'data'        => empty($data['region']) ? 'us-east-1' : $data['region'],
-                    'required'    => false,
                 ]
             );
         }

--- a/plugins/MauticCloudStorageBundle/Integration/CloudStorageIntegration.php
+++ b/plugins/MauticCloudStorageBundle/Integration/CloudStorageIntegration.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * @copyright   2019 Mautic Contributors. All rights reserved
+ * @copyright   2014 Mautic Contributors. All rights reserved
  * @author      Mautic
  *
  * @link        http://mautic.org
@@ -13,7 +13,6 @@ namespace MauticPlugin\MauticCloudStorageBundle\Integration;
 
 use Gaufrette\Adapter;
 use Mautic\PluginBundle\Integration\AbstractIntegration;
-use Symfony\Component\DependencyInjection\Container;
 
 /**
  * Class CloudStorageIntegration.
@@ -24,36 +23,6 @@ abstract class CloudStorageIntegration extends AbstractIntegration
      * @var Adapter
      */
     protected $adapter;
-
-    /**
-     * @var Container
-     */
-    protected $container;
-
-    /**
-     * @param Container $container
-     */
-    public function setContainer(Container $container)
-    {
-        $this->container = $container;
-    }
-
-    /**
-     * @param \Symfony\Component\Form\FormBuilder| \Symfony\Component\Form\Form $builder
-     */
-    public function appendToForm(&$builder, $data, $formArea)
-    {
-        if ($formArea == 'features') {
-            $name = strtolower($this->getName());
-            if ($this->container->has('mautic.form.type.cloudstorage.'.$name)) {
-                $builder->add('provider', $name, [
-                    'label'    => 'mautic.integration.form.provider.settings',
-                    'required' => false,
-                    'data'     => (isset($data['provider'])) ? $data['provider'] : [],
-                ]);
-            }
-        }
-    }
 
     /**
      * {@inheritdoc}

--- a/plugins/MauticCloudStorageBundle/Integration/CloudStorageIntegration.php
+++ b/plugins/MauticCloudStorageBundle/Integration/CloudStorageIntegration.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * @copyright   2014 Mautic Contributors. All rights reserved
+ * @copyright   2019 Mautic Contributors. All rights reserved
  * @author      Mautic
  *
  * @link        http://mautic.org
@@ -13,6 +13,7 @@ namespace MauticPlugin\MauticCloudStorageBundle\Integration;
 
 use Gaufrette\Adapter;
 use Mautic\PluginBundle\Integration\AbstractIntegration;
+use Symfony\Component\DependencyInjection\Container;
 
 /**
  * Class CloudStorageIntegration.
@@ -25,14 +26,27 @@ abstract class CloudStorageIntegration extends AbstractIntegration
     protected $adapter;
 
     /**
-     * @param FormBuilder|Form $builder
+     * @var Container
+     */
+    protected $container;
+
+    /**
+     * @param Container $container
+     */
+    public function setContainer(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param \Symfony\Component\Form\FormBuilder| \Symfony\Component\Form\Form $builder
      */
     public function appendToForm(&$builder, $data, $formArea)
     {
         if ($formArea == 'features') {
             $name = strtolower($this->getName());
-            if ($this->factory->serviceExists('mautic.form.type.cloudstorage.'.$name)) {
-                $builder->add('provider', 'cloudstorage_'.$name, [
+            if ($this->container->has('mautic.form.type.cloudstorage.'.$name)) {
+                $builder->add('provider', $name, [
                     'label'    => 'mautic.integration.form.provider.settings',
                     'required' => false,
                     'data'     => (isset($data['provider'])) ? $data['provider'] : [],

--- a/plugins/MauticCloudStorageBundle/Integration/OpenStackIntegration.php
+++ b/plugins/MauticCloudStorageBundle/Integration/OpenStackIntegration.php
@@ -13,6 +13,7 @@ namespace MauticPlugin\MauticCloudStorageBundle\Integration;
 
 use Gaufrette\Adapter\LazyOpenCloud;
 use Gaufrette\Adapter\OpenStackCloudFiles\ObjectStoreFactory;
+use MauticPlugin\MauticCloudStorageBundle\Form\Type\OpenStackType;
 use OpenCloud\OpenStack;
 
 /**
@@ -107,5 +108,21 @@ class OpenStackIntegration extends CloudStorageIntegration
         $keys = $this->getDecryptedApiKeys();
 
         return $this->storeFactory->getObjectStore()->getContainer($keys['containerName'])->getObject($key)->getPublicUrl();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function appendToForm(&$builder, $data, $formArea)
+    {
+        if ('features' !== $formArea) {
+            return;
+        }
+
+        $builder->add('provider', OpenStackType::class, [
+            'label'    => 'mautic.integration.form.provider.settings',
+            'required' => false,
+            'data'     => (isset($data['provider'])) ? $data['provider'] : [],
+        ]);
     }
 }

--- a/plugins/MauticCloudStorageBundle/Integration/RackspaceIntegration.php
+++ b/plugins/MauticCloudStorageBundle/Integration/RackspaceIntegration.php
@@ -13,6 +13,7 @@ namespace MauticPlugin\MauticCloudStorageBundle\Integration;
 
 use Gaufrette\Adapter\LazyOpenCloud;
 use Gaufrette\Adapter\OpenStackCloudFiles\ObjectStoreFactory;
+use MauticPlugin\MauticCloudStorageBundle\Form\Type\RackspaceType;
 use OpenCloud\Rackspace;
 
 /**
@@ -115,5 +116,21 @@ class RackspaceIntegration extends CloudStorageIntegration
         $keys = $this->getDecryptedApiKeys();
 
         return $this->storeFactory->getObjectStore()->getContainer($keys['containerName'])->getObject($key)->getPublicUrl();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function appendToForm(&$builder, $data, $formArea)
+    {
+        if ('features' !== $formArea) {
+            return;
+        }
+
+        $builder->add('provider', RackspaceType::class, [
+            'label'    => 'mautic.integration.form.provider.settings',
+            'required' => false,
+            'data'     => (isset($data['provider'])) ? $data['provider'] : [],
+        ]);
     }
 }


### PR DESCRIPTION
- [x] Remove uses of MauticFactory

- [x] Search for and remove/refactor M2 @deprecated code if simple otherwise, create a new issue with details to be prioritized

- [x] https://github.com/symfony/symfony/blob/3.0/UPGRADE-3.0.md#form

MauticCloudStorageBundle/Form/Type/RackspaceType.php

- [x] Nr. 1 line 44: Overriding deprecated method MauticPlugin\MauticCloudStorageBundle\Form\Type\RackspaceType->getName()

MauticCloudStorageBundle/Form/Type/OpenStackType.php

- [x] Nr. 2 line 41: Overriding deprecated method MauticPlugin\MauticCloudStorageBundle\Form\Type\OpenStackType->getName()