### PR TITLE
MAUT-3377 - Refactor to build middleware cache on warmup

### DIFF
--- a/app/bundles/CoreBundle/Cache/MiddlewareCacheWarmer.php
+++ b/app/bundles/CoreBundle/Cache/MiddlewareCacheWarmer.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Cache;
+
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+class MiddlewareCacheWarmer implements CacheWarmerInterface
+{
+    public function warmUp($cacheDirectory)
+    {
+        // wip
+    }
+
+    public function isOptional()
+    {
+        return false;
+    }
+}

--- a/app/bundles/CoreBundle/Cache/MiddlewareCacheWarmer.php
+++ b/app/bundles/CoreBundle/Cache/MiddlewareCacheWarmer.php
@@ -12,17 +12,112 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Cache;
 
+use ReflectionClass;
+use ReflectionException;
+use SplPriorityQueue;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
 class MiddlewareCacheWarmer implements CacheWarmerInterface
 {
+    /**
+     * @var string
+     */
+    private $env;
+
+    /**
+     * @var string
+     */
+    private $cacheFile;
+
+    /**
+     * @var SplPriorityQueue|ReflectionClass[]
+     */
+    private $specs;
+
+    public function __construct(string $env)
+    {
+        $this->env       = $env;
+        $this->specs     = new SplPriorityQueue();
+    }
+
     public function warmUp($cacheDirectory)
     {
-        // wip
+        $this->cacheFile = sprintf('%s/middlewares.cache.php', $cacheDirectory);
+        $this->createCacheFile($cacheDirectory);
     }
 
     public function isOptional()
     {
         return false;
+    }
+
+    private function createCacheFile($cacheDirectory): void
+    {
+        $middlewarsDir = __DIR__.'/../../../middlewares';
+
+        $this->loadFromDirectory($middlewarsDir);
+
+        $envDir = $middlewarsDir.'/'.ucfirst($this->env);
+
+        if (file_exists($envDir)) {
+            $this->loadFromDirectory($envDir, $this->env);
+        }
+
+        if (file_exists($this->cacheFile)) {
+            unlink($this->cacheFile);
+        }
+
+        if (false === file_exists($cacheDirectory)) {
+            mkdir($cacheDirectory, 0755, true);
+        }
+
+        $data  = [];
+        $this->specs->setExtractFlags(SplPriorityQueue::EXTR_DATA);
+
+        /** @var ReflectionClass $middleware */
+        foreach ($this->specs as $middleware) {
+            $data[] = $middleware->getName();
+        }
+
+        $content = sprintf('<?php return %s;', var_export($data, true));
+
+        file_put_contents($this->cacheFile, $content);
+    }
+
+    private function loadFromDirectory(string $directory, ?string $env = null): void
+    {
+        $glob = glob($directory.'/*Middleware.php');
+
+        if (!empty($glob)) {
+            $this->addMiddlewares($glob, $env);
+        }
+    }
+
+    private function addMiddlewares(array $middlewares, ?string $env = null)
+    {
+        $prefix = 'Mautic\\Middleware\\';
+
+        if ($env) {
+            $prefix .= ucfirst($env).'\\';
+        }
+
+        foreach ($middlewares as $middleware) {
+            $this->push($prefix.basename(substr($middleware, 0, -4)));
+        }
+    }
+
+    private function push(string $middlewareClass): void
+    {
+        try {
+            $reflection = new ReflectionClass($middlewareClass);
+            $priority   = $reflection->getConstant('PRIORITY');
+
+            $this->specs->insert($reflection, $priority);
+        } catch (ReflectionException $e) {
+            /* If there's an error getting the kernel class, it's
+             * an invalid middleware. If it's invalid, don't push
+             * it to the stack
+             */
+        }
     }
 }

--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -568,6 +568,10 @@ return [
             ],
         ],
         'other' => [
+            'mautic.cache.warmer.middleware' => [
+                'class' => \Mautic\CoreBundle\Cache\MiddlewareCacheWarmer::class,
+                'tag'   => 'kernel.cache_warmer',
+            ],
             'mautic.http.client' => [
                 'class' => GuzzleHttp\Client::class,
             ],

--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -569,8 +569,11 @@ return [
         ],
         'other' => [
             'mautic.cache.warmer.middleware' => [
-                'class' => \Mautic\CoreBundle\Cache\MiddlewareCacheWarmer::class,
-                'tag'   => 'kernel.cache_warmer',
+                'class'     => \Mautic\CoreBundle\Cache\MiddlewareCacheWarmer::class,
+                'tag'       => 'kernel.cache_warmer',
+                'arguments' => [
+                    '%kernel.environment%',
+                ],
             ],
             'mautic.http.client' => [
                 'class' => GuzzleHttp\Client::class,


### PR DESCRIPTION
https://backlog.acquia.com/browse/MAUT-3377

Steps to test:
1. run app/console cache:warmup
2. Check that a middlewares.cache.php file is created in the var/cache directory for the relevant environment
3. Check that the file contains all middlewares
4. Confirm the instance loads