### PR TITLE
Fix sync multi sselect value for Zoho API v2

### DIFF
--- a/plugins/MauticCrmBundle/Api/Zoho/Mapper.php
+++ b/plugins/MauticCrmBundle/Api/Zoho/Mapper.php
@@ -83,6 +83,11 @@ class Mapper
      */
     public function setContact(array $contact)
     {
+        foreach ($contact as $field => &$value) {
+            if (strpos($value, '|') !== false) {
+                $value = explode('|', $value);
+            }
+        }
         $this->contact = $contact;
 
         return $this;

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -244,6 +244,14 @@ class ZohoIntegration extends CrmAbstractIntegration
                             }
                         }
 
+                        // normalize
+                        foreach ($newMatchedFields as $field=>$value) {
+                            $fields= $entity->getFields(true);
+                            if ($fields[$field]['type'] === 'multiselect') {
+                                $newMatchedFields[$field] = str_replace(';', '|', $value);
+                            }
+                        }
+
                         // update values if already empty
                         foreach ($matchedFields as $field => $value) {
                             if (empty($entity->getFieldValue($field))) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

During Zoho synchronisation, when a multiple select field is mapped on both side, if you select multiple choice in the Mautic side, all the choices are filled in one value the Zoho field

Mautic field : 
![image](https://user-images.githubusercontent.com/49391402/64415091-e9eef680-d094-11e9-97fe-863b0302340c.png)

Zoho Field : 
![image](https://user-images.githubusercontent.com/49391402/64415128-025f1100-d095-11e9-9718-f861bc2e3b31.png)

Steps to reproduce: 
1 Create a Multiple Select Custom Field on Mautic
2 Create A Multiple Select Custom Field on Zoho
3 Mapped those 2 field in the Zoho plugin
4 Create a contact in Mautic, choose 2 choices in the select field
5 Synchronize and see that the 2 choices are in only one in Zoho


#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps, see multi select in right way
