### PR TITLE
Fixed date/time comparison that started causing Pipedrive tests to fail for M3

### DIFF
--- a/plugins/MauticCrmBundle/Tests/Pipedrive/PipedriveTest.php
+++ b/plugins/MauticCrmBundle/Tests/Pipedrive/PipedriveTest.php
@@ -186,7 +186,7 @@ abstract class PipedriveTest extends MauticMysqlTestCase
 
     protected function createLeadIntegrationEntity($integrationEntityId, $internalEntityId)
     {
-        $date = (new DateTimeHelper('-3 years'))->getDateTime();
+        $date = (new DateTimeHelper('2017-05-15 00:00:00'))->getDateTime();
 
         $integrationEntity = new IntegrationEntity();
 
@@ -206,7 +206,7 @@ abstract class PipedriveTest extends MauticMysqlTestCase
 
     protected function createCompanyIntegrationEntity($integrationEntityId, $internalEntityId)
     {
-        $date = (new DateTimeHelper('-3 years'))->getDateTime();
+        $date = (new DateTimeHelper('2017-05-15 00:00:00'))->getDateTime();
 
         $integrationEntity = new IntegrationEntity();
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The Pipedrive tests were testing were comparing a fixed date from 2015 to a date/time(-3 years) which started to fail because the test is now more than 3 years old. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Pipedrive tests are failing

#### Steps to test this PR:
1. Pipedrive tests are now passing

