### PR TITLE
Fix eventName on CampaignSubscriber

### DIFF
--- a/app/bundles/StageBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/CampaignSubscriber.php
@@ -62,7 +62,7 @@ class CampaignSubscriber implements EventSubscriberInterface
         $event->addAction('stage.change', $action);
     }
 
-    public function onCampaignTriggerActionChangeStage(CampaignExecutionEvent $event)
+    public function onCampaignTriggerActionChangeStage(CampaignExecutionEvent $event, $eventName)
     {
         $stageChange = false;
         $lead        = $event->getLead();
@@ -87,7 +87,7 @@ class CampaignSubscriber implements EventSubscriberInterface
             $lead->stageChangeLogEntry(
                 $stageToChangeTo,
                 $stageToChangeTo->getId().': '.$stageToChangeTo->getName(),
-                $event->getName()
+                $eventName
             );
             $lead->setStage($stageToChangeTo);
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

Fixed by following the steps at https://gist.github.com/mickaelandrieu/5211d0047e7a6fbff925#eventdispatcher and https://symfony.com/doc/3.4/components/event_dispatcher.html#event-name-introspection

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | Closes #8875 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. See https://github.com/mautic/mautic/issues/8875

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Test again with the steps at https://github.com/mautic/mautic/issues/8875
