### PR TITLE
M3 Fix form field placeholder persistence

### DIFF
--- a/app/bundles/FormBundle/Views/Builder/fieldwrapper.html.php
+++ b/app/bundles/FormBundle/Views/Builder/fieldwrapper.html.php
@@ -32,7 +32,6 @@ if (!isset($inBuilder)) {
             'inForm'        => true,
             'id'            => $field['id'],
             'formId'        => $formId,
-            'formName'      => $formName,
             'contactFields' => (isset($contactFields)) ? $contactFields : [],
             'companyFields' => (isset($companyFields)) ? $companyFields : [],
             'inBuilder'     => $inBuilder,

--- a/app/migrations/Version20200302164801.php
+++ b/app/migrations/Version20200302164801.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * @copyright   2020 Mautic, Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\SkipMigration;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+class Version20200302164801 extends AbstractMauticMigration
+{
+    public function getDescription(): string
+    {
+        return 'Replaces serialized empty_value to placeholder in form_fields.properties column';
+    }
+
+    /**
+     * @throws DBALException
+     */
+    public function preUp(Schema $schema): void
+    {
+        $sql = "
+            SELECT id
+            FROM {$this->prefix}form_fields
+            WHERE properties LIKE '%s:11:\"empty_value\"%'
+        ";
+
+        $stmt = $this->connection->prepare($sql);
+        $stmt->execute();
+        $found = (bool) $stmt->fetch(FetchMode::ASSOCIATIVE);
+
+        if (!$found) {
+            throw new SkipMigration('Schema includes this migration');
+        }
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("
+            UPDATE {$this->prefix}form_fields
+            SET properties = REPLACE(properties, 's:11:\"empty_value\"', 's:11:\"placeholder\"')
+            WHERE properties LIKE '%s:11:\"empty_value\"%';
+        ");
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8494
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Form fields can have the empty_value parameter stored in the database. See this row:
```sql
INSERT INTO `form_fields` (`id`, `form_id`, `label`, `show_label`, `alias`, `type`, `is_custom`, `custom_parameters`, `default_value`, `is_required`, `validation_message`, `help_message`, `field_order`, `properties`, `label_attr`, `input_attr`, `container_attr`, `lead_field`, `save_result`, `is_auto_fill`, `show_when_value_exists`, `show_after_x_submissions`, `validation`)
VALUES
	(207, 199, 'Country', 1, 'country', 'country', 0, 'a:0:{}', NULL, 0, NULL, NULL, 6, 'a:2:{s:11:\"empty_value\";N;s:8:\"multiple\";i:0;}', NULL, NULL, NULL, 'country', 1, 0, 1, NULL, NULL);
```
This form field parameter was removed from Symfony 3 and replaced with placeholder.

Warning it produces on form preview:
```
Symfony\Component\Debug\Exception\ContextErrorException: PHP Notice - Undefined index: placeholder
/app/bundles/FormBundle/Views/Field/select.html.php:35
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Open edit dialog for select field in M3 form edit. You 'll get 
```
[2020-03-02 14:45:53] mautic.ERROR: Symfony\Component\Debug\Exception\ContextErrorException: PHP Notice - Undefined variable: form - in file /Users/lukas.drahy/dev/community-fork/app/bundles/FormBundle/Views/Builder/fieldwrapper.html.php - at line 35  
```

![Snímek obrazovky 2020-03-02 v 15 46 06](https://user-images.githubusercontent.com/12815758/75686846-2f375e00-5c9d-11ea-8daa-92d7a4839896.png)


2. Use form with empty_value defined in M2 or replace `placeholder` to `empty_value` in `form_fields.properties` serialized string
3. Use M3 to show preview dependent form
4. You'll get 
```
Symfony\Component\Debug\Exception\ContextErrorException: PHP Notice - Undefined index: placeholder
/app/bundles/FormBundle/Views/Field/select.html.php:35
```

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Run migrations
2. Same as reproduction steps