### PR TITLE
Restores auth settings for legacy integrations

### DIFF
--- a/app/bundles/NotificationBundle/Integration/OneSignalIntegration.php
+++ b/app/bundles/NotificationBundle/Integration/OneSignalIntegration.php
@@ -75,17 +75,6 @@ class OneSignalIntegration extends AbstractIntegration
     }
 
     /**
-     * @return array
-     */
-    public function getFormSettings()
-    {
-        return [
-            'requires_callback'      => false,
-            'requires_authorization' => false,
-        ];
-    }
-
-    /**
      * {@inheritdoc}
      *
      * @return string

--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -204,6 +204,19 @@ class PluginController extends FormController
                     $em          = $this->get('doctrine.orm.entity_manager');
                     $integration = $entity->getName();
 
+                    if (isset($form['apiKeys'])) {
+                        $keys = $form['apiKeys']->getData();
+
+                        // Prevent merged keys
+                        $secretKeys = $integrationObject->getSecretKeys();
+                        foreach ($secretKeys as $secretKey) {
+                            if (empty($keys[$secretKey]) && !empty($currentKeys[$secretKey])) {
+                                $keys[$secretKey] = $currentKeys[$secretKey];
+                            }
+                        }
+                        $integrationObject->encryptAndSetApiKeys($keys, $entity);
+                    }
+
                     if (!$authorize) {
                         $features = $entity->getSupportedFeatures();
                         if (in_array('public_profile', $features) || in_array('push_lead', $features)) {
@@ -243,17 +256,6 @@ class PluginController extends FormController
                             }
                         }
                     } else {
-                        $keys = $form['apiKeys']->getData();
-
-                        // Prevent merged keys
-                        $secretKeys = $integrationObject->getSecretKeys();
-                        foreach ($secretKeys as $secretKey) {
-                            if (empty($keys[$secretKey]) && !empty($currentKeys[$secretKey])) {
-                                $keys[$secretKey] = $currentKeys[$secretKey];
-                            }
-                        }
-                        $integrationObject->encryptAndSetApiKeys($keys, $entity);
-
                         //make sure they aren't overwritten because of API connection issues
                         $entity->setFeatureSettings($currentFeatureSettings);
                     }

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -2231,16 +2231,16 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
         switch ($type) {
             case 'oauth1a':
             case 'oauth2':
-                $callback = $authorization = true;
+                $callback = true;
                 break;
             default:
-                $callback = $authorization = false;
+                $callback = false;
                 break;
         }
 
         return [
             'requires_callback'      => $callback,
-            'requires_authorization' => $authorization,
+            'requires_authorization' => (bool) $this->getRequiredKeyFields(),
             'default_features'       => [],
             'enable_data_priority'   => $enableDataPriority,
         ];

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -791,7 +791,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
         $method   = strtoupper($method);
         $authType = (empty($settings['auth_type'])) ? $this->getAuthenticationType() : $settings['auth_type'];
 
-        list($parameters, $headers) = $this->prepareRequest($url, $parameters, $method, $settings, $authType);
+        [$parameters, $headers] = $this->prepareRequest($url, $parameters, $method, $settings, $authType);
 
         if (empty($settings['ignore_event_dispatch'])) {
             $event = $this->dispatcher->dispatch(
@@ -899,7 +899,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
             foreach ($parseHeaders as $key => $value) {
                 // Ignore string keys which assume it is already parsed and avoids splitting up a value that includes colons (such as a date/time)
                 if (!is_string($key) && false !== strpos($value, ':')) {
-                    list($key, $value) = explode(':', $value);
+                    [$key, $value]     = explode(':', $value);
                     $key               = trim($key);
                     $value             = trim($value);
                 }
@@ -1214,7 +1214,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
                     $refreshTokenKeys = $this->getRefreshTokenKeys();
 
                     if (!empty($refreshTokenKeys)) {
-                        list($refreshTokenKey, $expiryKey) = $refreshTokenKeys;
+                        [$refreshTokenKey, $expiryKey] = $refreshTokenKeys;
 
                         $settings['refresh_token'] = $refreshTokenKey;
                     }
@@ -1346,7 +1346,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
                 if (!isset($this->keys[$authTokenKey])) {
                     $valid = false;
                 } elseif (!empty($refreshTokenKeys)) {
-                    list($refreshTokenKey, $expiryKey) = $refreshTokenKeys;
+                    [$refreshTokenKey, $expiryKey] = $refreshTokenKeys;
                     if (!empty($this->keys[$refreshTokenKey]) && !empty($expiryKey) && isset($this->keys[$expiryKey])
                         && time() > $this->keys[$expiryKey]
                     ) {
@@ -1688,7 +1688,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
         foreach ($availableFields as $key => $field) {
             $integrationKey = $matchIntegrationKey = $this->convertLeadFieldKey($key, $field);
             if (is_array($integrationKey)) {
-                list($integrationKey, $matchIntegrationKey) = $integrationKey;
+                [$integrationKey, $matchIntegrationKey] = $integrationKey;
             } elseif (!isset($config['leadFields'][$integrationKey])) {
                 continue;
             }
@@ -2231,16 +2231,18 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
         switch ($type) {
             case 'oauth1a':
             case 'oauth2':
-                $callback = true;
+                $callback              = true;
+                $requiresAuthorization = true;
                 break;
             default:
-                $callback = false;
+                $callback              = false;
+                $requiresAuthorization = false;
                 break;
         }
 
         return [
             'requires_callback'      => $callback,
-            'requires_authorization' => (bool) $this->getRequiredKeyFields(),
+            'requires_authorization' => $requiresAuthorization,
             'default_features'       => [],
             'enable_data_priority'   => $enableDataPriority,
         ];

--- a/app/bundles/SmsBundle/Integration/TwilioIntegration.php
+++ b/app/bundles/SmsBundle/Integration/TwilioIntegration.php
@@ -61,17 +61,6 @@ class TwilioIntegration extends AbstractIntegration
     }
 
     /**
-     * @return array
-     */
-    public function getFormSettings()
-    {
-        return [
-            'requires_callback'      => false,
-            'requires_authorization' => false,
-        ];
-    }
-
-    /**
      * {@inheritdoc}
      *
      * @return string

--- a/plugins/MauticCitrixBundle/Integration/CitrixAbstractIntegration.php
+++ b/plugins/MauticCitrixBundle/Integration/CitrixAbstractIntegration.php
@@ -90,17 +90,6 @@ abstract class CitrixAbstractIntegration extends AbstractIntegration
     }
 
     /**
-     * @return array
-     */
-    public function getFormSettings()
-    {
-        return [
-            'requires_callback'      => true,
-            'requires_authorization' => true,
-        ];
-    }
-
-    /**
      * @return string
      */
     public function getApiUrl()

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -142,17 +142,6 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @return array
-     */
-    public function getFormSettings()
-    {
-        return [
-            'requires_callback'      => false,
-            'requires_authorization' => true,
-        ];
-    }
-
-    /**
      * @return bool
      */
     public function authCallback($settings = [], $parameters = [])

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -136,21 +136,6 @@ class HubspotIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @return array
-     */
-    public function getFormSettings()
-    {
-        $enableDataPriority = $this->getDataPriority();
-
-        return [
-            'requires_callback'      => false,
-            'requires_authorization' => false,
-            'default_features'       => [],
-            'enable_data_priority'   => $enableDataPriority,
-        ];
-    }
-
-    /**
      * {@inheritdoc}
      *
      * @return string

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -1117,19 +1117,6 @@ class SugarcrmIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @return array
-     */
-    public function getFormSettings()
-    {
-        $settings                           = parent::getFormSettings();
-        $settings['requires_callback']      = false;
-        $settings['requires_authorization'] = true;
-        //'requires_callback'      => false,
-        //'requires_authorization' => true,
-        return $settings;
-    }
-
-    /**
      * @param \Mautic\LeadBundle\Entity\Lead $lead
      * @param array                          $config
      *

--- a/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
@@ -297,17 +297,6 @@ class VtigerIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @return array
-     */
-    public function getFormSettings()
-    {
-        return [
-            'requires_callback'      => false,
-            'requires_authorization' => true,
-        ];
-    }
-
-    /**
      * Get available company fields for choices in the config UI.
      *
      * @param array $settings

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -137,17 +137,6 @@ class ZohoIntegration extends CrmAbstractIntegration
     /**
      * @return array
      */
