### PR TITLE
M3 saml signature bug

### DIFF
--- a/app/bundles/UserBundle/Security/SAML/Store/TrustOptionsStore.php
+++ b/app/bundles/UserBundle/Security/SAML/Store/TrustOptionsStore.php
@@ -66,6 +66,10 @@ class TrustOptionsStore implements TrustOptionsStoreInterface
     {
         $this->trustOptions = $trustOptions = new TrustOptions();
 
+        if (!$this->coreParametersHelper->get('saml_idp_own_certificate')) {
+            return $trustOptions;
+        }
+
         $trustOptions->setSignAuthnRequest(true);
         $trustOptions->setEncryptAssertions(true);
         $trustOptions->setEncryptAuthnRequest(true);

--- a/app/bundles/UserBundle/Tests/Security/SAML/Store/TrustOptionsStoreTest.php
+++ b/app/bundles/UserBundle/Tests/Security/SAML/Store/TrustOptionsStoreTest.php
@@ -69,4 +69,26 @@ class TrustOptionsStoreTest extends TestCase
 
         $this->assertFalse($this->store->has('barfoo'));
     }
+
+    public function testTrustOptionsDoNotSignRequestForDefault()
+    {
+        $this->coreParametersHelper->expects($this->once())
+            ->method('get')
+            ->with('saml_idp_own_certificate')
+            ->willReturn('');
+
+        $store = $this->store->get('foobar');
+        $this->assertFalse($store->getSignAuthnRequest());
+    }
+
+    public function testTrustOptionsSignRequestForCustom()
+    {
+        $this->coreParametersHelper->expects($this->once())
+            ->method('get')
+            ->with('saml_idp_own_certificate')
+            ->willReturn('abc');
+
+        $store = $this->store->get('foobar');
+        $this->assertTrue($store->getSignAuthnRequest());
+    }
 }


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
Not uploading a custom certificate signed the request with the vendor's certificate which was unexpectedly a BC change with M2. This prevents signing when not using a custom certificate.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup SAML with an IDP and do not upload a 509 certificate

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat reproduction steps
