### PR TITLE
Fix password reset link

### DIFF
--- a/app/bundles/UserBundle/Controller/PublicController.php
+++ b/app/bundles/UserBundle/Controller/PublicController.php
@@ -42,9 +42,9 @@ class PublicController extends FormController
                 } else {
                     try {
                         $model->sendResetEmail($user);
-                        $this->addFlash('mautic.user.user.notice.passwordreset', [], 'notice', null, false);
+                        $this->addFlash('mautic.user.user.notice.passwordreset');
                     } catch (\Exception $exception) {
-                        $this->addFlash('mautic.user.user.notice.passwordreset.error', [], 'error', null, false);
+                        $this->addFlash('mautic.user.user.notice.passwordreset.error', [], 'error');
                     }
 
                     return $this->redirect($this->generateUrl('login'));
@@ -97,7 +97,7 @@ class PublicController extends FormController
                             $user->setPassword($encodedPassword);
                             $model->saveEntity($user);
 
-                            $this->addFlash('mautic.user.user.notice.passwordreset.success', [], 'notice', null, false);
+                            $this->addFlash('mautic.user.user.notice.passwordreset.success');
 
                             $this->request->getSession()->remove('resetToken');
 
@@ -114,7 +114,7 @@ class PublicController extends FormController
                             ],
                         ]);
                     } else {
-                        $this->addFlash('mautic.user.user.notice.passwordreset.missingtoken', [], 'notice', null, false);
+                        $this->addFlash('mautic.user.user.notice.passwordreset.missingtoken');
 
                         return $this->redirect($this->generateUrl('mautic_user_passwordresetconfirm'));
                     }

--- a/app/bundles/UserBundle/Model/UserModel.php
+++ b/app/bundles/UserBundle/Model/UserModel.php
@@ -23,6 +23,7 @@ use Mautic\UserBundle\Model\UserToken\UserTokenServiceInterface;
 use Mautic\UserBundle\UserEvents;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 
 class UserModel extends FormModel
@@ -292,7 +293,7 @@ class UserModel extends FormModel
             $this->logger->addError($exception->getMessage());
             throw new \RuntimeException();
         }
-        $resetLink  = $this->router->generate('mautic_user_passwordresetconfirm', ['token' => $resetToken->getSecret()], true);
+        $resetLink  = $this->router->generate('mautic_user_passwordresetconfirm', ['token' => $resetToken->getSecret()], UrlGeneratorInterface::ABSOLUTE_URL);
 
         $mailer->setTo([$user->getEmail() => $user->getName()]);
         $mailer->setSubject($this->translator->trans('mautic.user.user.passwordreset.subject'));

--- a/app/bundles/UserBundle/Tests/Model/UserModelTest.php
+++ b/app/bundles/UserBundle/Tests/Model/UserModelTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * @copyright   2020 Mautic, Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\UserBundle\Tests\Model;
+
+use Mautic\EmailBundle\Helper\MailHelper;
+use Mautic\UserBundle\Model\UserModel;
+use Mautic\UserBundle\Model\UserToken\UserTokenServiceInterface;
+use PHPUnit\Framework\TestCase;
+
+class UserModelTest extends TestCase
+{
+    /**
+     * @var UserModel
+     */
+    private $userModel;
+
+    /**
+     * @var MailHelper
+     */
+    private $mailHelper;
+
+    /**
+     * @var UserTokenServiceInterface
+     */
+    private $userTokenServiceInterface;
+
+    public function setUp()
+    {
+        $this->mailHelper = $this->createMock(MailHelper::class);
+        $this->userTokenServiceInterface = $this->createMock(UserTokenServiceInterface::class);
+
+        $this->userModel = new UserModel($this->mailHelper, $this->userTokenServiceInterface);
+    }
+
+    public function
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
When users request a password reset, the link sent in the email is an invalid link.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Send a password reset link to your email.
2. Email link is invalid (relative url).

#### Steps to test this PR:
1. Send a password reset link to your email.
2. Email link is valid (absolute url).