### PR TITLE
Email builder apply fix

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -298,7 +298,6 @@ return [
                 'arguments' => [
                     'translator',
                     'doctrine.orm.entity_manager',
-                    'request_stack',
                     'mautic.stage.model.stage',
                 ],
             ],

--- a/app/bundles/EmailBundle/Tests/Form/Type/EmailTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/EmailTypeTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Form\Type;
+
+use Doctrine\ORM\EntityManager;
+use Mautic\CoreBundle\Form\Type\FormButtonsType;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Form\Type\EmailType;
+use Mautic\StageBundle\Model\StageModel;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class EmailTypeTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var MockObject|TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var MockObject|EntityManager
+     */
+    private $entityManager;
+
+    /**
+     * @var MockObject|StageModel
+     */
+    private $stageModel;
+
+    /**
+     * @var MockObject|FormBuilderInterface
+     */
+    private $formBuilder;
+
+    /**
+     * @var EmailType
+     */
+    private $form;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->translator    = $this->createMock(TranslatorInterface::class);
+        $this->entityManager = $this->createMock(EntityManager::class);
+        $this->stageModel    = $this->createMock(StageModel::class);
+        $this->formBuilder   = $this->createMock(FormBuilderInterface::class);
+        $this->form          = new EmailType(
+            $this->translator,
+            $this->entityManager,
+            $this->stageModel
+        );
+
+        $this->formBuilder->method('create')->willReturnSelf();
+    }
+
+    public function testBuildForm()
+    {
+        $options = [
+            'data' => new Email(),
+        ];
+
+        $this->formBuilder->expects($this->at(46))
+            ->method('add')
+            ->with(
+                'buttons',
+                FormButtonsType::class,
+                [
+                    'pre_extra_buttons' => [
+                        [
+                            'name'  => 'builder',
+                            'label' => 'mautic.core.builder',
+                            'attr'  => [
+                                'class'   => 'btn btn-default btn-dnd btn-nospin text-primary btn-builder',
+                                'icon'    => 'fa fa-cube',
+                                'onclick' => "Mautic.launchBuilder('emailform', 'email');",
+                            ],
+                        ],
+                    ],
+                ]
+            );
+
+        $this->form->buildForm($this->formBuilder, $options);
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8626
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The Apply button in the Email Builder stopped working properly. I found what the problem is and traced down when was the bug introduced. Of course, I found myself [introducing it](https://github.com/mautic/mautic/commit/f46fcdfd39d9239e1ef3994e573ba02a9398b12e#diff-60072ef0fa130a4dd3a382f1cd777131L504) during M3 refactoring.

The problem was in the form name that was passed to the JS method.

I did some cleaning up of the form type class when in there.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to Email Builder.
2. Click the Apply button in the email builder itself.
- It will save the changes, but it won't open the email builder again. You will end up in the form.

#### Steps to test this PR:
1. Load up [this PR](https://3x.mautibox.com)
2. Click the Apply button in the email builder again.
- It will save the changes and opens the builder again after save.
