### PR TITLE
Fix Sparkpost batch recipient counter

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
@@ -13,7 +13,6 @@
 
 namespace Mautic\EmailBundle\Swiftmailer\Transport;
 
-use GuzzleHttp\Client;
 use Mautic\EmailBundle\Model\TransportCallback;
 use Mautic\EmailBundle\Swiftmailer\Sparkpost\SparkpostFactoryInterface;
 use Mautic\LeadBundle\Entity\DoNotContact;
@@ -339,9 +338,14 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
      *
      * @return int
      */
-    public function getBatchRecipientCount(\Swift_Message $message, $toBeAdded = 1, $type = 'to')
+    public function getBatchRecipientCount(\Swift_Message $message, $toBeAdded = 1, $type = 'to'): int
     {
-        return count($message->getTo()) + count($message->getCc()) + count($message->getBcc()) + $toBeAdded;
+        // These getters could return null
+        $toCount  = $message->getTo() ? count($message->getTo()) : 0;
+        $ccCount  = $message->getCc() ? count($message->getCc()) : 0;
+        $bccCount = $message->getBcc() ? count($message->getBcc()) : 0;
+
+        return $toCount + $ccCount + $bccCount + $toBeAdded;
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8022
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When using `mautic:campaigns:trigger` with at leas one email to send using Sparkpost, it fails with 
```
[2020-01-06 13:13:25] mautic.NOTICE: Symfony\Component\Debug\Exception\ContextErrorException: Warning: count(): Parameter must be an array or an object that implements Countable (uncaught exception) at /Users/lukas.drahy/dev/community-fork/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php line 344 while running console command `mautic:campaigns:trigger`
[stack trace]
#0 /Users/lukas.drahy/dev/community-fork/app/bundles/EmailBundle/Helper/MailHelper.php(1184): Mautic\EmailBundle\Swiftmailer\Transport\SparkpostTransport->getBatchRecipientCount(Object(Mautic\EmailBundle\Swiftmailer\Message\MauticMessage), 1, 'to')
#1 /Users/lukas.drahy/dev/community-fork/app/bundles/EmailBundle/Helper/MailHelper.php(1060): Mautic\EmailBundle\Helper\MailHelper->checkBatchMaxRecipients()
#2 /Users/lukas.drahy/dev/community-fork/app/bundles/EmailBundle/Model/SendEmailToContact.php(235): Mautic\EmailBundle\Helper\MailHelper->addTo('lukas@drahy.net', 'Lukas Drahy')
#3 /Users/lukas.drahy/dev/community-fork/app/bundles/EmailBundle/Model/EmailModel.php(1465): Mautic\EmailBundle\Model\SendEmailToContact->setContact(Array, Array)
#4 /Users/lukas.drahy/dev/community-fork/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php(352): Mautic\EmailBundle\Model\EmailModel->sendEmail(Object(Mautic\EmailBundle\Entity\Email), Array, Array)
#5 /Users/lukas.drahy/dev/community-fork/vendor/symfony/event-dispatcher/Debug/WrappedListener.php(115): Mautic\EmailBundle\EventListener\CampaignSubscriber->onCampaignTriggerActionSendEmailToContact(Object(Mautic\CampaignBundle\Event\PendingEvent), 'mautic.email.on...', Object(Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher))
#6 /Users/lukas.drahy/dev/community-fork/vendor/symfony/event-dispatcher/EventDispatcher.php(214): Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke(Object(Mautic\CampaignBundle\Event\PendingEvent), 'mautic.email.on...', Object(Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher))
#7 /Users/lukas.drahy/dev/community-fork/vendor/symfony/event-dispatcher/EventDispatcher.php(44): Symfony\Component\EventDispatcher\EventDispatcher->doDispatch(Array, 'mautic.email.on...', Object(Mautic\CampaignBundle\Event\PendingEvent))
#8 /Users/lukas.drahy/dev/community-fork/vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php(143): Symfony\Component\EventDispatcher\EventDispatcher->dispatch('mautic.email.on...', Object(Mautic\CampaignBundle\Event\PendingEvent))
#9 /Users/lukas.drahy/dev/community-fork/app/bundles/CampaignBundle/Executioner/Dispatcher/ActionDispatcher.php(100): Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch('mautic.email.on...', Object(Mautic\CampaignBundle\Event\PendingEvent))
#10 /Users/lukas.drahy/dev/community-fork/app/bundles/CampaignBundle/Executioner/Event/ActionExecutioner.php(73): Mautic\CampaignBundle\Executioner\Dispatcher\ActionDispatcher->dispatchEvent(Object(Mautic\CampaignBundle\EventCollector\Accessor\Event\ActionAccessor), Object(Mautic\CampaignBundle\Entity\Event), Object(Doctrine\Common\Collections\ArrayCollection))
#11 /Users/lukas.drahy/dev/community-fork/app/bundles/CampaignBundle/Executioner/EventExecutioner.php(228): Mautic\CampaignBundle\Executioner\Event\ActionExecutioner->execute(Object(Mautic\CampaignBundle\EventCollector\Accessor\Event\ActionAccessor), Object(Doctrine\Common\Collections\ArrayCollection))
#12 /Users/lukas.drahy/dev/community-fork/app/bundles/CampaignBundle/Executioner/EventExecutioner.php(195): Mautic\CampaignBundle\Executioner\EventExecutioner->executeLogs(Object(Mautic\CampaignBundle\Entity\Event), Object(Doctrine\Common\Collections\ArrayCollection), Object(Mautic\CampaignBundle\Executioner\Result\Counter))
#13 /Users/lukas.drahy/dev/community-fork/app/bundles/CampaignBundle/Executioner/EventExecutioner.php(275): Mautic\CampaignBundle\Executioner\EventExecutioner->executeForContacts(Object(Mautic\CampaignBundle\Entity\Event), Object(Doctrine\Common\Collections\ArrayCollection), Object(Mautic\CampaignBundle\Executioner\Result\Counter), false)
#14 /Users/lukas.drahy/dev/community-fork/app/bundles/CampaignBundle/Executioner/KickoffExecutioner.php(238): Mautic\CampaignBundle\Executioner\EventExecutioner->executeEventsForContacts(Object(Doctrine\Common\Collections\ArrayCollection), Object(Doctrine\Common\Collections\ArrayCollection), Object(Mautic\CampaignBundle\Executioner\Result\Counter))
#15 /Users/lukas.drahy/dev/community-fork/app/bundles/CampaignBundle/Executioner/KickoffExecutioner.php(137): Mautic\CampaignBundle\Executioner\KickoffExecutioner->executeOrScheduleEvent()
#16 /Users/lukas.drahy/dev/community-fork/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php(401): Mautic\CampaignBundle\Executioner\KickoffExecutioner->execute(Object(Mautic\CampaignBundle\Entity\Campaign), Object(Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter), Object(Symfony\Component\Console\Output\ConsoleOutput))
#17 /Users/lukas.drahy/dev/community-fork/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php(357): Mautic\CampaignBundle\Command\TriggerCampaignCommand->executeKickoff()
#18 /Users/lukas.drahy/dev/community-fork/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php(302): Mautic\CampaignBundle\Command\TriggerCampaignCommand->triggerCampaign(Object(Mautic\CampaignBundle\Entity\Campaign))
#19 /Users/lukas.drahy/dev/community-fork/vendor/symfony/console/Command/Command.php(255): Mautic\CampaignBundle\Command\TriggerCampaignCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#20 /Users/lukas.drahy/dev/community-fork/vendor/symfony/console/Application.php(1000): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#21 /Users/lukas.drahy/dev/community-fork/vendor/symfony/framework-bundle/Console/Application.php(86): Symfony\Component\Console\Application->doRunCommand(Object(Mautic\CampaignBundle\Command\TriggerCampaignCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#22 /Users/lukas.drahy/dev/community-fork/vendor/symfony/console/Application.php(255): Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand(Object(Mautic\CampaignBundle\Command\TriggerCampaignCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#23 /Users/lukas.drahy/dev/community-fork/vendor/symfony/framework-bundle/Console/Application.php(74): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#24 /Users/lukas.drahy/dev/community-fork/vendor/symfony/console/Application.php(148): Symfony\Bundle\FrameworkBundle\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#25 /Users/lukas.drahy/dev/community-fork/bin/console(41): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#26 {main}  
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Set Sparkpost in mail configuration as transport (API key in secured)
2. Use `whatever@mautic.com` as e-mail sender in the same config
3. `bin/console mautic:campaigns:trigge -e dev -v`

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Use reproduction steps
