### PR TITLE
Exclude Twig Test folders from deletion

### DIFF
--- a/build/processfiles.php
+++ b/build/processfiles.php
@@ -163,7 +163,7 @@ system('find . -name ".git*" -prune -exec rm -rf {} \\;');
 system('find . -name .DS_Store -exec rm -rf {} \\;');
 
 // Delete test directories
-system('find . -type d -name Test ! -path "./vendor/twig/twig/lib/Twig/Node/Expression/Test" ! -path "./vendor/twig/twig/lib/Twig/Test" -prune -exec rm -rf {} \\;');
-system('find . -type d -name test ! -path "./vendor/twig/twig/lib/Twig/Node/Expression/Test" ! -path "./vendor/twig/twig/lib/Twig/Test" -prune -exec rm -rf {} \\;');
+system('find . -type d -name Test ! -path "./vendor/twig/twig/lib/Twig/Node/Expression/Test" ! -path "./vendor/twig/twig/lib/Twig/Test" ! -path "./vendor/twig/twig/src/Node/Expression/Test" ! -path "./vendor/twig/twig/src/Test" -prune -exec rm -rf {} \\;');
+system('find . -type d -name test ! -path "./vendor/twig/twig/lib/Twig/Node/Expression/Test" ! -path "./vendor/twig/twig/lib/Twig/Test" ! -path "./vendor/twig/twig/src/Node/Expression/Test" ! -path "./vendor/twig/twig/src/Test" -prune -exec rm -rf {} \\;');
 system('find . -type d -name Tests -prune -exec rm -rf {} \\;');
 system('find . -type d -name tests -prune -exec rm -rf {} \\;');


### PR DESCRIPTION
Closes #8329

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #8329
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. See #8329
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Follow the steps in #8329. Step 4 shouldn't throw an error anymore

#### List deprecations along with the new alternative:
1. N/A
2. 

#### List backwards compatibility breaks:
1. N/A
2. 
