### PR TITLE
Bugfix for Hubspot contact fields not syncing issue

### DIFF
--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -190,7 +190,7 @@ class HubspotIntegration extends CrmAbstractIntegration
      */
     public function getAvailableLeadFields($settings = [])
     {
-        if ($fields = parent::getAvailableLeadFields()) {
+        if ($fields = parent::getAvailableLeadFields($settings)) {
             return $fields;
         }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #4888 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Hubspot plugin integration fields are not in sync. New fields added on Hubspot tool are not reflected in Mautic. 
This issue also exist in 2.x

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to Settings>Plugins and Enable Hubspot integration. 
2. Add your Hubspot API key (Free testing account available) https://knowledge.hubspot.com/integrations/how-do-i-get-my-hubspot-api-key
3. In the Hubspot integration window, goto Field mapping tab where it shows all available fields pulled from Hubspot API
4. Add any new contact property from Hubspot dashboard https://knowledge.hubspot.com/crm-setup/manage-your-properties#create-custom-properties
5. This new field should be available on Mautic side in Hubspot plugin for mapping Settings > Plugins > Hubspot (Field mapping tab) But it's not.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/)
2. Same as Steps to reproduce the bug:

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
