### PR TITLE
Forgotten choices to fqcn

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/DashboardLeadsLifetimeWidgetType.php
+++ b/app/bundles/LeadBundle/Form/Type/DashboardLeadsLifetimeWidgetType.php
@@ -14,6 +14,7 @@ namespace Mautic\LeadBundle\Form\Type;
 use Mautic\LeadBundle\Model\ListModel;
 use Recurr\Transformer\TranslatorInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class DashboardLeadsLifetimeWidgetType extends AbstractType
@@ -43,7 +44,7 @@ class DashboardLeadsLifetimeWidgetType extends AbstractType
             $segments[$list['name']] = $list['id'];
         }
 
-        $builder->add('flag', 'choice', [
+        $builder->add('flag', ChoiceType::class, [
                 'label'             => 'mautic.lead.list.filter',
                 'multiple'          => true,
                 'choices'           => $segments,

--- a/app/bundles/LeadBundle/Form/Type/PreferenceChannelsType.php
+++ b/app/bundles/LeadBundle/Form/Type/PreferenceChannelsType.php
@@ -13,6 +13,7 @@ namespace Mautic\LeadBundle\Form\Type;
 
 use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -49,6 +50,6 @@ class PreferenceChannelsType extends AbstractType
 
     public function getParent()
     {
-        return 'choice';
+        return ChoiceType::class;
     }
 }

--- a/app/bundles/LeadBundle/Form/Type/PreferenceChannelsType.php
+++ b/app/bundles/LeadBundle/Form/Type/PreferenceChannelsType.php
@@ -36,7 +36,7 @@ class PreferenceChannelsType extends AbstractType
         $resolver->setDefaults(
             [
                 'choices'     => function (Options $options) use ($model) {
-                    return array_flip($model->getPreferenceChannels());
+                    return $model->getPreferenceChannels();
                 },
                 'placeholder' => '',
                 'attr'        => ['class' => 'form-control'],


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | /
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Open campaign builder
2. Create new action "Add Do Not Contact" -> error `Could not load type "choice": class does not exist.`
3. Same for action "Remove from Do Not Contact". Fix that one too.

#### Steps to test this PR:
1. Open campaign builder
2. Create new action "Add Do Not Contact" -> form loads properly
3. Same for action "Remove from Do Not Contact". Fix that one too.
