### PR TITLE
Fix UpdateHelper error code

### DIFF
--- a/app/bundles/CoreBundle/Helper/UpdateHelper.php
+++ b/app/bundles/CoreBundle/Helper/UpdateHelper.php
@@ -153,13 +153,22 @@ class UpdateHelper
                 'message' => 'mautic.core.updater.error.fetching.updates',
             ];
         } catch (RequestException $exception) {
-            $this->logger->error(
-                sprintf(
-                    'UPDATE CHECK: Could not fetch a release list: %s (%s)',
-                    $exception->getResponse()->getStatusCode(),
-                    $exception->getResponse()->getReasonPhrase()
-                )
-            );
+            if (!empty($exception->getResponse())) {
+                $this->logger->error(
+                    sprintf(
+                        'UPDATE CHECK: Could not fetch a release list: %s (%s)',
+                        $exception->getResponse()->getStatusCode(),
+                        $exception->getResponse()->getReasonPhrase()
+                    )
+                );
+            } else {
+                $this->logger->error(
+                    sprintf(
+                        'UPDATE CHECK: Could not fetch a release list: %s',
+                        $exception->getMessage()
+                    )
+                );
+            }
 
             return [
                 'error'   => true,
@@ -226,13 +235,22 @@ class UpdateHelper
 
             $this->client->request('POST', $statUrl, $options);
         } catch (RequestException $exception) {
-            $this->logger->error(
-                sprintf(
-                    'STAT UPDATE: Error communicating with the stat server: %s (%s)',
-                    $exception->getResponse()->getStatusCode(),
-                    $exception->getResponse()->getReasonPhrase()
-                )
-            );
+            if (!empty($exception->getResponse())) {
+                $this->logger->error(
+                    sprintf(
+                        'STAT UPDATE: Error communicating with the stat server: %s (%s)',
+                        $exception->getResponse()->getStatusCode(),
+                        $exception->getResponse()->getReasonPhrase()
+                    )
+                );
+            } else {
+                $this->logger->error(
+                    sprintf(
+                        'STAT UPDATE: Error communicating with the stat server: %s',
+                        $exception->getMessage()
+                    )
+                );
+            }
         } catch (\Exception $exception) {
             // Not so concerned about failures here, move along
             $this->logger->error(sprintf('STAT UPDATE: %s', $exception->getMessage()));


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR fixes an issue for systems that for whatever reason cannot connect to the update or stats server (SSL errors, connection issues, etc.), and will add the proper error messages to Mautic's log file.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Disable your internet connection
2. Run `php bin/console mautic:update:find`
2. You'll see:
```
In UpdateHelper.php line 235:
  Call to a member function getStatusCode() on null  
```

#### Steps to test this PR:
1. Checkout this PR (or patch file manually)
2. Repeat above steps
3. You'll see:
```
An error occurred while checking for updates. Please try again later.
```
... and then when checking the logs you'll see:
```
[2020-06-15 21:01:37] mautic.ERROR: STAT UPDATE: Error communicating with the stat server: cURL error 6: Could not resolve host: updates.mautic.org (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) [] []
[2020-06-15 21:01:37] mautic.ERROR: UPDATE CHECK: Could not fetch a release list: cURL error 6: Could not resolve host: api.github.com (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) [] []
```

