### PR TITLE
Update permission choices array format to fetch proper details.

### DIFF
--- a/app/bundles/UserBundle/Security/Permissions/UserPermissions.php
+++ b/app/bundles/UserBundle/Security/Permissions/UserPermissions.php
@@ -60,11 +60,11 @@ class UserPermissions extends AbstractPermissions
             PermissionListType::class,
             [
                 'choices'           => [
-                    'editname'     => 'mautic.user.account.permissions.editname',
-                    'editusername' => 'mautic.user.account.permissions.editusername',
-                    'editemail'    => 'mautic.user.account.permissions.editemail',
-                    'editposition' => 'mautic.user.account.permissions.editposition',
-                    'full'         => 'mautic.user.account.permissions.editall',
+                    'mautic.user.account.permissions.editname'     => 'editname',
+                    'mautic.user.account.permissions.editusername' => 'editusername',
+                    'mautic.user.account.permissions.editemail'    => 'editemail',
+                    'mautic.user.account.permissions.editposition' => 'editposition',
+                    'mautic.user.account.permissions.editall'      => 'full',
                 ],
                 'label'  => 'mautic.user.permissions.profile',
                 'data'   => (!empty($data['profile']) ? $data['profile'] : []),


### PR DESCRIPTION
Fixes https://github.com/mautic/mautic/issues/8860

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/8860
| BC breaks? | N
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Update the proper format in choices array.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a role with all permissions full except Segments which has no permissions set
2. 

#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Create a role with all permissions full except Segments which has no permissions set. More here https://github.com/mautic/mautic/issues/8860

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
