### PR TITLE
Fix possibility to overwrite objects in the sync engine

### DIFF
--- a/app/bundles/IntegrationsBundle/Entity/FieldChangeRepository.php
+++ b/app/bundles/IntegrationsBundle/Entity/FieldChangeRepository.php
@@ -147,7 +147,7 @@ class FieldChangeRepository extends CommonRepository
                 $qb->expr()->andX(
                     $qb->expr()->eq('f.integration', ':integration'),
                     $qb->expr()->eq('f.object_type', ':objectType'),
-                    $qb->expr()->gte('f.object_id', ':objectId')
+                    $qb->expr()->eq('f.object_id', ':objectId')
                 )
             )
             ->setParameter('integration', $integration)

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Entity/FieldChangeRepositoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Entity/FieldChangeRepositoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\IntegrationsBundle\Tests\Unit\Entity;
+
+use Doctrine\DBAL\Query\Expression\CompositeExpression;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Mautic\CoreBundle\Test\Doctrine\DBALMocker;
+use Mautic\IntegrationsBundle\Entity\FieldChangeRepository;
+use PHPUnit\Framework\TestCase;
+
+class FieldChangeRepositoryTest extends TestCase
+{
+    public function testWhereQueryPartForFindingChangesForSingleObject()
+    {
+        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
+        $dbalMock = new DBALMocker($this);
+        $metadata = $this->createMock(ClassMetadata::class);
+
+        $integration = 'test';
+        $objectType  = 'foobar';
+        $objectId    = 5;
+
+        $repository = new FieldChangeRepository($dbalMock->getMockEm(), $metadata);
+        $repository->findChangesForObject($integration, $objectType, $objectId);
+
+        $where = $dbalMock->getQueryPart('where');
+        $this->assertCount(1, $where);
+        $this->assertCount(1, $where[0]);
+
+        /** @var CompositeExpression $expr */
+        $expr = $where[0][0];
+        $this->assertSame(
+            '(f.integration = :integration) AND (f.object_type = :objectType) AND (f.object_id = :objectId)',
+            (string) $expr
+        );
+
+        $parameters = $dbalMock->getQueryPart('parameters');
+        $this->assertCount(3, $parameters);
+        $this->assertEquals('integration', $parameters[0][0]);
+        $this->assertEquals($integration, $parameters[0][1]);
+        $this->assertEquals('objectType', $parameters[1][0]);
+        $this->assertEquals($objectType, $parameters[1][1]);
+        $this->assertEquals('objectId', $parameters[2][0]);
+        $this->assertEquals($objectId, $parameters[2][1]);
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This won't be reproducible without an integration that leverages this but the gist is that the wrong expression would find any changes on Mautic's side for an ID greater than the one being synced and thus overwrite the contact with the data of another. 

[//]: # ( As applicable: )

#### Steps to test this PR:
1. Code review and run test
