### PR TITLE
 Fix select contact source from campaign forms

### DIFF
--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -532,7 +532,7 @@ class CampaignModel extends CommonFormModel
                 $repo             = $this->formModel->getRepository();
                 $repo->setCurrentUser($this->userHelper->getUser());
 
-                $forms = $repo->getFormList('', 0, 0, $viewOther, CampaignType::class);
+                $forms = $repo->getFormList('', 0, 0, $viewOther, 'campaign');
 
                 if ($forms) {
                     foreach ($forms as $form) {


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8427
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Unable to select campaign form in campaign sources

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form first. Shouldn't be a Problem!
2. Start creating a Campaign.
3. Open Campaign Builder and choose "Campaign forms" as contact source.
4. Search for the previously created form - GOOD LUCK 😜

https://github.com/mautic/mautic/issues/8427

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat reproduction steps and you'll be lucky ;-)
