### PR TITLE
Add possibility to have only isPublished interface without Auth

### DIFF
--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -203,16 +203,6 @@ class PluginController extends FormController
                 if ($authorize || $valid) {
                     $em          = $this->get('doctrine.orm.entity_manager');
                     $integration = $entity->getName();
-                    $keys        = $form['apiKeys']->getData();
-
-                    // Prevent merged keys
-                    $secretKeys = $integrationObject->getSecretKeys();
-                    foreach ($secretKeys as $secretKey) {
-                        if (empty($keys[$secretKey]) && !empty($currentKeys[$secretKey])) {
-                            $keys[$secretKey] = $currentKeys[$secretKey];
-                        }
-                    }
-                    $integrationObject->encryptAndSetApiKeys($keys, $entity);
 
                     if (!$authorize) {
                         $features = $entity->getSupportedFeatures();
@@ -253,6 +243,17 @@ class PluginController extends FormController
                             }
                         }
                     } else {
+                        $keys = $form['apiKeys']->getData();
+
+                        // Prevent merged keys
+                        $secretKeys = $integrationObject->getSecretKeys();
+                        foreach ($secretKeys as $secretKey) {
+                            if (empty($keys[$secretKey]) && !empty($currentKeys[$secretKey])) {
+                                $keys[$secretKey] = $currentKeys[$secretKey];
+                            }
+                        }
+                        $integrationObject->encryptAndSetApiKeys($keys, $entity);
+
                         //make sure they aren't overwritten because of API connection issues
                         $entity->setFeatureSettings($currentFeatureSettings);
                     }

--- a/app/bundles/PluginBundle/Form/Type/DetailsType.php
+++ b/app/bundles/PluginBundle/Form/Type/DetailsType.php
@@ -35,37 +35,38 @@ class DetailsType extends AbstractType
     {
         $builder->add('isPublished', YesNoButtonGroupType::class);
 
-        $keys          = $options['integration_object']->getRequiredKeyFields();
-        $decryptedKeys = $options['integration_object']->decryptApiKeys($options['data']->getApiKeys());
-        $formSettings  = $options['integration_object']->getFormDisplaySettings();
+        $formSettings = $options['integration_object']->getFormDisplaySettings();
 
-        if (!empty($formSettings['hide_keys'])) {
-            foreach ($formSettings['hide_keys'] as $key) {
-                unset($keys[$key]);
+        if (!empty($formSettings['requires_authorization'])) {
+            $keys          = $options['integration_object']->getRequiredKeyFields();
+            $decryptedKeys = $options['integration_object']->decryptApiKeys($options['data']->getApiKeys());
+
+            if (!empty($formSettings['hide_keys'])) {
+                foreach ($formSettings['hide_keys'] as $key) {
+                    unset($keys[$key]);
+                }
             }
-        }
 
-        $builder->add('apiKeys', KeysType::class, [
-            'label'              => false,
-            'integration_keys'   => $keys,
-            'data'               => $decryptedKeys,
-            'integration_object' => $options['integration_object'],
-        ]);
-
-        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($keys, $decryptedKeys, $options) {
-            $data = $event->getData();
-            $form = $event->getForm();
-
-            $form->add('apiKeys', KeysType::class, [
+            $builder->add('apiKeys', KeysType::class, [
                 'label'              => false,
                 'integration_keys'   => $keys,
                 'data'               => $decryptedKeys,
                 'integration_object' => $options['integration_object'],
-                'is_published'       => (int) $data['isPublished'],
             ]);
-        });
 
-        if (!empty($formSettings['requires_authorization'])) {
+            $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($keys, $decryptedKeys, $options) {
+                $data = $event->getData();
+                $form = $event->getForm();
+
+                $form->add('apiKeys', KeysType::class, [
+                    'label'              => false,
+                    'integration_keys'   => $keys,
+                    'data'               => $decryptedKeys,
+                    'integration_object' => $options['integration_object'],
+                    'is_published'       => (int) $data['isPublished'],
+                ]);
+            });
+
             $disabled = false;
             $label    = ($options['integration_object']->isAuthorized()) ? 'reauthorize' : 'authorize';
 

--- a/app/bundles/PluginBundle/Views/Integration/form.html.php
+++ b/app/bundles/PluginBundle/Views/Integration/form.html.php
@@ -97,28 +97,30 @@ $hasFeatureErrors =
     <div class="tab-pane fade <?php if (isset($activeTab) && 'details-container' == $activeTab): echo 'in active'; endif; ?> bdr-w-0" id="details-container">
         <?php echo $view['form']->row($form['isPublished']); ?>
         <?php echo $view['form']->rowIfExists($form, 'virtual'); ?>
-        <?php echo $view['form']->row($form['apiKeys']); ?>
-        <?php if (isset($formNotes['authorization'])): ?>
-            <div class="alert alert-<?php echo $formNotes['authorization']['type']; ?>">
-                <?php echo $view['translator']->trans($formNotes['authorization']['note']); ?>
-            </div>
-        <?php endif; ?>
-        <?php if (count($form['apiKeys']) && !empty($callbackUrl)): ?>
-            <div class="well well-sm">
-                <?php echo $view['translator']->trans('mautic.integration.callbackuri'); ?><br/>
-                <input type="text" readonly onclick="this.setSelectionRange(0, this.value.length);" value="<?php echo $view->escape($callbackUrl); ?>" class="form-control"/>
-            </div>
-        <?php endif; ?>
-        <?php if (isset($form['authButton'])): ?>
-            <div class="row">
-                <div class="col-xs-12 text-center">
-                    <?php
-                    $attr          = $form['authButton']->vars['attr'];
-                    $attr['class'] = 'btn btn-success btn-lg';
-                    echo $view['form']->widget($form['authButton'], ['attr' => $attr]);
-                    ?>
+        <?php if (isset($form['apiKeys'])): ?>
+            <?php echo $view['form']->row($form['apiKeys']); ?>
+            <?php if (isset($formNotes['authorization'])): ?>
+                <div class="alert alert-<?php echo $formNotes['authorization']['type']; ?>">
+                    <?php echo $view['translator']->trans($formNotes['authorization']['note']); ?>
                 </div>
-            </div>
+            <?php endif; ?>
+            <?php if (count($form['apiKeys']) && !empty($callbackUrl)): ?>
+                <div class="well well-sm">
+                    <?php echo $view['translator']->trans('mautic.integration.callbackuri'); ?><br/>
+                    <input type="text" readonly onclick="this.setSelectionRange(0, this.value.length);" value="<?php echo $view->escape($callbackUrl); ?>" class="form-control"/>
+                </div>
+            <?php endif; ?>
+            <?php if (isset($form['authButton'])): ?>
+                <div class="row">
+                    <div class="col-xs-12 text-center">
+                        <?php
+                        $attr          = $form['authButton']->vars['attr'];
+                        $attr['class'] = 'btn btn-success btn-lg';
+                        echo $view['form']->widget($form['authButton'], ['attr' => $attr]);
+                        ?>
+                    </div>
+                </div>
+            <?php endif; ?>
         <?php endif; ?>
         <?php if (isset($formNotes['custom'])):
             if (is_string($formNotes['custom'])):


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

#### Description:
Add possibility to have only isPublished interface without Auth form.

Set requires_authorization to false to have only isPublished button.

![Screenshot_2020-03-31 Manage Plugins Webmecanik Automation](https://user-images.githubusercontent.com/27768270/78036737-f1485b00-736a-11ea-86c9-464db9c399ba.png)
