### PR TITLE
Add back a method removed in 3.x that the campaign segment share feature depended on

### DIFF
--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -554,4 +554,31 @@ class CampaignRepository extends CommonRepository
             ->execute()
             ->fetch();
     }
+
+    /**
+     * @param int   $segmentId
+     * @param array $campaignIds
+     *
+     * @return array
+     */
+    public function getCampaignsSegmentShare($segmentId, $campaignIds = [])
+    {
+        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        $q->select('c.id, c.name, ROUND(IFNULL(COUNT(DISTINCT t.lead_id)/COUNT(DISTINCT cl.lead_id)*100, 0),1) segmentCampaignShare');
+        $q->from(MAUTIC_TABLE_PREFIX.'campaigns', 'c')
+            ->leftJoin('c', MAUTIC_TABLE_PREFIX.'campaign_leads', 'cl', 'cl.campaign_id = c.id AND cl.manually_removed = 0')
+            ->leftJoin('cl',
+                '(SELECT lll.lead_id AS ll, lll.lead_id FROM lead_lists_leads lll WHERE lll.leadlist_id = '.$segmentId
+                .' AND lll.manually_removed = 0)',
+                't',
+                't.lead_id = cl.lead_id'
+            );
+        $q->groupBy('c.id');
+
+        if (!empty($campaignIds)) {
+            $q->where($q->expr()->in('c.id', $campaignIds));
+        }
+
+        return $q->execute()->fetchAll();
+    }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This adds back the method added in #7285 that must have been accidentally removed during the merge/rebase into 3.x. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Edit a segment (I edited https://m3.mautibox.com/3.x/s/segments/edit/1)
2. Save or cancel
3. Go back to the overview page and the error will be shown if in the dev environment, otherwise an error recorded in the logs due to the ajax request failing with a 500 - if not click on the 'campaign share' tab.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat and the page/tab should load and stats updated
