### PR TITLE
Run CS Fixer only on changed files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,4 @@ jobs:
         IFS='
         '
         CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")
-        bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no
-
+        bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no ${CHANGED_FILES}

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,4 @@ jobs:
       script: composer phpstan
     -
       name: CS Fixer
-      script: 
-        IFS='
-        '
-        CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")
-        bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no ${CHANGED_FILES}
+      script: bin/php-cs-fixer fix --config=.php_cs -v --dry-run --using-cache=no --show-progress=dots --diff $(git diff --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,5 +40,10 @@ jobs:
       name: PHPSTAN
       script: composer phpstan
     -
-      name: CS
-      script: composer cs
+      name: CS Fixer
+      script: 
+        IFS='
+        '
+        CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")
+        bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no
+

--- a/app/bundles/ApiBundle/Controller/ClientController.php
+++ b/app/bundles/ApiBundle/Controller/ClientController.php
@@ -12,10 +12,10 @@
 namespace Mautic\ApiBundle\Controller;
 
 use Mautic\CoreBundle\Controller\FormController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 
-/**
- * Class ClientController.
- */
 class ClientController extends FormController
 {
     /**
@@ -23,7 +23,7 @@ class ClientController extends FormController
      *
      * @param int $page
      *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\Response
+     * @return JsonResponse|Response
      */
     public function indexAction($page = 1)
     {
@@ -121,7 +121,7 @@ class ClientController extends FormController
     }
 
     /**
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function authorizedClientsAction()
     {
@@ -134,7 +134,7 @@ class ClientController extends FormController
     /**
      * @param int $clientId
      *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return JsonResponse|RedirectResponse
      */
     public function revokeAction($clientId)
     {
@@ -183,7 +183,7 @@ class ClientController extends FormController
     /**
      * @param mixed $objectId
      *
-     * @return array|\Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     * @return array|JsonResponse|RedirectResponse|Response
      */
     public function newAction($objectId = 0)
     {
@@ -278,7 +278,7 @@ class ClientController extends FormController
      * @param int  $objectId
      * @param bool $ignorePost
      *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     * @return JsonResponse|RedirectResponse|Response
      */
     public function editAction($objectId, $ignorePost = false)
     {
@@ -384,7 +384,7 @@ class ClientController extends FormController
      *
      * @param int $objectId
      *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return JsonResponse|RedirectResponse
      */
     public function deleteAction($objectId)
     {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | /
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Currently the CS Fixer runs on all Mautic files on each commit. That is wasting resources and time. It takes 2-3 minutes to run. We need it to run only on the changed files.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Visit another PR and check Travis. For example here https://travis-ci.org/mautic/mautic/builds/643348806

#### Steps to test this PR:
1. Check travis of this PR. It should check only the changed files. The job should take ~1 minute now.
