### PR TITLE
Byte size bug fix

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -111,6 +111,7 @@ All fixtures must be defined as services in a bundle's config.php
 *   Removed the now unused FormSubmitHelper 
 *   AbTestHelper class removed, use DetermineWinnerSubscriber instead
 *   Removed service mautic.form.type.asset_dashboard_downloads_in_time_widget with not existing class
+*   Static method Asset::convertSizeToBytes() removed. Use Mautic\CoreBundle\Helper\FileHelper::convertPHPSizeToBytes() instead.
 
 ### CampaignBundle
 *   Deprecated LegacyEventDispatcher and legacy events removed:

--- a/app/bundles/AssetBundle/Controller/AssetController.php
+++ b/app/bundles/AssetBundle/Controller/AssetController.php
@@ -11,15 +11,12 @@
 
 namespace Mautic\AssetBundle\Controller;
 
-use Mautic\AssetBundle\Entity\Asset;
 use Mautic\CoreBundle\Controller\FormController;
 use Mautic\CoreBundle\Form\Type\DateRangeType;
+use Mautic\CoreBundle\Helper\FileHelper;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
-/**
- * Class AssetController.
- */
 class AssetController extends FormController
 {
     /**
@@ -290,7 +287,7 @@ class AssetController extends FormController
         if (null == $entity) {
             $entity = $model->getEntity();
         }
-        $entity->setMaxSize(Asset::convertSizeToBytes($this->get('mautic.helper.core_parameters')->getParameter('max_size').'M')); // convert from MB to B
+        $entity->setMaxSize(FileHelper::convertMegabytesToBytes($this->get('mautic.helper.core_parameters')->getParameter('max_size')));
         $method  = $this->request->getMethod();
         $session = $this->get('session');
 
@@ -424,7 +421,7 @@ class AssetController extends FormController
         /** @var \Mautic\AssetBundle\Model\AssetModel $model */
         $model  = $this->getModel('asset');
         $entity = $model->getEntity($objectId);
-        $entity->setMaxSize(Asset::convertSizeToBytes($this->get('mautic.helper.core_parameters')->getParameter('max_size').'M')); // convert from MB to B
+        $entity->setMaxSize(FileHelper::convertMegabytesToBytes($this->get('mautic.helper.core_parameters')->getParameter('max_size')));
         $session    = $this->get('session');
         $page       = $session->get('mautic.asset.page', 1);
         $method     = $this->request->getMethod();

--- a/app/bundles/AssetBundle/Entity/Asset.php
+++ b/app/bundles/AssetBundle/Entity/Asset.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\CoreBundle\Entity\FormEntity;
+use Mautic\CoreBundle\Helper\FileHelper;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 use Symfony\Component\HttpFoundation\File\File;
@@ -23,9 +24,6 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
-/**
- * Class Asset.
- */
 class Asset extends FormEntity
 {
     /**
@@ -1298,39 +1296,6 @@ class Asset extends FormEntity
     }
 
     /**
-     * Borrowed from Symfony\Component\HttpFoundation\File\UploadedFile::getMaxFilesize.
-     *
-     * @param $size
-     *
-     * @return int|string
-     */
-    public static function convertSizeToBytes($size)
-    {
-        if ('' === $size) {
-            return PHP_INT_MAX;
-        }
-
-        $max = ltrim($size, '+');
-        if (0 === strpos($max, '0x')) {
-            $max = intval($max, 16);
-        } elseif (0 === strpos($max, '0')) {
-            $max = intval($max, 8);
-        } else {
-            $max = intval($max);
-        }
-
-        switch (strtolower(substr($size, -1))) {
-            case 't':
-            case 'g':
-            case 'm':
-            case 'k':
-                $max *= 1024;
-        }
-
-        return $max;
-    }
-
-    /**
      * Get value from PHP configuration with special handling of -1.
      *
      * @param string    $setting
@@ -1347,7 +1312,7 @@ class Asset extends FormEntity
         }
 
         if ($convertToBytes) {
-            $value = self::convertSizeToBytes($value);
+            $value = FileHelper::convertPHPSizeToBytes($value);
         }
 
         return (int) $value;

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -23,6 +23,7 @@ use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\CoreBundle\Helper\Chart\LineChart;
 use Mautic\CoreBundle\Helper\Chart\PieChart;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\FileHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\EmailBundle\Entity\Email;
@@ -35,9 +36,6 @@ use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 
-/**
- * Class AssetModel.
- */
 class AssetModel extends FormModel
 {
     /**
@@ -502,7 +500,7 @@ class AssetModel extends FormModel
     public function getMaxUploadSize($unit = 'M', $humanReadable = false)
     {
         $maxAssetSize  = $this->maxAssetSize;
-        $maxAssetSize  = (-1 == $maxAssetSize || 0 === $maxAssetSize) ? PHP_INT_MAX : Asset::convertSizeToBytes($maxAssetSize.'M');
+        $maxAssetSize  = (-1 == $maxAssetSize || 0 === $maxAssetSize) ? PHP_INT_MAX : FileHelper::convertMegabytesToBytes($maxAssetSize);
         $maxPostSize   = Asset::getIniValue('post_max_size');
         $maxUploadSize = Asset::getIniValue('upload_max_filesize');
         $memoryLimit   = Asset::getIniValue('memory_limit');

--- a/app/bundles/CoreBundle/Helper/FileHelper.php
+++ b/app/bundles/CoreBundle/Helper/FileHelper.php
@@ -41,20 +41,36 @@ class FileHelper
         return self::convertBytesToMegabytes($maxUploadSizeInBytes);
     }
 
+    /**
+     * @param string $sSize
+     *
+     * @return int
+     */
     public static function convertPHPSizeToBytes($sSize)
     {
+        $sSize = trim($sSize);
+
         if (is_numeric($sSize)) {
-            return $sSize;
+            return (int) $sSize;
         }
+
         $sSuffix = substr($sSize, -1);
         $iValue  = substr($sSize, 0, -1);
 
         //missing breaks are important
         switch (strtoupper($sSuffix)) {
             case 'P':
+                $iValue *= 1024;
+                // no break
             case 'T':
+                $iValue *= 1024;
+                // no break
             case 'G':
+                $iValue *= 1024;
+                // no break
             case 'M':
+                $iValue *= 1024;
+                // no break
             case 'K':
                 $iValue *= 1024;
                 break;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/FileHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/FileHelperTest.php
@@ -21,11 +21,8 @@ class FileHelperTest extends \PHPUnit\Framework\TestCase
      * @covers       \Mautic\CoreBundle\Helper\FileHelper::convertBytesToMegabytes
      *
      * @dataProvider bytesToMegabytesProvider
-     *
-     * @param int   $byte
-     * @param float $megabyte
      */
-    public function testConversionFromBytesToMegabytes($byte, $megabyte)
+    public function testConversionFromBytesToMegabytes(int $byte, float $megabyte)
     {
         $fileHelper = new FileHelper();
 
@@ -48,11 +45,8 @@ class FileHelperTest extends \PHPUnit\Framework\TestCase
      * @covers       \Mautic\CoreBundle\Helper\FileHelper::convertMegabytesToBytes
      *
      * @dataProvider megabytesToBytesProvider
-     *
-     * @param int $megabyte
-     * @param int $byte
      */
-    public function testConversionFromMegabytesToBytes($megabyte, $byte)
+    public function testConversionFromMegabytesToBytes(int $megabyte, int $byte)
     {
         $fileHelper = new FileHelper();
 
@@ -65,6 +59,34 @@ class FileHelperTest extends \PHPUnit\Framework\TestCase
             [0, 0],
             [1, 1048576],
             [5, 5242880],
+        ];
+    }
+
+    /**
+     * @testdox Conversion of PHP size to Bytes
+     *
+     * @covers       \Mautic\CoreBundle\Helper\FileHelper::convertPHPSizeToBytes
+     *
+     * @dataProvider phpSizeToBytesProvider
+     */
+    public function testConvertPHPSizeToBytes(string $phpSize, int $bytes)
+    {
+        $fileHelper = new FileHelper();
+
+        $this->assertSame($bytes, $fileHelper::convertPHPSizeToBytes($phpSize));
+    }
+
+    public function phpSizeToBytesProvider()
+    {
+        return [
+            ['3048M', 3196059648],
+            ['127M', 133169152],
+            ['1k', 1024],
+            ['1K ', 1024],
+            ['1M', 1048576],
+            ['1G', 1073741824],
+            ['1P', 1125899906842624],
+            ['1024', 1024],
         ];
     }
 }

--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -228,7 +228,7 @@ class CheckStep implements StepInterface
         }
 
         $memoryLimit    = FileHelper::convertPHPSizeToBytes(ini_get('memory_limit'));
-        $suggestedLimit = FileHelper::convertPHPSizeToBytes('128M');
+        $suggestedLimit = FileHelper::convertPHPSizeToBytes('512M');
         if ($memoryLimit < $suggestedLimit) {
             $messages[] = 'mautic.install.memory.limit';
         }

--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -13,6 +13,7 @@ namespace Mautic\InstallBundle\Configurator\Step;
 
 use Mautic\CoreBundle\Configurator\Configurator;
 use Mautic\CoreBundle\Configurator\Step\StepInterface;
+use Mautic\CoreBundle\Helper\FileHelper;
 use Mautic\CoreBundle\Security\Cryptography\Cipher\Symmetric\OpenSSLCipher;
 use Mautic\InstallBundle\Configurator\Form\CheckStepType;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -226,9 +227,8 @@ class CheckStep implements StepInterface
             }
         }
 
-        $memoryLimit    = $this->toBytes(ini_get('memory_limit'));
-        $suggestedLimit = 128 * 1024 * 1024;
-
+        $memoryLimit    = FileHelper::convertPHPSizeToBytes(ini_get('memory_limit'));
+        $suggestedLimit = FileHelper::convertPHPSizeToBytes('128M');
         if ($memoryLimit < $suggestedLimit) {
             $messages[] = 'mautic.install.memory.limit';
         }
@@ -277,34 +277,5 @@ class CheckStep implements StepInterface
         }
 
         return $parameters;
