### PR TITLE
M3 oauth fix

### DIFF
--- a/app/bundles/ApiBundle/Config/config.php
+++ b/app/bundles/ApiBundle/Config/config.php
@@ -97,6 +97,23 @@ return [
     ],
 
     'services' => [
+        'controllers' => [
+            'mautic.api' => [
+                'class'     => \Mautic\ApiBundle\Controller\oAuth2\AuthorizeController::class,
+                'arguments' => [
+                    'request_stack',
+                    'fos_oauth_server.authorize.form',
+                    'fos_oauth_server.authorize.form.handler.default',
+                    'fos_oauth_server.server',
+                    'templating',
+                    'security.token_storage',
+                    'router',
+                    'fos_oauth_server.client_manager.default',
+                    'event_dispatcher',
+                    'session',
+                ],
+            ],
+        ],
         'events' => [
             'mautic.api.subscriber' => [
                 'class'     => \Mautic\ApiBundle\EventListener\ApiSubscriber::class,

--- a/app/bundles/ApiBundle/Config/config.php
+++ b/app/bundles/ApiBundle/Config/config.php
@@ -127,13 +127,13 @@ return [
         ],
         'forms' => [
             'mautic.form.type.apiclients' => [
-                'class'     => 'Mautic\ApiBundle\Form\Type\ClientType',
+                'class'     => \Mautic\ApiBundle\Form\Type\ClientType::class,
                 'arguments' => [
                     'request_stack',
                     'translator',
                     'validator',
-                    'router',
                     'session',
+                    'router',
                 ],
             ],
             'mautic.form.type.apiconfig' => [

--- a/app/bundles/ApiBundle/Controller/oAuth1/AuthorizeController.php
+++ b/app/bundles/ApiBundle/Controller/oAuth1/AuthorizeController.php
@@ -19,9 +19,6 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-/**
- * Class AuthorizeController.
- */
 class AuthorizeController extends Controller
 {
     /**
@@ -36,11 +33,9 @@ class AuthorizeController extends Controller
     {
         $oauth_token    = $request->get('oauth_token', null);
         $oauth_callback = $request->get('oauth_callback', null);
-
-        $securityContext = $this->container->get('security.token_storage');
-        $tokenProvider   = $this->container->get('bazinga.oauth.provider.token_provider');
-
-        $user = $securityContext->getToken()->getUser();
+        $tokenStorage   = $this->container->get('security.token_storage');
+        $tokenProvider  = $this->container->get('bazinga.oauth.provider.token_provider');
+        $user           = $tokenStorage->getToken()->getUser();
 
         if (!$user instanceof UserInterface) {
             throw new AccessDeniedException('This user does not have access to this section.');
@@ -55,7 +50,7 @@ class AuthorizeController extends Controller
         }
 
         if ($token instanceof RequestTokenInterface) {
-            $tokenProvider->setUserForRequestToken($token, $securityContext->getToken()->getUser());
+            $tokenProvider->setUserForRequestToken($token, $tokenStorage->getToken()->getUser());
 
             return new Response($this->container->get('templating')->render('MauticApiBundle:Authorize:oAuth1/authorize.html.php', [
                 'consumer'       => $token->getConsumer(),

--- a/app/bundles/ApiBundle/Controller/oAuth1/SecurityController.php
+++ b/app/bundles/ApiBundle/Controller/oAuth1/SecurityController.php
@@ -15,7 +15,7 @@ use Mautic\CoreBundle\Controller\CommonController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception as Exception;
-use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\Security\Core\Security;
 
 class SecurityController extends CommonController
 {
@@ -29,11 +29,11 @@ class SecurityController extends CommonController
         $session = $request->getSession();
 
         //get the login error if there is one
-        if ($request->attributes->has(SecurityContext::AUTHENTICATION_ERROR)) {
-            $error = $request->attributes->get(SecurityContext::AUTHENTICATION_ERROR);
+        if ($request->attributes->has(Security::AUTHENTICATION_ERROR)) {
+            $error = $request->attributes->get(Security::AUTHENTICATION_ERROR);
         } else {
-            $error = $session->get(SecurityContext::AUTHENTICATION_ERROR);
-            $session->remove(SecurityContext::AUTHENTICATION_ERROR);
+            $error = $session->get(Security::AUTHENTICATION_ERROR);
+            $session->remove(Security::AUTHENTICATION_ERROR);
         }
         if (!empty($error)) {
             if (($error instanceof Exception\BadCredentialsException)) {
@@ -48,7 +48,7 @@ class SecurityController extends CommonController
         return $this->render(
             'MauticApiBundle:Security:login.html.php',
             [
-                'last_username' => $session->get(SecurityContext::LAST_USERNAME),
+                'last_username' => $session->get(Security::LAST_USERNAME),
                 'route'         => 'mautic_oauth1_server_auth_login_check',
             ]
         );

--- a/app/bundles/ApiBundle/Controller/oAuth2/AuthorizeController.php
+++ b/app/bundles/ApiBundle/Controller/oAuth2/AuthorizeController.php
@@ -12,64 +12,138 @@
 namespace Mautic\ApiBundle\Controller\oAuth2;
 
 use FOS\OAuthServerBundle\Event\OAuthEvent;
+use FOS\OAuthServerBundle\Form\Handler\AuthorizeFormHandler;
+use FOS\OAuthServerBundle\Model\ClientManagerInterface;
+use OAuth2\OAuth2;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-/**
- * Class AuthorizeController.
- */
 class AuthorizeController extends \FOS\OAuthServerBundle\Controller\AuthorizeController
 {
     /**
-     * Authorize.
-     *
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var Form
+     */
+    private $authorizeForm;
+
+    /**
+     * @var AuthorizeFormHandler
+     */
+    private $authorizeFormHandler;
+
+    /**
+     * @var OAuth2
+     */
+    private $oAuth2Server;
+
+    /**
+     * @var EngineInterface
+     */
+    private $templating;
+
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * This constructor must be duplicated from the extended class so our custom code could access the properties.
+     */
+    public function __construct(
+        RequestStack $requestStack,
+        Form $authorizeForm,
+        AuthorizeFormHandler $authorizeFormHandler,
+        OAuth2 $oAuth2Server,
+        EngineInterface $templating,
+        TokenStorageInterface $tokenStorage,
+        UrlGeneratorInterface $router,
+        ClientManagerInterface $clientManager,
+        EventDispatcherInterface $eventDispatcher,
+        SessionInterface $session = null,
+        $templateEngineType = 'php'
+    ) {
+        $this->session              = $session;
+        $this->authorizeForm        = $authorizeForm;
+        $this->authorizeFormHandler = $authorizeFormHandler;
+        $this->oAuth2Server         = $oAuth2Server;
+        $this->templating           = $templating;
+        $this->tokenStorage         = $tokenStorage;
+        $this->eventDispatcher      = $eventDispatcher;
+
+        parent::__construct(
+            $requestStack,
+            $authorizeForm,
+            $authorizeFormHandler,
+            $oAuth2Server,
+            $templating,
+            $tokenStorage,
+            $router,
+            $clientManager,
+            $eventDispatcher,
+            $session,
+            $templateEngineType
+        );
+    }
+
+    /**
      * @param Request $request
      *
      * @return \FOS\OAuthServerBundle\Controller\Response|\Symfony\Component\HttpFoundation\Response
      *
      * @throws \OAuth2\OAuth2RedirectException
      * @throws AccessDeniedException
-     *
-     * @author Chris Jones <leeked@gmail.com>
      */
     public function authorizeAction(Request $request)
     {
-        $user = $this->container->get('security.token_storage')->getToken()->getUser();
+        $user = $this->tokenStorage->getToken()->getUser();
 
         if (!$user instanceof UserInterface) {
             throw new AccessDeniedException('This user does not have access to this section.');
         }
 
-        if (true === $this->container->get('session')->get('_fos_oauth_server.ensure_logout')) {
-            $this->container->get('session')->invalidate(600);
-            $this->container->get('session')->set('_fos_oauth_server.ensure_logout', true);
+        if (true === $this->session->get('_fos_oauth_server.ensure_logout')) {
+            $this->session->invalidate(600);
+            $this->session->set('_fos_oauth_server.ensure_logout', true);
         }
 
-        $form        = $this->container->get('fos_oauth_server.authorize.form');
-        $formHandler = $this->container->get('fos_oauth_server.authorize.form.handler');
+        $event = new OAuthEvent($user, $this->getClient());
 
-        $event = $this->container->get('event_dispatcher')->dispatch(
+        $this->eventDispatcher->dispatch(
             OAuthEvent::PRE_AUTHORIZATION_PROCESS,
-            new OAuthEvent($user, $this->getClient())
+            $event
         );
 
         if ($event->isAuthorizedClient()) {
             $scope = $request->get('scope', null);
 
-            return $this->container
-                ->get('fos_oauth_server.server')
-                ->finishClientAuthorization(true, $user, $request, $scope);
+            return $this->oAuth2Server->finishClientAuthorization(true, $user, $request, $scope);
         }
 
-        if (true === $formHandler->process()) {
-            return $this->processSuccess($user, $formHandler, $request);
+        if (true === $this->authorizeFormHandler->process()) {
+            return $this->processSuccess($user, $this->authorizeFormHandler, $request);
         }
 
-        return $this->container->get('templating')->renderResponse(
+        return $this->templating->renderResponse(
             'MauticApiBundle:Authorize:oAuth2/authorize.html.php',
             [
-                'form'   => $form->createView(),
+                'form'   => $this->authorizeForm->createView(),
                 'client' => $this->getClient(),
             ]
         );

--- a/app/bundles/ApiBundle/Controller/oAuth2/SecurityController.php
+++ b/app/bundles/ApiBundle/Controller/oAuth2/SecurityController.php
@@ -15,11 +15,8 @@ use Mautic\CoreBundle\Controller\CommonController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception as Exception;
-use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\Security\Core\Security;
 
-/**
- * Class SecurityController.
- */
 class SecurityController extends CommonController
 {
     /**
@@ -32,11 +29,11 @@ class SecurityController extends CommonController
         $session = $request->getSession();
 
         //get the login error if there is one
-        if ($request->attributes->has(SecurityContext::AUTHENTICATION_ERROR)) {
-            $error = $request->attributes->get(SecurityContext::AUTHENTICATION_ERROR);
+        if ($request->attributes->has(Security::AUTHENTICATION_ERROR)) {
+            $error = $request->attributes->get(Security::AUTHENTICATION_ERROR);
         } else {
-            $error = $session->get(SecurityContext::AUTHENTICATION_ERROR);
-            $session->remove(SecurityContext::AUTHENTICATION_ERROR);
+            $error = $session->get(Security::AUTHENTICATION_ERROR);
+            $session->remove(Security::AUTHENTICATION_ERROR);
         }
         if (!empty($error)) {
             if (($error instanceof Exception\BadCredentialsException)) {
@@ -56,7 +53,7 @@ class SecurityController extends CommonController
         return $this->render(
             'MauticApiBundle:Security:login.html.php',
             [
-                'last_username' => $session->get(SecurityContext::LAST_USERNAME),
+                'last_username' => $session->get(Security::LAST_USERNAME),
                 'route'         => 'mautic_oauth2_server_auth_login_check',
             ]
         );

--- a/app/bundles/ApiBundle/Form/Type/ClientType.php
+++ b/app/bundles/ApiBundle/Form/Type/ClientType.php
@@ -161,28 +161,22 @@ class ClientType extends AbstractType
                 ]
             );
 
-            $translator = $this->translator;
-            $validator  = $this->validator;
-
             $builder->addEventListener(
                 FormEvents::POST_SUBMIT,
-                function (FormEvent $event) use ($translator, $validator) {
+                function (FormEvent $event) {
                     $form = $event->getForm();
                     $data = $event->getData();
 
                     if ($form->has('redirectUris')) {
                         foreach ($data->getRedirectUris() as $uri) {
                             $urlConstraint = new OAuthCallback();
-                            $urlConstraint->message = $translator->trans(
+                            $urlConstraint->message = $this->translator->trans(
                                 'mautic.api.client.redirecturl.invalid',
                                 ['%url%' => $uri],
                                 'validators'
                             );
 
-                            $errors = $validator->validateValue(
-                                $uri,
-                                $urlConstraint
-                            );
+                            $errors = $this->validator->validate($uri, $urlConstraint);
 
                             if (!empty($errors)) {
                                 foreach ($errors as $error) {

--- a/app/bundles/ApiBundle/Form/Type/ClientType.php
+++ b/app/bundles/ApiBundle/Form/Type/ClientType.php
@@ -30,9 +30,6 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-/**
- * Class ClientType.
- */
 class ClientType extends AbstractType
 {
     /**
@@ -56,8 +53,6 @@ class ClientType extends AbstractType
     private $router;
 
     /**
-     * Constructor.
-     *
      * @param RequestStack        $requestStack
      * @param TranslatorInterface $translator
      * @param ValidatorInterface  $validator
@@ -247,24 +242,18 @@ class ClientType extends AbstractType
                 ]
             );
 
-            $translator = $this->translator;
-            $validator  = $this->validator;
-
             $builder->addEventListener(
                 FormEvents::POST_SUBMIT,
-                function (FormEvent $event) use ($translator, $validator) {
+                function (FormEvent $event) {
                     $form = $event->getForm();
                     $data = $event->getData();
 
                     if ($form->has('callback')) {
                         $uri = $data->getCallback();
                         $urlConstraint = new OAuthCallback();
-                        $urlConstraint->message = $translator->trans('mautic.api.client.redirecturl.invalid', ['%url%' => $uri], 'validators');
+                        $urlConstraint->message = $this->translator->trans('mautic.api.client.redirecturl.invalid', ['%url%' => $uri], 'validators');
 
-                        $errors = $validator->validateValue(
-                            $uri,
-                            $urlConstraint
-                        );
+                        $errors = $this->validator->validate($uri, $urlConstraint);
 
                         if (!empty($errors)) {
                             foreach ($errors as $error) {

--- a/app/bundles/ApiBundle/Form/Validator/Constraints/OAuthCallback.php
+++ b/app/bundles/ApiBundle/Form/Validator/Constraints/OAuthCallback.php
@@ -11,17 +11,15 @@
 
 namespace Mautic\ApiBundle\Form\Validator\Constraints;
 
+use Mautic\ApiBundle\Form\Validator\Constraints\OAuthCallbackValidator;
 use Symfony\Component\Validator\Constraint;
 
-/**
- * @Annotation
- */
 class OAuthCallback extends Constraint
 {
     public $message = 'The callback URL is invalid.';
 
     public function validatedBy()
     {
-        return 'oauth_callback';
+        return OAuthCallbackValidator::class;
     }
 }

--- a/app/bundles/ApiBundle/Model/ClientModel.php
+++ b/app/bundles/ApiBundle/Model/ClientModel.php
@@ -15,6 +15,7 @@ use Mautic\ApiBundle\ApiEvents;
 use Mautic\ApiBundle\Entity\oAuth1\Consumer;
 use Mautic\ApiBundle\Entity\oAuth2\Client;
 use Mautic\ApiBundle\Event\ClientEvent;
+use Mautic\ApiBundle\Form\Type\ClientType;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\UserBundle\Entity\User;
 use Symfony\Component\EventDispatcher\Event;
@@ -22,9 +23,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 
-/**
- * Class ClientModel.
- */
 class ClientModel extends FormModel
 {
     /**
@@ -38,8 +36,6 @@ class ClientModel extends FormModel
     protected $session;
 
     /**
-     * ClientModel constructor.
-     *
      * @param RequestStack $requestStack
      */
     public function __construct(RequestStack $requestStack)
@@ -75,9 +71,9 @@ class ClientModel extends FormModel
     public function getRepository()
     {
         if ('oauth2' == $this->apiMode) {
-            return $this->em->getRepository('MauticApiBundle:oAuth2\Client');
+            return $this->em->getRepository(Client::class);
         } else {
-            return $this->em->getRepository('MauticApiBundle:oAuth1\Consumer');
+            return $this->em->getRepository(Consumer::class);
         }
     }
 
@@ -102,7 +98,7 @@ class ClientModel extends FormModel
 
         $params = (!empty($action)) ? ['action' => $action] : [];
 
-        return $formFactory->create('client', $entity, $params);
+        return $formFactory->create(ClientType::class, $entity, $params);
     }
 
     /**

--- a/app/bundles/ApiBundle/Security/OAuth1/Firewall/OAuthListener.php
+++ b/app/bundles/ApiBundle/Security/OAuth1/Firewall/OAuthListener.php
@@ -18,14 +18,9 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
-/**
- * Class OAuthListener.
- */
 class OAuthListener extends \Bazinga\OAuthServerBundle\Security\Firewall\OAuthListener
 {
     /**
-     * @author William DURAND <william.durand1@gmail.com>
-     *
      * @param GetResponseEvent $event
      *
      * @throws AuthenticationException
@@ -48,7 +43,7 @@ class OAuthListener extends \Bazinga\OAuthServerBundle\Security\Firewall\OAuthLi
             $returnValue = $this->authenticationManager->authenticate($token);
 
             if ($returnValue instanceof TokenInterface) {
-                return $this->securityContext->setToken($returnValue);
+                return $this->tokenStorage->setToken($returnValue);
             } elseif ($returnValue instanceof Response) {
                 return $event->setResponse($returnValue);
             }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | /
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8024
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Creating API credentials nor API access via Oauth1a did not work on the M3 branch. This PR fixes that. 

When I was in it, I tested also Oauth2 and it had similar issues so this PR fixes those too.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to create Oauth1 credentials
2. You won't be able to do that due to various errors.

#### Steps to test this PR:
1. Try now. You'll be able to create the credentials now. 
2. And you'll be also able to authenticate against Mautic with Oauth1 and make successful API requests. I used [API tester](https://github.com/mautic/api-library) to test that.
3. Test Oauth2 too. Clear session in the API tester for that.
