### PR TITLE
Fix inability to view contacts in mysql 8

### DIFF
--- a/app/bundles/CoreBundle/Entity/AuditLogRepository.php
+++ b/app/bundles/CoreBundle/Entity/AuditLogRepository.php
@@ -232,13 +232,15 @@ class AuditLogRepository extends CommonRepository
             ->groupBy('l.ip_address');
 
         if ($lead instanceof Lead) {
+            $dateTimeFormat = 'Y-m-d H:i:s';
+
             // Just a check to ensure reused IDs (happens with innodb) doesn't infect data
-            $dt = new DateTimeHelper($lead->getDateAdded(), 'Y-m-d H:i:s', 'local');
+            $dateTimeHelper = new DateTimeHelper($lead->getDateAdded(), $dateTimeFormat, 'local');
 
             $sqb->andWhere(
                 $sqb->expr()->andX(
                     $sqb->expr()->eq('l.object_id', $lead->getId()),
-                    $sqb->expr()->gte('l.date_added', $sqb->expr()->literal($dt->getUtcTimestamp()))
+                    $sqb->expr()->gte('l.date_added', $sqb->expr()->literal($dateTimeHelper->toUtcString($dateTimeFormat)))
                 )
             );
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7612
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
It's impossible to view a contact on MySQL version 8.0.16 or later.
Probably this is caused by https://bugs.mysql.com/bug.php?id=95466

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Install MySQL version 8.0.16 or later.
2. Go to Contacts page, try to open (view) any contact.
3. You will get a popup with the error message.

#### Steps to test this PR:
1. Install MySQL version 8.0.16 or later.
2. Load up [this PR](https://mautibox.com)
3. Go to Contacts page, try to open (view) any contact.
4. You should be able to view contacts.