### PR TITLE
Update message id to fetch the proper translation for button label

### DIFF
--- a/app/bundles/CoreBundle/Views/Variant/row.html.php
+++ b/app/bundles/CoreBundle/Views/Variant/row.html.php
@@ -62,7 +62,7 @@ $isCurrent = ($variant->getId() === $activeEntity->getId());
                 </div>
                 <div class="col-xs-11">
                     <?php if ($isWinner): ?>
-                        <div class="mr-xs pull-left" data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.core.ab_test.make_winner'); ?>">
+                        <div class="mr-xs pull-left" data-toggle="tooltip" title="<?php echo $view['translator']->trans('mautic.core.ab_test.makewinner'); ?>">
                             <a class="btn btn-warning"
                                data-toggle="confirmation"
                                href="<?php echo $view['router']->path(
@@ -80,7 +80,7 @@ $isCurrent = ($variant->getId() === $activeEntity->getId());
                                ); ?>"
                                data-confirm-text="<?php echo $view->escape(
                                    $view['translator']->trans(
-                                       'mautic.core.ab_test.make_winner'
+                                       'mautic.core.ab_test.makewinner'
                                    )
                                ); ?>"
                                data-confirm-callback="executeAction"


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N 
| Automated tests included? | N
| Related user documentation PR URL | N/A 
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8616
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Update the message id to fetch the proper translation.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.   Create a variant for an email
2.  Check out the two items above - one is when assigning a winner (you'll need to send to a segment) and one is just by hovering over the trophy.


#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Check the steps to reproduce

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
