### PR TITLE
Update the group field html to display input outside label tag.

### DIFF
--- a/app/bundles/FormBundle/Views/Field/group.html.php
+++ b/app/bundles/FormBundle/Views/Field/group.html.php
@@ -52,10 +52,8 @@ $checkboxBrackets = ('checkbox' == $type) ? '[]' : '';
 
 $option = <<<HTML
 
-                    <label id="mauticform_{$containerType}_label_{$id}" for="mauticform_{$containerType}_{$type}_{$id}" {$optionLabelAttr}>
-                        <input {$inputAttr}{$checked} name="mauticform[{$field['alias']}]{$checkboxBrackets}" id="mauticform_{$containerType}_{$type}_{$id}" type="{$type}" value="{$view->escape($listValue)}" />
-                        $listLabel
-                    </label>
+                    <label id="mauticform_{$containerType}_label_{$id}" for="mauticform_{$containerType}_{$type}_{$id}" {$optionLabelAttr}>$listLabel</label>
+                    <input {$inputAttr}{$checked} name="mauticform[{$field['alias']}]{$checkboxBrackets}" id="mauticform_{$containerType}_{$type}_{$id}" type="{$type}" value="{$view->escape($listValue)}" />
 HTML;
 
 if ($wrapDiv):


### PR DESCRIPTION
Closes https://github.com/mautic/mautic/issues/8724

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8724
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Create a radio/checkbox group
2. View the HTML that is output when rendering the form

#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Create the form and add checkbox group.
3. Check the generated HTML format using inspect element.

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
