### PR TITLE
Ensure that isEnabled is an int when submitting

### DIFF
--- a/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
+++ b/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
@@ -51,7 +51,8 @@ class MessageApiController extends CommonApiController
                         'channel'   => $channelType,
                     ];
                 } else {
-                    $params['channels'][$channelType]['channel'] = $channelType;
+                    $params['channels'][$channelType]['channel']   = $channelType;
+                    $params['channels'][$channelType]['isEnabled'] = (int) $params['channels'][$channelType]['isEnabled'];
                 }
             }
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | API Library unit tests
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | N/A
| BC breaks? | No
| Deprecations? | No

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

When updating the mautic api library for 3.x and changing to json_encode instead of http_build_query, the messages tests starting failing, it was more due to an issue here in Mautic with the isEnabled value not being an int