### PR TITLE
Allow HTML for Webhook campaign action

### DIFF
--- a/app/bundles/WebhookBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/WebhookBundle/EventListener/CampaignSubscriber.php
@@ -63,10 +63,11 @@ class CampaignSubscriber implements EventSubscriberInterface
     public function onCampaignBuild(Events\CampaignBuilderEvent $event)
     {
         $sendWebhookAction = [
-            'label'       => 'mautic.webhook.event.sendwebhook',
-            'description' => 'mautic.webhook.event.sendwebhook_desc',
-            'formType'    => CampaignEventSendWebhookType::class,
-            'eventName'   => WebhookEvents::ON_CAMPAIGN_TRIGGER_ACTION,
+            'label'              => 'mautic.webhook.event.sendwebhook',
+            'description'        => 'mautic.webhook.event.sendwebhook_desc',
+            'formType'           => CampaignEventSendWebhookType::class,
+            'formTypeCleanMasks' => 'clean',
+            'eventName'          => WebhookEvents::ON_CAMPAIGN_TRIGGER_ACTION,
         ];
         $event->addAction('campaign.sendwebhook', $sendWebhookAction);
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Noticed we cannot use HTML for Send a webhook campaign action. 
Sometimes we need send data with HTML formatting.
This PR allow it.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Create campaign with send a webhook action
2.  Try set to additional data label + value with html
3. Save and open and see HTML code was remove

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2.  Repeat all steps to reproduce
3.  Noticed HTML  allowed in values

![image](https://user-images.githubusercontent.com/462477/52902991-c8bdda00-3218-11e9-8ea3-76e2c95a8360.png)

