### PR TITLE
Exclude DataFixtures folders from deleted files

### DIFF
--- a/build/processfiles.php
+++ b/build/processfiles.php
@@ -18,7 +18,7 @@ chdir($baseDir.'/packaging');
 
 system('rm -f app/phpunit.*');
 system('rm -f app/tests.bootstrap*');
-system('rm -rf app/bundles/*/Tests');
+system('find app/bundles/*/Tests/* ! -path "*/Tests/DataFixtures*" -prune -exec rm -rf {} \\;');
 system('rm -rf app/bundles/CoreBundle/Test');
 system('rm -rf app/cache/*');
 system('rm -rf app/logs/*');
@@ -165,5 +165,5 @@ system('find . -name .DS_Store -exec rm -rf {} \\;');
 // Delete test directories
 system('find . -type d -name Test ! -path "./vendor/twig/twig/lib/Twig/Node/Expression/Test" ! -path "./vendor/twig/twig/lib/Twig/Test" ! -path "./vendor/twig/twig/src/Node/Expression/Test" ! -path "./vendor/twig/twig/src/Test" -prune -exec rm -rf {} \\;');
 system('find . -type d -name test ! -path "./vendor/twig/twig/lib/Twig/Node/Expression/Test" ! -path "./vendor/twig/twig/lib/Twig/Test" ! -path "./vendor/twig/twig/src/Node/Expression/Test" ! -path "./vendor/twig/twig/src/Test" -prune -exec rm -rf {} \\;');
-system('find . -type d -name Tests -prune -exec rm -rf {} \\;');
+system('find . -path "*/Tests/*" ! -path "./app/bundles/*/Tests*" ! -path "./plugins/*/Tests/DataFixtures*" -prune -exec rm -rf {} \\;');
 system('find . -type d -name tests -prune -exec rm -rf {} \\;');


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | X
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | Closes #8885
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. See https://github.com/mautic/mautic/issues/8885
2. 

#### Steps to test this PR:
1. Download this package, which is based on this PR: https://github.com/dennisameling/mautic/releases/download/3.0.0-8885/3.0.0-beta2.zip
2. Again run the steps at https://github.com/mautic/mautic/issues/8885, no warnings should show up