### PR TITLE
Fix #7559: Merge lead devices when merging leads (3.x rebase of #7561)

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadDeviceRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadDeviceRepository.php
@@ -175,4 +175,19 @@ class LeadDeviceRepository extends CommonRepository
             ->execute()
             ->fetchAll();
     }
+
+    /**
+     * Updates lead ID (e.g. after a lead merge).
+     *
+     * @param $fromLeadId
+     * @param $toLeadId
+     */
+    public function updateLead($fromLeadId, $toLeadId)
+    {
+        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        $q->update(MAUTIC_TABLE_PREFIX.'lead_devices')
+            ->set('lead_id', (int) $toLeadId)
+            ->where('lead_id = '.(int) $fromLeadId)
+            ->execute();
+    }
 }

--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -17,6 +17,7 @@ use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadDevice;
 use Mautic\LeadBundle\Entity\LeadEventLog;
 use Mautic\LeadBundle\Entity\LeadNote;
 use Mautic\LeadBundle\Entity\ListLead;
@@ -281,6 +282,11 @@ class LeadSubscriber implements EventSubscriberInterface
         );
 
         $this->entityManager->getRepository(LeadNote::class)->updateLead(
+            $event->getLoser()->getId(),
+            $event->getVictor()->getId()
+        );
+
+        $this->entityManager->getRepository(LeadDevice::class)->updateLead(
             $event->getLoser()->getId(),
             $event->getVictor()->getId()
         );


### PR DESCRIPTION
closes https://github.com/mautic/mautic/issues/7559
| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #7559
| BC breaks? | 
| Deprecations? | 

#### Description:
Fix #7559 by adding a standard `updateLead()` method to the `LeadDeviceRepository` and calling it from the same place as the other lead-related merge handlers.

#### Steps to reproduce the bug:
1. Create an identified contact
2. Create a new anonymous contact by browsing a tracked page in a test browser.  Take note of the document.cookie `mtc_id` and `mautic_device_id` values
3. Merge the second contact into the first (e.g. by adding an email address) in the Mautic UI or via the API
4. Refresh the same tracked page in the test browser and observe that `mtc_id` and `mautic_device_id` have changed, and a new anonymous contact has been created, because the old device records were deleted.

#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Same as above, but on step 4 the device ID should remain the same, and the `mtc_id` should be the ID of the contact created in the first step.
