### PR TITLE
Refactor deprecations in MauticCrm bundle (M3 migration)

### DIFF
--- a/plugins/MauticCrmBundle/Config/config.php
+++ b/plugins/MauticCrmBundle/Config/config.php
@@ -148,7 +148,6 @@ return [
         'forms' => [
             'mautic.form.type.connectwise.campaignaction' => [
                 'class' => MauticPlugin\MauticCrmBundle\Form\Type\IntegrationCampaignsTaskType::class,
-                'alias' => 'integration_campaign_task',
             ],
         ],
     ],

--- a/plugins/MauticCrmBundle/Form/Type/IntegrationCampaignsTaskType.php
+++ b/plugins/MauticCrmBundle/Form/Type/IntegrationCampaignsTaskType.php
@@ -15,9 +15,9 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Callback;
-use Symfony\Component\Validator\ExecutionContextInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * Class IntegrationCampaignsTaskType.
@@ -89,15 +89,15 @@ class IntegrationCampaignsTaskType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setOptional(['helper']);
+        $resolver->setDefined(['helper']);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'integration_campaign_task';
     }

--- a/plugins/MauticCrmBundle/Form/Type/IntegrationCampaignsTaskType.php
+++ b/plugins/MauticCrmBundle/Form/Type/IntegrationCampaignsTaskType.php
@@ -56,8 +56,9 @@ class IntegrationCampaignsTaskType extends AbstractType
             'campaign_activity_type',
             ChoiceType::class,
             [
-                'choices' => array_flip($activityTypes), // Choice type expects labels as keys
-                'attr'    => [
+                'choices'           => array_flip($activityTypes), // Choice type expects labels as keys
+                'choices_as_values' => true,
+                'attr'              => [
                     'class' => 'form-control', ],
                 'label'    => 'mautic.plugin.integration.campaigns.connectwise.activity.type',
                 'required' => false,
@@ -68,8 +69,9 @@ class IntegrationCampaignsTaskType extends AbstractType
             'campaign_members',
             ChoiceType::class,
             [
-                'choices' => array_flip($members),  // Choice type expects labels as keys
-                'attr'    => [
+                'choices'           => array_flip($members),  // Choice type expects labels as keys
+                'choices_as_values' => true,
+                'attr'              => [
                     'class' => 'form-control', ],
                 'label'       => 'mautic.plugin.integration.campaigns.connectwise.members',
                 'constraints' => [

--- a/plugins/MauticCrmBundle/Form/Type/IntegrationCampaignsTaskType.php
+++ b/plugins/MauticCrmBundle/Form/Type/IntegrationCampaignsTaskType.php
@@ -56,7 +56,7 @@ class IntegrationCampaignsTaskType extends AbstractType
             'campaign_activity_type',
             ChoiceType::class,
             [
-                'choices' => $activityTypes,
+                'choices' => array_flip($activityTypes), // Choice type expects labels as keys
                 'attr'    => [
                     'class' => 'form-control', ],
                 'label'    => 'mautic.plugin.integration.campaigns.connectwise.activity.type',
@@ -68,7 +68,7 @@ class IntegrationCampaignsTaskType extends AbstractType
             'campaign_members',
             ChoiceType::class,
             [
-                'choices' => $members,
+                'choices' => array_flip($members),  // Choice type expects labels as keys
                 'attr'    => [
                     'class' => 'form-control', ],
                 'label'       => 'mautic.plugin.integration.campaigns.connectwise.members',

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -292,7 +292,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'updateBlanks' => 'mautic.integrations.blanks',
+                        'mautic.integrations.blanks' => 'updateBlanks',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,
@@ -307,8 +307,8 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'Contact' => 'mautic.connectwise.object.contact',
-                        'company' => 'mautic.connectwise.object.company',
+                        'mautic.connectwise.object.contact' => 'Contact',
+                        'mautic.connectwise.object.company' => 'company',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -17,6 +17,8 @@ use Mautic\PluginBundle\Entity\IntegrationEntity;
 use Mautic\PluginBundle\Entity\IntegrationEntityRepository;
 use Mautic\PluginBundle\Exception\ApiErrorException;
 use Mautic\PluginBundle\Integration\IntegrationObject;
+use MauticPlugin\MauticCrmBundle\Form\Type\IntegrationCampaignsTaskType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilder;
 
 /**
@@ -287,7 +289,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
         if ($formArea == 'features') {
             $builder->add(
                 'updateBlanks',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'updateBlanks' => 'mautic.integrations.blanks',
@@ -302,7 +304,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
             );
             $builder->add(
                 'objects',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'Contact' => 'mautic.connectwise.object.contact',
@@ -336,7 +338,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
 
                 $builder->add(
                         'campaign_task',
-                        'integration_campaign_task',
+                        IntegrationCampaignsTaskType::class,
                         [
                             'label'  => false,
                             'helper' => $this->factory->getHelper('integration'),

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -294,12 +294,13 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
                     'choices' => [
                         'mautic.integrations.blanks' => 'updateBlanks',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => 'mautic.integrations.form.blanks',
-                    'label_attr'  => ['class' => 'control-label'],
-                    'empty_value' => false,
-                    'required'    => false,
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => 'mautic.integrations.form.blanks',
+                    'label_attr'        => ['class' => 'control-label'],
+                    'empty_value'       => false,
+                    'required'          => false,
                 ]
             );
             $builder->add(
@@ -310,12 +311,13 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
                         'mautic.connectwise.object.contact' => 'Contact',
                         'mautic.connectwise.object.company' => 'company',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => 'mautic.connectwise.form.objects_to_pull_from',
-                    'label_attr'  => ['class' => ''],
-                    'empty_value' => false,
-                    'required'    => false,
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => 'mautic.connectwise.form.objects_to_pull_from',
+                    'label_attr'        => ['class' => ''],
+                    'empty_value'       => false,
+                    'required'          => false,
                 ]
             );
         }

--- a/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -81,7 +81,7 @@ class DynamicsIntegration extends CrmAbstractIntegration
             ChoiceType::class,
             [
                 'choices' => [
-                    'updateBlanks' => 'mautic.integrations.blanks',
+                    'mautic.integrations.blanks' => 'updateBlanks',
                 ],
                 'expanded'    => true,
                 'multiple'    => true,
@@ -97,8 +97,8 @@ class DynamicsIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'contacts' => 'mautic.dynamics.object.contact',
-                        'company'  => 'mautic.dynamics.object.company',
+                        'mautic.dynamics.object.contact'  => 'contacts',
+                        'mautic.dynamics.object.company'  => 'company',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,

--- a/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -21,6 +21,7 @@ use Mautic\PluginBundle\Exception\ApiErrorException;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilder;
 
 class DynamicsIntegration extends CrmAbstractIntegration
@@ -77,7 +78,7 @@ class DynamicsIntegration extends CrmAbstractIntegration
     {
         $builder->add(
             'updateBlanks',
-            'choice',
+            ChoiceType::class,
             [
                 'choices' => [
                     'updateBlanks' => 'mautic.integrations.blanks',
@@ -93,7 +94,7 @@ class DynamicsIntegration extends CrmAbstractIntegration
         if ($formArea === 'features') {
             $builder->add(
                 'objects',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'contacts' => 'mautic.dynamics.object.contact',

--- a/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -83,12 +83,13 @@ class DynamicsIntegration extends CrmAbstractIntegration
                 'choices' => [
                     'mautic.integrations.blanks' => 'updateBlanks',
                 ],
-                'expanded'    => true,
-                'multiple'    => true,
-                'label'       => 'mautic.integrations.form.blanks',
-                'label_attr'  => ['class' => 'control-label'],
-                'empty_value' => false,
-                'required'    => false,
+                'choices_as_values' => true,
+                'expanded'          => true,
+                'multiple'          => true,
+                'label'             => 'mautic.integrations.form.blanks',
+                'label_attr'        => ['class' => 'control-label'],
+                'empty_value'       => false,
+                'required'          => false,
             ]
         );
         if ($formArea === 'features') {
@@ -100,12 +101,13 @@ class DynamicsIntegration extends CrmAbstractIntegration
                         'mautic.dynamics.object.contact'  => 'contacts',
                         'mautic.dynamics.object.company'  => 'company',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => 'mautic.dynamics.form.objects_to_pull_from',
-                    'label_attr'  => ['class' => ''],
-                    'empty_value' => false,
-                    'required'    => false,
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => 'mautic.dynamics.form.objects_to_pull_from',
+                    'label_attr'        => ['class' => ''],
+                    'empty_value'       => false,
+                    'required'          => false,
                 ]
             );
         }

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -19,6 +19,7 @@ use Mautic\LeadBundle\Entity\StagesChangeLog;
 use Mautic\PluginBundle\Entity\IntegrationEntityRepository;
 use Mautic\StageBundle\Entity\Stage;
 use MauticPlugin\MauticCrmBundle\Api\HubspotApi;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 /**
  * Class HubspotIntegration.
@@ -272,7 +273,7 @@ class HubspotIntegration extends CrmAbstractIntegration
         if ($formArea == 'features') {
             $builder->add(
                 'objects',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'contacts' => 'mautic.hubspot.object.contact',

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -276,8 +276,8 @@ class HubspotIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'contacts' => 'mautic.hubspot.object.contact',
-                        'company'  => 'mautic.hubspot.object.company',
+                        'mautic.hubspot.object.contact' => 'contacts',
+                        'mautic.hubspot.object.company' => 'company',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -279,12 +279,13 @@ class HubspotIntegration extends CrmAbstractIntegration
                         'mautic.hubspot.object.contact' => 'contacts',
                         'mautic.hubspot.object.company' => 'company',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => $this->getTranslator()->trans('mautic.crm.form.objects_to_pull_from', ['%crm%' => 'Hubspot']),
-                    'label_attr'  => ['class' => ''],
-                    'empty_value' => false,
-                    'required'    => false,
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => $this->getTranslator()->trans('mautic.crm.form.objects_to_pull_from', ['%crm%' => 'Hubspot']),
+                    'label_attr'        => ['class' => ''],
+                    'empty_value'       => false,
+                    'required'          => false,
                 ]
             );
         }

--- a/plugins/MauticCrmBundle/Integration/PipedriveIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/PipedriveIntegration.php
@@ -224,7 +224,7 @@ class PipedriveIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices'     => [
-                        'company'  => 'mautic.pipedrive.object.organization',
+                        'mautic.pipedrive.object.organization'  => 'company',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,
@@ -240,7 +240,7 @@ class PipedriveIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices'     => [
-                        'enabled' => 'mautic.pipedrive.add.edit.contact.import.enabled',
+                        'mautic.pipedrive.add.edit.contact.import.enabled' => 'enabled',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,

--- a/plugins/MauticCrmBundle/Integration/PipedriveIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/PipedriveIntegration.php
@@ -4,6 +4,7 @@ namespace MauticPlugin\MauticCrmBundle\Integration;
 
 use Doctrine\ORM\EntityManager;
 use MauticPlugin\MauticCrmBundle\Integration\Pipedrive\Export\LeadExport;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class PipedriveIntegration extends CrmAbstractIntegration
@@ -220,7 +221,7 @@ class PipedriveIntegration extends CrmAbstractIntegration
         if ($formArea == 'features') {
             $builder->add(
                 'objects',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices'     => [
                         'company'  => 'mautic.pipedrive.object.organization',
@@ -236,7 +237,7 @@ class PipedriveIntegration extends CrmAbstractIntegration
 
             $builder->add(
                 'import',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices'     => [
                         'enabled' => 'mautic.pipedrive.add.edit.contact.import.enabled',

--- a/plugins/MauticCrmBundle/Integration/PipedriveIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/PipedriveIntegration.php
@@ -226,12 +226,13 @@ class PipedriveIntegration extends CrmAbstractIntegration
                     'choices'     => [
                         'mautic.pipedrive.object.organization'  => 'company',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => 'mautic.pipedrive.form.objects_to_pull_from',
-                    'label_attr'  => ['class' => ''],
-                    'empty_value' => false,
-                    'required'    => false,
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => 'mautic.pipedrive.form.objects_to_pull_from',
+                    'label_attr'        => ['class' => ''],
+                    'empty_value'       => false,
+                    'required'          => false,
                 ]
             );
 
@@ -242,12 +243,13 @@ class PipedriveIntegration extends CrmAbstractIntegration
                     'choices'     => [
                         'mautic.pipedrive.add.edit.contact.import.enabled' => 'enabled',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => 'mautic.pipedrive.add.edit.contact.import',
-                    'label_attr'  => ['class' => ''],
-                    'empty_value' => false,
-                    'required'    => false,
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => 'mautic.pipedrive.add.edit.contact.import',
+                    'label_attr'        => ['class' => ''],
+                    'empty_value'       => false,
+                    'required'          => false,
                 ]
             );
         }

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -553,13 +553,14 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     'choices' => [
                         'mautic.salesforce.sandbox' => 'sandbox',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => 'mautic.salesforce.form.sandbox',
-                    'label_attr'  => ['class' => 'control-label'],
-                    'empty_value' => false,
-                    'required'    => false,
-                    'attr'        => [
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => 'mautic.salesforce.form.sandbox',
+                    'label_attr'        => ['class' => 'control-label'],
+                    'empty_value'       => false,
+                    'required'          => false,
+                    'attr'              => [
                         'onclick' => 'Mautic.postForm(mQuery(\'form[name="integration_details"]\'),\'\');',
                     ],
                 ]
@@ -572,13 +573,14 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     'choices' => [
                         'mautic.salesforce.updateOwner' => 'updateOwner',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => 'mautic.salesforce.form.updateOwner',
-                    'label_attr'  => ['class' => 'control-label'],
-                    'empty_value' => false,
-                    'required'    => false,
-                    'attr'        => [
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => 'mautic.salesforce.form.updateOwner',
+                    'label_attr'        => ['class' => 'control-label'],
+                    'empty_value'       => false,
+                    'required'          => false,
+                    'attr'              => [
                         'onclick' => 'Mautic.postForm(mQuery(\'form[name="integration_details"]\'),\'\');',
                     ],
                 ]
@@ -590,12 +592,13 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     'choices' => [
                         'mautic.integrations.blanks' => 'updateBlanks',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => 'mautic.integrations.form.blanks',
-                    'label_attr'  => ['class' => 'control-label'],
-                    'empty_value' => false,
-                    'required'    => false,
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => 'mautic.integrations.form.blanks',
+                    'label_attr'        => ['class' => 'control-label'],
+                    'empty_value'       => false,
+                    'required'          => false,
                 ]
             );
             $builder->add(
@@ -605,12 +608,13 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     'choices' => [
                         'mautic.integrations.update.dnc.by.date' => 'updateDncByDate',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => 'mautic.integrations.form.update.dnc.by.date.label',
-                    'label_attr'  => ['class' => 'control-label'],
-                    'empty_value' => false,
-                    'required'    => false,
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => 'mautic.integrations.form.update.dnc.by.date.label',
+                    'label_attr'        => ['class' => 'control-label'],
+                    'empty_value'       => false,
+                    'required'          => false,
                 ]
             );
 
@@ -624,12 +628,13 @@ class SalesforceIntegration extends CrmAbstractIntegration
                         'mautic.salesforce.object.company'  => 'company',
                         'mautic.salesforce.object.activity' => 'Activity',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => 'mautic.salesforce.form.objects_to_pull_from',
-                    'label_attr'  => ['class' => ''],
-                    'empty_value' => false,
-                    'required'    => false,
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => 'mautic.salesforce.form.objects_to_pull_from',
+                    'label_attr'        => ['class' => ''],
+                    'empty_value'       => false,
+                    'required'          => false,
                 ]
             );
 
@@ -637,9 +642,10 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 'activityEvents',
                 ChoiceType::class,
                 [
-                    'choices'    => array_flip($this->leadModel->getEngagementTypes()), // Choice type expects labels as keys
-                    'label'      => 'mautic.salesforce.form.activity_included_events',
-                    'label_attr' => [
+                    'choices'           => array_flip($this->leadModel->getEngagementTypes()), // Choice type expects labels as keys
+                    'choices_as_values' => true,
+                    'label'             => 'mautic.salesforce.form.activity_included_events',
+                    'label_attr'        => [
                         'class'       => 'control-label',
                         'data-toggle' => 'tooltip',
                         'title'       => $this->translator->trans('mautic.salesforce.form.activity.events.tooltip'),

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -2591,17 +2591,6 @@ class SalesforceIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param array $fields
-     *
-     * @return array
-     *
-     * @deprecated 2.6.0 to be removed in 3.0
-     */
-    public function amendToSfFields($fields)
-    {
-    }
-
-    /**
      * @param string $object
      *
      * @return array

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -29,6 +29,7 @@ use MauticPlugin\MauticCrmBundle\Integration\Salesforce\ResultsPaginator;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -547,7 +548,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
         if ($formArea == 'features') {
             $builder->add(
                 'sandbox',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'sandbox' => 'mautic.salesforce.sandbox',
@@ -566,7 +567,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
             $builder->add(
                 'updateOwner',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'updateOwner' => 'mautic.salesforce.updateOwner',
@@ -584,7 +585,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
             );
             $builder->add(
                 'updateBlanks',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'updateBlanks' => 'mautic.integrations.blanks',
@@ -599,7 +600,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
             );
             $builder->add(
                 'updateDncByDate',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'updateDncByDate' => 'mautic.integrations.update.dnc.by.date',
@@ -615,7 +616,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
             $builder->add(
                 'objects',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'Lead'     => 'mautic.salesforce.object.lead',
@@ -651,7 +652,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
             $builder->add(
                 'namespace',
-                'text',
+                TextType::class,
                 [
                     'label'      => 'mautic.salesforce.form.namespace_prefix',
                     'label_attr' => ['class' => 'control-label'],

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -551,7 +551,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'sandbox' => 'mautic.salesforce.sandbox',
+                        'mautic.salesforce.sandbox' => 'sandbox',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,
@@ -570,7 +570,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'updateOwner' => 'mautic.salesforce.updateOwner',
+                        'mautic.salesforce.updateOwner' => 'updateOwner',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,
@@ -588,7 +588,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'updateBlanks' => 'mautic.integrations.blanks',
+                        'mautic.integrations.blanks' => 'updateBlanks',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,
@@ -603,7 +603,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'updateDncByDate' => 'mautic.integrations.update.dnc.by.date',
+                        'mautic.integrations.update.dnc.by.date' => 'updateDncByDate',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,
@@ -619,10 +619,10 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'Lead'     => 'mautic.salesforce.object.lead',
-                        'Contact'  => 'mautic.salesforce.object.contact',
-                        'company'  => 'mautic.salesforce.object.company',
-                        'Activity' => 'mautic.salesforce.object.activity',
+                        'mautic.salesforce.object.lead'     => 'Lead',
+                        'mautic.salesforce.object.contact'  => 'Contact',
+                        'mautic.salesforce.object.company'  => 'company',
+                        'mautic.salesforce.object.activity' => 'Activity',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,
@@ -637,7 +637,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 'activityEvents',
                 ChoiceType::class,
                 [
-                    'choices'    => $this->leadModel->getEngagementTypes(),
+                    'choices'    => array_flip($this->leadModel->getEngagementTypes()), // Choice type expects labels as keys
                     'label'      => 'mautic.salesforce.form.activity_included_events',
                     'label_attr' => [
                         'class'       => 'control-label',

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -1564,17 +1564,6 @@ class SugarcrmIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param array $fields
-     *
-     * @return array
-     *
-     * @deprecated 2.6.0 to be removed in 3.0
-     */
-    public function amendToSfFields($fields)
-    {
-    }
-
-    /**
      * @param array $lead
      */
     protected function getOwnerEmail($lead)

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -993,7 +993,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
         if ($formArea == 'features') {
             $builder->add(
                 'updateOwner',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'updateOwner' => 'mautic.sugarcrm.updateOwner',
@@ -1012,7 +1012,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
 
             $builder->add(
                 'updateDnc',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'updateDnc' => 'mautic.sugarcrm.updateDnc',
@@ -1031,7 +1031,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
 
             $builder->add(
                 'updateBlanks',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'updateBlanks' => 'mautic.integrations.blanks',
@@ -1047,7 +1047,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
 
             $builder->add(
                 'objects',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'Leads'    => 'mautic.sugarcrm.object.lead',

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -1710,7 +1710,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                         ++$updated;
                     }
                 } else {
-                    $error = 'Uknown status code '.$item['httpStatusCode'];
+                    $error = 'Unknown status code '.$item['httpStatusCode'];
                     $this->logIntegrationError(new \Exception($error.' ('.$item['reference_id'].')'));
                 }
             }

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -998,13 +998,14 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                     'choices' => [
                         'mautic.sugarcrm.updateOwner' => 'updateOwner',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => 'mautic.sugarcrm.form.updateOwner',
-                    'label_attr'  => ['class' => 'control-label'],
-                    'empty_value' => false,
-                    'required'    => false,
-                    'attr'        => [
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => 'mautic.sugarcrm.form.updateOwner',
+                    'label_attr'        => ['class' => 'control-label'],
+                    'empty_value'       => false,
+                    'required'          => false,
+                    'attr'              => [
                         'onclick' => 'Mautic.postForm(mQuery(\'form[name="integration_details"]\'),\'\');',
                     ],
                 ]
@@ -1017,13 +1018,14 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                     'choices' => [
                         'mautic.sugarcrm.updateDnc' => 'updateDnc',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => 'mautic.sugarcrm.form.updateDnc',
-                    'label_attr'  => ['class' => 'control-label'],
-                    'empty_value' => false,
-                    'required'    => false,
-                    'attr'        => [
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => 'mautic.sugarcrm.form.updateDnc',
+                    'label_attr'        => ['class' => 'control-label'],
+                    'empty_value'       => false,
+                    'required'          => false,
+                    'attr'              => [
                         'onclick' => 'Mautic.postForm(mQuery(\'form[name="integration_details"]\'),\'\');',
                     ],
                 ]
@@ -1036,12 +1038,13 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                     'choices' => [
                         'mautic.integrations.blanks' => 'updateBlanks',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => 'mautic.integrations.form.blanks',
-                    'label_attr'  => ['class' => 'control-label'],
-                    'empty_value' => false,
-                    'required'    => false,
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => 'mautic.integrations.form.blanks',
+                    'label_attr'        => ['class' => 'control-label'],
+                    'empty_value'       => false,
+                    'required'          => false,
                 ]
             );
 
@@ -1054,12 +1057,13 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                         'mautic.sugarcrm.object.contact' => 'Contacts',
                         'mautic.sugarcrm.object.company' => 'company',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => 'mautic.sugarcrm.form.objects_to_pull_from',
-                    'label_attr'  => ['class' => ''],
-                    'empty_value' => false,
-                    'required'    => false,
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => 'mautic.sugarcrm.form.objects_to_pull_from',
+                    'label_attr'        => ['class' => ''],
+                    'empty_value'       => false,
+                    'required'          => false,
                 ]
             );
 
@@ -1067,9 +1071,10 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                 'activityEvents',
                 ChoiceType::class,
                 [
-                    'choices'    => array_flip($this->leadModel->getEngagementTypes()), // Choice type expects labels as keys
-                    'label'      => 'mautic.salesforce.form.activity_included_events',
-                    'label_attr' => [
+                    'choices'           => array_flip($this->leadModel->getEngagementTypes()), // Choice type expects labels as keys
+                    'choices_as_values' => true,
+                    'label'             => 'mautic.salesforce.form.activity_included_events',
+                    'label_attr'        => [
                         'class'       => 'control-label',
                         'data-toggle' => 'tooltip',
                         'title'       => $this->translator->trans('mautic.salesforce.form.activity.events.tooltip'),

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -978,8 +978,8 @@ class SugarcrmIntegration extends CrmAbstractIntegration
         if ($formArea == 'keys') {
             $builder->add('version', 'button_group', [
                 'choices' => [
-                    '6' => '6.x/community',
-                    '7' => '7.x',
+                    '6.x/community' => '6',
+                    '7.x'           => '7',
                 ],
                 'label'       => 'mautic.sugarcrm.form.version',
                 'constraints' => [
@@ -996,7 +996,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'updateOwner' => 'mautic.sugarcrm.updateOwner',
+                        'mautic.sugarcrm.updateOwner' => 'updateOwner',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,
@@ -1015,7 +1015,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'updateDnc' => 'mautic.sugarcrm.updateDnc',
+                        'mautic.sugarcrm.updateDnc' => 'updateDnc',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,
@@ -1034,7 +1034,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'updateBlanks' => 'mautic.integrations.blanks',
+                        'mautic.integrations.blanks' => 'updateBlanks',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,
@@ -1050,9 +1050,9 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'Leads'    => 'mautic.sugarcrm.object.lead',
-                        'Contacts' => 'mautic.sugarcrm.object.contact',
-                        'company'  => 'mautic.sugarcrm.object.company',
+                        'mautic.sugarcrm.object.lead'    => 'Leads',
+                        'mautic.sugarcrm.object.contact' => 'Contacts',
+                        'mautic.sugarcrm.object.company' => 'company',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,
@@ -1067,7 +1067,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                 'activityEvents',
                 ChoiceType::class,
                 [
-                    'choices'    => $this->leadModel->getEngagementTypes(),
+                    'choices'    => array_flip($this->leadModel->getEngagementTypes()), // Choice type expects labels as keys
                     'label'      => 'mautic.salesforce.form.activity_included_events',
                     'label_attr' => [
                         'class'       => 'control-label',

--- a/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
@@ -11,6 +11,8 @@
 
 namespace MauticPlugin\MauticCrmBundle\Integration;
 
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+
 /**
  * Class VtigerIntegration.
  */
@@ -277,7 +279,7 @@ class VtigerIntegration extends CrmAbstractIntegration
         if ($formArea == 'features') {
             $builder->add(
                 'objects',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'contacts' => 'mautic.vtiger.object.contact',

--- a/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
@@ -282,8 +282,8 @@ class VtigerIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'contacts' => 'mautic.vtiger.object.contact',
-                        'company'  => 'mautic.vtiger.object.company',
+                        'mautic.vtiger.object.contact' => 'contacts',
+                        'mautic.vtiger.object.company' => 'company',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,

--- a/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
@@ -285,12 +285,13 @@ class VtigerIntegration extends CrmAbstractIntegration
                         'mautic.vtiger.object.contact' => 'contacts',
                         'mautic.vtiger.object.company' => 'company',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => 'mautic.vtiger.form.objects_to_pull_from',
-                    'label_attr'  => ['class' => ''],
-                    'empty_value' => false,
-                    'required'    => false,
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => 'mautic.vtiger.form.objects_to_pull_from',
+                    'label_attr'        => ['class' => ''],
+                    'empty_value'       => false,
+                    'required'          => false,
                 ]
             );
         }

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -616,7 +616,7 @@ class ZohoIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'updateBlanks' => 'mautic.integrations.blanks',
+                        'mautic.integrations.blanks' => 'updateBlanks',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,
@@ -633,10 +633,10 @@ class ZohoIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'zoho.com'    => 'mautic.plugin.zoho.zone_us',
-                        'zoho.eu'     => 'mautic.plugin.zoho.zone_europe',
-                        'zoho.co.jp'  => 'mautic.plugin.zoho.zone_japan',
-                        'zoho.com.cn' => 'mautic.plugin.zoho.zone_china',
+                        'mautic.plugin.zoho.zone_us'     => 'zoho.com',
+                        'mautic.plugin.zoho.zone_europe' => 'zoho.eu',
+                        'mautic.plugin.zoho.zone_japan'  => 'zoho.co.jp',
+                        'mautic.plugin.zoho.zone_china'  => 'zoho.com.cn',
                     ],
                     'label'       => 'mautic.plugin.zoho.zone_select',
                     'empty_value' => false,
@@ -652,9 +652,9 @@ class ZohoIntegration extends CrmAbstractIntegration
                 ChoiceType::class,
                 [
                     'choices' => [
-                        'Leads'    => 'mautic.zoho.object.lead',
-                        'Contacts' => 'mautic.zoho.object.contact',
-                        'company'  => 'mautic.zoho.object.account',
+                        'mautic.zoho.object.lead'    => 'Leads',
+                        'mautic.zoho.object.contact' => 'Contacts',
+                        'mautic.zoho.object.account' => 'company',
                     ],
                     'expanded'    => true,
                     'multiple'    => true,

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -618,12 +618,13 @@ class ZohoIntegration extends CrmAbstractIntegration
                     'choices' => [
                         'mautic.integrations.blanks' => 'updateBlanks',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => 'mautic.integrations.form.blanks',
-                    'label_attr'  => ['class' => 'control-label'],
-                    'empty_value' => false,
-                    'required'    => false,
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => 'mautic.integrations.form.blanks',
+                    'label_attr'        => ['class' => 'control-label'],
+                    'empty_value'       => false,
+                    'required'          => false,
                 ]
             );
         }
@@ -638,10 +639,11 @@ class ZohoIntegration extends CrmAbstractIntegration
                         'mautic.plugin.zoho.zone_japan'  => 'zoho.co.jp',
                         'mautic.plugin.zoho.zone_china'  => 'zoho.com.cn',
                     ],
-                    'label'       => 'mautic.plugin.zoho.zone_select',
-                    'empty_value' => false,
-                    'required'    => true,
-                    'attr'        => [
+                    'choices_as_values' => true,
+                    'label'             => 'mautic.plugin.zoho.zone_select',
+                    'empty_value'       => false,
+                    'required'          => true,
+                    'attr'              => [
                         'tooltip' => 'mautic.plugin.zoho.zone.tooltip',
                     ],
                 ]
@@ -656,12 +658,13 @@ class ZohoIntegration extends CrmAbstractIntegration
                         'mautic.zoho.object.contact' => 'Contacts',
                         'mautic.zoho.object.account' => 'company',
                     ],
-                    'expanded'    => true,
-                    'multiple'    => true,
-                    'label'       => $this->getTranslator()->trans('mautic.crm.form.objects_to_pull_from', ['%crm%' => 'Zoho']),
-                    'label_attr'  => ['class' => ''],
-                    'empty_value' => false,
-                    'required'    => false,
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'label'             => $this->getTranslator()->trans('mautic.crm.form.objects_to_pull_from', ['%crm%' => 'Zoho']),
+                    'label_attr'        => ['class' => ''],
+                    'empty_value'       => false,
+                    'required'          => false,
                 ]
             );
         }

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -25,6 +25,7 @@ use MauticPlugin\MauticCrmBundle\Api\ZohoApi;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilder;
 
 /**
@@ -612,7 +613,7 @@ class ZohoIntegration extends CrmAbstractIntegration
         if ($formArea == 'features') {
             $builder->add(
                 'updateBlanks',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'updateBlanks' => 'mautic.integrations.blanks',
@@ -629,7 +630,7 @@ class ZohoIntegration extends CrmAbstractIntegration
         if ($formArea === 'keys') {
             $builder->add(
                 'datacenter',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'zoho.com'    => 'mautic.plugin.zoho.zone_us',
@@ -648,7 +649,7 @@ class ZohoIntegration extends CrmAbstractIntegration
         } elseif ('features' === $formArea) {
             $builder->add(
                 'objects',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices' => [
                         'Leads'    => 'mautic.zoho.object.lead',


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8011
| BC breaks? | 1. Deprecated method MauticPlugin\MauticCrmBundle\Integration\SalesforceIntegration::amendToSfFields removed. 2. Deprecated method MauticPlugin\MauticCrmBundle\Integration\SugarcrmIntegration::amendToSfFields removed
| Deprecations? | 


[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR containst changes that are neccessary to make MauticCrmBundle compatible with Symfony3.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Go to Plugins, try to authenticate ConnectWise plugin.
3. Optionally go to Plugin and try to open (probably not worth to authorize, it's hard to get all the credentials) the following integrations: Dynamics CRM, Hubspot, Pipedrive, Salesforce, Sugar CRM, Vtiger, Zoho.
3. If you are able to authorize ConnectWise and you are able to open popups with the integrations mentioned above then we can count this task as done.
