### PR TITLE
Respect configuration time format  in timeline

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -361,6 +361,7 @@ return [
                     '%mautic.date_format_dateonly%',
                     '%mautic.date_format_timeonly%',
                     'translator',
+                    'mautic.helper.core_parameters',
                 ],
                 'alias' => 'date',
             ],

--- a/app/bundles/CoreBundle/Helper/DateTimeHelper.php
+++ b/app/bundles/CoreBundle/Helper/DateTimeHelper.php
@@ -13,34 +13,16 @@ namespace Mautic\CoreBundle\Helper;
 
 class DateTimeHelper
 {
-    /**
-     * @var string
-     */
     private $string;
 
-    /**
-     * @var string
-     */
     private $format;
 
-    /**
-     * @var string
-     */
     private $timezone;
 
-    /**
-     * @var \DateTimeZone
-     */
     private $utc;
 
-    /**
-     * @var \DateTimeZone
-     */
     private $local;
 
-    /**
-     * @var \DateTimeInterface
-     */
     private $datetime;
 
     /**

--- a/app/bundles/CoreBundle/Helper/DateTimeHelper.php
+++ b/app/bundles/CoreBundle/Helper/DateTimeHelper.php
@@ -13,16 +13,34 @@ namespace Mautic\CoreBundle\Helper;
 
 class DateTimeHelper
 {
+    /**
+     * @var string
+     */
     private $string;
 
+    /**
+     * @var string
+     */
     private $format;
 
+    /**
+     * @var string
+     */
     private $timezone;
 
+    /**
+     * @var \DateTimeZone
+     */
     private $utc;
 
+    /**
+     * @var \DateTimeZone
+     */
     private $local;
 
+    /**
+     * @var \DateTimeInterface
+     */
     private $datetime;
 
     /**

--- a/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
@@ -18,24 +18,12 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class DateHelper extends Helper
 {
-    /**
-     * @var array
-     */
     protected $formats;
 
-    /**
-     * @var DateTimeHelper
-     */
     protected $helper;
 
-    /**
-     * @var TranslatorInterface
-     */
     protected $translator;
 
-    /**
-     * @var CoreParametersHelper
-     */
     private $coreParametersHelper;
 
     /**
@@ -181,7 +169,7 @@ class DateHelper extends Helper
         $dt       = $this->helper->getLocalDateTime();
 
         if ($textDate) {
-            return $this->translator->trans('mautic.core.date.'.$textDate, ['%time%' => $dt->format($this->coreParametersHelper->getParameter('date_format_timeonly'))]);
+            return $this->translator->trans('mautic.core.date.'.$textDate, ['%time%' => $dt->format($this->coreParametersHelper->get('date_format_timeonly'))]);
         } else {
             $interval = $this->helper->getDiff('now', null, true);
 

--- a/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
@@ -18,12 +18,24 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class DateHelper extends Helper
 {
+    /**
+     * @var string[]
+     */
     protected $formats;
 
+    /**
+     * @var DateTimeHelper
+     */
     protected $helper;
 
+    /**
+     * @var TranslatorInterface
+     */
     protected $translator;
 
+    /**
+     * @var CoreParametersHelper
+     */
     private $coreParametersHelper;
 
     /**

--- a/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
@@ -11,6 +11,7 @@
 
 namespace Mautic\CoreBundle\Templating\Helper;
 
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Symfony\Component\Templating\Helper\Helper;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -33,6 +34,11 @@ class DateHelper extends Helper
     protected $translator;
 
     /**
+     * @var CoreParametersHelper
+     */
+    private $coreParametersHelper;
+
+    /**
      * @param string $dateFullFormat
      * @param string $dateShortFormat
      * @param string $dateOnlyFormat
@@ -43,7 +49,8 @@ class DateHelper extends Helper
         $dateShortFormat,
         $dateOnlyFormat,
         $timeOnlyFormat,
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
+        CoreParametersHelper $coreParametersHelper
     ) {
         $this->formats = [
             'datetime' => $dateFullFormat,
@@ -52,8 +59,9 @@ class DateHelper extends Helper
             'time'     => $timeOnlyFormat,
         ];
 
-        $this->helper     = new DateTimeHelper(null, null, 'local');
-        $this->translator = $translator;
+        $this->helper               = new DateTimeHelper(null, null, 'local');
+        $this->translator           = $translator;
+        $this->coreParametersHelper = $coreParametersHelper;
     }
 
     /**
@@ -173,7 +181,7 @@ class DateHelper extends Helper
         $dt       = $this->helper->getLocalDateTime();
 
         if ($textDate) {
-            return $this->translator->trans('mautic.core.date.'.$textDate, ['%time%' => $dt->format('g:i a')]);
+            return $this->translator->trans('mautic.core.date.'.$textDate, ['%time%' => $dt->format($this->coreParametersHelper->getParameter('date_format_timeonly'))]);
         } else {
             $interval = $this->helper->getDiff('now', null, true);
 

--- a/app/bundles/CoreBundle/Tests/Unit/Templating/Helper/DateHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Templating/Helper/DateHelperTest.php
@@ -11,11 +11,15 @@
 
 namespace Mautic\CoreBundle\Tests\Unit\Templating\Helper;
 
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Templating\Helper\DateHelper;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class DateHelperTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|TranslatorInterface
+     */
     private $translator;
 
     /**
@@ -27,6 +31,11 @@ class DateHelperTest extends \PHPUnit\Framework\TestCase
      * @var string
      */
     private static $oldTimezone;
+
+    /**
+     * @var CoreParametersHelper|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $coreParametersHelper;
 
     public static function setupBeforeClass()
     {
@@ -40,13 +49,15 @@ class DateHelperTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $this->translator = $this->createMock(TranslatorInterface::class);
-        $this->helper     = new DateHelper(
+        $this->translator           = $this->createMock(TranslatorInterface::class);
+        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+        $this->helper               = new DateHelper(
             'F j, Y g:i a T',
             'D, M d',
             'F j, Y',
             'g:i a',
-            $this->translator
+            $this->translator,
+            $this->coreParametersHelper
         );
     }
 
@@ -78,5 +89,25 @@ class DateHelperTest extends \PHPUnit\Framework\TestCase
         $dateTime = new \DateTime('2016-01-27 14:30:00', new \DateTimeZone('UTC'));
 
         $this->assertSame('January 27, 2016 2:30 pm', $this->helper->toText($dateTime, 'UTC', 'Y-m-d H:i:s', true));
+    }
+
+    public function testToTextWithConfigurationToTime()
+    {
+        $this->coreParametersHelper->method('get')
+            ->with('date_format_timeonly')
+            ->willReturn('00:00:00');
+
+        $this->translator->method('trans')
+            ->willReturnCallback(
+                function (string $key, array $parameters = []) {
+                    if (isset($parameters['%time%'])) {
+                        return $parameters['%time%'];
+                    }
+                }
+            );
+
+        $dateTime = new \DateTime('now', new \DateTimeZone('UTC'));
+
+        $this->assertSame('00:00:00', $this->helper->toText($dateTime));
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
If we change configuration time format to 24 hours, timeline dates don't respect this format.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. You need contact with timeline events during few days
2. Then change Default Time Only Format  in Configuration to **G:i** format. 

![image](https://user-images.githubusercontent.com/462477/82343417-1a907980-99f3-11ea-989c-a5e666e935ab.png)

3.  Check mismatch time format. We expect 24hours format

![image](https://user-images.githubusercontent.com/49391402/82336648-237d4d00-99eb-11ea-8e37-3dffb46aac87.png)

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps. Check if time format  display properly
