### PR TITLE
Initial batch of Codeception acceptance tests for Companies

### DIFF
--- a/tests/acceptance/CompaniesCest.php
+++ b/tests/acceptance/CompaniesCest.php
@@ -109,4 +109,17 @@ class CompaniesCest
         $I->fillField('//*[@id="list-search"]', ''); // Clear field ready for subsequent tests
         $I->pressKey('//*[@id="list-search"]', WebDriverKeys::ENTER); // Press enter
     }
+
+    public function assignOwner(AcceptanceTester $I)
+    {
+        $I->amOnPage('/s/companies');
+        $I->click('//*[@id="companyTable"]/tbody/tr[1]/td[2]/div/a'); // Click on first company to edit
+        $I->wait(2);
+        $I->makeScreenshot('edit-company');
+        $I->see('Choose one...', '//*[@id="company_owner_chosen"]');
+        $I->click('//*[@id="company_owner_chosen"]');
+        $I->click('//*[@id="company_owner_chosen"]/div/ul/li[2]'); // Assign an owner
+        $I->click('//*[@id="company_buttons_apply_toolbar"]');
+        $I->dontSee('Choose one...', '//*[@id="company_owner_chosen"]');
+    }
 }

--- a/tests/acceptance/CompaniesCest.php
+++ b/tests/acceptance/CompaniesCest.php
@@ -139,4 +139,21 @@ class CompaniesCest
         $I->wait(2);
         $I->dontSee("$companyName1");
     }
+
+    public function batchDeleteCompanies(AcceptanceTester $I)
+    {
+        $I->amOnPage('/s/companies');
+        $companyName1=$I->grabTextFrom('//*[@id="companyTable"]/tbody/tr[1]/td[2]/div/a'); // Grab name of first company
+        $companyName2=$I->grabTextFrom('//*[@id="companyTable"]/tbody/tr[2]/td[2]/div/a'); // Grab name of second company
+        $I->checkOption('//*[@id="companyTable"]/tbody/tr[1]/td[1]/div/span/input'); // Select company 1
+        $I->checkOption('//*[@id="companyTable"]/tbody/tr[2]/td[1]/div/span/input'); // Select company 2
+        $I->click('//*[@id="companyTable"]/thead/tr/th[1]/div/div/button'); // Click for options
+        $I->click('//*[@id="companyTable"]/thead/tr/th[1]/div/div/ul/li[2]/a/span/span'); // Select delete
+        $I->wait(2);
+        $I->makeScreenshot('delete');
+        $I->click('/html/body/div[2]/div/div/div[2]/button[2]'); // Click delete button
+        $I->wait(2);
+        $I->dontSee("$companyName1");
+        $I->dontSee("$companyName2");
+    }
 }

--- a/tests/acceptance/CompaniesCest.php
+++ b/tests/acceptance/CompaniesCest.php
@@ -96,4 +96,17 @@ class CompaniesCest
         $I->wait(5);
         $I->dontSee("$companyName");
     }
+
+    public function searchCompanies(AcceptanceTester $I)
+    {
+        $I->amOnPage('/s/companies');
+        $companyName1=$I->grabTextFrom('//*[@id="companyTable"]/tbody/tr[1]/td[2]/div/a'); // Grab name of first company
+        $companyName2=$I->grabTextFrom('//*[@id="companyTable"]/tbody/tr[2]/td[2]/div/a'); // Grab name of second company
+        $I->fillField('//*[@id="list-search"]', "$companyName1"); // Search companies for Company 1
+        $I->pressKey('//*[@id="list-search"]', WebDriverKeys::ENTER); // Press enter
+        $I->wait(2);
+        $I->dontsee("$companyName2"); // Confirm we no longer see Company 2
+        $I->fillField('//*[@id="list-search"]', ''); // Clear field ready for subsequent tests
+        $I->pressKey('//*[@id="list-search"]', WebDriverKeys::ENTER); // Press enter
+    }
 }

