### PR TITLE
Allow custom orderBy to API

### DIFF
--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -486,7 +486,7 @@ class CommonApiController extends FOSRestController implements MauticController
             $columns,
             function (&$column, $key, $prefix) {
                 $column = trim($column);
-                if (false === strpos($column, $prefix)) {
+                if (1 === count(explode('.', $column))) {
                     $column = $prefix.$column;
                 }
             },

--- a/app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
@@ -24,6 +24,13 @@ class CommonApiControllerTest extends CampaignTestAbstract
         $this->assertEquals('f.dateAdded', $result);
     }
 
+    public function testAddAliasIfNotPresentWithOneColumnWithDifferentAlias()
+    {
+        $result = $this->getResultFromProtectedMethod('addAliasIfNotPresent', ['s.date_submitted', 'fs']);
+
+        $this->assertEquals('s.date_submitted', $result);
+    }
+
     public function testAddAliasIfNotPresentWithOneColumnWithAlias()
     {
         $result = $this->getResultFromProtectedMethod('addAliasIfNotPresent', ['f.dateAdded', 'f']);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/156
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
We were not able to order by date submitted of form results:
https://developer.mautic.org/#list-form-submissions

This PR allow define custom table alias to orderBy field from joined tables

Expected select for form submission in API 

`SELECT ... FROM form_results_5_table r INNER JOIN form_submissions s ON r.submission_id = s.id LEFT JOIN ip_addresses i ON s.ip_id = i.id WHERE r.form_id = 5 ORDER BY s.date_submited ASC LIMIT 10`

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try get form results by API https://developer.mautic.org/#list-form-submissions
2. Try order by date_submitted columns

API should looks like:

`$formApi->getSubmissions(5, '', 0, 10, 's.date_submitted');`

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps  and check If you're able to sort it by date_submitted
