### PR TITLE
Fix field updates on sync from integration

### DIFF
--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -432,7 +432,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
                 return;
             }
 
-            $fieldsToUpdateInMautic = array_intersect_key($leadFields, $fieldsToUpdateInMautic);
+            $fieldsToUpdateInMautic = array_intersect_key($leadFields, array_flip($fieldsToUpdateInMautic));
             $matchedFields          = array_intersect_key($matchedFields, array_flip($fieldsToUpdateInMautic));
             if ((isset($config['updateBlanks']) && isset($config['updateBlanks'][0]) && $config['updateBlanks'][0] == 'updateBlanks')) {
                 $matchedFields = $this->getBlankFieldsToUpdateInMautic($matchedFields, $lead->getFields(true), $leadFields, $data, $object);


### PR DESCRIPTION
closes https://github.com/mautic/mautic/issues/4626
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | /
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | [4626](https://github.com/mautic/mautic/issues/4626)
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This fixes the issue [4626](https://github.com/mautic/mautic/issues/4626) where fields from an integration were not synced to Mautic by the plugin. This particular workaround had been manually patched in for several releases by a few folks and we'd now like to submit it into the official codebase as it's been tested in production for some time (since October 2017).

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
See repro steps in issue [4626](https://github.com/mautic/mautic/issues/4626) 

#### Steps to test this PR:
1. Connect your integration (follow documentation)
2. Create a contact in your integration
3. Run cronjob mautic:integration:fetchleads --integration=<integration-name>
Replacing <integration-name> with specific integration used (i.e. Hubspot).
4. See your contact appear in Mautic
5. Modify fields in the integration
6. Run step 3 to sync changes
7. Observe the contact fields in Mautic reflect the updates made in the integration as expected
