### PR TITLE
Fixes issue with twig cache path and el finder paths not resolving and parameters resolving in mautic.bundles

### DIFF
--- a/app/bundles/CoreBundle/Monolog/Handler/FileLogHandler.php
+++ b/app/bundles/CoreBundle/Monolog/Handler/FileLogHandler.php
@@ -14,6 +14,7 @@ namespace Mautic\CoreBundle\Monolog\Handler;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\RotatingFileHandler;
+use Monolog\Logger;
 
 class FileLogHandler extends RotatingFileHandler
 {
@@ -22,10 +23,8 @@ class FileLogHandler extends RotatingFileHandler
         $logPath     = $coreParametersHelper->get('log_path');
         $logFileName = $coreParametersHelper->get('log_file_name');
         $maxFiles    = $coreParametersHelper->get('max_log_files');
-        $debugMode   = $coreParametersHelper->get('debug', false);
-
-        $level = $debugMode ? 'debug' : 'notice';
-        $level = constant('Monolog\Logger::'.strtoupper($level));
+        $debugMode   = $coreParametersHelper->get('debug', false) || (defined('MAUTIC_ENV') && 'dev' === MAUTIC_ENV);
+        $level       = $debugMode ? Logger::DEBUG : Logger::ERROR;
 
         if ($debugMode) {
             $this->setFormatter($exceptionFormatter);

--- a/app/bundles/CoreBundle/Monolog/Handler/FileLogHandler.php
+++ b/app/bundles/CoreBundle/Monolog/Handler/FileLogHandler.php
@@ -24,7 +24,7 @@ class FileLogHandler extends RotatingFileHandler
         $logFileName = $coreParametersHelper->get('log_file_name');
         $maxFiles    = $coreParametersHelper->get('max_log_files');
         $debugMode   = $coreParametersHelper->get('debug', false) || (defined('MAUTIC_ENV') && 'dev' === MAUTIC_ENV);
-        $level       = $debugMode ? Logger::DEBUG : Logger::ERROR;
+        $level       = $debugMode ? Logger::DEBUG : Logger::NOTICE;
 
         if ($debugMode) {
             $this->setFormatter($exceptionFormatter);

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -28,39 +28,69 @@ $buildBundles = function ($namespace, $bundle) use ($container, $paths, $root, &
 
         // Check for a single config file
         $config = (file_exists($directory.'/Config/config.php')) ? include $directory.'/Config/config.php' : [];
-
-        // Remove optional services (has argument optional = true) if the service class does not exist
-        if (isset($config['services'])) {
-            $config['services'] = (new \Tightenco\Collect\Support\Collection($config['services']))
-                ->mapWithKeys(function (array $serviceGroup, string $groupName) {
-                    $serviceGroup = (new \Tightenco\Collect\Support\Collection($serviceGroup))
-                        ->reject(function ($serviceDefinition) {
-                            // Rejects services defined as optional where the service class does not exist.
-                            return is_array($serviceDefinition)
-                                && isset($serviceDefinition['optional'])
-                                && true === $serviceDefinition['optional']
-                                && isset($serviceDefinition['class'])
-                                && false === class_exists($serviceDefinition['class']);
-                        })->toArray();
-
-                    return [$groupName => $serviceGroup];
-                })->toArray();
-        }
-
-        // Services need to have percent signs escaped to prevent ParameterCircularReferenceException
-        if (isset($config['services'])) {
-            array_walk_recursive(
-                $config['services'],
-                function (&$v, $k) {
-                    $v = str_replace('%', '%%', $v);
+        $config = (new \Tightenco\Collect\Support\Collection($config))
+            ->transform(function ($configGroup, string $configGroupName) use (&$ipLookupServices) {
+                if (!is_array($configGroup)) {
+                    return $configGroup;
                 }
-            );
-        }
 
-        // Register IP lookup services
-        if (isset($config['ip_lookup_services'])) {
-            $ipLookupServices = array_merge($ipLookupServices, $config['ip_lookup_services']);
-        }
+                $configGroup = new \Tightenco\Collect\Support\Collection($configGroup);
+
+                switch ($configGroupName) {
+                    case 'ip_lookup_services':
+                        $ipLookupServices = array_merge($ipLookupServices, $configGroup->toArray());
+                        break;
+                    case 'services':
+                        return $configGroup
+                            ->reject(function ($serviceDefinition) {
+                                // Remove optional services (has argument optional = true) if the service class does not exist
+                                return is_array($serviceDefinition)
+                                    && isset($serviceDefinition['optional'])
+                                    && true === $serviceDefinition['optional']
+                                    && isset($serviceDefinition['class'])
+                                    && false === class_exists($serviceDefinition['class']);
+                            })
+                            ->transform(function ($serviceDefinition) {
+                                // Encodes percent signs so they are not compiled in the container
+                                if (is_array($serviceDefinition)) {
+                                    array_walk_recursive(
+                                        $serviceDefinition,
+                                        function (&$value) {
+                                            $value = str_replace('%', '%%', $value);
+                                        }
+                                    );
+
+                                    return $serviceDefinition;
+                                }
+
+                                return str_replace('%', '%%', $serviceDefinition);
+                            })
+                            ->toArray();
+                        break;
+                    case 'parameters':
+                        return $configGroup
+                            // Encodes percent signs so they are not compiled in the container
+                            ->transform(function ($parameterValue) {
+                                if (is_array($parameterValue)) {
+                                    array_walk_recursive(
+                                        $parameterValue,
+                                        function (&$value) {
+                                            $value = str_replace('%', '%%', $value);
+                                        }
+                                    );
+
+                                    return $parameterValue;
+                                }
+
+                                return str_replace('%', '%%', $parameterValue);
+                            })
+                            ->toArray();
+                        break;
+                    default:
+                        return $configGroup;
+                }
+            })
+            ->toArray();
 
         // Check for staticphp mapping
         if (file_exists($directory.'/Entity')) {

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -476,12 +476,12 @@ $container->loadFromExtension('fm_elfinder', [
                 'roots' => [
                     'uploads' => [
                         'driver'            => 'LocalFileSystem',
-                        'path'              => '%env(MAUTIC_EL_FINDER_PATH)%',
+                        'path'              => '%env(resolve:MAUTIC_EL_FINDER_PATH)%',
                         'upload_allow'      => ['image/png', 'image/jpg', 'image/jpeg'],
                         'upload_deny'       => ['all'],
                         'upload_max_size'   => '2M',
                         'accepted_name'     => '/^[\w\x{0300}-\x{036F}][\w\x{0300}-\x{036F}\s\.\%\-]*$/u', // Supports diacritic symbols
-                        'url'               => '%env(MAUTIC_EL_FINDER_URL)%', // We need to specify URL in case mod_rewrite is disabled
+                        'url'               => '%env(resolve:MAUTIC_EL_FINDER_URL)%', // We need to specify URL in case mod_rewrite is disabled
                     ],
                 ],
             ],

--- a/app/config/config_prod.php
+++ b/app/config/config_prod.php
@@ -56,7 +56,7 @@ $container->loadFromExtension('monolog', [
 
 //Twig Configuration
 $container->loadFromExtension('twig', [
-    'cache'       => '%env(MAUTIC_TWIG_CACHE_DIR)%',
+    'cache'       => '%env(resolve:MAUTIC_TWIG_CACHE_DIR)%',
     'auto_reload' => true,
     'paths'       => [
         '%kernel.root_dir%/bundles' => 'bundles',


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This fixes a couple few issues:

1. Services and parameters stored in the container as mautic.bundles could be resolved so escaped % signs to prevent this (for testing, Mautic should continue to work as expected :-))
2. Some parameters did not resolve container parameters such as %kernel.cache_dir% would cause
```
php bin/console cache:warmup -vvv
In FilesystemCache.php line 59:
  [RuntimeException]                                                            
  Unable to create the cache directory (%kernel.root_dir%/../var/tmp/twig/b1).  
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Ensure that cache_path and tmp_path are not stored in local.php so they default. Run `php bin/console cache:warmup` and you'll get the error above

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Run `php bin/console cache:warmup` and it should build successfully

