### PR TITLE
IntegrationBundle: Updated field mapping form render logic to render fields with "mappedField" index.

### DIFF
--- a/app/bundles/IntegrationsBundle/Views/Config/field_mapping.html.php
+++ b/app/bundles/IntegrationsBundle/Views/Config/field_mapping.html.php
@@ -12,7 +12,7 @@
 ?>
 <?php echo $view['form']->row($form['filter-totalFieldCount']); ?>
 <?php foreach ($form as $fieldName => $fieldForm): ?>
-<?php if (!in_array($fieldName, ['filter-keyword', 'filter-totalFieldCount'])): ?>
+<?php if (isset($fieldForm['mappedField'])): ?>
     <div class="row">
         <div class="col-sm-12"><?php echo $view['form']->label($fieldForm); ?></div>
     </div>


### PR DESCRIPTION
**Please be sure you are submitting this against the _3.x_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  Y
| New feature? |  N
| Automated tests included? | -
| Related user documentation PR URL |  -
| Related developer documentation PR URL | -
| Issues addressed (#s or URLs) | -
| BC breaks? | -
| Deprecations? | -


[//]: # ( Required: )
#### Description:
The invalid field name like digit zero, are not consider in mapping tab for rendering. Instead it renders it out from the tab-container, please see the screenshot,
<img width="608" alt="Screenshot 2020-04-13 at 8 28 55 PM" src="https://user-images.githubusercontent.com/1046788/79130956-6aad6800-7dc5-11ea-913b-0d3933c99f24.png">

This distorts the configuration and the same field is not correctly mapped.
 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
