### PR TITLE
Fixed campaign membership manipulation

### DIFF
--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -184,7 +184,7 @@ class LeadSubscriber implements EventSubscriberInterface
                         }
                     }
 
-                    $this->membershipManager->removeContacts($removeContacts, $this->campaignReferences[$c['id']], false);
+                    $this->membershipManager->removeContacts($removeContacts, $this->campaignReferences[$c['id']], true);
                 }
             }
             $this->entityManager->clear(Lead::class);
@@ -229,13 +229,13 @@ class LeadSubscriber implements EventSubscriberInterface
                 }
 
                 if ('added' == $action) {
-                    $this->membershipManager->addContact($lead, $campaign);
+                    $this->membershipManager->addContact($lead, $campaign, false);
                 } else {
                     if (array_intersect($leadListIds, $campaignLists[$c['id']])) {
                         continue;
                     }
 
-                    $this->membershipManager->removeContact($lead, $campaign);
+                    $this->membershipManager->removeContact($lead, $campaign, true);
                 }
 
                 unset($campaign);

--- a/app/bundles/CampaignBundle/Tests/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/LeadSubscriberTest.php
@@ -94,7 +94,7 @@ class LeadSubscriberTest extends \PHPUnit\Framework\TestCase
             $this->campaignModelMock,
             $this->createMock(LeadModel::class),
             $this->createMock(Translator::class),
-            $this->makeEntityManagerMock(),
+            $this->makeBatchEntityManagerMock(),
             $this->createMock(Router::class),
             $this->createMock(CorePermissions::class)
         );
@@ -116,7 +116,7 @@ class LeadSubscriberTest extends \PHPUnit\Framework\TestCase
             ->with(
                 $this->containsOnlyInstancesOf(Lead::class),
                 $this->isInstanceOf(Campaign::class),
-                $this->isFalse()
+                $this->isTrue()
             );
 
         $membershipManagerMock->expects($this->never())->method('addContacts');
@@ -127,7 +127,7 @@ class LeadSubscriberTest extends \PHPUnit\Framework\TestCase
             $this->campaignModelMock,
             $this->createMock(LeadModel::class),
             $this->createMock(Translator::class),
-            $this->makeEntityManagerMock(),
+            $this->makeBatchEntityManagerMock(),
             $this->createMock(Router::class),
             $this->createMock(CorePermissions::class)
         );
@@ -136,7 +136,93 @@ class LeadSubscriberTest extends \PHPUnit\Framework\TestCase
         unset($leadSubscriber);
     }
 
