### PR TITLE
Fixes Anchor in url doesn't work after redirect with utm

### DIFF
--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -444,7 +444,14 @@ class PublicController extends CommonFormController
 
         // Ensure the URL does not have encoded ampersands
         $url = str_replace('&amp;', '&', $redirect->getUrl());
-
+        
+        //cut out a fragment from the address to remember and insert it at the end of the url
+        $fragment = false;
+        if (strpos($url, '#') !== false) {            
+            $fragment = '#'.parse_url($url, PHP_URL_FRAGMENT);
+            $url = str_replace($fragment,'',$url);
+        }
+        
         // Get query string
         $query = $this->request->query->all();
 
@@ -457,7 +464,12 @@ class PublicController extends CommonFormController
             $url .= (strpos($url, '?') !== false) ? '&' : '?';
             $url .= http_build_query($query);
         }
-
+        
+        //adding a fragment to the end of the url (#anchor)
+        if($fragment) {
+            $url .= $fragment;
+        }
+        
         // If the IP address is not trackable, it means it came form a configured "do not track" IP or a "do not track" user agent
         // This prevents simulated clicks from 3rd party services such as URL shorteners from simulating clicks
         $ipAddress = $this->container->get('mautic.helper.ip_lookup')->getIpAddress();


### PR DESCRIPTION
 it resolves #8791

**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

1. Create an email with an anchor link (for example, #my_anchor).
2. In the email settings, fill in the Google Analytics UTM tags fields.
3. Send an email by segment or through a campaign.
4. In this received email, follow the link.

It turns out that the anchor is located inside the url, although it should be at the very end.
not correct:
https://domain.com/test_url#my_anchor?utm_source=1&utm_medium=1&utm_campaign=3&utm_content=4

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Follow steps above and check that the URL is correct:
https://domain.com/test_url?utm_source=1&utm_medium=1&utm_campaign=3&utm_content=4#my_anchor
