### PR TITLE
Mails get SPAM detected 550-5.7.0 by t-online

### DIFF
--- a/themes/skyline/html/email.html.twig
+++ b/themes/skyline/html/email.html.twig
@@ -57,7 +57,7 @@
 
     <style type="text/css" media="screen">
         @media screen {
-             /* Thanks Outlook 2013! http://goo.gl/XLxpyl*/
+             /* Thanks Outlook 2013! dropped shortlink t-online spam detection for shortlinks*/
             td, h1, h2, h3 {
                 font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
             }

--- a/themes/skyline/html/email.html.twig
+++ b/themes/skyline/html/email.html.twig
@@ -57,7 +57,7 @@
 
     <style type="text/css" media="screen">
         @media screen {
-             /* Thanks Outlook 2013! dropped shortlink t-online spam detection for shortlinks*/
+             /* Thanks Outlook 2013! */
             td, h1, h2, h3 {
                 font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
             }


### PR DESCRIPTION
After checking an undelivered mail issue with t-online, we found this short link in theme so this should be dropped.

the shortlink: http://goo.gl/XLxpyl is recognized as spam by deutsche Telekom - T-Online (27 Million MailsUsers), The result of this "bug" is that mautic-theme skyline is unusable for mail sending to t-online users. This bug is only recognized by direct talk with t-online postmasters.

Comment is functional not needed, testing is not neccessary, so easy to fix 

doc t-online here https://postmaster.t-online.de/#t3.3

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| Automated tests included? | no
| Related user documentation PR URL | no
| Related developer documentation PR URL | no
| Issues addressed (#s or URLs) | ?
| BC breaks? | ?
| Deprecations? | ?

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
