### PR TITLE
Maut 2460 auto generate plain text

### DIFF
--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -14,6 +14,7 @@ namespace Mautic\EmailBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Helper\MailHelper;
+use Mautic\EmailBundle\Helper\PlainTextHelper;
 use Mautic\LeadBundle\Entity\Lead;
 
 /**
@@ -201,6 +202,9 @@ class EmailSendEvent extends CommonEvent
         } else {
             $this->content = $content;
         }
+        if ($content !== '') {
+            $this->setGeneratedPlainText();
+        }
     }
 
     /**
@@ -226,6 +230,24 @@ class EmailSendEvent extends CommonEvent
             $this->helper->setPlainText($content);
         } else {
             $this->plainText = $content;
+        }
+        if ($content === '') {
+            $this->setGeneratedPlainText();
+        }
+    }
+
+    /**
+     *
+     */
+    private function setGeneratedPlainText()
+    {
+        $htmlContent = $this->getContent();
+        if ($this->getPlainText() === '' && $htmlContent !== ''){
+            $parser = new PlainTextHelper();
+            $generatedPlainText = $parser->setHtml($htmlContent)->getText();
+            if($generatedPlainText !== ''){
+                $this->setPlainText($generatedPlainText);
+            }
         }
     }
 

--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -237,15 +237,15 @@ class EmailSendEvent extends CommonEvent
     }
 
     /**
-     *
+     * Check if plain text is empty. If yes, generate it.
      */
     private function setGeneratedPlainText()
     {
         $htmlContent = $this->getContent();
-        if ($this->getPlainText() === '' && $htmlContent !== ''){
-            $parser = new PlainTextHelper();
+        if ($this->getPlainText() === '' && $htmlContent !== '') {
+            $parser             = new PlainTextHelper();
             $generatedPlainText = $parser->setHtml($htmlContent)->getText();
-            if($generatedPlainText !== ''){
+            if ($generatedPlainText !== '') {
                 $this->setPlainText($generatedPlainText);
             }
         }

--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -202,9 +202,8 @@ class EmailSendEvent extends CommonEvent
         } else {
             $this->content = $content;
         }
-        if ($content !== '') {
-            $this->setGeneratedPlainText();
-        }
+        $this->setGeneratedPlainText();
+
     }
 
     /**
@@ -231,9 +230,8 @@ class EmailSendEvent extends CommonEvent
         } else {
             $this->plainText = $content;
         }
-        if ($content === '') {
-            $this->setGeneratedPlainText();
-        }
+        $this->setGeneratedPlainText();
+
     }
 
     /**

--- a/app/bundles/EmailBundle/Tests/Event/EmailSendEventTest.php
+++ b/app/bundles/EmailBundle/Tests/Event/EmailSendEventTest.php
@@ -1,0 +1,61 @@
+<?php
+
+
+namespace Mautic\EmailBundle\Tests\Event;
+
+
+use Mautic\EmailBundle\Event\EmailSendEvent;
+
+class EmailSendEventTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EmailSendEvent
+     */
+    private $emailSendEvent;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->emailSendEvent = new EmailSendEvent();
+    }
+
+    /**
+     * Firstly set HTML content, then set empty plain content. Plain text should be generated.
+     */
+    public function testSetPlainTextWhenNeedGeneratedPlainText()
+    {
+        $this->emailSendEvent->setContent('<h1>HTML content</h1>');
+        $this->emailSendEvent->setPlainText('');
+        $this->assertSame('HTML CONTENT', $this->emailSendEvent->getPlainText());
+    }
+
+    /**
+     * Firstly set HTML content, then set plain content. Plain text should not be generated.
+     */
+    public function testSetPlainTextWhenNotNeedGeneratedPlainText()
+    {
+        $this->emailSendEvent->setContent('<h1>HTML content</h1>');
+        $this->emailSendEvent->setPlainText('plain content');
+        $this->assertSame('plain content', $this->emailSendEvent->getPlainText());
+    }
+
+    /**
+     * Firstly set empty plain content, then set HTML content. Plain text should be generated.
+     */
+    public function testSetContentWhenNeedGeneratedPlainText()
+    {
+        $this->emailSendEvent->setPlainText('');
+        $this->emailSendEvent->setContent('<h1>HTML content</h1>');
+        $this->assertSame('HTML CONTENT', $this->emailSendEvent->getPlainText());
+    }
+
+    /**
+     * Firstly set plain content, then set HTML content. Plain text should not be generated.
+     */
+    public function testSetContentWhenNotNeedGeneratedPlainText()
+    {
+        $this->emailSendEvent->setPlainText('plain content');
+        $this->emailSendEvent->setContent('<h1>HTML content</h1>');
+        $this->assertSame('plain content', $this->emailSendEvent->getPlainText());
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Event/EmailSendEventTest.php
+++ b/app/bundles/EmailBundle/Tests/Event/EmailSendEventTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Mautic\EmailBundle\Tests\Event;
-
 
 use Mautic\EmailBundle\Event\EmailSendEvent;
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Yes
| Automated tests included? | Yes
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If the plain text is empty, generate it automatically.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Go to /s/emails
3. Create a new email and leave the plain text empty
4. Send example
5. The mail should have the plain text alternative (you can see in mailhog)

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
