### PR TITLE
Polyfills for new features in PHP 7.3 and 7.4 added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,8 @@
         "symfony/swiftmailer-bundle": "~3.3",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/security-acl": "~3.0.0",
+        "symfony/polyfill-php73": "^1.13",
+        "symfony/polyfill-php74": "^1.13",
 
         "sensio/distribution-bundle": "~5.0",
         "sensio/framework-extra-bundle": "~3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "941bbb34e03f01626d3e289e73792305",
+    "content-hash": "299f27e22890bf63cae0468e2e0bde31",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -9667,6 +9667,65 @@
                 "shim"
             ],
             "time": "2019-11-27T16:25:15+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php74",
+            "version": "v1.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php74.git",
+                "reference": "51c0b4b164592ab7fa9a82fb126f02a3f7870456"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php74/zipball/51c0b4b164592ab7fa9a82fb126f02a3f7870456",
+                "reference": "51c0b4b164592ab7fa9a82fb126f02a3f7870456",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.13-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php74\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-11-27T14:18:11+00:00"
         },
         {
             "name": "symfony/polyfill-util",


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | Y
| Automated tests included? | /
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8122
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Symfony created simple polyfill libraries that provide functions and contstants that were implemented in higher PHP versions. It will make development more pleasant.

https://github.com/symfony/polyfill

As an example, these helpful functions will be available even for PHP 7.2: `array_key_first` and `array_key_last` functions introduced in PHP 7.3;

I marked this PR as a bug fix too because we are already using method `is_countable` in M3 that was introduced in PHP 7.3. So this polyfill will fix it for PHP 7.2.

#### Steps to test this PR:
1. There is nothing to test.
