### PR TITLE
Restore API permissions for M3

### DIFF
--- a/app/bundles/CoreBundle/Helper/CoreParametersHelper.php
+++ b/app/bundles/CoreBundle/Helper/CoreParametersHelper.php
@@ -88,7 +88,7 @@ class CoreParametersHelper
 
     private function resolveParameters(): void
     {
-        $all = $this->parameters->keys();
+        $all = $this->parameters->all();
 
         foreach ($all as $key => $value) {
             $this->resolvedParameters[$key] = $this->get($key, $value);

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/CoreParametersHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/CoreParametersHelperTest.php
@@ -26,24 +26,36 @@ class CoreParametersHelperTest extends TestCase
      */
     private $container;
 
-    /**
-     * @var CoreParametersHelper
-     */
-    private $helper;
-
     protected function setUp()
     {
         $this->container = $this->createMock(ContainerInterface::class);
-        $this->helper    = new CoreParametersHelper($this->container);
     }
 
     public function testAllReturnsResolvedParameters()
     {
-        $all = $this->helper->all();
+        $this->container->method('hasParameter')
+            ->willReturnCallback(
+                function (string $key) {
+                    return 'mautic.cache_path' === $key;
+                }
+            );
+
+        $this->container->expects($this->once())
+            ->method('getParameter')
+            ->with('mautic.cache_path')
+            ->willReturn('/path/to/cache');
+
+        $all = $this->getHelper()->all();
 
         // Assert that a few of the config keys exist
         Assert::assertArrayHasKey('api_enabled', $all);
         Assert::assertArrayHasKey('cache_path', $all);
+        Assert::assertSame('/path/to/cache', $all['cache_path']);
         Assert::assertArrayHasKey('log_path', $all);
+    }
+
+    private function getHelper(): CoreParametersHelper
+    {
+        return new CoreParametersHelper($this->container);
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/CoreParametersHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/CoreParametersHelperTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://www.mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Tests\Unit\Helper;
+
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class CoreParametersHelperTest extends TestCase
+{
+    /**
+     * @var MockObject|ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var CoreParametersHelper
+     */
+    private $helper;
+
+    protected function setUp()
+    {
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->helper    = new CoreParametersHelper($this->container);
+    }
+
+    public function testAllReturnsResolvedParameters()
+    {
+        $all = $this->helper->all();
+
+        // Assert that a few of the config keys exist
+        Assert::assertArrayHasKey('api_enabled', $all);
+        Assert::assertArrayHasKey('cache_path', $all);
+        Assert::assertArrayHasKey('log_path', $all);
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The API permissions disappeared because the isEnabled method depended on the api_enabled configuration option. However, permission classes were passed an array of config keys, not key/value pairs so `!empty($this->params['api_enabled'])` was always false since the key did not exist. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a role, set is admin to false, and look for the API Permissions which won't be visible

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat and API permissions are back