### PR TITLE
Prevent wrong campaign scheduling If  daily options are filled

### DIFF
--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -159,6 +159,11 @@ class Interval implements ScheduleModeInterface
             return false;
         }
 
+        // Restrict just for daily scheduling
+        if ('d' !== $event->getTriggerIntervalUnit()) {
+            return false;
+        }
+
         if (
             null === $event->getTriggerHour() &&
             (null === $event->getTriggerRestrictedStartHour() || null === $event->getTriggerRestrictedStopHour()) &&

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -237,6 +237,8 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
             ->willReturn([$dow]);
         $event->method('getCampaign')
             ->willReturn($campaign);
+        $event->method('getTriggerIntervalUnit')
+            ->willReturn('d');
 
         $contact = $this->createMock(Lead::class);
         $contact->method('getId')


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
We noticed wrong campaign scheduling If you switch from daily settings to minutes.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create basic campaign 
2. Create campaign action (for example Modify tags) and schedule it for day interval  + 10 days at 10:00
3. Run campaign and check scheduling of action is OK
![image](https://user-images.githubusercontent.com/462477/82057049-1d256300-96c3-11ea-9114-b59c8814f0d4.png)
4. Then change the scheduling of action from days to minutes and set 5 minutes
5. Run campaign and see scheduling of action is set to 10:00 event thought you  expect scheduling from now + 10 minutes 
![image](https://user-images.githubusercontent.com/462477/82057176-40e8a900-96c3-11ea-891c-09bbc9d37117.png)

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps and scheduling should works properly

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
