### PR TITLE
Adds support for plugins to append to the response of the mt()

### DIFF
--- a/app/bundles/PageBundle/Event/TrackingEvent.php
+++ b/app/bundles/PageBundle/Event/TrackingEvent.php
@@ -1,10 +1,10 @@
 <?php
 
 /*
- * @copyright   2014 Mautic Contributors. All rights reserved
+ * @copyright   2020 Mautic Contributors. All rights reserved
  * @author      Mautic
  *
- * @link        http://mautic.org
+ * @link        https://mautic.org
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */

--- a/app/bundles/PageBundle/Event/TrackingEvent.php
+++ b/app/bundles/PageBundle/Event/TrackingEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+declare(strict_types=1);
+
+namespace Mautic\PageBundle\Event;
+
+use Mautic\LeadBundle\Entity\Lead;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+
+class TrackingEvent extends Event
+{
+    /**
+     * @var Lead
+     */
+    private $contact;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var ParameterBag
+     */
+    private $response;
+
+    public function __construct(Lead $contact, Request $request, array $mtcSessionResponses)
+    {
+        $this->contact  = $contact;
+        $this->request  = $request;
+        $this->response = new ParameterBag($mtcSessionResponses);
+    }
+
+    public function getContact(): Lead
+    {
+        return $this->contact;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+
+    public function getResponse(): ParameterBag
+    {
+        return $this->response;
+    }
+}

--- a/app/bundles/PageBundle/PageEvents.php
+++ b/app/bundles/PageBundle/PageEvents.php
@@ -147,4 +147,12 @@ final class PageEvents
      * @var string
      */
     const ON_DETERMINE_DWELL_TIME_WINNER = 'mautic.page.on_dwell_time_winner';
+
+    /**
+     * The mautic.page.on_contact_tracked event is dispatched when a contact is tracked via the mt() tracking event.
+     *
+     * The event listener receives a
+     * Mautic\PageBundle\Event\TrackingEvent
+     */
+    const ON_CONTACT_TRACKED = 'mautic.page.on_contact_tracked';
 }

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
@@ -23,16 +23,20 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Helper\PrimaryCompanyHelper;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PageBundle\Controller\PublicController;
+use Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingServiceInterface;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Event\TrackingEvent;
+use Mautic\PageBundle\Helper\TrackingHelper;
 use Mautic\PageBundle\Model\PageModel;
 use Mautic\PageBundle\Model\RedirectModel;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Logger;
+use Mautic\PageBundle\PageEvents;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Router;
 
@@ -366,5 +370,107 @@ class PublicControllerTest extends TestCase
 
         $response = $this->controller->redirectAction($redirectId);
         $this->assertInstanceOf(RedirectResponse::class, $response);
