### PR TITLE
Refactor usage of deprecated ParameterBag code.

### DIFF
--- a/app/bundles/AssetBundle/Controller/AssetController.php
+++ b/app/bundles/AssetBundle/Controller/AssetController.php
@@ -311,7 +311,8 @@ class AssetController extends FormController
         ], 'validators');
 
         // Create temporary asset ID
-        $tempId = ($method == 'POST') ? $this->request->request->get('asset[tempId]', '', true) : uniqid('tmp_');
+        $asset  = $this->request->request->get('asset', []);
+        $tempId = $method === 'POST' ? ($asset['tempId'] ?? '') : uniqid('tmp_');
         $entity->setTempId($tempId);
 
         // Set the page we came from
@@ -480,7 +481,8 @@ class AssetController extends FormController
         }
 
         // Create temporary asset ID
-        $tempId = ($method == 'POST') ? $this->request->request->get('asset[tempId]', '', true) : uniqid('tmp_');
+        $asset  = $this->request->request->get('asset', []);
+        $tempId = $method === 'POST' ? ($asset['tempId'] ?? '') : uniqid('tmp_');
         $entity->setTempId($tempId);
 
         //Create the form

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -450,7 +450,8 @@ class CampaignController extends AbstractStandardFormController
         } elseif ('new' === $action && empty($sessionId)) {
             $sessionId = 'mautic_'.sha1(uniqid(mt_rand(), true));
             if ($this->request->request->has('campaign')) {
-                $sessionId = $this->request->request->get('campaign[sessionId]', $sessionId, true);
+                $campaign  = $this->request->request->get('campaign', []);
+                $sessionId = $campaign['sessionId'] ?? $sessionId;
             }
         } elseif ('edit' === $action) {
             $sessionId = $campaign->getId();

--- a/app/bundles/CampaignBundle/Controller/EventController.php
+++ b/app/bundles/CampaignBundle/Controller/EventController.php
@@ -218,19 +218,20 @@ class EventController extends CommonFormController
      */
     public function editAction($objectId)
     {
-        $session    = $this->get('session');
-        $valid      = $cancelled = false;
-        $method     = $this->request->getMethod();
-        $campaignId = $method === 'POST'
-            ? $this->request->request->get('campaignevent[campaignId]', '', true)
+        $session       = $this->get('session');
+        $valid         = $cancelled = false;
+        $method        = $this->request->getMethod();
+        $campaignEvent = $this->request->request->get('campaignevent', []);
+        $campaignId    = $method === 'POST'
+            ? ($campaignEvent['campaignId'] ?? '')
             : $this->request->query->get('campaignId');
         $modifiedEvents = $session->get('mautic.campaign.'.$campaignId.'.events.modified', []);
         $event          = array_key_exists($objectId, $modifiedEvents) ? $modifiedEvents[$objectId] : [];
 
         if ($method === 'POST') {
             $event = array_merge($event, [
-                'anchor'          => $this->request->request->get('campaignevent[anchor]', '', true),
-                'anchorEventType' => $this->request->request->get('campaignevent[anchorEventType]', '', true),
+                'anchor'          => $campaignEvent['anchor'] ?? '',
+                'anchorEventType' => $campaignEvent['anchorEventType'] ?? '',
             ]);
         } else {
             if (!isset($event['anchor'])) {

--- a/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
+++ b/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
@@ -131,18 +131,18 @@ class DynamicContentController extends FormController
         }
 
         /** @var \Mautic\DynamicContentBundle\Model\DynamicContentModel $model */
-        $model  = $this->getModel('dynamicContent');
-        $page   = $this->get('session')->get('mautic.dynamicContent.page', 1);
-        $retUrl = $this->generateUrl('mautic_dynamicContent_index', ['page' => $page]);
-        $action = $this->generateUrl('mautic_dynamicContent_action', ['objectAction' => 'new']);
-
-        $updateSelect = ($this->request->getMethod() === 'POST')
-            ? $this->request->request->get('dwc[updateSelect]', false, true)
+        $method       = $this->request->getMethod();
+        $model        = $this->getModel('dynamicContent');
+        $page         = $this->get('session')->get('mautic.dynamicContent.page', 1);
+        $retUrl       = $this->generateUrl('mautic_dynamicContent_index', ['page' => $page]);
+        $action       = $this->generateUrl('mautic_dynamicContent_action', ['objectAction' => 'new']);
+        $dwc          = $this->request->request->get('dwc', []);
+        $updateSelect = $method === 'POST'
+            ? ($dwc['updateSelect'] ?? false)
             : $this->request->get('updateSelect', false);
+        $form         = $model->createForm($entity, $this->get('form.factory'), $action, ['update_select' => $updateSelect]);
 
-        $form = $model->createForm($entity, $this->get('form.factory'), $action, ['update_select' => $updateSelect]);
-
-        if ($this->request->getMethod() === 'POST') {
+        if ($method === 'POST') {
             $valid = false;
 
             if (!$cancelled = $this->isFormCancelled($form)) {
@@ -276,16 +276,17 @@ class DynamicContentController extends FormController
             return $this->isLocked($postActionVars, $entity, 'dynamicContent');
         }
 
-        $action = $this->generateUrl('mautic_dynamicContent_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-
-        $updateSelect = ($this->request->getMethod() === 'POST')
-            ? $this->request->request->get('dwc[updateSelect]', false, true)
+        $action       = $this->generateUrl('mautic_dynamicContent_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
+        $method       = $this->request->getMethod();
+        $dwc          = $this->request->request->get('dwc', []);
+        $updateSelect = $method === 'POST'
+            ? ($dwc['updateSelect'] ?? false)
             : $this->request->get('updateSelect', false);
 
         $form = $model->createForm($entity, $this->get('form.factory'), $action, ['update_select' => $updateSelect]);
 
         ///Check for a submitted form and process it
-        if (!$ignorePost && $this->request->getMethod() == 'POST') {
+        if (!$ignorePost && $method === 'POST') {
             $valid = false;
 
             if (!$cancelled = $this->isFormCancelled($form)) {

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -449,20 +449,18 @@ class EmailController extends FormController
 
         $method  = $this->request->getMethod();
         $session = $this->get('session');
+
         if (!$this->get('mautic.security')->isGranted('email:emails:create')) {
             return $this->accessDenied();
         }
 
         //set the page we came from
-        $page   = $session->get('mautic.email.page', 1);
-        $action = $this->generateUrl('mautic_email_action', ['objectAction' => 'new']);
-
-        $updateSelect = ($method == 'POST')
-            ? $this->request->request->get('emailform[updateSelect]', false, true)
-            : $this->request->get(
-                'updateSelect',
-                false
-            );
+        $page         = $session->get('mautic.email.page', 1);
+        $action       = $this->generateUrl('mautic_email_action', ['objectAction' => 'new']);
+        $emailForm    = $this->request->request->get('emailform', []);
+        $updateSelect = $method === 'POST'
+            ? ($emailForm['updateSelect'] ?? false)
+            : $this->request->get('updateSelect', false);
 
         if ($updateSelect) {
             // Force type to template
@@ -473,8 +471,9 @@ class EmailController extends FormController
         $form = $model->createForm($entity, $this->get('form.factory'), $action, ['update_select' => $updateSelect]);
 
         ///Check for a submitted form and process it
-        if ($method == 'POST') {
+        if ($method === 'POST') {
             $valid = false;
+
             if (!$cancelled = $this->isFormCancelled($form)) {
                 $formData = $this->request->request->get('emailform');
                 if ($valid = $this->isFormValid($form) && $this->isFormValidForWebinar($formData, $form, $entity)) {
@@ -656,14 +655,11 @@ class EmailController extends FormController
         }
 
         //Create the form
-        $action = $this->generateUrl('mautic_email_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-
-        $updateSelect = ($method == 'POST')
-            ? $this->request->request->get('emailform[updateSelect]', false, true)
-            : $this->request->get(
-                'updateSelect',
-                false
-            );
+        $action       = $this->generateUrl('mautic_email_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
+        $emailform    = $this->request->request->get('emailform', []);
+        $updateSelect = $method === 'POST'
+            ? ($emailform['updateSelect'] ?? false)
+            : $this->request->get('updateSelect', false);
 
         if ($updateSelect) {
             // Force type to template
@@ -673,7 +669,7 @@ class EmailController extends FormController
         $form = $model->createForm($entity, $this->get('form.factory'), $action, ['update_select' => $updateSelect]);
 
         ///Check for a submitted form and process it
-        if (!$ignorePost && $method == 'POST') {
+        if (!$ignorePost && $method === 'POST') {
             $valid = false;
             if (!$cancelled = $this->isFormCancelled($form)) {
                 $formData = $this->request->request->get('emailform');

--- a/app/bundles/FormBundle/Controller/ActionController.php
+++ b/app/bundles/FormBundle/Controller/ActionController.php
@@ -150,11 +150,12 @@ class ActionController extends CommonFormController
     {
         $session    = $this->get('session');
         $method     = $this->request->getMethod();
-        $formId     = ($method == 'POST') ? $this->request->request->get('formaction[formId]', '', true) : $this->request->query->get('formId');
+        $formaction = $this->request->request->get('formaction', []);
+        $formId     = $method === 'POST' ? ($formaction['formId'] ?? '') : $this->request->query->get('formId');
         $actions    = $session->get('mautic.form.'.$formId.'.actions.modified', []);
         $success    = 0;
         $valid      = $cancelled      = false;
-        $formAction = (array_key_exists($objectId, $actions)) ? $actions[$objectId] : null;
+        $formAction = array_key_exists($objectId, $actions) ? $actions[$objectId] : null;
 
         if ($formAction !== null) {
             $actionType             = $formAction['type'];

--- a/app/bundles/FormBundle/Controller/FieldController.php
+++ b/app/bundles/FormBundle/Controller/FieldController.php
@@ -188,11 +188,12 @@ class FieldController extends CommonFormController
     {
         $session   = $this->get('session');
         $method    = $this->request->getMethod();
-        $formId    = ($method == 'POST') ? $this->request->request->get('formfield[formId]', '', true) : $this->request->query->get('formId');
+        $formfield = $this->request->request->get('formfield', []);
+        $formId    = $method === 'POST' ? ($formfield['formId'] ?? '') : $this->request->query->get('formId');
         $fields    = $session->get('mautic.form.'.$formId.'.fields.modified', []);
         $success   = 0;
-        $valid     = $cancelled     = false;
-        $formField = (array_key_exists($objectId, $fields)) ? $fields[$objectId] : [];
+        $valid     = $cancelled = false;
+        $formField = array_key_exists($objectId, $fields) ? $fields[$objectId] : [];
 
         if ($formField !== null) {
             $fieldType = $formField['type'];

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -284,9 +284,9 @@ class FormController extends CommonFormController
         }
 
         //set the page we came from
-        $page = $this->get('session')->get('mautic.form.page', 1);
-
-        $sessionId = $this->request->request->get('mauticform[sessionId]', 'mautic_'.sha1(uniqid(mt_rand(), true)), true);
+        $page       = $this->get('session')->get('mautic.form.page', 1);
+        $mauticform = $this->request->request->get('mauticform', []);
+        $sessionId  = $mauticform['sessionId'] ?? 'mautic_'.sha1(uniqid(mt_rand(), true));
 
         //set added/updated fields
         $modifiedFields = $session->get('mautic.form.'.$sessionId.'.fields.modified', []);

--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -147,17 +147,14 @@ class CompanyController extends FormController
         }
 
         //set the page we came from
-        $page = $this->get('session')->get('mautic.company.page', 1);
-
-        $action = $this->generateUrl('mautic_company_action', ['objectAction' => 'new']);
-
+        $page         = $this->get('session')->get('mautic.company.page', 1);
+        $method       = $this->request->getMethod();
+        $action       = $this->generateUrl('mautic_company_action', ['objectAction' => 'new']);
+        $company      = $this->request->request->get('company', []);
         $updateSelect = InputHelper::clean(
-            ($this->request->getMethod() == 'POST')
-                ? $this->request->request->get('company[updateSelect]', false, true)
-                : $this->request->get(
-                'updateSelect',
-                false
-            )
+            $method === 'POST'
+                ? ($company['updateSelect'] ?? false)
+                : $this->request->get('updateSelect', false)
         );
 
         $fields = $this->getModel('lead.field')->getPublishedFieldArrays('company');
@@ -327,12 +324,11 @@ class CompanyController extends FormController
         }
 
         $action       = $this->generateUrl('mautic_company_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-        $updateSelect = ($this->request->getMethod() == 'POST')
-            ? $this->request->request->get('company[updateSelect]', false, true)
-            : $this->request->get(
-                'updateSelect',
-                false
-            );
+        $method       = $this->request->getMethod();
+        $company      = $this->request->request->get('company', []);
+        $updateSelect = $method === 'POST'
+            ? ($company['updateSelect'] ?? false)
+            : $this->request->get('updateSelect', false);
 
         $fields = $this->getModel('lead.field')->getPublishedFieldArrays('company');
         $form   = $model->createForm(
@@ -343,8 +339,9 @@ class CompanyController extends FormController
         );
 
         ///Check for a submitted form and process it
-        if (!$ignorePost && $this->request->getMethod() == 'POST') {
+        if (!$ignorePost && $method === 'POST') {
             $valid = false;
+
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($valid = $this->isFormValid($form)) {
                     $data = $this->request->request->get('company');

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -728,7 +728,8 @@ class LeadController extends FormController
      */
     private function uploadAvatar(Lead $lead)
     {
-        $file      = $this->request->files->get('lead[custom_avatar]', null, true);
+        $lead      = $this->request->files->get('lead', []);
+        $file      = $lead['custom_avatar'] ?? null;
         $avatarDir = $this->get('mautic.helper.template.avatar')->getAvatarPath(true);
 
         if (!file_exists($avatarDir)) {

--- a/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
@@ -272,11 +272,11 @@ class MobileNotificationController extends FormController
         }
 
         //set the page we came from
-        $page   = $session->get('mautic.mobile_notification.page', 1);
-        $action = $this->generateUrl('mautic_mobile_notification_action', ['objectAction' => 'new']);
-
-        $updateSelect = ($method == 'POST')
-            ? $this->request->request->get('notification[updateSelect]', false, true)
+        $page         = $session->get('mautic.mobile_notification.page', 1);
+        $action       = $this->generateUrl('mautic_mobile_notification_action', ['objectAction' => 'new']);
+        $notification = $this->request->request->get('notification', []);
+        $updateSelect = $method === 'POST'
+            ? ($notification['updateSelect'] ?? false)
             : $this->request->get('updateSelect', false);
 
         if ($updateSelect) {
@@ -287,7 +287,7 @@ class MobileNotificationController extends FormController
         $form = $model->createForm($entity, $this->get('form.factory'), $action, ['update_select' => $updateSelect]);
 
         ///Check for a submitted form and process it
-        if ($method == 'POST') {
+        if ($method === 'POST') {
             $valid = false;
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($valid = $this->isFormValid($form)) {
@@ -443,10 +443,10 @@ class MobileNotificationController extends FormController
         }
 
         //Create the form
-        $action = $this->generateUrl('mautic_mobile_notification_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-
-        $updateSelect = ($method == 'POST')
-            ? $this->request->request->get('notification[updateSelect]', false, true)
+        $action       = $this->generateUrl('mautic_mobile_notification_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
+        $notification = $this->request->request->get('notification', []);
+        $updateSelect = $method === 'POST'
+            ? ($notification['updateSelect'] ?? false)
             : $this->request->get('updateSelect', false);
 
         $form = $model->createForm($entity, $this->get('form.factory'), $action, ['update_select' => $updateSelect]);

--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -276,11 +276,11 @@ class NotificationController extends FormController
         }
 
         //set the page we came from
-        $page   = $session->get('mautic.notification.page', 1);
-        $action = $this->generateUrl('mautic_notification_action', ['objectAction' => 'new']);
-
+        $page         = $session->get('mautic.notification.page', 1);
+        $action       = $this->generateUrl('mautic_notification_action', ['objectAction' => 'new']);
+        $notification = $this->request->request->get('notification', []);
         $updateSelect = ($method == 'POST')
-            ? $this->request->request->get('notification[updateSelect]', false, true)
+            ? ($notification['updateSelect'] ?? false)
             : $this->request->get('updateSelect', false);
 
         if ($updateSelect) {
@@ -291,7 +291,7 @@ class NotificationController extends FormController
         $form = $model->createForm($entity, $this->get('form.factory'), $action, ['update_select' => $updateSelect]);
 
         ///Check for a submitted form and process it
-        if ($method == 'POST') {
+        if ($method === 'POST') {
             $valid = false;
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($valid = $this->isFormValid($form)) {
@@ -444,17 +444,18 @@ class NotificationController extends FormController
         }
 
         //Create the form
-        $action = $this->generateUrl('mautic_notification_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-
-        $updateSelect = ($method == 'POST')
-            ? $this->request->request->get('notification[updateSelect]', false, true)
+        $action       = $this->generateUrl('mautic_notification_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
+        $notification = $this->request->request->get('notification', []);
+        $updateSelect = $method === 'POST'
+            ? ($notification['updateSelect'] ?? false)
             : $this->request->get('updateSelect', false);
 
         $form = $model->createForm($entity, $this->get('form.factory'), $action, ['update_select' => $updateSelect]);
 
         ///Check for a submitted form and process it
-        if (!$ignorePost && $method == 'POST') {
+        if (!$ignorePost && $method === 'POST') {
             $valid = false;
+
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($valid = $this->isFormValid($form)) {
                     //form is valid so process the data

--- a/app/bundles/PointBundle/Controller/PointController.php
+++ b/app/bundles/PointBundle/Controller/PointController.php
@@ -130,21 +130,22 @@ class PointController extends AbstractFormController
         }
 
         //set the page we came from
-        $page = $this->get('session')->get('mautic.point.page', 1);
-
-        $actionType = ($this->request->getMethod() == 'POST') ? $this->request->request->get('point[type]', '', true) : '';
-
-        $action  = $this->generateUrl('mautic_point_action', ['objectAction' => 'new']);
-        $actions = $model->getPointActions();
-        $form    = $model->createForm($entity, $this->get('form.factory'), $action, [
+        $page       = $this->get('session')->get('mautic.point.page', 1);
+        $method     = $this->request->getMethod();
+        $point      = $this->request->request->get('point', []);
+        $actionType = $method === 'POST' ? ($point['type'] ?? '') : '';
+        $action     = $this->generateUrl('mautic_point_action', ['objectAction' => 'new']);
+        $actions    = $model->getPointActions();
+        $form       = $model->createForm($entity, $this->get('form.factory'), $action, [
             'pointActions' => $actions,
             'actionType'   => $actionType,
         ]);
         $viewParameters = ['page' => $page];
 
         ///Check for a submitted form and process it
-        if ($this->request->getMethod() == 'POST') {
+        if ($method === 'POST') {
             $valid = false;
+
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($valid = $this->isFormValid($form)) {
                     //form is valid so process the data
@@ -261,7 +262,9 @@ class PointController extends AbstractFormController
             return $this->isLocked($postActionVars, $entity, 'point');
         }
 
-        $actionType = ($this->request->getMethod() == 'POST') ? $this->request->request->get('point[type]', '', true) : $entity->getType();
+        $method     = $this->request->getMethod();
+        $point      = $this->request->request->get('point', []);
+        $actionType = $method === 'POST' ? ($point['type'] ?? '') : $entity->getType();
 
         $action  = $this->generateUrl('mautic_point_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
         $actions = $model->getPointActions();
@@ -271,8 +274,9 @@ class PointController extends AbstractFormController
         ]);
 
         ///Check for a submitted form and process it
-        if (!$ignorePost && $this->request->getMethod() == 'POST') {
+        if (!$ignorePost && $method === 'POST') {
             $valid = false;
+
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($valid = $this->isFormValid($form)) {
                     //form is valid so process the data

--- a/app/bundles/PointBundle/Controller/TriggerController.php
+++ b/app/bundles/PointBundle/Controller/TriggerController.php
@@ -188,8 +188,9 @@ class TriggerController extends FormController
             $entity = $model->getEntity();
         }
 
-        $session   = $this->get('session');
-        $sessionId = $this->request->request->get('pointtrigger[sessionId]', 'mautic_'.sha1(uniqid(mt_rand(), true)), true);
+        $session      = $this->get('session');
+        $pointTrigger = $this->request->request->get('pointtrigger', []);
+        $sessionId    = $pointTrigger['sessionId'] ?? 'mautic_'.sha1(uniqid(mt_rand(), true));
 
         if (!$this->get('mautic.security')->isGranted('point:triggers:create')) {
             return $this->accessDenied();

--- a/app/bundles/PointBundle/Controller/TriggerEventController.php
+++ b/app/bundles/PointBundle/Controller/TriggerEventController.php
@@ -153,15 +153,15 @@ class TriggerEventController extends CommonFormController
     {
         $session      = $this->get('session');
         $method       = $this->request->getMethod();
-        $triggerId    = ($method == 'POST') ? $this->request->request->get('pointtriggerevent[triggerId]', '', true) : $this->request->query->get('triggerId');
+        $triggerEvent = $this->request->request->get('pointtriggerevent', []);
+        $triggerId    = $method === 'POST' ? ($triggerEvent['triggerId'] ?? '') : $this->request->query->get('triggerId');
         $events       = $session->get('mautic.point.'.$triggerId.'.triggerevents.modified', []);
         $success      = 0;
-        $valid        = $cancelled        = false;
-        $triggerEvent = (array_key_exists($objectId, $events)) ? $events[$objectId] : null;
+        $valid        = $cancelled = false;
+        $triggerEvent = array_key_exists($objectId, $events) ? $events[$objectId] : null;
 
         if ($triggerEvent !== null) {
-            $eventType = $triggerEvent['type'];
-
+            $eventType                = $triggerEvent['type'];
             $events                   = $this->getModel('point.trigger')->getEvents();
             $triggerEvent['settings'] = $events[$eventType];
 

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -263,11 +263,11 @@ class SmsController extends FormController
         }
 
         //set the page we came from
-        $page   = $session->get('mautic.sms.page', 1);
-        $action = $this->generateUrl('mautic_sms_action', ['objectAction' => 'new']);
-
-        $updateSelect = ($method == 'POST')
-            ? $this->request->request->get('sms[updateSelect]', false, true)
+        $page         = $session->get('mautic.sms.page', 1);
+        $action       = $this->generateUrl('mautic_sms_action', ['objectAction' => 'new']);
+        $sms          = $this->request->request->get('sms', []);
+        $updateSelect = $method === 'POST'
+            ? ($sms['updateSelect'] ?? false)
             : $this->request->get('updateSelect', false);
 
         if ($updateSelect) {
@@ -431,10 +431,10 @@ class SmsController extends FormController
         }
 
         //Create the form
-        $action = $this->generateUrl('mautic_sms_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-
-        $updateSelect = ($method == 'POST')
-            ? $this->request->request->get('sms[updateSelect]', false, true)
+        $action       = $this->generateUrl('mautic_sms_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
+        $sms          = $this->request->request->get('sms', []);
+        $updateSelect = $method === 'POST'
+            ? ($sms['updateSelect'] ?? false)
             : $this->request->get('updateSelect', false);
 
         $form = $model->createForm($entity, $this->get('form.factory'), $action, ['update_select' => $updateSelect]);

--- a/app/bundles/StageBundle/Controller/StageController.php
+++ b/app/bundles/StageBundle/Controller/StageController.php
@@ -142,14 +142,13 @@ class StageController extends AbstractFormController
         }
 
         //set the page we came from
-        $page = $this->get('session')->get('mautic.stage.page', 1);
-
-        $actionType = ($this->request->getMethod() == 'POST') ? $this->request->request->get('stage[type]', '', true)
-            : '';
-
-        $action  = $this->generateUrl('mautic_stage_action', ['objectAction' => 'new']);
-        $actions = $model->getStageActions();
-        $form    = $model->createForm(
+        $page       = $this->get('session')->get('mautic.stage.page', 1);
+        $method     = $this->request->getMethod();
+        $stage      = $this->request->request->get('stage', []);
+        $actionType = $method === 'POST' ? ($stage['type'] ?? '') : '';
+        $action     = $this->generateUrl('mautic_stage_action', ['objectAction' => 'new']);
+        $actions    = $model->getStageActions();
+        $form       = $model->createForm(
             $entity,
             $this->get('form.factory'),
             $action,
@@ -161,8 +160,9 @@ class StageController extends AbstractFormController
         $viewParameters = ['page' => $page];
 
         ///Check for a submitted form and process it
-        if ($this->request->getMethod() == 'POST') {
+        if ($method === 'POST') {
             $valid = false;
+
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($valid = $this->isFormValid($form)) {
                     //form is valid so process the data

--- a/app/bundles/StageBundle/Controller/StageController.php
+++ b/app/bundles/StageBundle/Controller/StageController.php
@@ -160,7 +160,7 @@ class StageController extends AbstractFormController
         $viewParameters = ['page' => $page];
 
         ///Check for a submitted form and process it
-        if ($method === 'POST') {
+        if ('POST' === $method) {
             $valid = false;
 
             if (!$cancelled = $this->isFormCancelled($form)) {
@@ -272,7 +272,7 @@ class StageController extends AbstractFormController
         ];
 
         //form not found
-        if ($entity === null) {
+        if (null === $entity) {
             return $this->postActionRedirect(
                 array_merge(
                     $postActionVars,

--- a/app/bundles/UserBundle/Controller/ProfileController.php
+++ b/app/bundles/UserBundle/Controller/ProfileController.php
@@ -149,8 +149,8 @@ class ProfileController extends FormController
             $this->get('session')->set('formProcessed', 1);
 
             //check to see if the password needs to be rehashed
-            $user                  = $this->request->request->get('user', []);
-            $submittedPassword     = $user['plainPassword']['password'] ?? null;
+            $formUser              = $this->request->request->get('user', []);
+            $submittedPassword     = $formUser['plainPassword']['password'] ?? null;
             $encoder               = $this->get('security.encoder_factory')->getEncoder($me);
             $overrides['password'] = $model->checkNewPassword($me, $encoder, $submittedPassword);
             if (!$cancelled = $this->isFormCancelled($form)) {

--- a/app/bundles/UserBundle/Controller/ProfileController.php
+++ b/app/bundles/UserBundle/Controller/ProfileController.php
@@ -149,7 +149,8 @@ class ProfileController extends FormController
             $this->get('session')->set('formProcessed', 1);
 
             //check to see if the password needs to be rehashed
-            $submittedPassword     = $this->request->request->get('user[plainPassword][password]', null, true);
+            $user                  = $this->request->request->get('user', []);
+            $submittedPassword     = $user['plainPassword']['password'] ?? null;
             $encoder               = $this->get('security.encoder_factory')->getEncoder($me);
             $overrides['password'] = $model->checkNewPassword($me, $encoder, $submittedPassword);
             if (!$cancelled = $this->isFormCancelled($form)) {

--- a/app/bundles/UserBundle/Controller/RoleController.php
+++ b/app/bundles/UserBundle/Controller/RoleController.php
@@ -150,7 +150,8 @@ class RoleController extends FormController
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($valid = $this->isFormValid($form)) {
                     //set the permissions
-                    $permissions = $this->request->request->get('role[permissions]', null, true);
+                    $role        = $this->request->request->get('role', []);
+                    $permissions = $role['permissions'] ?? null;
                     $model->setRolePermissions($entity, $permissions);
 
                     //form is valid so process the data
@@ -254,12 +255,14 @@ class RoleController extends FormController
         $form              = $model->createForm($entity, $this->get('form.factory'), $action, ['permissionsConfig' => $permissionsConfig['config']]);
 
         ///Check for a submitted form and process it
-        if (!$ignorePost && $this->request->getMethod() == 'POST') {
+        if (!$ignorePost && $this->request->getMethod() === 'POST') {
             $valid = false;
+
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($valid = $this->isFormValid($form)) {
                     //set the permissions
-                    $permissions = $this->request->request->get('role[permissions]', null, true);
+                    $role        = $this->request->request->get('role', []);
+                    $permissions = $role['permissions'] ?? null;
                     $model->setRolePermissions($entity, $permissions);
 
                     //form is valid so process the data

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -144,7 +144,8 @@ class UserController extends FormController
             $valid = false;
             if (!$cancelled = $this->isFormCancelled($form)) {
                 //check to see if the password needs to be rehashed
-                $submittedPassword = $this->request->request->get('user[plainPassword][password]', null, true);
+                $user              = $this->request->request->get('user', []);
+                $submittedPassword = $user['plainPassword']['password'] ?? null;
                 $encoder           = $this->get('security.encoder_factory')->getEncoder($user);
                 $password          = $model->checkNewPassword($user, $encoder, $submittedPassword);
 
@@ -272,11 +273,13 @@ class UserController extends FormController
         $form   = $model->createForm($user, $this->get('form.factory'), $action);
 
         ///Check for a submitted form and process it
-        if (!$ignorePost && $this->request->getMethod() == 'POST') {
+        if (!$ignorePost && $this->request->getMethod() === 'POST') {
             $valid = false;
+
             if (!$cancelled = $this->isFormCancelled($form)) {
                 //check to see if the password needs to be rehashed
-                $submittedPassword = $this->request->request->get('user[plainPassword][password]', null, true);
+                $user              = $this->request->request->get('user', []);
+                $submittedPassword = $user['plainPassword']['password'] ?? null;
                 $encoder           = $this->get('security.encoder_factory')->getEncoder($user);
                 $password          = $model->checkNewPassword($user, $encoder, $submittedPassword);
 
@@ -449,9 +452,11 @@ class UserController extends FormController
         $currentUser = $this->user;
 
         if ($this->request->getMethod() == 'POST') {
-            $formUrl   = $this->request->request->get('contact[returnUrl]', '', true);
-            $returnUrl = ($formUrl) ? urldecode($formUrl) : $this->generateUrl('mautic_dashboard_index');
+            $contact   = $this->request->request->get('contact', []);
+            $formUrl   = $contact['returnUrl'] ?? '';
+            $returnUrl = $formUrl ? urldecode($formUrl) : $this->generateUrl('mautic_dashboard_index');
             $valid     = false;
+
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($valid = $this->isFormValid($form)) {
                     $subject = InputHelper::clean($form->get('msg_subject')->getData());

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -144,8 +144,8 @@ class UserController extends FormController
             $valid = false;
             if (!$cancelled = $this->isFormCancelled($form)) {
                 //check to see if the password needs to be rehashed
-                $user              = $this->request->request->get('user', []);
-                $submittedPassword = $user['plainPassword']['password'] ?? null;
+                $formUser          = $this->request->request->get('user', []);
+                $submittedPassword = $formUser['plainPassword']['password'] ?? null;
                 $encoder           = $this->get('security.encoder_factory')->getEncoder($user);
                 $password          = $model->checkNewPassword($user, $encoder, $submittedPassword);
 
@@ -251,8 +251,7 @@ class UserController extends FormController
             ],
         ];
 
-        //user not found
-        if ($user === null) {
+        if (null === $user) {
             return $this->postActionRedirect(
                 array_merge($postActionVars, [
                     'flashes' => [
@@ -278,8 +277,8 @@ class UserController extends FormController
 
             if (!$cancelled = $this->isFormCancelled($form)) {
                 //check to see if the password needs to be rehashed
-                $user              = $this->request->request->get('user', []);
-                $submittedPassword = $user['plainPassword']['password'] ?? null;
+                $formUser          = $this->request->request->get('user', []);
+                $submittedPassword = $formUser['plainPassword']['password'] ?? null;
                 $encoder           = $this->get('security.encoder_factory')->getEncoder($user);
                 $password          = $model->checkNewPassword($user, $encoder, $submittedPassword);
 

--- a/plugins/MauticFocusBundle/Controller/FocusController.php
+++ b/plugins/MauticFocusBundle/Controller/FocusController.php
@@ -167,12 +167,11 @@ class FocusController extends FormController
      */
     protected function getPostActionRedirectArguments(array $args, $action)
     {
-        $updateSelect = ($this->request->getMethod() == 'POST')
-            ? $this->request->request->get('focus[updateSelect]', false, true)
-            : $this->request->get(
-                'updateSelect',
-                false
-            );
+        $focus        = $this->request->request->get('focus', []);
+        $updateSelect = $this->request->getMethod() === 'POST'
+            ? ($focus['updateSelect'] ?? false)
+            : $this->request->get('updateSelect', false);
+
         if ($updateSelect) {
             switch ($action) {
                 case 'new':
@@ -199,12 +198,11 @@ class FocusController extends FormController
      */
     protected function getEntityFormOptions()
     {
-        $updateSelect = ($this->request->getMethod() == 'POST')
-            ? $this->request->request->get('focus[updateSelect]', false, true)
-            : $this->request->get(
-                'updateSelect',
-                false
-            );
+        $focus        = $this->request->request->get('focus', []);
+        $updateSelect = $this->request->getMethod() === 'POST'
+            ? ($focus['updateSelect'] ?? false)
+            : $this->request->get('updateSelect', false);
+
         if ($updateSelect) {
             return ['update_select' => $updateSelect];
         }

--- a/plugins/MauticFocusBundle/EventListener/StatSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/StatSubscriber.php
@@ -76,7 +76,8 @@ class StatSubscriber extends CommonSubscriber
     public function onFormSubmit(SubmissionEvent $event)
     {
         // Check the request for a focus field
-        $id = $this->request->request->get('mauticform[focusId]', false, true);
+        $mauticform = $this->request->request->get('mauticform', []);
+        $id         = $mauticform['focusId'] ?? false;
 
         if (!empty($id)) {
             $focus = $this->model->getEntity($id);

--- a/plugins/MauticSocialBundle/Controller/MonitoringController.php
+++ b/plugins/MauticSocialBundle/Controller/MonitoringController.php
@@ -135,7 +135,8 @@ class MonitoringController extends FormController
 
         // get the network type from the request on submit. helpful for validation error
         // rebuilds structure of the form when it gets updated on submit
-        $networkType = ($this->request->getMethod() == 'POST') ? $this->request->request->get('monitoring[networkType]', '', true) : '';
+        $monitoring  = $this->request->request->get('monitoring', []);
+        $networkType = $method === 'POST' ? ($monitoring['networkType'] ?? '') : '';
 
         // build the form
         $form = $model->createForm(
@@ -155,8 +156,7 @@ class MonitoringController extends FormController
         if ($method == 'POST') {
             $viewParameters = ['page' => $page];
             $template       = 'MauticSocialBundle:Monitoring:index';
-
-            $valid = false;
+            $valid          = false;
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($valid = $this->isFormValid($form)) {
                     //form is valid so process the data
@@ -290,8 +290,9 @@ class MonitoringController extends FormController
 
         // get the network type from the request on submit. helpful for validation error
         // rebuilds structure of the form when it gets updated on submit
-        $networkType = ($this->request->getMethod() == 'POST') ? $this->request->request->get('monitoring[networkType]', '', true)
-            : $entity->getNetworkType();
+        $method      = $this->request->getMethod();
+        $monitoring  = $this->request->request->get('monitoring', []);
+        $networkType = $method === 'POST' ? ($monitoring['networkType'] ?? '') : $entity->getNetworkType();
 
         // build the form
         $form = $model->createForm(
@@ -306,8 +307,9 @@ class MonitoringController extends FormController
         );
 
         ///Check for a submitted form and process it
-        if ($this->request->getMethod() == 'POST') {
+        if ($method === 'POST') {
             $valid = false;
+
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($valid = $this->isFormValid($form)) {
                     //form is valid so process the data


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N/A
| Automated tests included? | N/A
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | https://github.com/symfony/symfony/blob/3.0/UPGRADE-3.0.md#httpfoundation
| Issues addressed (#s or URLs) | #8023 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Removes deep item access from the request as documented in the symfony dev docs linked above.

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Test creating and editing throughout the app, specifically around
- Assets
- Campaigns
- Campaign Events
- Dynamic Content
- Emails
- Forms
- Form Actions
- Form Fields
- Companies
- Contacts
- Notifications
- Point Actions
- Point Triggers
- SMS
- Stages
- Profiles
- Roles
- Users
- Profile (your own user)
- Focus Items
- Social items (twitter monitoring)