### PR TITLE
Go to webinar fixes

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadList.php
+++ b/app/bundles/LeadBundle/Entity/LeadList.php
@@ -219,6 +219,10 @@ class LeadList extends FormEntity
      */
     public function getFilters()
     {
+        if (is_array($this->filters)) {
+            return $this->addLegacyParams($this->filters);
+        }
+
         return $this->filters;
     }
 
@@ -320,5 +324,24 @@ class LeadList extends FormEntity
     {
         $this->isChanged('isPreferenceCenter', $isPreferenceCenter);
         $this->isPreferenceCenter = $isPreferenceCenter;
+    }
+
+    /**
+     * @deprecated remove after several of years.
+     *
+     * This is needed go keep BC after we moved 'filter' and 'display' params
+     * to the 'properties' array.
+     */
+    private function addLegacyParams(array $filters): array
+    {
+        return array_map(
+            function (array $filter) {
+                $filter['filter'] = $filter['properties']['filter'] ?? $filter['filter'];
+                $filter['display'] = $filter['properties']['display'] ?? $filter['display'];
+
+                return $filter;
+            },
+            $filters
+        );
     }
 }

--- a/app/bundles/LeadBundle/Entity/LeadList.php
+++ b/app/bundles/LeadBundle/Entity/LeadList.php
@@ -336,8 +336,8 @@ class LeadList extends FormEntity
     {
         return array_map(
             function (array $filter) {
-                $filter['filter'] = $filter['properties']['filter'] ?? $filter['filter'];
-                $filter['display'] = $filter['properties']['display'] ?? $filter['display'];
+                $filter['filter'] = $filter['properties']['filter'] ?? $filter['filter'] ?? null;
+                $filter['display'] = $filter['properties']['display'] ?? $filter['display'] ?? null;
 
                 return $filter;
             },

--- a/app/bundles/LeadBundle/Tests/Entity/LeadListTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadListTest.php
@@ -74,6 +74,16 @@ final class LeadListTest extends \PHPUnit\Framework\TestCase
                         'filter'  => '4',
                     ],
                 ],
+                [
+                    'object'     => 'lead',
+                    'glue'       => 'and',
+                    'field'      => 'city',
+                    'type'       => 'text',
+                    'operator'   => '=',
+                    'properties' => [
+                        'filter'  => 'Prague',
+                    ],
+                ],
             ]
         );
 
@@ -91,6 +101,18 @@ final class LeadListTest extends \PHPUnit\Framework\TestCase
                     ],
                     'filter'  => '4',
                     'display' => 'John Doe',
+                ],
+                [
+                    'object'     => 'lead',
+                    'glue'       => 'and',
+                    'field'      => 'city',
+                    'type'       => 'text',
+                    'operator'   => '=',
+                    'properties' => [
+                        'filter'  => 'Prague',
+                    ],
+                    'filter'  => 'Prague',
+                    'display' => null,
                 ],
             ],
             $entity->getFilters()

--- a/app/bundles/LeadBundle/Tests/Entity/LeadListTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadListTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Entity;
+
+use Mautic\LeadBundle\Entity\LeadList;
+
+final class LeadListTest extends \PHPUnit\Framework\TestCase
+{
+    public function testAddLegacyParamsWithEmptyFilters(): void
+    {
+        $entity = new LeadList();
+        $this->assertSame([], $entity->getFilters());
+    }
+
+    public function testAddLegacyParamsWithLegacyFilters(): void
+    {
+        $entity = new LeadList();
+
+        $entity->setFilters(
+            [
+                [
+                    'object'   => 'lead',
+                    'glue'     => 'and',
+                    'field'    => 'owner_id',
+                    'type'     => 'lookup_id',
+                    'operator' => '=',
+                    'display'  => 'John Doe',
+                    'filter'   => '4',
+                ],
+            ]
+        );
+
+        $this->assertSame(
+            [
+                [
+                    'object'   => 'lead',
+                    'glue'     => 'and',
+                    'field'    => 'owner_id',
+                    'type'     => 'lookup_id',
+                    'operator' => '=',
+                    'display'  => 'John Doe',
+                    'filter'   => '4',
+                ],
+            ],
+            $entity->getFilters()
+        );
+    }
+
+    public function testAddLegacyParamsWithNewFilters(): void
+    {
+        $entity = new LeadList();
+
+        $entity->setFilters(
+            [
+                [
+                    'object'     => 'lead',
+                    'glue'       => 'and',
+                    'field'      => 'owner_id',
+                    'type'       => 'lookup_id',
+                    'operator'   => '=',
+                    'properties' => [
+                        'display' => 'John Doe',
+                        'filter'  => '4',
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertSame(
+            [
+                [
+                    'object'     => 'lead',
+                    'glue'       => 'and',
+                    'field'      => 'owner_id',
+                    'type'       => 'lookup_id',
+                    'operator'   => '=',
+                    'properties' => [
+                        'display' => 'John Doe',
+                        'filter'  => '4',
+                    ],
+                    'filter'  => '4',
+                    'display' => 'John Doe',
+                ],
+            ],
+            $entity->getFilters()
+        );
+    }
+
+    public function testAddLegacyParamsWithHybridFilters(): void
+    {
+        $entity = new LeadList();
+
+        $entity->setFilters(
+            [
+                [
+                    'object'     => 'lead',
+                    'glue'       => 'and',
+                    'field'      => 'owner_id',
+                    'type'       => 'lookup_id',
+                    'operator'   => '=',
+                    'filter'     => 'outdated_id',
+                    'display'    => 'Outdated Name',
+                    'properties' => [
+                        'display' => 'John Doe',
+                        'filter'  => '4',
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertSame(
+            [
+                [
+                    'object'     => 'lead',
+                    'glue'       => 'and',
+                    'field'      => 'owner_id',
+                    'type'       => 'lookup_id',
+                    'operator'   => '=',
+                    'filter'     => '4',
+                    'display'    => 'John Doe',
+                    'properties' => [
+                        'display' => 'John Doe',
+                        'filter'  => '4',
+                    ],
+                ],
+            ],
+            $entity->getFilters()
+        );
+    }
+}

--- a/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
+++ b/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
@@ -172,8 +172,8 @@ class LeadSubscriber implements EventSubscriberInterface
                             'list' => array_flip($eventNamesWithAny),
                         ],
                         'operators' => [
-                            'in'  => $this->translator->trans('mautic.core.operator.in'),
-                            '!in' => $this->translator->trans('mautic.core.operator.notin'),
+                            $this->translator->trans('mautic.core.operator.in')    => 'in',
+                            $this->translator->trans('mautic.core.operator.notin') => '!in',
                         ],
                     ]
                 );
@@ -189,8 +189,8 @@ class LeadSubscriber implements EventSubscriberInterface
                         'list' => array_flip($eventNamesWithAny),
                     ],
                     'operators' => [
-                        'in'  => $this->translator->trans('mautic.core.operator.in'),
-                        '!in' => $this->translator->trans('mautic.core.operator.notin'),
+                        $this->translator->trans('mautic.core.operator.in')    => 'in',
+                        $this->translator->trans('mautic.core.operator.notin') => '!in',
                     ],
                 ]
             );
@@ -205,7 +205,7 @@ class LeadSubscriber implements EventSubscriberInterface
                         'list' => array_flip($eventNamesWithoutAny),
                     ],
                     'operators' => [
-                        'in' => $this->translator->trans('mautic.core.operator.in'),
+                        $this->translator->trans('mautic.core.operator.in') => 'in',
                     ],
                 ]
             );

