### PR TITLE
Remove logging of extraneous schema error during install.

### DIFF
--- a/app/bundles/LeadBundle/EventListener/DoctrineSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/DoctrineSubscriber.php
@@ -118,6 +118,9 @@ class DoctrineSubscriber implements \Doctrine\Common\EventSubscriber
                 }
             }
         } catch (\Exception $e) {
+            if (defined('MAUTIC_INSTALLER')) {
+                return;
+            }
             //table doesn't exist or something bad happened so oh well
             $this->logger->addError('SCHEMA ERROR: '.$e->getMessage());
         }


### PR DESCRIPTION
closes https://github.com/mautic/mautic/issues/3436

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | /
| Related user documentation PR URL |  / 
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/3436
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )
Fixes issue where error is logged during installation when no error condition exists.

> mautic.ERROR: SCHEMA ERROR: An exception occurred while executing 'SELECT f.alias, f.is_unique_identifer as is_unique, f.type, f.object FROM mau_lead_fields f WHERE f.object = 'lead' ORDER BY f.field_order ASC': SQLSTATE[42S02]: Base table or view not found: 1146 Table 'local-mautictest.mau_lead_fields' doesn't exist


[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Install Mautic
2. Observe error in log

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Install Mautic
3. Observe error no longer appears in the log
