### PR TITLE
M3 contact sync triger for company change

### DIFF
--- a/app/bundles/IntegrationsBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/LeadSubscriber.php
@@ -156,6 +156,19 @@ class LeadSubscriber implements EventSubscriberInterface
         $this->fieldChangeRepo->deleteEntitiesForObject((int) $event->getCompany()->deletedId, Company::class);
     }
 
+    public function onLeadCompanyChange(Events\LeadChangeCompanyEvent $event): void
+    {
+        $lead = $event->getLead();
+
+        // This mechanism is not able to record multiple company changes.
+        $changes['company'] = [
+            0 => '',
+            1 => $lead->getCompany(),
+        ];
+
+        $this->recordFieldChanges($changes, $lead->getId(), Lead::class);
+    }
+
     /**
      * @param int $objectId
      *

--- a/app/bundles/IntegrationsBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/LeadSubscriber.php
@@ -61,6 +61,7 @@ class LeadSubscriber implements EventSubscriberInterface
             LeadEvents::LEAD_POST_DELETE    => ['onLeadPostDelete', 255],
             LeadEvents::COMPANY_POST_SAVE   => ['onCompanyPostSave', 0],
             LeadEvents::COMPANY_POST_DELETE => ['onCompanyPostDelete', 255],
+            LeadEvents::LEAD_COMPANY_CHANGE => ['onLeadCompanyChange', 128],
         ];
     }
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
@@ -104,6 +104,27 @@ class LeadSubscriberTest extends TestCase
         $this->subscriber->onLeadPostSave($event);
     }
 
+    public function testOnLeadCompanyChange(): void
+    {
+        $leadId      = 3;
+        $companyName = 'Dell';
+
+        $lead = $this->createMock(Lead::class);
+        $lead->expects($this->at(0))
+            ->method('getCompany')
+            ->willReturn($companyName);
+        $lead->expects($this->at(0))
+            ->method('getId')
+            ->willReturn($leadId);
+
+        $event = $this->createMock(LeadEvent::class);
+        $event->expects($this->once())
+            ->method('getLead')
+            ->willReturn($lead);
+
+        $this->subscriber->onLeadPostSave($event);
+    }
+
     public function testOnLeadPostSaveNoAction(): void
     {
         $fieldChanges = [];

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
@@ -56,6 +56,7 @@ class LeadSubscriberTest extends TestCase
                 LeadEvents::LEAD_POST_DELETE    => ['onLeadPostDelete', 255],
                 LeadEvents::COMPANY_POST_SAVE   => ['onCompanyPostSave', 0],
                 LeadEvents::COMPANY_POST_DELETE => ['onCompanyPostDelete', 255],
+                LeadEvents::LEAD_COMPANY_CHANGE => ['onLeadCompanyChange', 128],
             ],
             LeadSubscriber::getSubscribedEvents()
         );

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -292,7 +292,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
      */
     public function addLeadToCompany($companies, $lead)
     {
-        // Primary company name to be peristed to the lead's contact company field
+        // Primary company name to be persisted to the lead's contact company field
         $companyName        = '';
         $companyLeadAdd     = [];
         $searchForCompanies = [];


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Company not updated when changed in Mautic via plugin sync in target service.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Use plugin and service with ability to sync contact to company relationship (This is not used in community I think)
2. Run sync
3. Company for contact is not updated via service API

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Run reproduction steps
3. Subscribed listener action `\Mautic\IntegrationsBundle\EventListener\LeadSubscriber::onLeadCompanyChange` is triggered