--- a/tests/acceptance/CompaniesCest.php
+++ b/tests/acceptance/CompaniesCest.php
@@ -156,4 +156,17 @@ class CompaniesCest
         $I->dontSee("$companyName1");
         $I->dontSee("$companyName2");
     }
+
+    public function cloneCompanies(AcceptanceTester $I)
+    {
+        $I->amOnPage('/s/companies');
+        $companyName1=$I->grabTextFrom('//*[@id="companyTable"]/tbody/tr[1]/td[2]/div/a'); // Grab name of first company
+        $I->click('//*[@id="companyTable"]/tbody/tr[1]/td[1]/div/div/button/i');
+        $I->click('//*[@id="companyTable"]/tbody/tr[1]/td[1]/div/div/ul/li[2]/a'); // Click to clone company
+        $I->wait(1);
+        $I->fillField('//*[@id="company_companyname"]', "$companyName1 clone");
+        $I->click('//*[@id="company_buttons_save_toolbar"]');
+        $I->wait(2);
+        $I->see("$companyName1 clone");
+    }
 }

--- a/tests/acceptance/CompaniesCest.php
+++ b/tests/acceptance/CompaniesCest.php
@@ -115,11 +115,28 @@ class CompaniesCest
         $I->amOnPage('/s/companies');
         $I->click('//*[@id="companyTable"]/tbody/tr[1]/td[2]/div/a'); // Click on first company to edit
         $I->wait(2);
-        $I->makeScreenshot('edit-company');
         $I->see('Choose one...', '//*[@id="company_owner_chosen"]');
         $I->click('//*[@id="company_owner_chosen"]');
         $I->click('//*[@id="company_owner_chosen"]/div/ul/li[2]'); // Assign an owner
         $I->click('//*[@id="company_buttons_apply_toolbar"]');
         $I->dontSee('Choose one...', '//*[@id="company_owner_chosen"]');
+    }
+
+    public function mergeCompanies(AcceptanceTester $I)
+    {
+        //TODO Could maybe check the number of contacts post-merge is equal to the sum of company 1 & 2
+        $I->amOnPage('/s/companies');
+        $companyName1=$I->grabTextFrom('//*[@id="companyTable"]/tbody/tr[1]/td[2]/div/a'); // Grab name of first company
+        $companyName2=$I->grabTextFrom('//*[@id="companyTable"]/tbody/tr[2]/td[2]/div/a'); // Grab name of second company
+        $I->click('//*[@id="companyTable"]/tbody/tr[1]/td[2]/div/a');
+        $I->waitForElementVisible('//*[@id="company_buttons_merge_toolbar"]', 2);
+        $I->click('//*[@id="company_buttons_merge_toolbar"]');
+        $I->wait(1);
+        $I->click('//*[@id="company_merge_company_to_merge_chosen"]');
+        $I->fillField('//*[@id="company_merge_company_to_merge_chosen"]/div/div/input', "$companyName2");
+        $I->click('//*[@id="company_merge_company_to_merge_chosen"]/div/ul/li');
+        $I->click('//*[@id="MauticSharedModal"]/div/div/div[3]/div/button[2]');
+        $I->wait(2);
+        $I->dontSee("$companyName1");
     }
 }

