### PR TITLE
Add regex to check if serialized string contain an object

### DIFF
--- a/app/bundles/CoreBundle/Helper/Serializer.php
+++ b/app/bundles/CoreBundle/Helper/Serializer.php
@@ -16,7 +16,7 @@ class Serializer
     /**
      * Unserializing a string can be a security vulnerability as it can contain classes that can execute a PHP code.
      * PHP >=7 has the `['allowed_classes' => false]` option to disable classes altogether or whitelist those needed.
-     * PHP <7 do not accept the second parameter, throw warning and return false so we have to handle it diffenetly.
+     * PHP <7 do not accept the second parameter, throw warning and return false so we have to handle it differently.
      * This helper method is secure for PHP >= 7 by default and handle all PHP versions.
      *
      * PHP does not recommend untrusted user input even with ['allowed_classes' => false]
@@ -28,7 +28,7 @@ class Serializer
      */
     public static function decode($serializedString, array $options = ['allowed_classes' => false])
     {
-        if (stripos($serializedString, 'o:') !== false) {
+        if (preg_match('/(^|;|{|})O:\+?[0-9]+:"/', $serializedString) === 1) {
             throw new \InvalidArgumentException(sprintf('The string %s contains an object.', $serializedString));
         }
 


### PR DESCRIPTION
closes https://github.com/mautic/mautic/issues/8158
closes https://github.com/mautic/mautic/issues/8142
closes https://github.com/mautic/mautic/issues/8126
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Error appear when deserializing array from database due to 'o:' contain in string, like "No:".

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a test page with o: in the page title
2. Visit the page (in incognito mode)
3. See that the contact created can't be opened
4. Check to see errors in the logs
`[2019-12-30 09:37:38] mautic.CRITICAL: Uncaught PHP Exception InvalidArgumentException: "The string a:12:{s:10:"page_title";s:67:"No: foo test";s:13:"page_language";s:2:"fr";s:13:"page_referrer";s:13:"www.foo.com";s:8:"page_url";s:47:"https://www.foo.com/test";s:7:"counter";s:1:"0";s:16:"mautic_device_id";s:23:"j2rh1xs8fxk5r8de1f7mwgd";s:10:"resolution";s:7:"851x393";s:15:"timezone_offset";s:3:"-60";s:8:"platform";s:12:"Linux armv8l";s:12:"do_not_track";s:7:"unknown";s:7:"adblock";s:5:"false";s:11:"fingerprint";s:32:"0cdd95fd3b844a04d821b54e3a34bad6";} contains an object." at /app/bundles/CoreBundle/Helper/Serializer.php line 36`

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/8266)
2. See that the contact created can be opened
