### PR TITLE
Maut 3476 optionlist fix

### DIFF
--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -1115,14 +1115,7 @@ class FormModel extends CommonFormModel
         }
 
         if (!empty($list)) {
-            switch ($contactField->getType()) {
-                case 'multiselect':
-                    $formFieldProps['optionlist'] = ['list' => $list];
-                    unset($formFieldProps['list']); // Just because of previous bug MAUT-3476
-                    break;
-                default:
-                    $formFieldProps['list'] = ['list' => $list];
-            }
+            $formFieldProps['list'] = ['list' => $list];
             $formField->setProperties($formFieldProps);
         }
     }

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -1115,7 +1115,14 @@ class FormModel extends CommonFormModel
         }
 
         if (!empty($list)) {
-            $formFieldProps['list'] = ['list' => $list];
+            switch ($contactField->getType()) {
+                case 'multiselect':
+                    $formFieldProps['optionlist'] = ['list' => $list];
+                    unset($formFieldProps['list']); // Just because of previous bug MAUT-3476
+                    break;
+                default:
+                    $formFieldProps['list'] = ['list' => $list];
+            }
             $formField->setProperties($formFieldProps);
         }
     }

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -1116,6 +1116,9 @@ class FormModel extends CommonFormModel
 
         if (!empty($list)) {
             $formFieldProps['list'] = ['list' => $list];
+            if (array_key_exists('optionlist', $formFieldProps)) {
+                $formFieldProps['optionlist'] = ['list' => $list];
+            }
             $formField->setProperties($formFieldProps);
         }
     }

--- a/app/bundles/FormBundle/Views/Field/field_helper.php
+++ b/app/bundles/FormBundle/Views/Field/field_helper.php
@@ -158,11 +158,9 @@ if (isset($list) || isset($properties['syncList']) || isset($properties['list'])
     if (empty($parseList)) {
         if (isset($list)) {
             $parseList = $list;
-        }
-        elseif (!empty($properties['optionlist'])) {
+        } elseif (!empty($properties['optionlist'])) {
             $parseList = $properties['optionlist'];
-        }
-        elseif (!empty($properties['list'])) {
+        } elseif (!empty($properties['list'])) {
             $parseList = $properties['list'];
         }
 

--- a/app/bundles/FormBundle/Views/Field/field_helper.php
+++ b/app/bundles/FormBundle/Views/Field/field_helper.php
@@ -156,11 +156,12 @@ if (isset($list) || isset($properties['syncList']) || isset($properties['list'])
     }
 
     if (empty($parseList)) {
+        $leadFieldType = $formFields[$field['leadField']]['type'];
         if (isset($list)) {
             $parseList = $list;
-        } elseif (!empty($properties['list'])) {
+        } elseif (!empty($properties['list']) && 'multiselect' !== $leadFieldType) {
             $parseList = $properties['list'];
-        } elseif (!empty($properties['optionlist'])) {
+        } elseif (!empty($properties['optionlist']) && 'multiselect' === $leadFieldType) {
             $parseList = $properties['optionlist'];
         }
 

--- a/app/bundles/FormBundle/Views/Field/field_helper.php
+++ b/app/bundles/FormBundle/Views/Field/field_helper.php
@@ -156,13 +156,14 @@ if (isset($list) || isset($properties['syncList']) || isset($properties['list'])
     }
 
     if (empty($parseList)) {
-        $leadFieldType = $formFields[$field['leadField']]['type'];
         if (isset($list)) {
             $parseList = $list;
-        } elseif (!empty($properties['list']) && 'multiselect' !== $leadFieldType) {
-            $parseList = $properties['list'];
-        } elseif (!empty($properties['optionlist']) && 'multiselect' === $leadFieldType) {
+        }
+        elseif (!empty($properties['optionlist'])) {
             $parseList = $properties['optionlist'];
+        }
+        elseif (!empty($properties['list'])) {
+            $parseList = $properties['list'];
         }
 
         if (isset($parseList['list'])) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Optionlist does not work

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Create a select-multiple custom field with options
2. Create a form field that maps to the new custom field, set Use Assigned Contact Field Values to No & add fields
3. Switch 'Use assigned...' to Yes.
4. Save and close
5. And then change 'Use assigned...' to No.
6. You still see assigned values

#### Steps to test this PR:
0. Load up [this PR](https://mautibox.com)
1. How to reproduce the bug:
2. Create a select-multiple custom field with options
3. Create a form field that maps to the new custom field, set Use Assigned Contact Field Values to No & add fields
4. Switch 'Use assigned...' to Yes.
5. Save and close
6. And then change 'Use assigned...' to No.
7. You should see your custom values

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
