### PR TITLE
Fix error with OneSignal integration

### DIFF
--- a/app/bundles/NotificationBundle/EventListener/ChannelSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/ChannelSubscriber.php
@@ -68,30 +68,30 @@ class ChannelSubscriber implements EventSubscriberInterface
                     ],
                 ]
             );
-        }
 
-        $supportedFeatures = $integration->getSupportedFeatures();
+            $supportedFeatures = $integration->getSupportedFeatures();
 
-        if (in_array('mobile', $supportedFeatures)) {
-            $event->addChannel(
-                'mobile_notification',
-                [
-                    MessageModel::CHANNEL_FEATURE => [
-                        'campaignAction'             => 'notification.send_mobile_notification',
-                        'campaignDecisionsSupported' => [
-                            'page.pagehit',
-                            'asset.download',
-                            'form.submit',
+            if (in_array('mobile', $supportedFeatures)) {
+                $event->addChannel(
+                    'mobile_notification',
+                    [
+                        MessageModel::CHANNEL_FEATURE => [
+                            'campaignAction'             => 'notification.send_mobile_notification',
+                            'campaignDecisionsSupported' => [
+                                'page.pagehit',
+                                'asset.download',
+                                'form.submit',
+                            ],
+                            'lookupFormType'             => NotificationListType::class,
+                            'repository'                 => 'MauticNotificationBundle:Notification',
+                            'lookupOptions'              => [
+                                'mobile'  => true,
+                                'desktop' => false,
+                            ],
                         ],
-                        'lookupFormType' => NotificationListType::class,
-                        'repository'     => 'MauticNotificationBundle:Notification',
-                        'lookupOptions'  => [
-                            'mobile'  => true,
-                            'desktop' => false,
-                        ],
-                    ],
-                ]
-            );
+                    ]
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
I don't know why but on my enviroment OneSignal integration is not initialize properly. This cause error while open contact detail. 
This PR fixes this issue

> Internal Server Error - Call to a member function getSupportedFeatures() on boolean

Trace

```
\app\bundles\NotificationBundle\EventListener\ChannelSubscriber.php:73 at
\vendor\symfony\event-dispatcher\Debug\WrappedListener.php:115 at Mautic\NotificationBundle\EventListener\ChannelSubscriber -> onAddChannel ( object(ChannelEvent), 'mautic.add_channel', object(TraceableEventDispatcher) )
\vendor\symfony\event-dispatcher\EventDispatcher.php:214 at Symfony\Component\EventDispatcher\Debug\WrappedListener -> __invoke ( object(ChannelEvent), 'mautic.add_channel', object(TraceableEventDispatcher) )
\vendor\symfony\event-dispatcher\EventDispatcher.php:44 at Symfony\Component\EventDispatcher\EventDispatcher -> doDispatch ( array(object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener)), 'mautic.add_channel', object(ChannelEvent) )
\vendor\symfony\event-dispatcher\Debug\TraceableEventDispatcher.php:143 at Symfony\Component\EventDispatcher\EventDispatcher -> dispatch ( 'mautic.add_channel', object(ChannelEvent) )
\app\bundles\ChannelBundle\Helper\ChannelListHelper.php:150 at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher -> dispatch ( 'mautic.add_channel', object(ChannelEvent) )
\app\bundles\ChannelBundle\Helper\ChannelListHelper.php:72 at Mautic\ChannelBundle\Helper\ChannelListHelper -> setupChannels ( )
\app\bundles\ChannelBundle\Model\MessageModel.php:127 at Mautic\ChannelBundle\Helper\ChannelListHelper -> getFeatureChannels ( 'marketing_messages' )
\app\bundles\ChannelBundle\EventListener\CampaignSubscriber.php:109 at Mautic\ChannelBundle\Model\MessageModel -> getChannels ( )
\vendor\symfony\event-dispatcher\Debug\WrappedListener.php:115 at Mautic\ChannelBundle\EventListener\CampaignSubscriber -> onCampaignBuild ( object(CampaignBuilderEvent), 'mautic.campaign_on_build', object(TraceableEventDispatcher) )
\vendor\symfony\event-dispatcher\EventDispatcher.php:214 at Symfony\Component\EventDispatcher\Debug\WrappedListener -> __invoke ( object(CampaignBuilderEvent), 'mautic.campaign_on_build', object(TraceableEventDispatcher) )
\vendor\symfony\event-dispatcher\EventDispatcher.php:44 at Symfony\Component\EventDispatcher\EventDispatcher -> doDispatch ( array(object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener)), 'mautic.campaign_on_build', object(CampaignBuilderEvent) )
\vendor\symfony\event-dispatcher\Debug\TraceableEventDispatcher.php:143 at Symfony\Component\EventDispatcher\EventDispatcher -> dispatch ( 'mautic.campaign_on_build', object(CampaignBuilderEvent) )
\app\bundles\CampaignBundle\EventCollector\EventCollector.php:108 at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher -> dispatch ( 'mautic.campaign_on_build', object(CampaignBuilderEvent) )
\app\bundles\CampaignBundle\EventCollector\EventCollector.php:90 at Mautic\CampaignBundle\EventCollector\EventCollector -> buildEventList ( )
\app\bundles\CampaignBundle\EventListener\LeadSubscriber.php:281 at Mautic\CampaignBundle\EventCollector\EventCollector -> getEventsArray ( )
\app\bundles\CampaignBundle\EventListener\LeadSubscriber.php:251 at Mautic\CampaignBundle\EventListener\LeadSubscriber -> addTimelineEvents ( object(LeadTimelineEvent), 'campaign.event', 'Campaign action triggered' )
\vendor\symfony\event-dispatcher\Debug\WrappedListener.php:115 at Mautic\CampaignBundle\EventListener\LeadSubscriber -> onTimelineGenerate ( object(LeadTimelineEvent), 'mautic.lead_timeline_on_generate', object(TraceableEventDispatcher) )
\vendor\symfony\event-dispatcher\EventDispatcher.php:214 at Symfony\Component\EventDispatcher\Debug\WrappedListener -> __invoke ( object(LeadTimelineEvent), 'mautic.lead_timeline_on_generate', object(TraceableEventDispatcher) )
\vendor\symfony\event-dispatcher\EventDispatcher.php:44 at Symfony\Component\EventDispatcher\EventDispatcher -> doDispatch ( array(object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener)), 'mautic.lead_timeline_on_generate', object(LeadTimelineEvent) )
\vendor\symfony\event-dispatcher\Debug\TraceableEventDispatcher.php:143 at Symfony\Component\EventDispatcher\EventDispatcher -> dispatch ( 'mautic.lead_timeline_on_generate', object(LeadTimelineEvent) )
\app\bundles\LeadBundle\Model\LeadModel.php:2118 at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher -> dispatch ( 'mautic.lead_timeline_on_generate', object(LeadTimelineEvent) )
\app\bundles\LeadBundle\Controller\LeadDetailsTrait.php:314 at Mautic\LeadBundle\Model\LeadModel -> getEngagements ( object(Lead), array('search' => '', 'includeEvents' => array(), 'excludeEvents' => array()), array('timestamp', 'DESC'), '1', '25' )
\app\bundles\LeadBundle\Controller\LeadController.php:377 at Mautic\LeadBundle\Controller\LeadController -> getEngagements ( object(Lead) )
\app\bundles\CoreBundle\Controller\CommonController.php:449 at Mautic\LeadBundle\Controller\LeadController -> viewAction ( '3', '' )
\vendor\symfony\http-kernel\HttpKernel.php:151 at Mautic\CoreBundle\Controller\CommonController -> executeAction ( 'view', '3', '0', '' )
\vendor\symfony\http-kernel\HttpKernel.php:68 at Symfony\Component\HttpKernel\HttpKernel -> handleRaw ( object(Request), '1' )
\vendor\symfony\http-kernel\Kernel.php:200 at Symfony\Component\HttpKernel\HttpKernel -> handle ( object(Request), '1', true )
\app\AppKernel.php:104 at Symfony\Component\HttpKernel\Kernel -> handle ( object(Request), '1', true )
\app\middlewares\CORSMiddleware.php:91 at AppKernel -> handle ( object(Request), '1', true )
\app\middlewares\CatchExceptionMiddleware.php:43 at Mautic\Middleware\CORSMiddleware -> handle ( object(Request), '1', true )
\app\middlewares\Dev\IpRestrictMiddleware.php:64 at Mautic\Middleware\CatchExceptionMiddleware -> handle ( object(Request), '1', true )
\app\middlewares\VersionCheckMiddleware.php:67 at Mautic\Middleware\Dev\IpRestrictMiddleware -> handle ( object(Request), '1', true )
\app\middlewares\TrustMiddleware.php:51 at Mautic\Middleware\VersionCheckMiddleware -> handle ( object(Request), '1', true )
\vendor\stack\builder\src\Stack\StackedHttpKernel.php:23 at Mautic\Middleware\TrustMiddleware -> handle ( object(Request), '1', true )
\vendor\stack\run\src\Stack\run.php:13 at Stack\StackedHttpKernel -> handle ( object(Request) )
\index_dev.php:25 at Stack\run ( object(StackedHttpKernel) )
```



#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Just code review is enought
