### PR TITLE
Fixes issue where support for tokenization was not detected in the MailHelper

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -21,6 +21,7 @@ use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\EmailBundle\Swiftmailer\Exception\BatchQueueMaxException;
 use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
+use Mautic\EmailBundle\Swiftmailer\Transport\SpoolTransport;
 use Mautic\EmailBundle\Swiftmailer\Transport\TokenTransportInterface;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -266,7 +267,12 @@ class MailHelper
         $this->returnPath = $factory->getParameter('mailer_return_path');
 
         // Check if batching is supported by the transport
-        if ('memory' == $this->factory->getParameter('mailer_spool_type') && $this->transport instanceof TokenTransportInterface) {
+        if ('memory' == $this->factory->getParameter('mailer_spool_type')
+            && (
+                $this->transport instanceof TokenTransportInterface
+                || ($this->transport instanceof SpoolTransport && $this->transport->supportsTokenization())
+            )
+        ) {
             $this->tokenizationEnabled = true;
         }
 
@@ -737,7 +743,7 @@ class MailHelper
         /** @var \Swift_Mime_SimpleMimeEntity $child */
         foreach ($children as $child) {
             $childType  = $child->getContentType();
-            list($type) = sscanf($childType, '%[^/]/%s');
+            [$type]     = sscanf($childType, '%[^/]/%s');
 
             if ('text' == $type) {
                 $childBody = $child->getBody();
@@ -1928,7 +1934,7 @@ class MailHelper
 
         if ($settings = $this->isMontoringEnabled('EmailBundle', 'bounces')) {
             // Append the bounce notation
-            list($email, $domain) = explode('@', $settings['address']);
+            [$email, $domain] = explode('@', $settings['address']);
             $email .= '+bounce';
             if ($idHash || $this->idHash) {
                 $email .= '_'.($idHash ?: $this->idHash);
@@ -1952,7 +1958,7 @@ class MailHelper
 
         if ($settings = $this->isMontoringEnabled('EmailBundle', 'unsubscribes')) {
             // Append the bounce notation
-            list($email, $domain) = explode('@', $settings['address']);
+            [$email, $domain] = explode('@', $settings['address']);
             $email .= '+unsubscribe';
             if ($idHash || $this->idHash) {
                 $email .= '_'.($idHash ?: $this->idHash);

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -267,11 +267,9 @@ class MailHelper
         $this->returnPath = $factory->getParameter('mailer_return_path');
 
         // Check if batching is supported by the transport
-        if ('memory' == $this->factory->getParameter('mailer_spool_type')
-            && (
-                $this->transport instanceof TokenTransportInterface
-                || ($this->transport instanceof SpoolTransport && $this->transport->supportsTokenization())
-            )
+        if (
+            ('memory' == $this->factory->getParameter('mailer_spool_type') && $this->transport instanceof TokenTransportInterface)
+            || ($this->transport instanceof SpoolTransport && $this->transport->supportsTokenization())
         ) {
             $this->tokenizationEnabled = true;
         }

--- a/app/bundles/EmailBundle/Swiftmailer/Spool/DelegatingSpool.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Spool/DelegatingSpool.php
@@ -96,4 +96,9 @@ class DelegatingSpool extends \Swift_FileSpool
 
         return str_replace('%kernel.root_dir%', $rootPath, $filePath);
     }
+
+    public function getRealTransport(): \Swift_Transport
+    {
+        return $this->realTransport;
+    }
 }

--- a/app/bundles/EmailBundle/Swiftmailer/Spool/DelegatingSpool.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Spool/DelegatingSpool.php
@@ -12,6 +12,7 @@
 namespace Mautic\EmailBundle\Swiftmailer\Spool;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\EmailBundle\Swiftmailer\Transport\TokenTransportInterface;
 use Swift_Mime_SimpleMessage;
 
 /**
@@ -77,6 +78,11 @@ class DelegatingSpool extends \Swift_FileSpool
     public function wasMessageSpooled(): bool
     {
         return $this->messageSpooled;
+    }
+
+    public function isTokenizationEnabled(): bool
+    {
+        return !$this->fileSpoolEnabled && $this->realTransport instanceof TokenTransportInterface;
     }
 
     private function getSpoolDir(): string

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/SpoolTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/SpoolTransport.php
@@ -64,4 +64,9 @@ class SpoolTransport extends \Swift_Transport_SpoolTransport
 
         return $count;
     }
+
+    public function supportsTokenization(): bool
+    {
+        return $this->spool->isTokenizationEnabled();
+    }
 }

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/SpoolTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/SpoolTransport.php
@@ -69,4 +69,14 @@ class SpoolTransport extends \Swift_Transport_SpoolTransport
     {
         return $this->spool->isTokenizationEnabled();
     }
+
+    public function getMaxBatchLimit()
+    {
+        return $this->spool->getRealTransport()->getMaxBatchLimit();
+    }
+
+    public function getBatchRecipientCount(\Swift_Message $message, $toBeAdded = 1, $type = 'to')
+    {
+        return $this->spool->getRealTransport()->getBatchRecipientCount($message, $toBeAdded, $type);
+    }
 }

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -28,11 +28,6 @@ use Monolog\Logger;
 class MailHelperTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var FromEmailHelper|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private $fromEmailHelper;
-
-    /**
      * @var MauticFactory|\PHPUnit\Framework\MockObject\MockObject
      */
     private $mockFactory;
@@ -90,7 +85,6 @@ class MailHelperTest extends \PHPUnit\Framework\TestCase
     {
         defined('MAUTIC_ENV') or define('MAUTIC_ENV', 'test');
 
-        $this->fromEmailHelper = $this->createMock(FromEmailHelper::class);
         $this->mockFactory     = $this->createMock(MauticFactory::class);
         $this->mockFactory->method('get')
             ->with('mautic.helper.from_email_helper')

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -85,11 +85,7 @@ class MailHelperTest extends \PHPUnit\Framework\TestCase
     {
         defined('MAUTIC_ENV') or define('MAUTIC_ENV', 'test');
 
-        $this->mockFactory     = $this->createMock(MauticFactory::class);
-        $this->mockFactory->method('get')
-            ->with('mautic.helper.from_email_helper')
-            ->willReturn($this->fromEmailHelper);
-
+        $this->mockFactory           = $this->createMock(MauticFactory::class);
         $this->swiftEventsDispatcher = $this->createMock(\Swift_Events_EventDispatcher::class);
         $this->delegatingSpool       = $this->createMock(DelegatingSpool::class);
 

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/Spool/DelegatingSpoolTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/Spool/DelegatingSpoolTest.php
@@ -132,6 +132,7 @@ class DelegatingSpoolTest extends TestCase
 
         $spool = new DelegatingSpool($this->coreParametersHelper, $this->realTransport);
         $this->assertFalse($spool->isTokenizationEnabled());
+    }
 
     public function testDelegateMessageWillReturnIntEvenIfTransportWillNot()
     {

--- a/app/bundles/EmailBundle/Tests/Transport/SpoolTransportTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/SpoolTransportTest.php
@@ -44,14 +44,14 @@ class SpoolTransportTest extends TestCase
         $this->spool           = $this->createMock(DelegatingSpool::class);
         $this->message         = $this->createMock(\Swift_Mime_SimpleMessage::class);
         $this->sendEvent       = $this->createMock(\Swift_Events_SendEvent::class);
-
-        $this->eventDispatcher->expects($this->once())
-            ->method('createSendEvent')
-            ->willReturn($this->sendEvent);
     }
 
     public function testSpooledEventIsDispatched()
     {
+        $this->eventDispatcher->expects($this->once())
+            ->method('createSendEvent')
+            ->willReturn($this->sendEvent);
+
         $this->spool->expects($this->once())
             ->method('delegateMessage')
             ->willReturn(1);
@@ -74,6 +74,10 @@ class SpoolTransportTest extends TestCase
 
     public function testSuccessEventIsDispatched()
     {
+        $this->eventDispatcher->expects($this->once())
+            ->method('createSendEvent')
+            ->willReturn($this->sendEvent);
+
         $this->spool->expects($this->once())
             ->method('delegateMessage')
             ->willReturn(1);
@@ -96,6 +100,10 @@ class SpoolTransportTest extends TestCase
 
     public function testFailedEventIsDispatched()
     {
+        $this->eventDispatcher->expects($this->once())
+            ->method('createSendEvent')
+            ->willReturn($this->sendEvent);
+
         $this->spool->expects($this->once())
             ->method('delegateMessage')
             ->willReturn(0);
@@ -114,5 +122,25 @@ class SpoolTransportTest extends TestCase
         $sent   = $transport->send($this->message, $failed);
 
         $this->assertEquals(0, $sent);
+    }
+
+    public function testThatSupportsTokenizationMethodReturnsTrueIfTokenizationIsEnabled()
+    {
+        $this->spool->expects($this->once())
+            ->method('isTokenizationEnabled')
+            ->willReturn(true);
+
+        $transport = new SpoolTransport($this->eventDispatcher, $this->spool);
+        $this->assertTrue($transport->supportsTokenization());
+    }
+
+    public function testThatSupportsTokenizationMethodReturnsFalseIfTokenizationIsDisabled()
+    {
+        $this->spool->expects($this->once())
+            ->method('isTokenizationEnabled')
+            ->willReturn(false);
+
+        $transport = new SpoolTransport($this->eventDispatcher, $this->spool);
+        $this->assertFalse($transport->supportsTokenization());
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Each time one of our instances attempts to send an email the sending fails with:
```
Mautic\EmailBundle\Swiftmailer\Momentum\Exception\Facade\MomentumSendException: At least one valid recipient is required in app/bundles/EmailBundle/Swiftmailer/Momentum/Facade/MomentumFacade.php:112
```

#### Steps to test this PR:
1. Manual testing requires an API based transport such as sparkpost or sendgrid (Momentum is an on-prem solution by sparkpost and thus not accessible to most for manual testing)
2. Send a segment email with contact tokens embedded to a segment with more than one contact  and ensure that each contact receives the email with the appropriate tokens replaced. 
3. Code review the new unit tests (obviously they should pass)