### PR TITLE
Fix case in SmsModel

### DIFF
--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -511,6 +511,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface
         $results = [];
         switch ($type) {
             case 'sms':
+            case SmsType::class:
                 $entities = $this->getRepository()->getSmsList(
                     $filter,
                     $limit,

--- a/app/bundles/SmsBundle/Tests/Model/SmsModelTest.php
+++ b/app/bundles/SmsBundle/Tests/Model/SmsModelTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Mautic\SmsBundle\Tests\Model;
+
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
+use Mautic\SmsBundle\Entity\SmsRepository;
+use Mautic\SmsBundle\Form\Type\SmsType;
+use Mautic\SmsBundle\Model\SmsModel;
+
+class SmsModelTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test to get lookup results when class name is sent as a parameter.
+     */
+    public function testGetLookupResultsWhenTypeIsClass()
+    {
+        $entities       = [['name' => 'Mautic', 'id' => 1, 'language' => 'cs']];
+        $repositoryMock = $this->createMock(SmsRepository::class);
+        $repositoryMock->method('getSmsList')
+            ->with('', 10, 0, true, false)
+            ->willReturn($entities);
+        // Partial mock, mocks just getRepository
+        $smsModel = $this->getMockBuilder(SmsModel::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getRepository'])
+            ->getMock();
+        $smsModel->method('getRepository')
+            ->willReturn($repositoryMock);
+        $securityMock = $this->createMock(CorePermissions::class);
+        $securityMock->method('isGranted')
+            ->with('sms:smses:viewother')
+            ->willReturn(true);
+        $smsModel->setSecurity($securityMock);
+        $textMessages = $smsModel->getLookupResults(SmsType::class);
+        $this->assertSame('Mautic', $textMessages['cs'][1], 'Mautic is the right text message name');
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8513
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Text message drop downs are empty in Marketing Messages and in campaign action's send text message.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Add bogus credentials to twilio integration and publish
2. Go to Channels -> Text Messages and create a new one
3. Create a new marketing message, click the Text Message, click Yes and notice the drop down is empty
4. Create a new campaign, and add a send text message action, also notice the drop down is empty

#### Steps to test this PR:
0. Load up [this PR](https://mautibox.com)
1. Add bogus credentials to twilio integration and publish
2. Go to Channels -> Text Messages and create a new one
3. Create a new marketing message, click the Text Message, click Yes and notice the drop down is not empty
4. Create a new campaign, and add a send text message action, also notice the drop down is not empty

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
