### PR TITLE
Focus: fix snapshop service not working - return 500 error

### DIFF
--- a/plugins/MauticFocusBundle/Controller/AjaxController.php
+++ b/plugins/MauticFocusBundle/Controller/AjaxController.php
@@ -41,23 +41,26 @@ class AjaxController extends CommonAjaxController
                 $snapshotUrl = $this->get('mautic.helper.core_parameters')->getParameter('website_snapshot_url');
                 $snapshotKey = $this->get('mautic.helper.core_parameters')->getParameter('website_snapshot_key');
 
-                $http     = $this->get('mautic.http.connector');
-                $response = $http->get($snapshotUrl.'?url='.urlencode($website).'&key='.$snapshotKey, [], 30);
+                try {
+                    $http     = $this->get('mautic.http.connector');
+                    $response = $http->get($snapshotUrl.'?url='.urlencode($website).'&key='.$snapshotKey, [], 30);
 
-                if ($response->code === 200) {
-                    $package = json_decode($response->body, true);
-                    if (isset($package['images'])) {
-                        $data['image']['desktop'] = $package['images']['desktop'];
-                        $data['image']['mobile']  = $package['images']['mobile'];
-                        $palette                  = $package['palette'];
-                        $data['colors']           = [
-                            'primaryColor'    => $palette[0],
-                            'textColor'       => FocusModel::isLightColor($palette[0]) ? '#000000' : '#ffffff',
-                            'buttonColor'     => $palette[1],
-                            'buttonTextColor' => FocusModel::isLightColor($palette[1]) ? '#000000' : '#ffffff',
-                        ];
-                        $data['success'] = 1;
+                    if ($response->code === 200) {
+                        $package = json_decode($response->body, true);
+                        if (isset($package['images'])) {
+                            $data['image']['desktop'] = $package['images']['desktop'];
+                            $data['image']['mobile']  = $package['images']['mobile'];
+                            $palette                  = $package['palette'];
+                            $data['colors']           = [
+                                'primaryColor'    => $palette[0],
+                                'textColor'       => FocusModel::isLightColor($palette[0]) ? '#000000' : '#ffffff',
+                                'buttonColor'     => $palette[1],
+                                'buttonTextColor' => FocusModel::isLightColor($palette[1]) ? '#000000' : '#ffffff',
+                            ];
+                            $data['success'] = 1;
+                        }
                     }
+                } catch (\RuntimeException $exception) {
                 }
             }
         }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/issues/7179
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This is just proper solution for M2 not working focus snapshot service fixed in M3

https://github.com/mautic/mautic/issues/7179

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create focus with  website
2. Try open builder
3. return 500 error

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Should skip error
