### PR TITLE
Fixed path to plugins migrations directory

### DIFF
--- a/app/bundles/IntegrationsBundle/Bundle/AbstractPluginBundle.php
+++ b/app/bundles/IntegrationsBundle/Bundle/AbstractPluginBundle.php
@@ -38,7 +38,7 @@ abstract class AbstractPluginBundle extends PluginBundleBase
         $migrationEngine = new Engine(
             $entityManager,
             $tablePrefix,
-            __DIR__.'/../../'.$plugin->getBundle(),
+            __DIR__.'/../../../../plugins/'.$plugin->getBundle(),
             $plugin->getBundle()
         );
 


### PR DESCRIPTION
This fixes a bug that was causing migrations from plugins to not run because the migrations path was wrong.