### PR TITLE
M3 refactor on campaign trigger action send email to user

### DIFF
--- a/app/bundles/CampaignBundle/Entity/Event.php
+++ b/app/bundles/CampaignBundle/Entity/Event.php
@@ -528,7 +528,7 @@ class Event implements ChannelInterface
     public function setType($type)
     {
         $this->isChanged('type', $type);
-        $this->type = $type;
+        $this->eventType = $type;
 
         return $this;
     }
@@ -540,7 +540,7 @@ class Event implements ChannelInterface
      */
     public function getType()
     {
-        return $this->type;
+        return $this->eventType;
     }
 
     /**

--- a/app/bundles/CampaignBundle/Entity/Event.php
+++ b/app/bundles/CampaignBundle/Entity/Event.php
@@ -528,7 +528,7 @@ class Event implements ChannelInterface
     public function setType($type)
     {
         $this->isChanged('type', $type);
-        $this->eventType = $type;
+        $this->type = $type;
 
         return $this;
     }
@@ -540,7 +540,7 @@ class Event implements ChannelInterface
      */
     public function getType()
     {
-        return $this->eventType;
+        return $this->type;
     }
 
     /**

--- a/app/bundles/CampaignBundle/Entity/LeadEventLog.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLog.php
@@ -43,7 +43,7 @@ class LeadEventLog implements ChannelInterface
     private $campaign;
 
     /**
-     * @var \Mautic\CoreBundle\Entity\IpAddress
+     * @var IpAddress
      */
     private $ipAddress;
 

--- a/app/bundles/CampaignBundle/Event/ContextTrait.php
+++ b/app/bundles/CampaignBundle/Event/ContextTrait.php
@@ -11,12 +11,16 @@
 
 namespace Mautic\CampaignBundle\Event;
 
+use Mautic\CampaignBundle\Entity\Event;
+
 trait ContextTrait
 {
     /**
      * Check if an event is applicable.
      *
      * @param $eventType
+     *
+     * @return bool
      */
     public function checkContext($eventType)
     {
@@ -24,7 +28,7 @@ trait ContextTrait
             return false;
         }
 
-        $type = ($this->event instanceof \Mautic\CampaignBundle\Entity\Event) ? $this->event->getType() : $this->event['type'];
+        $type = ($this->event instanceof Event) ? $this->event->getType() : $this->event['type'];
 
         return strtolower($eventType) === strtolower($type);
     }

