### PR TITLE
Fix Salesforce multiselect field sync

### DIFF
--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -473,6 +473,12 @@ class SalesforceIntegration extends CrmAbstractIntegration
                                 $dataObject['Email__Lead'] = InputHelper::email($dataObject['Email__Lead']);
                             }
 
+                            // normalize multiselect field
+                            foreach ($dataObject as &$dataO) {
+                                if (is_string($dataO)) {
+                                    $dataO = str_replace(';', '|', $dataO);
+                                }
+                            }
                             $entity                = $this->getMauticLead($dataObject, true, null, null, $object);
                             $mauticObjectReference = 'lead';
                             $detachClass           = Lead::class;
@@ -2575,6 +2581,11 @@ class SalesforceIntegration extends CrmAbstractIntegration
      */
     public function amendLeadDataBeforePush(&$mappedData)
     {
+        // normalize for multiselect field
+        foreach ($mappedData as &$data) {
+            $data = str_replace('|', ';', $data);
+        }
+
         $mappedData = StateValidationHelper::validate($mappedData);
     }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixed sync multiselect fiedls from and to Mautic.


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup salesforce sync https://www.mautic.org/docs/en/plugins/salesforce.html
2. Create multiselect field in mautic and multiselect field in Salesforce 
3. Try sync it with at least two selected options from multiselect view
4. You should see nothing/or wrong/or error sync of this field

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps and multiselect field should be synced properly