### PR TITLE
Prevent 404 error for page redirect with whitespace (3.x)

### DIFF
--- a/app/bundles/CoreBundle/Helper/UrlHelper.php
+++ b/app/bundles/CoreBundle/Helper/UrlHelper.php
@@ -201,6 +201,7 @@ class UrlHelper
         }
 
         $url = self::sanitizeUrlScheme($url);
+        $url = self::sanitizeUrlPath($url);
         $url = self::sanitizeUrlQuery($url);
 
         return $url;
@@ -232,6 +233,23 @@ class UrlHelper
         // Set default scheme to http if missing
         if (empty($scheme)) {
             $url = sprintf('http%s', $url);
+        }
+
+        return $url;
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return string
+     */
+    private static function sanitizeUrlPath($url)
+    {
+        $path = parse_url($url, PHP_URL_PATH);
+
+        if (!empty($path)) {
+            $sanitizedPath = str_replace(' ', '%20', $path);
+            $url           = str_replace($path, $sanitizedPath, $url);
         }
 
         return $url;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/UrlHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/UrlHelperTest.php
@@ -79,6 +79,14 @@ class UrlHelperTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testSanitizeAbsoluteUrlSanitizePathWhitespace()
+    {
+        $this->assertEquals(
+            'http://username:password@hostname:9090/some%20path%20with%20whitespace',
+            UrlHelper::sanitizeAbsoluteUrl('http://username:password@hostname:9090/some path with whitespace')
+        );
+    }
+
     public function testGetUrlsFromPlaintextWithHttp()
     {
         $this->assertEquals(


### PR DESCRIPTION
This PR is copy of PR #8253 merged to 3.x branch as @escopecz suggested in related PR.

closes #7337


[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #7337
| BC breaks? | N
| Deprecations? | N

[//]: # ( Required: )
#### Description:
When you create an email that contains link with whitespace (e.g. some file on the server "my raport.xml") and that whitespace is not properly encoded (as %20) then the redirect that is generated by Mautic will return 404. I know that it is not valid URL address, but browsers are able to handle that, ale automatically convert the whitespace. The problem is that Mautic user has working link on email preview (before it is replaced by token) and the contact has 404 redirect link on when gets the email.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create an email that contains link with whitespace e.g. "https://yourdomain.local/my report.xml"
2. Send example email. When the link is not replaced by token the browser will handle it that way: "https://yourdomain.local/my%20report.xml"
3. Send email to contact (In Campaign or Contacts -> Send email). The link is replaced by Mautic page redirect token which shows 404

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat steps to reproduce