### PR TITLE
Integration mapping filter save fix

### DIFF
--- a/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsObjectFieldType.php
+++ b/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsObjectFieldType.php
@@ -67,8 +67,7 @@ class IntegrationSyncSettingsObjectFieldType extends AbstractType
             throw new InvalidFormOptionException('field "'.$field->getName().'" must allow at least 1 direction for sync');
         }
 
-        reset($choices);
-        $defaultChoice = key($choices);
+        $defaultChoice = $choices[array_key_first($choices)];
 
         $builder->add(
             'syncDirection',

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Form/Type/IntegrationSyncSettingsObjectFieldTypeTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Form/Type/IntegrationSyncSettingsObjectFieldTypeTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://www.mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\IntegrationsBundle\Tests\Unit\Form\Type;
+
+use Mautic\IntegrationsBundle\Exception\InvalidFormOptionException;
+use Mautic\IntegrationsBundle\Form\Type\IntegrationSyncSettingsObjectFieldType;
+use Mautic\IntegrationsBundle\Mapping\MappedFieldInfoInterface;
+use Mautic\IntegrationsBundle\Sync\DAO\Mapping\ObjectMappingDAO;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class IntegrationSyncSettingsObjectFieldTypeTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var MockObject|FormBuilderInterface
+     */
+    private $formBuilder;
+
+    /**
+     * @var IntegrationSyncSettingsObjectFieldType
+     */
+    private $form;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->formBuilder = $this->createMock(FormBuilderInterface::class);
+        $this->form        = new IntegrationSyncSettingsObjectFieldType();
+    }
+
+    public function testBuildFormForWrongField(): void
+    {
+        $options = ['field' => 'unicorn'];
+        $this->expectException(InvalidFormOptionException::class);
+        $this->form->buildForm($this->formBuilder, $options);
+    }
+
+    public function testBuildFormForMappedField(): void
+    {
+        $field   = $this->createMock(MappedFieldInfoInterface::class);
+        $options = [
+            'field'        => $field,
+            'placeholder'  => 'Placeholder ABC',
+            'object'       => 'Object A',
+            'integration'  => 'Integration A',
+            'mauticFields' => [
+                'mautic_field_a' => 'Mautic Field A',
+                'mautic_field_b' => 'Mautic Field B',
+            ],
+        ];
+
+        $field->method('showAsRequired')->willReturn(true);
+        $field->method('getName')->willReturn('Integration Field A');
+        $field->method('isBidirectionalSyncEnabled')->willReturn(false);
+        $field->method('isToIntegrationSyncEnabled')->willReturn(true);
+        $field->method('isToMauticSyncEnabled')->willReturn(true);
+
+        $this->formBuilder->expects($this->at(0))
+            ->method('add')
+            ->with(
+                'mappedField',
+                ChoiceType::class,
+                [
+                    'label'          => false,
+                    'choices'        => [
+                        'Mautic Field A' => 'mautic_field_a',
+                        'Mautic Field B' => 'mautic_field_b',
+                    ],
+                    'required'       => true,
+                    'placeholder'    => '',
+                    'error_bubbling' => false,
+                    'attr'           => [
+                        'class'            => 'form-control integration-mapped-field',
+                        'data-placeholder' => $options['placeholder'],
+                        'data-object'      => $options['object'],
+                        'data-integration' => $options['integration'],
+                        'data-field'       => 'Integration Field A',
+                    ],
+                ]
+            );
+
+        $this->formBuilder->expects($this->at(1))
+            ->method('add')
+            ->with(
+                'syncDirection',
+                ChoiceType::class,
+                [
+                    'choices' => [
+                        'mautic.integration.sync_direction_integration' => ObjectMappingDAO::SYNC_TO_INTEGRATION,
+                        'mautic.integration.sync_direction_mautic'      => ObjectMappingDAO::SYNC_TO_MAUTIC,
+                    ],
+                    'label'      => false,
+                    'empty_data' => ObjectMappingDAO::SYNC_TO_INTEGRATION,
+                    'attr'       => [
+                        'class'            => 'integration-sync-direction',
+                        'data-object'      => 'Object A',
+                        'data-integration' => 'Integration A',
+                        'data-field'       => 'Integration Field A',
+                    ],
+                ]
+            );
+
+        $this->form->buildForm($this->formBuilder, $options);
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Edit an authorized integration that has sync and some objects to sync turned on. Must be based on the IntegrationsBundle
2. In a mapping form tab where you have some required field mapped, search for some field.
3. Map the field to some Mautic field and save.
4. It will fail form validation with no message and resets all fields for the object.

#### Steps to test this PR:
1. Cancel the edit form and edit again. The changes were not saved so all the fields you had mapped before are still mapped.
2. Repeat the steps. It saves the updated, filtered fields and leave the rest so everything saves properly.
