### PR TITLE
Return unique clicked stats in email detail stats graph

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -748,7 +748,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             $sentCounts         = $statRepo->getSentCount($emailIds, $lists->getKeys(), $query);
             $readCounts         = $statRepo->getReadCount($emailIds, $lists->getKeys(), $query);
             $failedCounts       = $statRepo->getFailedCount($emailIds, $lists->getKeys(), $query);
-            $clickCounts        = $trackableRepo->getCount('email', $em ailIds, $lists->getKeys(), $query, false, 'DISTINCT .ph.lead_id');
+            $clickCounts        = $trackableRepo->getCount('email', $emailIds, $lists->getKeys(), $query, false, 'DISTINCT .ph.lead_id');
             $unsubscribedCounts = $dncRepo->getCount('email', $emailIds, DoNotContact::UNSUBSCRIBED, $lists->getKeys(), $query);
             $bouncedCounts      = $dncRepo->getCount('email', $emailIds, DoNotContact::BOUNCED, $lists->getKeys(), $query);
 

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -748,7 +748,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             $sentCounts         = $statRepo->getSentCount($emailIds, $lists->getKeys(), $query);
             $readCounts         = $statRepo->getReadCount($emailIds, $lists->getKeys(), $query);
             $failedCounts       = $statRepo->getFailedCount($emailIds, $lists->getKeys(), $query);
-            $clickCounts        = $trackableRepo->getCount('email', $emailIds, $lists->getKeys(), $query);
+            $clickCounts        = $trackableRepo->getCount('email', $em ailIds, $lists->getKeys(), $query, false, 'DISTINCT .ph.lead_id');
             $unsubscribedCounts = $dncRepo->getCount('email', $emailIds, DoNotContact::UNSUBSCRIBED, $lists->getKeys(), $query);
             $bouncedCounts      = $dncRepo->getCount('email', $emailIds, DoNotContact::BOUNCED, $lists->getKeys(), $query);
 
@@ -780,7 +780,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
                 $statRepo->getSentCount($emailIds, $lists->getKeys(), $query, true),
                 $statRepo->getReadCount($emailIds, $lists->getKeys(), $query, true),
                 $statRepo->getFailedCount($emailIds, $lists->getKeys(), $query, true),
-                $trackableRepo->getCount('email', $emailIds, $lists->getKeys(), $query, true),
+                $trackableRepo->getCount('email', $emailIds, $lists->getKeys(), $query, true, 'DISTINCT .ph.lead_id'),
                 $dncRepo->getCount('email', $emailIds, DoNotContact::UNSUBSCRIBED, $lists->getKeys(), $query, true),
                 $dncRepo->getCount('email', $emailIds, DoNotContact::BOUNCED, $lists->getKeys(), $query, true),
             ];

--- a/app/bundles/PageBundle/Entity/TrackableRepository.php
+++ b/app/bundles/PageBundle/Entity/TrackableRepository.php
@@ -141,13 +141,15 @@ class TrackableRepository extends CommonRepository
      * @param $channel
      * @param $channelIds
      * @param $listId
+     * @param bool $combined
+     * @param string $countColumn
      *
      * @return array|int
      */
-    public function getCount($channel, $channelIds, $listId, ChartQuery $chartQuery = null, $combined = false)
+    public function getCount($channel, $channelIds, $listId, ChartQuery $chartQuery = null, $combined = false, $countColumn = 'ph.id')
     {
         $q = $this->_em->getConnection()->createQueryBuilder()
-            ->select('count(ph.id) as click_count')
+            ->select('count('.$countColumn.') as click_count')
             ->from(MAUTIC_TABLE_PREFIX.'channel_url_trackables', 'cut')
             ->innerJoin('cut', MAUTIC_TABLE_PREFIX.'page_hits', 'ph', 'ph.redirect_id = cut.redirect_id AND ph.source = cut.channel AND ph.source_id = cut.channel_id');
 

--- a/app/bundles/PageBundle/Entity/TrackableRepository.php
+++ b/app/bundles/PageBundle/Entity/TrackableRepository.php
@@ -141,7 +141,7 @@ class TrackableRepository extends CommonRepository
      * @param $channel
      * @param $channelIds
      * @param $listId
-     * @param bool $combined
+     * @param bool   $combined
      * @param string $countColumn
      *
      * @return array|int


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
We noticed graphs in segment email display total clicks for email.  
But graph display data are related to send volume, then we expect clicked related to send volume.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create segment email with two links
2. Create two contacts and send segment email to contacts
3. Open both emails and click few times on links
4: Go to Email detail and see If graph show to many clicks. We expect 2 sent/read/clicked emails

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps and see If  stats are correct
