### PR TITLE
Gravatar path fix

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -372,7 +372,6 @@ return [
             'mautic.helper.template.gravatar' => [
                 'class'     => \Mautic\CoreBundle\Templating\Helper\GravatarHelper::class,
                 'arguments' => [
-                    'mautic.helper.paths',
                     'mautic.helper.template.default_avatar',
                     'mautic.helper.core_parameters',
                     'request_stack',

--- a/app/bundles/CoreBundle/Templating/Helper/GravatarHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/GravatarHelper.php
@@ -41,13 +41,11 @@ class GravatarHelper extends Helper
     private $requestStack;
 
     public function __construct(
-        PathsHelper $pathsHelper,
         DefaultAvatarHelper $defaultAvatarHelper,
         CoreParametersHelper $coreParametersHelper,
         RequestStack $requestStack
     ) {
         $this->devMode             = MAUTIC_ENV === 'dev';
-        $pathsHelper->getSystemPath('images');
         $this->defaultAvatarHelper = $defaultAvatarHelper;
         $this->requestStack        = $requestStack;
         $this->devHosts            = (array) $coreParametersHelper->get('dev_hosts');

--- a/app/bundles/CoreBundle/Templating/Helper/GravatarHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/GravatarHelper.php
@@ -72,7 +72,7 @@ class GravatarHelper extends Helper
             ?
             'https://www.mautic.org/media/images/default_avatar.png'
             :
-            $this->defaultAvatarHelper->getDefaultAvatar(false);
+            $this->defaultAvatarHelper->getDefaultAvatar();
 
         $url = 'https://www.gravatar.com/avatar/'.md5(strtolower(trim($email))).'?s='.$size;
 

--- a/app/bundles/CoreBundle/Templating/Helper/GravatarHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/GravatarHelper.php
@@ -68,7 +68,7 @@ class GravatarHelper extends Helper
                     array_merge($this->devHosts, ['127.0.0.1', 'fe80::1', '::1'])
                 )))
             ?
-            'https://www.mautic.org/media/images/default_avatar.png'
+            'https://www.gravatar.com/avatar?d=mp'
             :
             $this->defaultAvatarHelper->getDefaultAvatar();
 

--- a/app/bundles/CoreBundle/Templating/Helper/GravatarHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/GravatarHelper.php
@@ -68,9 +68,9 @@ class GravatarHelper extends Helper
                     array_merge($this->devHosts, ['127.0.0.1', 'fe80::1', '::1'])
                 )))
             ?
-            'https://www.gravatar.com/avatar?d=mp'
+            'mp'
             :
-            $this->defaultAvatarHelper->getDefaultAvatar();
+            $this->defaultAvatarHelper->getDefaultAvatar(true);
 
         $url = 'https://www.gravatar.com/avatar/'.md5(strtolower(trim($email))).'?s='.$size;
 

--- a/app/bundles/CoreBundle/Templating/Helper/GravatarHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/GravatarHelper.php
@@ -72,7 +72,7 @@ class GravatarHelper extends Helper
             ?
             'https://www.mautic.org/media/images/default_avatar.png'
             :
-            $this->defaultAvatarHelper->getDefaultAvatar(true);
+            $this->defaultAvatarHelper->getDefaultAvatar(false);
 
         $url = 'https://www.gravatar.com/avatar/'.md5(strtolower(trim($email))).'?s='.$size;
 

