### PR TITLE
Remove doctrine/doctrine-cache-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,6 @@
         "sensio/framework-extra-bundle": "~3.0",
 
         "doctrine/doctrine-bundle": "~1.11.0",
-        "doctrine/doctrine-cache-bundle": "~1.4.0",
         "doctrine/doctrine-fixtures-bundle": "~3.3.0",
         "doctrine/doctrine-migrations-bundle": "~2.1",
         "doctrine/annotations": "~1.8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dda8f39a5af815bc4b70c5ccc0255378",
+    "content-hash": "8142957e3499440deecd55de896def52",
     "packages": [
         {
             "name": "aws/aws-sdk-php",


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? |
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8289
| BC breaks? | doctrine/doctrine-cache-bundle is removed because we are supposed to use symfony/cache package
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
doctrine/doctrine-cache-bundle should be removed from composer.json because we now use symfony/cache for caching.


#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. `composer install`
3. Clear the cache. Make sure Mautic is loading.