### PR TITLE
Fix var directory paths in installer

### DIFF
--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -45,7 +45,7 @@ class CheckStep implements StepInterface
      *
      * @var string
      */
-    public $cache_path = '%kernel.root_dir%/var/cache';
+    public $cache_path = '%kernel.root_dir%/../var/cache';
 
     /**
      * Absolute path to log directory.
@@ -53,7 +53,7 @@ class CheckStep implements StepInterface
      *
      * @var string
      */
-    public $log_path = '%kernel.root_dir%/var/logs';
+    public $log_path = '%kernel.root_dir%/../var/logs';
 
     /**
      * Set the domain URL for use in getting the absolute URL for cli/cronjob generated URLs.
@@ -108,11 +108,11 @@ class CheckStep implements StepInterface
             $messages[] = 'mautic.install.config.unwritable';
         }
 
-        if (!is_writable(str_replace('%kernel.root_dir%', dirname($this->kernelRoot), $this->cache_path))) {
+        if (!is_writable(str_replace('%kernel.root_dir%', $this->kernelRoot, $this->cache_path))) {
             $messages[] = 'mautic.install.cache.unwritable';
         }
 
-        if (!is_writable(str_replace('%kernel.root_dir%', dirname($this->kernelRoot), $this->log_path))) {
+        if (!is_writable(str_replace('%kernel.root_dir%', $this->kernelRoot, $this->log_path))) {
             $messages[] = 'mautic.install.logs.unwritable';
         }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
1. Installer is producing writable path errors in first step

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Use mautic/3.x branch lcoally
2. Delete `local.php` 
3. Send request to mautic and config check will display errors with paths

#### Steps to test this PR:
1. Try this PR locally and it works
