### PR TITLE
Deleting mapped objects

### DIFF
--- a/app/bundles/IntegrationsBundle/Config/config.php
+++ b/app/bundles/IntegrationsBundle/Config/config.php
@@ -56,6 +56,7 @@ return [
                 'class'     => \Mautic\IntegrationsBundle\EventListener\LeadSubscriber::class,
                 'arguments' => [
                     'mautic.integrations.repository.field_change',
+                    'mautic.integrations.repository.object_mapping',
                     'mautic.integrations.helper.variable_expresser',
                     'mautic.integrations.helper.sync_integrations',
                 ],

--- a/app/bundles/IntegrationsBundle/Entity/ObjectMappingRepository.php
+++ b/app/bundles/IntegrationsBundle/Entity/ObjectMappingRepository.php
@@ -145,6 +145,17 @@ class ObjectMappingRepository extends CommonRepository
         return $qb->execute();
     }
 
+    public function deleteEntitiesForObject(int $internalObjectId, string $internalObject): void
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $qb->delete(ObjectMapping::class, 'm');
+        $qb->where('m.internalObjectName = :internalObject');
+        $qb->andWhere('m.internalObjectId = :internalObjectId');
+        $qb->setParameter('internalObject', $internalObject);
+        $qb->setParameter('internalObjectId', $internalObjectId);
+        $qb->getQuery()->execute();
+    }
+
     /**
      * @return ObjectMapping[]
      */

--- a/app/bundles/IntegrationsBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/LeadSubscriber.php
@@ -15,6 +15,7 @@ namespace Mautic\IntegrationsBundle\EventListener;
 
 use Mautic\IntegrationsBundle\Entity\FieldChange;
 use Mautic\IntegrationsBundle\Entity\FieldChangeRepository;
+use Mautic\IntegrationsBundle\Entity\ObjectMappingRepository;
 use Mautic\IntegrationsBundle\Exception\IntegrationNotFoundException;
 use Mautic\IntegrationsBundle\Helper\SyncIntegrationsHelper;
 use Mautic\IntegrationsBundle\Sync\Exception\ObjectNotFoundException;
@@ -35,6 +36,11 @@ class LeadSubscriber implements EventSubscriberInterface
     private $fieldChangeRepo;
 
     /**
+     * @var ObjectMappingRepository
+     */
+    private $objectMappingRepository;
+
+    /**
      * @var VariableExpresserHelperInterface
      */
     private $variableExpressor;
@@ -46,12 +52,14 @@ class LeadSubscriber implements EventSubscriberInterface
 
     public function __construct(
         FieldChangeRepository $fieldChangeRepo,
+        ObjectMappingRepository $objectMappingRepository,
         VariableExpresserHelperInterface $variableExpressor,
         SyncIntegrationsHelper $syncIntegrationsHelper
     ) {
-        $this->fieldChangeRepo        = $fieldChangeRepo;
-        $this->variableExpressor      = $variableExpressor;
-        $this->syncIntegrationsHelper = $syncIntegrationsHelper;
+        $this->fieldChangeRepo         = $fieldChangeRepo;
+        $this->objectMappingRepository = $objectMappingRepository;
+        $this->variableExpressor       = $variableExpressor;
+        $this->syncIntegrationsHelper  = $syncIntegrationsHelper;
     }
 
     public static function getSubscribedEvents(): array
