### PR TITLE
M3 tokens for landing page not functioning

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/froala/plugins/token.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/froala/plugins/token.js
@@ -57,7 +57,7 @@
                     } else if (k.match(/pagelink=/i) && v.match(/a:/)){
                         delete tokens[k];
                         nv = v.replace('a:', '');
-                        k = '<a title="Page Link" href=""' + k + '">' + nv + '</a>';
+                        k = '<a title="Page Link" href="' + k + '">' + nv + '</a>';
                         tokens[k] = nv;
                     } else if (k.match(/dwc=/i)){
                         var tn = k.substr(5, k.length - 6);

--- a/app/bundles/PageBundle/Form/Type/RedirectListType.php
+++ b/app/bundles/PageBundle/Form/Type/RedirectListType.php
@@ -27,8 +27,11 @@ class RedirectListType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
+        $choices = $this->coreParametersHelper->get('redirect_list_types');
+        $choices = (null === $choices) ? [] : array_flip($choices);
+
         $resolver->setDefaults([
-            'choices'     => array_flip($this->coreParametersHelper->get('redirect_list_types')),
+            'choices'     => $choices,
             'expanded'    => false,
             'multiple'    => false,
             'label'       => 'mautic.page.form.redirecttype',

--- a/app/bundles/PageBundle/Tests/Form/Type/RedirectListTypeTest.php
+++ b/app/bundles/PageBundle/Tests/Form/Type/RedirectListTypeTest.php
@@ -1,0 +1,104 @@
+<?php
+/*
+ * @copyright   2020 Mautic, Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\PageBundle\Tests\Form\Type;
+
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\PageBundle\Form\Type\RedirectListType;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class RedirectListTypeTest extends TestCase
+{
+    /**
+     * @var CoreParametersHelper|MockObject
+     */
+    private $coreParametersHelper;
+
+    /**
+     * @var RedirectListType
+     */
+    private $form;
+
+    public function setUp()
+    {
+        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+        $this->form                 = new RedirectListType($this->coreParametersHelper);
+    }
+
+    public function testGetParent()
+    {
+        $this->assertSame(ChoiceType::class, $this->form->getParent());
+    }
+
+    public function testConfigureOptionsChoicesUndefined()
+    {
+        $resolver = new OptionsResolver();
+        $this->form->configureOptions($resolver);
+
+        $expectedOptions = [
+            'choices'    => [],
+            'expanded'   => false,
+            'multiple'   => false,
+            'label'      => 'mautic.page.form.redirecttype',
+            'label_attr' => [
+                'class' => 'control-label',
+            ],
+            'placeholder' => false,
+            'required'    => false,
+            'attr'        => [
+                'class' => 'form-control',
+            ],
+            'feature' => 'all',
+        ];
+
+        $this->assertSame($expectedOptions, $resolver->resolve());
+    }
+
+    public function testConfigureOptionsChoicesDefined()
+    {
+        $choices = [
+            '1' => 'Jarda',
+            '2' => 'Pepa',
+        ];
+
+        $this->coreParametersHelper->expects($this->once())
+            ->method('get')
+            ->willReturn($choices);
+
+        $resolver = new OptionsResolver();
+        $this->form->configureOptions($resolver);
+
+        $expectedOptions = [
+            'choices'    => array_flip($choices),
+            'expanded'   => false,
+            'multiple'   => false,
+            'label'      => 'mautic.page.form.redirecttype',
+            'label_attr' => [
+                'class' => 'control-label',
+            ],
+            'placeholder' => false,
+            'required'    => false,
+            'attr'        => [
+                'class' => 'form-control',
+            ],
+            'feature' => 'all',
+        ];
+
+        $this->assertSame($expectedOptions, $resolver->resolve());
+    }
+
+    public function testGetBlockPrefix()
+    {
+        $this->assertSame('redirect_list', $this->form->getBlockPrefix());
+    }
+}


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
Tokens for Landing Pages do not function in the email builder.
Workaround: the link option using the landing page URL does work.

This was working in M2.

Fixes empty `redirect_list_types` in CoreParametersHelper too. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create landing page if you don't have one
2. Create template email (You can use segment too with own reproductuion steps)
3. type in text editor `{your-landing-page-name` and press enter (this creates link to landing page in email - autocompletion is wrongly translated to this html
![Snímek obrazovky 2020-05-21 v 15 07 17](https://user-images.githubusercontent.com/12815758/82662444-24ea8780-9c2e-11ea-8c25-3fc54d8a8bad.png)

4. close builder, save e-mail
5. click to send example and use gmail your gmail
6. text containing title of landing page is present, but not presented as hyperlink

- In gmal : href attr is not presaent
![Snímek obrazovky 2020-05-20 v 14 17 05](https://user-images.githubusercontent.com/12815758/82445149-9dbdd800-9aa4-11ea-8dbe-a52f32156b91.png)
- In Mailhog hyperlink does not contain value and target presented as Mailhog http address.
![Snímek obrazovky 2020-05-20 v 14 15 54](https://user-images.githubusercontent.com/12815758/82445224-baf2a680-9aa4-11ea-9641-de11a2ee1838.png)



#### Steps to test this PR:
1. Load PR into https://m3.mautibox.com/
2. Repeat reproduction steps 

