### PR TITLE
Fix lead gravatar

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -373,7 +373,7 @@ return [
                 'class'     => \Mautic\CoreBundle\Templating\Helper\GravatarHelper::class,
                 'arguments' => [
                     'mautic.helper.paths',
-                    'mautic.helper.template.avatar',
+                    'mautic.helper.template.default_avatar',
                     'mautic.helper.core_parameters',
                     'request_stack',
                 ],

--- a/app/bundles/CoreBundle/Templating/Helper/GravatarHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/GravatarHelper.php
@@ -14,7 +14,7 @@ namespace Mautic\CoreBundle\Templating\Helper;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Helper\UrlHelper;
-use Mautic\LeadBundle\Templating\Helper\AvatarHelper;
+use Mautic\LeadBundle\Templating\Helper\DefaultAvatarHelper;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Templating\Helper\Helper;
 
@@ -31,9 +31,9 @@ class GravatarHelper extends Helper
     private $devHosts = [];
 
     /**
-     * @var AvatarHelper
+     * @var DefaultAvatarHelper
      */
-    private $avatarHelper;
+    private $defaultAvatarHelper;
 
     /**
      * @var RequestStack
@@ -42,15 +42,15 @@ class GravatarHelper extends Helper
 
     public function __construct(
         PathsHelper $pathsHelper,
-        AvatarHelper $avatarHelper,
+        DefaultAvatarHelper $defaultAvatarHelper,
         CoreParametersHelper $coreParametersHelper,
         RequestStack $requestStack
     ) {
-        $this->devMode      = MAUTIC_ENV === 'dev';
+        $this->devMode             = MAUTIC_ENV === 'dev';
         $pathsHelper->getSystemPath('images');
-        $this->avatarHelper = $avatarHelper;
-        $this->requestStack = $requestStack;
-        $this->devHosts     = (array) $coreParametersHelper->get('dev_hosts');
+        $this->defaultAvatarHelper = $defaultAvatarHelper;
+        $this->requestStack        = $requestStack;
+        $this->devHosts            = (array) $coreParametersHelper->get('dev_hosts');
     }
 
     /**
@@ -72,7 +72,7 @@ class GravatarHelper extends Helper
             ?
             'https://www.mautic.org/media/images/default_avatar.png'
             :
-            $this->avatarHelper->getDefaultAvatar(true);
+            $this->defaultAvatarHelper->getDefaultAvatar(true);
 
         $url = 'https://www.gravatar.com/avatar/'.md5(strtolower(trim($email))).'?s='.$size;
 

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -933,8 +933,17 @@ return [
                 'arguments' => [
                     'templating.helper.assets',
                     'mautic.helper.paths',
+                    'mautic.helper.template.gravatar',
+                    'mautic.helper.template.default_avatar',
                 ],
                 'alias'     => 'lead_avatar',
+            ],
+            'mautic.helper.template.default_avatar' => [
+                'class'     => Mautic\LeadBundle\Templating\Helper\DefaultAvatarHelper::class,
+                'arguments' => [
+                    'mautic.helper.paths',
+                ],
+                'alias'     => 'default_avatar',
             ],
             'mautic.helper.field.alias' => [
                 'class'     => \Mautic\LeadBundle\Helper\FieldAliasHelper::class,

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -942,6 +942,7 @@ return [
                 'class'     => Mautic\LeadBundle\Templating\Helper\DefaultAvatarHelper::class,
                 'arguments' => [
                     'mautic.helper.paths',
+                    'templating.helper.assets',
                 ],
                 'alias'     => 'default_avatar',
             ],

--- a/app/bundles/LeadBundle/Templating/Helper/DefaultAvatarHelper.php
+++ b/app/bundles/LeadBundle/Templating/Helper/DefaultAvatarHelper.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Mautic\LeadBundle\Templating\Helper;
+
+use Mautic\CoreBundle\Helper\PathsHelper;
+use Mautic\CoreBundle\Helper\UrlHelper;
+
+class DefaultAvatarHelper
+{
+    /**
+     * @var PathsHelper
+     */
+    private $pathsHelper;
+
+    public function __construct(
+        PathsHelper $pathsHelper
+    ) {
+        $this->pathsHelper = $pathsHelper;
+    }
+
+    /**
+     * @param bool|false $absolute
+     */
+    public function getDefaultAvatar(bool $absolute = false): string
+    {
+        $img = $this->pathsHelper->getSystemPath('assets', $absolute).'/images/avatar.png';
+
+        return UrlHelper::rel2abs($this->assetsHelper->getUrl($img));
+    }
+}

