### PR TITLE
Update form submission results to use local timezone based on configuration in Mautic.

### DIFF
--- a/app/bundles/CoreBundle/Helper/DateTimeHelper.php
+++ b/app/bundles/CoreBundle/Helper/DateTimeHelper.php
@@ -63,7 +63,7 @@ class DateTimeHelper
     public function setDateTime($datetime = '', $fromFormat = 'Y-m-d H:i:s', $timezone = 'local')
     {
         if ('local' == $timezone) {
-            $timezone = date_default_timezone_get();
+            $timezone = ArrayHelper::getValue('default_timezone', (new ParamsLoaderHelper())->getParameters(), date_default_timezone_get());
         } elseif (empty($timezone)) {
             $timezone = 'UTC';
         }

--- a/app/bundles/FormBundle/Views/Result/list.html.php
+++ b/app/bundles/FormBundle/Views/Result/list.html.php
@@ -116,7 +116,7 @@ $formId = $form->getId();
                     </a>
                     <?php endif; ?>
                 </td>
-                <td><?php echo $view['date']->toFull($item['dateSubmitted'], 'UTC'); ?></td>
+                <td><?php echo $view['date']->toFull($item['dateSubmitted'], 'local'); ?></td>
                 <td><?php echo $view->escape($item['ipAddress']); ?></td>
                 <?php foreach ($item['results'] as $key => $r): ?>
                     <?php $isTextarea = 'textarea' === $r['type']; ?>


### PR DESCRIPTION
closes #8666 

| Q  | A
| --- | ---
| Bug fix? |  Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #8666
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
I. Upcoming Events

1. Go to configuration, set default timezone not UTC, example Ho Chi Minh (UTC+7)
2. Create a test contact
3. Create a test segment
4. Add test contact to test segment
5. Create a test campaign with source test segment
6. Add a action example +1 point immediately and an action with at a relative time 15' or at specific date/time
7. Go to contact and see campaign trigger and see History, trigger +1 point immediately time UTC+7 but on Upcoming Events, time always UTC.

II. Date on form

1. Create a test form Name and email
2. Embed form on a landing page
3. Submit form
4. Go to form results and see that Date Submitted always UTC
5. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
