### PR TITLE
MAUT-3480 / Warm up cache in MiddlewareBuilder.php

### DIFF
--- a/app/middlewares/MiddlewareBuilder.php
+++ b/app/middlewares/MiddlewareBuilder.php
@@ -59,10 +59,19 @@ class MiddlewareBuilder
     private function loadMiddlewares(): void
     {
         if (!$this->hasCacheFile()) {
+            $this->warmUpCacheCommand();
+        }
+
+        if (!$this->hasCacheFile()) {
             throw new FileNotFoundException('No middleware cache file found. Please warm the middleware cache first.');
         }
 
         $this->loadCacheFile();
+    }
+
+    private function warmUpCacheCommand(): void
+    {
+        shell_exec('bin/console cache:warmup --env='.$this->app->getEnvironment());
     }
 
     private function hasCacheFile(): bool

--- a/app/middlewares/MiddlewareBuilder.php
+++ b/app/middlewares/MiddlewareBuilder.php
@@ -12,6 +12,7 @@
 namespace Mautic\Middleware;
 
 use AppKernel;
+use Mautic\CoreBundle\Cache\MiddlewareCacheWarmer;
 use ReflectionClass;
 use ReflectionException;
 use SplPriorityQueue;
@@ -71,7 +72,8 @@ class MiddlewareBuilder
 
     private function warmUpCacheCommand(): void
     {
-        shell_exec('bin/console cache:warmup --env='.$this->app->getEnvironment());
+        $middlewareCacheWarmer = new MiddlewareCacheWarmer($this->app->getEnvironment());
+        $middlewareCacheWarmer->warmUp($this->app->getCacheDir());
     }
 
     private function hasCacheFile(): bool

--- a/app/middlewares/MiddlewareBuilder.php
+++ b/app/middlewares/MiddlewareBuilder.php
@@ -17,7 +17,6 @@ use ReflectionClass;
 use ReflectionException;
 use SplPriorityQueue;
 use Stack\StackedHttpKernel;
-use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 
 class MiddlewareBuilder
 {
@@ -61,10 +60,6 @@ class MiddlewareBuilder
     {
         if (!$this->hasCacheFile()) {
             $this->warmUpCacheCommand();
-        }
-
-        if (!$this->hasCacheFile()) {
-            throw new FileNotFoundException('No middleware cache file found. Please warm the middleware cache first.');
         }
 
         $this->loadCacheFile();


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8566
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If you clear the cache by rm -rf var/cache/* and refresh Mautic you get an error: Symfony\Component\Filesystem\Exception\FileNotFoundException: No middleware cache file found. Please warm the middleware cache first.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Clear the cache rm -rf var/cache/*
2. Refresh Mautic
3. See the error

#### Steps to test this PR:
1. Clear the cache rm -rf var/cache/*
2. Refresh Mautic
3. See Mautic

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
