### PR TITLE
M3 Set campaign trigger to the next selected day of week when delay in days is set

### DIFF
--- a/app/bundles/CampaignBundle/Controller/EventController.php
+++ b/app/bundles/CampaignBundle/Controller/EventController.php
@@ -259,6 +259,7 @@ class EventController extends CommonFormController
          * AJAX request, or we are not granted campaign edit/create, deny access.
          */
         if (empty($event)
+            || empty($event['eventType'])
             || !in_array($event['eventType'], $this->supportedEventTypes)
             || !isset($event['type'])
             || !$this->request->isXmlHttpRequest()

--- a/app/bundles/CampaignBundle/Controller/EventController.php
+++ b/app/bundles/CampaignBundle/Controller/EventController.php
@@ -238,7 +238,7 @@ class EventController extends CommonFormController
                 'anchorEventType' => $campaignEvent['anchorEventType'] ?? '',
             ]);
         } else {
-            if (!isset($event['anchor'])) {
+            if (!isset($event['anchor']) && !empty($event['decisionPath'])) {
                 // Used to generate label
                 $event['anchor'] = $event['decisionPath'];
             }

--- a/app/bundles/CampaignBundle/Executioner/InactiveExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/InactiveExecutioner.php
@@ -337,7 +337,7 @@ class InactiveExecutioner implements ExecutionerInterface
                 ' to be executed on '.$eventExecutionDate->format('Y-m-d H:i:s e')
             );
 
-            if ($this->scheduler->shouldScheduleForInactive($event) || $this->scheduler->shouldSchedule($eventExecutionDate, $executionDate)) {
+            if ($this->scheduler->shouldScheduleForInactive($event, $eventExecutionDate, $executionDate)) {
                 $childrenCounter->advanceTotalScheduled($contacts->count());
                 $this->scheduler->schedule($event, $eventExecutionDate, $contacts, true);
 

--- a/app/bundles/CampaignBundle/Executioner/InactiveExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/InactiveExecutioner.php
@@ -337,7 +337,7 @@ class InactiveExecutioner implements ExecutionerInterface
                 ' to be executed on '.$eventExecutionDate->format('Y-m-d H:i:s e')
             );
 
-            if ($this->scheduler->shouldSchedule($eventExecutionDate, $executionDate, $event)) {
+            if ($this->scheduler->shouldScheduleForInactive($event) || $this->scheduler->shouldSchedule($eventExecutionDate, $executionDate)) {
                 $childrenCounter->advanceTotalScheduled($contacts->count());
                 $this->scheduler->schedule($event, $eventExecutionDate, $contacts, true);
 

--- a/app/bundles/CampaignBundle/Executioner/InactiveExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/InactiveExecutioner.php
@@ -337,7 +337,7 @@ class InactiveExecutioner implements ExecutionerInterface
                 ' to be executed on '.$eventExecutionDate->format('Y-m-d H:i:s e')
             );
 
-            if ($this->scheduler->shouldSchedule($eventExecutionDate, $executionDate)) {
+            if ($this->scheduler->shouldSchedule($eventExecutionDate, $executionDate, $event)) {
                 $childrenCounter->advanceTotalScheduled($contacts->count());
                 $this->scheduler->schedule($event, $eventExecutionDate, $contacts, true);
 

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
@@ -315,7 +315,7 @@ class EventScheduler
         return $executionDate > $now;
     }
 
-    public function shouldScheduleForInactive(Event $event): bool
+    public function shouldScheduleForInactive(Event $event, \DateTime $executionDate, \DateTime $now): bool
     {
         if (null !== $event) {
             $eventProperties = $event->getProperties();

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
@@ -294,7 +294,7 @@ class EventScheduler
 
     public function getExecutionDateForInactivity(\DateTime $eventExecutionDate, \DateTime $earliestExecutionDate, \DateTime $now): \DateTime
     {
-        if ($earliestExecutionDate->getTimestamp() === $eventExecutionDate->getTimestamp()) {
+        if ($eventExecutionDate->getTimestamp() === $earliestExecutionDate->getTimestamp()) {
             // Inactivity is based on the "wait" period so execute now
             return clone $now;
         }

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
@@ -302,16 +302,8 @@ class EventScheduler
         return $eventExecutionDate;
     }
 
-    public function shouldSchedule(\DateTime $executionDate, \DateTime $now, Event $event = null): bool
+    public function shouldSchedule(\DateTime $executionDate, \DateTime $now): bool
     {
-        if (null !== $event) {
-            $eventProperties = $event->getProperties();
-            if (!empty($eventProperties['triggerRestrictedDaysOfWeek'])) {
-                // Event has days in week specified. Needs to be recalculated to the next day configured
-                return true;
-            }
-        }
-
         // Mainly for functional tests so we don't have to wait minutes but technically can be used in an environment as well if this behavior
         // is desired by system admin
         if (false === (bool) getenv('CAMPAIGN_EXECUTIONER_SCHEDULER_ACKNOWLEDGE_SECONDS')) {
@@ -321,6 +313,19 @@ class EventScheduler
         }
 
         return $executionDate > $now;
+    }
+
+    public function shouldScheduleForInactive(Event $event): bool
+    {
+        if (null !== $event) {
+            $eventProperties = $event->getProperties();
+            if (!empty($eventProperties['triggerRestrictedDaysOfWeek'])) {
+                // Event has days in week specified. Needs to be recalculated to the next day configured
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
@@ -325,7 +325,7 @@ class EventScheduler
             }
         }
 
-        return false;
+        return $this->shouldSchedule($executionDate, $now);
     }
 
     /**

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
@@ -310,6 +310,14 @@ class EventScheduler
      */
     public function shouldSchedule(\DateTime $executionDate, \DateTime $now)
     {
+        if (null !== $event) {
+            $eventProperties = $event->getProperties();
+            if (!empty($eventProperties['triggerRestrictedDaysOfWeek'])) {
+                // Event has days in week specified. Needs to be recalculated to the next day configured
+                return true;
+            }
+        }
+
         // Mainly for functional tests so we don't have to wait minutes but technically can be used in an environment as well if this behavior
         // is desired by system admin
         if (false === (bool) getenv('CAMPAIGN_EXECUTIONER_SCHEDULER_ACKNOWLEDGE_SECONDS')) {

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
@@ -302,10 +302,7 @@ class EventScheduler
         return $eventExecutionDate;
     }
 
-    /**
-     * @return bool
-     */
-    public function shouldSchedule(\DateTime $executionDate, \DateTime $now)
+    public function shouldSchedule(\DateTime $executionDate, \DateTime $now, Event $event = null): bool
     {
         if (null !== $event) {
             $eventProperties = $event->getProperties();

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
@@ -292,10 +292,7 @@ class EventScheduler
         return $eventExecutionDates;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getExecutionDateForInactivity(\DateTime $eventExecutionDate, \DateTime $earliestExecutionDate, \DateTime $now)
+    public function getExecutionDateForInactivity(\DateTime $eventExecutionDate, \DateTime $earliestExecutionDate, \DateTime $now): \DateTime
     {
         if ($earliestExecutionDate->getTimestamp() === $eventExecutionDate->getTimestamp()) {
             // Inactivity is based on the "wait" period so execute now

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -120,10 +120,6 @@ class Interval implements ScheduleModeInterface
         $startTime             = $event->getTriggerRestrictedStartHour();
         $endTime               = $event->getTriggerRestrictedStopHour();
         $daysOfWeek            = $event->getTriggerRestrictedDaysOfWeek();
-        $triggerInterval       = $event->getTriggerInterval();
-        $triggerIntervalUnit   = $event->getTriggerIntervalUnit();
-
-        $isTriggerIntervalInDaysSet = 'd' === $triggerIntervalUnit && $triggerInterval > 0;
 
         // Get the difference between now and the date we're supposed to be executing
         $compareFromDateTime = $compareFromDateTime ? clone $compareFromDateTime : new \DateTime('now');
@@ -140,8 +136,7 @@ class Interval implements ScheduleModeInterface
                 $hour,
                 $startTime,
                 $endTime,
-                $daysOfWeek,
-                $isTriggerIntervalInDaysSet
+                $daysOfWeek
             );
             if (!isset($groupedExecutionDates[$groupExecutionDate->getTimestamp()])) {
                 $groupedExecutionDates[$groupExecutionDate->getTimestamp()] = new GroupExecutionDateDAO($groupExecutionDate);
@@ -176,18 +171,19 @@ class Interval implements ScheduleModeInterface
     }
 
     /**
+     * @param $eventId
+     *
      * @return \DateTime
      */
     private function getGroupExecutionDateTime(
-        int $eventId,
+        $eventId,
         Lead $contact,
         \DateInterval $diff,
         \DateTime $compareFromDateTime,
         \DateTime $hour = null,
         \DateTime $startTime = null,
         \DateTime $endTime = null,
-        array $daysOfWeek = [],
-        bool $isTriggerIntervalInDaysSet = false
+        array $daysOfWeek = []
     ) {
         $this->logger->debug(
             sprintf('CAMPAIGN: Comparing calculated executed time for event ID %s and contact ID %s with %s', $eventId, $contact->getId(), $compareFromDateTime->format('Y-m-d H:i:s e'))
@@ -219,7 +215,7 @@ class Interval implements ScheduleModeInterface
             $groupDateTime->add($diff);
         }
 
-        if ($daysOfWeek && !$isTriggerIntervalInDaysSet) {
+        if ($daysOfWeek) {
             $this->logger->debug(
                 sprintf(
                     'CAMPAIGN: Scheduling event ID %s for contact ID %s based on DOW restrictions of %s',

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -262,6 +262,29 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('America/New_York', $executionDate->getTimezone()->getName());
     }
 
+    public function testScheduleDayOfWeek()
+    {
+        $scheduler = $this->getScheduler();
+
+        $event = new Event();
+        $this->assertFalse($scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
+
+        $event->setProperties([
+            'triggerRestrictedDaysOfWeek' => [],
+        ]);
+
+        $this->assertFalse($scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
+
+        $event->setProperties([
+            'triggerRestrictedDaysOfWeek' => [
+                0 => 1,
+                1 => 2,
+            ],
+        ]);
+
+        $this->assertTrue($scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
+    }
+
     private function getScheduler()
     {
         return new EventScheduler(

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -133,8 +133,6 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         ]);
 
         $this->assertTrue($this->scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
-
-        $this->assertTrue($this->scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
     }
 
     public function testGetExecutionDateForInactivity()

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -116,14 +116,17 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
 
     public function testShouldScheduleForInactive()
     {
+        $date  = new \DateTime();
+        $now   = new \DateTime();
         $event = new Event();
-        $this->assertFalse($this->scheduler->shouldScheduleForInactive($event));
+
+        $this->assertFalse($this->scheduler->shouldScheduleForInactive($event, $date, $now));
 
         $event->setProperties([
             'triggerRestrictedDaysOfWeek' => [],
         ]);
 
-        $this->assertFalse($this->scheduler->shouldScheduleForInactive($event));
+        $this->assertFalse($this->scheduler->shouldScheduleForInactive($event, $date, $now));
 
         $event->setProperties([
             'triggerRestrictedDaysOfWeek' => [
@@ -132,7 +135,11 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
             ],
         ]);
 
-        $this->assertTrue($this->scheduler->shouldScheduleForInactive($event));
+        $this->assertTrue($this->scheduler->shouldScheduleForInactive($event, $date, $now));
+
+        $date->add(new \DateInterval('P2D'));
+        $event = new Event();
+        $this->assertTrue($this->scheduler->shouldScheduleForInactive($event, $date, $now));
     }
 
     public function testGetExecutionDateForInactivity()

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -62,6 +62,11 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
      */
     private $coreParamtersHelper;
 
+    /**
+     * @var EventScheduler
+     */
+    private $scheduler;
+
     protected function setUp()
     {
         $this->logger              = new NullLogger();
@@ -77,12 +82,22 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         $this->dateTimeScheduler = new DateTime($this->logger);
         $this->eventCollector    = $this->createMock(EventCollector::class);
         $this->dispatcher        = $this->createMock(EventDispatcherInterface::class);
+
+        $this->scheduler         = new EventScheduler(
+            $this->logger,
+            $this->eventLogger,
+            $this->intervalScheduler,
+            $this->dateTimeScheduler,
+            $this->eventCollector,
+            $this->dispatcher,
+            $this->coreParamtersHelper
+        );
     }
 
     public function testShouldScheduleIgnoresSeconds()
     {
         $this->assertFalse(
-            $this->getScheduler()->shouldSchedule(
+            $this->scheduler->shouldSchedule(
                 new \DateTime('2018-07-03 09:20:45'),
                 new \DateTime('2018-07-03 09:20:30')
             )
@@ -92,7 +107,7 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
     public function testShouldSchedule()
     {
         $this->assertTrue(
-            $this->getScheduler()->shouldSchedule(
+            $this->scheduler->shouldSchedule(
                 new \DateTime('2018-07-03 09:21:45'),
                 new \DateTime('2018-07-03 09:20:30')
             )
@@ -101,16 +116,14 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
 
     public function testScheduleDayOfWeek()
     {
-        $scheduler = $this->getScheduler();
-
         $event = new Event();
-        $this->assertFalse($scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
+        $this->assertFalse($this->scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
 
         $event->setProperties([
             'triggerRestrictedDaysOfWeek' => [],
         ]);
 
-        $this->assertFalse($scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
+        $this->assertFalse($this->scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
 
         $event->setProperties([
             'triggerRestrictedDaysOfWeek' => [
@@ -119,9 +132,9 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
             ],
         ]);
 
-        $this->assertTrue($scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
+        $this->assertTrue($this->scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
 
-        $this->assertTrue($scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
+        $this->assertTrue($this->scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
     }
 
     public function testEventDoesNotGetRescheduledForRelativeTimeWhenValidated()
@@ -171,10 +184,8 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         $log->method('getEvent')
             ->willReturn($event);
 
-        $scheduler = $this->getScheduler();
-
-        $executionDate = $scheduler->validateExecutionDateTime($log, $simulatedNow);
-        $this->assertFalse($scheduler->shouldSchedule($executionDate, $simulatedNow));
+        $executionDate = $this->scheduler->validateExecutionDateTime($log, $simulatedNow);
+        $this->assertFalse($this->scheduler->shouldSchedule($executionDate, $simulatedNow));
         $this->assertEquals('2018-08-31 09:00:00', $executionDate->format('Y-m-d H:i:s'));
         $this->assertEquals('America/New_York', $executionDate->getTimezone()->getName());
     }
@@ -226,10 +237,8 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         $log->method('getEvent')
             ->willReturn($event);
 
-        $scheduler = $this->getScheduler();
-
-        $executionDate = $scheduler->validateExecutionDateTime($log, $simulatedNow);
-        $this->assertTrue($scheduler->shouldSchedule($executionDate, $simulatedNow));
+        $executionDate = $this->scheduler->validateExecutionDateTime($log, $simulatedNow);
+        $this->assertTrue($this->scheduler->shouldSchedule($executionDate, $simulatedNow));
         $this->assertEquals('2018-08-31 11:00:00', $executionDate->format('Y-m-d H:i:s'));
         $this->assertEquals('America/New_York', $executionDate->getTimezone()->getName());
     }
@@ -279,24 +288,10 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         $log->method('getEvent')
             ->willReturn($event);
 
-        $scheduler     = $this->getScheduler();
-        $executionDate = $scheduler->validateExecutionDateTime($log, $simulatedNow);
+        $executionDate = $this->scheduler->validateExecutionDateTime($log, $simulatedNow);
 
-        $this->assertFalse($scheduler->shouldSchedule($executionDate, $simulatedNow));
+        $this->assertFalse($this->scheduler->shouldSchedule($executionDate, $simulatedNow));
         $this->assertEquals('2018-08-31 13:00:15', $executionDate->format('Y-m-d H:i:s'));
         $this->assertEquals('America/New_York', $executionDate->getTimezone()->getName());
-    }
-
-    private function getScheduler()
-    {
-        return new EventScheduler(
-            $this->logger,
-            $this->eventLogger,
-            $this->intervalScheduler,
-            $this->dateTimeScheduler,
-            $this->eventCollector,
-            $this->dispatcher,
-            $this->coreParamtersHelper
-        );
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -117,7 +117,7 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
     public function testShouldScheduleForInactive()
     {
         $date  = new \DateTime();
-        $now   = new \DateTime();
+        $now   = clone $date;
         $event = new Event();
 
         $this->assertFalse($this->scheduler->shouldScheduleForInactive($event, $date, $now));
@@ -145,7 +145,7 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
     public function testGetExecutionDateForInactivity()
     {
         $date = new \DateTime();
-        $now  = new \DateTime();
+        $now  = clone $date;
         $now->add(new \DateInterval('P2D'));
 
         $clonedNow = $this->scheduler->getExecutionDateForInactivity($date, $date, $now);

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -137,6 +137,23 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
     }
 
+    public function testGetExecutionDateForInactivity()
+    {
+        $date = new \DateTime();
+        $now  = new \DateTime();
+        $now->add(new \DateInterval('P2D'));
+
+        $clonedNow = $this->scheduler->getExecutionDateForInactivity($date, $date, $now);
+        $this->assertNotSame($now, $clonedNow);
+        $this->assertSame($now->getTimestamp(), $clonedNow->getTimestamp());
+
+        $secondDate = clone $date;
+        $secondDate->add(new \DateInterval('P1D'));
+
+        $resultDate = $this->scheduler->getExecutionDateForInactivity($date, $secondDate, $now);
+        $this->assertSame($date, $resultDate);
+    }
+
     public function testEventDoesNotGetRescheduledForRelativeTimeWhenValidated()
     {
         $campaign = $this->createMock(Campaign::class);

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -114,16 +114,16 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testScheduleDayOfWeek()
+    public function testShouldScheduleForInactive()
     {
         $event = new Event();
-        $this->assertFalse($this->scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
+        $this->assertFalse($this->scheduler->shouldScheduleForInactive($event));
 
         $event->setProperties([
             'triggerRestrictedDaysOfWeek' => [],
         ]);
 
-        $this->assertFalse($this->scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
+        $this->assertFalse($this->scheduler->shouldScheduleForInactive($event));
 
         $event->setProperties([
             'triggerRestrictedDaysOfWeek' => [
@@ -132,7 +132,7 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
             ],
         ]);
 
-        $this->assertTrue($this->scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
+        $this->assertTrue($this->scheduler->shouldScheduleForInactive($event));
     }
 
     public function testGetExecutionDateForInactivity()

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -99,6 +99,31 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testScheduleDayOfWeek()
+    {
+        $scheduler = $this->getScheduler();
+
+        $event = new Event();
+        $this->assertFalse($scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
+
+        $event->setProperties([
+            'triggerRestrictedDaysOfWeek' => [],
+        ]);
+
+        $this->assertFalse($scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
+
+        $event->setProperties([
+            'triggerRestrictedDaysOfWeek' => [
+                0 => 1,
+                1 => 2,
+            ],
+        ]);
+
+        $this->assertTrue($scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
+
+        $this->assertTrue($scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
+    }
+
     public function testEventDoesNotGetRescheduledForRelativeTimeWhenValidated()
     {
         $campaign = $this->createMock(Campaign::class);
@@ -260,29 +285,6 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($scheduler->shouldSchedule($executionDate, $simulatedNow));
         $this->assertEquals('2018-08-31 13:00:15', $executionDate->format('Y-m-d H:i:s'));
         $this->assertEquals('America/New_York', $executionDate->getTimezone()->getName());
-    }
-
-    public function testScheduleDayOfWeek()
-    {
-        $scheduler = $this->getScheduler();
-
-        $event = new Event();
-        $this->assertFalse($scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
-
-        $event->setProperties([
-            'triggerRestrictedDaysOfWeek' => [],
-        ]);
-
-        $this->assertFalse($scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
-
-        $event->setProperties([
-            'triggerRestrictedDaysOfWeek' => [
-                0 => 1,
-                1 => 2,
-            ],
-        ]);
-
-        $this->assertTrue($scheduler->shouldSchedule(new \DateTime(), new \DateTime(), $event));
     }
 
     private function getScheduler()


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
User has set campaign actions (specifically emails) to only trigger on specified days of the week, but is receiving those emails on un-selected days of the week. 

#### Steps to reproduce the bug:
You need to be able to change date in your testing environment.

1. Create campaign like this one. 
![Snímek obrazovky 2020-06-04 v 15 57 42](https://user-images.githubusercontent.com/12815758/83766226-6b070880-a67c-11ea-92cd-696151685b9c.png)
![Snímek obrazovky 2020-06-04 v 15 58 16](https://user-images.githubusercontent.com/12815758/83766235-6d696280-a67c-11ea-8a92-19aab8204107.png)
![Snímek obrazovky 2020-06-04 v 16 08 13](https://user-images.githubusercontent.com/12815758/83767252-b2da5f80-a67d-11ea-80dd-50ea6e85ff4f.png)
![Snímek obrazovky 2020-06-04 v 15 59 30](https://user-images.githubusercontent.com/12815758/83766242-70fce980-a67c-11ea-98b5-1f73a2c1f660.png)

2. Email subjects must be different and both e-mails must be set in events
3. Check days of week for the latest event to today and day before today
4. Run worker. You'll immediately reveive welcome email which has no day in week set
5. Move system date to tomorrow
	- In OSX `sudo date -u {month}{day}{hour}{min}{year}` like `sudo date -u 0603160020`
6. Worker is still running and you'll receive second email from campaign 
	- This is wrong. Next available day of week must be set in `mautic_campaign_lead_event_log.trigger_date`
7. Reset your system date 
	- In OSX with `sudo sntp -sS time.apple.com`

#### Steps to test this PR:
1. Use steps 1-5 from reproduction steps
2. Date in `mautic_campaign_lead_event_log.trigger_date` for new row will be set to next available day of week
3. Move system date to that day
4. You'll receive second email