### PR TITLE
Fix conversion exception

### DIFF
--- a/app/migrations/Version20200402100233.php
+++ b/app/migrations/Version20200402100233.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   <year> Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        https://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\SkipMigration;
+use Doctrine\ORM\QueryBuilder;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+final class Version20200402100233 extends AbstractMauticMigration
+{
+    public function getDescription(): string
+    {
+        return 'This migration fixes "Serialized array includes null-byte" error when merging some contacts.';
+    }
+
+    public function preUp(Schema $schema): void
+    {
+        $this->getIpDetailsWithNullByteSymbols();
+        throw new \Exception();
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Please modify to your needs
+    }
+
+    /**
+     * Get hourly average based on last 30 days of sending.
+     *
+     * @return float|int
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function getIpDetailsWithNullByteSymbols()
+    {
+        /** @var QueryBuilder $queryBuilder */
+        $queryBuilder = $this->container->get('doctrine')->getManager()->createQueryBuilder();
+        $queryBuilder
+            ->from('MauticCoreBundle:IpAddress', 'ia')
+            ->where($queryBuilder->expr()->like('ip_details'));
+    }
+}

--- a/app/migrations/Version20200402100233.php
+++ b/app/migrations/Version20200402100233.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * @copyright   <year> Mautic Contributors. All rights reserved.
+ * @copyright   2020 Mautic Contributors. All rights reserved.
  * @author      Mautic
  * @link        https://mautic.org
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html

--- a/app/migrations/Version20200402100233.php
+++ b/app/migrations/Version20200402100233.php
@@ -86,8 +86,6 @@ final class Version20200402100233 extends AbstractMauticMigration
             ->orWhere($queryBuilder->expr()->like('ia.ipDetails', ':search2'))
             ->setParameter('search2', '%;O:%');
 
-        $query = $queryBuilder->getQuery();
-
         return $queryBuilder->getQuery()->iterate();
     }
 }

--- a/app/migrations/Version20200402100233.php
+++ b/app/migrations/Version20200402100233.php
@@ -49,7 +49,8 @@ final class Version20200402100233 extends AbstractMauticMigration
 
             $entityHasToBeSaved = false;
             foreach ($ipDetails as $key => $record) {
-                // Objects cannot be saved because they contain null byte symbols.
+                // Objects cannot be saved because they contain null byte symbols
+                // if we try to serialize them
                 if (is_object($record)) {
                     unset($ipDetails[$key]);
                     $entityHasToBeSaved = true;

--- a/app/migrations/Version20200402100233.php
+++ b/app/migrations/Version20200402100233.php
@@ -24,7 +24,7 @@ final class Version20200402100233 extends AbstractMauticMigration
 
     public function getDescription(): string
     {
-        return 'This migration fixes "Serialized array includes null-byte" error when merging some contacts.';
+        return 'This migration fixes "Serialized array includes null-byte" exception when merging some contacts.';
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20200402100233.php
+++ b/app/migrations/Version20200402100233.php
@@ -49,7 +49,7 @@ final class Version20200402100233 extends AbstractMauticMigration
 
             $entityHasToBeSaved = false;
             foreach ($ipDetails as $key => $record) {
-                // Objects cannot be saved because they contain null byte symbols
+                // Objects cannot be saved because they will contain null byte symbols
                 // if we try to serialize them
                 if (is_object($record)) {
                     unset($ipDetails[$key]);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Mautic throws an exception because some of the records in the database contain null byte characters.
This PR fixes it by removing these null bytes. We don't need them because they are used in serialized objects. These serialized objects should not be stored in the ip_addresses table, so we can delete them and this should fix the errors.


[//]: # ( As applicable: )

#### Steps to reproduce the bug:
##### Notice: add DB prefix to the table names below if you use table prefix in your Mautic installation.


1. Create 2 contacts (Contact #1 and Contact #2).
2. Run the following SQL query
```sql
INSERT INTO
	ip_addresses (ip_address, ip_details)
VALUES
('100.100.100.100','a:11:{s:4:\"city\";N;s:6:\"region\";s:0:\"\";s:7:\"zipcode\";N;s:7:\"country\";s:14:\"United Kingdom\";s:8:\"latitude\";d:51.5;s:9:\"longitude\";d:-0.13;s:3:\"isp\";s:0:\"\";s:12:\"organization\";s:0:\"\";s:8:\"timezone\";s:13:\"Europe/London\";s:5:\"extra\";s:0:\"\";s:9:\"connector\";O:16:\"Joomla\\Http\\Http\":2:{s:10:\"\0*\0options\";a:0:{}s:12:\"\0*\0transport\";O:26:\"Joomla\\Http\\Transport\\Curl\":1:{s:10:\"\0*\0options\";a:0:{}}}}');
```
3. Associate the second contact (Contact #2) with the IP address that you've just created. To do so go to the `lead_ips_xref` table and add a record there.
You need to insert ID of the second contact and ID of the IP address you created in the previous step.
4. Go to the details page of the first contact (Contact #1). Select "Merge" in the upper right corner of the screen, merge the first contact with the second contact (Contact #2).
5. You will see an exception in the popup.

#### Steps to test this PR:
1. After you followed `Steps to reproduce`, apply a database migration from this PR.
```bash
php bin/console doctrine:migrations:execute 20200402100233
```
2. Refresh the page and try to merge the contacts now. You should be able to successfully merge them.
