### PR TITLE
Reenable populating form values from URL for anonymous contacts

### DIFF
--- a/media/js/mautic-form-src.js
+++ b/media/js/mautic-form-src.js
@@ -70,9 +70,34 @@
                 }
             }
 
+            this.populateFromUrlParams();
             this.bindClickEvents();
             Profiler.runTime();
-        };
+          };
+
+          Form.populateFromUrlParams = function () {
+            /* Credit to @shawncarr for this code: https://gist.github.com/shawncarr/56c2484cb50bc923107f210310366ad0 */
+            document.addEventListener("readystatechange", function () {
+              if (event.target.readyState == "interactive") {
+                if (document.forms.length !== 0 && location.search) {
+                  var query = location.search.substr(1);
+                  query.split("&").forEach(function (part) {
+                    if (part.indexOf("=") !== -1) {
+                      var item = part.split("=");
+                      var key = item[0];
+                      var value = decodeURIComponent(item[1]);
+                      var inputs = document.getElementsByName(
+                        "mauticform[" + key + "]"
+                      );
+                      inputs.forEach(function (input) {
+                        input.value = value;
+                      });
+                    }
+                  });
+                }
+              }
+            });
+          };
 
         Form.bindClickEvents = function() {
             if (Core.debug()) console.log('binding modal click events');


### PR DESCRIPTION
closes #6990

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? |N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #6990
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
At some point the ability to populate form values via the URL of the page broke/disappeared. Several of us are using @shawncarr's gist (https://gist.github.com/shawncarr/56c2484cb50bc923107f210310366ad0) to accomplish this with success so it makes sense to incorporate that code into Mautic. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a form
2. Pass values to prefill it on the url.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create a form and embed it in either a landing page or a web page
3. Add url parameters to the embedding page to prefill the form, [per the documentation](https://docs.mautic.org/en/components/forms/managing-forms#pre-populate-a-form-field-value)

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
