### PR TITLE
Fields visible in form detail

### DIFF
--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -227,7 +227,7 @@ class FormController extends CommonFormController
 
         $activeFormFields = [];
         $fieldHelper      = $this->get('mautic.helper.form.field_helper');
-        $availableFields  = $fieldHelper->getChoiceList($customComponents['fields']);
+        $availableFields  = array_flip($fieldHelper->getChoiceList($customComponents['fields']));
         foreach ($activeForm->getFields() as $field) {
             if (!isset($availableFields[$field->getType()])) {
                 continue;

--- a/app/bundles/FormBundle/Views/Form/details.html.php
+++ b/app/bundles/FormBundle/Views/Form/details.html.php
@@ -233,7 +233,7 @@ $showActions = count($activeFormActions);
             <div class="tab-pane fade<?php if (!$showActions) {
                                             echo ' active in';
                                         } ?> bdr-w-0" id="fields-container">
-                <h5 class="fw-sb mb-xs">Form Field</h5>
+                <h5 class="fw-sb mb-xs"><?php echo $view['translator']->trans('mautic.form.field'); ?></h5>
                 <ul class="list-group mb-xs">
                     <?php /** @var \Mautic\FormBundle\Entity\Field $field */
                     foreach ($activeFormFields as $field) : ?>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8531
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The fields are not displaying on the Fields tab of the form details page.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Create a new form
2. View the details page
3. Notice that the Fields tab is empty

#### Steps to test this PR:

1. Load up [this PR](https://mautibox.com)
2. Create a new form
3. View the details page
4. Notice that the Fields tab is there

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
