### PR TITLE
Hotfix to not typecast numbers without a precision to float in contact API responses

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
+++ b/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
@@ -68,8 +68,50 @@ trait CustomFieldsApiControllerTrait
         if ($entity instanceof CustomFieldEntityInterface) {
             $fields        = $entity->getFields();
             $fields['all'] = $entity->getProfileFields();
+
+            // Temporary hack to address numbers being type casted to float which broke some API implementations because M2 used to return
+            // these as strings and values are normalized in a dozen differneet ways throughout LeadModel::setFieldValues methods and became
+            // too risky to hotfix
+            $fields = $this->fixNumbers($fields);
+
             $entity->setFields($fields);
         }
+    }
+
+    private function fixNumbers(array $fields): array
+    {
+        $numberFields = [];
+        foreach ($fields as $group => $groupFields) {
+            if ('all' === $group) {
+                continue;
+            }
+
+            foreach ($groupFields as $field => $fieldDefinition) {
+                if ('points' === $field) {
+                    // Points were always a number in M2
+                    $numberFields[$field] = (int) $fields[$group][$field]['value'];
+                }
+
+                if ('number' !== $fieldDefinition['type'] || null === $fields[$group][$field]['value']) {
+                    continue;
+                }
+
+                // Some requests don't seem to have properties unserialized by default (even in M2)
+                $properties = is_string($fieldDefinition['properties']) ? unserialize($fieldDefinition['properties']) : $fieldDefinition['properties'];
+
+                $fields[$group][$field]['value']           = empty($properties['scale']) ? (int) $fields[$group][$field]['value']
+                    : (float) $fields[$group][$field]['value'];
+                $fields[$group][$field]['normalizedValue'] = empty($properties['scale']) ? (int) $fields[$group][$field]['normalizedValue']
+                    : (float) $fields[$group][$field]['normalizedValue'];
+
+                $numberFields[$field] = $fields[$group][$field]['value'];
+            }
+        }
+
+        // Fix "all" fields
+        $fields['all'] = array_merge($fields['all'], $numberFields);
+
+        return $fields;
     }
 
     /**


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
In Mautic 2, number custom fields were all strings in the API responses. However, somewhere in M3 (serializer behavior change?), those started to be returned as floats with `.0` even though precision was empty or set to 0.

This broke some languages from correctly unserializing the response. 

Unfortunately, it wasn't easy to solve at the entity level because Mautic handles the parameter binding differently depending on if it was a post or patch and thus one change would break another. It seems that data is passed through setFieldValues multiple times, updateFieldValues end up with one value in memory that overrides original values in `getFields.` Due to the complexity of figuring out how to fix all that, this PR does a temporary hotfix that corrects the data before it is sent to the serializer. 

The API functional tests have been updated to ensure that points are handled correctly which Mautic sees as a "number" custom field. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a custom field type of number and ensure that precision is left empty
2. Create/update a contact with a value for the custom field
3. Using the API, fetch the contact and review the field value in the response. It will have a .0 appended. 
4. Update the contact custom field to have a precision of 1.
4. Update the contact with an actual float value like (123.4). It should return in the response as 123.4. 

![Screen Shot 2020-05-14 at 15 50 01](https://user-images.githubusercontent.com/63312/81985434-e0daff80-95fb-11ea-8873-8e9b0259ff40.png)

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat the above. This time if the custom field has a precision of 0, it should be an integer in the response (also check points). If the custom field has a precision of 1, it should be a float.  

#### Other areas of Mautic that may be affected by the change:
1. This should only affect the API responses for contacts. But it's possible the changed behavior causing this issue may cause issues in other parts of the product. We'll need to explore this along with a more permanent fix.  

![Screen Shot 2020-05-14 at 15 50 54](https://user-images.githubusercontent.com/63312/81985427-dd477880-95fb-11ea-8f05-d017c18d047d.png)

![Screen Shot 2020-05-14 at 15 53 34](https://user-images.githubusercontent.com/63312/81985417-da4c8800-95fb-11ea-8bf5-c8586c6bacf1.png)

![Screen Shot 2020-05-14 at 15 57 53](https://user-images.githubusercontent.com/63312/81985402-d6206a80-95fb-11ea-90c6-e23ecb2d11ce.png)
