### PR TITLE
Upload custom image

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/libraries/bootstrap/less/media.less
+++ b/app/bundles/CoreBundle/Assets/css/libraries/bootstrap/less/media.less
@@ -64,3 +64,10 @@
   padding-left: 0;
   list-style: none;
 }
+
+// Contact image
+form[name="lead"] {
+  .media-body {
+    width: 100%;
+  }
+}

--- a/app/bundles/CoreBundle/Assets/css/libraries/libraries.css
+++ b/app/bundles/CoreBundle/Assets/css/libraries/libraries.css
@@ -5307,6 +5307,9 @@ a.thumbnail.active {
   padding-left: 0;
   list-style: none;
 }
+form[name="lead"] .media-body {
+  width: 100%;
+}
 .list-group {
   margin-bottom: 20px;
   padding-left: 0;

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -734,9 +734,9 @@ class LeadController extends FormController
      */
     private function uploadAvatar(Lead $lead)
     {
-        $lead      = $this->request->files->get('lead', []);
-        $file      = $lead['custom_avatar'] ?? null;
-        $avatarDir = $this->get('mautic.helper.template.avatar')->getAvatarPath(true);
+        $leadInformation = $this->request->files->get('lead', []);
+        $file            = $leadInformation['custom_avatar'] ?? null;
+        $avatarDir       = $this->get('mautic.helper.template.avatar')->getAvatarPath(true);
 
         if (!file_exists($avatarDir)) {
             mkdir($avatarDir);

--- a/app/bundles/LeadBundle/Form/Type/LeadType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadType.php
@@ -62,8 +62,8 @@ class LeadType extends AbstractType
 
         if (!$options['isShortForm']) {
             $imageChoices = [
-                'gravatar' => 'Gravatar',
-                'custom'   => 'mautic.lead.lead.field.custom_avatar',
+                'Gravatar'                             => 'gravatar',
+                'mautic.lead.lead.field.custom_avatar' => 'custom',
             ];
 
             $cache = $options['data']->getSocialCache();


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8529
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When selecting "custom" for the "Preferred profile image" when editing a contact, no upload input is displayed. It looks like the values and labels are reversed for that field because the labels are all lowercase where they are capital in M2. #8530 may be related or caused by the same issue.

Also, the preview is too large and cuts off.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Edit/create a new contact
2. On the left, choose "custom" for the preferred profile image
3. The upload input does not show up

#### Steps to test this PR:
0. Load up [this PR](https://mautibox.com)
1. Edit/create a new contact
2. On the left, choose "custom" for the preferred profile image
3. The upload input shows up

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
