### PR TITLE
MAUT-3469 / Fix and test isFormCancelled

### DIFF
--- a/app/bundles/CoreBundle/Controller/AbstractFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractFormController.php
@@ -139,7 +139,7 @@ abstract class AbstractFormController extends CommonController
     {
         $formData = $this->request->request->get($form->getName());
 
-        return array_key_exists('buttons', $formData) && array_key_exists('cancel', $formData['buttons']);
+        return is_array($formData) && array_key_exists('buttons', $formData) && array_key_exists('cancel', $formData['buttons']);
     }
 
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Controller/AbstractFormControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Controller/AbstractFormControllerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Mautic\CoreBundle\Tests\Unit\Controller;
+
+use Mautic\CoreBundle\Controller\AbstractFormController;
+use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+
+class AbstractFormControllerTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|AbstractFormController
+     */
+    private $classFromAbstractFormController;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|ParameterBag
+     */
+    private $parameterBagMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|Request
+     */
+    private $requestMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|Form
+     */
+    private $formMock;
+
+    /**
+     * Create a new instance from the AbstractFormController Class and creates mocks.
+     */
+    protected function setUp(): void
+    {
+        $this->classFromAbstractFormController = new class() extends AbstractFormController {
+            public function returnIsFormCancelled(Form $form): bool
+            {
+                return $this->isFormCancelled($form);
+            }
+        };
+        $this->parameterBagMock     = $this->createMock(ParameterBag::class);
+        $this->requestMock          = $this->createMock(Request::class);
+        $this->requestMock->request = $this->parameterBagMock;
+        $this->formMock             = $this->createMock(Form::class);
+    }
+
+    /**
+     * Test to send a Form that does not have an array representation in request.
+     */
+    public function testIsFormCancelledWhenFormArrayNull(): void
+    {
+        $this->parameterBagMock->method('get')
+            ->with('company')
+            ->willReturn([]);
+        $this->classFromAbstractFormController->setRequest($this->requestMock);
+        $this->formMock->method('getName')
+            ->willReturn('company');
+        $isFormCancelled = $this->classFromAbstractFormController->returnIsFormCancelled($this->formMock);
+        $this->assertFalse($isFormCancelled);
+    }
+
+    /**
+     * Test to send a Form that has an array representation in request. And the cancel button was clicked.
+     */
+    public function testIsFormCancelledWhenCancelled(): void
+    {
+        $this->parameterBagMock->method('get')
+            ->with('company_merge')
+            ->willReturn(['buttons' => ['cancel' => null]]);
+        $this->classFromAbstractFormController->setRequest($this->requestMock);
+        $this->formMock->method('getName')
+            ->willReturn('company_merge');
+        $isFormCancelled = $this->classFromAbstractFormController->returnIsFormCancelled($this->formMock);
+        $this->assertTrue($isFormCancelled);
+    }
+
+    /**
+     * Test to send a Form that has an array representation in request. And the submit button was clicked.
+     */
+    public function testIsFormCancelledWhenNotCancelled(): void
+    {
+        $this->parameterBagMock->method('get')
+            ->with('company_merge')
+            ->willReturn(['buttons' => ['submit' => null]]);
+        $this->classFromAbstractFormController->setRequest($this->requestMock);
+        $this->formMock->method('getName')
+            ->willReturn('company_merge');
+        $isFormCancelled = $this->classFromAbstractFormController->returnIsFormCancelled($this->formMock);
+        $this->assertFalse($isFormCancelled);
+    }
+}

--- a/app/bundles/CoreBundle/Tests/Unit/Controller/AbstractFormControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Controller/AbstractFormControllerTest.php
@@ -53,7 +53,7 @@ class AbstractFormControllerTest extends \PHPUnit\Framework\TestCase
     {
         $this->parameterBagMock->method('get')
             ->with('company')
-            ->willReturn([]);
+            ->willReturn(null);
         $this->classFromAbstractFormController->setRequest($this->requestMock);
         $this->formMock->method('getName')
             ->willReturn('company');


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8486
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Merging a company from the individual company page causes the error.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Open a company
2. Select to merge with another company
3. Error thrown

#### Steps to test this PR:

1. Load up [this PR](https://mautibox.com)
2. Open a company
3. Select to merge with another company
4. No error

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
