### PR TITLE
Fix plugin auth popup

### DIFF
--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -151,7 +151,9 @@ class PluginController extends FormController
         }
 
         $session   = $this->get('session');
-        $authorize = $this->request->request->get('integration_details[in_auth]', false, true);
+
+        $integrationDetailsPost = $this->request->request->get('integration_details', [], true);
+        $authorize              = empty($integrationDetailsPost['in_auth']) ? false : true;
 
         /** @var \Mautic\PluginBundle\Helper\IntegrationHelper $integrationHelper */
         $integrationHelper = $this->factory->getHelper('integration');


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8498
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Clicking the authorize app button for integrations does not open the popup in order to authorize an integration.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to Plugins and click on Salesforce
2. Enter client id and client secret (anything just to reproduce)
3. Click the Authorize App button
4. The popup to login does not open with no alerts in the browser that it was blocked

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
1. Same as reproduction steps, but popup will open or chrome will notify you about blocked popup

was caused by replaced line
xdebug output:
![Snímek obrazovky 2020-03-10 v 18 32 09](https://user-images.githubusercontent.com/12815758/76342259-9e94f980-62fe-11ea-954d-c186a7a25b04.png)
