### PR TITLE
Fix profile form fields to user Symfony classname form types.

### DIFF
--- a/app/bundles/UserBundle/Controller/ProfileController.php
+++ b/app/bundles/UserBundle/Controller/ProfileController.php
@@ -13,6 +13,7 @@ namespace Mautic\UserBundle\Controller;
 
 use Mautic\CoreBundle\Controller\FormController;
 use Mautic\CoreBundle\Helper\LanguageHelper;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
  * Class ProfileController.
@@ -61,7 +62,7 @@ class ProfileController extends FormController
                         $form->remove('firstName');
                         $form->add(
                             'firstName_unbound',
-                            'text',
+                            TextType::class,
                             [
                                 'label'      => 'mautic.core.firstname',
                                 'label_attr' => ['class' => 'control-label'],
@@ -76,7 +77,7 @@ class ProfileController extends FormController
                         $form->remove('lastName');
                         $form->add(
                             'lastName_unbound',
-                            'text',
+                            TextType::class,
                             [
                                 'label'      => 'mautic.core.lastname',
                                 'label_attr' => ['class' => 'control-label'],
@@ -94,7 +95,7 @@ class ProfileController extends FormController
                         $form->remove('username');
                         $form->add(
                             'username_unbound',
-                            'text',
+                            TextType::class,
                             [
                                 'label'      => 'mautic.core.username',
                                 'label_attr' => ['class' => 'control-label'],
@@ -111,7 +112,7 @@ class ProfileController extends FormController
                         $form->remove('position');
                         $form->add(
                             'position_unbound',
-                            'text',
+                            TextType::class,
                             [
                                 'label'      => 'mautic.core.position',
                                 'label_attr' => ['class' => 'control-label'],
@@ -128,7 +129,7 @@ class ProfileController extends FormController
                         $form->remove('email');
                         $form->add(
                             'email_unbound',
-                            'text',
+                            TextType::class,
                             [
                                 'label'      => 'mautic.core.type.email',
                                 'label_attr' => ['class' => 'control-label'],


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N/A
| Automated tests included? | N
| Related user documentation PR URL |  N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | N/A
| Deprecations? | N/A

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixes the user profile form (`/s/account` page) for non-admin users when that user does not have the correct permission set. As it is, the page will fail to load if users do not have sufficient access to edit user profile fields.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new Role with Full Access to contact permissions only.
2. Create a new user assigned to that role.
3. Log in as that user and load your profile page (click top left user name > Account)
4. Page will fail to load. Confirm error in error logs.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat process to test, but the created user should now be able to access.