@@ -119,6 +127,7 @@ class LeadSubscriber implements EventSubscriberInterface
     public function onLeadPostDelete(Events\LeadEvent $event): void
     {
         $this->fieldChangeRepo->deleteEntitiesForObject((int) $event->getLead()->deletedId, MauticSyncDataExchange::OBJECT_CONTACT);
+        $this->objectMappingRepository->deleteEntitiesForObject((int) $event->getLead()->deletedId, MauticSyncDataExchange::OBJECT_CONTACT);
     }
 
     /**
@@ -155,6 +164,7 @@ class LeadSubscriber implements EventSubscriberInterface
     public function onCompanyPostDelete(Events\CompanyEvent $event): void
     {
         $this->fieldChangeRepo->deleteEntitiesForObject((int) $event->getCompany()->deletedId, MauticSyncDataExchange::OBJECT_COMPANY);
+        $this->objectMappingRepository->deleteEntitiesForObject((int) $event->getCompany()->deletedId, MauticSyncDataExchange::OBJECT_COMPANY);
     }
 
     public function onLeadCompanyChange(Events\LeadChangeCompanyEvent $event): void

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Entity/ObjectMappingRepositoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Entity/ObjectMappingRepositoryTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\IntegrationsBundle\Tests\Unit\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\NoResultException;
+use Doctrine\ORM\QueryBuilder;
+use Mautic\IntegrationsBundle\Entity\ObjectMappingRepository;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class ObjectMappingRepositoryTest extends TestCase
+{
+    /**
+     * @var MockObject|EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var MockObject|ClassMetadata
+     */
+    private $classMetadata;
+
+    /**
+     * @var MockObject|AbstractQuery
+     */
+    private $query;
+
+    /**
+     * @var MockObject|QueryBuilder
+     */
+    private $queryBuilder;
+
+    /**
+     * @var ObjectMappingRepository
+     */
+    private $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        defined('MAUTIC_TABLE_PREFIX') || define('MAUTIC_TABLE_PREFIX', getenv('MAUTIC_DB_PREFIX') ?: '');
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->classMetadata = $this->createMock(ClassMetadata::class);
+        $this->queryBuilder  = new QueryBuilder($this->entityManager);
+        $this->repository    = new ObjectMappingRepository($this->entityManager, $this->classMetadata);
+
+        // This is terrible, but the Query class is final and AbstractQuery doesn't have some methods used.
+        $this->query = $this->getMockBuilder(AbstractQuery::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['setParameters', 'setFirstResult', 'setMaxResults', 'getSingleResult', 'getSQL', '_doExecute'])
+            ->getMock();
+
+        $this->entityManager->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturn($this->queryBuilder);
+
+        $this->query->expects($this->once())
+            ->method('setFirstResult')
+            ->willReturnSelf();
+
+        $this->query->expects($this->once())
+            ->method('setMaxResults')
+            ->willReturnSelf();
+    }
+
+    public function testDeleteEntitiesForObject(): void
+    {
+        $this->entityManager->expects($this->once())
+            ->method('createQuery')
+            ->with('DELETE Mautic\IntegrationsBundle\Entity\ObjectMapping m WHERE m.internalObjectName = :internalObject AND m.internalObjectId = :internalObjectId')
+            ->willReturn($this->query);
+
+        $this->query->expects($this->once())
+            ->method('setParameters')
+            ->with($this->callback(function (ArrayCollection $collection) {
+                /** @var Parameter $parameter */
+                $parameter = $collection[0];
+                $this->assertSame('internalObject', $parameter->getName());
+                $this->assertSame('company', $parameter->getValue());
+
+                /** @var Parameter $parameter */
+                $parameter = $collection[1];
+                $this->assertSame('internalObjectId', $parameter->getName());
+                $this->assertSame(123, $parameter->getValue());
+
+                return true;
+            }))
+            ->willReturnSelf();
+
+        // Stopping early to avoid Mocking hell. We have what we needed.
+        $this->query->expects($this->once())
+            ->method('_doExecute')
+            ->willReturn(0);
+
+        $this->repository->deleteEntitiesForObject(123, 'company');
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

We were deleting contacts and companies from the `mautic_sync_object_field_change_report` table, but we need to do the same also for `mautic_sync_object_mapping`

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. If you don't have any rows in the `mautic_sync_object_mapping` then you will have to configure some integration built on the IntegrationsBundle and sync some contacts and companies.
2. Delete a contact/company that is mapped in the table in Mautic.
- Check that the row in the table still exists.

#### Steps to test this PR:
1. Delete another company/contact
2. The row in the `mautic_sync_object_mapping` table was deleted too.
