### PR TITLE
Fix "ConversionException: Serialized array includes null-byte" exception/error

### DIFF
--- a/app/bundles/CoreBundle/Doctrine/Type/ArrayType.php
+++ b/app/bundles/CoreBundle/Doctrine/Type/ArrayType.php
@@ -43,7 +43,8 @@ class ArrayType extends \Doctrine\DBAL\Types\ArrayType
         $serialized = serialize($value);
 
         if (false !== strpos($serialized, chr(0))) {
-            throw new \Doctrine\DBAL\Types\ConversionException('Serialized array includes null-byte. This cannot be saved as a text. Please check if you not provided object with protected or private members.');
+            $serialized = str_replace("\0", '__NULL_BYTE__', $serialized);
+            throw new ConversionException('Serialized array includes null-byte. This cannot be saved as a text. Please check if you not provided object with protected or private members. Serialized Array: '.$serialized);
         }
 
         return $serialized;
@@ -57,7 +58,28 @@ class ArrayType extends \Doctrine\DBAL\Types\ArrayType
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
         try {
-            return parent::convertToPHPValue($value, $platform);
+            $value = parent::convertToPHPValue($value, $platform);
+            if (!is_array($value) || (1 > count($value))) {
+                return $value;
+            }
+
+            foreach ($value as $key => $element) {
+                if (!is_object($element)) {
+                    continue;
+                }
+
+                $reflectionObject     = new \ReflectionObject($element);
+                $reflectionProperties = $reflectionObject->getProperties(\ReflectionProperty::IS_PROTECTED | \ReflectionProperty::IS_PRIVATE);
+
+                // Let's check if $value contains objects with private or protected members.
+                // If it contains such objects we have to remove them from $array.
+                // This will "heal" the database. There must be no null bytes.
+                if (0 < count($reflectionProperties)) {
+                    unset($value[$key]);
+                }
+            }
+
+            return $value;
         } catch (ConversionException $exception) {
             return [];
         } catch (ContextErrorException $exeption) {

--- a/app/bundles/CoreBundle/Tests/Unit/Doctrine/ArrayTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Doctrine/ArrayTypeTest.php
@@ -103,4 +103,55 @@ class ArrayTypeTest extends \PHPUnit\Framework\TestCase
             $result
         );
     }
+
+    public function testGiven_objectWithPrivateProperty_when_convertsToPHPValue_then_getsArrayWithoutObject()
+    {
+        $array = [
+            0,
+            new ExampleClassWithPrivateProperty(),
+        ];
+
+        $array = serialize($array);
+
+        $result = $this->arrayType->convertToPHPValue($array, $this->platform);
+        $this->assertEquals(
+            [0],
+            $result
+        );
+    }
+
+    public function testGiven_objectWithProtectedProperty_when_convertsToPHPValue_then_getsArrayWithoutObject()
+    {
+        $array = [
+            0,
+            new ExampleClassWithProtectedProperty(),
+        ];
+
+        $array = serialize($array);
+
+        $result = $this->arrayType->convertToPHPValue($array, $this->platform);
+        $this->assertEquals(
+            [0],
+            $result
+        );
+    }
+
+    public function testGiven_objectWithPublicProperty_when_convertsToPHPValue_then_getsArrayWithObject()
+    {
+        $array = [
+            0,
+            new ExampleClassWithPublicProperty(),
+        ];
+
+        $array = serialize($array);
+
+        $result = $this->arrayType->convertToPHPValue($array, $this->platform);
+        $this->assertEquals(
+            [
+                0,
+                new ExampleClassWithPublicProperty(),
+            ],
+            $result
+        );
+    }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Mautic throws an exception because some of the records in the database contain null byte characters.
This PR fixes it by removing these null bytes. We don't need them because they are used in serialized objects. These serialized objects should not be stored in the ip_addresses table, so we can delete them and this should fix the errors.


[//]: # ( As applicable: )

#### Steps to reproduce the bug:
##### Notice: add DB prefix to the table names below if you use table prefix in your Mautic installation.


1. Create 2 contacts (Contact #1 and Contact #2).
2. Run the following SQL query
```sql
INSERT INTO
	ip_addresses (ip_address, ip_details)
VALUES
('100.100.100.100','a:11:{s:4:\"city\";N;s:6:\"region\";s:0:\"\";s:7:\"zipcode\";N;s:7:\"country\";s:14:\"United Kingdom\";s:8:\"latitude\";d:51.5;s:9:\"longitude\";d:-0.13;s:3:\"isp\";s:0:\"\";s:12:\"organization\";s:0:\"\";s:8:\"timezone\";s:13:\"Europe/London\";s:5:\"extra\";s:0:\"\";s:9:\"connector\";O:16:\"Joomla\\Http\\Http\":2:{s:10:\"\0*\0options\";a:0:{}s:12:\"\0*\0transport\";O:26:\"Joomla\\Http\\Transport\\Curl\":1:{s:10:\"\0*\0options\";a:0:{}}}}');
```
3. Associate the second contact (Contact #2) with the IP address that you've just created. To do so go to the `lead_ips_xref` table and add a record there.
You need to insert ID of the second contact and ID of the IP address you created in the previous step.
4. Go to the details page of the first contact (Contact #1). Select "Merge" in the upper right corner of the screen, merge the first contact with the second contact (Contact #2).
5. You will see an exception in the popup.

#### Steps to test this PR:
1. Repeat the steps. You should be able to merge the contact now.