### PR TITLE
Disable click outside modals

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/3.bootstrap.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/3.bootstrap.js
@@ -820,7 +820,7 @@ if (typeof jQuery === 'undefined') {
     }
 
     Modal.DEFAULTS = {
-        backdrop: true,
+        backdrop: false,
         keyboard: true,
         show: true
     }
@@ -946,12 +946,12 @@ if (typeof jQuery === 'undefined') {
             this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />')
                 .appendTo(document.body)
 
-            this.$element.on('click.dismiss.bs.modal', $.proxy(function (e) {
+            /*this.$element.on('click.dismiss.bs.modal', $.proxy(function (e) {
                 if (e.target !== e.currentTarget) return
                 this.options.backdrop == 'static'
                     ? this.$element[0].focus.call(this.$element[0])
                     : this.hide.call(this)
-            }, this))
+            }, this))*/
 
             if (doAnimate) this.$backdrop[0].offsetWidth // force reflow
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | No
| New feature? | No
| Automated tests included? |No
| Related user documentation PR URL | No
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Disable the click on the overlay to close the modal. 
Users report losing their information after trying to selecting e field inside the modal.
The mouse button released outside closed the modal and they lose their information.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Select some input and release the mouse button outside the modal
2. The modal close itself without confirmation
