### PR TITLE
M3 changed to flush queue before cc and bcc are cleared

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1788,9 +1788,11 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
     /**
      * Get line chart data of emails sent and read.
      *
-     * @param char   $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
-     * @param string $dateFormat
-     * @param bool   $canViewOthers
+     * @param          $reason
+     * @param          $canViewOthers
+     * @param int|null $companyId
+     * @param int|null $campaignId
+     * @param int|null $segmentId
      *
      * @return array
      */

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1564,26 +1564,23 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
 
             if (!$mailer->addTo($toAddress)) {
                 $errors[] = "{$toAddress}: ".$this->translator->trans('mautic.email.bounce.reason.bad_email');
-            } else {
-                if (!$mailer->queue(true)) {
-                    $errorArray = $mailer->getErrors();
-                    unset($errorArray['failures']);
-                    $errors[] = "{$toAddress}: ".implode('; ', $errorArray);
-                }
+                continue;
+            }
 
-                if ($saveStat) {
-                    $saveEntities[] = $mailer->createEmailStat(false, $toAddress);
-                }
+            if (!$mailer->queue(true)) {
+                $errorArray = $mailer->getErrors();
+                unset($errorArray['failures']);
+                $errors[] = "{$toAddress}: ".implode('; ', $errorArray);
+            }
 
-                // If this is the first message, flush the queue before we clear the cc and bcc
-                if ($firstMail) {
-                    $errors[]  = $this->flushQueue($mailer);
-                    $firstMail = false;
-                }
+            if ($saveStat) {
+                $saveEntities[] = $mailer->createEmailStat(false, $toAddress);
+            }
 
-                // Clear CC and BCC to do not duplicate the send several times
-                $mailer->setCc([]);
-                $mailer->setBcc([]);
+            // If this is the first message, flush the queue. This process clears the cc and bcc.
+            if (true === $firstMail) {
+                $errors[]  = $this->flushQueue($mailer);
+                $firstMail = false;
             }
         }
 
@@ -1612,20 +1609,23 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
 
             if (!$mailer->setTo($user['email'], $user['firstname'].' '.$user['lastname'])) {
                 $errors[] = "{$user['email']}: ".$this->translator->trans('mautic.email.bounce.reason.bad_email');
-            } else {
-                if (!$mailer->queue(true)) {
-                    $errorArray = $mailer->getErrors();
-                    unset($errorArray['failures']);
-                    $errors[] = "{$user['email']}: ".implode('; ', $errorArray);
-                }
+                continue;
+            }
 
-                if ($saveStat) {
-                    $saveEntities[] = $mailer->createEmailStat(false, $user['email']);
-                }
+            if (!$mailer->queue(true)) {
+                $errorArray = $mailer->getErrors();
+                unset($errorArray['failures']);
+                $errors[] = "{$user['email']}: ".implode('; ', $errorArray);
+            }
 
-                // Clear CC and BCC to do not duplicate the send several times
-                $mailer->setCc([]);
-                $mailer->setBcc([]);
+            if ($saveStat) {
+                $saveEntities[] = $mailer->createEmailStat(false, $user['email']);
+            }
+
+            // If this is the first message, flush the queue. This process clears the cc and bcc.
+            if (true === $firstMail) {
+                $this->flushQueue($mailer);
+                $firstMail = false;
             }
         }
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
Fixing bug where cc and bcc emails are not sent from the Send to User campaign action. This is required for fixing the Selenium tests. We also want to avoid regressing the bug where the cc and bcc emails could get sent multiple times if there is more than one email in the 'To' field.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a campaign with action 'Send Email to User'
2. In the action, add 2 unique emails each to the 'To', 'Cc' and 'Bcc' fields
3. Trigger the campaign action
4. Check that each email address receives exactly one email

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat reproduction steps