--- a/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
+++ b/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
@@ -237,11 +237,7 @@ class LeadSubscriber implements EventSubscriberInterface
             $eventFilters = [$product.'-registration', $product.'-attendance', $product.'-no-attendance'];
 
             if (in_array($currentFilter, $eventFilters, true)) {
-                if (array_key_exists('filter', $details)) {
-                    $eventNames = $details['filter'];
-                } else {
-                    $eventNames = $details['properties']['filter'];
-                }
+                $eventNames = $details['filter'];
                 if (!is_iterable($eventNames)) {
                     $eventNames = [$eventNames];
                 }

--- a/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
+++ b/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
@@ -169,7 +169,7 @@ class LeadSubscriber implements EventSubscriberInterface
                         'label'      => $this->translator->trans('plugin.citrix.event.'.$product.'.registration'),
                         'properties' => [
                             'type' => 'select',
-                            'list' => $eventNamesWithAny,
+                            'list' => array_flip($eventNamesWithAny),
                         ],
                         'operators' => [
                             'in'  => $this->translator->trans('mautic.core.operator.in'),
@@ -186,7 +186,7 @@ class LeadSubscriber implements EventSubscriberInterface
                     'label'      => $this->translator->trans('plugin.citrix.event.'.$product.'.attendance'),
                     'properties' => [
                         'type' => 'select',
-                        'list' => $eventNamesWithAny,
+                        'list' => array_flip($eventNamesWithAny),
                     ],
                     'operators' => [
                         'in'  => $this->translator->trans('mautic.core.operator.in'),
@@ -202,7 +202,7 @@ class LeadSubscriber implements EventSubscriberInterface
                     'label'      => $this->translator->trans('plugin.citrix.event.'.$product.'.no.attendance'),
                     'properties' => [
                         'type' => 'select',
-                        'list' => $eventNamesWithoutAny,
+                        'list' => array_flip($eventNamesWithoutAny),
                     ],
                     'operators' => [
                         'in' => $this->translator->trans('mautic.core.operator.in'),
@@ -237,7 +237,14 @@ class LeadSubscriber implements EventSubscriberInterface
             $eventFilters = [$product.'-registration', $product.'-attendance', $product.'-no-attendance'];
 
             if (in_array($currentFilter, $eventFilters, true)) {
-                $eventNames = $details['filter'];
+                if (array_key_exists('filter', $details)) {
+                    $eventNames = $details['filter'];
+                } else {
+                    $eventNames = $details['properties']['filter'];
+                }
+                if (!is_iterable($eventNames)) {
+                    $eventNames = [$eventNames];
+                }
                 $isAnyEvent = in_array('any', $eventNames, true);
                 $eventNames = array_map(function ($v) use ($q) {
                     return $q->expr()->literal($v);

--- a/plugins/MauticCitrixBundle/Form/Type/CitrixCampaignActionType.php
+++ b/plugins/MauticCitrixBundle/Form/Type/CitrixCampaignActionType.php
@@ -75,7 +75,7 @@ class CitrixCampaignActionType extends AbstractType
             ChoiceType::class,
             [
                 'label'   => $this->translator->trans('plugin.citrix.action.criteria'),
-                'choices' => $newChoices,
+                'choices' => array_flip($newChoices),
             ]
         );
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Several flip arrays. Segment update with Webinar does not work.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to Segment.
2. Turn on GoToWebinar Plugin
3. Register some emails from Mautic contacts to webinars
4. Filter by Webinar registered
5. You should see flipped keys values for webinar, choose one and save it
6. The segment update does not work: mautic:segments:update 
7. The key values are also flipped in the campaign GoToWebinar action

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Turn on GoToWebinar Plugin
3. Register some emails from Mautic contacts to webinars
4. Filter by Webinar registered
5. You should see the webinar names, choose one and save it
6. The segment update works well: mautic:segments:update 
7. The key values are OK in the campaign GoToWebinar action


#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