-    }
-
-    /**
-     * Takes the memory limit string form php.ini and returns numeric value in bytes.
-     *
-     * @param string $val
-     *
-     * @return int
-     */
-    private function toBytes($val)
-    {
-        $val = trim($val);
-
-        if (-1 == $val) {
-            return PHP_INT_MAX;
-        }
-
-        $last = strtolower($val[strlen($val) - 1]);
-        $val  = (int) $val;
-
-        switch ($last) {
-            // The 'G' modifier is available since PHP 5.1.0
-            case 'g':
-            case 'm':
-            case 'k':
-                $val *= 1024;
-        }
-
-        return $val;
     }
 }

--- a/rector.yaml
+++ b/rector.yaml
@@ -23,3 +23,4 @@ parameters:
         - 'Rector\DeadCode\Rector\If_\SimplifyIfElseWithSameContentRector' # Removes code that is not the same.
         - 'Rector\DeadCode\Rector\For_\RemoveDeadIfForeachForRector' # Problematic with some copy-pasted code.
         - 'Rector\DeadCode\Rector\Ternary\TernaryToBooleanOrFalseToBooleanAndRector' # see https://github.com/rectorphp/rector/issues/2765
+        - 'Rector\DeadCode\Rector\Switch_\RemoveDuplicatedCaseInSwitchRector' # see https://github.com/rectorphp/rector/issues/2730


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | Y
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

https://github.com/mautic/mautic/pull/8355 removed some rows in the switch statement that are necessary. I'm discussing the issue in https://github.com/rectorphp/rector/issues/2730.

Also, Mautic had 3 different methods to count values from php.ini. I removed 2 and replaced it with the one remaining.

Also, the suggested memory_limit of 128M (which is default value anyway) was too low for Mautic. Increasing to 512M.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to install Mautic.
2. Notice the warning about memory limit even though your memory limit is higher than 128M in your php.ini.

#### Steps to test this PR:
1. Reload
2. The memory warning is gone.
3. Also test asset upload as there were changes in it.

#### List backwards compatibility breaks:
1. Static method `Asset::convertSizeToBytes()` removed. Use `Mautic\CoreBundle\Helper\FileHelper::convertPHPSizeToBytes()` instead.
