### PR TITLE
Fix PHP 7.3 compatibility

### DIFF
--- a/app/bundles/LeadBundle/EventListener/SetContactAvatarFormSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SetContactAvatarFormSubscriber.php
@@ -73,10 +73,10 @@ class SetContactAvatarFormSubscriber extends CommonSubscriber
                 case 'file':
                     $properties = $field->getProperties();
                     if (empty($properties[FormFieldFileType::PROPERTY_PREFERED_PROFILE_IMAGE])) {
-                        continue;
+                        break;
                     }
                     if (empty($results[$field->getAlias()])) {
-                        continue;
+                        break;
                     }
                     try {
                         $filePath = $this->uploader->getCompleteFilePath($field, $results[$field->getAlias()]);


### PR DESCRIPTION
After merging https://github.com/mautic/mautic/pull/6991, the staging branch PHP 7.3 Travis test fails with the following error:

```
Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?
```

This PR fixes that warning.

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

#### Steps to test this PR:
1. If Travis tests in this PR pass, we should be good to go.

