### PR TITLE
Makes permission class instantiation compatible with #7312

### DIFF
--- a/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/Metadata/PermissionClassMetadataTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/Metadata/PermissionClassMetadataTest.php
@@ -17,15 +17,10 @@ use PHPUnit\Framework\TestCase;
 
 class PermissionClassMetadataTest extends TestCase
 {
-    /**
-     * @var BundleMetadata
-     */
-    private $metadata;
-
-    protected function setUp()
+    public function testPermissionsFound()
     {
         $metadataArray = [
-            'isPlugin'          => true,
+            'isPlugin'          => false,
             'base'              => 'Core',
             'bundle'            => 'CoreBundle',
             'relative'          => 'app/bundles/MauticCoreBundle',
@@ -35,14 +30,31 @@ class PermissionClassMetadataTest extends TestCase
             'bundleClass'       => '\\Mautic\\CoreBundle',
         ];
 
-        $this->metadata = new BundleMetadata($metadataArray);
-    }
-
-    public function testPermissionsFound()
-    {
-        $permissionClassMetadata = new PermissionClassMetadata($this->metadata);
+        $metadata                = new BundleMetadata($metadataArray);
+        $permissionClassMetadata = new PermissionClassMetadata($metadata);
         $permissionClassMetadata->build();
 
-        $this->assertTrue(isset($this->metadata->toArray()['permissionClasses']['core']));
+        $this->assertTrue(isset($metadata->toArray()['permissionClasses']['core']));
+        $this->assertCount(1, $metadata->toArray()['permissionClasses']);
+    }
+
+    public function testCompatibilityWithPermissionServices()
+    {
+        $metadataArray = [
+            'isPlugin'          => false,
+            'base'              => 'Asset',
+            'bundle'            => 'AssetBundle',
+            'relative'          => 'app/bundles/MauticAssetBundle',
+            'directory'         => __DIR__.'/../../../../../../AssetBundle',
+            'namespace'         => 'Mautic\\AssetBundle',
+            'symfonyBundleName' => 'MauticAssetBundle',
+            'bundleClass'       => '\\Mautic\\AssetBundle',
+        ];
+
+        $metadata                = new BundleMetadata($metadataArray);
+        $permissionClassMetadata = new PermissionClassMetadata($metadata);
+        $permissionClassMetadata->build();
+
+        $this->assertTrue(isset($metadata->toArray()['permissionClasses']['asset']));
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
#7312 will introduce support for permissions as services with proper dependency injection. This simply makes the PermissionClassMetadata builder compatible with it for when it is gets merged. 

[//]: # ( As applicable: )
#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Ensure that Mautic's cache compiles, loadable in the browser and the tests pass
