### PR TITLE
M3: Fix incorrect column types and missing indexes

### DIFF
--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -72,13 +72,13 @@ class FieldModel extends FormModel
             'object'   => 'lead',
         ],
         'mobile' => [
-            'type'     => TelType::class,
+            'type'     => 'tel',
             'fixed'    => true,
             'listable' => true,
             'object'   => 'lead',
         ],
         'phone' => [
-            'type'     => TelType::class,
+            'type'     => 'tel',
             'fixed'    => true,
             'listable' => true,
             'object'   => 'lead',
@@ -91,7 +91,7 @@ class FieldModel extends FormModel
             'default'  => 0,
         ],
         'fax' => [
-            'type'     => TelType::class,
+            'type'     => 'tel',
             'listable' => true,
             'object'   => 'lead',
         ],
@@ -220,7 +220,7 @@ class FieldModel extends FormModel
             'object'   => 'company',
         ],
         'companyphone' => [
-            'type'     => TelType::class,
+            'type'     => 'tel',
             'fixed'    => true,
             'listable' => true,
             'object'   => 'company',
@@ -267,7 +267,7 @@ class FieldModel extends FormModel
             'object'     => 'company',
         ],
         'companyfax' => [
-            'type'     => TelType::class,
+            'type'     => 'tel',
             'listable' => true,
             'group'    => 'professional',
             'object'   => 'company',

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -15,7 +15,6 @@ use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Exception\DriverException;
 use Mautic\CoreBundle\Doctrine\Helper\ColumnSchemaHelper;
 use Mautic\CoreBundle\Doctrine\Helper\IndexSchemaHelper;
-use Mautic\CoreBundle\Form\Type\TelType;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\LeadBundle\Entity\LeadField;


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Install Mautic 3 using the `3.x` branch.
2. Check types of the following columns: companies table - companyphone, companyfax columns; leads table - phone, mobile, fax columns.
3. All of the columns above are of longtext type.
4. <column_name>_search indexes are missing (e.g. `phone_search`).

#### Steps to test this PR:
1. Install Mautic 3 using this branch.
2. Check types of the following columns: companies table - companyphone, companyfax columns; leads table - phone, mobile, fax columns.
3. All of the columns above must be of varchar type.
4. <column_name>_search indexes must be present.