### PR TITLE
Webhooks: JSON payload if content-type header is set to 'application/json'

### DIFF
--- a/app/bundles/WebhookBundle/Helper/CampaignHelper.php
+++ b/app/bundles/WebhookBundle/Helper/CampaignHelper.php
@@ -91,6 +91,9 @@ class CampaignHelper
             case 'post':
             case 'put':
             case 'patch':
+                if($headers['content-type'] == 'application/json') {
+                    $payload = json_encode($payload);
+                }
                 $response = $this->connector->$method($url, $payload, $headers, $timeout);
                 break;
             case 'delete':


### PR DESCRIPTION
closes https://github.com/mautic/mautic/issues/7869

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| Automated tests included? |no
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7869
| BC breaks? | no
| Deprecations? | no

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

In a campaign, fix the "Send a Webhook" for services requiring a JSON Payload, by adding a conversion to JSON if the head 'content-type' is set to 'application/json'

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Cf https://github.com/mautic/mautic/issues/7869

#### Steps to test this PR:
1. Cf https://github.com/mautic/mautic/issues/7869

#### List deprecations along with the new alternative:
N/A 

#### List backwards compatibility breaks:
N/A
