### PR TITLE
Segment filters based on entity select box fixes

### DIFF
--- a/app/bundles/LeadBundle/Views/List/form.html.php
+++ b/app/bundles/LeadBundle/Views/List/form.html.php
@@ -149,10 +149,10 @@ $filterErrors = ($view['form']->containsErrors($form['filters'])) ? 'class="text
         <select class="form-control not-chosen <?php echo $template; ?>" name="leadlist[filters][__name__][filter]" id="leadlist_filters___name___filter"<?php echo $attr; ?>>
             <?php
             if (isset($form->vars[$dataKey])):
-                foreach ($form->vars[$dataKey] as $value => $label):
-                    if (is_array($label)):
-                        echo "<optgroup label=\"$value\">\n";
-                        foreach ($label as $optionValue => $optionLabel):
+                foreach ($form->vars[$dataKey] as $label => $value):
+                    if (is_array($value)):
+                        echo "<optgroup label=\"$label\">\n";
+                        foreach ($value as $optionLabel => $optionValue):
                             echo "<option value=\"$optionValue\">$optionLabel</option>\n";
                         endforeach;
                         echo "</optgroup>\n";


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
@dongilbert noticed that the segment filters based on entity select boxes does not work correctly. This PR fixes that.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new segment filter based on asset downloads.
2. Change filter to including so you could see the select box.
3. Notice the list looks correct. You can see the asset IDs instead of labels.
4. Save the segment.
5. You get a validation error and if you check the asset select box now you can see labels instead of IDs.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Follow the steps now. There should not be any IDs visible in the select box and no validation error.
