### PR TITLE
Fixed CompanyExportTest and LeadExportTest

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -320,14 +320,6 @@ class AppKernel extends Kernel
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function getProjectDir(): string
-    {
-        return dirname(__DIR__);
-    }
-
-    /**
      * Get local config file.
      */
     public function getLocalConfigFile(): string

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -289,6 +289,11 @@ class AppKernel extends Kernel
         return __DIR__;
     }
 
+    public function getProjectDir(): string
+    {
+        return dirname(__DIR__);
+    }
+
     /**
      * {@inheritdoc}
      *

--- a/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
+++ b/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Routing\RouterInterface;
 
 abstract class AbstractMauticTestCase extends WebTestCase
 {
@@ -62,6 +63,13 @@ abstract class AbstractMauticTestCase extends WebTestCase
 
         $this->container = $this->client->getContainer();
         $this->em        = $this->container->get('doctrine')->getManager();
+
+        /** @var RouterInterface $router */
+        $router = $this->container->get('router');
+        $scheme = $router->getContext()->getScheme();
+        $secure = strcasecmp($scheme, 'https');
+
+        $this->client->setServerParameter('HTTPS', $secure);
 
         $this->mockServices();
     }

--- a/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
+++ b/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
@@ -67,7 +67,7 @@ abstract class AbstractMauticTestCase extends WebTestCase
         /** @var RouterInterface $router */
         $router = $this->container->get('router');
         $scheme = $router->getContext()->getScheme();
-        $secure = strcasecmp($scheme, 'https');
+        $secure = 0 === strcasecmp($scheme, 'https');
 
         $this->client->setServerParameter('HTTPS', $secure);
 

--- a/plugins/MauticCrmBundle/Tests/Pipedrive/Export/CompanyExportTest.php
+++ b/plugins/MauticCrmBundle/Tests/Pipedrive/Export/CompanyExportTest.php
@@ -31,18 +31,16 @@ class CompanyExportTest extends PipedriveTest
             ]
         );
 
-        $this->client->request(
-            Request::METHOD_POST,
-            '/s/companies/new?mauticUserLastActive=1&mauticLastNotificationId=',
-            [
-                'company' => [
-                    'companyname'     => 'Test Name',
-                    'companyaddress1' => 'Test Address',
-                ],
-            ],
-            [],
-            $this->createAjaxHeaders()
-        );
+        $crawler     = $this->client->request(Request::METHOD_GET, '/s/companies/new');
+        $formCrawler = $crawler->filter('form[name=company]');
+        $this->assertSame(1, $formCrawler->count());
+
+        $form = $formCrawler->form();
+        $form->setValues([
+            'company[companyname]'     => 'Test Name',
+            'company[companyaddress1]' => 'Test Address',
+        ]);
+        $this->client->submit($form);
 
         /** @var Company $company */
         $integrationEntities = $this->em->getRepository(IntegrationEntity::class)->findAll();
@@ -73,18 +71,16 @@ class CompanyExportTest extends PipedriveTest
             ]
         );
 
-        $this->client->request(
-            Request::METHOD_POST,
-            '/s/companies/new?mauticUserLastActive=1&mauticLastNotificationId=',
-            [
-                'company' => [
-                    'companyname'     => $testName,
-                    'companyaddress1' => $testAddress1,
-                ],
-            ],
-            [],
-            $this->createAjaxHeaders()
-        );
+        $crawler     = $this->client->request(Request::METHOD_GET, '/s/companies/new');
+        $formCrawler = $crawler->filter('form[name=company]');
+        $this->assertSame(1, $formCrawler->count());
+
+        $form = $formCrawler->form();
+        $form->setValues([
+            'company[companyname]'     => $testName,
+            'company[companyaddress1]' => $testAddress1,
+        ]);
+        $this->client->submit($form);
 
         $integrationEntities = $this->em->getRepository(IntegrationEntity::class)->findAll();
         $company             = $this->em->getRepository(Company::class)->findOneById(1);
@@ -121,18 +117,16 @@ class CompanyExportTest extends PipedriveTest
 
         $company = $this->createCompany();
 
-        $this->client->request(
-            Request::METHOD_POST,
-            's/companies/edit/'.$company->getId().'?mauticUserLastActive=1&mauticLastNotificationId=',
-            [
-                'company' => [
-                    'companyname'     => $testName,
-                    'companyaddress1' => $testAddress1,
-                ],
-            ],
-            [],
-            $this->createAjaxHeaders()
-        );
+        $crawler     = $this->client->request(Request::METHOD_GET, '/s/companies/edit/'.$company->getId());
+        $formCrawler = $crawler->filter('form[name=company]');
+        $this->assertSame(1, $formCrawler->count());
+
+        $form = $formCrawler->form();
+        $form->setValues([
+            'company[companyname]'     => $testName,
+            'company[companyaddress1]' => $testAddress1,
+        ]);
+        $this->client->submit($form);
 
         $integrationEntities = $this->em->getRepository(IntegrationEntity::class)->findAll();
         $companies           = $this->em->getRepository(Company::class)->findAll();
