### PR TITLE
Fixed mysql8 error: Incorrect DATETIME value

### DIFF
--- a/app/bundles/CoreBundle/Entity/AuditLogRepository.php
+++ b/app/bundles/CoreBundle/Entity/AuditLogRepository.php
@@ -238,7 +238,7 @@ class AuditLogRepository extends CommonRepository
             $sqb->andWhere(
                 $sqb->expr()->andX(
                     $sqb->expr()->eq('l.object_id', $lead->getId()),
-                    $sqb->expr()->gte('l.date_added', $sqb->expr()->literal($dt->getUtcTimestamp()))
+                    $sqb->expr()->gte('l.date_added', $dt->getUtcTimestamp())
                 )
             );
         }


### PR DESCRIPTION
closes #7612

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | yes
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7612
| BC breaks? | need to test against mysql 5 and 8


[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )


#### Steps to reproduce the bug:
1. Use mysql 8.0.19
2. Try to open a contact in mautic - see an error

This PR should be tested against mysql 5 as well.