### PR TITLE
Fixing PHP Warning - count(): Parameter must be an array or an object…

### DIFF
--- a/app/bundles/CoreBundle/Model/IteratorExportDataModel.php
+++ b/app/bundles/CoreBundle/Model/IteratorExportDataModel.php
@@ -63,7 +63,6 @@ class IteratorExportDataModel implements \Iterator
             $this->totalResult = $this->data ? count($this->data) : 0;
             $this->total       = $this->total + $this->totalResult;
             $this->position    = 0;
-            ++$this->page;
         }
     }
 

--- a/app/bundles/CoreBundle/Model/IteratorExportDataModel.php
+++ b/app/bundles/CoreBundle/Model/IteratorExportDataModel.php
@@ -13,9 +13,6 @@ namespace Mautic\CoreBundle\Model;
 
 use Mautic\CoreBundle\Helper\DataExporterHelper;
 
-/**
- * Class IteratorExportDataModel.
- */
 class IteratorExportDataModel implements \Iterator
 {
     private $position;
@@ -24,12 +21,8 @@ class IteratorExportDataModel implements \Iterator
     private $callback;
     private $total;
     private $data;
-    private $page;
     private $totalResult;
 
-    /**
-     * IteratorExportDataModel constructor.
-     */
     public function __construct(AbstractCommonModel $model, $args, callable $callback)
     {
         $this->model       = $model;
@@ -37,7 +30,6 @@ class IteratorExportDataModel implements \Iterator
         $this->callback    = $callback;
         $this->position    = 0;
         $this->total       = 0;
-        $this->page        = 1;
         $this->totalResult = 0;
         $this->data        = 0;
     }
@@ -68,8 +60,8 @@ class IteratorExportDataModel implements \Iterator
         if ($this->position === $this->totalResult) {
             $data              = new DataExporterHelper();
             $this->data        = $data->getDataForExport($this->total, $this->model, $this->args, $this->callback);
-            $this->total       = $this->total + count($this->data);
-            $this->totalResult = count($this->data);
+            $this->totalResult = $this->data ? count($this->data) : 0;
+            $this->total       = $this->total + $this->totalResult;
             $this->position    = 0;
             ++$this->page;
         }
@@ -118,8 +110,8 @@ class IteratorExportDataModel implements \Iterator
     {
         $data              = new DataExporterHelper();
         $this->data        = $data->getDataForExport($this->total, $this->model, $this->args, $this->callback);
-        $this->total       = $this->total + count($this->data);
-        $this->totalResult = count($this->data);
+        $this->totalResult = $this->data ? count($this->data) : 0;
+        $this->total       = $this->total + $this->totalResult;
         $this->position    = 0;
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Model/IteratorExportDataModelTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Model/IteratorExportDataModelTest.php
@@ -9,7 +9,7 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-namespace Mautic\CoreBundle\Tests\Unit\Validator;
+namespace Mautic\CoreBundle\Tests\Unit\Model;
 
 use Mautic\CoreBundle\Entity\CommonRepository;
 use Mautic\CoreBundle\Model\AbstractCommonModel;

--- a/app/bundles/CoreBundle/Tests/Unit/Model/IteratorExportDataModelTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Model/IteratorExportDataModelTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Tests\Unit\Validator;
+
+use Mautic\CoreBundle\Entity\CommonRepository;
+use Mautic\CoreBundle\Model\AbstractCommonModel;
+use Mautic\CoreBundle\Model\IteratorExportDataModel;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class IteratorExportDataModelTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var MockObject|AbstractCommonModel
+     */
+    private $commonModel;
+
+    /**
+     * @var MockObject|CommonRepository
+     */
+    private $commonRepository;
+
+    /**
+     * @var IteratorExportDataModel
+     */
+    private $iteratorExportDataModel;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->commonModel      = $this->createMock(AbstractCommonModel::class);
+        $this->commonRepository = $this->createMock(CommonRepository::class);
+        $args                   = ['limit' => 1000];
+        $callback               = function ($var) {
+            return $var;
+        };
+
+        $this->iteratorExportDataModel = new IteratorExportDataModel($this->commonModel, $args, $callback);
+    }
+
+    public function testWorkflowWithItems(): void
+    {
+        $this->commonModel->expects($this->once())
+            ->method('getEntities')
+            ->with(['limit' => 1000, 'start' => 0])
+            ->willReturn(['results' => [['a'], ['b']]]);
+
+        $this->commonModel->method('getRepository')->willReturn($this->commonRepository);
+
+        $this->assertSame(0, $this->iteratorExportDataModel->key());
+        $this->iteratorExportDataModel->rewind();
+        $this->iteratorExportDataModel->next();
+        $this->assertSame(1, $this->iteratorExportDataModel->key());
+    }
+
+    public function testWorkflowWithoutItems(): void
+    {
+        $this->commonModel->expects($this->once())
+            ->method('getEntities')
+            ->with(['limit' => 1000, 'start' => 0])
+            ->willReturn(['results' => []]);
+
+        $this->commonModel->method('getRepository')->willReturn($this->commonRepository);
+
+        $this->assertSame(0, $this->iteratorExportDataModel->key());
+        $this->iteratorExportDataModel->rewind();
+        $this->iteratorExportDataModel->next();
+        $this->assertSame(1, $this->iteratorExportDataModel->key());
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

PHP 7.2+ has problem with `count(null)` ant throws this:
```
Symfony\Component\Debug\Exception\ContextErrorException: PHP Warning - count(): Parameter must be an array or an object that implements Countable
in /app/bundles/CoreBundle/Model/IteratorExportDataModel.php:71
```

This PR ensures that count will be called only with countable.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. The error happens on contact export, but it may happen only under special unknown conditions.

#### Steps to test this PR:
1. I was able to reproduce it in the attached unit test. Ensure that the tests are passing on Travis.