### PR TITLE
Fix timeline layout

### DIFF
--- a/app/bundles/LeadBundle/Assets/css/lead.css
+++ b/app/bundles/LeadBundle/Assets/css/lead.css
@@ -156,7 +156,7 @@ ul.tag-cloud li {
 }
 .history-search{
     overflow: visible!important;
-    height: 53px;
+    min-height: 53px;
 }
 .timeline-icon {
     width: 50px;

--- a/app/bundles/LeadBundle/Views/Timeline/index.html.php
+++ b/app/bundles/LeadBundle/Views/Timeline/index.html.php
@@ -18,30 +18,32 @@
     </div>
     <?php if (isset($events['types']) && is_array($events['types'])) : ?>
         <div class="history-search panel-footer text-muted">
-            <div class="col-sm-5">
-                <select name="includeEvents[]" multiple="multiple" class="form-control bdr-w-0" data-placeholder="<?php echo $view['translator']->trans('mautic.lead.lead.filter.bundles.include.placeholder'); ?>">
-                    <?php foreach ($events['types'] as $typeKey => $typeName) : ?>
-                        <option value="<?php echo $view->escape($typeKey); ?>"<?php echo in_array($typeKey, $events['filters']['includeEvents']) ? ' selected' : ''; ?> >
-                            <?php echo $typeName; ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
-            <div class="col-sm-5">
-                <select name="excludeEvents[]" multiple="multiple" class="form-control bdr-w-0" data-placeholder="<?php echo $view['translator']->trans('mautic.lead.lead.filter.bundles.exclude.placeholder'); ?>">
-                    <?php foreach ($events['types'] as $typeKey => $typeName) : ?>
-                        <option value="<?php echo $view->escape($typeKey); ?>"<?php echo in_array($typeKey, $events['filters']['excludeEvents']) ? ' selected' : ''; ?> >
-                            <?php echo $typeName; ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
-            <div class="col-sm-2">
-                <a class="btn btn-default btn-block" href="<?php echo $view['router']->url('mautic_contact_timeline_export_action', ['leadId' => $lead->getId()]); ?>" data-toggle="download">
-                    <span>
-                        <i class="fa fa-download"></i> <span class="hidden-xs hidden-sm"><?php echo $view['translator']->trans('mautic.core.export'); ?></span>
-                    </span>
-                </a>
+            <div class="row">
+                <div class="col-sm-5">
+                    <select name="includeEvents[]" multiple="multiple" class="form-control bdr-w-0" data-placeholder="<?php echo $view['translator']->trans('mautic.lead.lead.filter.bundles.include.placeholder'); ?>">
+                        <?php foreach ($events['types'] as $typeKey => $typeName) : ?>
+                            <option value="<?php echo $view->escape($typeKey); ?>"<?php echo in_array($typeKey, $events['filters']['includeEvents']) ? ' selected' : ''; ?> >
+                                <?php echo $typeName; ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-sm-5">
+                    <select name="excludeEvents[]" multiple="multiple" class="form-control bdr-w-0" data-placeholder="<?php echo $view['translator']->trans('mautic.lead.lead.filter.bundles.exclude.placeholder'); ?>">
+                        <?php foreach ($events['types'] as $typeKey => $typeName) : ?>
+                            <option value="<?php echo $view->escape($typeKey); ?>"<?php echo in_array($typeKey, $events['filters']['excludeEvents']) ? ' selected' : ''; ?> >
+                                <?php echo $typeName; ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-sm-2">
+                    <a class="btn btn-default btn-block" href="<?php echo $view['router']->url('mautic_contact_timeline_export_action', ['leadId' => $lead->getId()]); ?>" data-toggle="download">
+                        <span>
+                            <i class="fa fa-download"></i> <span class="hidden-xs hidden-sm"><?php echo $view['translator']->trans('mautic.core.export'); ?></span>
+                        </span>
+                    </a>
+                </div>
             </div>
         </div>
     <?php endif; ?>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Fix to https://github.com/mautic/mautic/issues/8823 

When selecting multiple filters the field expands (outside its container)  and shoves the table across the page which is not a great user experience.

![screenshot-m3 mautibox com-2020 05 23-18_15_50](https://user-images.githubusercontent.com/2930593/82736481-fea61400-9d21-11ea-9055-dd79364de328.png)


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Open a contact with multiple audit logs
2. Filter by multiple typesand notice the effect on the user interface

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 
