### PR TITLE
Save email_id to email_stats for quick Emails

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1356,7 +1356,7 @@ class LeadController extends FormController
                         
                         /** @var EmailModel $emailModel */
                         $emailModel = $this->getModel('email');
-                        if(($emailEntity = $emailModel->getEntity((int)$email['templates']))){
+                        if(($emailEntity = $emailModel->getEntity((int) $email['templates']))){
                             $mailer->setEmail($emailEntity);
                         }
 

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1356,7 +1356,7 @@ class LeadController extends FormController
                         
                         /** @var EmailModel $emailModel */
                         $emailModel = $this->getModel('email');
-                        if (($emailEntity = $emailModel->getEntity((int) $email['templates']))){
+                        if (($emailEntity = $emailModel->getEntity((int) $email['templates']))) {
                             $mailer->setEmail($emailEntity);
                         }
 

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1356,7 +1356,7 @@ class LeadController extends FormController
                         
                         /** @var EmailModel $emailModel */
                         $emailModel = $this->getModel('email');
-                        if(($emailEntity = $emailModel->getEntity((int) $email['templates']))){
+                        if (($emailEntity = $emailModel->getEntity((int) $email['templates']))){
                             $mailer->setEmail($emailEntity);
                         }
 

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1353,6 +1353,12 @@ class LeadController extends FormController
                         $mailer->setIdHash();
 
                         $mailer->setSubject($email['subject']);
+                        
+                        /** @var EmailModel $emailModel */
+                        $emailModel = $this->getModel('email');
+                        if(($emailEntity = $emailModel->getEntity((int)$email['templates']))){
+                            $mailer->setEmail($emailEntity);
+                        }
 
                         // Ensure safe emoji for notification
                         $subject = EmojiHelper::toHtml($email['subject']);


### PR DESCRIPTION
The problem when I send an Email from the Contact page, the Mautic doesn't save email_id to the email_stats and as example performance center doesn't work for these emails.
I don't know is it a bug or not, please let me know if not.