### PR TITLE
URL validation improvement

### DIFF
--- a/app/bundles/CoreBundle/Helper/UrlHelper.php
+++ b/app/bundles/CoreBundle/Helper/UrlHelper.php
@@ -326,18 +326,19 @@ class UrlHelper
     }
 
     /**
-     * FILTER_VALIDATE_URL allow only alphanumerics [0-9a-zA-Z], the special characters "$-_.+!*'()," [not including the quotes - ed]. This validation passed also special characters in URL.
+     *  This method return true with special characters in URL, for example https://domain.tld/é.pdf
+     * filter_var($url, FILTER_VALIDATE_URL) allow only alphanumerics [0-9a-zA-Z], the special characters "$-_.+!*'()," [not including the quotes - ed].
      *
      * @param string $url
      *
      * @return bool
      */
-    public static function isValidateUrl($url)
+    public static function isValidUrl($url)
     {
         $path         = parse_url($url, PHP_URL_PATH);
         $encodedPath  = array_map('urlencode', explode('/', $path));
         $url          = str_replace($path, implode('/', $encodedPath), $url);
 
-        return filter_var($url, FILTER_VALIDATE_URL);
+        return (bool) filter_var($url, FILTER_VALIDATE_URL);
     }
 }

--- a/app/bundles/CoreBundle/Helper/UrlHelper.php
+++ b/app/bundles/CoreBundle/Helper/UrlHelper.php
@@ -326,6 +326,8 @@ class UrlHelper
     }
 
     /**
+     * FILTER_VALIDATE_URL allow only alphanumerics [0-9a-zA-Z], the special characters "$-_.+!*'()," [not including the quotes - ed]. This validation passed also special characters in URL.
+     *
      * @param string $url
      *
      * @return bool
@@ -333,8 +335,8 @@ class UrlHelper
     public static function isValidateUrl($url)
     {
         $path         = parse_url($url, PHP_URL_PATH);
-        $encoded_path = array_map('urlencode', explode('/', $path));
-        $url          = str_replace($path, implode('/', $encoded_path), $url);
+        $encodedPath  = array_map('urlencode', explode('/', $path));
+        $url          = str_replace($path, implode('/', $encodedPath), $url);
 
         return filter_var($url, FILTER_VALIDATE_URL);
     }

--- a/app/bundles/CoreBundle/Helper/UrlHelper.php
+++ b/app/bundles/CoreBundle/Helper/UrlHelper.php
@@ -324,4 +324,18 @@ class UrlHelper
 
         return $string;
     }
+
+    /**
+     * @param string $url
+     *
+     * @return bool
+     */
+    public static function isValidateUrl($url)
+    {
+        $path         = parse_url($url, PHP_URL_PATH);
+        $encoded_path = array_map('urlencode', explode('/', $path));
+        $url          = str_replace($path, implode('/', $encoded_path), $url);
+
+        return filter_var($url, FILTER_VALIDATE_URL);
+    }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/UrlHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/UrlHelperTest.php
@@ -181,4 +181,12 @@ STRING
             )
         );
     }
+
+    public function testUrlValid()
+    {
+        $this->assertTrue(UrlHelper::isValidUrl('https://domain.tld/e'));
+        $this->assertTrue(UrlHelper::isValidUrl('https://domain.tld/é'));
+        $this->assertFalse(UrlHelper::isValidUrl('notvalidurl'));
+        $this->assertFalse(UrlHelper::isValidUrl('notvalidurlé'));
+    }
 }

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -491,7 +491,7 @@ class PublicController extends CommonFormController
 
         $url = UrlHelper::sanitizeAbsoluteUrl($url);
 
-        if (!UrlHelper::isValidateUrl($url)) {
+        if (!UrlHelper::isValidUrl($url)) {
             throw $this->createNotFoundException($this->translator->trans('mautic.core.url.error.404', ['%url%' => $url]));
         }
 

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -491,7 +491,7 @@ class PublicController extends CommonFormController
 
         $url = UrlHelper::sanitizeAbsoluteUrl($url);
 
-        if (false === filter_var($url, FILTER_VALIDATE_URL)) {
+        if (!UrlHelper::isValidateUrl($url)) {
             throw $this->createNotFoundException($this->translator->trans('mautic.core.url.error.404', ['%url%' => $url]));
         }
 


### PR DESCRIPTION
closes https://github.com/mautic/mautic/issues/8597
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Validation URL failed if URL contains special chars

`filter_var($url, FILTER_VALIDATE_URL)`

because

Only alphanumerics [0-9a-zA-Z], the special characters "$-_.+!*'()," [not including the quotes - ed], and reserved characters used for their reserved purposes may be used unencoded within a URL

This PR added support for special characters in URL.

This PR require merge https://github.com/mautic/mautic/pull/9108 first

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create email with and create link with URL https://domain.tld/name-with-special-character-é.pdf 
2. Send email and try open the link
3. Should return 404 error because validation return false on that URL

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com) - require this PR merged before https://github.com/mautic/mautic/pull/9108
2. Repeat all steps and try if your redirect link from email return https://domain.tld/name-with-special-character-é.pdf 
