### PR TITLE
Fixing campaign detail page

### DIFF
--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -592,7 +592,7 @@ return [
         ],
         'fixtures' => [
             'mautic.campaign.fixture.campaign' => [
-                'class'    => \Mautic\CampaignBundle\Tests\DataFixtures\ORM\CampaignData::class,
+                'class'    => \Mautic\CampaignBundle\Tests\DataFixtures\Orm\CampaignData::class,
                 'tag'      => \Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass::FIXTURE_TAG,
                 'optional' => true,
             ],

--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -590,6 +590,13 @@ return [
                 'tag' => 'console.command',
             ],
         ],
+        'fixtures' => [
+            'mautic.campaign.fixture.campaign' => [
+                'class'    => \Mautic\CampaignBundle\Tests\DataFixtures\ORM\CampaignData::class,
+                'tag'      => \Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass::FIXTURE_TAG,
+                'optional' => true,
+            ],
+        ],
     ],
     'parameters' => [
         'campaign_time_wait_on_event_false' => 'PT1H',

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -748,7 +748,7 @@ class CampaignController extends AbstractStandardFormController
                         'campaign'        => $entity,
                         'stats'           => $stats,
                         'events'          => $sortedEvents,
-                        'eventSettings'   => $eventCollector->getEvents(),
+                        'eventSettings'   => $eventCollector->getEventsArray(),
                         'sources'         => $this->getCampaignModel()->getLeadSources($entity),
                         'dateRangeForm'   => $dateRangeForm->createView(),
                         'campaignSources' => $this->campaignSources,
@@ -770,7 +770,7 @@ class CampaignController extends AbstractStandardFormController
                 $args['viewParameters'] = array_merge(
                     $args['viewParameters'],
                     [
-                        'eventSettings'   => $eventCollector->getEvents(),
+                        'eventSettings'   => $eventCollector->getEventsArray(),
                         'campaignEvents'  => $this->campaignEvents,
                         'campaignSources' => $this->campaignSources,
                         'deletedEvents'   => $this->deletedEvents,

--- a/app/bundles/CampaignBundle/Controller/EventController.php
+++ b/app/bundles/CampaignBundle/Controller/EventController.php
@@ -80,7 +80,7 @@ class EventController extends CommonFormController
         $eventCollector = $this->get('mautic.campaign.event_collector');
 
         //fire the builder event
-        $events = $eventCollector->getEvents();
+        $events = $eventCollector->getEventsArray();
         $form   = $this->get('form.factory')->create(
             EventType::class,
             $event,
@@ -280,7 +280,7 @@ class EventController extends CommonFormController
          * the supported events for this type because we already made
          * sure that we're accessing a supported event type above.
          *
-         * Method getEvents() returns translated labels & descriptions
+         * Method getEventsArray() returns translated labels & descriptions
          */
 
         /** @var EventCollector $eventCollector */

--- a/app/bundles/CampaignBundle/Controller/EventController.php
+++ b/app/bundles/CampaignBundle/Controller/EventController.php
@@ -285,7 +285,7 @@ class EventController extends CommonFormController
 
         /** @var EventCollector $eventCollector */
         $eventCollector  = $this->get('mautic.campaign.event_collector');
-        $supportedEvents = $eventCollector->getEvents()[$event['eventType']];
+        $supportedEvents = $eventCollector->getEventsArray()[$event['eventType']];
         $form            = $this->get('form.factory')->create(
             EventType::class,
             $event,
@@ -450,7 +450,7 @@ class EventController extends CommonFormController
         if ('POST' == $this->request->getMethod() && null !== $event) {
             /** @var EventCollector $eventCollector */
             $eventCollector    = $this->get('mautic.campaign.event_collector');
-            $events            = $eventCollector->getEvents();
+            $events            = $eventCollector->getEventsArray();
             $event['settings'] = $events[$event['eventType']][$event['type']];
 
             // Add the field to the delete list
@@ -515,7 +515,7 @@ class EventController extends CommonFormController
         if ('POST' == $this->request->getMethod() && null !== $event) {
             /** @var EventCollector $eventCollector */
             $eventCollector    = $this->get('mautic.campaign.event_collector');
-            $events            = $eventCollector->getEvents();
+            $events            = $eventCollector->getEventsArray();
             $event['settings'] = $events[$event['eventType']][$event['type']];
 
             //add the field to the delete list

--- a/app/bundles/CampaignBundle/EventCollector/Accessor/EventAccessor.php
+++ b/app/bundles/CampaignBundle/EventCollector/Accessor/EventAccessor.php
@@ -36,9 +36,6 @@ class EventAccessor
      */
     private $decisions = [];
 
-    /**
-     * EventAccessor constructor.
-     */
     public function __construct(array $events)
     {
         $this->buildEvents($events);

--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -266,7 +266,7 @@ class LeadSubscriber implements EventSubscriberInterface
         $options                   = $event->getQueryOptions();
         $options['scheduledState'] = ('campaign.event' === $eventTypeKey) ? false : true;
         $logs                      = $this->contactEventLogRepository->getLeadLogs($event->getLeadId(), $options);
-        $eventSettings             = $this->eventCollector->getEvents();
+        $eventSettings             = $this->eventCollector->getEventsArray();
 
         // Add total number to counter
         $event->addToCounter($eventTypeKey, $logs);

--- a/app/bundles/CampaignBundle/Tests/DataFixtures/Orm/CampaignData.php
+++ b/app/bundles/CampaignBundle/Tests/DataFixtures/Orm/CampaignData.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CampaignBundle\Tests\DataFixtures\ORM;
+
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Mautic\CampaignBundle\Entity\Campaign;
+
+class CampaignData extends AbstractFixture implements OrderedFixtureInterface
+{
+    public function load(ObjectManager $manager)
+    {
+        $campaign = new Campaign();
+
+        $campaign->setName('Campaign A');
+        $campaign->setCanvasSettings([
+            'nodes' => [
+              0 => [
+                'id'        => '148',
+                'positionX' => '760',
+                'positionY' => '155',
+              ],
+              1 => [
+                'id'        => 'lists',
+                'positionX' => '860',
+                'positionY' => '50',
+              ],
+            ],
+            'connections' => [
+              0 => [
+                'sourceId' => 'lists',
+                'targetId' => '148',
+                'anchors'  => [
+                  'source' => 'leadsource',
+                  'target' => 'top',
+                ],
+              ],
+            ],
+          ]
+        );
+
+        $manager->persist($campaign);
+        $manager->flush();
+    }
+
+    /**
+     * @return int
+     */
+    public function getOrder()
+    {
+        return 0;
+    }
+}

--- a/app/bundles/CampaignBundle/Tests/DataFixtures/Orm/CampaignData.php
+++ b/app/bundles/CampaignBundle/Tests/DataFixtures/Orm/CampaignData.php
@@ -1,10 +1,10 @@
 <?php
 
 /*
- * @copyright   2017 Mautic Contributors. All rights reserved
+ * @copyright   2020 Mautic Contributors. All rights reserved
  * @author      Mautic
  *
- * @link        http://mautic.org
+ * @link        https://mautic.org
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */

--- a/app/bundles/CampaignBundle/Tests/DataFixtures/Orm/CampaignData.php
+++ b/app/bundles/CampaignBundle/Tests/DataFixtures/Orm/CampaignData.php
@@ -9,7 +9,7 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-namespace Mautic\CampaignBundle\Tests\DataFixtures\ORM;
+namespace Mautic\CampaignBundle\Tests\DataFixtures\Orm;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/DetailsTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/DetailsTest.php
@@ -11,7 +11,7 @@
 
 namespace Mautic\CampaignBundle\Tests\Functional\Campaign;
 
-use Mautic\CampaignBundle\Tests\DataFixtures\ORM\CampaignData;
+use Mautic\CampaignBundle\Tests\DataFixtures\Orm\CampaignData;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 
 class DetailsTest extends MauticMysqlTestCase

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/DetailsTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/DetailsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CampaignBundle\Tests\Functional\Campaign;
+
+use Mautic\CampaignBundle\Tests\DataFixtures\ORM\CampaignData;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+
+class DetailsTest extends MauticMysqlTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->loadFixtures([CampaignData::class], true);
+    }
+
+    public function testDetailsPageLoadCorrectly()
+    {
+        $this->client->request('GET', 's/campaigns/view/1');
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertContains('Campaign A', $this->client->getResponse()->getContent());
+    }
+}

--- a/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
@@ -790,7 +790,7 @@ class ReportSubscriber implements EventSubscriberInterface
         $filters = array_merge($filters, $event->getCategoryColumns('cat.'), $attributionColumns);
 
         // Setup available channels
-        $availableChannels = $this->eventCollector->getEvents();
+        $availableChannels = $this->eventCollector->getEventsArray();
         $channels          = [];
         $channelActions    = [];
         foreach ($availableChannels['decision'] as $channel => $decision) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

https://github.com/mautic/mautic/pull/8374 broke the campaign detail page. This PR adds a functional test that ensures the details page loads properly and fixes the issue.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to a campaign detail page.
2. Notice it's broken.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. The campaign detail page is loading as before.