### PR TITLE
Fix dynamic content for owner field

### DIFF
--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -498,6 +498,8 @@ Mautic.updateLookupListFilter = function(field, datum) {
 
 Mautic.activateSegmentFilterTypeahead = function(displayId, filterId, fieldOptions, mQueryObject) {
 
+    var mQueryBackup = mQuery;
+
     if(typeof mQueryObject == 'function'){
         mQuery = mQueryObject;
     }
@@ -505,6 +507,8 @@ Mautic.activateSegmentFilterTypeahead = function(displayId, filterId, fieldOptio
     mQuery('#' + displayId).attr('data-lookup-callback', 'updateLookupListFilter');
 
     Mautic.activateFieldTypeahead(displayId, filterId, [], 'lead:fieldList')
+
+    mQuery = mQueryBackup;
 };
 
 Mautic.addLeadListFilter = function (elId, elObj) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
We noticed issue with dynamic content for owner condition. This issue were related to this fix https://github.com/mautic/mautic/pull/5741 (mQuery objects conflicts)

I am not JS expert, then maybe this require another touch. But solution should works.

This PR require `mautic:assets:generate` on production.


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create email with blank theme and open builder
2. Create dynamic content with variant 1 with condition Owner equal to some user
3. Close builder
4. Open builder again 
5. See not editable token `{dynamiccontent="Dynamic Content 2"}`

![image](https://user-images.githubusercontent.com/462477/72734632-67c22300-3b9a-11ea-9a9a-06fca81a5c0d.png)


#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps
3. Dynamic content slot should be editable 
