### PR TITLE
Quick dirty fix for API default settings in form

### DIFF
--- a/app/bundles/ConfigBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ConfigBundle/Form/Type/ConfigType.php
@@ -36,6 +36,19 @@ class ConfigType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        // TODO very dirty quick fix for https://github.com/mautic/mautic/issues/8854
+        if (isset($options['data']['apiconfig']['parameters']['api_oauth2_access_token_lifetime'])
+            && 3600 === $options['data']['apiconfig']['parameters']['api_oauth2_access_token_lifetime']
+        ) {
+            $options['data']['apiconfig']['parameters']['api_oauth2_access_token_lifetime'] = 60;
+        }
+
+        if (isset($options['data']['apiconfig']['parameters']['api_oauth2_refresh_token_lifetime'])
+            && 1209600 === $options['data']['apiconfig']['parameters']['api_oauth2_refresh_token_lifetime']
+        ) {
+            $options['data']['apiconfig']['parameters']['api_oauth2_refresh_token_lifetime'] = 14;
+        }
+
         foreach ($options['data'] as $config) {
             if (isset($config['formAlias']) && !empty($config['parameters'])) {
                 $checkThese = array_intersect(array_keys($config['parameters']), $options['fileFields']);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | Closes #8854 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. See https://github.com/mautic/mautic/issues/8854, default values are `3600` and `1209600` in the UI --> you can also check https://m3.mautibox.com/3.x/s/config/edit which has the wrong default values as well
2. 

#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com) --> direct link = https://m3.mautibox.com/8912/s/config/edit
2. Try again with the steps at https://github.com/mautic/mautic/issues/8854, default values should be `60` and `14`
