### PR TITLE
Improve empty placeholder for code mode and text slot 

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/libraries/builder.css
+++ b/app/bundles/CoreBundle/Assets/css/libraries/builder.css
@@ -5494,16 +5494,14 @@ div[data-slot].ui-sortable-helper {
   font: normal normal normal 14px/1 FontAwesome;
 }
 div:empty[data-slot],
-div.empty[data-slot],
-.codemodeHtmlContainer:empty {
+div.empty[data-slot] {
   padding: 1em 0 0em 0;
   display: block;
   position: relative;
   margin-bottom: 2px;
 }
 div:empty[data-slot]:before,
-div.empty[data-slot]:before,
-.codemodeHtmlContainer:empty:before {
+div.empty[data-slot]:before {
   content: "\f044";
   font: normal normal normal 14px/1 FontAwesome;
   position: absolute;

--- a/app/bundles/CoreBundle/Assets/css/libraries/builder.less
+++ b/app/bundles/CoreBundle/Assets/css/libraries/builder.less
@@ -265,13 +265,13 @@ div[data-slot].ui-sortable-helper {
         font: normal normal normal 14px/1 FontAwesome;
     }
 }
-div:empty[data-slot],div.empty[data-slot],.codemodeHtmlContainer:empty {
+div:empty[data-slot],div.empty[data-slot] {
     padding:1em 0 0em 0;
     display:block;
     position:relative;
     margin-bottom:2px;
 }
-div:empty[data-slot]:before,div.empty[data-slot]:before,.codemodeHtmlContainer:empty:before {
+div:empty[data-slot]:before,div.empty[data-slot]:before {
     content: "\f044";
     font: normal normal normal 14px/1 FontAwesome;
     position:absolute;

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -2030,7 +2030,7 @@ Mautic.setEmptySlotPlaceholder = function (slot) {
     clonedSlot.find('div[data-slot-focus="true"]').remove()
     clonedSlot.find('div[data-slot-toolbar="true"]').remove()
 
-    if ((clonedSlot.text()).trim() == '') {
+    if ((clonedSlot.text()).trim() == '' && !clonedSlot.find('img').length) {
         slot.addClass('empty');
     } else {
         slot.removeClass('empty');

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -424,7 +424,7 @@ Mautic.updateIframeContent = function(iframeId, content, slot) {
         }
     } else if (slot) {
         slot.html(content);
-        Mautic.emptyPlaceholder(slot.parent());
+        Mautic.setEmptySlotPlaceholder(slot.parent());
     }
 };
 
@@ -582,8 +582,7 @@ Mautic.sanitizeHtmlBeforeSave = function(htmlContent) {
 };
 
 /**
- * Clones full HTML document by creating a virtual iframe, putting the HTML into it and
- * reading it back. This is async process.
+ * Clones full HTML document by creating a virtual iframe, putting the HTML into it and reading it back. This is async process.
  *
  * @param  object   content
  * @param  Function callback(clonedContent)
@@ -1279,7 +1278,7 @@ Mautic.initSlotListeners = function() {
             }
 
             slot.append(slotToolbar);
-            Mautic.emptyPlaceholder(slot);
+            Mautic.setEmptySlotPlaceholder(slot);
         }, function() {
             if (Mautic.sortActive) {
                 // don't activate while sorting
@@ -1468,7 +1467,7 @@ Mautic.initSlotListeners = function() {
                     // replace DEC with content from the first editor
                     if (!(focusType == 'dynamicContent' && mQuery(this).attr('id').match(/filters/))) {
                         clickedSlot.html(slotHtml.html());
-                        Mautic.emptyPlaceholder(clickedSlot);
+                        Mautic.setEmptySlotPlaceholder(clickedSlot);
                     }
                 });
 
@@ -2026,8 +2025,12 @@ Mautic.getDynamicContentMaxId = function() {
     return maxId;
 };
 
-Mautic.emptyPlaceholder = function (slot) {
-    if ((slot.text()).trim() == '') {
+Mautic.setEmptySlotPlaceholder = function (slot) {
+    var clonedSlot = slot.clone();
+    clonedSlot.find('div[data-slot-focus="true"]').remove()
+    clonedSlot.find('div[data-slot-toolbar="true"]').remove()
+
+    if ((clonedSlot.text()).trim() == '') {
         slot.addClass('empty');
     } else {
         slot.removeClass('empty');

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -424,6 +424,7 @@ Mautic.updateIframeContent = function(iframeId, content, slot) {
         }
     } else if (slot) {
         slot.html(content);
+        Mautic.emptyPlaceholder(slot.parent());
     }
 };
 
@@ -1278,6 +1279,7 @@ Mautic.initSlotListeners = function() {
             }
 
             slot.append(slotToolbar);
+            Mautic.emptyPlaceholder(slot);
         }, function() {
             if (Mautic.sortActive) {
                 // don't activate while sorting
@@ -1466,6 +1468,7 @@ Mautic.initSlotListeners = function() {
                     // replace DEC with content from the first editor
                     if (!(focusType == 'dynamicContent' && mQuery(this).attr('id').match(/filters/))) {
                         clickedSlot.html(slotHtml.html());
+                        Mautic.emptyPlaceholder(clickedSlot);
                     }
                 });
 
@@ -2021,6 +2024,14 @@ Mautic.getDynamicContentMaxId = function() {
     if (isNaN(maxId) || Number.NEGATIVE_INFINITY === maxId) maxId = 0;
 
     return maxId;
+};
+
+Mautic.emptyPlaceholder = function (slot) {
+    if ((slot.text()).trim() == '') {
+        slot.addClass('empty');
+    } else {
+        slot.removeClass('empty');
+    }
 };
 
 // Init inside the builder's iframe


### PR DESCRIPTION
closes https://github.com/mautic/mautic/issues/8325

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8325
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR improve https://github.com/mautic/mautic/pull/6810
Placeholder for empty text or code mode slot not work with  html   tags without content. This PR should fixed it.

This PR require `mautic:assets:generate`

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create email with code mode slot
2. Set `<strong></strong>` to code mode block and click to another slot
3. You shouldn't see any placeholder, not possible click to code mode slot in builder again

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps. Now code mode block should works with HTML tags without content
3. Also test text slot If works properly

![image](https://user-images.githubusercontent.com/462477/72759302-8e517f80-3bd5-11ea-8d54-939310444fb9.png)


#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
