### PR TITLE
Generate the secret hash before save rather than after

### DIFF
--- a/app/bundles/WebhookBundle/Form/Type/WebhookType.php
+++ b/app/bundles/WebhookBundle/Form/Type/WebhookType.php
@@ -34,6 +34,9 @@ class WebhookType extends AbstractType
     {
         $builder->addEventSubscriber(new CleanFormSubscriber(['description' => 'strict_html']));
 
+        /** @var Webhook $webhook */
+        $webhook = $builder->getData();
+
         $builder->add(
             'name',
             TextType::class,
@@ -78,8 +81,8 @@ class WebhookType extends AbstractType
                     'class'   => 'form-control',
                     'tooltip' => 'mautic.webhook.secret.tooltip',
                 ],
-                'empty_data' => EncryptionHelper::generateKey(),
-                'required'   => false,
+                'data'     => $webhook->getSecret() ?? EncryptionHelper::generateKey(),
+                'required' => false,
             ]
         );
 
@@ -126,20 +129,24 @@ class WebhookType extends AbstractType
 
         $builder->add('isPublished', YesNoButtonGroupType::class);
 
-        $builder->add('eventsOrderbyDir', ChoiceType::class, [
-            'choices' => [
-                'mautic.core.form.default'                                  => '',
-                'mautic.webhook.config.event.orderby.chronological'         => Criteria::ASC,
-                'mautic.webhook.config.event.orderby.reverse.chronological' => Criteria::DESC,
-            ],
-            'label' => 'mautic.webhook.config.event.orderby',
-            'attr'  => [
-                'class'   => 'form-control',
-                'tooltip' => 'mautic.webhook.config.event.orderby.tooltip',
-            ],
-            'placeholder'       => '',
-            'required'          => false,
-            ]);
+        $builder->add(
+            'eventsOrderbyDir',
+            ChoiceType::class,
+            [
+                'choices' => [
+                    'mautic.core.form.default'                                  => '',
+                    'mautic.webhook.config.event.orderby.chronological'         => Criteria::ASC,
+                    'mautic.webhook.config.event.orderby.reverse.chronological' => Criteria::DESC,
+                ],
+                'label' => 'mautic.webhook.config.event.orderby',
+                'attr'  => [
+                    'class'   => 'form-control',
+                    'tooltip' => 'mautic.webhook.config.event.orderby.tooltip',
+                ],
+                'placeholder' => '',
+                'required'    => false,
+            ]
+        );
     }
 
     public function configureOptions(OptionsResolver $resolver)


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | /
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The webhook secure hash was generated after the new webhook was saved. The test webhook button then did not use any hash. This PR generates the hash when the form is displayed.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to the new webhook form. 
2. Notice the secure field is empty.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Go to the new webhook form. 
3. Notice the secure field is not empty.
