### PR TITLE
Issue 8432 cookie php73

### DIFF
--- a/app/bundles/CoreBundle/Helper/CookieHelper.php
+++ b/app/bundles/CoreBundle/Helper/CookieHelper.php
@@ -95,7 +95,9 @@ class CookieHelper
                 ($domain == null) ? $this->domain : $domain,
                 ($secure == null) ? $this->secure : $secure,
                 ($httponly == null) ? $this->httponly : $httponly,
-                $sameSiteNoneTextGreaterPhp73
+                [
+                    'samesite' => $sameSiteNoneTextGreaterPhp73
+                ]
             );
         } else {
             setcookie(

--- a/app/bundles/CoreBundle/Helper/CookieHelper.php
+++ b/app/bundles/CoreBundle/Helper/CookieHelper.php
@@ -18,13 +18,13 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class CookieHelper
 {
-    const SAME_SITE = '; samesite=';
-    const SAME_SITE_VALUE = 'none';
-    private $path        = null;
-    private $domain      = null;
-    private $secure      = false;
-    private $httponly    = false;
-    private $request     = null;
+    const SAME_SITE       = '; SameSite=';
+    const SAME_SITE_VALUE = 'None';
+    private $path         = null;
+    private $domain       = null;
+    private $secure       = false;
+    private $httponly     = false;
+    private $request      = null;
 
     /**
      * CookieHelper constructor.
@@ -79,10 +79,10 @@ class CookieHelper
         }
 
         // If https, SameSite equals None
-        $sameSiteNoneText = '';
+        $sameSiteNoneText             = '';
         $sameSiteNoneTextGreaterPhp73 = null;
         if ($secure === true or ($secure === null and $this->secure === true)) {
-            $sameSiteNoneText = self::SAME_SITE . self::SAME_SITE_VALUE;
+            $sameSiteNoneText             = self::SAME_SITE.self::SAME_SITE_VALUE;
             $sameSiteNoneTextGreaterPhp73 = self::SAME_SITE_VALUE;
         }
 
@@ -90,13 +90,13 @@ class CookieHelper
             setcookie(
                 $name,
                 $value,
-                ($expire) ? (int) (time() + $expire) : null,
-                (($path == null) ? $this->path : $path).$sameSiteNoneText,
-                ($domain == null) ? $this->domain : $domain,
-                ($secure == null) ? $this->secure : $secure,
-                ($httponly == null) ? $this->httponly : $httponly,
                 [
-                    'samesite' => $sameSiteNoneTextGreaterPhp73
+                    'expires'  => ($expire) ? (int) (time() + $expire) : null,
+                    'path'     => (($path == null) ? $this->path : $path),
+                    'domain'   => ($domain == null) ? $this->domain : $domain,
+                    'secure'   => ($secure == null) ? $this->secure : $secure,
+                    'httponly' => ($httponly == null) ? $this->httponly : $httponly,
+                    'samesite' => $sameSiteNoneTextGreaterPhp73,
                 ]
             );
         } else {
@@ -104,7 +104,7 @@ class CookieHelper
                 $name,
                 $value,
                 ($expire) ? (int) (time() + $expire) : null,
-                (($path == null) ? $this->path : $path),
+                (($path == null) ? $this->path : $path).$sameSiteNoneText,
                 ($domain == null) ? $this->domain : $domain,
                 ($secure == null) ? $this->secure : $secure,
                 ($httponly == null) ? $this->httponly : $httponly

--- a/app/bundles/CoreBundle/Helper/CookieHelper.php
+++ b/app/bundles/CoreBundle/Helper/CookieHelper.php
@@ -18,7 +18,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class CookieHelper
 {
-    const SAME_SITE_NONE = '; samesite=none';
+    const SAME_SITE = '; samesite=';
+    const SAME_SITE_VALUE = 'none';
     private $path        = null;
     private $domain      = null;
     private $secure      = false;
@@ -79,19 +80,34 @@ class CookieHelper
 
         // If https, SameSite equals None
         $sameSiteNoneText = '';
+        $sameSiteNoneTextGreaterPhp73 = null;
         if ($secure === true or ($secure === null and $this->secure === true)) {
-            $sameSiteNoneText = self::SAME_SITE_NONE;
+            $sameSiteNoneText = self::SAME_SITE . self::SAME_SITE_VALUE;
+            $sameSiteNoneTextGreaterPhp73 = self::SAME_SITE_VALUE;
         }
 
-        setcookie(
-            $name,
-            $value,
-            ($expire) ? (int) (time() + $expire) : null,
-            (($path == null) ? $this->path : $path).$sameSiteNoneText,
-            ($domain == null) ? $this->domain : $domain,
-            ($secure == null) ? $this->secure : $secure,
-            ($httponly == null) ? $this->httponly : $httponly
-        );
+        if (version_compare(phpversion(), '7.3', '>=')) {
+            setcookie(
+                $name,
+                $value,
+                ($expire) ? (int) (time() + $expire) : null,
+                (($path == null) ? $this->path : $path).$sameSiteNoneText,
+                ($domain == null) ? $this->domain : $domain,
+                ($secure == null) ? $this->secure : $secure,
+                ($httponly == null) ? $this->httponly : $httponly,
+                $sameSiteNoneTextGreaterPhp73
+            );
+        } else {
+            setcookie(
+                $name,
+                $value,
+                ($expire) ? (int) (time() + $expire) : null,
+                (($path == null) ? $this->path : $path),
+                ($domain == null) ? $this->domain : $domain,
+                ($secure == null) ? $this->secure : $secure,
+                ($httponly == null) ? $this->httponly : $httponly
+            );
+        }
     }
 
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/CookieHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/CookieHelperTest.php
@@ -51,7 +51,7 @@ class CookieHelperTest extends PHPUnit_Framework_TestCase
         $cookieHelper->setCookie($cookieName, 'test');
 
         $cookie = $this->getCookie($cookieName);
-        $this->assertContains('samesite=none', $cookie);
+        $this->assertContains('SameSite=None', $cookie);
         $this->assertContains('secure', $cookie);
     }
 
@@ -76,7 +76,7 @@ class CookieHelperTest extends PHPUnit_Framework_TestCase
         $cookieHelper->setCookie($cookieName, 'test');
 
         $cookie = $this->getCookie($cookieName);
-        $this->assertNotContains('samesite=none', $cookie);
+        $this->assertNotContains('SameSite=None', $cookie);
         $this->assertNotContains('secure', $cookie);
     }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

Closes #8432 

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Support for PHP 7.3
| Automated tests included? | Tested by CookieHelperTest
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8432
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
PHP 7.3 handles samesite in different way in setcookie function.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Switch to PHP 7.3
2. Run test and you should get warnings.

#### Steps to test this PR:
1. No warning for PHP 7.3
2. Cookies are sent and have secure and samesitee=None

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