@@ -164,18 +158,16 @@ class CompanyExportTest extends PipedriveTest
         $company = $this->createCompany();
         $this->createCompanyIntegrationEntity($integrationId, $company->getId());
 
-        $this->client->request(
-            Request::METHOD_POST,
-            's/companies/edit/'.$company->getId().'?mauticUserLastActive=1&mauticLastNotificationId=',
-            [
-                'company' => [
-                    'companyname'     => $testName,
-                    'companyaddress1' => $testAddress1,
-                ],
-            ],
-            [],
-            $this->createAjaxHeaders()
-        );
+        $crawler     = $this->client->request(Request::METHOD_GET, '/s/companies/edit/'.$company->getId());
+        $formCrawler = $crawler->filter('form[name=company]');
+        $this->assertSame(1, $formCrawler->count());
+
+        $form = $formCrawler->form();
+        $form->setValues([
+            'company[companyname]'     => $testName,
+            'company[companyaddress1]' => $testAddress1,
+        ]);
+        $this->client->submit($form);
 
         $integrationEntities = $this->em->getRepository(IntegrationEntity::class)->findAll();
         $companies           = $this->em->getRepository(Company::class)->findAll();

--- a/plugins/MauticCrmBundle/Tests/Pipedrive/Export/LeadExportTest.php
+++ b/plugins/MauticCrmBundle/Tests/Pipedrive/Export/LeadExportTest.php
@@ -128,22 +128,20 @@ class LeadExportTest extends PipedriveTest
         $this->createCompanyIntegrationEntity($integrationCompanyId, $company->getId());
         $this->createCompanyIntegrationEntity($integrationCompany2Id, $company2->getId());
 
-        $this->client->request(
-            Request::METHOD_POST,
-            '/s/contacts/edit/'.$lead->getId().'?mauticUserLastActive=1&mauticLastNotificationId=',
-            [
-                'lead' => [
-                    'firstname'  => 'Test',
-                    'lastname'   => 'User',
-                    'email'      => 'test@test.pl',
-                    'points'     => 0,
-                    'phone'      => 123456789,
-                     '_token'    => $this->getCsrfToken('lead'),
-                ],
-            ],
-            [],
-            $this->createAjaxHeaders()
-        );
+        $crawler     = $this->client->request(Request::METHOD_GET, '/s/contacts/edit/'.$lead->getId());
+        $formCrawler = $crawler->filter('form[name=lead]');
+        $this->assertSame(1, $formCrawler->count());
+
+        $form = $formCrawler->form();
+        $form->setValues([
+            'lead[firstname]'     => 'Test',
+            'lead[lastname]'      => 'User',
+            'lead[email]'         => 'test@test.pl',
+            'lead[points]'        => 0,
+            'lead[phone]'         => 123456789,
+            'lead[companies]'     => [],
+        ]);
+        $this->client->submit($form);
 
         $requests = $GLOBALS['requests'];
         $request  = $requests['PUT/Api/Put/persons/'.$integrationId][1];
@@ -173,23 +171,20 @@ class LeadExportTest extends PipedriveTest
         $lead  = $this->createLead();
         $this->addPipedriveOwner($pipedriveOwnerId, $owner->getEmail());
 
-        $this->client->request(
-            Request::METHOD_POST,
-            '/s/contacts/edit/'.$lead->getId().'?mauticUserLastActive=1&mauticLastNotificationId=',
-            [
-                'lead' => [
-                    'firstname'  => 'Test',
-                    'lastname'   => 'User',
-                    'email'      => 'test@test.pl',
-                    'points'     => 0,
-                    'phone'      => 123456789,
-                    'owner'      => $owner->getId(),
-                     '_token'    => $this->getCsrfToken('lead'),
-                ],
-            ],
-            [],
-            $this->createAjaxHeaders()
-        );
+        $crawler     = $this->client->request(Request::METHOD_GET, '/s/contacts/edit/'.$lead->getId());
+        $formCrawler = $crawler->filter('form[name=lead]');
+        $this->assertSame(1, $formCrawler->count());
+
+        $form = $formCrawler->form();
+        $form->setValues([
+            'lead[firstname]' => 'Test',
+            'lead[lastname]'  => 'User',
+            'lead[email]'     => 'test@test.pl',
+            'lead[points]'    => 0,
+            'lead[phone]'     => 123456789,
+            'lead[owner]'     => $owner->getId(),
+        ]);
+        $this->client->submit($form);
 
         $requests = $GLOBALS['requests'];
         $request  = $requests['POST/Api/Put/persons'][0];

