### PR TITLE
Fix PHP notice undefined index frequency_number

### DIFF
--- a/app/bundles/SmsBundle/Helper/SmsHelper.php
+++ b/app/bundles/SmsBundle/Helper/SmsHelper.php
@@ -69,7 +69,7 @@ class SmsHelper
         $this->integrationHelper    = $integrationHelper;
         $integration                = $integrationHelper->getIntegrationObject('Twilio');
         $settings                   = $integration->getIntegrationSettings()->getFeatureSettings();
-        $this->smsFrequencyNumber   = $settings['frequency_number'];
+        $this->smsFrequencyNumber   = !empty($settings['frequency_number']) ? $settings['frequency_number'] : null;
         $this->disableTrackableUrls = !empty($settings['disable_trackable_urls']) ? true : false;
     }
 


### PR DESCRIPTION
Closes #8384

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. See #8384 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Enable the API + Basic Auth
3. Test again with steps in #8384. You shouldn't be getting a notice now anymore

#### List deprecations along with the new alternative:
1. N/A
2. 

#### List backwards compatibility breaks:
1. N/A
2. 
