### PR TITLE
M3 fix assets form

### DIFF
--- a/app/bundles/AssetBundle/Config/config.php
+++ b/app/bundles/AssetBundle/Config/config.php
@@ -9,9 +9,6 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-use Mautic\AssetBundle\EventListener\BuilderSubscriber;
-use Mautic\AssetBundle\EventListener\ReportSubscriber;
-
 return [
     'routes' => [
         'main' => [
@@ -89,14 +86,14 @@ return [
                 ],
             ],
             'mautic.asset.reportbundle.subscriber' => [
-                'class'     => ReportSubscriber::class,
+                'class'     => \Mautic\AssetBundle\EventListener\ReportSubscriber::class,
                 'arguments' => [
                     'mautic.lead.model.company_report_data',
                     'mautic.asset.repository.download',
                 ],
             ],
             'mautic.asset.builder.subscriber' => [
-                'class'     => BuilderSubscriber::class,
+                'class'     => \Mautic\AssetBundle\EventListener\BuilderSubscriber::class,
                 'arguments' => [
                     'mautic.security',
                     'mautic.asset.helper.token',
@@ -195,13 +192,13 @@ return [
         ],
         'others' => [
             'mautic.asset.upload.error.handler' => [
-                'class'     => 'Mautic\AssetBundle\ErrorHandler\DropzoneErrorHandler',
+                'class'     => \Mautic\AssetBundle\ErrorHandler\DropzoneErrorHandler::class,
                 'arguments' => 'mautic.factory',
             ],
             // Override the DropzoneController
             'oneup_uploader.controller.dropzone.class' => \Mautic\AssetBundle\Controller\UploadController::class,
             'mautic.asset.helper.token'                => [
-                'class'     => 'Mautic\AssetBundle\Helper\TokenHelper',
+                'class'     => \Mautic\AssetBundle\Helper\TokenHelper::class,
                 'arguments' => 'mautic.asset.model.asset',
             ],
         ],

--- a/app/bundles/AssetBundle/Config/config.php
+++ b/app/bundles/AssetBundle/Config/config.php
@@ -186,9 +186,6 @@ return [
             'mautic.form.type.assetconfig' => [
                 'class' => \Mautic\AssetBundle\Form\Type\ConfigType::class,
             ],
-            'mautic.form.type.asset_dashboard_downloads_in_time_widget' => [
-                'class' => \Mautic\AssetBundle\Form\Type\DashboardDownloadsInTimeWidgetType::class,
-            ],
         ],
         'others' => [
             'mautic.asset.upload.error.handler' => [

--- a/app/bundles/AssetBundle/Config/config.php
+++ b/app/bundles/AssetBundle/Config/config.php
@@ -199,7 +199,7 @@ return [
                 'arguments' => 'mautic.factory',
             ],
             // Override the DropzoneController
-            'oneup_uploader.controller.dropzone.class' => 'Mautic\AssetBundle\Controller\UploadController',
+            'oneup_uploader.controller.dropzone.class' => \Mautic\AssetBundle\Controller\UploadController::class,
             'mautic.asset.helper.token'                => [
                 'class'     => 'Mautic\AssetBundle\Helper\TokenHelper',
                 'arguments' => 'mautic.asset.model.asset',

--- a/app/bundles/AssetBundle/Controller/UploadController.php
+++ b/app/bundles/AssetBundle/Controller/UploadController.php
@@ -14,15 +14,18 @@ namespace Mautic\AssetBundle\Controller;
 use Oneup\UploaderBundle\Controller\DropzoneController;
 use Oneup\UploaderBundle\Uploader\Response\EmptyResponse;
 use Symfony\Component\HttpFoundation\File\Exception\UploadException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 class UploadController extends DropzoneController
 {
     /**
-     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     * @return JsonResponse
      */
     public function upload()
     {
-        $request  = $this->container->get('request');
+        /** @var Request $request */
+        $request  = $this->container->get('request_stack')->getCurrentRequest();
         $response = new EmptyResponse();
         $files    = $this->getFiles($request->files);
 

--- a/app/bundles/AssetBundle/Entity/Asset.php
+++ b/app/bundles/AssetBundle/Entity/Asset.php
@@ -1172,7 +1172,7 @@ class Asset extends FormEntity
     public static function loadValidatorMetadata(ClassMetadata $metadata)
     {
         // Add a constraint to manage the file upload data
-        $metadata->addConstraint(new Assert\Callback(['\\Mautic\\AssetBundle\\Entity\\Asset', 'validateFile']));
+        $metadata->addConstraint(new Assert\Callback([__CLASS__, 'validateFile']));
     }
 
     /**

--- a/app/bundles/AssetBundle/Form/Type/AssetType.php
+++ b/app/bundles/AssetBundle/Form/Type/AssetType.php
@@ -169,7 +169,7 @@ class AssetType extends AbstractType
 
         $builder->add('isPublished', YesNoButtonGroupType::class);
 
-        $builder->add('publishUp', 'datetime', [
+        $builder->add('publishUp', DateTimeType::class, [
             'widget'     => 'single_text',
             'label'      => 'mautic.core.form.publishup',
             'label_attr' => ['class' => 'control-label'],


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8282
| BC breaks? | Y
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Assets upload was not working,

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Go to Components > Assets > New
2. Try to upload new asset

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat reproduction steps

#### List backwards compatibility breaks:
1.  Removed service `mautic.form.type.asset_dashboard_downloads_in_time_widget` with not existing class