--- a/tests/acceptance/CompaniesCest.php
+++ b/tests/acceptance/CompaniesCest.php
@@ -1,0 +1,86 @@
+<?php
+
+
+class CompaniesCest
+{
+    public function _before(\Step\Acceptance\Login $I)
+    {
+        $I->loginAsUser(); // Check for existing session or log in
+        $I->amOnPage('/s/dashboard'); // Go to dashboard
+    }
+
+    public function _after(AcceptanceTester $I)
+    {
+    }
+
+    // tests
+    public function createCompany(AcceptanceTester $I)
+    {
+        $I->amOnPage('/s/companies');
+        $I->dontSee('Test Company'); // Check we don't already have a test company present
+        $I->click('//*[@id="toolbar"]/div[1]/a/span/span'); // Click to create new button
+        $I->wait(2);
+        $I->fillField('//*[@id="company_companyname"]', 'Test Company');
+        $I->fillField('//*[@id="company_companyemail"]', 'test@example.com');
+        $I->fillField('//*[@id="company_companyaddress1"]', 'Address 1');
+        $I->fillField('//*[@id="company_companyaddress2"]', 'Address 2');
+        $I->fillField('//*[@id="company_companycity"]', 'City');
+        $I->click('//*[@id="company_companystate_chosen"]'); // Click to show dropdown
+        $I->fillField('//*[@id="company_companystate_chosen"]/div/div/input', 'California'); //Enter state
+        $I->click('//*[@id="company_companystate_chosen"]/div/ul/li[2]'); // Select state
+        $I->fillField('//*[@id="company_companyzipcode"]', 'CA12345');
+        $I->click('//*[@id="company_companycountry_chosen"]');
+        $I->fillField('//*[@id="company_companycountry_chosen"]/div/div/input', 'United States');
+        $I->click('//*[@id="company_companycountry_chosen"]/div/ul/li');
+        $I->fillField('//*[@id="company_companyphone"]', '+12345678901');
+        $I->fillField('//*[@id="company_companywebsite"]', 'https://www.mautic.com');
+        $I->click('//*[@id="company_owner_chosen"]');
+        $I->click('//*[@id="company_owner_chosen"]/div/ul/li[2]');
+        $I->click('//*[@id="app-content"]/div/form/div[1]/div[1]/div/ul/li[2]/a'); // Click to add professional fields
+        $I->fillField('//*[@id="company_companynumber_of_employees"]', '599');
+        $I->fillField('//*[@id="company_companyfax"]', '+12345678901');
+        $I->fillField('//*[@id="company_companyannual_revenue"]', '1500000'); // Must be a numerical field with no commas
+        $I->click('//*[@id="company_companyindustry_chosen"]');
+        $I->fillField('//*[@id="company_companyindustry_chosen"]/div/div/input', 'Communications');
+        $I->click('//*[@id="company_companyindustry_chosen"]/div/ul/li[1]/em');
+        $I->fillField('//*[@id="company_companydescription"]', 'A test company');
+        $I->click('//*[@id="company_buttons_save_toolbar"]'); // Save company
+        $I->wait(2);
+        $I->see('Test Company'); // Check we see test company in the companies list
+    }
+
+    public function editCompany(AcceptanceTester $I)
+    {
+        $I->amOnPage('/s/companies');
+        $I->dontSee('Amazon Test'); // Check we haven't already run this test
+        $I->click('//*[@id="companyTable"]/tbody/tr[1]/td[2]/div/a'); // Click on first company to edit
+        $I->wait(2);
+        $I->fillField('//*[@id="company_companyname"]', 'Amazon Test');
+        $I->fillField('//*[@id="company_companyemail"]', 'test@example.com');
+        $I->fillField('//*[@id="company_companyaddress1"]', 'Address 1');
+        $I->fillField('//*[@id="company_companyaddress2"]', 'Address 2');
+        $I->fillField('//*[@id="company_companycity"]', 'City');
+        $I->click('//*[@id="company_companystate_chosen"]'); // Click to show dropdown
+        $I->fillField('//*[@id="company_companystate_chosen"]/div/div/input', 'California'); //Enter state
+        $I->click('//*[@id="company_companystate_chosen"]/div/ul/li[2]'); // Select state
+        $I->fillField('//*[@id="company_companyzipcode"]', 'CA12345');
+        $I->click('//*[@id="company_companycountry_chosen"]');
+        $I->fillField('//*[@id="company_companycountry_chosen"]/div/div/input', 'United States');
+        $I->click('//*[@id="company_companycountry_chosen"]/div/ul/li');
+        $I->fillField('//*[@id="company_companyphone"]', '+12345678901');
+        $I->fillField('//*[@id="company_companywebsite"]', 'https://www.mautic.com');
+        $I->click('//*[@id="company_owner_chosen"]');
+        $I->click('//*[@id="company_owner_chosen"]/div/ul/li[2]');
+        $I->click('//*[@id="app-content"]/div/form/div[1]/div[1]/div/ul/li[2]/a'); // Click to add professional fields
+        $I->fillField('//*[@id="company_companynumber_of_employees"]', '599');
+        $I->fillField('//*[@id="company_companyfax"]', '+12345678901');
+        $I->fillField('//*[@id="company_companyannual_revenue"]', '1500000'); // Must be a numerical field with no commas
+        $I->click('//*[@id="company_companyindustry_chosen"]');
+        $I->fillField('//*[@id="company_companyindustry_chosen"]/div/div/input', 'Communications');
+        $I->click('//*[@id="company_companyindustry_chosen"]/div/ul/li[1]/em');
+        $I->fillField('//*[@id="company_companydescription"]', 'Testing Editing Company');
+        $I->click('//*[@id="company_buttons_save_toolbar"]'); // Save company
+        $I->wait(2);
+        $I->see('Amazon Test');
+    }
+}

