### PR TITLE
Fix anchor links during redirection

### DIFF
--- a/app/bundles/CoreBundle/Helper/UrlHelper.php
+++ b/app/bundles/CoreBundle/Helper/UrlHelper.php
@@ -73,6 +73,38 @@ class UrlHelper
     }
 
     /**
+     * Append query string to URL.
+     *
+     * @param string $url
+     * @param string $appendQueryString
+     *
+     * @return string
+     */
+    public static function appendQueryToUrl($url, $appendQueryString)
+    {
+        $query     = parse_url($url, PHP_URL_QUERY);
+
+        if ($query) {
+            $appendQueryString = '&'.$appendQueryString;
+        } else {
+            $appendQueryString = '?'.$appendQueryString;
+        }
+
+        $anchorParts = explode('#', $url);
+        // join url without anchor + $appendQueryString
+        $url = $anchorParts[0].$appendQueryString;
+        // prevent & or ? twice
+        $url = str_replace(['&&', '??'], ['&', '?'], $url);
+
+        // anchor
+        if (isset($anchorParts[1])) {
+            $url = sprintf('%s#%s', $url, $anchorParts[1]);
+        }
+
+        return $url;
+    }
+
+    /**
      * @param $rel
      *
      * @return string

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/UrlHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/UrlHelperTest.php
@@ -15,6 +15,24 @@ use Mautic\CoreBundle\Helper\UrlHelper;
 
 class UrlHelperTest extends \PHPUnit\Framework\TestCase
 {
+    public function testAppendQueryToUrl()
+    {
+        $appendQueryString = 'utm_source=mautic.org';
+
+        $urls = [
+            'https://mautic.org'               => 'https://mautic.org?'.$appendQueryString,
+            'https://mautic.org?'              => 'https://mautic.org?'.$appendQueryString,
+            'https://mautic.org?test=1'        => 'https://mautic.org?test=1&'.$appendQueryString,
+            'https://mautic.org?test=1&'       => 'https://mautic.org?test=1&'.$appendQueryString,
+            'https://mautic.org?test=1#anchor' => 'https://mautic.org?test=1&'.$appendQueryString.'#anchor',
+            'https://mautic.org?#anchor'       => 'https://mautic.org?'.$appendQueryString.'#anchor',
+            'https://mautic.org#anchor'        => 'https://mautic.org?'.$appendQueryString.'#anchor',
+        ];
+        foreach ($urls as $url=>$expectedUrl) {
+            $this->assertEquals(UrlHelper::appendQueryToUrl($url, $appendQueryString), $expectedUrl);
+        }
+    }
+
     public function testSanitizeAbsoluteUrlDoesNotModifyCorrectFullUrl()
     {
         $this->assertEquals(
@@ -75,7 +93,9 @@ class UrlHelperTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertEquals(
             'http://username:password@hostname:9090/path?ar_g1=value&arg2=some+email%40address.com#anchor',
-            UrlHelper::sanitizeAbsoluteUrl('http://username:password@hostname:9090/path?ar g1=value&arg2=some+email@address.com#anchor')
+            UrlHelper::sanitizeAbsoluteUrl(
+                'http://username:password@hostname:9090/path?ar g1=value&arg2=some+email@address.com#anchor'
+            )
         );
     }
 
@@ -98,9 +118,11 @@ class UrlHelperTest extends \PHPUnit\Framework\TestCase
     public function testGetUrlsFromPlaintextSkipDefaultTokenValues()
     {
         $this->assertEquals(
-            // 1 is skipped because it's set as the token default
+        // 1 is skipped because it's set as the token default
             [0 => 'https://find.this', 2 => '{contactfield=website|http://skip.this}'],
-            UrlHelper::getUrlsFromPlaintext('Find this url: https://find.this, but allow this token because we know its a url: {contactfield=website|http://skip.this}! ')
+            UrlHelper::getUrlsFromPlaintext(
+                'Find this url: https://find.this, but allow this token because we know its a url: {contactfield=website|http://skip.this}! '
+            )
         );
     }
 
@@ -108,7 +130,9 @@ class UrlHelperTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertEquals(
             ['http://mautic.org', 'http://mucktick.org'],
-            UrlHelper::getUrlsFromPlaintext('Hello there, http://mautic.org is the correct URL. Not http://mucktick.org.')
+            UrlHelper::getUrlsFromPlaintext(
+                'Hello there, http://mautic.org is the correct URL. Not http://mucktick.org.'
+            )
         );
     }
 

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -452,8 +452,7 @@ class PublicController extends CommonFormController
 
         // Tak on anything left to the URL
         if (count($query)) {
-            $url .= (false !== strpos($url, '?')) ? '&' : '?';
-            $url .= http_build_query($query);
+            $url = UrlHelper::appendQueryToUrl($url, http_build_query($query));
         }
 
         // If the IP address is not trackable, it means it came form a configured "do not track" IP or a "do not track" user agent

--- a/app/bundles/PageBundle/Model/RedirectModel.php
+++ b/app/bundles/PageBundle/Model/RedirectModel.php
@@ -82,14 +82,9 @@ class RedirectModel extends FormModel
         );
 
         if (!empty($utmTags)) {
-            $utmTags   = $this->getUtmTagsForUrl($utmTags);
-            $query     = parse_url($url, PHP_URL_QUERY);
-            $urlString = http_build_query($utmTags, '', '&');
-            if ($query) {
-                $url .= '&'.$urlString;
-            } else {
-                $url .= '?'.$urlString;
-            }
+            $utmTags         = $this->getUtmTagsForUrl($utmTags);
+            $appendUtmString = http_build_query($utmTags, '', '&');
+            $url             = UrlHelper::appendQueryToUrl($url, $appendUtmString);
         }
 
         if ($shortenUrl) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/5417
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR resolve issue with anchor in URL If URL contains another query parameters.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Add link with hash to email 
2.  Set UTM Campaign Data on email 
3.  Send email (preview omits UTM Campaign links)
4.  Check if #links work or not  

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2.  Repeat all steps to reproduce. Check if works properly
You should try all variants with UTM, without UTM tags. with `{pagelink=1}` token etc.