### PR TITLE
Integration bundle flip array

### DIFF
--- a/app/bundles/IntegrationsBundle/Form/Type/IntegrationConfigType.php
+++ b/app/bundles/IntegrationsBundle/Form/Type/IntegrationConfigType.php
@@ -78,7 +78,7 @@ class IntegrationConfigType extends AbstractType
                 [
                     'label'      => 'mautic.integration.features',
                     'label_attr' => ['class' => 'control-label'],
-                    'choices'    => $integrationObject->getSupportedFeatures(),
+                    'choices'    => array_flip($integrationObject->getSupportedFeatures()),
                     'expanded'   => true,
                     'multiple'   => true,
                     'required'   => false,

--- a/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsObjectFieldType.php
+++ b/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsObjectFieldType.php
@@ -54,13 +54,13 @@ class IntegrationSyncSettingsObjectFieldType extends AbstractType
 
         $choices = [];
         if ($field->isBidirectionalSyncEnabled()) {
-            $choices[ObjectMappingDAO::SYNC_BIDIRECTIONALLY] = 'mautic.integration.sync_direction_bidirectional';
+            $choices['mautic.integration.sync_direction_bidirectional'] = ObjectMappingDAO::SYNC_BIDIRECTIONALLY;
         }
         if ($field->isToIntegrationSyncEnabled()) {
-            $choices[ObjectMappingDAO::SYNC_TO_INTEGRATION] = 'mautic.integration.sync_direction_integration';
+            $choices['mautic.integration.sync_direction_integration'] = ObjectMappingDAO::SYNC_TO_INTEGRATION;
         }
         if ($field->isToMauticSyncEnabled()) {
-            $choices[ObjectMappingDAO::SYNC_TO_MAUTIC] = 'mautic.integration.sync_direction_mautic';
+            $choices['mautic.integration.sync_direction_mautic'] = ObjectMappingDAO::SYNC_TO_MAUTIC;
         }
 
         if (empty($choices)) {

--- a/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsType.php
+++ b/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsType.php
@@ -40,7 +40,7 @@ class IntegrationSyncSettingsType extends AbstractType
             'objects',
             ChoiceType::class,
             [
-                'choices'     => $objects,
+                'choices'     => array_flip($objects),
                 'expanded'    => true,
                 'multiple'    => true,
                 'label'       => 'mautic.integration.sync_objects',

--- a/app/bundles/IntegrationsBundle/Views/Config/form.html.php
+++ b/app/bundles/IntegrationsBundle/Views/Config/form.html.php
@@ -9,7 +9,7 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-echo $view['assets']->includeScript('plugins/IntegrationsBundle/Assets/js/integrations.js', 'integrationsConfigOnLoad', 'integrationsConfigOnLoad');
+echo $view['assets']->includeScript('app/bundles/IntegrationsBundle/Assets/js/integrations.js', 'integrationsConfigOnLoad', 'integrationsConfigOnLoad');
 
 /** @var \Mautic\IntegrationsBundle\Integration\Interfaces\IntegrationInterface $integrationObject Set through buildView */
 $activeTab = $activeTab ?: 'details-container';


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: Thhe plugin can not work with Integration bundle. Problem is the flipped key, value pairs.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. In the installation windows of plugin, there are visible keys coming from the Integration bundle like 'bidirectionally' in mapping section.
2. There is also an error that integration.js is missing.

#### Steps to test this PR:
1. Install plugin.
2. Run sync: bin/console mautic:integrations:sync [PluginName]

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