--- a/plugins/MauticCrmBundle/Tests/Pipedrive/Export/LeadExportTest.php
+++ b/plugins/MauticCrmBundle/Tests/Pipedrive/Export/LeadExportTest.php
@@ -49,20 +49,17 @@ class LeadExportTest extends PipedriveTest
         $this->em->flush();
 
         for ($i = 0; $i < $iterations; ++$i) {
-            $this->client->request(
-                Request::METHOD_POST,
-                '/s/contacts/new?qf=1&mauticUserLastActive=1&mauticLastNotificationId=',
-                [
-                    'lead' => [
-                        'firstname' => 'Test'.$i,
-                        'lastname'  => 'User'.$i,
-                        'email'     => 'test'.$i.'@test.pl',
-                        // '_token'    => $this->getCsrfToken('lead'),
-                    ],
-                ],
-                [],
-                $this->createAjaxHeaders()
-            );
+            $crawler     = $this->client->request(Request::METHOD_GET, '/s/contacts/new');
+            $formCrawler = $crawler->filter('form[name=lead]');
+            $this->assertSame(1, $formCrawler->count());
+
+            $form = $formCrawler->form();
+            $form->setValues([
+                'lead[firstname]' => 'Test'.$i,
+                'lead[lastname]'  => 'User'.$i,
+                'lead[email]'     => 'test'.$i.'@test.pl',
+            ]);
+            $this->client->submit($form);
         }
 
         $integrationEntities = $this->em->getRepository(IntegrationEntity::class)->findAll();
@@ -85,22 +82,20 @@ class LeadExportTest extends PipedriveTest
         );
         $lead = $this->createLead();
 
-        $this->client->request(
-            Request::METHOD_POST,
-            '/s/contacts/edit/'.$lead->getId().'?mauticUserLastActive=1&mauticLastNotificationId=',
-            [
-                'lead' => [
-                    'firstname' => 'Test',
-                    'lastname'  => 'User',
-                    'email'     => 'test@test.pl',
-                    'points'    => 0,
-                    'phone'     => 123456789,
-                    // '_token'    => $this->getCsrfToken('lead'),
-                ],
-            ],
-            [],
-            $this->createAjaxHeaders()
-        );
+        $crawler     = $this->client->request(Request::METHOD_GET, '/s/contacts/edit/'.$lead->getId());
+        $formCrawler = $crawler->filter('form[name=lead]');
+        $this->assertSame(1, $formCrawler->count());
+
+        $form = $formCrawler->form();
+        $form->setValues([
+            'lead[firstname]' => 'Test',
+            'lead[lastname]'  => 'User',
+            'lead[email]'     => 'test@test.pl',
+            'lead[points]'    => 0,
+            'lead[phone]'     => 123456789,
+        ]);
+        $this->client->submit($form);
+
         $requests = $GLOBALS['requests'];
         $request  = $requests['POST/Api/Put/persons'];
 
@@ -138,12 +133,12 @@ class LeadExportTest extends PipedriveTest
             '/s/contacts/edit/'.$lead->getId().'?mauticUserLastActive=1&mauticLastNotificationId=',
             [
                 'lead' => [
-                    'firstname' => 'Test',
-                    'lastname'  => 'User',
-                    'email'     => 'test@test.pl',
-                    'points'    => 0,
-                    'phone'     => 123456789,
-                    // '_token'    => $this->getCsrfToken('lead'),
+                    'firstname'  => 'Test',
+                    'lastname'   => 'User',
+                    'email'      => 'test@test.pl',
+                    'points'     => 0,
+                    'phone'      => 123456789,
+                     '_token'    => $this->getCsrfToken('lead'),
                 ],
             ],
             [],
@@ -183,13 +178,13 @@ class LeadExportTest extends PipedriveTest
             '/s/contacts/edit/'.$lead->getId().'?mauticUserLastActive=1&mauticLastNotificationId=',
             [
                 'lead' => [
-                    'firstname' => 'Test',
-                    'lastname'  => 'User',
-                    'email'     => 'test@test.pl',
-                    'points'    => 0,
-                    'phone'     => 123456789,
-                    'owner'     => $owner->getId(),
-                    // '_token'    => $this->getCsrfToken('lead'),
+                    'firstname'  => 'Test',
+                    'lastname'   => 'User',
+                    'email'      => 'test@test.pl',
+                    'points'     => 0,
+                    'phone'      => 123456789,
+                    'owner'      => $owner->getId(),
+                     '_token'    => $this->getCsrfToken('lead'),
                 ],
             ],
             [],


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:
Running `\MauticPlugin\MauticCrmBundle\Tests\Pipedrive\Export\CompanyExportTest` and `\MauticPlugin\MauticCrmBundle\Tests\Pipedrive\Export\LeadExportTest` isolated (filtered out) do not pass. The reason is that there is a missing CSRF token in the `POST` data.

I also added AppKernel::getProjectDir() method so the value of %kernel.project_dir% parameter returns a proper value.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Running `bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --filter '\\Pipedrive\\Export\\(CompanyExportTest|LeadExportTest)::'` outputs failed tests

#### Steps to test this PR:
1. Running `bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --filter '\\Pipedrive\\Export\\(CompanyExportTest|LeadExportTest)::'` does not output any failed tests