### PR TITLE
Integrations bundle template fix

### DIFF
--- a/app/bundles/CoreBundle/Templating/TemplateReference.php
+++ b/app/bundles/CoreBundle/Templating/TemplateReference.php
@@ -92,11 +92,13 @@ class TemplateReference extends BaseTemplateReference
                     // Theme override
                     $template = $themeDir.'/html/'.$this->parameters['bundle'].'/'.$path;
                 } else {
+                    // We prefer /*Bundle/Views/something.html.php
                     preg_match('/Mautic(.*?)Bundle/', $this->parameters['bundle'], $match);
 
                     if (
                         (!empty($match[1]) && file_exists($bundleRoot.'/'.$match[1].'Bundle/Views/'.$path)) ||
-                        file_exists($pluginRoot.'/'.$this->parameters['bundle'].'/Views/'.$path)
+                        file_exists($pluginRoot.'/'.$this->parameters['bundle'].'/Views/'.$path) || // Check plugin dir directly
+                        file_exists('app/bundles/'.$this->parameters['bundle'].'/Views/'.$path) // Bundles dir directly
                     ) {
                         // Mautic core template
                         $template = '@'.$this->get('bundle').'/Views/'.$path;
@@ -114,7 +116,7 @@ class TemplateReference extends BaseTemplateReference
         }
 
         if (empty($template)) {
-            //try the parent
+            // Try the parent
             return parent::getPath();
         }
 

--- a/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsObjectFieldType.php
+++ b/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsObjectFieldType.php
@@ -38,7 +38,7 @@ class IntegrationSyncSettingsObjectFieldType extends AbstractType
             ChoiceType::class,
             [
                 'label'          => false,
-                'choices'        => $options['mauticFields'],
+                'choices'        => array_flip($options['mauticFields']),
                 'required'       => $field->showAsRequired(),
                 'placeholder'    => '',
                 'error_bubbling' => false,

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelperTest.php
@@ -147,7 +147,7 @@ class ContactObjectHelperTest extends TestCase
         $this->connection->expects($this->once())
             ->method('executeQuery')
             ->with(
-                'SELECT c.companyname FROM companies c WHERE c.id = :id',
+                'SELECT c.companyname FROM '.MAUTIC_TABLE_PREFIX.'companies c WHERE c.id = :id',
                 ['id' => $companyId]
             )
             ->willReturn($statement);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Config form views in the integration bundle are not found because its bundle file is not prefixed with `Mautic`. This adds support for those. This has been tested and working in the Acquia, Inc cloud so I'm back PR'ing to the community. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Install HelloWorld plugin for Mautic 3 (https://github.com/mautic-inc/plugin-helloworld)
2. Go to Plugins and click on the HelloWorld integration and just an info box will open

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Go to Plugins and click on the HelloWorld integration and the config form should show

