### PR TITLE
Increase minimal PHP version from 5.6.19 to 7.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ services:
   - mysql
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
 
 cache:
@@ -31,7 +28,7 @@ before_install:
   - export SYMFONY_ENV="test"
 
   # install PHPSTAN for PHP 7+
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.6" ]]; then composer global require phpstan/phpstan-shim:0.8.5; fi
+  - composer global require phpstan/phpstan-shim:0.8.5
 
 install:
   - composer install
@@ -42,8 +39,7 @@ script:
   - bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --fail-on-warning
 
   # Run PHPSTAN analysis for PHP 7+
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.6" ]]; then ~/.composer/vendor/phpstan/phpstan-shim/phpstan.phar analyse app/bundles/DashboardBundle app/bundles/ConfigBundle app/bundles/CampaignBundle app/bundles/WebhookBundle app/bundles/LeadBundle app/bundles/FormBundle; fi
+  - ~/.composer/vendor/phpstan/phpstan-shim/phpstan.phar analyse app/bundles/DashboardBundle app/bundles/ConfigBundle app/bundles/CampaignBundle app/bundles/WebhookBundle app/bundles/LeadBundle app/bundles/FormBundle
 
   # Check if the code standards weren't broken.
-  # Run it only on PHP 7.2 which should be the fastest. No need to run it for all PHP versions
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then bin/php-cs-fixer fix -v --dry-run --diff; fi
+  - bin/php-cs-fixer fix -v --dry-run --diff

--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -104,7 +104,7 @@ class CheckStep implements StepInterface
     {
         $messages = [];
 
-        if (version_compare(PHP_VERSION, '5.6.19', '<')) {
+        if (version_compare(PHP_VERSION, '7.2.0', '<')) {
             $messages[] = 'mautic.install.php.version.not.supported';
         }
 
@@ -138,16 +138,6 @@ class CheckStep implements StepInterface
 
         if (get_magic_quotes_gpc()) {
             $messages[] = 'mautic.install.magic_quotes_enabled';
-        }
-
-        if (
-            version_compare(PHP_VERSION, '5.6.0', '>=')
-            &&
-            version_compare(PHP_VERSION, '7', '<')
-            &&
-            ini_get('always_populate_raw_post_data') != -1
-        ) {
-            $messages[] = 'mautic.install.always_populate_raw_post_data_enabled';
         }
 
         if (!function_exists('json_encode')) {

--- a/app/bundles/InstallBundle/Translations/en_US/messages.ini
+++ b/app/bundles/InstallBundle/Translations/en_US/messages.ini
@@ -1,4 +1,3 @@
-mautic.install.always_populate_raw_post_data_enabled="PHP version 5.6.x requires the PHP configuration directive always_populate_raw_post_data be set to -1. This is handled automatically by the .htaccess file when using Apache and mod_php5, but must be set manually in php.ini for other server configurations. Please add 'always_populate_raw_post_data = -1' to your php.ini and restart your web server."
 mautic.install.extension.eaccelerator="eAccelerator is incompatible Mautic. Please disable it."
 mautic.install.apc.version="When using APC, you must use version %minapc% or newer. You have version %currentapc% installed. Please update your APC extension."
 mautic.install.composer.dependencies="Vendor libraries must be installed. If you are running Mautic from source, please run 'composer install'. If you downloaded Mautic, please check for the 'vendor' folder."

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportUtmTagSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportUtmTagSubscriberTest.php
@@ -139,7 +139,7 @@ class ReportUtmTagSubscriberTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $reportBuilderEvent->getTables()); //Different order of keys on PHP 5.6.
+        $this->assertSame($expected, $reportBuilderEvent->getTables());
     }
 
     public function testReportGenerateNoJoinedTables()

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentReportSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentReportSubscriberTest.php
@@ -184,7 +184,7 @@ class SegmentReportSubscriberTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $reportBuilderEvent->getTables()); //Different order of keys on PHP 5.6.
+        $this->assertSame($expected, $reportBuilderEvent->getTables());
     }
 
     public function testReportGenerate()

--- a/app/middlewares/VersionCheckMiddleware.php
+++ b/app/middlewares/VersionCheckMiddleware.php
@@ -19,7 +19,7 @@ class VersionCheckMiddleware implements HttpKernelInterface, PrioritizedMiddlewa
 {
     const PRIORITY = 10;
 
-    const MAUTIC_MINIMUM_PHP = '5.6.19';
+    const MAUTIC_MINIMUM_PHP = '7.2.0';
     const MAUTIC_MAXIMUM_PHP = '7.2.999';
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         ]
     },
     "require": {
-        "php": ">=5.6.19 <7.3",
+        "php": ">=7.2.0 <7.3",
 
         "symfony/console": "~2.8",
         "symfony/debug": "~2.8",
@@ -158,7 +158,7 @@
     "config": {
         "bin-dir": "bin",
         "platform": {
-            "php": "5.6.19"
+            "php": "7.2.0"
         }
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -10636,10 +10636,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6.19 <7.3"
+        "php": ">=7.2.0 <7.3"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.19"
+        "php": "7.2.0"
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8162
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Increasing the minimal PHP version. Getting rid of outdated, unsupported PHP versions.

#### Steps to test this PR:
1. There is nothing to test, really.

#### List deprecations along with the new alternative:
1. https://docs.google.com/document/d/1lHNK8hHQtvyWlz9OtfAoLupDVb5-QunQjq-HAGlAsS4/edit#heading=h.45b6ke9j8i3r