### PR TITLE
add automatically plain text version to email if not set

### DIFF
--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -14,6 +14,7 @@ namespace Mautic\EmailBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Helper\MailHelper;
+use Mautic\EmailBundle\Helper\PlainTextHelper;
 use Mautic\LeadBundle\Entity\Lead;
 
 /**
@@ -200,6 +201,7 @@ class EmailSendEvent extends CommonEvent
         } else {
             $this->content = $content;
         }
+        $this->setGeneratedPlainText();
     }
 
     /**
@@ -225,6 +227,22 @@ class EmailSendEvent extends CommonEvent
             $this->helper->setPlainText($content);
         } else {
             $this->plainText = $content;
+        }
+        $this->setGeneratedPlainText();
+    }
+
+    /**
+     * Check if plain text is empty. If yes, generate it.
+     */
+    private function setGeneratedPlainText()
+    {
+        $htmlContent = $this->getContent();
+        if ('' === $this->getPlainText() && '' !== $htmlContent) {
+            $parser             = new PlainTextHelper();
+            $generatedPlainText = $parser->setHtml($htmlContent)->getText();
+            if ('' !== $generatedPlainText) {
+                $this->setPlainText($generatedPlainText);
+            }
         }
     }
 

--- a/app/bundles/EmailBundle/Tests/Event/EmailSendEventTest.php
+++ b/app/bundles/EmailBundle/Tests/Event/EmailSendEventTest.php
@@ -4,7 +4,7 @@ namespace Mautic\EmailBundle\Tests\Event;
 
 use Mautic\EmailBundle\Event\EmailSendEvent;
 
-class EmailSendEventTest extends \PHPUnit_Framework_TestCase
+class EmailSendEventTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var EmailSendEvent

--- a/app/bundles/EmailBundle/Tests/Event/EmailSendEventTest.php
+++ b/app/bundles/EmailBundle/Tests/Event/EmailSendEventTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Mautic\EmailBundle\Tests\Event;
+
+use Mautic\EmailBundle\Event\EmailSendEvent;
+
+class EmailSendEventTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EmailSendEvent
+     */
+    private $emailSendEvent;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->emailSendEvent = new EmailSendEvent();
+    }
+
+    /**
+     * Firstly set HTML content, then set empty plain content. Plain text should be generated.
+     */
+    public function testSetPlainTextWhenNeedGeneratedPlainText()
+    {
+        $this->emailSendEvent->setContent('<h1>HTML content</h1>');
+        $this->emailSendEvent->setPlainText('');
+        $this->assertSame('HTML CONTENT', $this->emailSendEvent->getPlainText());
+    }
+
+    /**
+     * Firstly set HTML content, then set plain content. Plain text should not be generated.
+     */
+    public function testSetPlainTextWhenNotNeedGeneratedPlainText()
+    {
+        $this->emailSendEvent->setContent('<h1>HTML content</h1>');
+        $this->emailSendEvent->setPlainText('plain content');
+        $this->assertSame('plain content', $this->emailSendEvent->getPlainText());
+    }
+
+    /**
+     * Firstly set empty plain content, then set HTML content. Plain text should be generated.
+     */
+    public function testSetContentWhenNeedGeneratedPlainText()
+    {
+        $this->emailSendEvent->setPlainText('');
+        $this->emailSendEvent->setContent('<h1>HTML content</h1>');
+        $this->assertSame('HTML CONTENT', $this->emailSendEvent->getPlainText());
+    }
+
+    /**
+     * Firstly set plain content, then set HTML content. Plain text should not be generated.
+     */
+    public function testSetContentWhenNotNeedGeneratedPlainText()
+    {
+        $this->emailSendEvent->setPlainText('plain content');
+        $this->emailSendEvent->setContent('<h1>HTML content</h1>');
+        $this->assertSame('plain content', $this->emailSendEvent->getPlainText());
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Yes
| Automated tests included? | Yes
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If the plain text is empty, generate it automatically.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Go to /s/emails
3. Create a new email and leave the plain text empty
4. Send example
5. The mail should have the plain text alternative (you can see in mailhog)

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
