### PR TITLE
Fixes the telephone form field CSS class name

### DIFF
--- a/app/bundles/FormBundle/Views/Field/tel.html.php
+++ b/app/bundles/FormBundle/Views/Field/tel.html.php
@@ -9,14 +9,12 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-use Mautic\CoreBundle\Form\Type\TelType;
-
 echo $view->render(
     'MauticFormBundle:Field:text.html.php',
     [
         'field'    => $field,
         'inForm'   => (isset($inForm)) ? $inForm : false,
-        'type'     => TelType::class,
+        'type'     => 'tel',
         'id'       => $id,
         'formId'   => (isset($formId)) ? $formId : 0,
         'formName' => (isset($formName)) ? $formName : '',


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The $type in form fields are used to to generate the CSS class names. So what was `mauticform-tel` in M2 became `mauticform-Mautic\CoreBundle\Form\Type\TelType` in M3. This reverts that to keep BC for websites that depend on that CSS class name to style their forms. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Edit a form created in M2 that had a telephone field  (or just create a field in M3) and search for the CSS class name in the rendered content. Note the FQCN in the CSS class name. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat and the telephone field classname should be `mauticform-tel`
