### PR TITLE
Add "Test" automatically to "send example" emails

### DIFF
--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -32,6 +32,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EmailController extends FormController
 {
+    const EXAMPLE_EMAIL_SUBJECT_PREFIX = '[TEST]';
+
     use BuilderControllerTrait;
     use FormErrorMessagesTrait;
     use EntityContactsTrait;
@@ -1329,6 +1331,7 @@ class EmailController extends FormController
     public function sendExampleAction($objectId)
     {
         $model  = $this->getModel('email');
+        /** @var Email $entity */
         $entity = $model->getEntity($objectId);
 
         //not found or not allowed
@@ -1352,6 +1355,10 @@ class EmailController extends FormController
         // Get the quick add form
         $action = $this->generateUrl('mautic_email_action', ['objectAction' => 'sendExample', 'objectId' => $objectId]);
         $user   = $this->get('mautic.helper.user')->getUser();
+
+        // We have to add prefix to example emails
+        $subject = sprintf('%s %s', static::EXAMPLE_EMAIL_SUBJECT_PREFIX, $entity->getSubject());
+        $entity->setSubject($subject);
 
         $form = $this->createForm(ExampleSendType::class, ['emails' => ['list' => [$user->getEmail()]]], ['action' => $action]);
         /* @var \Mautic\EmailBundle\Model\EmailModel $model */

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
@@ -12,10 +12,16 @@
 namespace Mautic\EmailBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Factory\ModelFactory;
+use Mautic\CoreBundle\Helper\UserHelper;
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\EmailBundle\Controller\EmailController;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Model\EmailModel;
+use Mautic\UserBundle\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactory;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -33,20 +39,30 @@ class EmailControllerTest extends \PHPUnit\Framework\TestCase
     private $routerMock;
     private $flashBagMock;
     private $controller;
+    private $corePermissionsMock;
+    private $helperUserMock;
+    private $formFactoryMock;
+    private $formMock;
+    private $templatingMock;
 
     protected function setUp()
     {
         parent::setUp();
 
-        $this->translatorMock   = $this->createMock(TranslatorInterface::class);
-        $this->sessionMock      = $this->createMock(Session::class);
-        $this->modelFactoryMock = $this->createMock(ModelFactory::class);
-        $this->containerMock    = $this->createMock(Container::class);
-        $this->routerMock       = $this->createMock(Router::class);
-        $this->modelMock        = $this->createMock(EmailModel::class);
-        $this->emailMock        = $this->createMock(Email::class);
-        $this->flashBagMock     = $this->createMock(FlashBagInterface::class);
-        $this->controller       = new EmailController();
+        $this->translatorMock       = $this->createMock(TranslatorInterface::class);
+        $this->sessionMock          = $this->createMock(Session::class);
+        $this->modelFactoryMock     = $this->createMock(ModelFactory::class);
+        $this->containerMock        = $this->createMock(Container::class);
+        $this->routerMock           = $this->createMock(Router::class);
+        $this->modelMock            = $this->createMock(EmailModel::class);
+        $this->emailMock            = $this->createMock(Email::class);
+        $this->flashBagMock         = $this->createMock(FlashBagInterface::class);
+        $this->corePermissionsMock  = $this->createMock(CorePermissions::class);
+        $this->helperUserMock       = $this->createMock(UserHelper::class);
+        $this->formFactoryMock      = $this->createMock(FormFactory::class);
+        $this->formMock             = $this->createMock(Form::class);
+        $this->templatingMock       = $this->createMock(DelegatingEngine::class);
+        $this->controller           = new EmailController();
         $this->controller->setContainer($this->containerMock);
         $this->controller->setTranslator($this->translatorMock);
         $this->sessionMock->method('getFlashBag')->willReturn($this->flashBagMock);
@@ -151,5 +167,96 @@ class EmailControllerTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->controller->sendAction(5);
         $this->assertEquals(302, $response->getStatusCode());
+    }
+
+    public function testThatExampleEmailsHaveTestStringInTheirSubject()
+    {
+        $this->emailMock->expects($this->once())
+            ->method('setSubject')
+            ->with($this->stringStartsWith(EmailController::EXAMPLE_EMAIL_SUBJECT_PREFIX));
+
+        $this->containerMock->expects($this->at(0))
+            ->method('get')
+            ->with('mautic.model.factory')
+            ->willReturn($this->modelFactoryMock);
+
+        $this->modelFactoryMock->expects($this->at(0))
+            ->method('getModel')
+            ->with('email')
+            ->willReturn($this->modelMock);
+
+        $this->modelMock->expects($this->at(0))
+            ->method('getEntity')
+            ->with(1)
+            ->willReturn($this->emailMock);
+
+        $this->containerMock->expects($this->at(1))
+            ->method('get')
+            ->with('mautic.security')
+            ->willReturn($this->corePermissionsMock);
+
+        $this->corePermissionsMock->expects($this->at(0))
+            ->method('hasEntityAccess')
+            ->with('email:emails:viewown', 'email:emails:viewother', null)
+            ->willReturn(true);
+
+        $this->containerMock->expects($this->at(2))
+            ->method('get')
+            ->with('router')
+            ->willReturn($this->routerMock);
+
+        $this->routerMock->expects($this->at(0))
+            ->method('generate')
+            ->with('mautic_email_action', [
+                'objectAction' => 'sendExample',
+                'objectId'     => 1,
+            ], 1)
+            ->willReturn('someUrl');
+
+        $this->containerMock->expects($this->at(3))
+            ->method('get')
+            ->with('mautic.helper.user')
+            ->willReturn($this->helperUserMock);
+
+        $this->helperUserMock->expects($this->at(0))
+            ->method('getUser')
+            ->willReturn(new User(false));
+
+        $this->containerMock->expects($this->at(4))
+            ->method('get')
+            ->with('form.factory')
+            ->willReturn($this->formFactoryMock);
+
+        $this->formFactoryMock->expects($this->at(0))
+            ->method('create')
+            ->with('Mautic\EmailBundle\Form\Type\ExampleSendType',
+                [
+                    'emails' => [
+                        'list' => [
+                            0 => null,
+                        ],
+                    ],
+                ],
+                [
+                    'action' => 'someUrl',
+                ]
+            )
+            ->willReturn($this->formMock);
+
+        $this->containerMock->expects($this->at(5))
+            ->method('has')
+            ->with('templating')
+            ->willReturn(true);
+
+        $this->containerMock->expects($this->at(6))
+            ->method('get')
+            ->with('templating')
+            ->willReturn($this->templatingMock);
+
+        $this->templatingMock->expects($this->once())
+            ->method('render')
+            ->willReturn('');
+
+        $this->controller->sendExampleAction(1);
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Y
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
We would like to have the words `[TEST]` automatically added to the subject line of 'send example' emails to easily differentiate between example emails and real emails.

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Go to emails page, open (view) any email in Mautic.
2. Click on the "Send Example" button.
3. You should receive an email with the `[TEST]` string in the subject.