### PR TITLE
M3: Refactor Deprecations - CampaignBundle #7987

### DIFF
--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -193,11 +193,9 @@ return [
             'mautic.campaign.type.form'                 => [
                 'class'     => 'Mautic\CampaignBundle\Form\Type\CampaignType',
                 'arguments' => 'mautic.factory',
-                'alias'     => 'campaign',
             ],
             'mautic.campaignrange.type.action'          => [
                 'class' => 'Mautic\CampaignBundle\Form\Type\EventType',
-                'alias' => 'campaignevent',
             ],
             'mautic.campaign.type.campaignlist'         => [
                 'class'     => 'Mautic\CampaignBundle\Form\Type\CampaignListType',
@@ -206,33 +204,26 @@ return [
                     'translator',
                     'mautic.security',
                 ],
-                'alias'     => 'campaign_list',
             ],
             'mautic.campaign.type.trigger.leadchange'   => [
                 'class' => 'Mautic\CampaignBundle\Form\Type\CampaignEventLeadChangeType',
-                'alias' => 'campaignevent_leadchange',
             ],
             'mautic.campaign.type.action.addremovelead' => [
                 'class' => 'Mautic\CampaignBundle\Form\Type\CampaignEventAddRemoveLeadType',
-                'alias' => 'campaignevent_addremovelead',
             ],
             'mautic.campaign.type.action.jump_to_event' => [
                 'class' => \Mautic\CampaignBundle\Form\Type\CampaignEventJumpToEventType::class,
-                'alias' => 'campaignevent_jump_to_event',
             ],
             'mautic.campaign.type.canvassettings'       => [
                 'class' => 'Mautic\CampaignBundle\Form\Type\EventCanvasSettingsType',
-                'alias' => 'campaignevent_canvassettings',
             ],
             'mautic.campaign.type.leadsource'           => [
                 'class'     => 'Mautic\CampaignBundle\Form\Type\CampaignLeadSourceType',
                 'arguments' => 'mautic.factory',
-                'alias'     => 'campaign_leadsource',
             ],
             'mautic.form.type.campaignconfig'           => [
                 'class'     => 'Mautic\CampaignBundle\Form\Type\ConfigType',
                 'arguments' => 'translator',
-                'alias'     => 'campaignconfig',
             ],
         ],
         'models'       => [

--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -192,7 +192,7 @@ return [
         'forms'        => [
             'mautic.campaign.type.form'                 => [
                 'class'     => 'Mautic\CampaignBundle\Form\Type\CampaignType',
-                'arguments' => 'mautic.factory',
+                'arguments' => 'mautic.security',
             ],
             'mautic.campaignrange.type.action'          => [
                 'class' => 'Mautic\CampaignBundle\Form\Type\EventType',

--- a/app/bundles/CampaignBundle/Controller/EventController.php
+++ b/app/bundles/CampaignBundle/Controller/EventController.php
@@ -12,6 +12,7 @@
 namespace Mautic\CampaignBundle\Controller;
 
 use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Form\Type\EventType;
 use Mautic\CoreBundle\Controller\FormController as CommonFormController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -77,7 +78,7 @@ class EventController extends CommonFormController
         //fire the builder event
         $events = $this->getModel('campaign')->getEvents();
         $form   = $this->get('form.factory')->create(
-            'campaignevent',
+            EventType::class,
             $event,
             [
                 'action'   => $this->generateUrl('mautic_campaignevent_action', ['objectAction' => 'new']),
@@ -280,7 +281,7 @@ class EventController extends CommonFormController
          */
         $supportedEvents = $this->getModel('campaign')->getEvents()[$event['eventType']];
         $form            = $this->get('form.factory')->create(
-            'campaignevent',
+            EventType::class,
             $event,
             [
                 'action'   => $this->generateUrl('mautic_campaignevent_action', ['objectAction' => 'edit', 'objectId' => $objectId]),

--- a/app/bundles/CampaignBundle/Controller/SourceController.php
+++ b/app/bundles/CampaignBundle/Controller/SourceController.php
@@ -12,6 +12,7 @@
 namespace Mautic\CampaignBundle\Controller;
 
 use Mautic\CampaignBundle\Entity\Source;
+use Mautic\CampaignBundle\Form\Type\CampaignLeadSourceType;
 use Mautic\CoreBundle\Controller\FormController as CommonFormController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -60,7 +61,7 @@ class SourceController extends CommonFormController
 
         $sourceList = $this->getModel('campaign')->getSourceLists($sourceType);
         $form       = $this->get('form.factory')->create(
-            'campaign_leadsource',
+            CampaignLeadSourceType::class,
             $source,
             [
                 'action'         => $this->generateUrl('mautic_campaignsource_action', ['objectAction' => 'new', 'objectId' => $objectId]),
@@ -165,7 +166,7 @@ class SourceController extends CommonFormController
 
         $sourceList = $this->getModel('campaign')->getSourceLists($sourceType);
         $form       = $this->get('form.factory')->create(
-            'campaign_leadsource',
+            CampaignLeadSourceType::class,
             $source,
             [
                 'action'         => $this->generateUrl('mautic_campaignsource_action', ['objectAction' => 'edit', 'objectId' => $objectId]),

--- a/app/bundles/CampaignBundle/EventListener/CampaignActionChangeMembershipSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignActionChangeMembershipSubscriber.php
@@ -15,6 +15,7 @@ use Mautic\CampaignBundle\CampaignEvents;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Event\CampaignBuilderEvent;
 use Mautic\CampaignBundle\Event\PendingEvent;
+use Mautic\CampaignBundle\Form\Type\CampaignEventAddRemoveLeadType;
 use Mautic\CampaignBundle\Membership\MembershipManager;
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -65,7 +66,7 @@ class CampaignActionChangeMembershipSubscriber implements EventSubscriberInterfa
             [
                 'label'           => 'mautic.campaign.event.addremovelead',
                 'description'     => 'mautic.campaign.event.addremovelead_descr',
-                'formType'        => 'campaignevent_addremovelead',
+                'formType'        => CampaignEventAddRemoveLeadType::class,
                 'formTypeOptions' => [
                     'include_this' => true,
                 ],

--- a/app/bundles/CampaignBundle/Form/Type/CampaignEventAddRemoveLeadType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignEventAddRemoveLeadType.php
@@ -48,6 +48,11 @@ class CampaignEventAddRemoveLeadType extends AbstractType
         ]);
     }
 
+    public function getBlockPrefix()
+    {
+        return 'campaignevent_addremovelead';
+    }
+
     /**
      * @param OptionsResolver $resolver
      */

--- a/app/bundles/CampaignBundle/Form/Type/CampaignEventAddRemoveLeadType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignEventAddRemoveLeadType.php
@@ -53,7 +53,7 @@ class CampaignEventAddRemoveLeadType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'campaignevent_addremovelead';
+        return self::class;
     }
 
     /**

--- a/app/bundles/CampaignBundle/Form/Type/CampaignEventAddRemoveLeadType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignEventAddRemoveLeadType.php
@@ -13,7 +13,7 @@ namespace Mautic\CampaignBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class CampaignEventAddRemoveLeadType.
@@ -26,7 +26,7 @@ class CampaignEventAddRemoveLeadType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('addTo', 'campaign_list', [
+        $builder->add('addTo', CampaignListType::class, [
             'label'      => 'mautic.campaign.form.addtocampaigns',
             'label_attr' => ['class' => 'control-label'],
             'attr'       => [
@@ -37,7 +37,7 @@ class CampaignEventAddRemoveLeadType extends AbstractType
             'this_translation' => 'mautic.campaign.form.thiscampaign_restart',
         ]);
 
-        $builder->add('removeFrom', 'campaign_list', [
+        $builder->add('removeFrom', CampaignListType::class, [
             'label'      => 'mautic.campaign.form.removefromcampaigns',
             'label_attr' => ['class' => 'control-label'],
             'attr'       => [
@@ -51,15 +51,15 @@ class CampaignEventAddRemoveLeadType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'campaignevent_addremovelead';
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'include_this' => false,

--- a/app/bundles/CampaignBundle/Form/Type/CampaignEventAddRemoveLeadType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignEventAddRemoveLeadType.php
@@ -49,14 +49,6 @@ class CampaignEventAddRemoveLeadType extends AbstractType
     }
 
     /**
-     * @return string
-     */
-    public function getBlockPrefix()
-    {
-        return self::class;
-    }
-
-    /**
      * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)

--- a/app/bundles/CampaignBundle/Form/Type/CampaignEventJumpToEventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignEventJumpToEventType.php
@@ -56,12 +56,4 @@ class CampaignEventJumpToEventType extends AbstractType
         // Allows additional values (new events) to be selected before persisting
         $builder->get('jumpToEvent')->resetViewTransformers();
     }
-
-    /**
-     * @return string
-     */
-    public function getBlockPrefix()
-    {
-        return self::class;
-    }
 }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignEventJumpToEventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignEventJumpToEventType.php
@@ -12,6 +12,7 @@
 namespace Mautic\CampaignBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
@@ -31,7 +32,7 @@ class CampaignEventJumpToEventType extends AbstractType
 
         $builder->add(
             'jumpToEvent',
-            'choice',
+            ChoiceType::class,
             [
                 'choices'    => [],
                 'multiple'   => false,
@@ -59,7 +60,7 @@ class CampaignEventJumpToEventType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'campaignevent_jump_to_event';
     }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignEventJumpToEventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignEventJumpToEventType.php
@@ -56,4 +56,9 @@ class CampaignEventJumpToEventType extends AbstractType
         // Allows additional values (new events) to be selected before persisting
         $builder->get('jumpToEvent')->resetViewTransformers();
     }
+
+    public function getBlockPrefix()
+    {
+        return 'campaignevent_jump_to_event';
+    }
 }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignEventJumpToEventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignEventJumpToEventType.php
@@ -62,6 +62,6 @@ class CampaignEventJumpToEventType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'campaignevent_jump_to_event';
+        return self::class;
     }
 }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignEventLeadChangeType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignEventLeadChangeType.php
@@ -57,6 +57,6 @@ class CampaignEventLeadChangeType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'campaignevent_leadchange';
+        return self::class;
     }
 }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignEventLeadChangeType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignEventLeadChangeType.php
@@ -41,7 +41,7 @@ class CampaignEventLeadChangeType extends AbstractType
             'data'        => $data,
         ]);
 
-        $builder->add('campaigns', 'campaign_list', [
+        $builder->add('campaigns', CampaignListType::class, [
             'label'      => 'mautic.campaign.form.limittocampaigns',
             'label_attr' => ['class' => 'control-label'],
             'attr'       => [
@@ -55,7 +55,7 @@ class CampaignEventLeadChangeType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'campaignevent_leadchange';
     }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignEventLeadChangeType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignEventLeadChangeType.php
@@ -51,4 +51,9 @@ class CampaignEventLeadChangeType extends AbstractType
             'required' => false,
         ]);
     }
+
+    public function getBlockPrefix()
+    {
+        return 'campaignevent_leadchange';
+    }
 }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignEventLeadChangeType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignEventLeadChangeType.php
@@ -51,12 +51,4 @@ class CampaignEventLeadChangeType extends AbstractType
             'required' => false,
         ]);
     }
