### PR TITLE
Fix report time frame

### DIFF
--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -515,11 +515,6 @@ class ReportModel extends FormModel
                 $options['dateTo'] = new \DateTime();
             }
 
-            // Fix the time frames
-            if ($options['dateFrom'] == $options['dateTo']) {
-                $options['dateTo']->modify('+1 day');
-            }
-
             // Adjust dateTo to be end of day or to current hour if today
             $now = new \DateTime();
             if ($now->format('Y-m-d') == $options['dateTo']->format('Y-m-d')) {

--- a/app/bundles/ReportBundle/Views/Report/details_data.html.php
+++ b/app/bundles/ReportBundle/Views/Report/details_data.html.php
@@ -130,16 +130,18 @@ $graphContent = $view->render(
                                                 }
                                                 ?>
                                                 <?php
-                                                switch ($cellType) {
-                                                    case 'datetime':
-                                                        echo $view['date']->toFullConcat($cellVal, 'UTC');
-                                                        break;
-                                                    case 'date':
-                                                        echo $view['date']->toShort($cellVal, 'UTC');
-                                                        break;
-                                                    default:
-                                                        echo $view['formatter']->_($cellVal, $cellType);
-                                                        break;
+                                                if ($cellVal) {
+                                                    switch ($cellType) {
+                                                        case 'datetime':
+                                                            echo $view['date']->toFullConcat($cellVal, 'UTC');
+                                                            break;
+                                                        case 'date':
+                                                            echo $view['date']->toShort($cellVal, 'UTC');
+                                                            break;
+                                                        default:
+                                                            echo $view['formatter']->_($cellVal, $cellType);
+                                                            break;
+                                                    }
                                                 }
                                                 ?>
                                                 <?php if ($closeLink): ?></a><?php endif; ?>

--- a/app/bundles/ReportBundle/Views/Report/details_data.html.php
+++ b/app/bundles/ReportBundle/Views/Report/details_data.html.php
@@ -129,7 +129,19 @@ $graphContent = $view->render(
                                                     $cellType = 'date';
                                                 }
                                                 ?>
-                                                <?php echo $view['formatter']->_($cellVal, $cellType); ?>
+                                                <?php
+                                                switch ($cellType) {
+                                                    case 'datetime':
+                                                        echo $view['date']->toFullConcat($cellVal, 'UTC');
+                                                        break;
+                                                    case 'date':
+                                                        echo $view['date']->toShort($cellVal, 'UTC');
+                                                        break;
+                                                    default:
+                                                        echo $view['formatter']->_($cellVal, $cellType);
+                                                        break;
+                                                }
+                                                ?>
                                                 <?php if ($closeLink): ?></a><?php endif; ?>
                                         </td>
                                     <?php endif; ?>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Noticed wrong time frame for reports and wrong date time format.


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Set default timezone in configuration to Paris
1. Create two contacts with Date added date  during 2 days (26.4.2020 7:00:00 and 27.4.2020 7:00:00  for example) and Last Active date with same date as Date added (modify by mysql)
2. Then create report for contacts with column ID and Last Active date.
3. Go to report and filter 26.4.2020 to 26.4.2020
4. You should see both contacts, but expect just one of them
5. Also check date in column list - you should see 26.4.2020 5:00:00, expect 26.4.2020 7:00:00

#### Steps to test this PR:
1. This PR is not able to test by Mautibox, because require this PR https://github.com/mautic/mautic/pull/7752
2. Apply this PR and repeat all steps
3. You should see correct filter data and correct date time in column list
