### PR TITLE
Increase limit for unique filename

### DIFF
--- a/app/bundles/CoreBundle/Helper/FilePathResolver.php
+++ b/app/bundles/CoreBundle/Helper/FilePathResolver.php
@@ -18,14 +18,8 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class FilePathResolver
 {
-    /**
-     * @var Filesystem
-     */
     private $filesystem;
 
-    /**
-     * @var InputHelper
-     */
     private $inputHelper;
 
     public function __construct(Filesystem $filesystem, InputHelper $inputHelper)
@@ -61,7 +55,7 @@ class FilePathResolver
             $filePath = $this->getFilePath($uploadDir, $name, $ext);
             ++$i;
 
-            if ($i > 100) {
+            if ($i > 1000) {
                 throw new FilePathException('Could not generate path');
             }
         }

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/FilePathResolverTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/FilePathResolverTest.php
@@ -90,7 +90,7 @@ class FilePathResolverTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $filesystemMock->expects($this->exactly(100))
+        $filesystemMock->expects($this->exactly(1000))
             ->method('exists')
             ->willReturn(true);
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | https://github.com/mautic/mautic-documentation/pull/76
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
In our form we crossed limit to sending same filename more like 100 times. Then form return validation error on send. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

**Code review should be enough**

1. Create form with upload file and enable validation.
2. Upload same  file more like 100 time
3. Form start returning validation error

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps and form not returning validation error

