### PR TITLE
Fix sent email point actions issues

### DIFF
--- a/app/bundles/EmailBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/PointSubscriber.php
@@ -121,6 +121,6 @@ class PointSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->pointModel->triggerAction('email.send', $event->getEmail(), null, $lead);
+        $this->pointModel->triggerAction('email.send', $event->getEmail(), null, $lead, true);
     }
 }

--- a/app/bundles/EmailBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/PointSubscriber.php
@@ -27,19 +27,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class PointSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var PointModel
-     */
     private $pointModel;
 
-    /**
-     * @var EntityManager
-     */
     private $entityManager;
 
-    /**
-     * @var array
-     */
     private $triggered = [];
 
     public function __construct(PointModel $pointModel, EntityManager $entityManager)
@@ -120,7 +111,7 @@ class PointSubscriber implements EventSubscriberInterface
      */
     public function onEmailSend(EmailSendEvent $event)
     {
-        if ($leadArray = $event->getLead()) {
+        if ($leadArray = $event->getLead() && !empty($leadArray['id'])) {
             $lead = $this->entityManager->getReference(Lead::class, $leadArray['id']);
         } else {
             return;

--- a/app/bundles/EmailBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/PointSubscriber.php
@@ -111,7 +111,8 @@ class PointSubscriber implements EventSubscriberInterface
      */
     public function onEmailSend(EmailSendEvent $event)
     {
-        if ($leadArray = $event->getLead() && !empty($leadArray['id'])) {
+        $leadArray = $event->getLead();
+        if ($leadArray && is_array($leadArray) && !empty($leadArray['id'])) {
             $lead = $this->entityManager->getReference(Lead::class, $leadArray['id']);
         } else {
             return;

--- a/app/bundles/EmailBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/PointSubscriber.php
@@ -33,6 +33,11 @@ class PointSubscriber implements EventSubscriberInterface
     private $pointModel;
 
     /**
+     * @var array
+     */
+    private $triggered = [];
+
+    /**
      * @var EntityManager
      */
     private $entityManager;
@@ -121,6 +126,10 @@ class PointSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->pointModel->triggerAction('email.send', $event->getEmail(), null, $lead, true);
+        if (!isset($this->triggered[$lead->getId()][$event->getEmail()->getId()])) {
+            $this->pointModel->triggerAction('email.send', $event->getEmail(), null, $lead, true);
+        }
+
+        $this->triggered[$lead->getId()][$event->getEmail()->getId()] = true;
     }
 }

--- a/app/bundles/EmailBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/PointSubscriber.php
@@ -33,14 +33,14 @@ class PointSubscriber implements EventSubscriberInterface
     private $pointModel;
 
     /**
-     * @var array
-     */
-    private $triggered = [];
-
-    /**
      * @var EntityManager
      */
     private $entityManager;
+
+    /**
+     * @var array
+     */
+    private $triggered = [];
 
     public function __construct(PointModel $pointModel, EntityManager $entityManager)
     {
@@ -126,10 +126,21 @@ class PointSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if (!isset($this->triggered[$lead->getId()][$event->getEmail()->getId()])) {
+        if ($this->shouldTriggerPointEmailSendAction($event, $lead)) {
             $this->pointModel->triggerAction('email.send', $event->getEmail(), null, $lead, true);
         }
+    }
 
-        $this->triggered[$lead->getId()][$event->getEmail()->getId()] = true;
+    private function shouldTriggerPointEmailSendAction(EmailSendEvent $event, Lead $lead)
+    {
+        if ($event->getEmail()) {
+            if (!isset($this->triggered[$lead->getId()][$event->getEmail()->getId()])) {
+                $this->triggered[$lead->getId()][$event->getEmail()->getId()] = true;
+
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/app/bundles/EmailBundle/Form/Type/EmailOpenType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailOpenType.php
@@ -26,7 +26,8 @@ class EmailOpenType extends AbstractType
                 'class'   => 'form-control',
                 'tooltip' => 'mautic.email.open.limittoemails_descr',
             ],
-            'required' => false,
+            'required'   => false,
+            'email_type' => null,
         ];
 
         if (isset($options['list_options'])) {

--- a/app/bundles/PointBundle/Model/PointModel.php
+++ b/app/bundles/PointBundle/Model/PointModel.php
@@ -196,14 +196,17 @@ class PointModel extends CommonFormModel
      * Triggers a specific point change.
      *
      * @param       $type
-     * @param mixed $eventDetails passthrough from function triggering action to the callback function
-     * @param mixed $typeId       Something unique to the triggering event to prevent  unnecessary duplicate calls
+     * @param mixed $eventDetails     passthrough from function triggering action to the callback function
+     * @param mixed $typeId           Something unique to the triggering event to prevent  unnecessary duplicate calls
      * @param Lead  $lead
+     * @param bool  $allowUserRequest
+     *
+     * @throws \ReflectionException
      */
-    public function triggerAction($type, $eventDetails = null, $typeId = null, Lead $lead = null)
+    public function triggerAction($type, $eventDetails = null, $typeId = null, Lead $lead = null, $allowUserRequest = false)
     {
-        //only trigger actions for anonymous users
-        if (!$this->security->isAnonymous()) {
+        //only trigger actions for not logged Mautic users
+        if (!$this->security->isAnonymous() && !$allowUserRequest) {
             return;
         }
 


### PR DESCRIPTION
closes https://github.com/mautic/mautic/issues/8603
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8603
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Noticed few issues with sent emails point actions
1,  Noticed segment broadcast emails cannot be list in select box https://github.com/mautic/mautic/issues/8603
2, Noticed segment broadcast emails not trigger points action during the send email by web
3, Noticed email sent point action with enable repeatable, trigger point action  two times


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a segment email, with a test segment and contact
2. Create an action point on email opening as in the screenshot below :
![image](https://user-images.githubusercontent.com/49391402/77765911-37d24880-703f-11ea-907f-3f9107854012.png)
3. See in the limit to these selected mails that you can't find the mail you create before or any manual email
![image](https://user-images.githubusercontent.com/49391402/77766007-5cc6bb80-703f-11ea-903a-c15bb1e971c9.png)

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps, see all emails in list
