### PR TITLE
WIP: M3 fix form filter query

### DIFF
--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -86,7 +86,8 @@ class FormController extends CommonFormController
             ]
         );
 
-        $count = count($forms);
+        $forms->getQuery()->setParameters([]);
+        $count = $forms->count();
 
         if ($count && $count < ($start + 1)) {
             //the number of entities are now less then the current page so redirect to the last page

--- a/composer.lock
+++ b/composer.lock
@@ -1557,16 +1557,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "v2.7.0",
+            "version": "v2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "4d763ca4c925f647b248b9fa01b5f47aa3685d62"
+                "reference": "445796af0e873d9bd04f2502d322a7d5009b6846"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/4d763ca4c925f647b248b9fa01b5f47aa3685d62",
-                "reference": "4d763ca4c925f647b248b9fa01b5f47aa3685d62",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/445796af0e873d9bd04f2502d322a7d5009b6846",
+                "reference": "445796af0e873d9bd04f2502d322a7d5009b6846",
                 "shasum": ""
             },
             "require": {
@@ -1579,6 +1579,7 @@
                 "doctrine/instantiator": "^1.3",
                 "doctrine/persistence": "^1.2",
                 "ext-pdo": "*",
+                "ocramius/package-versions": "^1.2",
                 "php": "^7.1",
                 "symfony/console": "^3.0|^4.0|^5.0"
             },
@@ -1636,7 +1637,7 @@
                 "database",
                 "orm"
             ],
-            "time": "2019-11-19T08:38:05+00:00"
+            "time": "2020-02-15T14:35:56+00:00"
         },
         {
             "name": "doctrine/persistence",
@@ -7943,16 +7944,16 @@
         },
         {
             "name": "symfony/doctrine-bridge",
-            "version": "v3.4.37",
+            "version": "v3.4.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-bridge.git",
-                "reference": "0ddc9bfbf64396f5f399dde2eeec6d20c82da222"
+                "reference": "4f82aa0fc119ac494c9925c3c68b5c0af3f71ce5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/0ddc9bfbf64396f5f399dde2eeec6d20c82da222",
-                "reference": "0ddc9bfbf64396f5f399dde2eeec6d20c82da222",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/4f82aa0fc119ac494c9925c3c68b5c0af3f71ce5",
+                "reference": "4f82aa0fc119ac494c9925c3c68b5c0af3f71ce5",
                 "shasum": ""
             },
             "require": {
@@ -8020,7 +8021,7 @@
             ],
             "description": "Symfony Doctrine Bridge",
             "homepage": "https://symfony.com",
-            "time": "2020-01-01T11:03:25+00:00"
+            "time": "2020-02-24T13:11:05+00:00"
         },
         {
             "name": "symfony/dotenv",


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8496
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Go to the list of forms and search for has:results forms. It errors with Too many parameters: the query defines 0 parameters and you bound 1 at vendor/doctrine/orm/lib/Doctrine/ORM/Query/QueryException.php:105

Same happens when using the name:* search.

Is seems that there is a problem in `\Mautic\CoreBundle\Entity\CommonRepository::buildWhereClause()` methods which contains logic colliding with behaviour of Doctrine/ORM 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to forms
2. search for `has:results`
3. search for `name:*`

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Same as reproduction steps

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
