### PR TITLE
M3: fix form buttons

### DIFF
--- a/app/bundles/CoreBundle/Controller/AbstractFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractFormController.php
@@ -141,27 +141,27 @@ abstract class AbstractFormController extends CommonController
      *
      * @param Form $form
      *
-     * @return int
+     * @return bool
      */
     protected function isFormCancelled(Form $form)
     {
-        $name = $form->getName();
+        $formData = $this->request->request->get($form->getName());
 
-        return false !== $this->request->request->get($name.'[buttons][cancel]', false, true);
+        return array_key_exists('buttons', $formData) && array_key_exists('cancel', $formData['buttons']);
     }
 
     /**
      * Checks to see if the form was applied or saved.
      *
-     * @param $form
+     * @param Form $form
      *
      * @return bool
      */
-    protected function isFormApplied($form)
+    protected function isFormApplied(Form $form)
     {
-        $name = $form->getName();
+        $formData = $this->request->request->get($form->getName());
 
-        return false !== $this->request->request->get($name.'[buttons][apply]', false, true);
+        return array_key_exists('buttons', $formData) && array_key_exists('apply', $formData['buttons']);
     }
 
     /**


### PR DESCRIPTION
Contact, Role, User, etc forms in Mautic would never be able to be cancelled - they all treated a `Cancel` button click as an `Apply`. This was due to usage of deprecated deep item access in the AbstractFormController `isFormCancelled` and `isFormApplied` code. 

This PR fixes that.

Testing:
1) In the 3.x branch, edit a contact in your Mautic instance, but click Cancel. 
2) See that the form is submitted and the contact is updated.
3) On this branch, do the same.
4) See that the form is cancelled and the contact is not updated.
5) Repeat for various other forms (companies, forms, campaigns, etc) to spot check.