--- a/app/bundles/CampaignBundle/Event/PendingEvent.php
+++ b/app/bundles/CampaignBundle/Event/PendingEvent.php
@@ -47,11 +47,11 @@ class PendingEvent extends AbstractLogCollectionEvent
     private $now;
 
     /**
-     * PendingEvent constructor.
-     *
      * @param AbstractEventAccessor $config
      * @param Event                 $event
      * @param ArrayCollection       $logs
+     *
+     * @throws \Exception
      */
     public function __construct(AbstractEventAccessor $config, Event $event, ArrayCollection $logs)
     {

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -165,10 +165,8 @@ return [
             'mautic.email.campaignbundle.subscriber' => [
                 'class'     => \Mautic\EmailBundle\EventListener\CampaignSubscriber::class,
                 'arguments' => [
-                    'mautic.lead.model.lead',
                     'mautic.email.model.email',
                     'mautic.campaign.model.event',
-                    'mautic.channel.model.queue',
                     'mautic.email.model.send_email_to_user',
                     'translator',
                 ],

--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -17,7 +17,6 @@ use Mautic\CampaignBundle\Event\CampaignBuilderEvent;
 use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
 use Mautic\CampaignBundle\Event\PendingEvent;
 use Mautic\CampaignBundle\Model\EventModel;
-use Mautic\ChannelBundle\Model\MessageQueueModel;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Event\EmailOpenEvent;
@@ -30,7 +29,6 @@ use Mautic\EmailBundle\Helper\UrlMatcher;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\EmailBundle\Model\SendEmailToUser;
 use Mautic\LeadBundle\Entity\Lead;
-use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PageBundle\Entity\Hit;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -41,19 +39,9 @@ use Symfony\Component\Translation\TranslatorInterface;
 class CampaignSubscriber implements EventSubscriberInterface
 {
     /**
-     * @var LeadModel
-     */
-    private $leadModel;
-
-    /**
      * @var EmailModel
      */
     private $emailModel;
-
-    /**
-     * @var EmailModel
-     */
-    private $messageQueueModel;
 
     /**
      * @var EventModel
@@ -71,24 +59,19 @@ class CampaignSubscriber implements EventSubscriberInterface
     private $translator;
 
     /**
-     * @param LeadModel         $leadModel
-     * @param EmailModel        $emailModel
-     * @param EventModel        $eventModel
-     * @param MessageQueueModel $messageQueueModel
-     * @param SendEmailToUser   $sendEmailToUser
+     * @param EmailModel          $emailModel
+     * @param EventModel          $eventModel
+     * @param SendEmailToUser     $sendEmailToUser
+     * @param TranslatorInterface $translator
      */
     public function __construct(
-        LeadModel $leadModel,
         EmailModel $emailModel,
         EventModel $eventModel,
-        MessageQueueModel $messageQueueModel,
         SendEmailToUser $sendEmailToUser,
         TranslatorInterface $translator
     ) {
-        $this->leadModel          = $leadModel;
         $this->emailModel         = $emailModel;
         $this->campaignEventModel = $eventModel;
-        $this->messageQueueModel  = $messageQueueModel;
         $this->sendEmailToUser    = $sendEmailToUser;
         $this->translator         = $translator;
     }

--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -25,6 +25,7 @@ use Mautic\EmailBundle\Event\EmailReplyEvent;
 use Mautic\EmailBundle\Exception\EmailCouldNotBeSentException;
 use Mautic\EmailBundle\Form\Type\EmailClickDecisionType;
 use Mautic\EmailBundle\Form\Type\EmailSendType;
+use Mautic\EmailBundle\Form\Type\EmailToUserType;
 use Mautic\EmailBundle\Helper\UrlMatcher;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\EmailBundle\Model\SendEmailToUser;
@@ -183,7 +184,7 @@ class CampaignSubscriber implements EventSubscriberInterface
                 'label'                => 'mautic.email.campaign.event.send.to.user',
                 'description'          => 'mautic.email.campaign.event.send.to.user_descr',
                 'batchEventName'       => EmailEvents::ON_CAMPAIGN_BATCH_ACTION,
-                'formType'             => 'email_to_user',
+                'formType'             => EmailToUserType::class,
                 'formTypeOptions'      => ['update_select' => 'campaignevent_properties_useremail_email'],
                 'formTheme'            => 'MauticEmailBundle:FormTheme\EmailSendList',
                 'channel'              => 'email',

--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -374,6 +374,8 @@ class CampaignSubscriber implements EventSubscriberInterface
 
     /**
      * @param PendingEvent $event
+     *
+     * @throws ORMException
      */
     public function onCampaignTriggerActionSendEmailToUser(PendingEvent $event): void
     {

--- a/app/bundles/EmailBundle/Model/SendEmailToUser.php
+++ b/app/bundles/EmailBundle/Model/SendEmailToUser.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\EmailBundle\Model;
 
+use Doctrine\ORM\ORMException;
 use Mautic\EmailBundle\Exception\EmailCouldNotBeSentException;
 use Mautic\EmailBundle\OptionsAccessor\EmailToUserAccessor;
 use Mautic\LeadBundle\Entity\Lead;
@@ -18,7 +19,9 @@ use Mautic\UserBundle\Hash\UserHash;
 
 class SendEmailToUser
 {
-    /** @var EmailModel */
+    /**
+     * @var EmailModel
+     */
     private $emailModel;
 
     public function __construct(EmailModel $emailModel)
@@ -31,6 +34,7 @@ class SendEmailToUser
      * @param Lead  $lead
      *
      * @throws EmailCouldNotBeSentException
+     * @throws ORMException
      */
     public function sendEmailToUsers(array $config, Lead $lead)
     {

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -87,7 +87,7 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
     public function testOnCampaignTriggerActionSendEmailToUserWithWrongEventType()
     {
         $eventAccessor = $this->createMock(ActionAccessor::class);
-        $event         = (new Event())->setEventType('email.send');
+        $event         = new Event();
         $lead          = (new Lead())->setEmail('tester@mautic.org');
 
         $leadEventLog = $this->createMock(LeadEventLog::class);
@@ -109,7 +109,7 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
     public function testOnCampaignTriggerActionSendEmailToUserWithSendingTheEmail()
     {
         $eventAccessor = $this->createMock(ActionAccessor::class);
-        $event         = (new Event())->setEventType('email.send.to.user');
+        $event         = (new Event())->setType('email.send.to.user');
         $lead          = (new Lead())->setEmail('tester@mautic.org');
 
         $leadEventLog = $this->createMock(LeadEventLog::class);

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -108,7 +108,19 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testOnCampaignTriggerActionSendEmailToUserWithSendingTheEmail()
     {
-        $lead = new Lead();
+        $eventAccessor = $this->createMock(ActionAccessor::class);
+        $event         = (new Event())->setEventType('email.send');
+        $lead          = (new Lead())->setEmail('tester@mautic.org');
+
+        $leadEventLog = $this->createMock(LeadEventLog::class);
+        $leadEventLog
+            ->method('getLead')
+            ->willReturn($lead);
+        $leadEventLog
+            ->method('getId')
+            ->willReturn(6);
+
+        $logs = new ArrayCollection([$leadEventLog]);
 
         $args = [
             'lead'  => $lead,
@@ -122,12 +134,11 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
             'eventSettings'   => [],
         ];
 
-        $mockSendEmailToUser->expects($this->once())
+        $this->sendEmailToUser->expects($this->once())
             ->method('sendEmailToUsers')
             ->with($this->config, $lead);
 
-        $event = new CampaignExecutionEvent($args, false);
-
+        $event = new PendingEvent($eventAccessor, $event, $logs);
         $this->subscriber->onCampaignTriggerActionSendEmailToUser($event);
 
         $this->assertTrue($event->getResult());

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -18,13 +18,11 @@ use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
 use Mautic\CampaignBundle\Event\PendingEvent;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\ActionAccessor;
 use Mautic\CampaignBundle\Model\EventModel;
-use Mautic\ChannelBundle\Model\MessageQueueModel;
 use Mautic\EmailBundle\EventListener\CampaignSubscriber;
 use Mautic\EmailBundle\Exception\EmailCouldNotBeSentException;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\EmailBundle\Model\SendEmailToUser;
 use Mautic\LeadBundle\Entity\Lead;
-use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
@@ -100,10 +98,11 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $logs = new ArrayCollection([$leadEventLog]);
 
-        $event = new PendingEvent($eventAccessor, $event, $logs);
-        $this->subscriber->onCampaignTriggerActionSendEmailToUser($event);
+        $pendingEvent = new PendingEvent($eventAccessor, $event, $logs);
+        $this->subscriber->onCampaignTriggerActionSendEmailToUser($pendingEvent);
 
-        $this->assertCount(0, $event->getSuccessful());
+        $this->assertCount(0, $pendingEvent->getSuccessful());
+        $this->assertCount(0, $pendingEvent->getFailures());
     }
 
     public function testOnCampaignTriggerActionSendEmailToUserWithSendingTheEmail()
@@ -126,41 +125,16 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $logs = new ArrayCollection([$leadEventLog]);
 
-        $eventType = new PendingEvent($eventAccessor, $event, $logs);
-        $this->subscriber->onCampaignTriggerActionSendEmailToUser($eventType);
+        $pendingEvent = new PendingEvent($eventAccessor, $event, $logs);
+        $this->subscriber->onCampaignTriggerActionSendEmailToUser($pendingEvent);
 
-        $this->assertCount(1, $eventType->getSuccessful());
+        $this->assertCount(1, $pendingEvent->getSuccessful());
+        $this->assertCount(0, $pendingEvent->getFailures());
     }
 
     public function testOnCampaignTriggerActionSendEmailToUserWithError()
     {
         $lead = new Lead();
-
-        $mockLeadModel = $this->getMockBuilder(LeadModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $mockEmailModel = $this->getMockBuilder(EmailModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $mockEventModel = $this->getMockBuilder(EventModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $mockMessageQueueModel = $this->getMockBuilder(MessageQueueModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $mockSendEmailToUser = $this->getMockBuilder(SendEmailToUser::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $mockTranslator = $this->getMockBuilder(TranslatorInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $subscriber = new CampaignSubscriber($mockLeadModel, $mockEmailModel, $mockEventModel, $mockMessageQueueModel, $mockSendEmailToUser, $mockTranslator);
 
         $args = [
             'lead'  => $lead,


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8058
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
https://github.com/mautic/mautic/issues/8058

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create campaign with action Send email to user
3. Trigger campaign and check if email was sent to user properly

#### List backwards compatibility breaks:
1. 'email.send.to.user' action is now using  `EmailEvents::ON_CAMPAIGN_BATCH_ACTION` instead of `EmailEvents::ON_CAMPAIGN_TRIGGER_ACTION`