### PR TITLE
Fix category filter

### DIFF
--- a/app/bundles/CategoryBundle/Controller/CategoryController.php
+++ b/app/bundles/CategoryBundle/Controller/CategoryController.php
@@ -47,7 +47,7 @@ class CategoryController extends AbstractFormController
         $session = $this->get('session');
 
         $search = $this->request->query->get('search', $session->get('mautic.category.filter', ''));
-        $bundle = $this->request->query->get('bundle', $session->get('mautic.category.type', ''));
+        $bundle = $this->request->query->get('bundle', $session->get('mautic.category.type', $bundle));
 
         if ($bundle) {
             $session->set('mautic.category.type', $bundle);

--- a/app/bundles/CategoryBundle/Controller/CategoryController.php
+++ b/app/bundles/CategoryBundle/Controller/CategoryController.php
@@ -46,8 +46,8 @@ class CategoryController extends AbstractFormController
     {
         $session = $this->get('session');
 
-        $search = $this->request->get('search', $session->get('mautic.category.filter', ''));
-        $bundle = $this->request->get('bundle', $session->get('mautic.category.type', ''));
+        $search = $this->request->query->get('search', $session->get('mautic.category.filter', ''));
+        $bundle = $this->request->query->get('bundle', $session->get('mautic.category.type', ''));
 
         if ($bundle) {
             $session->set('mautic.category.type', $bundle);

--- a/app/bundles/CategoryBundle/Tests/Controller/CategoryControllerFunctionalTest.php
+++ b/app/bundles/CategoryBundle/Tests/Controller/CategoryControllerFunctionalTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Mautic\CategoryBundle\Tests\Controller;
+
+use Mautic\CategoryBundle\Entity\Category;
+use Mautic\CategoryBundle\Model\CategoryModel;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+
+class CategoryControllerFunctionalTest extends MauticMysqlTestCase
+{
+    /**
+     * Create two new categories.
+     *
+     * @throws \Exception
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $categoriesData = [
+            [
+                'title'  => 'TestTitleCategoryController1',
+                'bundle' => 'page',
+                ],
+            [
+                'title'  => 'TestTitleCategoryController2',
+                'bundle' => 'global',
+            ],
+        ];
+        /** @var CategoryModel $model */
+        $model      = $this->container->get('mautic.category.model.category');
+
+        foreach ($categoriesData as $categoryData) {
+            $category = new Category();
+            $category->setIsPublished(true)
+                ->setTitle($categoryData['title'])
+                ->setBundle($categoryData['bundle']);
+            $model->saveEntity($category);
+        }
+    }
+
+    /**
+     * Get all results without filtering.
+     */
+    public function testIndexActionWhenNotFiltered(): void
+    {
+        $this->client->request('GET', '/s/categories?tmpl=list&bundle=category');
+        $clientResponse         = $this->client->getResponse();
+        $clientResponseContent  = $clientResponse->getContent();
+
+        $this->assertSame(200, $clientResponse->getStatusCode(), 'Return code must be 200.');
+        $this->assertStringContainsString('TestTitleCategoryController1', $clientResponseContent, 'The return must contain TestTitleCategoryController1');
+        $this->assertStringContainsString('TestTitleCategoryController2', $clientResponseContent, 'The return must contain TestTitleCategoryController2');
+    }
+
+    /**
+     * Get a result with filter.
+     */
+    public function testIndexActionWhenFiltered(): void
+    {
+        $this->client->request('GET', '/s/categories/page?tmpl=list&bundle=page');
+        $clientResponse         = $this->client->getResponse();
+        $clientResponseContent  = $clientResponse->getContent();
+
+        $this->assertSame(200, $clientResponse->getStatusCode(), 'Return code must be 200.');
+        $this->assertStringContainsString('TestTitleCategoryController1', $clientResponseContent, 'The return must contain TestTitleCategoryController1');
+        $this->assertStringNotContainsString('TestTitleCategoryController2', $clientResponseContent, 'The return must not contain TestTitleCategoryController2');
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |https://github.com/mautic/mautic/issues/8465
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Categories filter does not work

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create 2 categories with different types
2. Filter in the categories list view on one of those 2 types
3. See both results


#### Steps to test this PR:
0. Load up [this PR](https://mautibox.com)
1. Create 2 categories with different types
2. Filter in the categories list view on one of those 2 types
3. See one result

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
