### PR TITLE
Default email_frequency_time should be a string by default and not an integer

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -850,7 +850,7 @@ return [
         'mailer_is_owner'                     => false,
         'default_signature_text'              => null,
         'email_frequency_number'              => 0,
-        'email_frequency_time'                => 0,
+        'email_frequency_time'                => 'DAY',
         'show_contact_preferences'            => false,
         'show_contact_frequency'              => false,
         'show_contact_pause_dates'            => false,


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
email_frequency_time is supposed to be a string with `DAY`, `MONTH`, etc values. But the default was set to 0 so that when a configuration was saved after a new install, the following exception would occur: 

```
Internal Server Error - Non-numeric env var "resolve:MAUTIC_EMAIL_FREQUENCY_TIME" cannot be cast to int.
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Either go through a new install or just delete `email_frequency_time` from app/config/local.php
2. Go to the Configuration and save
3. Should hit the exception

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Delete `email_frequency_time` from the app/config/local.php
3. Clear Symfony's cache (because it cached to convert email_frequency_time to an int)
4. Repeat test.