--- a/app/bundles/LeadBundle/Templating/Helper/AvatarHelper.php
+++ b/app/bundles/LeadBundle/Templating/Helper/AvatarHelper.php
@@ -138,7 +138,7 @@ class AvatarHelper extends Helper
      */
     public function getDefaultAvatar(bool $absolute = false): string
     {
-        return $this->defaultAvatarHelper->getDefaultAvatar();
+        return $this->defaultAvatarHelper->getDefaultAvatar($absolute);
     }
 
     /**

--- a/app/bundles/LeadBundle/Templating/Helper/AvatarHelper.php
+++ b/app/bundles/LeadBundle/Templating/Helper/AvatarHelper.php
@@ -132,9 +132,9 @@ class AvatarHelper extends Helper
     }
 
     /**
-     * @param bool|false $absolute
-     *
      * @deprecated Use DefaultAvatarHelper::getDefaultAvatar instead of it
+     *
+     * @param bool|false $absolute
      */
     public function getDefaultAvatar(bool $absolute = false): string
     {

--- a/app/bundles/LeadBundle/Templating/Helper/AvatarHelper.php
+++ b/app/bundles/LeadBundle/Templating/Helper/AvatarHelper.php
@@ -132,13 +132,13 @@ class AvatarHelper extends Helper
     }
 
     /**
-     * @deprecated Use DefaultAvatarHelper::getDefaultAvatar instead of it
-     *
      * @param bool|false $absolute
+     *
+     * @deprecated Use DefaultAvatarHelper::getDefaultAvatar instead of it
      */
     public function getDefaultAvatar(bool $absolute = false): string
     {
-        return $this->defaultAvatarHelper->getDefaultAvatar($absolute);
+        return $this->defaultAvatarHelper->getDefaultAvatar();
     }
 
     /**

--- a/app/bundles/LeadBundle/Templating/Helper/DefaultAvatarHelper.php
+++ b/app/bundles/LeadBundle/Templating/Helper/DefaultAvatarHelper.php
@@ -3,7 +3,6 @@
 namespace Mautic\LeadBundle\Templating\Helper;
 
 use Mautic\CoreBundle\Helper\PathsHelper;
-use Mautic\CoreBundle\Helper\UrlHelper;
 use Mautic\CoreBundle\Templating\Helper\AssetsHelper;
 
 class DefaultAvatarHelper

--- a/app/bundles/LeadBundle/Templating/Helper/DefaultAvatarHelper.php
+++ b/app/bundles/LeadBundle/Templating/Helper/DefaultAvatarHelper.php
@@ -26,7 +26,7 @@ class DefaultAvatarHelper
         $this->assetsHelper = $assetsHelper;
     }
 
-    public function getDefaultAvatar($absolute = false): string
+    public function getDefaultAvatar(bool $absolute = false): string
     {
         $img = $this->pathsHelper->getSystemPath('assets').'/images/avatar.png';
 

--- a/app/bundles/LeadBundle/Templating/Helper/DefaultAvatarHelper.php
+++ b/app/bundles/LeadBundle/Templating/Helper/DefaultAvatarHelper.php
@@ -26,9 +26,13 @@ class DefaultAvatarHelper
         $this->assetsHelper = $assetsHelper;
     }
 
-    public function getDefaultAvatar(): string
+    public function getDefaultAvatar($absolute = false): string
     {
-        $img = $this->pathsHelper->getSystemPath('assets', false).'/images/avatar.png';
+        $img = $this->pathsHelper->getSystemPath('assets', $absolute).'/images/avatar.png';
+
+        if ($absolute) {
+            return $img;
+        }
 
         return UrlHelper::rel2abs($this->assetsHelper->getUrl($img));
     }

--- a/app/bundles/LeadBundle/Templating/Helper/DefaultAvatarHelper.php
+++ b/app/bundles/LeadBundle/Templating/Helper/DefaultAvatarHelper.php
@@ -28,12 +28,8 @@ class DefaultAvatarHelper
 
     public function getDefaultAvatar($absolute = false): string
     {
-        $img = $this->pathsHelper->getSystemPath('assets', $absolute).'/images/avatar.png';
+        $img = $this->pathsHelper->getSystemPath('assets').'/images/avatar.png';
 
-        if ($absolute) {
-            return $img;
-        }
-
-        return UrlHelper::rel2abs($this->assetsHelper->getUrl($img));
+        return $this->assetsHelper->getUrl($img, null, null, $absolute);
     }
 }

--- a/app/bundles/LeadBundle/Templating/Helper/DefaultAvatarHelper.php
+++ b/app/bundles/LeadBundle/Templating/Helper/DefaultAvatarHelper.php
@@ -26,12 +26,9 @@ class DefaultAvatarHelper
         $this->assetsHelper = $assetsHelper;
     }
 
-    /**
-     * @param bool|false $absolute
-     */
-    public function getDefaultAvatar(bool $absolute = false): string
+    public function getDefaultAvatar(): string
     {
-        $img = $this->pathsHelper->getSystemPath('assets', $absolute).'/images/avatar.png';
+        $img = $this->pathsHelper->getSystemPath('assets', false).'/images/avatar.png';
 
         return UrlHelper::rel2abs($this->assetsHelper->getUrl($img));
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Wrong path to default gravatar.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. You need to bypass the localhost condition. Modify CoreBundle/Templating/Helper/GravatarHelper line 76 to look like:
'''
        $localDefault = ($this->devMode
            || ($request
                && in_array(
                    $request->getClientIp(),
                    array_merge($this->devHosts, ['127.0.0.1', 'fe80::1', '::1'])
                )))
            ?
            'https://www.mautic.org/media/images/default_avatar.png'
            :
            $this->defaultAvatarHelper->getDefaultAvatar(true);
        $localDefault = $this->defaultAvatarHelper->getDefaultAvatar(true);
        $url = 'https://www.gravatar.com/avatar/'.md5(strtolower(trim($email))).'?s='.$size;
'''
2. In Xdebug inspect that the url is wrong - there is an absolute path.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. The Gravatar should return the default image for contacts that have gravatar selected in Mautic but do not have gravatar image.

Test locally:
1. You need to bypass the localhost condition. Modify CoreBundle/Templating/Helper/GravatarHelper line 76 to look like:
'''
        $localDefault = ($this->devMode
            || ($request
                && in_array(
                    $request->getClientIp(),
                    array_merge($this->devHosts, ['127.0.0.1', 'fe80::1', '::1'])
                )))
            ?
            'https://www.mautic.org/media/images/default_avatar.png'
            :
            $this->defaultAvatarHelper->getDefaultAvatar(false);
        $localDefault = $this->defaultAvatarHelper->getDefaultAvatar(false);
        $url = 'https://www.gravatar.com/avatar/'.md5(strtolower(trim($email))).'?s='.$size;
'''
2. In Xdebug inspect that the url is right

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
