### PR TITLE
MAUT-3351-right-fields-mapping

### DIFF
--- a/app/bundles/PluginBundle/Views/FormTheme/Integration/fields_row.html.php
+++ b/app/bundles/PluginBundle/Views/FormTheme/Integration/fields_row.html.php
@@ -130,7 +130,7 @@ $indexCount = 1;
                     foreach ($mauticChoices as $keyLabel => $options): ?>
                     <?php if (is_array($options)) : ?>
                     <optgroup label="<?php echo $keyLabel; ?>">
-                        <?php foreach ($options as $keyValue => $o): ?>
+                        <?php foreach ($options as $o => $keyValue): ?>
                         <option value="<?php echo $view->escape($keyValue); ?>" <?php if ($keyValue === $child->vars['data']): echo 'selected'; $selected = true; elseif (empty($selected) && '-1' == $keyValue): echo 'selected'; endif; ?>>
                             <?php echo $o; ?>
                         </option>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Flip keys and values for fields mapping.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Open Facebook plugin
2. Set some fields mapping
3. Apply
4. The settings disappear

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Open Facebook plugin
3. Set some fields mapping
4. Apply
5. The mapping of the fields is there

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
