### PR TITLE
MAUTIC_DEV_HOSTS server variable renamed

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -39,6 +39,20 @@ If you have `api_rate_limiter_cache` present in you `app/config/local.php`, you 
 ],
 ```
 
+In case you've been using `$_SERVER['MAUTIC_DEV_HOSTS']` to add more allowed IP addresses for the development enviroment, there had to be 2 changes because it was conflicting with handling configuration with environment variables.
+1. Change `MAUTIC_DEV_HOSTS` to `MAUTIC_CUSTOM_DEV_HOSTS`.
+2. It's not a string anymore, but a JSON encoded array.
+
+Before:
+```
+$_SERVER['MAUTIC_DEV_HOSTS'] = '1.2.3.4';
+```
+
+After:
+```
+$_SERVER['MAUTIC_CUSTOM_DEV_HOSTS'] = '["1.2.3.4"]';
+```
+
 #### Removing the Container as a Configuration Dependency
 Mautic's Configuration is no longer dependent on the Symfony container. This means that any parameter that has to be used in a cache compiler pass is no longer compatible with the UI. These "advanced" configuration options have to be manually set in the local.php file then delete Mautic's cache. For example, the QueueBundle must now be manually configured due to its dependency on cache compilers.
 

--- a/app/middlewares/Dev/IpRestrictMiddleware.php
+++ b/app/middlewares/Dev/IpRestrictMiddleware.php
@@ -33,9 +33,6 @@ class IpRestrictMiddleware implements HttpKernelInterface, PrioritizedMiddleware
      */
     protected $allowedIps;
 
-    /**
-     * CatchExceptionMiddleware constructor.
-     */
     public function __construct(HttpKernelInterface $app)
     {
         $this->app        = $app;
@@ -46,8 +43,8 @@ class IpRestrictMiddleware implements HttpKernelInterface, PrioritizedMiddleware
             $this->allowedIps = array_merge($this->allowedIps, $parameters['dev_hosts']);
         }
 
-        if (isset($_SERVER['MAUTIC_DEV_HOSTS'])) {
-            $localIps         = explode(' ', $_SERVER['MAUTIC_DEV_HOSTS']);
+        if (isset($_SERVER['MAUTIC_CUSTOM_DEV_HOSTS'])) {
+            $localIps         = json_decode($_SERVER['MAUTIC_CUSTOM_DEV_HOSTS'], true);
             $this->allowedIps = array_merge($this->allowedIps, $localIps);
         }
     }

--- a/app/middlewares/Tests/Dev/IpRestrictMiddlewareTest.php
+++ b/app/middlewares/Tests/Dev/IpRestrictMiddlewareTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Middleware\Tests\Dev;
+
+use Mautic\Middleware\Dev\IpRestrictMiddleware;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class IpRestrictMiddlewareTest extends \PHPUnit\Framework\TestCase
+{
+    public function testWorkflowWithLocalhostIp(): void
+    {
+        $inputRequest = new Request();
+        $inputRequest->server->set('REMOTE_ADDR', '127.0.0.1'); // 127.0.0.1 is always allowed.
+        $httpKernel = new class() implements HttpKernelInterface {
+            public function __construct()
+            {
+            }
+
+            public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+            {
+                return new Response();
+            }
+        };
+
+        $middleware = new IpRestrictMiddleware($httpKernel);
+        $response   = $middleware->handle($inputRequest);
+
+        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testWorkflowWithDisallowedIp(): void
+    {
+        $inputRequest = new Request();
+        $inputRequest->server->set('REMOTE_ADDR', 'unallowed.ip.address');
+        $httpKernel                 = new class() implements HttpKernelInterface {
+            public $handleWasCalled = false;
+
+            public function __construct()
+            {
+            }
+
+            public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+            {
+                $this->handleWasCalled = true;
+            }
+        };
+
+        $middleware = new IpRestrictMiddleware($httpKernel);
+        $response   = $middleware->handle($inputRequest);
+
+        Assert::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        Assert::assertFalse($httpKernel->handleWasCalled);
+    }
+
+    public function testWorkflowWithConfiguredIp(): void
+    {
+        // Remember original custom_dev_hosts value so we could return it afterwards.
+        $originalDevHostsValue = $_SERVER['MAUTIC_CUSTOM_DEV_HOSTS'] ?? '[]';
+
+        $_SERVER['MAUTIC_CUSTOM_DEV_HOSTS'] = '["configured.ip.address"]';
+
+        $inputRequest = new Request();
+        $inputRequest->server->set('REMOTE_ADDR', 'configured.ip.address');
+        $httpKernel = new class($inputRequest) implements HttpKernelInterface {
+            public function __construct()
+            {
+            }
+
+            public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+            {
+                return new Response();
+            }
+        };
+
+        $middleware = new IpRestrictMiddleware($httpKernel);
+        $response   = $middleware->handle($inputRequest);
+
+        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        // Set the original value back.
+        $_SERVER['MAUTIC_CUSTOM_DEV_HOSTS'] = $originalDevHostsValue;
+    }
+}

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -19,6 +19,9 @@
         <testsuite name="Plugin tests">
             <directory>./../plugins/*Bundle/Tests</directory>
         </testsuite>
+        <testsuite name="Middleware tests">
+            <directory>middlewares/Tests</directory>
+        </testsuite>
     </testsuites>
 
     <filter>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? |Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | Y
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Configuring allowed dev IP addresses with `$_SERVER['MAUTIC_DEV_HOSTS'];` didn't work on M3 after the configuration values refactoring to use environment variables. If set, it caused error like this one:
```
Symfony\Component\DependencyInjection\Exception\RuntimeException: Invalid JSON in env var "resolve:MAUTIC_DEV_HOSTS": Syntax error
/vendor/symfony/dependency-injection/EnvVarProcessor.php:128
/vendor/symfony/dependency-injection/EnvVarProcessor.php:128 at
/vendor/symfony/dependency-injection/Container.php:491 at Symfony\Component\DependencyInjection\EnvVarProcessor -> getEnv ( 'json', 'resolve:MAUTIC_DEV_HOSTS', object(Closure) )
```

See attached change in the [upgrade doc](https://github.com/mautic/mautic/compare/3.x...escopecz:m3.dev-hosts-rename?expand=1#diff-0901ceb76939b17cd920bc69aa52d21f)

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create app/config/paths_local.php with this content:
```php
<?php

use Symfony\Component\HttpFoundation\Request;

$request = Request::createFromGlobals();
Request::setTrustedProxies(['127.0.0.1', $request->server->get('REMOTE_ADDR')]);
$_SERVER['MAUTIC_DEV_HOSTS'] = json_encode([$request->getClientIp()]);
```
2. Clear the cache
3. Load the configuration
- See the error.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Refresh the configuration. It should load without any error.

#### List backwards compatibility breaks:
1. `$_SERVER['MAUTIC_DEV_HOSTS'];`. See the attached upgrading doc.
