### PR TITLE
Make sure the lifetime interval is an integer

### DIFF
--- a/app/config/security.php
+++ b/app/config/security.php
@@ -110,7 +110,7 @@ $firewalls = [
         ],
         'remember_me' => [
             'secret'   => '%mautic.rememberme_key%',
-            'lifetime' => '%mautic.rememberme_lifetime%',
+            'lifetime' => intval('%mautic.rememberme_lifetime%'),
             'path'     => '%mautic.rememberme_path%',
             'domain'   => '%mautic.rememberme_domain%',
         ],


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N 
| Related developer documentation PR URL | N 
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
I was having issues with PHP 7.2 where the interval was being filled in but it came back as a string instead of an integer. Changing this fixed it for me, but I'm not sure if this is the right place to do so.
 
I'll try to add steps to reproduce but it's better to have it already out there to help others.