### PR TITLE
Primary company is not displayed properly on the lead view page

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -276,6 +276,10 @@ class LeadController extends FormController
         /** @var \Mautic\LeadBundle\Model\LeadModel $model */
         $model = $this->getModel('lead.lead');
 
+        // When we change company data these changes get cached
+        // so we need to clear the entity manager
+        $model->getRepository()->clear();
+
         /** @var \Mautic\LeadBundle\Entity\Lead $lead */
         $lead = $model->getEntity($objectId);
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Some fields get cached and we are getting incorrect `Primary Company` value when we change the company name.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create or edit a contact.
2. Click on a company field.
3. Choose `Create new`.
4. Create a company, save the company, save the contact.
5. Click on details.
6. You will see incorrect `Primary Company` value (either empty or previous value).

#### Steps to test this PR:
1. Create or edit a contact.
2. Click on a company field.
3. Choose `Create new`.
4. Create a company, save the company, save the contact.
5. Click on details.
6. You should see correct `Primary Company` value.