### PR TITLE
Fix for auditlog model and fix for RouterHelper removed generate method

### DIFF
--- a/app/bundles/ApiBundle/Views/SubscribedEvents/Search/global.html.php
+++ b/app/bundles/ApiBundle/Views/SubscribedEvents/Search/global.html.php
@@ -11,12 +11,12 @@
 ?>
 
 <?php if (!empty($showMore)): ?>
-<a href="<?php echo $view['router']->generate('mautic_client_index', ['search' => $searchString]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->url('mautic_client_index', ['search' => $searchString]); ?>" data-toggle="ajax">
     <span><?php echo $view['translator']->trans('mautic.core.search.more', ['%count%' => $remaining]); ?></span>
 </a>
 <?php else: ?>
 <?php if ($canEdit): ?>
-<a href="<?php echo $view['router']->generate('mautic_client_action', ['objectAction' => 'edit', 'objectId' => $client->getId()]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->url('mautic_client_action', ['objectAction' => 'edit', 'objectId' => $client->getId()]); ?>" data-toggle="ajax">
     <?php echo $client->getName(); ?>
 </a>
 <?php else: ?>

--- a/app/bundles/AssetBundle/Controller/AssetController.php
+++ b/app/bundles/AssetBundle/Controller/AssetController.php
@@ -181,7 +181,7 @@ class AssetController extends FormController
         }
 
         // Audit Log
