### PR TITLE
Fix failing ThemeHelper test

### DIFF
--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -587,7 +587,7 @@ class ThemeHelper
         $themes = $this->getInstalledThemes('all', true);
         foreach ($themes as $theme) {
             // Already handled the default
-            if ($theme['name'] === $defaultTheme->getTheme()) {
+            if ($theme['key'] === $defaultTheme->getTheme()) {
                 continue;
             }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | y
| New feature? | n
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Fixes the condition to compare theme keys on both sides. Theme key
usually differs from theme name (the first letter case is
different - at least on a case sensitive FS). Fortunatelly this bug
only affected tests which depend on order of processing (mocks
are using expects and willReturn).

To test make sure tests are passing.

The reason for this bug being there for so long is that the order in which getInstalledThemes returns the themes is not defined and the bug appears only if the defaultTheme happens to be the first in the list.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Make sure the tests are passing
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