-
-    /**
-     * @return string
-     */
-    public function getBlockPrefix()
-    {
-        return self::class;
-    }
 }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
@@ -116,6 +116,6 @@ class CampaignLeadSourceType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'campaign_leadsource';
+        return self::class;
     }
 }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
@@ -116,6 +116,6 @@ class CampaignLeadSourceType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return self::class;
+        return 'campaign_leadsource';
     }
 }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
@@ -11,7 +11,6 @@
 
 namespace Mautic\CampaignBundle\Form\Type;
 
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -25,19 +24,6 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  */
 class CampaignLeadSourceType extends AbstractType
 {
-    /**
-     * @var
-     */
-    private $factory;
-
-    /**
-     * @param MauticFactory $factory
-     */
-    public function __constuct(MauticFactory $factory)
-    {
-        $this->factory = $factory;
-    }
-
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $sourceType = $options['data']['sourceType'];

--- a/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
@@ -14,8 +14,10 @@ namespace Mautic\CampaignBundle\Form\Type;
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
@@ -44,13 +46,14 @@ class CampaignLeadSourceType extends AbstractType
             case 'lists':
                 $builder->add(
                     'lists',
-                    'choice',
+                    ChoiceType::class,
                     [
-                        'choices'    => $options['source_choices'],
-                        'multiple'   => true,
-                        'label'      => 'mautic.campaign.leadsource.lists',
-                        'label_attr' => ['class' => 'control-label'],
-                        'attr'       => [
+                        'choices'           => array_flip($options['source_choices']),
+                        'choices_as_values' => true,
+                        'multiple'          => true,
+                        'label'             => 'mautic.campaign.leadsource.lists',
+                        'label_attr'        => ['class' => 'control-label'],
+                        'attr'              => [
                             'class' => 'form-control',
                         ],
                         'constraints' => [
@@ -66,13 +69,14 @@ class CampaignLeadSourceType extends AbstractType
             case 'forms':
                 $builder->add(
                     'forms',
-                    'choice',
+                    ChoiceType::class,
                     [
-                        'choices'    => $options['source_choices'],
-                        'multiple'   => true,
-                        'label'      => 'mautic.campaign.leadsource.forms',
-                        'label_attr' => ['class' => 'control-label'],
-                        'attr'       => [
+                        'choices'           => array_flip($options['source_choices']),
+                        'choices_as_values' => true,
+                        'multiple'          => true,
+                        'label'             => 'mautic.campaign.leadsource.forms',
+                        'label_attr'        => ['class' => 'control-label'],
+                        'attr'              => [
                             'class' => 'form-control',
                         ],
                         'constraints' => [
@@ -89,11 +93,11 @@ class CampaignLeadSourceType extends AbstractType
                 break;
         }
 
-        $builder->add('sourceType', 'hidden');
+        $builder->add('sourceType', HiddenType::class);
 
-        $builder->add('droppedX', 'hidden');
+        $builder->add('droppedX', HiddenType::class);
 
-        $builder->add('droppedY', 'hidden');
+        $builder->add('droppedY', HiddenType::class);
 
         $update = !empty($options['data'][$sourceType]);
         if (!empty($update)) {
@@ -114,9 +118,9 @@ class CampaignLeadSourceType extends AbstractType
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setRequired(['source_choices']);
     }
@@ -124,7 +128,7 @@ class CampaignLeadSourceType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'campaign_leadsource';
     }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
@@ -12,7 +12,6 @@
 namespace Mautic\CampaignBundle\Form\Type;
 
 use Mautic\CampaignBundle\Model\CampaignModel;
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -41,7 +40,9 @@ class CampaignListType extends AbstractType
     private $canViewOther = false;
 
     /**
-     * @param MauticFactory $factory
+     * @param CampaignModel       $campaignModel
+     * @param TranslatorInterface $translator
+     * @param CorePermissions     $security
      */
     public function __construct(CampaignModel $campaignModel, TranslatorInterface $translator, CorePermissions $security)
     {

--- a/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
@@ -89,4 +89,9 @@ class CampaignListType extends AbstractType
     {
         return ChoiceType::class;
     }
+
+    public function getBlockPrefix()
+    {
+        return 'campaign_list';
+    }
 }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
@@ -85,14 +85,6 @@ class CampaignListType extends AbstractType
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getBlockPrefix()
-    {
-        return self::class;
-    }
-
     public function getParent()
     {
         return ChoiceType::class;

--- a/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
@@ -15,6 +15,7 @@ use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -70,14 +71,15 @@ class CampaignListType extends AbstractType
                         $choices = ['this' => $options['this_translation']] + $choices;
                     }
 
-                    return $choices;
+                    return array_flip($choices);
                 },
-                'empty_value'      => false,
-                'expanded'         => false,
-                'multiple'         => true,
-                'required'         => false,
-                'include_this'     => false,
-                'this_translation' => 'mautic.campaign.form.thiscampaign',
+                'choices_as_values' => true,
+                'empty_value'       => false,
+                'expanded'          => false,
+                'multiple'          => true,
+                'required'          => false,
+                'include_this'      => false,
+                'this_translation'  => 'mautic.campaign.form.thiscampaign',
             ]
         );
     }
@@ -85,13 +87,13 @@ class CampaignListType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'campaign_list';
     }
 
     public function getParent()
     {
-        return 'choice';
+        return ChoiceType::class;
     }
 }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
@@ -62,17 +62,17 @@ class CampaignListType extends AbstractType
                     $choices   = [];
                     $campaigns = $this->model->getRepository()->getPublishedCampaigns(null, null, true, $this->canViewOther);
                     foreach ($campaigns as $campaign) {
-                        $choices[$campaign['id']] = $campaign['name'];
+                        $choices[$campaign['name']] = $campaign['id'];
                     }
 
                     //sort by language
-                    asort($choices);
+                    ksort($choices);
 
                     if ($options['include_this']) {
                         $choices = ['this' => $options['this_translation']] + $choices;
                     }
 
-                    return array_flip($choices);
+                    return $choices;
                 },
                 'choices_as_values' => true,
                 'empty_value'       => false,
