### PR TITLE
twig-bridge should also be forced to 2.8 to avoid #8119

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "sensio/distribution-bundle": "~5.0",
 
         "symfony/twig-bundle": "~2.8",
-        "symfony/twig-bridge": "2.8",
+        "symfony/twig-bridge": "~2.8",
 
         "doctrine/dbal": "~2.5.4",
         "doctrine/common": "~2.5.3",

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
         "sensio/distribution-bundle": "~5.0",
 
         "symfony/twig-bundle": "~2.8",
+        "symfony/twig-bridge": "2.8",
 
         "doctrine/dbal": "~2.5.4",
         "doctrine/common": "~2.5.3",


### PR DESCRIPTION
closes https://github.com/mautic/mautic/issues/8119

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | #8119
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
twig-bridge should also be forced to 2.8 to avoid #8119. Some dependency resolution resolves to twig-bridge v3.0.9 in the current develop branch. We need the 2.8 branch for all dependencies to be compatible.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. composer install causes twig-bridge 3.0.9
2. console cache:clear

#### Steps to test this PR:
1. run composer install

#### List deprecations along with the new alternative:
1. /
2. /

#### List backwards compatibility breaks:
1. /
2. /