-        $logs = $this->getModel('core.auditLog')->getLogForObject('asset', $activeAsset->getId(), $activeAsset->getDateAdded());
+        $logs = $this->getModel('core.auditlog')->getLogForObject('asset', $activeAsset->getId(), $activeAsset->getDateAdded());
 
         return $this->delegateView([
             'returnUrl'      => $action,

--- a/app/bundles/AssetBundle/Views/Asset/details.html.php
+++ b/app/bundles/AssetBundle/Views/Asset/details.html.php
@@ -157,7 +157,7 @@ $view['slots']->set(
         <div class="tab-content pa-md preview-detail">
             <?php echo $view->render(
                 'MauticAssetBundle:Asset:preview.html.php',
-                ['activeAsset' => $activeAsset, 'assetDownloadUrl' => $view['router']->generate(
+                ['activeAsset' => $activeAsset, 'assetDownloadUrl' => $view['router']->url(
                     'mautic_asset_action',
                     ['objectAction' => 'preview', 'objectId' => $activeAsset->getId()]
                 )]

--- a/app/bundles/AssetBundle/Views/Asset/form.html.php
+++ b/app/bundles/AssetBundle/Views/Asset/form.html.php
@@ -69,7 +69,7 @@ $view['slots']->set('mauticContent', 'asset');
 		    	<div class="col-md-6">
 		    		<div class="row">
 				    	<div class="form-group col-xs-12 preview">
-				    		<?php echo $view->render('MauticAssetBundle:Asset:preview.html.php', ['activeAsset' => $activeAsset, 'assetDownloadUrl' => $view['router']->generate(
+				    		<?php echo $view->render('MauticAssetBundle:Asset:preview.html.php', ['activeAsset' => $activeAsset, 'assetDownloadUrl' => $view['router']->url(
                                 'mautic_asset_action',
                                 ['objectAction' => 'preview', 'objectId' => $activeAsset->getId()]
                             )]); ?>

--- a/app/bundles/AssetBundle/Views/SubscribedEvents/Search/global.html.php
+++ b/app/bundles/AssetBundle/Views/SubscribedEvents/Search/global.html.php
@@ -10,11 +10,11 @@
  */
 ?>
 <?php if (!empty($showMore)): ?>
-<a href="<?php echo $view['router']->generate('mautic_asset_index', ['search' => $searchString]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->url('mautic_asset_index', ['search' => $searchString]); ?>" data-toggle="ajax">
     <span><?php echo $view->escape($view['translator']->trans('mautic.core.search.more', ['%count%' => $remaining])); ?></span>
 </a>
 <?php else: ?>
-<a href="<?php echo $view['router']->generate('mautic_asset_action', ['objectAction' => 'view', 'objectId' => $asset->getId()]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->url('mautic_asset_action', ['objectAction' => 'view', 'objectId' => $asset->getId()]); ?>" data-toggle="ajax">
     <?php echo $view->escape($asset->getTitle()); ?>
     <span class="label label-default pull-right" data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.asset.downloadcount'); ?>" data-placement="left">
         <?php echo $asset->getDownloadCount(); ?>

--- a/app/bundles/AssetBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/AssetBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -11,7 +11,7 @@
 ?>
 
 <div>
-<?php echo $view->render('MauticAssetBundle:Asset:preview.html.php', ['activeAsset' => $event['extra']['asset'], 'assetDownloadUrl' => $view['router']->generate(
+<?php echo $view->render('MauticAssetBundle:Asset:preview.html.php', ['activeAsset' => $event['extra']['asset'], 'assetDownloadUrl' => $view['router']->url(
     'mautic_asset_action',
     ['objectAction' => 'preview', 'objectId' => $event['extra']['asset']->getId()]
 )]); ?>

--- a/app/bundles/CampaignBundle/Views/SubscribedEvents/Search/global.html.php
+++ b/app/bundles/CampaignBundle/Views/SubscribedEvents/Search/global.html.php
@@ -11,12 +11,12 @@
 ?>
 
 <?php if (!empty($showMore)): ?>
-    <a href="<?php echo $view['router']->generate('mautic_campaign_index', ['search' => $searchString]); ?>" data-toggle="ajax">
+    <a href="<?php echo $view['router']->url('mautic_campaign_index', ['search' => $searchString]); ?>" data-toggle="ajax">
         <span><?php echo $view['translator']->trans('mautic.core.search.more', ['%count%' => $remaining]); ?></span>
     </a>
 </div>
 <?php else: ?>
-<a href="<?php echo $view['router']->generate('mautic_campaign_action', ['objectAction' => 'view', 'objectId' => $campaign->getId()]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->url('mautic_campaign_action', ['objectAction' => 'view', 'objectId' => $campaign->getId()]); ?>" data-toggle="ajax">
     <?php echo $campaign->getName(); ?>
 </a>
 <?php endif; ?>

--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -1145,7 +1145,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
         $this->setListFilters();
 
         // Audit log entries
-        $logs = ($logObject) ? $this->getModel('core.auditLog')->getLogForObject($logObject, $objectId, $entity->getDateAdded(), 10, $logBundle) : [];
+        $logs = ($logObject) ? $this->getModel('core.auditlog')->getLogForObject($logObject, $objectId, $entity->getDateAdded(), 10, $logBundle) : [];
 
         // Generate route
         $routeVars = [

--- a/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
+++ b/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
@@ -390,7 +390,7 @@ class DynamicContentController extends FormController
         list($translationParent, $translationChildren) = $entity->getTranslations();
 
         // Audit Log
-        $logs = $this->getModel('core.auditLog')->getLogForObject('dynamicContent', $entity->getId(), $entity->getDateAdded());
+        $logs = $this->getModel('core.auditlog')->getLogForObject('dynamicContent', $entity->getId(), $entity->getDateAdded());
 
         // Init the date range filter form
         $dateRangeValues = $this->request->get('daterange', []);

--- a/app/bundles/DynamicContentBundle/Views/DynamicContent/list.html.php
+++ b/app/bundles/DynamicContentBundle/Views/DynamicContent/list.html.php
@@ -109,7 +109,7 @@ if ('index' == $tmpl) {
                             'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                             ['item' => $item, 'model' => 'dynamicContent']
                         ); ?>
-                        <a href="<?php echo $view['router']->generate(
+                        <a href="<?php echo $view['router']->url(
                             'mautic_dynamicContent_action',
                             ['objectAction' => 'view', 'objectId' => $item->getId()]
                         ); ?>" data-toggle="ajax">
@@ -157,7 +157,7 @@ if ('index' == $tmpl) {
                     'page'       => $page,
                     'limit'      => $limit,
                     'menuLinkId' => 'mautic_dynamicContent_index',
-                    'baseUrl'    => $view['router']->generate('mautic_dynamicContent_index'),
+                    'baseUrl'    => $view['router']->url('mautic_dynamicContent_index'),
                     'sessionVar' => 'dynamicContent',
                 ]
             ); ?>

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -361,7 +361,7 @@ class EmailController extends FormController
         list($translationParent, $translationChildren) = $email->getTranslations();
 
         // Audit Log
-        $logs = $this->getModel('core.auditLog')->getLogForObject('email', $email->getId(), $email->getDateAdded());
+        $logs = $this->getModel('core.auditlog')->getLogForObject('email', $email->getId(), $email->getDateAdded());
 
         // Get click through stats
         $trackableLinks = $model->getEmailClickStats($email->getId());

--- a/app/bundles/EmailBundle/Views/SubscribedEvents/Search/global.html.php
+++ b/app/bundles/EmailBundle/Views/SubscribedEvents/Search/global.html.php
@@ -11,11 +11,11 @@
 ?>
 
 <?php if (!empty($showMore)): ?>
-<a href="<?php echo $view['router']->generate('mautic_email_index', ['search' => $searchString]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->path('mautic_email_index', ['search' => $searchString]); ?>" data-toggle="ajax">
     <span><?php echo $view['translator']->trans('mautic.core.search.more', ['%count%' => $remaining]); ?></span>
 </a>
 <?php else: ?>
-<a href="<?php echo $view['router']->generate('mautic_email_action', ['objectAction' => 'view', 'objectId' => $email->getId()]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->path('mautic_email_action', ['objectAction' => 'view', 'objectId' => $email->getId()]); ?>" data-toggle="ajax">
     <?php echo $email->getName(); ?>
     <span class="label label-default pull-right" data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.email.readcount'); ?>" data-placement="left">
         <?php echo $email->getReadCount(); ?>

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -197,7 +197,7 @@ class FormController extends CommonFormController
         );
 
         // Audit Log
-        $logs = $this->getModel('core.auditLog')->getLogForObject('form', $objectId, $activeForm->getDateAdded());
+        $logs = $this->getModel('core.auditlog')->getLogForObject('form', $objectId, $activeForm->getDateAdded());
 
         // Init the date range filter form
         $dateRangeValues = $this->request->get('daterange', []);

--- a/app/bundles/FormBundle/Views/SubscribedEvents/Search/global.html.php
+++ b/app/bundles/FormBundle/Views/SubscribedEvents/Search/global.html.php
@@ -11,11 +11,11 @@
 ?>
 
 <?php if (!empty($showMore)): ?>
-<a href="<?php echo $view['router']->generate('mautic_form_index', ['search' => $searchString]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->url('mautic_form_index', ['search' => $searchString]); ?>" data-toggle="ajax">
     <span><?php echo $view['translator']->trans('mautic.core.search.more', ['%count%' => $remaining]); ?></span>
 </a>
 <?php else: ?>
-    <a href="<?php echo $view['router']->generate('mautic_form_action', ['objectAction' => 'view', 'objectId' => $form->getId()]); ?>" data-toggle="ajax">
+    <a href="<?php echo $view['router']->url('mautic_form_action', ['objectAction' => 'view', 'objectId' => $form->getId()]); ?>" data-toggle="ajax">
     <?php echo $form->getName(); ?>
     <span class="label label-default pull-right" data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.form.form.resultcount'); ?>" data-placement="left">
         <?php echo $form->getResultCount(); ?>

--- a/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
+++ b/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
@@ -251,7 +251,7 @@ trait LeadDetailsTrait
 
         // Audit Log
         /** @var AuditLogModel $auditlogModel */
-        $auditlogModel = $this->getModel('core.auditLog');
+        $auditlogModel = $this->getModel('core.auditlog');
         /** @var AuditLogRepository $repo */
         $repo     = $auditlogModel->getRepository();
         $logCount = $repo->getAuditLogsCount($lead, $filters);

--- a/app/bundles/LeadBundle/Views/Auditlog/index.html.php
+++ b/app/bundles/LeadBundle/Views/Auditlog/index.html.php
@@ -37,7 +37,7 @@
                 </select>
             </div>
             <div class="col-sm-2">
-                <a class="btn btn-default btn-block" href="<?php echo $view['router']->generate('mautic_contact_auditlog_export_action', ['leadId' => $lead->getId()]); ?>" data-toggle="download">
+                <a class="btn btn-default btn-block" href="<?php echo $view['router']->url('mautic_contact_auditlog_export_action', ['leadId' => $lead->getId()]); ?>" data-toggle="download">
                     <span>
                         <i class="fa fa-download"></i> <span class="hidden-xs hidden-sm"><?php echo $view['translator']->trans('mautic.core.export'); ?></span>
                     </span>

--- a/app/bundles/LeadBundle/Views/Company/list.html.php
+++ b/app/bundles/LeadBundle/Views/Company/list.html.php
@@ -115,7 +115,7 @@ if ('index' == $tmpl) {
                                        )
                                    ): ?>
 
-                            <a href="<?php echo $view['router']->generate(
+                            <a href="<?php echo $view['router']->url(
                                 'mautic_company_action',
                                 ['objectAction' => 'edit', 'objectId' => $item->getId()]
                             ); ?>" data-toggle="ajax">
@@ -177,7 +177,7 @@ if ('index' == $tmpl) {
                 'page'       => $page,
                 'limit'      => $limit,
                 'menuLinkId' => 'mautic_company_index',
-                'baseUrl'    => $view['router']->generate('mautic_company_index'),
+                'baseUrl'    => $view['router']->url('mautic_company_index'),
                 'sessionVar' => 'company',
             ]
         ); ?>

--- a/app/bundles/LeadBundle/Views/Note/note.html.php
+++ b/app/bundles/LeadBundle/Views/Note/note.html.php
@@ -48,7 +48,7 @@ switch ($type) {
             <div class="media-body col-xs-11 pa-10">
                 <div class="pull-right btn-group">
                     <?php if ($permissions['edit']): ?>
-                        <a class="btn btn-default btn-xs" href="<?php echo $view['router']->generate('mautic_contactnote_action', ['leadId' => $lead->getId(), 'objectAction' => 'edit', 'objectId' => $id]); ?>" data-toggle="ajaxmodal" data-target="#MauticSharedModal" data-header="<?php echo $view['translator']->trans('mautic.lead.note.header.edit'); ?>"><i class="fa fa-pencil"></i></a>
+                        <a class="btn btn-default btn-xs" href="<?php echo $view['router']->url('mautic_contactnote_action', ['leadId' => $lead->getId(), 'objectAction' => 'edit', 'objectId' => $id]); ?>" data-toggle="ajaxmodal" data-target="#MauticSharedModal" data-header="<?php echo $view['translator']->trans('mautic.lead.note.header.edit'); ?>"><i class="fa fa-pencil"></i></a>
                     <?php endif; ?>
                      <?php if ($permissions['delete']): ?>
                          <a class="btn btn-default btn-xs"

--- a/app/bundles/LeadBundle/Views/SubscribedEvents/Search/global.html.php
+++ b/app/bundles/LeadBundle/Views/SubscribedEvents/Search/global.html.php
@@ -10,7 +10,7 @@
  */
 ?>
 <?php if (!empty($showMore)): ?>
-    <a href="<?php echo $view['router']->generate('mautic_contact_index', ['search' => $searchString]); ?>" data-toggle="ajax">
+    <a href="<?php echo $view['router']->url('mautic_contact_index', ['search' => $searchString]); ?>" data-toggle="ajax">
         <span><?php echo $view['translator']->trans('mautic.core.search.more', ['%count%' => $remaining]); ?></span>
     </a>
 <?php else: ?>
@@ -18,7 +18,7 @@
     <span class="pull-left pr-xs pt-xs" style="width:36px">
         <span class="img-wrapper img-rounded"><img src="<?php echo $view['gravatar']->getImage($fields['core']['email']['value'], '100'); ?>" /></span>
     </span>
-    <a href="<?php echo $view['router']->generate('mautic_contact_action', ['objectAction' => 'view', 'objectId' => $lead->getId()]); ?>" data-toggle="ajax">
+    <a href="<?php echo $view['router']->url('mautic_contact_action', ['objectAction' => 'view', 'objectId' => $lead->getId()]); ?>" data-toggle="ajax">
         <span><?php echo $lead->getPrimaryIdentifier(true); ?></span>
         <?php
         $color = $lead->getColor();

--- a/app/bundles/LeadBundle/Views/Timeline/index.html.php
+++ b/app/bundles/LeadBundle/Views/Timeline/index.html.php
@@ -37,7 +37,7 @@
                 </select>
             </div>
             <div class="col-sm-2">
-                <a class="btn btn-default btn-block" href="<?php echo $view['router']->generate('mautic_contact_timeline_export_action', ['leadId' => $lead->getId()]); ?>" data-toggle="download">
+                <a class="btn btn-default btn-block" href="<?php echo $view['router']->url('mautic_contact_timeline_export_action', ['leadId' => $lead->getId()]); ?>" data-toggle="download">
                     <span>
                         <i class="fa fa-download"></i> <span class="hidden-xs hidden-sm"><?php echo $view['translator']->trans('mautic.core.export'); ?></span>
                     </span>

--- a/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
@@ -193,7 +193,7 @@ class MobileNotificationController extends FormController
         }
 
         // Audit Log
-        $logs = $this->getModel('core.auditLog')->getLogForObject('notification', $notification->getId(), $notification->getDateAdded());
+        $logs = $this->getModel('core.auditlog')->getLogForObject('notification', $notification->getId(), $notification->getDateAdded());
 
         // Init the date range filter form
         $dateRangeValues = $this->request->get('daterange', []);

--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -197,7 +197,7 @@ class NotificationController extends FormController
         }
 
         // Audit Log
-        $logs = $this->getModel('core.auditLog')->getLogForObject('notification', $notification->getId(), $notification->getDateAdded());
+        $logs = $this->getModel('core.auditlog')->getLogForObject('notification', $notification->getId(), $notification->getDateAdded());
 
         // Init the date range filter form
         $dateRangeValues = $this->request->get('daterange', []);

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -285,7 +285,7 @@ class PageController extends FormController
         $dateRangeForm   = $this->get('form.factory')->create(DateRangeType::class, $dateRangeValues, ['action' => $action]);
 
         // Audit Log
-        $logs = $this->getModel('core.auditLog')->getLogForObject('page', $activePage->getId(), $activePage->getDateAdded());
+        $logs = $this->getModel('core.auditlog')->getLogForObject('page', $activePage->getId(), $activePage->getDateAdded());
 
         $pageviews = $model->getHitsLineChartData(
             null,

--- a/app/bundles/PageBundle/Views/SubscribedEvents/Search/global.html.php
+++ b/app/bundles/PageBundle/Views/SubscribedEvents/Search/global.html.php
@@ -10,11 +10,11 @@
  */
 ?>
 <?php if (!empty($showMore)): ?>
-<a href="<?php echo $view['router']->generate('mautic_page_index', ['search' => $searchString]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->url('mautic_page_index', ['search' => $searchString]); ?>" data-toggle="ajax">
     <span><?php echo $view['translator']->trans('mautic.core.search.more', ['%count%' => $remaining]); ?></span>
 </a>
 <?php else: ?>
-<a href="<?php echo $view['router']->generate('mautic_page_action', ['objectAction' => 'view', 'objectId' => $page->getId()]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->url('mautic_page_action', ['objectAction' => 'view', 'objectId' => $page->getId()]); ?>" data-toggle="ajax">
     <?php echo $page->getTitle(); ?>
     <span class="label label-default pull-right" data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.page.hits'); ?>" data-placement="left">
         <?php echo $page->getHits(); ?>

--- a/app/bundles/PointBundle/Views/SubscribedEvents/Search/global_point.html.php
+++ b/app/bundles/PointBundle/Views/SubscribedEvents/Search/global_point.html.php
@@ -11,13 +11,13 @@
 ?>
 
 <?php if (!empty($showMore)): ?>
-    <a href="<?php echo $view['router']->generate('mautic_point_index', ['search' => $searchString]); ?>" data-toggle="ajax">
+    <a href="<?php echo $view['router']->url('mautic_point_index', ['search' => $searchString]); ?>" data-toggle="ajax">
         <span><?php echo $view['translator']->trans('mautic.core.search.more', ['%count%' => $remaining]); ?></span>
     </a>
 </div>
 <?php else: ?>
 <?php if ($canEdit): ?>
-<a href="<?php echo $view['router']->generate('mautic_point_action', ['objectAction' => 'edit', 'objectId' => $item->getId()]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->url('mautic_point_action', ['objectAction' => 'edit', 'objectId' => $item->getId()]); ?>" data-toggle="ajax">
     <?php echo $item->getName(); ?>
 </a>
 <?php else: ?>

--- a/app/bundles/PointBundle/Views/SubscribedEvents/Search/global_trigger.html.php
+++ b/app/bundles/PointBundle/Views/SubscribedEvents/Search/global_trigger.html.php
@@ -11,13 +11,13 @@
 ?>
 
 <?php if (!empty($showMore)): ?>
-    <a href="<?php echo $view['router']->generate('mautic_pointtrigger_index', ['search' => $searchString]); ?>" data-toggle="ajax">
+    <a href="<?php echo $view['router']->url('mautic_pointtrigger_index', ['search' => $searchString]); ?>" data-toggle="ajax">
         <span><?php echo $view['translator']->trans('mautic.core.search.more', ['%count%' => $remaining]); ?></span>
     </a>
 </div>
 <?php else: ?>
 <?php if ($canEdit): ?>
-<a href="<?php echo $view['router']->generate('mautic_pointtrigger_index', ['objectAction' => 'edit', 'objectId' => $item->getId()]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->url('mautic_pointtrigger_index', ['objectAction' => 'edit', 'objectId' => $item->getId()]); ?>" data-toggle="ajax">
     <?php echo $item->getName(); ?>
 </a>
 <?php else: ?>

--- a/app/bundles/ReportBundle/Views/SubscribedEvents/Search/global.html.php
+++ b/app/bundles/ReportBundle/Views/SubscribedEvents/Search/global.html.php
@@ -10,11 +10,11 @@
  */
 ?>
 <?php if (!empty($showMore)): ?>
-<a href="<?php echo $view['router']->generate('mautic_report_index', ['search' => $searchString]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->url('mautic_report_index', ['search' => $searchString]); ?>" data-toggle="ajax">
     <span><?php echo $view['translator']->trans('mautic.core.search.more', ['%count%' => $remaining]); ?></span>
 </a>
 <?php else: ?>
-<a href="<?php echo $view['router']->generate('mautic_report_view', ['objectId' => $item->getId()]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->url('mautic_report_view', ['objectId' => $item->getId()]); ?>" data-toggle="ajax">
     <?php echo $item->getName(); ?>
 </a>
 <?php endif; ?>

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -183,7 +183,7 @@ class SmsController extends FormController
         }
 
         // Audit Log
-        $logs = $this->getModel('core.auditLog')->getLogForObject('sms', $sms->getId(), $sms->getDateAdded());
+        $logs = $this->getModel('core.auditlog')->getLogForObject('sms', $sms->getId(), $sms->getDateAdded());
 
         // Init the date range filter form
         $dateRangeValues = $this->request->get('daterange', []);

--- a/app/bundles/StageBundle/Views/Stage/list.html.php
+++ b/app/bundles/StageBundle/Views/Stage/list.html.php
@@ -91,7 +91,7 @@ if ('index' == $tmpl) {
                                 ['item' => $item, 'model' => 'stage']
                             ); ?>
                             <?php if ($permissions['stage:stages:edit']): ?>
-                            <a href="<?php echo $view['router']->generate(
+                            <a href="<?php echo $view['router']->url(
                                 'mautic_stage_action',
                                 ['objectAction' => 'edit', 'objectId' => $item->getId()]
                             ); ?>" data-toggle="ajax">
@@ -132,7 +132,7 @@ if ('index' == $tmpl) {
                 'page'       => $page,
                 'limit'      => $limit,
                 'menuLinkId' => 'mautic_stage_index',
-                'baseUrl'    => $view['router']->generate('mautic_stage_index'),
+                'baseUrl'    => $view['router']->url('mautic_stage_index'),
                 'sessionVar' => 'stage',
             ]
         ); ?>

--- a/app/bundles/StageBundle/Views/SubscribedEvents/Search/global.html.php
+++ b/app/bundles/StageBundle/Views/SubscribedEvents/Search/global.html.php
@@ -11,13 +11,13 @@
 ?>
 
 <?php if (!empty($showMore)): ?>
-    <a href="<?php echo $view['router']->generate('mautic_stage_index', ['search' => $searchString]); ?>" data-toggle="ajax">
+    <a href="<?php echo $view['router']->url('mautic_stage_index', ['search' => $searchString]); ?>" data-toggle="ajax">
         <span><?php echo $view['translator']->trans('mautic.core.search.more', ['%count%' => $remaining]); ?></span>
     </a>
 </div>
 <?php else: ?>
 <?php if ($canEdit): ?>
-<a href="<?php echo $view['router']->generate('mautic_stage_action', ['objectAction' => 'edit', 'objectId' => $item->getId()]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->url('mautic_stage_action', ['objectAction' => 'edit', 'objectId' => $item->getId()]); ?>" data-toggle="ajax">
     <?php echo $item->getName(); ?>
 </a>
 <?php else: ?>

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -491,7 +491,7 @@ class UserController extends FormController
                         'details'   => $details,
                         'ipAddress' => $this->factory->getIpAddressFromRequest(),
                     ];
-                    $this->getModel('core.auditLog')->writeToLog($log);
+                    $this->getModel('core.auditlog')->writeToLog($log);
 
                     $this->addFlash('mautic.user.user.notice.messagesent', ['%name%' => $user->getName()]);
                 }

--- a/app/bundles/UserBundle/Views/SubscribedEvents/Search/global_role.html.php
+++ b/app/bundles/UserBundle/Views/SubscribedEvents/Search/global_role.html.php
@@ -11,12 +11,12 @@
 ?>
 
 <?php if (!empty($showMore)): ?>
-<a href="<?php echo $view['router']->generate('mautic_role_index', ['filter-user' => $searchString]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->url('mautic_role_index', ['filter-user' => $searchString]); ?>" data-toggle="ajax">
     <span><?php echo $view['translator']->trans('mautic.core.search.more', ['%count%' => $remaining]); ?></span>
 </a>
 <?php else: ?>
 <?php if ($canEdit): ?>
-<a href="<?php echo $view['router']->generate('mautic_role_action', ['objectAction' => 'edit', 'objectId' => $role->getId()]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->url('mautic_role_action', ['objectAction' => 'edit', 'objectId' => $role->getId()]); ?>" data-toggle="ajax">
     <?php echo $role->getName(true); ?>
 </a>
 <?php else: ?>

--- a/app/bundles/UserBundle/Views/SubscribedEvents/Search/global_user.html.php
+++ b/app/bundles/UserBundle/Views/SubscribedEvents/Search/global_user.html.php
@@ -11,7 +11,7 @@
 ?>
 
 <?php if (!empty($showMore)): ?>
-<a href="<?php echo $view['router']->generate('mautic_user_index', ['filter-user' => $searchString]); ?>" data-toggle="ajax">
+<a href="<?php echo $view['router']->url('mautic_user_index', ['filter-user' => $searchString]); ?>" data-toggle="ajax">
     <span><?php echo $view['translator']->trans('mautic.core.search.more', ['%count%' => $remaining]); ?></span>
 </a>
 <?php else: ?>
@@ -20,7 +20,7 @@
         <span class="img-wrapper img-rounded"><img src="<?php echo $view['gravatar']->getImage($user->getEmail(), '100'); ?>" /></span>
     </span>
     <?php if ($canEdit): ?>
-    <a href="<?php echo $view['router']->generate('mautic_user_action', ['objectAction' => 'edit', 'objectId' => $user->getId()]); ?>" data-toggle="ajax">
+    <a href="<?php echo $view['router']->url('mautic_user_action', ['objectAction' => 'edit', 'objectId' => $user->getId()]); ?>" data-toggle="ajax">
         <?php echo $user->getName(true); ?>
     </a>
     <?php else: ?>


### PR DESCRIPTION
The auditlog model was being called incorrectly, causing many areas in the 3.x branch to fail to load. Also, views using the removed `generate` method on the symfony view RouterHelper were updated to use the URL method instead.

Testing: 
In dev mode, contact detail pages won't load due to fetching a model by the incorrect name (`core.auditLog` camelcase instead of `core.auditlog` lowercase)
For the view routerhelper - in dev mode I couldn't get search views to load that used the `$view['router']->generate` method, had to update those to be `$view['router']->url`. We used those in the search views from each bundle (as seen in the files for this PR)