### PR TITLE
MAUT-3434 / Array flip operators

### DIFF
--- a/app/bundles/EmailBundle/Views/FormTheme/Email/dynamic_content_filter_entry_widget.html.php
+++ b/app/bundles/EmailBundle/Views/FormTheme/Email/dynamic_content_filter_entry_widget.html.php
@@ -49,7 +49,7 @@
                                         \Mautic\LeadBundle\Helper\FormFieldHelper::parseList($list);
                                     $list      = json_encode($choices);
                                     $callback  = (!empty($params['properties']['callback'])) ? $params['properties']['callback'] : '';
-                                    $operators = (!empty($params['operators'])) ? $view->escape(json_encode($params['operators'])) : '{}';
+                                    $operators = (!empty($params['operators'])) ? $view->escape(json_encode(array_flip($params['operators']))) : '{}';
                                     ?>
                                     <option value="<?php echo $view->escape($value); ?>" data-mautic="available_<?php echo $value; ?>" data-field-object="<?php echo $object; ?>" data-field-type="<?php echo $params['properties']['type']; ?>" data-field-list="<?php echo $view->escape($list); ?>" data-field-callback="<?php echo $callback; ?>" data-field-operators='<?php echo $operators; ?>' class="segment-filter fa <?php echo $icon; ?>"><?php echo $view['translator']->trans($params['label']); ?></option>
                                 <?php endforeach; ?>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8505
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When saving a new variant in an email for dynamic content, it fails validation (without any errors) but the operators are different after going back into the builder. It seems that the JS generated operators are switched then are correct after the form is rendered from the server.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Create a new email
2. Open the builder
3. Drag and drop a dynamic content slot onto the preview
4. Click on the Dynamic Content
5. Click Add Variant in the Customize Slot
6. Add a "Country" filter and select !=
7. Close the builder and save and close (fill in the rest of the required info if applicable)
8. The form will not save
9. Open the builder and click on the Dynamic Content to edit it
10. Click the Variation 1 tab and note that the operators are now words, not symbols.
11. Select Not equals, close the builder and save.
12. This time it saves.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. The same as for reproducing the bug, step 7 should let you save it.

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
