### PR TITLE
Enable overwrite with blank for API

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
+++ b/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
@@ -136,8 +136,9 @@ trait CustomFieldsApiControllerTrait
         }
 
         $overwriteWithBlank = !$isPostOrPatch;
-        if (isset($parameters['overwriteWithBlank']) && $parameters['overwriteWithBlank']) {
+        if (isset($parameters['overwriteWithBlank']) && !empty($parameters['overwriteWithBlank'])) {
             $overwriteWithBlank = true;
+            unset($parameters['overwriteWithBlank']);
         }
 
         $this->model->setFieldValues($entity, $parameters, $overwriteWithBlank);

--- a/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
+++ b/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
@@ -135,6 +135,11 @@ trait CustomFieldsApiControllerTrait
             );
         }
 
-        $this->model->setFieldValues($entity, $parameters, true);
+        $overwriteWithBlank = !$isPostOrPatch;
+        if (isset($parameters['overwriteWithBlank']) && $parameters['overwriteWithBlank']) {
+            $overwriteWithBlank = true;
+        }
+
+        $this->model->setFieldValues($entity, $parameters, $overwriteWithBlank);
     }
 }

--- a/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
+++ b/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
@@ -135,6 +135,6 @@ trait CustomFieldsApiControllerTrait
             );
         }
 
-        $this->model->setFieldValues($entity, $parameters, !$isPostOrPatch);
+        $this->model->setFieldValues($entity, $parameters, true);
     }
 }

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -138,54 +138,33 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals(4, $response['contact']['points']);
         $this->assertEquals(2, count($response['contact']['tags']));
 
-        $payload2             = ['email' => 'apiemail1@email.com'];
-        $payload2['lastname'] = '';
+        // without overwriteWithBlank lastname is not set empty
+        $payload['lastname'] = '';
+
         // Lets try to create the same contact to see that the values are not re-setted
