### PR TITLE
Field value campaign condition fix

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/6.forms.js
+++ b/app/bundles/CoreBundle/Assets/js/6.forms.js
@@ -676,7 +676,7 @@ Mautic.updateFieldOperatorValue = function(field, action, valueOnChange, valueOn
                     .attr('autocomplete', operatorFieldAttrs['autocomplete'])
                     .attr('value', operatorFieldAttrs['value'])
                     .attr('onchange', 'Mautic.updateLeadFieldValues(this)');
-                mQuery.each(response.operators, function(optionKey, optionVal) {
+                mQuery.each(response.operators, function(optionVal, optionKey) {
                     newOperatorField.append(Mautic.createOption(optionKey, optionVal));
                 });
                 newOperatorField.val(operatorField.val());

--- a/app/bundles/LeadBundle/Form/Type/LeadFieldsType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadFieldsType.php
@@ -32,8 +32,8 @@ class LeadFieldsType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'choices'           => function (Options $options) {
-                $fieldList = array_flip($this->fieldModel->getFieldList());
+            'choices' => function (Options $options) {
+                $fieldList = $this->flipSubarrays($this->fieldModel->getFieldList());
                 if ($options['with_tags']) {
                     $fieldList['Core']['mautic.lead.field.tags'] = 'tags';
                 }
@@ -50,11 +50,11 @@ class LeadFieldsType extends AbstractType
 
                 return $fieldList;
             },
-            'global_only'           => false,
-            'required'              => false,
-            'with_company_fields'   => false,
-            'with_tags'             => false,
-            'with_utm'              => false,
+            'global_only'         => false,
+            'required'            => false,
+            'with_company_fields' => false,
+            'with_tags'           => false,
+            'with_utm'            => false,
         ]);
     }
 
@@ -72,5 +72,15 @@ class LeadFieldsType extends AbstractType
     public function getBlockPrefix()
     {
         return 'leadfields_choices';
+    }
+
+    private function flipSubarrays(array $masterArrays): array
+    {
+        return array_map(
+            function (array $subArray) {
+                return array_flip($subArray);
+            },
+            $masterArrays
+        );
     }
 }

--- a/app/bundles/LeadBundle/Tests/Form/Type/LeadFieldsTypeTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Type/LeadFieldsTypeTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Form\Type;
+
+use Mautic\LeadBundle\Form\Type\LeadFieldsType;
+use Mautic\LeadBundle\Model\FieldModel;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class LeadFieldsTypeTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var MockObject|FieldModel
+     */
+    private $fieldModel;
+
+    /**
+     * @var LeadFieldsType
+     */
+    private $form;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fieldModel = $this->createMock(FieldModel::class);
+        $this->form       = new LeadFieldsType($this->fieldModel);
+    }
+
+    public function testTransform(): void
+    {
+        /** @var MockObject|OptionsResolver $optionsResolver */
+        $optionsResolver = $this->createMock(OptionsResolver::class);
+
+        $this->fieldModel->expects($this->exactly(2))
+            ->method('getFieldList')
+            ->willReturnOnConsecutiveCalls(
+                [
+                    'Core' => [
+                        'contact_field_1' => 'Contact field 1 label',
+                    ],
+                ],
+                [
+                    'company_field_1' => 'Company field 1 label',
+                ]
+            );
+
+        // All options are set to true with this.
+        $optionsResolver->method('offsetGet')
+            ->willReturn(true);
+
+        $optionsResolver->expects($this->once())
+            ->method('setDefaults')
+            ->with($this->callback(
+                function (array $defaults) use ($optionsResolver) {
+                    $choices = $defaults['choices']($optionsResolver);
+
+                    // Notice the labels and values are switched.
+                    $this->assertSame(
+                        [
+                            'Core' => [
+                              'Contact field 1 label'  => 'contact_field_1',
+                              'mautic.lead.field.tags' => 'tags',
+                            ],
+                            'Company' => [
+                              'Company field 1 label' => 'company_field_1',
+                            ],
+                            'UTM' => [
+                              'mautic.lead.field.utmcampaign' => 'utm_campaign',
+                              'mautic.lead.field.utmcontent'  => 'utm_content',
+                              'mautic.lead.field.utmmedium'   => 'utm_medium',
+                              'mautic.lead.field.umtsource'   => 'utm_source',
+                              'mautic.lead.field.utmterm'     => 'utm_term',
+                            ],
+                        ],
+                        $choices
+                    );
+
+                    return true;
+                }
+            ));
+
+        $this->form->configureOptions($optionsResolver);
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Field value campaign condition form does not load. This fixes that.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a new campaign
2. Open campaign builder
3. Select a source
4. Create new contact field value condition -> error

#### Steps to test this PR:
1. Create a new campaign
2. Open campaign builder
3. Select a source
4. Create new contact field value condition -> form loads and select boxes have correct option labels
5. Notice especially that the operators select is showing option labels correctly.
6. Select some field. It will refresh operators select.
7. Check 5 again.