### PR TITLE
Remove duplicated options from the email transport select box

### DIFF
--- a/app/bundles/EmailBundle/Form/Type/ConfigType.php
+++ b/app/bundles/EmailBundle/Form/Type/ConfigType.php
@@ -39,20 +39,12 @@ class ConfigType extends AbstractType
      */
     private $transportType;
 
-    /**
-     * @param TranslatorInterface $translator
-     * @param TransportType       $transportType
-     */
     public function __construct(TranslatorInterface $translator, TransportType $transportType)
     {
         $this->translator    = $translator;
         $this->transportType = $transportType;
     }
 
-    /**
-     * @param FormBuilderInterface $builder
-     * @param array                $options
-     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->addEventSubscriber(
@@ -807,9 +799,10 @@ class ConfigType extends AbstractType
      */
     private function getTransportChoices()
     {
-        $choices = $this->transportType->getTransportTypes();
+        $choices    = [];
+        $transports = $this->transportType->getTransportTypes();
 
-        foreach ($choices as $value => $label) {
+        foreach ($transports as $value => $label) {
             $choices[$this->translator->trans($label)] = $value;
         }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

All options in the Mautic config > email settings > email transport select box are duplicated.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to Mautic config > email settings > 
2. Notice that the email transport select box has duplicated options. Instead of 12 options there are 24.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. There are only 12 options
