### PR TITLE
Wrong event timestamp in contact history when user timezone is not UTC

### DIFF
--- a/app/bundles/CoreBundle/Helper/DateTimeHelper.php
+++ b/app/bundles/CoreBundle/Helper/DateTimeHelper.php
@@ -220,7 +220,7 @@ class DateTimeHelper
     public function getDiff($compare = 'now', $format = null, $resetTime = false)
     {
         if ($compare == 'now') {
-            $compare = new \DateTime();
+            $compare = new \DateTime('now', $this->datetime->getTimezone());
         }
 
         $with = clone $this->datetime;

--- a/app/bundles/CoreBundle/Tests/Unit/Templating/Helper/DateHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Templating/Helper/DateHelperTest.php
@@ -51,4 +51,52 @@ class DateHelperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('November 20, 2017 3:45 pm', $this->helper->toText($dateTime, 'UTC', 'Y-m-d H:i:s', true));
     }
+
+    public function testToTextYesterdayWithPragueTimezone()
+    {
+        $dateTime    = new \DateTime('yesterday', new \DateTimeZone('UTC'));
+
+        $this->translator->expects($this->any())
+            ->method('trans')
+            ->willReturnCallback(
+                function ($key) {
+                    return $key;
+                }
+            );
+
+        $result = $this->helper->toText($dateTime, 'Europe/Prague', 'Y-m-d H:i:s', true);
+        $this->assertSame('mautic.core.date.yesterday', $result);
+    }
+
+    public function testToTextTodayWithPragueTimezone()
+    {
+        $dateTime    = new \DateTime('now', new \DateTimeZone('UTC'));
+
+        $this->translator->expects($this->any())
+            ->method('trans')
+            ->willReturnCallback(
+                function ($key) {
+                    return $key;
+                }
+            );
+
+        $result = $this->helper->toText($dateTime, 'Europe/Prague', 'Y-m-d H:i:s', true);
+        $this->assertSame('mautic.core.date.today', $result);
+    }
+
+    public function testToTextTomorrowWithPragueTimezone()
+    {
+        $dateTime    = new \DateTime('tomorrow', new \DateTimeZone('UTC'));
+
+        $this->translator->expects($this->any())
+            ->method('trans')
+            ->willReturnCallback(
+                function ($key) {
+                    return $key;
+                }
+            );
+
+        $result = $this->helper->toText($dateTime, 'Europe/Prague', 'Y-m-d H:i:s', true);
+        $this->assertSame('mautic.core.date.tomorrow', $result);
+    }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
There is an issue with timestamps when user timezone is different than UTC (tested on Warsaw, Prague, Kiev, Moscow). 
On the screen event was triggered a day before, but history shows it as today.
![image](https://user-images.githubusercontent.com/8580942/76984307-edfea980-693e-11ea-99f0-0f66a2bd45a7.png)


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Set timezone UTC+1 (or more) eg. Warsaw
2. Create campaign and trigger an action on contact
3. On the next day check the contact history 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat steps to reproduce
