### PR TITLE
Disable RSS notifications from mautic.com until there is a community replacement

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -1100,7 +1100,7 @@ return [
         'batch_campaign_sleep_time' => false,
         'cors_restrict_domains'     => true,
         'cors_valid_domains'        => [],
-        'rss_notification_url'      => 'https://mautic.com/?feed=rss2&tag=notification',
+        'rss_notification_url'      => '',
         'max_entity_lock_time'      => 0,
         'default_daterange_filter'  => '-1 month',
     ],


### PR DESCRIPTION
…

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8258
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
mautic.com is no more as it is redirected to acquia.com. A temporary measure was put into place to not redirect the RSS feed URL to prevent #8258 but we need to disable this feature until/when/if a community replacement is determined.

This PR simply disables the RSS feed by removing the URL.  
