### PR TITLE
Hubspot support for read only fields

### DIFF
--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -579,6 +579,7 @@ class HubspotIntegration extends CrmAbstractIntegration
         $object         = 'contacts';
         $fieldsToUpdate = $this->getPriorityFieldsForIntegration($config);
         $createFields   = $config['leadFields'];
+
         //@todo Hubspot's createLead uses createOrUpdate endpoint which means we don't know before we send mapped data if the contact will be updated or created; so we have to send all mapped fields
         $updateFields = array_intersect_key(
             $createFields,

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -224,6 +224,9 @@ class HubspotIntegration extends CrmAbstractIntegration
                                     'label'    => $fieldInfo['label'],
                                     'required' => ('email' === $fieldInfo['name']),
                                 ];
+                                if (!empty($fieldInfo['readOnlyValue'])) {
+                                    $hubsFields[$object][$fieldInfo['name']]['update_mautic'] = 1;
+                                }
                             }
                         }
 
@@ -584,7 +587,7 @@ class HubspotIntegration extends CrmAbstractIntegration
         $mappedData = $this->populateLeadData(
             $lead,
             [
-                'leadFields'       => $createFields,
+                'leadFields'       => $updateFields,
                 'object'           => $object,
                 'feature_settings' => ['objects' => $config['objects']],
             ]


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
We've noticed a lot of Hubspot fields are readonly, then during the push we shouldn't try update it.

This PR allow this field sync just in one way - to Mautic

![image](https://user-images.githubusercontent.com/462477/81695238-a722c100-9462-11ea-9848-dc89d5dd08c8.png)


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup Hubspot integration
2. Setup matching e-mail and Became a Lead Date field (this field is readonly)  to another field in Mautic
3. Create form with email and second field to match contact field in step 2
4. Try submit form. You should see error in log

`[2020-05-12 09:26:40] mautic.CRITICAL: Uncaught PHP Exception Mautic\PluginBundle\Exception\ApiErrorException: "Property values were not valid Array ( [0] => Array ( [isValid] => [message] => "hs_object_id" is a calculated property; its value cannot be set. [error] => READ_ONLY_VALUE [name] => hs_object_id ) [1] => Array ( [isValid] => [message] => "recent_conversion_date" is a calculated property; its value cannot be set. [error] => READ_ONLY_VALUE [name] => recent_conversion_date ) [2] => Array ( [isValid] => [message] => "hs_lifecyclestage_lead_date" is a read only property; its value cannot be set. [error] => READ_ONLY_VALUE [name] => hs_lifecyclestage_lead_date ) ) " at`

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps
3. Field read-only should be not synced to Hubspot
