### PR TITLE
Community PR for MAUT-3279 - Fixing webhook test form

### DIFF
--- a/app/bundles/WebhookBundle/Config/config.php
+++ b/app/bundles/WebhookBundle/Config/config.php
@@ -105,6 +105,13 @@ return [
                     'mautic.http.connector',
                 ],
             ],
+            'mautic.webhook.http.client' => [
+                'class'     => \Mautic\WebhookBundle\Http\Client::class,
+                'arguments' => [
+                    'mautic.helper.core_parameters',
+                    'mautic.guzzle.client',
+                ],
+            ],
         ],
     ],
 

--- a/app/bundles/WebhookBundle/Http/Client.php
+++ b/app/bundles/WebhookBundle/Http/Client.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Mautic\WebhookBundle\Http;
+
+use GuzzleHttp\Psr7\Request;
+use Http\Adapter\Guzzle6\Client as GuzzleClient;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Psr\Http\Message\ResponseInterface;
+
+class Client
+{
+    /**
+     * @var CoreParametersHelper
+     */
+    private $coreParametersHelper;
+
+    /**
+     * @var GuzzleClient
+     */
+    private $httpClient;
+
+    public function __construct(
+        CoreParametersHelper $coreParametersHelper,
+        GuzzleClient $httpClient
+    ) {
+        $this->coreParametersHelper = $coreParametersHelper;
+        $this->httpClient           = $httpClient;
+    }
+
+    /**
+     * @param string $url
+     * @param string $secret
+     *
+     * @return ResponseInterface
+     */
+    public function post($url, array $payload, $secret)
+    {
+        $jsonPayload = json_encode($payload);
+        $signature   = base64_encode(hash_hmac('sha256', $jsonPayload, $secret, true));
+        $headers     = [
+            'Content-Type'      => 'application/json',
+            'X-Origin-Base-URL' => $this->coreParametersHelper->get('site_url'),
+            'Webhook-Signature' => $signature,
+        ];
+
+        return $this->httpClient->sendRequest(new Request('POST', $url, $headers, $jsonPayload));
+    }
+}


### PR DESCRIPTION
This is created to contribute work from https://github.com/mautic-inc/mautic-cloud/pull/701 back to community. It was intended to fix the webhook test functionality not working. It also refactors out the joomla htttp client to use the guzzle client.

Steps to test:
1. Go to webhooks page and fill out the form with a working webhook url
2. Click the 'Test' button 
3. Webhook should receive a test payload