### PR TITLE
Fixing "[WARNING] Some commands could not be registered." warning.

### DIFF
--- a/app/bundles/CoreBundle/Command/ApplyUpdatesCommand.php
+++ b/app/bundles/CoreBundle/Command/ApplyUpdatesCommand.php
@@ -14,7 +14,6 @@ namespace Mautic\CoreBundle\Command;
 use Mautic\CoreBundle\Exception\UpdateFailedException;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\ProgressBarHelper;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\CoreBundle\Update\StepProvider;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -23,6 +22,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * CLI Command to update the application.
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 class ApplyUpdatesCommand extends ContainerAwareCommand
 {
     /**
-     * @var Translator
+     * @var TranslatorInterface
      */
     private $translator;
 
@@ -59,7 +59,7 @@ class ApplyUpdatesCommand extends ContainerAwareCommand
      */
     private $progressBar;
 
-    public function __construct(Translator $translator, CoreParametersHelper $coreParametersHelper, StepProvider $stepProvider)
+    public function __construct(TranslatorInterface $translator, CoreParametersHelper $coreParametersHelper, StepProvider $stepProvider)
     {
         parent::__construct();
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _3.x_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | :white_check_mark: 
| New feature? | 
| Automated tests included? | 
| Related user documentation PR URL |  
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
The _Updates the Mautic applications_ command has detected the wrong instance of the argument passed. When executing cache:clear on terminal it show following warning message
```                                                                                                                        
 [WARNING] Some commands could not be registered:                                                                       
                                                                                                                        
In ApplyUpdatesCommand.php line 62:
                                                                                                                                                                                                                                                               
  Type error: Argument 1 passed to Mautic\CoreBundle\Command\ApplyUpdatesCommand::__construct() must be an instance of Mautic\CoreBundle\Translation\Translator, instance of Symfony\Component\Translation\DataCollectorTranslator given, called in /app/var/  
  cache/dev/ContainerLoewrrt/getMautic_Core_Command_ApplyUpdateService.php on line 8 
```

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. On the terminal, navigate to the root directory of Mautic 
2. Clear the cache by running `php bin/console cache:clear` command

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
