### PR TITLE
M3 Downgrade Doctrine/ORM from 2.7.2 to 2.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
         "doctrine/doctrine-migrations-bundle": "~2.1",
         "doctrine/annotations": "~1.8.0",
         "doctrine/data-fixtures": "~1.4.0",
+        "doctrine/orm": "2.7.0",
 
         "knplabs/gaufrette": "~0.9.0",
         "aws/aws-sdk-php": "~3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b31da94930e207e2aa8f184aadf8ad2c",
+    "content-hash": "e8a46baf1a0661f6fca1401be29683ab",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1614,16 +1614,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "v2.7.2",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "dafe298ce5d0b995ebe1746670704c0a35868a6a"
+                "reference": "4d763ca4c925f647b248b9fa01b5f47aa3685d62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/dafe298ce5d0b995ebe1746670704c0a35868a6a",
-                "reference": "dafe298ce5d0b995ebe1746670704c0a35868a6a",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/4d763ca4c925f647b248b9fa01b5f47aa3685d62",
+                "reference": "4d763ca4c925f647b248b9fa01b5f47aa3685d62",
                 "shasum": ""
             },
             "require": {
@@ -1636,7 +1636,6 @@
                 "doctrine/instantiator": "^1.3",
                 "doctrine/persistence": "^1.2",
                 "ext-pdo": "*",
-                "ocramius/package-versions": "^1.2",
                 "php": "^7.1",
                 "symfony/console": "^3.0|^4.0|^5.0"
             },
@@ -1694,7 +1693,7 @@
                 "database",
                 "orm"
             ],
-            "time": "2020-03-19T06:41:02+00:00"
+            "time": "2019-11-19T08:38:05+00:00"
         },
         {
             "name": "doctrine/persistence",
@@ -14415,5 +14414,6 @@
         "ext-zip": "^1.15",
         "ext-imap": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
Downgrading Doctrine ORM due to a BC break introduced in 2.7.1 that removed extra lazy loading for removeElement which is used throughout Mautic.

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Doctrine introduced a BC break that they described as a bug in 2.7.1. https://github.com/doctrine/orm/pull/7940#issuecomment-617275249

This caused the use of removeElement on a collection to hydrate the entire collection rather than executing an immediate DELETE query as has been the behavior between 2.4.0 and 2.7.0. Thus, very large webhook queues would result in memory max outs due to Doctrine attempting to load the entire payload into memory and made the DELETE query during the flush action.

removeElement is used throughout Mautic, thus, temporarily downgrading to 2.7.0 until this can be addressed throughout the app as necessary (where scale is of concern).

More info should have @alanhartless 

NOTE:
```
15:41 $ composer info | grep "doctrine/orm"
doctrine/orm                         v2.7.2                    Object-Relational-Mapper for PHP
```
This seems to be updated correctly with semantical versioning, when patch is available. However this bugfix seem to be not included in `2.7.2` - https://github.com/doctrine/orm/releases/tag/v2.7.2