--- a/tests/acceptance/CompaniesCest.php
+++ b/tests/acceptance/CompaniesCest.php
@@ -83,4 +83,17 @@ class CompaniesCest
         $I->wait(2);
         $I->see('Amazon Test');
     }
+
+    public function deleteCompanyFromList(AcceptanceTester $I)
+    {
+        $I->amOnPage('/s/companies');
+        $companyName=$I->grabTextFrom('//*[@id="companyTable"]/tbody/tr[1]/td[2]/div/a');
+        $I->see("$companyName");
+        $I->click('//*[@id="companyTable"]/tbody/tr[1]/td[1]/div/div/button/i');
+        $I->click('//*[@id="companyTable"]/tbody/tr[1]/td[1]/div/div/ul/li[3]/a/span/span');
+        $I->waitForElementVisible('/html/body/div[2]/div/div/div[2]/button[2]', 5); // Wait for modal to display
+        $I->click('/html/body/div[2]/div/div/div[2]/button[2]'); // Click delete
+        $I->wait(5);
+        $I->dontSee("$companyName");
+    }
 }


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | x
| Automated tests included? | x
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
We have almost no Codeception acceptance tests that could be run against new releases of Mautic. I've started writing some which we can hopefully use to improve our UAT process.

This PR covers what I believe to be the basic set of tests for Companies. It can probably be improved, optimised and more tests added to make sure we have full coverage of all the possible actions that can be taken against companies, but it's a starting point!

I plan to chip away at creating a basic set of tests for each bundle, and then we can expand on them going forward to add more complexity, refine, and optimise/test cross browser/platform etc with Browserstack. If anyone would like to help with this please ping me on Slack.

A couple of points to add if testing these:

* I had to force Codeception to use max resolution using the following in my acceptance.suite.yml on all environments:
```
actor: AcceptanceTester
modules:
    enabled:
        - WebDriver:
            url: http://local.mauticautomatedtests
            browser: chrome
            window_size: 1920x1080
        - \Helper\Acceptance
```
* On my Mac I had to set an argument of w2c: false per [this StackOverflow post](https://stackoverflow.com/questions/56556709/codeception-undefined-index-element-error/59875669#59875669).

* Depending on the speed of your environment, you may need to tinker with the wait periods. I tried to keep them as low as possible so as not to delay the tests overly, but if you have a slower machine you might find that errors are thrown. If you are seeing errors relating to fields not being visible or editable, throw in an `$I->makeScreenshot('file-name');` directly before the offending line and check the output to see if the field is in the process of being rendered.

* We are using a super outdated version of Codeception so some newer actions (e.g. clearField) are not available. This meant some slightly longer winded tests having to manually clear fields.

I wrote up the steps I followed to [get set up for testing and writing tests with Codeception](https://www.ruthcheesley.co.uk/blog/development/learning-to-write-acceptance-tests-with-codeception) in case it is helpful for anyone who would like to contribute to this going forward.

#### Steps to test this PR:
No testing required on the PR itself, but it would be helpful if some folk could test the acceptance tests and make sure they are correct/working as expected.