### PR TITLE
Recommended MySql version bumbed from 5.5.3 to 5.7.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ By contributing to this project, you accept and agree to the [Contributor Agreem
 	- recommended: `openssl`, `opcache` / `apcu` / `memcached`
 	- recommended for development: `xdebug`
 3. Recommended memory limit: minimally 256 MB for testing, 512 MB and more for production.
-4. Recommended MySQL defaults can be set by running the queries `SET GLOBAL innodb_default_row_format=DYNAMIC; SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));`
+4. Recommended MySQL minimal version 5.7.14 and defaults can be set by running the queries `SET GLOBAL innodb_default_row_format=DYNAMIC; SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));`
 
 ## Installation
 

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -13,6 +13,7 @@
 # Backwards compatibility breaking changes
 
 *   Minimal PHP version was increased from v5.6.19 to v7.2.0.
+*   Minimal MySql version was increased from v5.5.3 to v5.7.14
 *   Symfony deprecations were removed or refactored [https://github.com/symfony/symfony/blob/3.0/UPGRADE-3.0.md](https://github.com/symfony/symfony/blob/3.0/UPGRADE-3.0.md)
 *   Migrating the database should be done by upgrading to the latest 2.x series then to M3 as all 2.x migrations have been removed from the 3.x code
 *   jQuery v2.x has been replaced with jQuery v3.3.1. jQuery 2.x code is not supported anymore..

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -13,7 +13,7 @@
 # Backwards compatibility breaking changes
 
 *   Minimal PHP version was increased from v5.6.19 to v7.2.0.
-*   Minimal MySql version was increased from v5.5.3 to v5.7.14
+*   Minimal MySQL version was increased from v5.5.3 to v5.7.14
 *   Symfony deprecations were removed or refactored [https://github.com/symfony/symfony/blob/3.0/UPGRADE-3.0.md](https://github.com/symfony/symfony/blob/3.0/UPGRADE-3.0.md)
 *   Migrating the database should be done by upgrading to the latest 2.x series then to M3 as all 2.x migrations have been removed from the 3.x code
 *   jQuery v2.x has been replaced with jQuery v3.3.1. jQuery 2.x code is not supported anymore..


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://acquia.slack.com/archives/CPVGZE516/p1578392663001500
| BC breaks? | Yes, but it's only a recommendation, not hard limit.
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

I asked the community in Slack if we can bump the MySql version and there was no one against. It will let us use more advanced features like https://github.com/mautic/mautic/pull/7094.

#### Steps to test this PR:
1. Just a readme change. Nothing to test. Just review.