### PR TITLE
Campaign toggle fix

### DIFF
--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -386,7 +386,7 @@ class AjaxController extends CommonAjaxController
         $lead     = $leadModel->getEntity($leadId);
         $campaign = $campaignModel->getEntity($campaignId);
 
-        if (null === $lead && null === $campaign) {
+        if (null === $lead || null === $campaign) {
             return $this->sendJsonResponse($dataArray);
         }
 

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -11,23 +11,22 @@
 
 namespace Mautic\LeadBundle\Controller;
 
+use Mautic\CampaignBundle\Membership\MembershipManager;
+use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CoreBundle\Controller\AjaxController as CommonAjaxController;
 use Mautic\CoreBundle\Controller\AjaxLookupControllerTrait;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\LeadBundle\Entity\DoNotContact;
-use Mautic\LeadBundle\Entity\Tag;
 use Mautic\LeadBundle\Entity\UtmTag;
 use Mautic\LeadBundle\Event\LeadTimelineEvent;
 use Mautic\LeadBundle\Helper\FormFieldHelper;
 use Mautic\LeadBundle\LeadEvents;
+use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Segment\Stat\SegmentCampaignShare;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-/**
- * Class AjaxController.
- */
 class AjaxController extends CommonAjaxController
 {
     use AjaxLookupControllerTrait;
@@ -374,19 +373,35 @@ class AjaxController extends CommonAjaxController
         $campaignId = (int) $request->request->get('campaignId');
         $action     = InputHelper::clean($request->request->get('campaignAction'));
 
-        if (!empty($leadId) && !empty($campaignId) && in_array($action, ['remove', 'add'])) {
-            $leadModel     = $this->getModel('lead');
-            $campaignModel = $this->getModel('campaign');
-
-            $lead     = $leadModel->getEntity($leadId);
-            $campaign = $campaignModel->getEntity($campaignId);
-
-            if (null !== $lead && null !== $campaign) {
-                $class = "{$action}Lead";
-                $campaignModel->$class($campaign, $lead, true);
-                $dataArray['success'] = 1;
-            }
+        if (empty($leadId) || empty($campaignId) || !in_array($action, ['remove', 'add'])) {
+            return $this->sendJsonResponse($dataArray);
         }
+
+        /** @var LeadModel $leadModel */
+        $leadModel = $this->getModel('lead');
+
+        /** @var CampaignModel $campaignModel */
+        $campaignModel = $this->getModel('campaign');
+
+        $lead     = $leadModel->getEntity($leadId);
+        $campaign = $campaignModel->getEntity($campaignId);
+
+        if (null === $lead && null === $campaign) {
+            return $this->sendJsonResponse($dataArray);
+        }
+
+        /** @var MembershipManager $membershipManager */
+        $membershipManager = $this->get('mautic.campaign.membership.manager');
+
+        if ('add' === $action) {
+            $membershipManager->addContact($lead, $campaign);
+        }
+
+        if ('remove' === $action) {
+            $membershipManager->removeContact($lead, $campaign);
+        }
+
+        $dataArray['success'] = 1;
 
         return $this->sendJsonResponse($dataArray);
     }

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Controller;
+
+use Mautic\CampaignBundle\Tests\DataFixtures\Orm\CampaignData;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\InstallBundle\InstallFixtures\ORM\LeadFieldData;
+use Mautic\LeadBundle\DataFixtures\ORM\LoadLeadData;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AjaxControllerFunctionalTest extends MauticMysqlTestCase
+{
+    public function testToggleLeadCampaignAction()
+    {
+        $this->installDatabaseFixtures([LeadFieldData::class, CampaignData::class, LoadLeadData::class]);
+        $payload = [
+            'action'         => 'lead:toggleLeadCampaign',
+            'leadId'         => 1,
+            'campaignId'     => 1,
+            'campaignAction' => 'add',
+        ];
+
+        $this->client->request(Request::METHOD_POST, '/s/ajax', $payload, [], $this->createAjaxHeaders());
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+        dump($response);
+
+        $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertTrue(isset($response['success']), 'The response does not contain the `success` param.');
+        $this->assertSame(1, $response['success']);
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -13,18 +13,41 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Tests\Controller;
 
+use Doctrine\DBAL\Connection;
 use Mautic\CampaignBundle\Tests\DataFixtures\Orm\CampaignData;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\InstallBundle\InstallFixtures\ORM\LeadFieldData;
+use Mautic\InstallBundle\InstallFixtures\ORM\RoleData;
 use Mautic\LeadBundle\DataFixtures\ORM\LoadLeadData;
+use Mautic\UserBundle\DataFixtures\ORM\LoadRoleData;
+use Mautic\UserBundle\DataFixtures\ORM\LoadUserData;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 {
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = $this->container->get('doctrine.dbal.default_connection');
+
+        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
+    }
+
     public function testToggleLeadCampaignAction()
     {
-        $this->installDatabaseFixtures([LeadFieldData::class, CampaignData::class, LoadLeadData::class]);
+        $this->loadFixtures([LeadFieldData::class, RoleData::class, LoadRoleData::class, LoadUserData::class, CampaignData::class, LoadLeadData::class]);
+
+        // Ensure there is no member for campaign 1 yet.
+        $this->assertSame([], $this->getMembersForCampaign(1));
+
+        // Create the member now.
         $payload = [
             'action'         => 'lead:toggleLeadCampaign',
             'leadId'         => 1,
@@ -35,10 +58,41 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_POST, '/s/ajax', $payload, [], $this->createAjaxHeaders());
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
-        dump($response);
+
+        // Ensure the contact 1 is a campaign 1 member now.
+        $this->assertSame([['lead_id' => '1', 'manually_added' => '1', 'manually_removed' => '0']], $this->getMembersForCampaign(1));
 
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
         $this->assertTrue(isset($response['success']), 'The response does not contain the `success` param.');
         $this->assertSame(1, $response['success']);
+
+        // Let's remove the member now.
+        $payload = [
+            'action'         => 'lead:toggleLeadCampaign',
+            'leadId'         => 1,
+            'campaignId'     => 1,
+            'campaignAction' => 'remove',
+        ];
+
+        $this->client->request(Request::METHOD_POST, '/s/ajax', $payload, [], $this->createAjaxHeaders());
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+
+        // Ensure the contact 1 was removed as a member of campaign 1 member now.
+        $this->assertSame([['lead_id' => '1', 'manually_added' => '0', 'manually_removed' => '1']], $this->getMembersForCampaign(1));
+
+        $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertTrue(isset($response['success']), 'The response does not contain the `success` param.');
+        $this->assertSame(1, $response['success']);
+    }
+
+    private function getMembersForCampaign(int $campaignId): array
+    {
+        return $this->connection->createQueryBuilder()
+            ->select('cl.lead_id, cl.manually_added, cl.manually_removed')
+            ->from(MAUTIC_TABLE_PREFIX.'campaign_leads', 'cl')
+            ->where("cl.campaign_id = {$campaignId}")
+            ->execute()
+            ->fetchAll();
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8497
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR is fixing campaign toggle in the contact detail action. It's missing methods in the CampaignModel. I traced what happened. The methods [were deprecated](https://github.com/mautic/mautic/pull/6132/files#diff-422e4d345faf0771d385d5b4f3b9cb68R903) and during the M3 refactoring they [were removed](https://github.com/mautic/mautic/commit/3369e53d4fb26a5edb347a6d6b21054e23d66418#diff-422e4d345faf0771d385d5b4f3b9cb68L882). It was not obvious that the methods were still in use in the AjaxController because the method names were dynamically created. No tool nor human could find that usage.

I changed the controller method to use the return early principle and to use the method calls without any dynamic name magic. Also, it uses the right service now.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to a contacts details page and click the dropdown for more actions then "Campaigns"
2. Toggle campaigns (add or remove) for the contact and note that nothing happens. A 500 error is recorded.

#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. The toggle works properly. The contact is being manually added to the campaign.