--- a/app/bundles/LeadBundle/Templating/Helper/DefaultAvatarHelper.php
+++ b/app/bundles/LeadBundle/Templating/Helper/DefaultAvatarHelper.php
@@ -4,6 +4,7 @@ namespace Mautic\LeadBundle\Templating\Helper;
 
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Helper\UrlHelper;
+use Mautic\CoreBundle\Templating\Helper\AssetsHelper;
 
 class DefaultAvatarHelper
 {
@@ -12,10 +13,17 @@ class DefaultAvatarHelper
      */
     private $pathsHelper;
 
+    /**
+     * @var AssetsHelper
+     */
+    private $assetsHelper;
+
     public function __construct(
-        PathsHelper $pathsHelper
+        PathsHelper $pathsHelper,
+        AssetsHelper $assetsHelper
     ) {
-        $this->pathsHelper = $pathsHelper;
+        $this->pathsHelper  = $pathsHelper;
+        $this->assetsHelper = $assetsHelper;
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Helper/AvatarHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/AvatarHelperTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Mautic\LeadBundle\Tests\Helper;
+
+use Mautic\CoreBundle\Helper\PathsHelper;
+use Mautic\CoreBundle\Templating\Helper\AssetsHelper;
+use Mautic\CoreBundle\Templating\Helper\GravatarHelper;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Templating\Helper\AvatarHelper;
+use Mautic\LeadBundle\Templating\Helper\DefaultAvatarHelper;
+
+class AvatarHelperTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|AssetsHelper
+     */
+    private $assetsHelperMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|PathsHelper
+     */
+    private $pathsHelperMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|GravatarHelper
+     */
+    private $gravatarHelperMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|DefaultAvatarHelper
+     */
+    private $defaultAvatarHelperMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|Lead
+     */
+    private $leadMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|AvatarHelper
+     */
+    private $avatarHelper;
+
+    protected function setUp()
+    {
+        $this->assetsHelperMock        = $this->createMock(AssetsHelper::class);
+        $this->pathsHelperMock         = $this->createMock(PathsHelper::class);
+        $this->gravatarHelperMock      = $this->createMock(GravatarHelper::class);
+        $this->defaultAvatarHelperMock = $this->createMock(DefaultAvatarHelper::class);
+        $this->leadMock                = $this->createMock(Lead::class);
+        $this->avatarHelper            = new AvatarHelper($this->assetsHelperMock, $this->pathsHelperMock, $this->gravatarHelperMock, $this->defaultAvatarHelperMock);
+    }
+
+    /**
+     * Test to get gravatar.
+     */
+    public function testGetAvatarWhenGravatar()
+    {
+        $this->leadMock->method('getPreferredProfileImage')
+            ->willReturn('gravatar');
+        $this->leadMock->method('getSocialCache')
+            ->willReturn([]);
+        $this->leadMock->method('getEmail')
+            ->willReturn('mautic@acquia.com');
+        $this->gravatarHelperMock->method('getImage')
+            ->with('mautic@acquia.com')
+            ->willReturn('gravatarImage');
+        $avatar = $this->avatarHelper->getAvatar($this->leadMock);
+        $this->assertSame('gravatarImage', $avatar, 'Gravatar image should be returned');
+    }
+
+    /**
+     * Test to get default image.
+     */
+    public function testGetAvatarWhenDefault()
+    {
+        $this->leadMock->method('getPreferredProfileImage')
+            ->willReturn('gravatar');
+        $this->leadMock->method('getSocialCache')
+            ->willReturn([]);
+        $this->leadMock->method('getEmail')
+            ->willReturn('');
+        $this->defaultAvatarHelperMock->method('getDefaultAvatar')
+            ->willReturn('defaultImage');
+        $avatar = $this->avatarHelper->getAvatar($this->leadMock);
+        $this->assertSame('defaultImage', $avatar, 'Default image image should be returned');
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8530
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The gravatar image is not loading for a contact even though gravatar is selected and the email address is registered.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Edit a contact
2. Add an email for a known gravatar
3. Save
4. Notice that the default avatar image is still displayed

#### Steps to test this PR:
0. Load up [this PR](https://mautibox.com)
1. Edit a contact
2. Add an email for a known gravatar
3. Save
4. Notice that the gravatar is there

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