+    }
+
+    /**
+     * @covers \Mautic\PageBundle\Event\TrackingEvent::getContact
+     * @covers \Mautic\PageBundle\Event\TrackingEvent::getResponse
+     * @covers \Mautic\PageBundle\Event\TrackingEvent::getRequest
+     *
+     * @throws \Exception
+     */
+    public function testMtcTrackingEvent()
+    {
+        $request = new Request(
+            [
+                'foo' => 'bar',
+            ]
+        );
+
+        $contact = new Lead();
+        $contact->setEmail('foo@bar.com');
+
+        $mtcSessionEventArray = ['mtc' => 'foobar'];
+
+        $event           = new TrackingEvent($contact, $request, $mtcSessionEventArray);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with(PageEvents::ON_CONTACT_TRACKED, $event)
+            ->willReturnCallback(
+                function (string $eventName, TrackingEvent $event) {
+                    $contact  = $event->getContact()->getEmail();
+                    $request  = $event->getRequest();
+                    $response = $event->getResponse();
+
+                    $response->set('tracking', $contact);
+                    $response->set('foo', $request->get('foo'));
+                }
+            );
+
+        $security = $this->createMock(CorePermissions::class);
+        $security->expects($this->once())
+            ->method('isAnonymous')
+            ->willReturn(true);
+
+        $leadModel = $this->createMock(LeadModel::class);
+        $leadModel->expects($this->once())
+            ->method('getCurrentLead')
+            ->willReturn($contact);
+
+        $pageModel    = $this->createMock(PageModel::class);
+        $modelFactory = $this->createMock(ModelFactory::class);
+        $modelFactory->expects($this->exactly(2))
+            ->method('getModel')
+            ->willReturnCallback(
+                function (string $modelName) use ($leadModel, $pageModel) {
+                    switch ($modelName) {
+                        case 'lead':
+                            return $leadModel;
+                        case 'page':
+                            return $pageModel;
+                    }
+                }
+            );
+
+        $deviceTrackingService = $this->createMock(DeviceTrackingServiceInterface::class);
+
+        $trackingHelper = $this->createMock(TrackingHelper::class);
+        $trackingHelper->expects($this->once())
+            ->method('getSession')
+            ->willReturn($mtcSessionEventArray);
+
+        $container = $this->createMock(Container::class);
+        $container->method('get')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['mautic.security', Container::EXCEPTION_ON_INVALID_REFERENCE, $security],
+                        ['mautic.model.factory', Container::EXCEPTION_ON_INVALID_REFERENCE, $modelFactory],
+                        ['mautic.page.model.page', Container::EXCEPTION_ON_INVALID_REFERENCE, $pageModel],
+                        ['mautic.lead.model.lead', Container::EXCEPTION_ON_INVALID_REFERENCE, $leadModel],
+                        ['mautic.lead.service.device_tracking_service', Container::EXCEPTION_ON_INVALID_REFERENCE, $deviceTrackingService],
+                        ['mautic.page.helper.tracking', Container::EXCEPTION_ON_INVALID_REFERENCE, $trackingHelper],
+                        ['event_dispatcher', Container::EXCEPTION_ON_INVALID_REFERENCE, $eventDispatcher],
+                    ]
+                )
+            );
+
+        $publicController = new PublicController($deviceTrackingService);
+        $publicController->setContainer($container);
+        $publicController->setRequest($request);
+
+        $response = $publicController->trackingAction($request);
+
+        $json = json_decode($response->getContent(), true);
+
+        $this->assertEquals(
+            [
+                'mtc'      => 'foobar',
+                'tracking' => 'foo@bar.com',
+                'foo'      => 'bar',
+            ],
+            $json['events']
+        );
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Y
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/175
| Issues addressed (#s or URLs) | 
| BC breaks? | n
| Deprecations? |n 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This enables plugins to directly append responses to the mt() (/mtc/event) tracking event. There already existed supported to use the TrackingHelper to write to a session but this required listening to another event such as a campaign decision. 

This will enable integrations such as chat bots to personalize chat widgets without having to make subsequent AJAX calls after a the contact is tracked. 

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Run the unit test
2. If you want to hack in a test, copy the following file to app/bundles/PageBundle/EventSubscriber
```php
<?php

namespace Mautic\PageBundle\EventListener;

use Mautic\CoreBundle\CoreEvents;
use Mautic\CoreBundle\Event\BuildJsEvent;
use Mautic\PageBundle\Event\TrackingEvent;
use Mautic\PageBundle\PageEvents;
use Symfony\Component\EventDispatcher\EventSubscriberInterface;

class TestSubscriber implements EventSubscriberInterface
{
    public static function getSubscribedEvents()
    {
        return [
            CoreEvents::BUILD_MAUTIC_JS    => ['onBuildJs', 0],
            PageEvents::ON_CONTACT_TRACKED => ['onContactTracked', 0],
        ];
    }

    public function onBuildJs(BuildJsEvent $event)
    {
        $event->appendJs(
            <<<JS

        document.addEventListener('mauticPageEventDelivered', function(e) {
            var detail   = e.detail;
            if (detail.response && detail.response.events && detail.response.events.tracked) {
                console.log(detail.response.events.tracked);
            }
      });

JS
        );
    }

    public function onContactTracked(TrackingEvent $event)
    {
        $contact  = $event->getContact();
        $response = $event->getResponse();

        $response->set(
            'tracked',
            [
                'email' => $contact->getEmail()
            ]
        );
    }
}
```

Then append the following to app/bundles/PageBundle/config.php's `events` array
```
            'mautic.page.subscriber.test' => [
                'class' => \Mautic\PageBundle\EventListener\TestSubscriber::class,
            ],
```

Setup tracking on a 3rd party site/web script (https://www.mautic.org/docs/en/contacts/contact_monitoring.html#javascript-js-tracking), ensure you're logged out of Mautic or use an anonymous session/another browser, open the browser's developer console and view the output. You should see the `tracked` array written to console. It'll be a null email unless you identify the contact through the third parameter of the mt() function or submit a Mautic form. Then it should return the contact's email address.