### PR TITLE
Revert "Speed up leads custom fields"

### DIFF
--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -114,7 +114,12 @@ trait CustomFieldRepositoryTrait
                 //since we have to be cross-platform; it's way ugly
 
                 //We should probably totally ditch orm for leads
-                $order = $this->getTableAlias().'.id AS HIDDEN ORD';
+                $order = '(CASE';
+                foreach ($ids as $count => $id) {
+                    $order .= ' WHEN '.$this->getTableAlias().'.id = '.$id.' THEN '.$count;
+                    ++$count;
+                }
+                $order .= ' ELSE '.$count.' END) AS HIDDEN ORD';
 
                 //ORM - generates lead entities
                 /** @var \Doctrine\ORM\QueryBuilder $q */

--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -114,6 +114,9 @@ trait CustomFieldRepositoryTrait
                 //since we have to be cross-platform; it's way ugly
 
                 //We should probably totally ditch orm for leads
+
+                // This "hack" is in place to allow for custom ordering in the API.
+                // See https://github.com/mautic/mautic/pull/7494#issuecomment-600970208
                 $order = '(CASE';
                 foreach ($ids as $count => $id) {
                     $order .= ' WHEN '.$this->getTableAlias().'.id = '.$id.' THEN '.$count;


### PR DESCRIPTION
Reverts mautic/mautic#7494

The PR above caused an issue with custom ordering in Mautic's API, see https://github.com/mautic/mautic/pull/7494#issuecomment-600970208

**In addition, this PR adds a note about the reason for why the "hack" is in place, in case someone comes across it in the future.**