### PR TITLE
M3: Remove mkdir permission limit to make umask work as expected

### DIFF
--- a/app/bundles/CoreBundle/Cache/MiddlewareCacheWarmer.php
+++ b/app/bundles/CoreBundle/Cache/MiddlewareCacheWarmer.php
@@ -68,7 +68,7 @@ class MiddlewareCacheWarmer implements CacheWarmerInterface
         }
 
         if (false === file_exists($cacheDirectory)) {
-            mkdir($cacheDirectory, 0755, true);
+            mkdir($cacheDirectory, 0777, true);
         }
 
         $data  = [];

--- a/app/bundles/CoreBundle/Command/ModeratedCommand.php
+++ b/app/bundles/CoreBundle/Command/ModeratedCommand.php
@@ -90,7 +90,7 @@ abstract class ModeratedCommand extends ContainerAwareCommand
         // Setup the run directory for lock/pid files
         $this->runDirectory = $this->getContainer()->getParameter('kernel.cache_dir').'/../run';
         if (!file_exists($this->runDirectory)) {
-            if (!mkdir($this->runDirectory, 0755)) {
+            if (!mkdir($this->runDirectory)) {
                 $output->writeln('<error>'.$this->runDirectory.' could not be created.</error>');
 
                 return false;

--- a/app/bundles/CoreBundle/Helper/PathsHelper.php
+++ b/app/bundles/CoreBundle/Helper/PathsHelper.php
@@ -121,7 +121,7 @@ class PathsHelper
             case 'temporary':
             case 'tmp':
                 if (!is_dir($this->temporaryDir) && !file_exists($this->temporaryDir) && is_writable($this->temporaryDir)) {
-                    mkdir($this->temporaryDir, 0755, true);
+                    mkdir($this->temporaryDir, 0777, true);
                 }
 
                 return $this->temporaryDir;
@@ -145,7 +145,7 @@ class PathsHelper
                 $userPath .= '/'.$this->user->getId();
 
                 if (!is_dir($userPath) && !file_exists($userPath) && is_writable($userPath)) {
-                    mkdir($userPath, 0755);
+                    mkdir($userPath);
                 }
 
                 return $userPath;

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -286,7 +286,7 @@ class ImportController extends FormController
                                 $errorParameters = [];
                                 try {
                                     // Create the import dir recursively
-                                    $fs->mkdir($importDir, 0755);
+                                    $fs->mkdir($importDir);
 
                                     $fileData->move($importDir, $fileName);
 

--- a/upgrade.php
+++ b/upgrade.php
@@ -588,7 +588,7 @@ function copy_directory($src, $dest)
 
     // Make sure the destination exists
     if (!is_dir($dest)) {
-        if (!@mkdir($dest, 0755, true)) {
+        if (!@mkdir($dest, 0777, true)) {
             return sprintf(
                 'Could not move files from %s to production since the folder could not be created.',
                 str_replace(MAUTIC_UPGRADE_ROOT, '', $src)


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  y
| New feature? | 
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:

By default mkdir uses 777 permissions to create directories and then uses the system permission mask (umask) to limit the permission actually used. We should use this default mechanism 
and depend on umask to limit the permissions if needed instead of forcing our own permissions in Mautic code.

If we limit the permissions in php we prevent umask from working correctly which means
apache/OS cannot set different permissions if needed.

Testing this PR is difficult because the effects depend on system setup (umask). In most configurations this change will have very little affect (for example changing new directory permissions from 755 to 775).

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
Even if you run apache/php-fpm with modified umask (0000 for example) mautic doesn't honour it and creates new files/directories with 755 permissions

1. Clear mautic cache (`rm -r var/cache/*`)
2. Open a terminal and set your umask to 0000 by running `umask 0000` (which should set all new files to 666 permissions and directories to 777 permissions)
3. Run segment update command (`php bin/console mautic:segments:update`)
4. check the run directory permissions (`ls -l var/cache/run`) and see that it has 755 permissions instead of 777 permissions.

#### Steps to test this PR:
The only way to test this PR is to run a mautic installation with modified UMASK setting. When you do that you can see Mautic now honours the new settings.

1. Clear mautic cache (`rm -r var/cache/*`)
2. Open a terminal and set your umask to 0000 by running `umask 0000` (which should set all new files to 666 permissions and directories to 777 permissions)
3. Run segment update command (`php bin/console mautic:segments:update`)
4. check the run directory permissions (`ls -l var/cache/run`) and see that it now has 777 permissions as expected with umask set to 0000