@@ -90,7 +90,7 @@ class CampaignListType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'campaign_list';
+        return self::class;
     }
 
     public function getParent()

--- a/app/bundles/CampaignBundle/Form/Type/CampaignType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignType.php
@@ -149,12 +149,4 @@ class CampaignType extends AbstractType
             'data_class' => 'Mautic\CampaignBundle\Entity\Campaign',
         ]);
     }
-
-    /**
-     * @return string
-     */
-    public function getBlockPrefix()
-    {
-        return self::class;
-    }
 }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignType.php
@@ -73,13 +73,9 @@ class CampaignType extends AbstractType
         );
 
         //add category
-        $builder->add(
-            'category',
-            CategoryListType::class,
-            [
-                'bundle' => 'campaign',
-            ]
-        );
+        $builder->add('category', CategoryListType::class, [
+            'bundle' => 'campaign',
+        ]);
 
         if (!empty($options['data']) && $options['data']->getId()) {
             $readonly = !$this->security->isGranted('campaign:campaigns:publish');

--- a/app/bundles/CampaignBundle/Form/Type/CampaignType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignType.php
@@ -149,4 +149,9 @@ class CampaignType extends AbstractType
             'data_class' => 'Mautic\CampaignBundle\Entity\Campaign',
         ]);
     }
