### PR TITLE
Prevents redirecting to category list after creating a category from another form

### DIFF
--- a/app/bundles/CategoryBundle/Controller/CategoryController.php
+++ b/app/bundles/CategoryBundle/Controller/CategoryController.php
@@ -191,7 +191,7 @@ class CategoryController extends AbstractFormController
         $success    = $closeModal    = 0;
         $cancelled  = $valid  = false;
         $method     = $this->request->getMethod();
-        $inForm     = ('POST' == $method) ? $this->request->request->get('category_form[inForm]', 0, true) : $this->request->get('inForm', 0);
+        $inForm     = ('POST' == $method) ? $this->request->request->get('category_form')['inForm'] : $this->request->get('inForm', 0);
         $showSelect = $this->request->get('show_bundle_select', false);
 
         //not found
@@ -286,7 +286,8 @@ class CategoryController extends AbstractFormController
         $success   = $closeModal   = 0;
         $cancelled = $valid = false;
         $method    = $this->request->getMethod();
-        $inForm    = ('POST' == $method) ? $this->request->request->get('category_form[inForm]', 0, true) : $this->request->get('inForm', 0);
+        $inForm    = ('POST' == $method) ? $this->request->request->get('category_form')['inForm'] : $this->request->get('inForm', 0);
+
         //not found
         if (null === $entity) {
             $closeModal = true;


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8708
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This fixes the user experience when creating a new category from within another form (i.e. new email). 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to emails and try create email
2. Try create category inside create/edit email page
3. Try save and close category.
4. You are redirect to category page (expect close windows modal and set selectbox to new created category)

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat and this time it should close the modal and autoselect the new category
3. Go to the category list and ensure you can still create a category without any errors