-    private function makeEntityManagerMock()
+    public function testOnLeadListChangeWithAddedContact()
+    {
+        $removedLead = $this->createMock(Lead::class);
+        $leadList    = $this->createMock(LeadList::class);
+        $leadList->method('getId')->willReturn($this->segmentId);
+        $event = new ListChangeEvent($removedLead, $leadList, true);
+
+        $leadModel = $this->createMock(LeadModel::class);
+        $leadModel->expects($this->once())
+            ->method('getLists')
+            ->with($removedLead, $this->isTrue())
+            ->willReturn(
+                [
+                    $this->segmentId => [],
+                ]
+            );
+
+        $membershipManagerMock = $this->createMock(MembershipManager::class);
+        $membershipManagerMock->expects($this->exactly(2))
+            ->method('addContact')
+            ->with(
+                $this->isInstanceOf(Lead::class),
+                $this->isInstanceOf(Campaign::class),
+                $this->isFalse()
+            );
+
+        $membershipManagerMock->expects($this->never())->method('removeContact');
+
+        $leadSubscriber = new LeadSubscriber(
+            $membershipManagerMock,
+            $this->createMock(EventCollector::class),
+            $this->campaignModelMock,
+            $leadModel,
+            $this->createMock(Translator::class),
+            $this->makeSingleEntityManagerMock(),
+            $this->createMock(Router::class),
+            $this->createMock(CorePermissions::class)
+        );
+
+        $leadSubscriber->onLeadListChange($event);
+        unset($leadSubscriber);
+    }
+
+    public function testOnLeadListChangeWithRemovedContact()
+    {
+        $removedLead = $this->createMock(Lead::class);
+        $leadList    = $this->createMock(LeadList::class);
+        $leadList->method('getId')->willReturn($this->segmentId);
+        $event = new ListChangeEvent($removedLead, $leadList, false);
+
+        $leadModel = $this->createMock(LeadModel::class);
+        $leadModel->expects($this->once())
+            ->method('getLists')
+            ->with($removedLead, $this->isTrue())
+            ->willReturn(
+                [
+                    $this->segmentId => [],
+                ]
+            );
+
+        $membershipManagerMock = $this->createMock(MembershipManager::class);
+        $membershipManagerMock->expects($this->exactly(2))
+            ->method('removeContact')
+            ->with(
+                $this->isInstanceOf(Lead::class),
+                $this->isInstanceOf(Campaign::class),
+                $this->isTrue()
+            );
+
+        $membershipManagerMock->expects($this->never())->method('addContact');
+
+        $leadSubscriber = new LeadSubscriber(
+            $membershipManagerMock,
+            $this->createMock(EventCollector::class),
+            $this->campaignModelMock,
+            $leadModel,
+            $this->createMock(Translator::class),
+            $this->makeSingleEntityManagerMock(),
+            $this->createMock(Router::class),
+            $this->createMock(CorePermissions::class)
+        );
+
+        $leadSubscriber->onLeadListChange($event);
+        unset($leadSubscriber);
+    }
+
+    private function makeBatchEntityManagerMock()
     {
         $leadListRepositoryMock = $this->createMock(LeadListRepository::class);
         $leadListRepositoryMock->method('getLeadLists')->willReturn([$this->leadId => [$this->segmentId]]);
@@ -157,6 +243,31 @@ class LeadSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $entityManagerMock->method('getReference')->withConsecutive([Lead::class, $this->anything()], [Campaign::class, 1], [Campaign::class, 2])
             ->willReturnOnConsecutiveCalls(new Lead(), $mockCampaign1, $mockCampaign2);
+
+        return $entityManagerMock;
+    }
+
+    private function makeSingleEntityManagerMock()
+    {
+        $leadListRepositoryMock = $this->createMock(LeadListRepository::class);
+        $leadListRepositoryMock->method('getLeadLists')->willReturn([$this->leadId => [$this->segmentId]]);
+
+        $contactEventLogRepositoryMock = $this->createMock(LeadEventLogRepository::class);
+
+        $contactRepositoryMock = $this->createMock(LeadRepository::class);
+
+        $entityManagerMock = $this->createMock(EntityManager::class);
+        $entityManagerMock->method('getRepository')->withConsecutive([LeadList::class], [LeadEventLog::class], [CampaignLead::class])
+            ->willReturnOnConsecutiveCalls($leadListRepositoryMock, $contactEventLogRepositoryMock, $contactRepositoryMock);
+
+        $mockCampaign1 = $this->createMock(Campaign::class);
+        $mockCampaign1->method('getId')->willReturn(1);
+
+        $mockCampaign2 = $this->createMock(Campaign::class);
+        $mockCampaign2->method('getId')->willReturn(2);
+
+        $entityManagerMock->method('getReference')->withConsecutive([Campaign::class, 1], [Campaign::class, 2])
+            ->willReturnOnConsecutiveCalls($mockCampaign1, $mockCampaign2);
 
         return $entityManagerMock;
     }

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1517,13 +1517,13 @@ class LeadController extends FormController
 
                 if (!empty($add)) {
                     foreach ($add as $cid) {
-                        $membershipManager->addContacts(new ArrayCollection($entities), $campaigns[$cid], true);
+                        $membershipManager->addContacts(new ArrayCollection($entities), $campaigns[$cid]);
                     }
                 }
 
                 if (!empty($remove)) {
                     foreach ($remove as $cid) {
-                        $membershipManager->removeContacts(new ArrayCollection($entities), $campaigns[$cid], true);
+                        $membershipManager->removeContacts(new ArrayCollection($entities), $campaigns[$cid]);
                     }
                 }
             }

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Mautic\LeadBundle\Tests\Controller;
+
+use Doctrine\DBAL\Connection;
+use Mautic\CampaignBundle\Tests\DataFixtures\Orm\CampaignData;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\InstallBundle\InstallFixtures\ORM\LeadFieldData;
+use Mautic\InstallBundle\InstallFixtures\ORM\RoleData;
+use Mautic\LeadBundle\DataFixtures\ORM\LoadLeadData;
+use Mautic\UserBundle\DataFixtures\ORM\LoadRoleData;
+use Mautic\UserBundle\DataFixtures\ORM\LoadUserData;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class LeadControllerTest extends MauticMysqlTestCase
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = $this->container->get('doctrine.dbal.default_connection');
+
+        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
+    }
+
+    public function testContactsAreAddedToThenRemovedFromCampaignsInBatch()
+    {
+        $this->loadFixtures(
+            [LeadFieldData::class, RoleData::class, LoadRoleData::class, LoadUserData::class, CampaignData::class, LoadLeadData::class]
+        );
+
+        $payload = [
+            'lead_batch' => [
+                'add' => [1],
+                'ids' => json_encode([1, 2, 3]),
+            ],
+        ];
+
+        $this->client->request(Request::METHOD_POST, '/s/contacts/batchCampaigns', $payload);
+
+        $clientResponse = $this->client->getResponse();
+        $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
+
+        $this->assertSame(
+            [
+                [
+                    'lead_id'          => '1',
+                    'manually_added'   => '1',
+                    'manually_removed' => '0',
+                    'date_last_exited' => null,
+                ],
+                [
+                    'lead_id'          => '2',
+                    'manually_added'   => '1',
+                    'manually_removed' => '0',
+                    'date_last_exited' => null,
+                ],
+                [
+                    'lead_id'          => '3',
+                    'manually_added'   => '1',
+                    'manually_removed' => '0',
+                    'date_last_exited' => null,
+                ],
+            ],
+            $this->getMembersForCampaign(1)
+        );
+
+        $response = json_decode($clientResponse->getContent(), true);
+        $this->assertTrue(isset($response['closeModal']), 'The response does not contain the `closeModal` param.');
+        $this->assertTrue($response['closeModal']);
+        $this->assertContains('3 contacts affected', $response['flashes']);
+
+        $payload = [
+            'lead_batch' => [
+                'remove' => [1],
+                'ids'    => json_encode([1, 2, 3]),
+            ],
+        ];
+
+        $this->client->request(Request::METHOD_POST, '/s/contacts/batchCampaigns', $payload);
+
+        $clientResponse = $this->client->getResponse();
+        $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
+
+        $this->assertSame(
+            [
+                [
+                    'lead_id'          => '1',
+                    'manually_added'   => '0',
+                    'manually_removed' => '1',
+                    'date_last_exited' => null,
+                ],
+                [
+                    'lead_id'          => '2',
+                    'manually_added'   => '0',
+                    'manually_removed' => '1',
+                    'date_last_exited' => null,
+                ],
+                [
+                    'lead_id'          => '3',
+                    'manually_added'   => '0',
+                    'manually_removed' => '1',
+                    'date_last_exited' => null,
+                ],
+            ],
+            $this->getMembersForCampaign(1)
+        );
+
+        $response = json_decode($clientResponse->getContent(), true);
+        $this->assertTrue(isset($response['closeModal']), 'The response does not contain the `closeModal` param.');
+        $this->assertTrue($response['closeModal']);
+        $this->assertContains('3 contacts affected', $response['flashes']);
+    }
+
+    private function getMembersForCampaign(int $campaignId): array
+    {
+        return $this->connection->createQueryBuilder()
+            ->select('cl.lead_id, cl.manually_added, cl.manually_removed, cl.date_last_exited')
+            ->from(MAUTIC_TABLE_PREFIX.'campaign_leads', 'cl')
+            ->where("cl.campaign_id = {$campaignId}")
+            ->execute()
+            ->fetchAll();
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When using the campaign bundle's MembershipManager, the third argument for the add/remove methods should be used to note whether a contact was manually manipulated or not. In the case of `removeContact`(s), `$isExit` should be true if a segment automatically removed the contact and false/default other wise. There were a couple places from the deprecation code refactoring that reversed this which this PR corrects. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to /s/contacts
2. Select a bunch of contacts and click the bulk action dropdown
3. Add contacts to a campaign
4. Now do the same and remove the contacts from the same campaign
5. Check the campaign_leads table and note that those contacts should have en entry for this campaign, with manually_removed = 1 and a populated date_last_exited (this should be null because a segment did not remove automatically remove the contacts). 
6. Now create a segment with filters that match contacts and create a campaign using that segment as the source
7. Run the command to build the segment `php bin/console mautic:segments:update`
8. Look at the campaign_leads table for the new campaign. Notice that the contacts automatically added should have manually_added = 0 and manually_removed = 0.
9. Now update a contact so that it no longer meets the segment filter and rebuild the segment
10. Look at the campaign_leads table and find the contact for this campaign. Notice that manually_removed = 1 but date_last_exited is null (this is supposed to be a timestamp because the segment automatically removed the contact). 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat and the date_last_exited should be populated for segment removed contacts and should not for manually removed contacts. 
3. Run the tests
