### PR TITLE
Fix package release script for m3

### DIFF
--- a/build/package_release.php
+++ b/build/package_release.php
@@ -57,25 +57,25 @@ if (!isset($args['repackage'])) {
     passthru($systemGit.' ls-tree -r -t --name-only '.$gitSource, $releaseFiles);
     $releaseFiles = explode("\n", trim(ob_get_clean()));
 
-    if ($result !== 0) {
+    if (0 !== $result) {
         exit;
     }
 
     chdir(__DIR__);
     system('cd '.__DIR__.'/packaging && composer install --no-dev --no-scripts --optimize-autoloader && cd ..', $result);
-    if ($result !== 0) {
+    if (0 !== $result) {
         exit;
     }
 
     // Generate the bootstrap.php.cache file
     system(__DIR__.'/packaging/vendor/sensio/distribution-bundle/Resources/bin/build_bootstrap.php', $result);
-    if ($result !== 0) {
+    if (0 !== $result) {
         exit;
     }
 
     // Compile prod assets
-    system('cd '.__DIR__.'/packaging && php '.__DIR__.'/packaging/app/console mautic:assets:generate -e prod', $result);
-    if ($result !== 0) {
+    system('cd '.__DIR__.'/packaging && php '.__DIR__.'/packaging/bin/console mautic:assets:generate -e prod', $result);
+    if (0 !== $result) {
         exit;
     }
 
@@ -110,11 +110,11 @@ if (!isset($args['repackage'])) {
             $folderPath     = explode('/', $filename);
             $baseFolderName = $folderPath[0];
 
-            if (!$vendorsChanged && $filename == 'composer.lock') {
+            if (!$vendorsChanged && 'composer.lock' == $filename) {
                 $vendorsChanged = true;
             }
 
-            if (substr($file, 0, 1) == 'D') {
+            if ('D' == substr($file, 0, 1)) {
                 if (!in_array($filename, $releaseFiles)) {
                     $deletedFiles[$filename] = true;
                 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8260
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

In M3 the console script was moved from the app to the bin directory. That was the only issue in the build script

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run `php build/package_release.php -b=3.x`
2. It will fail with an error that app/console does not exist

#### Steps to test this PR:
1. Run the command again
2. It will finish and create production zip files in build/packages dir