### PR TITLE
Improve show script tags

### DIFF
--- a/app/bundles/CoreBundle/Templating/Helper/ContentHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/ContentHelper.php
@@ -84,7 +84,13 @@ class ContentHelper extends Helper
      */
     public function showScriptTags($html)
     {
-        return str_replace(['<script>', '</script>'], ['[script]', '[/script]'], $html);
+        $tagsToShow = ['script', 'style'];
+
+        foreach ($tagsToShow as $tag) {
+            $html = preg_replace('/<'.$tag.'(.*?)>(.*?)<\/'.$tag.'>/s', '['.$tag.'$1]$2[/'.$tag.']', $html);
+        }
+
+        return $html;
     }
 
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Templating/Helper/ContentHelperTest.html.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Templating/Helper/ContentHelperTest.html.php
@@ -17,30 +17,67 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ContentHelperTest extends \PHPUnit\Framework\TestCase
 {
-    public function testAssetContext()
+    /**
+     * @var ContentHelper
+     */
+    private $contentHelper;
+
+    protected function setUp()
     {
         $dispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $delegationMock = $this->getMockBuilder(DelegatingEngine::class)
-             ->disableOriginalConstructor()
-             ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $contentHelper = new ContentHelper($dispatcherMock, $delegationMock);
+        $this->contentHelper = new contenthelper($delegationMock, $dispatcherMock);
+    }
+
+    public function testShowScriptTagsContext()
+    {
+        $this->doShowTagsContext('script');
+    }
+
+    public function testShowStyleTagsContext()
+    {
+        $this->doShowTagsContext('style');
+    }
+
+    public function testShowScriptTagsInlineContext()
+    {
+        $sample   = 'Hi <script>console.log("do not mind me");</script> <script type="text/javascript">console.log("do not mind me");</script>';
+        $expected = 'Hi [script]console.log("do not mind me");[/script] [script type="text/javascript"]console.log("do not mind me");[/script]';
+
+        $result = $this->contentHelper->showScriptTags($sample);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    private function doShowTagsContext($tag)
+    {
         $sample        = '<h1>Hello World</h1>
 
-        <script>
+        <'.$tag.'>
             console.log("do not mind me");
-        </script>';
+        </'.$tag.'>
+        
+        <'.$tag.' type="text/javascript">
+            console.log("do not mind me");
+        </'.$tag.'>';
 
         $expected = '<h1>Hello World</h1>
 
-        [script]
+        ['.$tag.']
             console.log("do not mind me");
-        [/script]';
+        [/'.$tag.']
+        
+        ['.$tag.' type="text/javascript"]
+            console.log("do not mind me");
+        [/'.$tag.']';
 
-        $result = $contentHelper->showScriptTags($sample);
+        $result = $this->contentHelper->showScriptTags($sample);
 
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? | Yes
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR improve handle of javascript/css in the HTML field of Form.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create form with HTML field
3. Try insert  custom JS and CSS style, for example

```
<script type="text/javascript">console.log('test');</script>
<style type="text/css">.myCustomClass {color:red} </style>
```

![image](https://user-images.githubusercontent.com/462477/84226760-f6e8bc80-aae2-11ea-9400-2864480fc2d8.png)
4. Save
5. You should see now scripts and style in plain text fromat

![image](https://user-images.githubusercontent.com/462477/84226858-33b4b380-aae3-11ea-83b5-9e843975ae5e.png)