-    public function getFormSettings()
-    {
-        return [
-            'requires_callback'      => true,
-            'requires_authorization' => true,
-        ];
-    }
-
-    /**
-     * @return array
-     */
     public function getSupportedFeatures()
     {
         return ['push_lead', 'get_leads', 'push_leads'];

--- a/plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
@@ -150,19 +150,6 @@ class IcontactIntegration extends EmailAbstractIntegration
     }
 
     /**
-     * Returns settings for the integration form.
-     *
-     * @return array
-     */
-    public function getFormSettings()
-    {
-        return [
-            'requires_callback'      => false,
-            'requires_authorization' => true,
-        ];
-    }
-
-    /**
      * @return array
      */
     public function getAvailableLeadFields($settings = [])


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8760
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
https://github.com/mautic/mautic/pull/8610 appropriately wrapped the auth keys field with a `requires_authorization` check but for whatever reason, legacy integrations had this set to false which resulted in not being able to configure their keys (OneSignal, Pipedrive, Hubspot, Twilio, and maybe others). 

This PR removes unnecessary inherited `getFormSettings()` and updated the abstract method to set this based on whether the integration has required auth keys or not. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to configure Hubspot, Pipedrive, OneSignal, or Twilio and you will notice that it only has the is published toggle on the auth tab. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. The appropriate auth keys will show up again and clicking save or apply will persist the configured values

