### PR TITLE
Fix the error on report create page.

### DIFF
--- a/app/bundles/ReportBundle/Form/Type/ReportType.php
+++ b/app/bundles/ReportBundle/Form/Type/ReportType.php
@@ -228,9 +228,9 @@ class ReportType extends AbstractType
                     'aggregators',
                     CollectionType::class,
                     [
-                        'type'    => 'aggregator',
-                        'label'   => false,
-                        'options' => [
+                        'entry_type'    => AggregatorType::class,
+                        'label'         => false,
+                        'entry_options' => [
                             'columnList' => $columns->choices,
                             'required'   => false,
                         ],


### PR DESCRIPTION
Fixing https://github.com/mautic/mautic/issues/8713

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N 
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8713
| BC breaks? | N
| Deprecations? | N 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Internal server error on report creation page.
`[2020-04-23 12:34:27] mautic.CRITICAL: Uncaught PHP Exception Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException: "The option "type" does not exist. Defined options are: "action", "allow_add", "allow_delete", "allow_extra_fields", "allow_file_upload", "attr", "auto_initialize", ......`

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to Reports page
2. Try create new Report
3. See error


#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Go to Reports page
3. Try to create a new Report


#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
