### PR TITLE
Remove 'lead' array element from webhook payloads

### DIFF
--- a/app/bundles/LeadBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/WebhookSubscriber.php
@@ -121,7 +121,6 @@ class WebhookSubscriber extends CommonSubscriber
         // Consider this a new contact if it was just identified, otherwise consider it updated
             !empty($changes['dateIdentified']) ? LeadEvents::LEAD_POST_SAVE.'_new' : LeadEvents::LEAD_POST_SAVE.'_update',
             [
-                'lead'    => $event->getLead(),
                 'contact' => $event->getLead(),
             ],
             [
@@ -142,7 +141,6 @@ class WebhookSubscriber extends CommonSubscriber
         $this->webhookModel->queueWebhooksByType(
             LeadEvents::LEAD_POINTS_CHANGE,
             [
-                'lead'    => $event->getLead(),
                 'contact' => $event->getLead(),
                 'points'  => [
                     'old_points' => $event->getOldPoints(),
@@ -169,7 +167,6 @@ class WebhookSubscriber extends CommonSubscriber
             LeadEvents::LEAD_POST_DELETE,
             [
                 'id'      => $lead->deletedId,
-                'lead'    => $lead,
                 'contact' => $lead,
             ],
             [


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8073
| BC breaks? | Payloads for the following webhook events will no longer have the `lead` array element: `Contact Deleted Event`, `Contact Points Changed Event`, `Contact Updated Event`. `lead` element has been removed. We have the same information in the `contact` array element.
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Remove duplicated 'lead' array element from the webhook payload.
We don't want to duplicate the same information.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create a webhook. It should use one (or all) of the following events:  `Contact Deleted Event`, `Contact Points Changed Event`, `Contact Updated Event`.
3. You have to have an endpoint you can post your payloads to. Also, you will have to save that information somehow to be able to debug it (file_put_contents?)
4. Use URL of your debug endpoint as `Webhook POST Url` parameter, save the webhook.
5. Trigger the webhook event (either create a new lead or change its points or delete the lead that you've created).
6. Observe the payload. It must not contain `lead` element (array key).