### PR TITLE
Parameter always in the query

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -1460,7 +1460,7 @@ class CommonRepository extends EntityRepository
         foreach ($queryParameters as $k => $v) {
             // This where condition is always satisfied. It needs to be set to be sure that the
             // parameter is used.
-            $q->andWhere($this->getTableAlias().'.id '.'NOT IN(:'.$k.')');
+            $q->andWhere(':'.$k.' = :'.$k);
             if (true === $v || false === $v) {
                 $q->setParameter($k, $v, 'boolean');
             } else {

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -1458,9 +1458,6 @@ class CommonRepository extends EntityRepository
         // Parameters have to be set even if there are no expressions just in case a search command
         // passed back a parameter it used
         foreach ($queryParameters as $k => $v) {
-            // This where condition is always satisfied. It needs to be set to be sure that the
-            // parameter is used.
-            $q->andWhere(':'.$k.' = :'.$k);
             if (true === $v || false === $v) {
                 $q->setParameter($k, $v, 'boolean');
             } else {

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -1458,6 +1458,9 @@ class CommonRepository extends EntityRepository
         // Parameters have to be set even if there are no expressions just in case a search command
         // passed back a parameter it used
         foreach ($queryParameters as $k => $v) {
+            // This where condition is always satisfied. It needs to be set to be sure that the
+            // parameter is used.
+            $q->andWhere($this->getTableAlias().'.id '.'NOT IN(:'.$k.')');
             if (true === $v || false === $v) {
                 $q->setParameter($k, $v, 'boolean');
             } else {

--- a/app/bundles/FormBundle/Entity/FormRepository.php
+++ b/app/bundles/FormBundle/Entity/FormRepository.php
@@ -138,7 +138,7 @@ class FormRepository extends CommonRepository
                 $expr = $q->expr()->gt(sprintf('(%s)', $subquery), 1);
                 break;
             case $this->translator->trans('mautic.core.searchcommand.name'):
-                $q->expr()->like('f.name', ':'.$unique);
+                $expr            = $q->expr()->like('f.name', ':'.$unique);
                 $returnParameter = true;
                 break;
         }

--- a/app/bundles/FormBundle/Entity/FormRepository.php
+++ b/app/bundles/FormBundle/Entity/FormRepository.php
@@ -95,13 +95,14 @@ class FormRepository extends CommonRepository
      */
     protected function addSearchCommandWhereClause($q, $filter)
     {
-        list($expr, $parameters) = $this->addStandardSearchCommandWhereClause($q, $filter);
+        list($expr, $standardSearchParameters) = $this->addStandardSearchCommandWhereClause($q, $filter);
         if ($expr) {
-            return [$expr, $parameters];
+            return [$expr, $standardSearchParameters];
         }
 
         $command         = $filter->command;
         $unique          = $this->generateRandomParameterName();
+        $parameters      = [];
         $returnParameter = false; //returning a parameter that is not used will lead to a Doctrine error
 
         switch ($command) {

--- a/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Mautic\FormBundle\Tests\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+
+class FormControllerFunctionalTest extends MauticMysqlTestCase
+{
+    /**
+     * Filtering should return status code 200.
+     */
+    public function testIndexActionWhenFiltering(): void
+    {
+        $this->client->request('GET', '/s/forms?search=has%3Aresults&tmpl=list');
+        $clientResponse = $this->client->getResponse();
+        $this->assertSame(200, $clientResponse->getStatusCode(), 'Return code must be 200.');
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8496
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Search does not work.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
Go to the list of forms and search for has:results forms. It errors with Too many parameters: the query defines 0 parameters and you bound 1 at vendor/doctrine/orm/lib/Doctrine/ORM/Query/QueryException.php:105

Same happens when using the name:* search.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Go to the list of forms and search for has:results forms.
3. No errors

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
