### PR TITLE
Use absolute path instead of relative path for locating templates

### DIFF
--- a/app/bundles/CoreBundle/Templating/TemplateReference.php
+++ b/app/bundles/CoreBundle/Templating/TemplateReference.php
@@ -98,7 +98,7 @@ class TemplateReference extends BaseTemplateReference
                     if (
                         (!empty($match[1]) && file_exists($bundleRoot.'/'.$match[1].'Bundle/Views/'.$path)) ||
                         file_exists($pluginRoot.'/'.$this->parameters['bundle'].'/Views/'.$path) || // Check plugin dir directly
-                        file_exists('app/bundles/'.$this->parameters['bundle'].'/Views/'.$path) // Bundles dir directly
+                        file_exists($bundleRoot.'/'.$this->parameters['bundle'].'/Views/'.$path) // Bundles dir directly
                     ) {
                         // Mautic core template
                         $template = '@'.$this->get('bundle').'/Views/'.$path;


### PR DESCRIPTION
*Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
While writing plugins for Mautic 3.x, I noticed sometimes the view paths would not load correctly. I discovered it was due to this file_exists check using a relative path instead of the absolute path.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
