### PR TITLE
Fix UniqueUserAliasValidator violation build

### DIFF
--- a/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueUserAliasValidator.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueUserAliasValidator.php
@@ -51,11 +51,10 @@ class UniqueUserAliasValidator extends ConstraintValidator
             );
 
             if (count($lists)) {
-                $this->context->addViolationAt(
-                    $field,
-                    $constraint->message,
-                    ['%alias%' => $list->getAlias()]
-                );
+                $this->context->buildViolation($constraint->message)
+                    ->atPath($field)
+                    ->setParameter('%alias%', $list->getAlias())
+                    ->addViolation();
             }
         }
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Missing refactoring for M3.
When you'll try to sync contacts from plugin with same alias. You'll get Exception with method `addViolationAt`  does not exists.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Sync contact with the same alias and you'll get exception.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Do the same without exception.