-        $this->client->request('POST', '/api/contacts/new', $payload2);
-        $clientResponse = $this->client->getResponse();
-        $response       = json_decode($clientResponse->getContent(), true);
-
-        $this->assertEquals($contactId, $response['contact']['id']);
-        $this->assertEquals($payload['email'], $response['contact']['fields']['all']['email']);
-        $this->assertEquals($payload['firstname'], $response['contact']['fields']['all']['firstname']);
-        $this->assertNotEquals($payload2['lastname'], $response['contact']['fields']['all']['lastname']);
-        $this->assertEquals(4, $response['contact']['points']);
-        $this->assertEquals(2, count($response['contact']['tags']));
-    }
-
-    public function testSingleNewEndpointCreateAndUpdateOverwriteWithBlankTrue()
-    {
-        $payload = [
-            'email'              => 'apiemail1@email.com',
-            'firstname'          => 'API Update',
-            'lastname'           => 'customlastname',
-            'points'             => 4,
-            'tags'               => ['apitest', 'testapi'],
-            'overwriteWithBlank' => true,
-        ];
-
         $this->client->request('POST', '/api/contacts/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
-        $contactId      = $response['contact']['id'];
 
+        $this->assertEquals($contactId, $response['contact']['id']);
         $this->assertEquals($payload['email'], $response['contact']['fields']['all']['email']);
         $this->assertEquals($payload['firstname'], $response['contact']['fields']['all']['firstname']);
-        $this->assertEquals($payload['lastname'], $response['contact']['fields']['all']['lastname']);
+        $this->assertNotEmpty($response['contact']['fields']['all']['lastname']);
         $this->assertEquals(4, $response['contact']['points']);
         $this->assertEquals(2, count($response['contact']['tags']));
 
-        $payload2             = ['email' => 'apiemail1@email.com'];
-        $payload2['lastname'] = '';
+        // with overwriteWithBlank lastname is empty
+        $payload['overwriteWithBlank'] = true;
+
         // Lets try to create the same contact to see that the values are not re-setted
-        $this->client->request('POST', '/api/contacts/new', $payload2);
+        $this->client->request('POST', '/api/contacts/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
         $this->assertEquals($contactId, $response['contact']['id']);
         $this->assertEquals($payload['email'], $response['contact']['fields']['all']['email']);
         $this->assertEquals($payload['firstname'], $response['contact']['fields']['all']['firstname']);
-        $this->assertEquals($payload['lastname'], $response['contact']['fields']['all']['lastname']);
+        $this->assertEmpty($response['contact']['fields']['all']['lastname']);
         $this->assertEquals(4, $response['contact']['points']);
         $this->assertEquals(2, count($response['contact']['tags']));
     }

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -122,6 +122,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $payload = [
             'email'     => 'apiemail1@email.com',
             'firstname' => 'API Update',
+            'lastname'  => 'customlastname',
             'points'    => 4,
             'tags'      => ['apitest', 'testapi'],
         ];
@@ -133,17 +134,58 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->assertEquals($payload['email'], $response['contact']['fields']['all']['email']);
         $this->assertEquals($payload['firstname'], $response['contact']['fields']['all']['firstname']);
+        $this->assertEquals($payload['lastname'], $response['contact']['fields']['all']['lastname']);
         $this->assertEquals(4, $response['contact']['points']);
         $this->assertEquals(2, count($response['contact']['tags']));
 
+        $payload2             = ['email' => 'apiemail1@email.com'];
+        $payload2['lastname'] = '';
         // Lets try to create the same contact to see that the values are not re-setted
-        $this->client->request('POST', '/api/contacts/new', ['email' => 'apiemail1@email.com']);
+        $this->client->request('POST', '/api/contacts/new', $payload2);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
         $this->assertEquals($contactId, $response['contact']['id']);
         $this->assertEquals($payload['email'], $response['contact']['fields']['all']['email']);
         $this->assertEquals($payload['firstname'], $response['contact']['fields']['all']['firstname']);
+        $this->assertNotEquals($payload2['lastname'], $response['contact']['fields']['all']['lastname']);
+        $this->assertEquals(4, $response['contact']['points']);
+        $this->assertEquals(2, count($response['contact']['tags']));
+    }
+
+    public function testSingleNewEndpointCreateAndUpdateOverwriteWithBlankTrue()
+    {
+        $payload = [
+            'email'              => 'apiemail1@email.com',
+            'firstname'          => 'API Update',
+            'lastname'           => 'customlastname',
+            'points'             => 4,
+            'tags'               => ['apitest', 'testapi'],
+            'overwriteWithBlank' => true,
+        ];
+
+        $this->client->request('POST', '/api/contacts/new', $payload);
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+        $contactId      = $response['contact']['id'];
+
+        $this->assertEquals($payload['email'], $response['contact']['fields']['all']['email']);
+        $this->assertEquals($payload['firstname'], $response['contact']['fields']['all']['firstname']);
+        $this->assertEquals($payload['lastname'], $response['contact']['fields']['all']['lastname']);
+        $this->assertEquals(4, $response['contact']['points']);
+        $this->assertEquals(2, count($response['contact']['tags']));
+
+        $payload2             = ['email' => 'apiemail1@email.com'];
+        $payload2['lastname'] = '';
+        // Lets try to create the same contact to see that the values are not re-setted
+        $this->client->request('POST', '/api/contacts/new', $payload2);
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+
+        $this->assertEquals($contactId, $response['contact']['id']);
+        $this->assertEquals($payload['email'], $response['contact']['fields']['all']['email']);
+        $this->assertEquals($payload['firstname'], $response['contact']['fields']['all']['firstname']);
+        $this->assertEquals($payload['lastname'], $response['contact']['fields']['all']['lastname']);
         $this->assertEquals(4, $response['contact']['points']);
         $this->assertEquals(2, count($response['contact']['tags']));
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/138
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR enable overwriteWithBlank for contact/company create/edit API hook.
I think we need remove values from fields. Now it's not possible.

@escopecz please can you take a look? I didn't find  better way like new add  overwriteWithBlank param prevent BC


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try   create contact with firstname by API

`$response = $contactApi->create(['email'=>'email@email.com', 'firstname'=>'test']);`

`$response = $contactApi->create(['email'=>'email@email.com', 'firstname'=>'']);`

2. Expect firstname is empty. But firstname should be test

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2.  
`$response = $contactApi->create(['email'=>'email@email.com', 'firstname'=>'test']);`

`$response = $contactApi->create(['email'=>'email@email.com', 'firstname'=>'', 'overwriteWithBlank'=>true]);`

3. Firstname should be empty

