### PR TITLE
fix modal closing click release

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/3.bootstrap.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/3.bootstrap.js
@@ -1109,7 +1109,7 @@ if (typeof jQuery === 'undefined') {
                 .addClass('modal-backdrop ' + animate)
                 .appendTo(this.$body)
 
-            this.$element.on('click.dismiss.bs.modal', $.proxy(function (e) {
+            this.$element.on('mousedown.dismiss.bs.modal', $.proxy(function (e) {
                 if (this.ignoreBackdropClick) {
                     this.ignoreBackdropClick = false
                     return

--- a/app/bundles/CoreBundle/Assets/js/libraries/3.bootstrap.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/3.bootstrap.js
@@ -946,7 +946,7 @@ if (typeof jQuery === 'undefined') {
             this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />')
                 .appendTo(document.body)
 
-            this.$element.on('click.dismiss.bs.modal', $.proxy(function (e) {
+            this.$element.on('mousedown.dismiss.bs.modal', $.proxy(function (e) {
                 if (e.target !== e.currentTarget) return
                 this.options.backdrop == 'static'
                     ? this.$element[0].focus.call(this.$element[0])


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | [#8123](https://github.com/mautic/mautic/issues/8123)
| BC breaks? | No
| Deprecations? | No

[//]: # ( Required: )
#### Description:
Fix a modal closing issue on click event.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Open a modal anywhere in mautic (form field adding for example)
2. Click inside the modal and stay mousedown. Move your pointer outside the modal and release.
The modal closes. (More details and gif: https://github.com/mautic/mautic/issues/8123)

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Regenerate assets and clear browser cache.
3. Repeat the steps above. The modal doesn't close at the release (but keeps its normal behaviour when you click outside )
