### PR TITLE
Fix delete of multiple forms

### DIFF
--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -1081,7 +1081,8 @@ class FormController extends CommonFormController
 
             // Loop over the IDs to perform access checks pre-delete
             foreach ($ids as $objectId) {
-                $entity = $model->getEntity($objectId);
+                $objectId = (int) $objectId;
+                $entity   = $model->getEntity($objectId);
 
                 if (null === $entity) {
                     $flashes[] = [

--- a/app/bundles/FormBundle/Helper/FormUploader.php
+++ b/app/bundles/FormBundle/Helper/FormUploader.php
@@ -88,7 +88,7 @@ class FormUploader
 
     public function deleteFilesOfForm(Form $form)
     {
-        $formUploadDir = $this->getUploadDirOfForm($form);
+        $formUploadDir = $this->getUploadDirOfForm($form->deletedId);
         $this->fileUploader->delete($formUploadDir);
     }
 
@@ -123,7 +123,7 @@ class FormUploader
     private function getUploadDir(Field $field)
     {
         $fieldId       = $field->getId();
-        $formUploadDir = $this->getUploadDirOfForm($field->getForm());
+        $formUploadDir = $this->getUploadDirOfForm($field->getForm()->getId());
 
         return $formUploadDir.DIRECTORY_SEPARATOR.$fieldId;
     }
@@ -133,13 +133,13 @@ class FormUploader
      *
      * @throws \LogicException If formId is null
      */
-    private function getUploadDirOfForm(Form $form)
+    private function getUploadDirOfForm(?int $formId)
     {
         $uploadDir = $this->coreParametersHelper->get('form_upload_dir');
-        if (null === $form->deletedId) {
+        if (null === $formId) {
             throw new \LogicException('FormID can\'t be null');
         }
 
-        return $uploadDir.DIRECTORY_SEPARATOR.$form->deletedId;
+        return $uploadDir.DIRECTORY_SEPARATOR.$formId;
     }
 }

--- a/app/bundles/FormBundle/Helper/FormUploader.php
+++ b/app/bundles/FormBundle/Helper/FormUploader.php
@@ -135,12 +135,11 @@ class FormUploader
      */
     private function getUploadDirOfForm(Form $form)
     {
-        $formId    = $form->getId();
         $uploadDir = $this->coreParametersHelper->get('form_upload_dir');
-        if (null === $formId) {
+        if (null === $form->deletedId) {
             throw new \LogicException('FormID can\'t be null');
         }
 
-        return $uploadDir.DIRECTORY_SEPARATOR.$formId;
+        return $uploadDir.DIRECTORY_SEPARATOR.$form->deletedId;
     }
 }

--- a/app/bundles/FormBundle/Helper/FormUploader.php
+++ b/app/bundles/FormBundle/Helper/FormUploader.php
@@ -133,12 +133,9 @@ class FormUploader
      *
      * @throws \LogicException If formId is null
      */
-    private function getUploadDirOfForm(?int $formId)
+    private function getUploadDirOfForm(int $formId)
     {
         $uploadDir = $this->coreParametersHelper->get('form_upload_dir');
-        if (null === $formId) {
-            throw new \LogicException('FormID can\'t be null');
-        }
 
         return $uploadDir.DIRECTORY_SEPARATOR.$formId;
     }

--- a/app/bundles/FormBundle/Helper/FormUploader.php
+++ b/app/bundles/FormBundle/Helper/FormUploader.php
@@ -88,7 +88,8 @@ class FormUploader
 
     public function deleteFilesOfForm(Form $form)
     {
-        $formUploadDir = $this->getUploadDirOfForm($form->deletedId);
+        $formId = $form->getId() ?: $form->deletedId;
+        $formUploadDir = $this->getUploadDirOfForm($formId);
         $this->fileUploader->delete($formUploadDir);
     }
 

--- a/app/bundles/FormBundle/Helper/FormUploader.php
+++ b/app/bundles/FormBundle/Helper/FormUploader.php
@@ -88,7 +88,7 @@ class FormUploader
 
     public function deleteFilesOfForm(Form $form)
     {
-        $formId = $form->getId() ?: $form->deletedId;
+        $formId        = $form->getId() ?: $form->deletedId;
         $formUploadDir = $this->getUploadDirOfForm($formId);
         $this->fileUploader->delete($formUploadDir);
     }

--- a/app/bundles/FormBundle/Tests/Model/FormUploaderTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormUploaderTest.php
@@ -23,6 +23,10 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class FormUploaderTest extends \PHPUnit\Framework\TestCase
 {
+    private $formId1   = 1;
+    private $formId2   = 2;
+    private $uploadDir = 'path/to/file';
+
     /**
      * @testdox Uploader uploads files correctly
      *
@@ -30,8 +34,6 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
      */
     public function testSuccessfulUploadFiles()
     {
-        $uploadDir = 'path/to/file';
-
         $fileUploaderMock = $this->getMockBuilder(FileUploader::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -42,7 +44,7 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
         $coreParametersHelperMock->expects($this->exactly(2))
             ->method('get')
             ->with('form_upload_dir')
-            ->willReturn($uploadDir);
+            ->willReturn($this->uploadDir);
 
         $formUploader = new FormUploader($fileUploaderMock, $coreParametersHelperMock);
 
@@ -61,7 +63,7 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
         $form1Mock->expects($this->once())
             ->method('getId')
             ->with()
-            ->willReturn('formId1');
+            ->willReturn($this->formId1);
 
         $field1Mock = $this->getMockBuilder(Field::class)
             ->disableOriginalConstructor()
@@ -89,7 +91,7 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
         $form2Mock->expects($this->once())
             ->method('getId')
             ->with()
-            ->willReturn('formId2');
+            ->willReturn($this->formId2);
 
         $field2Mock = $this->getMockBuilder(Field::class)
             ->disableOriginalConstructor()
@@ -117,8 +119,8 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
         $submission = new Submission();
         $submission->setResults(['key' => 'value']);
 
-        $path1 = $uploadDir.'/formId1/fieldId1';
-        $path2 = $uploadDir.'/formId2/fieldId2';
+        $path1 = $this->uploadDir.'/1/fieldId1';
+        $path2 = $this->uploadDir.'/2/fieldId2';
 
         $fileUploaderMock->expects($this->at(0))
             ->method('upload')
@@ -148,8 +150,6 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
      */
     public function testUploadFilesWithError()
     {
-        $uploadDir = 'path/to/file';
-
         $fileUploaderMock = $this->getMockBuilder(FileUploader::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -160,7 +160,7 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
         $coreParametersHelperMock->expects($this->exactly(2))
             ->method('get')
             ->with('form_upload_dir')
-            ->willReturn($uploadDir);
+            ->willReturn($this->uploadDir);
 
         $formUploader = new FormUploader($fileUploaderMock, $coreParametersHelperMock);
 
@@ -179,7 +179,7 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
         $form1Mock->expects($this->once())
             ->method('getId')
             ->with()
-            ->willReturn('formId1');
+            ->willReturn($this->formId1);
 
         $field1Mock = $this->getMockBuilder(Field::class)
             ->disableOriginalConstructor()
@@ -207,7 +207,7 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
         $form2Mock->expects($this->once())
             ->method('getId')
             ->with()
-            ->willReturn('formId2');
+            ->willReturn($this->formId2);
 
         $field2Mock = $this->getMockBuilder(Field::class)
             ->disableOriginalConstructor()
@@ -235,8 +235,8 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
         $submission = new Submission();
         $submission->setResults(['key' => 'value']);
 
-        $path1 = $uploadDir.'/formId1/fieldId1';
-        $path2 = $uploadDir.'/formId2/fieldId2';
+        $path1 = $this->uploadDir.'/1/fieldId1';
+        $path2 = $this->uploadDir.'/2/fieldId2';
 
         $fileUploaderMock->expects($this->at(0))
             ->method('upload')
@@ -250,7 +250,7 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
 
         $fileUploaderMock->expects($this->once())
             ->method('delete')
-            ->with('path/to/file/formId1/fieldId1/upload1');
+            ->with('path/to/file/1/fieldId1/upload1');
 
         $this->expectException(FileUploadException::class);
         $this->expectExceptionMessage('file2');
@@ -302,8 +302,6 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetCompleteFilePath()
     {
-        $uploadDir = 'path/to/file';
-
         $fileUploaderMock = $this->getMockBuilder(FileUploader::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -314,7 +312,7 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
         $coreParametersHelperMock->expects($this->once())
             ->method('get')
             ->with('form_upload_dir')
-            ->willReturn($uploadDir);
+            ->willReturn($this->uploadDir);
 
         $formMock = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
@@ -323,7 +321,7 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
         $formMock->expects($this->once())
             ->method('getId')
             ->with()
-            ->willReturn('formId1');
+            ->willReturn($this->formId1);
 
         $fieldMock = $this->getMockBuilder(Field::class)
             ->disableOriginalConstructor()
@@ -343,7 +341,7 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
 
         $actual = $formUploader->getCompleteFilePath($fieldMock, 'fileName');
 
-        $this->assertSame('path/to/file/formId1/fieldId1/fileName', $actual);
+        $this->assertSame('path/to/file/1/fieldId1/fileName', $actual);
     }
 
     /**
@@ -353,15 +351,13 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
      */
     public function testDeleteAllFilesOfFormField()
     {
-        $uploadDir = 'path/to/file';
-
         $fileUploaderMock = $this->getMockBuilder(FileUploader::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $fileUploaderMock->expects($this->once())
             ->method('delete')
-            ->with('path/to/file/formId1/fieldId1');
+            ->with('path/to/file/1/fieldId1');
 
         $coreParametersHelperMock = $this->getMockBuilder(CoreParametersHelper::class)
             ->disableOriginalConstructor()
@@ -369,7 +365,7 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
         $coreParametersHelperMock->expects($this->once())
             ->method('get')
             ->with('form_upload_dir')
-            ->willReturn($uploadDir);
+            ->willReturn($this->uploadDir);
 
         $formUploader = new FormUploader($fileUploaderMock, $coreParametersHelperMock);
 
@@ -380,7 +376,7 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
         $formMock->expects($this->once())
             ->method('getId')
             ->with()
-            ->willReturn('formId1');
+            ->willReturn($this->formId1);
 
         $fieldMock = $this->getMockBuilder(Field::class)
             ->disableOriginalConstructor()

--- a/app/bundles/FormBundle/Tests/Model/FormUploaderTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormUploaderTest.php
@@ -399,4 +399,44 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
 
         $formUploader->deleteAllFilesOfFormField($fieldMock);
     }
+
+    public function testDeleteFilesOfForm()
+    {
+        $fileUploaderMock = $this->getMockBuilder(FileUploader::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $fileUploaderMock
+            ->method('delete')
+            ->with('path/to/file/1');
+
+        $coreParametersHelperMock = $this->getMockBuilder(CoreParametersHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $coreParametersHelperMock->expects($this->exactly(2))
+            ->method('get')
+            ->with('form_upload_dir')
+            ->willReturn($this->uploadDir);
+
+        $formMock = $this->getMockBuilder(Form::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $formMock->expects($this->at(0))
+            ->method('getId')
+            ->with()
+            ->willReturn($this->formId1);
+
+        $formMock->expects($this->at(1))
+            ->method('getId')
+            ->with()
+            ->willReturn(null);
+
+        $formUploader = new FormUploader($fileUploaderMock, $coreParametersHelperMock);
+        $formUploader->deleteFilesOfForm($formMock);
+
+        $formMock->deletedId = $this->formId1;
+
+        $formUploader->deleteFilesOfForm($formMock);
+    }
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8495
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When I go to the list of forms, select multiple and try to delete them I get this 500 error:

FormID can't be null

at ˇhttps://github.com/mautic/mautic/blob/3.x/app/bundles/FormBundle/Helper/FormUploader.php#L141ˇ

It was caused by getting form id from entity which was deleted and ID was null then. Id of deleted form entity is present in `Form:deletedId` then.

request:
ˇhttps://mautic.test/index_dev.php/s/forms/batchDelete?ids=[%22420%22,%22421%22,%22422%22,%22423%22,%22424%22,%22425%22,%22426%22,%22427%22,%22428%22,%22429%22,%22430%22,%22431%22,%22432%22,%22433%22,%22434%22,%22435%22,%22436%22,%22437%22,%22438%22,%22439%22,%22440%22,%22441%22,%22442%22,%22443%22,%22444%22,%22445%22]&mauticUserLastActive=1&mauticLastNotificationId=311ˇ

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to forms
2. Try to delete multiple items

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Same as reproduction steps
3. Create form with one File field and use it for file upload
4. Folder in `media/files/form/[formId]` created and it contains uploaded file
5. Delete form and the folder doesn't exists anymore
