### PR TITLE
Fix int nullable env procesor

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -614,6 +614,10 @@ return [
                 'class' => \Mautic\CoreBundle\DependencyInjection\EnvProcessor\NullableProcessor::class,
                 'tag'   => 'container.env_var_processor',
             ],
+            'mautic.di.env_processor.int_nullable' => [
+                'class' => \Mautic\CoreBundle\DependencyInjection\EnvProcessor\IntNullableProcessor::class,
+                'tag'   => 'container.env_var_processor',
+            ],
             'mautic.cipher.openssl' => [
                 'class'     => \Mautic\CoreBundle\Security\Cryptography\Cipher\Symmetric\OpenSSLCipher::class,
                 'arguments' => ['%kernel.environment%'],

--- a/app/bundles/CoreBundle/DependencyInjection/EnvProcessor/IntNullableProcessor.php
+++ b/app/bundles/CoreBundle/DependencyInjection/EnvProcessor/IntNullableProcessor.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\DependencyInjection\EnvProcessor;
+
+use Symfony\Component\DependencyInjection\EnvVarProcessorInterface;
+
+class IntNullableProcessor implements EnvVarProcessorInterface
+{
+    public function getEnv($prefix, $name, \Closure $getEnv)
+    {
+        $env = $getEnv($name);
+
+        return null === $env ? null : (int) $env;
+    }
+
+    public static function getProvidedTypes()
+    {
+        return [
+            'intNullable' => 'string|int',
+        ];
+    }
+}

--- a/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/EnvProcessor/IntNullableProcessorTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/EnvProcessor/IntNullableProcessorTest.php
@@ -14,7 +14,7 @@ namespace Mautic\CoreBundle\Tests\Unit\DependencyInjection\EnvProcessor;
 use Mautic\CoreBundle\DependencyInjection\EnvProcessor\IntNullableProcessor;
 use PHPUnit\Framework\TestCase;
 
-class NullableProcessorTest extends TestCase
+class IntNullableProcessorTest extends TestCase
 {
     public function testNullReturnedIfNullValue()
     {

--- a/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/EnvProcessor/IntNullableProcessorTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/EnvProcessor/IntNullableProcessorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Tests\Unit\DependencyInjection\EnvProcessor;
+
+use Mautic\CoreBundle\DependencyInjection\EnvProcessor\IntNullableProcessor;
+use PHPUnit\Framework\TestCase;
+
+class NullableProcessorTest extends TestCase
+{
+    public function testNullReturnedIfNullValue()
+    {
+        $getEnv = function (string $name) {
+            return null;
+        };
+
+        $processor = new IntNullableProcessor();
+
+        $value = $processor->getEnv('', 'test', $getEnv);
+
+        $this->assertNull($value);
+    }
+
+    public function testIntReturnedIfNotNull()
+    {
+        $getEnv = function (string $name) {
+            return '0';
+        };
+
+        $processor = new IntNullableProcessor();
+
+        $value = $processor->getEnv('', 'test', $getEnv);
+
+        $this->assertSame(0, $value);
+    }
+
+    public function testIntReturnedIfEmptyString()
+    {
+        $getEnv = function (string $name) {
+            return '';
+        };
+
+        $processor = new IntNullableProcessor();
+
+        $value = $processor->getEnv('', 'test', $getEnv);
+
+        $this->assertSame(0, $value);
+    }
+
+    public function testIntReturnedIfInt()
+    {
+        $getEnv = function (string $name) {
+            return 12;
+        };
+
+        $processor = new IntNullableProcessor();
+
+        $value = $processor->getEnv('', 'test', $getEnv);
+
+        $this->assertSame(12, $value);
+    }
+}

--- a/app/bundles/SmsBundle/Config/config.php
+++ b/app/bundles/SmsBundle/Config/config.php
@@ -307,7 +307,7 @@ return [
         'sms_password'             => null,
         'sms_sending_phone_number' => null,
         'sms_frequency_number'     => 0,
-        'sms_frequency_time'       => 0,
+        'sms_frequency_time'       => 'DAY',
         'sms_transport'            => 'mautic.sms.twilio.transport',
     ],
 ];

--- a/app/config/parameters.php
+++ b/app/config/parameters.php
@@ -34,7 +34,7 @@ foreach ($mauticParams as $k => $v) {
             $type = 'bool:';
             break;
         case is_int($v):
-            $type = 'int:';
+            $type = 'intNullable:';
             break;
         case is_array($v):
             $type = 'json:';


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Env variables type casted as ints could not support null values but our defaults from M2 were null. Many configurations thus have null values and thus would not load in M3.  

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Add `	'sms_frequency_number' => null,` to the local configuration file
2. Go to Mautic's Configuration
3. Note the 500

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Mautic's configuration should load
