### PR TITLE
M3: Fix submission error

### DIFF
--- a/app/bundles/FormBundle/Event/SubmissionEvent.php
+++ b/app/bundles/FormBundle/Event/SubmissionEvent.php
@@ -272,7 +272,9 @@ class SubmissionEvent extends CommonEvent
     public function setAction(?Action $action = null)
     {
         $this->action = $action;
-        $this->setContext($action->getType());
+        if (null !== $action) {
+            $this->setContext($action->getType());
+        }
     }
 
     public function getAction(): ?Action


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Just simple form with email field return fatal error. Reported here: 
https://github.com/mautic/mautic/issues/8469

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create simple form with email field without actions
2. Try submit from preview. Should return error 

`mautic.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Call to a member function getType() on null" at C:\wamp3-1-4\www\mautic3\app\bundles\FormBundle\Event\SubmissionEvent.php line 275 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Call to a member function getType() on null at C:\\wamp3-1-4\\www\\mautic3\\app\\bundles\\FormBundle\\Event\\SubmissionEvent.php:275)`
