### PR TITLE
Fixes dynamic web content

### DIFF
--- a/app/bundles/DynamicContentBundle/Helper/DynamicContentHelper.php
+++ b/app/bundles/DynamicContentBundle/Helper/DynamicContentHelper.php
@@ -56,8 +56,6 @@ class DynamicContentHelper
      */
     public function getDynamicContentForLead($slot, $lead)
     {
-        $this->realTimeExecutioner->execute('dwc.decision', $slot, 'dynamicContent')->getResponseArray();
-
         // Attempt campaign slots first
         $dwcActionResponse = $this->realTimeExecutioner->execute('dwc.decision', $slot, 'dynamicContent')->getActionResponses('dwc.push_content');
         if (!empty($dwcActionResponse)) {

--- a/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
@@ -50,7 +50,8 @@ class BuildJsSubscriber implements EventSubscriberInterface
     {
         return [
             CoreEvents::BUILD_MAUTIC_JS => [
-                ['onBuildJs', 255],
+                // onBuildJs must always needs to be last to ensure setup before delivering the event
+                ['onBuildJs', -255],
                 ['onBuildJsForVideo', 256],
                 ['onBuildJsForTrackingEvent', 256],
             ],
@@ -102,7 +103,7 @@ class BuildJsSubscriber implements EventSubscriberInterface
             
             return;
         }
-
+console.log(m.preEventDeliveryQueue.length, m.beforeFirstDeliveryMade);
         // Pre delivery events always take all known params and should use them in the request
         if (m.preEventDeliveryQueue.length && m.beforeFirstDeliveryMade === false) {
             for(var i = 0; i < m.preEventDeliveryQueue.length; i++) {

--- a/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
@@ -103,7 +103,7 @@ class BuildJsSubscriber implements EventSubscriberInterface
             
             return;
         }
-console.log(m.preEventDeliveryQueue.length, m.beforeFirstDeliveryMade);
+
         // Pre delivery events always take all known params and should use them in the request
         if (m.preEventDeliveryQueue.length && m.beforeFirstDeliveryMade === false) {
             for(var i = 0; i < m.preEventDeliveryQueue.length; i++) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |  https://github.com/mautic/mautic/issues/8510
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
A dangling line of code with a call to removed deprecated method caused dynamic content to fail rendering. 

Also, fingerprinting had a built in delay that allowed DWC to work. But with the removal of fingerprinting and thus the delay, DWC did not register its pre event callback before the first event was delivered. So DWC was never executed. This is fixed by simply ensuring that the tracking pixel code is the last to load in the mtc.js file giving the chance for all other code to setup before the first event is delivered. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a dynamic content item (can turn off campaign based and add a filter for this one)
2. Create a landing page and add a Dynamic content slot; use the slot name used in the item created above
3. Browse to the landing page's URL
4. Note the error page

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat and the content should show
3. Test by embedded the DWC into a 3rd party page per Mautic's docs https://www.mautic.org/docs/en/dwc/index.html. The DWC should show.
