### PR TITLE
Remove the Region dropdown and make it a text box

### DIFF
--- a/app/bundles/EmailBundle/Form/Type/ConfigType.php
+++ b/app/bundles/EmailBundle/Form/Type/ConfigType.php
@@ -329,7 +329,7 @@ class ConfigType extends AbstractType
                     'data-show-on' => '{"config_emailconfig_mailer_transport":['.$this->transportType->getAmazonService().']}',
                     'tooltip'      => 'mautic.email.config.mailer.amazon_host.tooltip',
                     'onchange'     => 'Mautic.disableSendTestEmailButton()',
-                ]
+                ],
             ]
         );
 

--- a/app/bundles/EmailBundle/Form/Type/ConfigType.php
+++ b/app/bundles/EmailBundle/Form/Type/ConfigType.php
@@ -319,22 +319,17 @@ class ConfigType extends AbstractType
 
         $builder->add(
             'mailer_amazon_region',
-            'choice',
+            'text',
             [
-                'choices'     => [
-                    'email-smtp.eu-west-1.amazonaws.com' => 'mautic.email.config.mailer.amazon_host.eu_west_1',
-                    'email-smtp.us-east-1.amazonaws.com' => 'mautic.email.config.mailer.amazon_host.us_east_1',
-                    'email-smtp.us-west-2.amazonaws.com' => 'mautic.email.config.mailer.amazon_host.eu_west_2',
-                ],
                 'label'       => 'mautic.email.config.mailer.amazon_host',
+                'label_attr'  => ['class' => 'control-label'],
                 'required'    => false,
                 'attr'        => [
                     'class'        => 'form-control',
                     'data-show-on' => '{"config_emailconfig_mailer_transport":['.$this->transportType->getAmazonService().']}',
                     'tooltip'      => 'mautic.email.config.mailer.amazon_host.tooltip',
                     'onchange'     => 'Mautic.disableSendTestEmailButton()',
-                ],
-                'empty_value' => false,
+                ]
             ]
         );
 


### PR DESCRIPTION
Multiple regions are being added to SES. Makes more sense to allow users to enter their region manually. Currently there is only the option of 3 out of the 11 available. I've made this a text box, tested connection and sent a test email. All worked without issue.

https://github.com/mautic/mautic/issues/8118


| Q  | A
| --- | ---
| Bug fix? | No
| New feature? | No 
| Automated tests included? | No
| Related user documentation PR URL |  None
| Related developer documentation PR URL | None
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8118
| BC breaks? | None
| Deprecations? | None

#### Description:
Allow the user to enter teh SMTP address of the Amazon SES service. Currently there is a dropdown with 3 listed, when there are 11 in total currently. Switching to a text input allows for the user to enter their region given by Amazon and will make it easier when Amazon add new regions in the future.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Enter a SES region and click on "Test Connection" then "Test Email". Then Send a test campaign email. All seem to work as before.