+
+    public function getBlockPrefix()
+    {
+        return 'campaign';
+    }
 }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignType.php
@@ -18,8 +18,12 @@ use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
 use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class CampaignType.
@@ -49,13 +53,13 @@ class CampaignType extends AbstractType
         $builder->addEventSubscriber(new CleanFormSubscriber(['description' => 'html']));
         $builder->addEventSubscriber(new FormExitSubscriber('campaign', $options));
 
-        $builder->add('name', 'text', [
+        $builder->add('name', TextType::class, [
             'label'      => 'mautic.core.name',
             'label_attr' => ['class' => 'control-label'],
             'attr'       => ['class' => 'form-control'],
         ]);
 
-        $builder->add('description', 'textarea', [
+        $builder->add('description', TextareaType::class, [
             'label'      => 'mautic.core.description',
             'label_attr' => ['class' => 'control-label'],
             'attr'       => ['class' => 'form-control editor'],
@@ -97,7 +101,7 @@ class CampaignType extends AbstractType
             'data'      => $data,
         ]);
 
-        $builder->add('publishUp', 'datetime', [
+        $builder->add('publishUp', DateTimeType::class, [
             'widget'     => 'single_text',
             'label'      => 'mautic.core.form.publishup',
             'label_attr' => ['class' => 'control-label'],
@@ -109,7 +113,7 @@ class CampaignType extends AbstractType
             'required' => false,
         ]);
 
-        $builder->add('publishDown', 'datetime', [
+        $builder->add('publishDown', DateTimeType::class, [
             'widget'     => 'single_text',
             'label'      => 'mautic.core.form.publishdown',
             'label_attr' => ['class' => 'control-label'],
@@ -121,7 +125,7 @@ class CampaignType extends AbstractType
             'required' => false,
         ]);
 
-        $builder->add('sessionId', 'hidden', [
+        $builder->add('sessionId', HiddenType::class, [
             'mapped' => false,
         ]);
 
@@ -145,9 +149,9 @@ class CampaignType extends AbstractType
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'data_class' => 'Mautic\CampaignBundle\Entity\Campaign',
@@ -157,7 +161,7 @@ class CampaignType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'campaign';
     }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignType.php
@@ -12,11 +12,11 @@
 namespace Mautic\CampaignBundle\Form\Type;
 
 use Mautic\CategoryBundle\Form\Type\CategoryListType;
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
 use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -30,18 +30,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class CampaignType extends AbstractType
 {
-    private $security;
-    private $translator;
-    private $em;
-
     /**
-     * @param MauticFactory $factory
+     * @var CorePermissions
      */
-    public function __construct(MauticFactory $factory)
+    private $security;
+
+    public function __construct(CorePermissions $security)
     {
-        $this->translator = $factory->getTranslator();
-        $this->security   = $factory->getSecurity();
-        $this->em         = $factory->getEntityManager();
+        $this->security   = $security;
     }
 
     /**

--- a/app/bundles/CampaignBundle/Form/Type/CampaignType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignType.php
@@ -155,6 +155,6 @@ class CampaignType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'campaign';
+        return self::class;
     }
 }

--- a/app/bundles/CampaignBundle/Form/Type/ConfigType.php
+++ b/app/bundles/CampaignBundle/Form/Type/ConfigType.php
@@ -58,12 +58,4 @@ class ConfigType extends AbstractType
             ]
         );
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return self::class;
-    }
 }

--- a/app/bundles/CampaignBundle/Form/Type/ConfigType.php
+++ b/app/bundles/CampaignBundle/Form/Type/ConfigType.php
@@ -58,4 +58,9 @@ class ConfigType extends AbstractType
             ]
         );
     }
+
+    public function getBlockPrefix()
+    {
+        return 'campaignconfig';
+    }
 }

--- a/app/bundles/CampaignBundle/Form/Type/ConfigType.php
+++ b/app/bundles/CampaignBundle/Form/Type/ConfigType.php
@@ -12,6 +12,7 @@
 namespace Mautic\CampaignBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -27,28 +28,29 @@ class ConfigType extends AbstractType
     {
         $builder->add(
             'campaign_time_wait_on_event_false',
-            'choice',
+            ChoiceType::class,
             [
                 'label'      => 'mautic.campaignconfig.campaign_time_wait_on_event_false',
                 'label_attr' => ['class' => 'control-label'],
                 'data'       => $options['data']['campaign_time_wait_on_event_false'],
                 'choices'    => [
-                    'null'  => '0 mn',
-                    'PT15M' => '15 mn',
-                    'PT30M' => '30 mn',
-                    'PT45M' => '45 mn',
-                    'PT1H'  => '1 h',
-                    'PT2H'  => '2 h',
-                    'PT4H'  => '4 h',
-                    'PT8H'  => '8 h',
-                    'PT12H' => '12 h',
-                    'PT1D'  => '24 h',
-                    'PT3D'  => '3 days',
-                    'PT5D'  => '5 days',
-                    'PT14D' => '1 week',
-                    'P3M'   => '3 months',
+                    '0 mn'       => 'null',
+                    '15 mn'      => 'PT15M',
+                    '30 mn'      => 'PT30M',
+                    '45 mn'      => 'PT45M',
+                    '1 h'        => 'PT1H',
+                    '2 h'        => 'PT2H',
+                    '4 h'        => 'PT4H',
+                    '8 h'        => 'PT8H',
+                    '12 h'       => 'PT12H',
+                    '24 h'       => 'PT1D',
+                    '3 days'     => 'PT3D',
+                    '5 days'     => 'PT5D',
+                    '1 week'     => 'PT14D',
+                    '3 months'   => 'P3M',
                 ],
-                'attr' => [
+                'choices_as_values' => true,
+                'attr'              => [
                     'class'   => 'form-control',
                     'tooltip' => 'mautic.campaignconfig.campaign_time_wait_on_event_false_tooltip',
                 ],

--- a/app/bundles/CampaignBundle/Form/Type/ConfigType.php
+++ b/app/bundles/CampaignBundle/Form/Type/ConfigType.php
@@ -64,6 +64,6 @@ class ConfigType extends AbstractType
      */
     public function getName()
     {
-        return 'campaignconfig';
+        return self::class;
     }
 }

--- a/app/bundles/CampaignBundle/Form/Type/EventCanvasSettingsType.php
+++ b/app/bundles/CampaignBundle/Form/Type/EventCanvasSettingsType.php
@@ -36,6 +36,6 @@ class EventCanvasSettingsType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'campaignevent_canvassettings';
+        return self::class;
     }
 }

--- a/app/bundles/CampaignBundle/Form/Type/EventCanvasSettingsType.php
+++ b/app/bundles/CampaignBundle/Form/Type/EventCanvasSettingsType.php
@@ -12,6 +12,7 @@
 namespace Mautic\CampaignBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -25,15 +26,15 @@ class EventCanvasSettingsType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('droppedX', 'hidden');
+        $builder->add('droppedX', HiddenType::class);
 
-        $builder->add('droppedY', 'hidden');
+        $builder->add('droppedY', HiddenType::class);
     }
 
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'campaignevent_canvassettings';
     }

--- a/app/bundles/CampaignBundle/Form/Type/EventCanvasSettingsType.php
+++ b/app/bundles/CampaignBundle/Form/Type/EventCanvasSettingsType.php
@@ -36,6 +36,6 @@ class EventCanvasSettingsType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return self::class;
+        return 'campaignevent_canvassettings';
     }
 }

--- a/app/bundles/CampaignBundle/Form/Type/EventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/EventType.php
@@ -17,6 +17,9 @@ use Mautic\CoreBundle\Form\Type\FormButtonsType;
 use Mautic\CoreBundle\Form\Type\PropertiesTrait;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -50,7 +53,7 @@ class EventType extends AbstractType
 
         $builder->add(
             'anchor',
-            'hidden',
+            HiddenType::class,
             [
                 'label' => false,
             ]
@@ -83,14 +86,15 @@ class EventType extends AbstractType
                 'triggerMode',
                 ButtonGroupType::class,
                 [
-                    'choices'     => $choices,
-                    'expanded'    => true,
-                    'multiple'    => false,
-                    'label_attr'  => ['class' => 'control-label'],
-                    'label'       => $label,
-                    'empty_value' => false,
-                    'required'    => false,
-                    'attr'        => [
+                    'choices'           => array_flip($choices),
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => false,
+                    'label_attr'        => ['class' => 'control-label'],
+                    'label'             => $label,
+                    'empty_value'       => false,
+                    'required'          => false,
+                    'attr'              => [
                         'onchange' => 'Mautic.campaignToggleTimeframes();',
                         'tooltip'  => 'mautic.campaign.form.type.help',
                     ],
@@ -100,7 +104,7 @@ class EventType extends AbstractType
 
             $builder->add(
                 'triggerDate',
-                'datetime',
+                DateTimeType::class,
                 [
                     'label'  => false,
                     'attr'   => [
@@ -117,7 +121,7 @@ class EventType extends AbstractType
                 || null === $options['data']['triggerInterval']) ? 1 : (int) $options['data']['triggerInterval'];
             $builder->add(
                 'triggerInterval',
-                'number',
+                NumberType::class,
                 [
                     'label' => false,
                     'attr'  => [
@@ -131,19 +135,20 @@ class EventType extends AbstractType
             $data = (!empty($options['data']['triggerIntervalUnit'])) ? $options['data']['triggerIntervalUnit'] : 'd';
             $builder->add(
                 'triggerIntervalUnit',
-                'choice',
+                ChoiceType::class,
                 [
                     'choices'     => [
-                        'i' => 'mautic.campaign.event.intervalunit.choice.i',
-                        'h' => 'mautic.campaign.event.intervalunit.choice.h',
-                        'd' => 'mautic.campaign.event.intervalunit.choice.d',
-                        'm' => 'mautic.campaign.event.intervalunit.choice.m',
-                        'y' => 'mautic.campaign.event.intervalunit.choice.y',
+                        'mautic.campaign.event.intervalunit.choice.i' => 'i',
+                        'mautic.campaign.event.intervalunit.choice.h' => 'h',
+                        'mautic.campaign.event.intervalunit.choice.d' => 'd',
+                        'mautic.campaign.event.intervalunit.choice.m' => 'm',
+                        'mautic.campaign.event.intervalunit.choice.y' => 'y',
                     ],
-                    'multiple'    => false,
-                    'label_attr'  => ['class' => 'control-label'],
-                    'label'       => false,
-                    'attr'        => [
+                    'choices_as_values' => true,
+                    'multiple'          => false,
+                    'label_attr'        => ['class' => 'control-label'],
+                    'label'             => false,
+                    'attr'              => [
                         'class' => 'form-control',
                     ],
                     'empty_value' => false,
@@ -211,18 +216,19 @@ class EventType extends AbstractType
                         'data-format' => 'H:i',
                     ],
                     'choices'  => [
-                        1  => 'mautic.report.schedule.day.monday',
-                        2  => 'mautic.report.schedule.day.tuesday',
-                        3  => 'mautic.report.schedule.day.wednesday',
-                        4  => 'mautic.report.schedule.day.thursday',
-                        5  => 'mautic.report.schedule.day.friday',
-                        6  => 'mautic.report.schedule.day.saturday',
-                        0  => 'mautic.report.schedule.day.sunday',
-                        -1 => 'mautic.report.schedule.day.week_days',
+                        'mautic.report.schedule.day.monday'     => 1,
+                        'mautic.report.schedule.day.tuesday'    => 2,
+                        'mautic.report.schedule.day.wednesday'  => 3,
+                        'mautic.report.schedule.day.thursday'   => 4,
+                        'mautic.report.schedule.day.friday'     => 5,
+                        'mautic.report.schedule.day.saturday'   => 6,
+                        'mautic.report.schedule.day.sunday'     => 0,
+                        'mautic.report.schedule.day.week_days'  => -1,
                     ],
-                    'expanded' => true,
-                    'multiple' => true,
-                    'required' => false,
+                    'choices_as_values' => true,
+                    'expanded'          => true,
+                    'multiple'          => true,
+                    'required'          => false,
                 ]
             );
         }
@@ -231,11 +237,11 @@ class EventType extends AbstractType
             $this->addPropertiesType($builder, $options, $masks);
         }
 
-        $builder->add('type', 'hidden');
-        $builder->add('eventType', 'hidden');
+        $builder->add('type', HiddenType::class);
+        $builder->add('eventType', HiddenType::class);
         $builder->add(
             'anchorEventType',
-            'hidden',
+            HiddenType::class,
             [
                 'mapped' => false,
                 'data'   => (isset($options['data']['anchorEventType'])) ? $options['data']['anchorEventType'] : '',
@@ -244,7 +250,7 @@ class EventType extends AbstractType
 
         $builder->add(
             'canvasSettings',
-            'campaignevent_canvassettings',
+            EventCanvasSettingsType::class,
             [
                 'label' => false,
             ]
@@ -273,7 +279,7 @@ class EventType extends AbstractType
 
         $builder->add(
             'campaignId',
-            'hidden',
+            HiddenType::class,
             [
                 'mapped' => false,
             ]
@@ -297,7 +303,7 @@ class EventType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'campaignevent';
     }

--- a/app/bundles/CampaignBundle/Form/Type/EventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/EventType.php
@@ -305,7 +305,7 @@ class EventType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'campaignevent';
+        return self::class;
     }
 
     /**

--- a/app/bundles/CampaignBundle/Form/Type/EventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/EventType.php
@@ -301,14 +301,6 @@ class EventType extends AbstractType
     }
 
     /**
-     * @return string
-     */
-    public function getBlockPrefix()
-    {
-        return self::class;
-    }
-
-    /**
      * @param array $data
      * @param       $name
      *

--- a/app/bundles/CampaignBundle/Form/Type/EventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/EventType.php
@@ -318,4 +318,9 @@ class EventType extends AbstractType
 
         return new \DateTime($data[$name]);
     }
+
+    public function getBlockPrefix()
+    {
+        return 'campaignevent';
+    }
 }

--- a/app/bundles/CampaignBundle/Helper/CampaignEventHelper.php
+++ b/app/bundles/CampaignBundle/Helper/CampaignEventHelper.php
@@ -12,7 +12,6 @@
 namespace Mautic\CampaignBundle\Helper;
 
 use Mautic\CampaignBundle\Event\CampaignLeadChangeEvent;
-use Mautic\CoreBundle\Factory\MauticFactory;
 
 class CampaignEventHelper
 {
@@ -45,45 +44,5 @@ class CampaignEventHelper
         }
 
         return true;
-    }
-
-    /**
-     * @deprecated to be removed in 3.0
-     *
-     * @param MauticFactory $factory
-     * @param               $lead
-     * @param               $event
-     *
-     * @throws \Doctrine\ORM\ORMException
-     */
-    public static function addRemoveLead(MauticFactory $factory, $lead, $event)
-    {
-        /** @var \Mautic\CampaignBundle\Model\CampaignModel $campaignModel */
-        $campaignModel       = $factory->getModel('campaign');
-        $properties          = $event['properties'];
-        $addToCampaigns      = $properties['addTo'];
-        $removeFromCampaigns = $properties['removeFrom'];
-        $em                  = $factory->getEntityManager();
-        $leadsModified       = false;
-
-        if (!empty($addToCampaigns)) {
-            foreach ($addToCampaigns as $c) {
-                $campaignModel->addLead($em->getReference('MauticCampaignBundle:Campaign', $c), $lead, true);
-            }
-            $leadsModified = true;
-        }
-
-        if (!empty($removeFromCampaigns)) {
-            foreach ($removeFromCampaigns as $c) {
-                if ($c == 'this') {
-                    $c = $event['campaign']['id'];
-                }
-
-                $campaignModel->removeLead($em->getReference('MauticCampaignBundle:Campaign', $c), $lead, true);
-            }
-            $leadsModified = true;
-        }
-
-        return $leadsModified;
     }
 }

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -20,6 +20,7 @@ use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
 use Mautic\CampaignBundle\Event as Events;
 use Mautic\CampaignBundle\EventCollector\EventCollector;
 use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
+use Mautic\CampaignBundle\Form\Type\CampaignType;
 use Mautic\CampaignBundle\Helper\ChannelExtractor;
 use Mautic\CampaignBundle\Helper\RemovedContactTracker;
 use Mautic\CampaignBundle\Membership\MembershipBuilder;
@@ -174,7 +175,7 @@ class CampaignModel extends CommonFormModel
             $options['action'] = $action;
         }
 
-        return $formFactory->create('campaign', $entity, $options);
+        return $formFactory->create(CampaignType::class, $entity, $options);
     }
 
     /**
@@ -567,7 +568,7 @@ class CampaignModel extends CommonFormModel
                 $repo             = $this->formModel->getRepository();
                 $repo->setCurrentUser($this->userHelper->getUser());
 
-                $forms = $repo->getFormList('', 0, 0, $viewOther, 'campaign');
+                $forms = $repo->getFormList('', 0, 0, $viewOther, CampaignType::class);
 
                 if ($forms) {
                     foreach ($forms as $form) {

--- a/app/bundles/EmailBundle/Form/Type/DashboardEmailsInTimeWidgetType.php
+++ b/app/bundles/EmailBundle/Form/Type/DashboardEmailsInTimeWidgetType.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\EmailBundle\Form\Type;
 
+use Mautic\CampaignBundle\Form\Type\CampaignListType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -60,7 +61,7 @@ class DashboardEmailsInTimeWidgetType extends AbstractType
 
         $builder->add(
             'campaignId',
-            'campaign_list',
+            CampaignListType::class,
             [
                 'label'       => 'mautic.email.campaignId.filter',
                 'label_attr'  => ['class' => 'control-label'],

--- a/app/bundles/EmailBundle/Form/Type/DashboardMostHitEmailRedirectsWidgetType.php
+++ b/app/bundles/EmailBundle/Form/Type/DashboardMostHitEmailRedirectsWidgetType.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\EmailBundle\Form\Type;
 
+use Mautic\CampaignBundle\Form\Type\CampaignListType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -32,7 +33,7 @@ class DashboardMostHitEmailRedirectsWidgetType extends AbstractType
 
         $builder->add(
             'campaignId',
-            'campaign_list',
+            CampaignListType::class,
             [
                 'label'       => 'mautic.email.campaignId.filter',
                 'label_attr'  => ['class' => 'control-label'],

--- a/app/bundles/EmailBundle/Form/Type/DashboardSentEmailToContactsWidgetType.php
+++ b/app/bundles/EmailBundle/Form/Type/DashboardSentEmailToContactsWidgetType.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\EmailBundle\Form\Type;
 
+use Mautic\CampaignBundle\Form\Type\CampaignListType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -32,7 +33,7 @@ class DashboardSentEmailToContactsWidgetType extends AbstractType
 
         $builder->add(
             'campaignId',
-            'campaign_list',
+            CampaignListType::class,
             [
                 'label'       => 'mautic.email.campaignId.filter',
                 'label_attr'  => ['class' => 'control-label'],

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadCampaignsType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadCampaignsType.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\LeadBundle\Form\Type;
 
+use Mautic\CampaignBundle\Form\Type\CampaignListType;
 use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
 use Mautic\LeadBundle\Model\ListModel;
 use Symfony\Component\Form\AbstractType;
@@ -42,7 +43,7 @@ class CampaignEventLeadCampaignsType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add('campaigns',
-            'campaign_list', [
+            CampaignListType::class, [
             'label'      => 'mautic.lead.lead.events.campaigns.membership',
             'label_attr' => ['class' => 'control-label'],
             'attr'       => [


### PR DESCRIPTION
PR for https://github.com/mautic/mautic/issues/7987

- [x]  Remove uses of MauticFactory
 - [ ] Search for and remove/refactor M2 @deprecated code if simple otherwise, create a new issue with details to be prioritized
 -- **Most of the deprecated code here is for deprecated campaign events. This will be separated into its own ticket given the size of the effort for refactoring this.**
- [x]  https://github.com/symfony/symfony/blob/3.0/UPGRADE-3.0.md#form

CampaignBundle/Form/Type/CampaignLeadSourceType.php
- [x]  Nr. 37 line 118: Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface
- [x]  Nr. 38 line 118: Overriding deprecated method Mautic\CampaignBundle\Form\Type\CampaignLeadSourceType->setDefaultOptions()
- [x]  Nr. 39 line 126: Overriding deprecated method Mautic\CampaignBundle\Form\Type\CampaignLeadSourceType->getName()

CampaignBundle/Form/Type/CampaignEventAddRemoveLeadType.php
- [x]  Nr. 40 line 62: Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface
 - [x] Nr. 41 line 54: Overriding deprecated method Mautic\CampaignBundle\Form\Type\CampaignEventAddRemoveLeadType->getName()
- [x]  Nr. 42 line 62: Overriding deprecated method Mautic\CampaignBundle\Form\Type\CampaignEventAddRemoveLeadType->setDefaultOptions()

CampaignBundle/Form/Type/ConfigType.php
- [x]  Nr. 43 line 63: Overriding deprecated method Mautic\CampaignBundle\Form\Type\ConfigType->getName()

CampaignBundle/Form/Type/CampaignEventLeadChangeType.php
- [x]  Nr. 44 line 57: Overriding deprecated method Mautic\CampaignBundle\Form\Type\CampaignEventLeadChangeType->getName()

CampaignBundle/Form/Type/EventCanvasSettingsType.php
- [x]  Nr. 45 line 36: Overriding deprecated method Mautic\CampaignBundle\Form\Type\EventCanvasSettingsType->getName()

CampaignBundle/Form/Type/CampaignListType.php
- [x]  Nr. 46 line 88: Overriding deprecated method Mautic\CampaignBundle\Form\Type\CampaignListType->getName()

CampaignBundle/Form/Type/CampaignType.php
- [x]  Nr. 47 line 143: Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface
 - [x] Nr. 48 line 143: Overriding deprecated method Mautic\CampaignBundle\Form\Type\CampaignType->setDefaultOptions()
- [x]  Nr. 49 line 153: Overriding deprecated method Mautic\CampaignBundle\Form\Type\CampaignType->getName()

CampaignBundle/Form/Type/CampaignEventJumpToEventType.php
- [x]  Nr. 50 line 62: Overriding deprecated method Mautic\CampaignBundle\Form\Type\CampaignEventJumpToEventType->getName()

CampaignBundle/Form/Type/EventType.php
- [x]  Nr. 51 line 298: Overriding deprecated method Mautic\CampaignBundle\Form\Type\EventType->getName()