### PR TITLE
Refactor deprecations in MauticEmailMarketing bundle (M3 migration)

### DIFF
--- a/plugins/MauticEmailMarketingBundle/Config/config.php
+++ b/plugins/MauticEmailMarketingBundle/Config/config.php
@@ -24,7 +24,7 @@ return [
             ],
             'mautic.form.type.emailmarketing.constantcontact' => [
                 'class'     => 'MauticPlugin\MauticEmailMarketingBundle\Form\Type\ConstantContactType',
-                'arguments' => ['mautic.factory', 'session', 'mautic.helper.core_parameters'],
+                'arguments' => ['mautic.helper.integration', 'mautic.plugin.model.plugin', 'session', 'mautic.helper.core_parameters'],
                 'alias'     => 'emailmarketing_constantcontact',
             ],
             'mautic.form.type.emailmarketing.icontact' => [

--- a/plugins/MauticEmailMarketingBundle/Config/config.php
+++ b/plugins/MauticEmailMarketingBundle/Config/config.php
@@ -19,7 +19,7 @@ return [
         'forms' => [
             'mautic.form.type.emailmarketing.mailchimp' => [
                 'class'     => 'MauticPlugin\MauticEmailMarketingBundle\Form\Type\MailchimpType',
-                'arguments' => ['mautic.helper.integration', 'mautic.plugin.model.plugin', 'mautic.helper.core_parameters'],
+                'arguments' => ['mautic.helper.integration', 'mautic.plugin.model.plugin', 'session', 'mautic.helper.core_parameters'],
             ],
             'mautic.form.type.emailmarketing.constantcontact' => [
                 'class'     => 'MauticPlugin\MauticEmailMarketingBundle\Form\Type\ConstantContactType',

--- a/plugins/MauticEmailMarketingBundle/Config/config.php
+++ b/plugins/MauticEmailMarketingBundle/Config/config.php
@@ -19,7 +19,7 @@ return [
         'forms' => [
             'mautic.form.type.emailmarketing.mailchimp' => [
                 'class'     => 'MauticPlugin\MauticEmailMarketingBundle\Form\Type\MailchimpType',
-                'arguments' => ['mautic.factory', 'session', 'mautic.helper.core_parameters'],
+                'arguments' => ['mautic.helper.integration', 'mautic.plugin.model.plugin', 'mautic.helper.core_parameters'],
                 'alias'     => 'emailmarketing_mailchimp',
             ],
             'mautic.form.type.emailmarketing.constantcontact' => [

--- a/plugins/MauticEmailMarketingBundle/Config/config.php
+++ b/plugins/MauticEmailMarketingBundle/Config/config.php
@@ -20,17 +20,14 @@ return [
             'mautic.form.type.emailmarketing.mailchimp' => [
                 'class'     => 'MauticPlugin\MauticEmailMarketingBundle\Form\Type\MailchimpType',
                 'arguments' => ['mautic.helper.integration', 'mautic.plugin.model.plugin', 'mautic.helper.core_parameters'],
-                'alias'     => 'emailmarketing_mailchimp',
             ],
             'mautic.form.type.emailmarketing.constantcontact' => [
                 'class'     => 'MauticPlugin\MauticEmailMarketingBundle\Form\Type\ConstantContactType',
                 'arguments' => ['mautic.helper.integration', 'mautic.plugin.model.plugin', 'session', 'mautic.helper.core_parameters'],
-                'alias'     => 'emailmarketing_constantcontact',
             ],
             'mautic.form.type.emailmarketing.icontact' => [
                 'class'     => 'MauticPlugin\MauticEmailMarketingBundle\Form\Type\IcontactType',
                 'arguments' => ['mautic.helper.integration', 'mautic.plugin.model.plugin', 'session', 'mautic.helper.core_parameters'],
-                'alias'     => 'emailmarketing_icontact',
             ],
         ],
         'integrations' => [

--- a/plugins/MauticEmailMarketingBundle/Config/config.php
+++ b/plugins/MauticEmailMarketingBundle/Config/config.php
@@ -29,7 +29,7 @@ return [
             ],
             'mautic.form.type.emailmarketing.icontact' => [
                 'class'     => 'MauticPlugin\MauticEmailMarketingBundle\Form\Type\IcontactType',
-                'arguments' => ['mautic.factory', 'session', 'mautic.helper.core_parameters'],
+                'arguments' => ['mautic.helper.integration', 'mautic.plugin.model.plugin', 'session', 'mautic.helper.core_parameters'],
                 'alias'     => 'emailmarketing_icontact',
             ],
         ],

--- a/plugins/MauticEmailMarketingBundle/Form/Type/ConstantContactType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/ConstantContactType.php
@@ -145,7 +145,7 @@ class ConstantContactType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'emailmarketing_constantcontact';
     }

--- a/plugins/MauticEmailMarketingBundle/Form/Type/ConstantContactType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/ConstantContactType.php
@@ -11,8 +11,9 @@
 
 namespace MauticPlugin\MauticEmailMarketingBundle\Form\Type;
 
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\PluginBundle\Helper\IntegrationHelper;
+use Mautic\PluginBundle\Model\PluginModel;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
@@ -27,9 +28,13 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 class ConstantContactType extends AbstractType
 {
     /**
-     * @var MauticFactory
+     * @var IntegrationHelper
      */
-    private $factory;
+    private $integrationHelper;
+
+    /** @var PluginModel */
+    private $pluginModel;
+
     /**
      * @var Session
      */
@@ -40,9 +45,10 @@ class ConstantContactType extends AbstractType
      */
     protected $coreParametersHelper;
 
-    public function __construct(MauticFactory $factory, Session $session, CoreParametersHelper $coreParametersHelper)
+    public function __construct(IntegrationHelper $integrationHelper, PluginModel $pluginModel, Session $session, CoreParametersHelper $coreParametersHelper)
     {
-        $this->factory              = $factory;
+        $this->integrationHelper    = $integrationHelper;
+        $this->pluginModel          = $pluginModel;
         $this->session              = $session;
         $this->coreParametersHelper = $coreParametersHelper;
     }
@@ -53,11 +59,8 @@ class ConstantContactType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        /** @var \Mautic\PluginBundle\Helper\IntegrationHelper $helper */
-        $helper = $this->factory->getHelper('integration');
-
         /** @var \MauticPlugin\MauticEmailMarketingBundle\Integration\ConstantContactIntegration $object */
-        $object          = $helper->getIntegrationObject('ConstantContact');
+        $object          = $this->integrationHelper->getIntegrationObject('ConstantContact');
         $integrationName = $object->getName();
         $session         = $this->session;
         $limit           = $session->get(
@@ -109,7 +112,7 @@ class ConstantContactType extends AbstractType
         }
 
         if (isset($options['form_area']) && $options['form_area'] == 'integration') {
-            $leadFields = $this->factory->getModel('plugin')->getLeadFields();
+            $leadFields = $this->pluginModel->getLeadFields();
 
             $fields = $object->getFormLeadFields();
 

--- a/plugins/MauticEmailMarketingBundle/Form/Type/ConstantContactType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/ConstantContactType.php
@@ -89,10 +89,11 @@ class ConstantContactType extends AbstractType
         }
 
         $builder->add('list', ChoiceType::class, [
-            'choices'  => $choices,
-            'label'    => 'mautic.emailmarketing.list',
-            'required' => false,
-            'attr'     => [
+            'choices'           => array_flip($choices), // Choice type expects labels as keys
+            'choices_as_values' => true,
+            'label'             => 'mautic.emailmarketing.list',
+            'required'          => false,
+            'attr'              => [
                 'tooltip' => 'mautic.emailmarketing.list.tooltip',
             ],
         ]);

--- a/plugins/MauticEmailMarketingBundle/Form/Type/ConstantContactType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/ConstantContactType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class ConstantContactType.
@@ -137,9 +137,9 @@ class ConstantContactType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setOptional(['form_area']);
+        $resolver->setDefined(['form_area']);
     }
 
     /**

--- a/plugins/MauticEmailMarketingBundle/Form/Type/ConstantContactType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/ConstantContactType.php
@@ -15,6 +15,7 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\PluginBundle\Model\PluginModel;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvent;
@@ -87,7 +88,7 @@ class ConstantContactType extends AbstractType
             $page    = 1;
         }
 
-        $builder->add('list', 'choice', [
+        $builder->add('list', ChoiceType::class, [
             'choices'  => $choices,
             'label'    => 'mautic.emailmarketing.list',
             'required' => false,

--- a/plugins/MauticEmailMarketingBundle/Form/Type/IcontactType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/IcontactType.php
@@ -140,7 +140,7 @@ class IcontactType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'emailmarketing_icontact';
     }

--- a/plugins/MauticEmailMarketingBundle/Form/Type/IcontactType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/IcontactType.php
@@ -15,6 +15,7 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\PluginBundle\Model\PluginModel;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvent;
@@ -87,7 +88,7 @@ class IcontactType extends AbstractType
             $page    = 1;
         }
 
-        $builder->add('list', 'choice', [
+        $builder->add('list', ChoiceType::class, [
             'choices'  => $choices,
             'label'    => 'mautic.emailmarketing.list',
             'required' => false,

--- a/plugins/MauticEmailMarketingBundle/Form/Type/IcontactType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/IcontactType.php
@@ -89,10 +89,11 @@ class IcontactType extends AbstractType
         }
 
         $builder->add('list', ChoiceType::class, [
-            'choices'  => $choices,
-            'label'    => 'mautic.emailmarketing.list',
-            'required' => false,
-            'attr'     => [
+            'choices'           => array_flip($choices), // Choice type expects labels as keys
+            'choices_as_values' => true,
+            'label'             => 'mautic.emailmarketing.list',
+            'required'          => false,
+            'attr'              => [
                 'tooltip' => 'mautic.emailmarketing.list.tooltip',
             ],
         ]);

--- a/plugins/MauticEmailMarketingBundle/Form/Type/IcontactType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/IcontactType.php
@@ -11,8 +11,9 @@
 
 namespace MauticPlugin\MauticEmailMarketingBundle\Form\Type;
 
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\PluginBundle\Helper\IntegrationHelper;
+use Mautic\PluginBundle\Model\PluginModel;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
@@ -27,9 +28,12 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 class IcontactType extends AbstractType
 {
     /**
-     * @var MauticFactory
+     * @var IntegrationHelper
      */
-    private $factory;
+    private $integrationHelper;
+
+    /** @var PluginModel */
+    private $pluginModel;
 
     /**
      * @var Session
@@ -41,9 +45,10 @@ class IcontactType extends AbstractType
      */
     protected $coreParametersHelper;
 
-    public function __construct(MauticFactory $factory, Session $session, CoreParametersHelper $coreParametersHelper)
+    public function __construct(IntegrationHelper $integrationHelper, PluginModel $pluginModel, Session $session, CoreParametersHelper $coreParametersHelper)
     {
-        $this->factory              = $factory;
+        $this->integrationHelper    = $integrationHelper;
+        $this->pluginModel          = $pluginModel;
         $this->session              = $session;
         $this->coreParametersHelper = $coreParametersHelper;
     }
@@ -54,11 +59,8 @@ class IcontactType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        /** @var \Mautic\PluginBundle\Helper\IntegrationHelper $helper */
-        $helper = $this->factory->getHelper('integration');
-
         /** @var \MauticPlugin\MauticEmailMarketingBundle\Integration\IcontactIntegration $object */
-        $object          = $helper->getIntegrationObject('Icontact');
+        $object          = $this->integrationHelper->getIntegrationObject('Icontact');
         $integrationName = $object->getName();
         $session         = $this->session;
         $limit           = $session->get(
@@ -105,7 +107,7 @@ class IcontactType extends AbstractType
         }
 
         if (isset($options['form_area']) && $options['form_area'] == 'integration') {
-            $leadFields = $this->factory->getModel('plugin')->getLeadFields();
+            $leadFields = $this->pluginModel->getLeadFields();
 
             $fields = $object->getFormLeadFields();
 

--- a/plugins/MauticEmailMarketingBundle/Form/Type/IcontactType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/IcontactType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class ConstantContactType.
@@ -132,9 +132,9 @@ class IcontactType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setOptional(['form_area']);
+        $resolver->setDefined(['form_area']);
     }
 
     /**

--- a/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
@@ -11,8 +11,9 @@
 
 namespace MauticPlugin\MauticEmailMarketingBundle\Form\Type;
 
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\PluginBundle\Helper\IntegrationHelper;
+use Mautic\PluginBundle\Model\PluginModel;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
@@ -28,9 +29,13 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 class MailchimpType extends AbstractType
 {
     /**
-     * @var MauticFactory
+     * @var IntegrationHelper
      */
-    private $factory;
+    private $integrationHelper;
+
+    /** @var PluginModel */
+    private $pluginModel;
+
     /**
      * @var Session
      */
@@ -41,9 +46,10 @@ class MailchimpType extends AbstractType
      */
     protected $coreParametersHelper;
 
-    public function __construct(MauticFactory $factory, Session $session, CoreParametersHelper $coreParametersHelper)
+    public function __construct(IntegrationHelper $integrationHelper, PluginModel $pluginModel, Session $session, CoreParametersHelper $coreParametersHelper)
     {
-        $this->factory              = $factory;
+        $this->integrationHelper    = $integrationHelper;
+        $this->pluginModel          = $pluginModel;
         $this->session              = $session;
         $this->coreParametersHelper = $coreParametersHelper;
     }
@@ -54,11 +60,8 @@ class MailchimpType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        /** @var \Mautic\PluginBundle\Helper\IntegrationHelper $helper */
-        $helper = $this->factory->getHelper('integration');
-
         /** @var \MauticPlugin\MauticEmailMarketingBundle\Integration\MailchimpIntegration $mailchimp */
-        $mailchimp = $helper->getIntegrationObject('Mailchimp');
+        $mailchimp = $this->integrationHelper->getIntegrationObject('Mailchimp');
 
         $api = $mailchimp->getApiHelper();
         try {
@@ -109,7 +112,7 @@ class MailchimpType extends AbstractType
         }
 
         if (isset($options['form_area']) && $options['form_area'] == 'integration') {
-            $leadFields = $this->factory->getModel('plugin')->getLeadFields();
+            $leadFields = $this->pluginModel->getLeadFields();
 
             $formModifier = function (FormInterface $form, $data) use ($mailchimp, $leadFields) {
                 $integrationName = $mailchimp->getName();

--- a/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
@@ -83,10 +83,11 @@ class MailchimpType extends AbstractType
         }
 
         $builder->add('list', ChoiceType::class, [
-            'choices'  => $choices,
-            'label'    => 'mautic.emailmarketing.list',
-            'required' => false,
-            'attr'     => [
+            'choices'           => array_flip($choices), // Choice type expects labels as keys
+            'choices_as_values' => true,
+            'label'             => 'mautic.emailmarketing.list',
+            'required'          => false,
+            'attr'              => [
                 'tooltip'  => 'mautic.emailmarketing.list.tooltip',
                 'onchange' => 'Mautic.getIntegrationLeadFields(\'Mailchimp\', this, {"list": this.value});',
             ],

--- a/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class MailchimpType.
@@ -188,9 +188,9 @@ class MailchimpType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setOptional(['form_area']);
+        $resolver->setDefined(['form_area']);
     }
 
     /**

--- a/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
@@ -196,7 +196,7 @@ class MailchimpType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'emailmarketing_mailchimp';
     }

--- a/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
@@ -15,6 +15,7 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\PluginBundle\Model\PluginModel;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvent;
@@ -81,7 +82,7 @@ class MailchimpType extends AbstractType
             $error   = $e->getMessage();
         }
 
-        $builder->add('list', 'choice', [
+        $builder->add('list', ChoiceType::class, [
             'choices'  => $choices,
             'label'    => 'mautic.emailmarketing.list',
             'required' => false,

--- a/plugins/MauticEmailMarketingBundle/Integration/ConstantContactIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/ConstantContactIntegration.php
@@ -192,6 +192,11 @@ class ConstantContactIntegration extends EmailAbstractIntegration
         return false;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return string|null
+     */
     public function getFormType()
     {
         return ConstantContactType::class;

--- a/plugins/MauticEmailMarketingBundle/Integration/ConstantContactIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/ConstantContactIntegration.php
@@ -11,6 +11,8 @@
 
 namespace MauticPlugin\MauticEmailMarketingBundle\Integration;
 
+use MauticPlugin\MauticEmailMarketingBundle\Form\Type\ConstantContactType;
+
 /**
  * Class ConstantContactIntegration.
  */
@@ -188,5 +190,10 @@ class ConstantContactIntegration extends EmailAbstractIntegration
         }
 
         return false;
+    }
+
+    public function getFormType()
+    {
+        return ConstantContactType::class;
     }
 }

--- a/plugins/MauticEmailMarketingBundle/Integration/EmailAbstractIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/EmailAbstractIntegration.php
@@ -37,12 +37,14 @@ abstract class EmailAbstractIntegration extends AbstractIntegration
     {
         if ($formArea == 'features' || $formArea == 'integration') {
             if ($this->isAuthorized()) {
-                $name = strtolower($this->getName());
-                if ($this->factory->serviceExists('mautic.form.type.emailmarketing.'.$name)) {
+                $formType = $this->getFormType();
+
+                if ($formType) {
                     if ($formArea == 'integration' && isset($data['leadFields']) && empty($data['list_settings']['leadFields'])) {
                         $data['list_settings']['leadFields'] = $data['leadFields'];
                     }
-                    $builder->add('list_settings', 'emailmarketing_'.$name, [
+
+                    $builder->add('list_settings', $formType, [
                         'label'     => false,
                         'form_area' => $formArea,
                         'data'      => (isset($data['list_settings'])) ? $data['list_settings'] : [],
@@ -59,6 +61,13 @@ abstract class EmailAbstractIntegration extends AbstractIntegration
     {
         return 'MauticEmailMarketingBundle:FormTheme\EmailMarketing';
     }
+
+    /**
+     * Returns form type.
+     *
+     * @return mixed
+     */
+    abstract public function getFormType();
 
     /**
      * Get the API helper.

--- a/plugins/MauticEmailMarketingBundle/Integration/EmailAbstractIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/EmailAbstractIntegration.php
@@ -65,7 +65,7 @@ abstract class EmailAbstractIntegration extends AbstractIntegration
     /**
      * Returns form type.
      *
-     * @return mixed
+     * @return string|null
      */
     abstract public function getFormType();
 

--- a/plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
@@ -11,6 +11,8 @@
 
 namespace MauticPlugin\MauticEmailMarketingBundle\Integration;
 
+use MauticPlugin\MauticEmailMarketingBundle\Form\Type\IcontactType;
+
 /**
  * Class IcontactIntegration.
  */
@@ -260,5 +262,10 @@ class IcontactIntegration extends EmailAbstractIntegration
         }
 
         return false;
+    }
+
+    public function getFormType()
+    {
+        return IcontactType::class;
     }
 }

--- a/plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
@@ -264,6 +264,11 @@ class IcontactIntegration extends EmailAbstractIntegration
         return false;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return string|null
+     */
     public function getFormType()
     {
         return IcontactType::class;

--- a/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
@@ -11,6 +11,8 @@
 
 namespace MauticPlugin\MauticEmailMarketingBundle\Integration;
 
+use MauticPlugin\MauticEmailMarketingBundle\Form\Type\MailchimpType;
+
 /**
  * Class MailchimpIntegration.
  */
@@ -197,5 +199,10 @@ class MailchimpIntegration extends EmailAbstractIntegration
         $settings['dynamic_contact_fields'] = true;
 
         return $settings;
+    }
+
+    public function getFormType()
+    {
+        return MailchimpType::class;
     }
 }

--- a/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
@@ -201,6 +201,11 @@ class MailchimpIntegration extends EmailAbstractIntegration
         return $settings;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return string|null
+     */
     public function getFormType()
     {
         return MailchimpType::class;


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8014
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR containst changes that are neccessary to make MauticEmailMarketing bundle compatible with Symfony3.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Go to Plugins, try to authenticate IContact and/or MailChimp and or ConstantContact integration.
3. If you are able to authenticate them, it means that the EmailMarketingBundle works.
