### PR TITLE
Mailjet transport fix

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Spool/DelegatingSpool.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Spool/DelegatingSpool.php
@@ -71,7 +71,7 @@ class DelegatingSpool extends \Swift_FileSpool
         }
 
         // Send immediately otherwise
-        return $this->realTransport->send($message, $failedRecipients);
+        return (int) $this->realTransport->send($message, $failedRecipients);
     }
 
     public function wasMessageSpooled(): bool

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/MailjetTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/MailjetTransport.php
@@ -72,7 +72,7 @@ class MailjetTransport extends \Swift_SmtpTransport implements CallbackTransport
             $message->setTo($this->getSandboxMail());
         }
 
-        parent::send($message, $failedRecipients);
+        return parent::send($message, $failedRecipients);
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | /
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR fixes error:
```
Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Return value of Mautic\EmailBundle\Swiftmailer\Spool\DelegatingSpool::delegateMessage() must be of the type integer, null returned in app/bundles/EmailBundle/Swiftmailer/Spool/DelegatingSpool.php:74
```

It happened for a client who was using MailJet. The fix is straight forward. I covered it with unit tests to ensure it works.

#### Steps to test this PR:
1. I don't think you must set up a MailJet account for test. Just make sure emails are sending with the transport you use.
