### PR TITLE
Cleanup mapping objects table after a contact or company is deleted

### DIFF
--- a/app/bundles/IntegrationsBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/LeadSubscriber.php
@@ -117,7 +117,7 @@ class LeadSubscriber implements EventSubscriberInterface
 
     public function onLeadPostDelete(Events\LeadEvent $event): void
     {
-        $this->fieldChangeRepo->deleteEntitiesForObject((int) $event->getLead()->deletedId, Lead::class);
+        $this->fieldChangeRepo->deleteEntitiesForObject((int) $event->getLead()->deletedId, MauticSyncDataExchange::OBJECT_CONTACT);
     }
 
     /**
@@ -153,7 +153,7 @@ class LeadSubscriber implements EventSubscriberInterface
 
     public function onCompanyPostDelete(Events\CompanyEvent $event): void
     {
-        $this->fieldChangeRepo->deleteEntitiesForObject((int) $event->getCompany()->deletedId, Company::class);
+        $this->fieldChangeRepo->deleteEntitiesForObject((int) $event->getCompany()->deletedId, MauticSyncDataExchange::OBJECT_COMPANY);
     }
 
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
@@ -264,7 +264,7 @@ class LeadSubscriberTest extends TestCase
 
         $this->fieldChangeRepository->expects($this->once())
             ->method('deleteEntitiesForObject')
-            ->with((int) $deletedId, Lead::class);
+            ->with((int) $deletedId, MauticSyncDataExchange::OBJECT_CONTACT);
 
         $this->subscriber->onLeadPostDelete($event);
     }
@@ -399,7 +399,7 @@ class LeadSubscriberTest extends TestCase
 
         $this->fieldChangeRepository->expects($this->once())
             ->method('deleteEntitiesForObject')
-            ->with((int) $deletedId, Company::class);
+            ->with((int) $deletedId, MauticSyncDataExchange::OBJECT_COMPANY);
 
         $this->subscriber->onCompanyPostDelete($event);
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The object mapping table would not get cleaned up after deleting contacts or companies because the on delete listeners were checking for internal_objects that were the classnames of the Lead or Company entity classes instead of what was actually stored. 

[//]: # ( As applicable: )
#### Steps to test this PR:
1. There are no public plugins dependent on this yet so code review and check the tests


