### PR TITLE
SugarCrm: Skip fetchDnc if entity not exists

### DIFF
--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -1427,8 +1427,12 @@ class SugarcrmIntegration extends CrmAbstractIntegration
         }
     }
 
-    private function fetchDncToMautic(Lead $lead, array $data)
+    private function fetchDncToMautic(Lead $lead = null, array $data)
     {
+        if (is_null($lead)) {
+            return;
+        }
+
         $features = $this->settings->getFeatureSettings();
         if (empty($features['updateDnc'])) {
             return;


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

We noticed this error in logs during the sync 

`[2020-02-27 09:03:06] mautic.NOTICE: Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Argument 1 passed to MauticPlugin\MauticCrmBundle\Integration\SugarcrmIntegration::fetchDncToMautic() must be an instance of Mautic\LeadBundle\Entity\Lead, null given, called in /path/to/mautic/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php on line 917 (uncaught exception) at /path/to/mautic/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php line 1488 while running console command mautic:integration:fetchleads [] []`

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Hard to reproduce. But this PR should avoid that
