### PR TITLE
Optimizations of the pre-commit hook

### DIFF
--- a/build/hooks/pre-commit
+++ b/build/hooks/pre-commit
@@ -12,10 +12,13 @@ if [ -x $PHP_CS_FIXER ]; then
 fi
 
 if $HAS_PHP_CS_FIXER; then
-    git status --porcelain | grep -e '^[AM]\(.*\).php$' | cut -c 3- | while read line; do
-        $PHP_CS_FIXER fix --config=$ROOT/.php_cs --verbose "$line";
-        git add "$line";
-    done
+
+    # Fix changed (indexed) files
+    $PHP_CS_FIXER fix --config=$ROOT/.php_cs --verbose --using-cache=no $(git diff --cached --name-only)
+
+    # Add the changes from CS Fixer back to the git index:
+    git add $(git diff --cached --name-only)
+
 else
     echo ""
     echo "Please install php-cs-fixer, e.g.:"


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | /
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

There are 2 optimizations of the pre-commit hook:
1. It removes the loop and adds a list of files as an argument instead. This will make the CS Fixer run faster when we won't initialize it for each file. Also, it will make more pleasant looking at the progress.
2. There is a way to get list of indexed files without a regex.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make a change in 2 files. A new line for example.
2. `git add -A` (add them to git index)
3. Run the pre-commit hook `./build/hooks/pre-commit`

Example output:
Notice the CS Fixer was initialized for each file and processed both files.
```
$ 
php-cs-fixer pre commit hook start
Loaded config default from "/Users/jan/dev/mautic/.php_cs".
Using cache file ".php_cs.cache".
Paths from configuration file have been overridden by paths provided as command arguments.
F
Legend: ?-unknown, I-invalid file syntax (file ignored), S-skipped (cached or empty file), .-no changes, F-fixed, E-error
   1) app/bundles/UserBundle/Controller/ProfileController.php (single_line_after_imports)

Fixed all files in 0.116 seconds, 16.000 MB memory used
Loaded config default from "/Users/jan/dev/mautic/.php_cs".
Using cache file ".php_cs.cache".
Paths from configuration file have been overridden by paths provided as command arguments.
F
Legend: ?-unknown, I-invalid file syntax (file ignored), S-skipped (cached or empty file), .-no changes, F-fixed, E-error
   1) app/bundles/UserBundle/Controller/PublicController.php (no_extra_blank_lines)

Fixed all files in 0.166 seconds, 14.
```

#### Steps to test this PR:
1. Make a change in 2 files. A new line for example.
2. `git add -A` (add them to git index)
3. Run the pre-commit hook`./build/hooks/pre-commit`

Example output:
Notice the CS Fixer was initialized once and processed both files.
```
php-cs-fixer pre commit hook start
Loaded config default from "/Users/jan/dev/mautic/.php_cs".
Paths from configuration file have been overridden by paths provided as command arguments.
FF
Legend: ?-unknown, I-invalid file syntax (file ignored), S-skipped (cached or empty file), .-no changes, F-fixed, E-error
   1) mautic/app/bundles/ApiBundle/Controller/CommonApiController.php (no_whitespace_in_blank_line, no_extra_blank_lines)
   2) mautic/app/bundles/UserBundle/Controller/ProfileController.php (no_extra_blank_lines)

Fixed all files in 0.686 seconds, 20.000 MB memory used
php-cs-fixer pre commit hook finish
```
