### PR TITLE
Fix iOS picture orientation after upload

### DIFF
--- a/app/bundles/FormBundle/Helper/FormUploader.php
+++ b/app/bundles/FormBundle/Helper/FormUploader.php
@@ -157,6 +157,9 @@ class FormUploader
     }
 
     /**
+     * Fix iOS picture orientation after upload PHP
+     * https://stackoverflow.com/questions/22308921/fix-ios-picture-orientation-after-upload-php.
+     *
      * @param $filename
      */
     private function fixRotationJPG($filename)


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
https://stackoverflow.com/questions/22308921/fix-ios-picture-orientation-after-upload-php

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
