### PR TITLE
Add "needs triage" label to new issues, update SECURITY.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug report
 about: Create a bug report
+labels: needs triage
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: Feature request
 about: Please share your ideas and find support at https://forum.mautic.org/c/ideas
+labels: needs triage
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/security_vulnerability.md
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.md
@@ -2,6 +2,7 @@
 name: Security vulnerability
 about: Please DO NOT report security vulnerabilities here. Send them to security@mautic.com
   instead.
+labels: needs triage
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported Versions
 
-| Branch | Beta Release | Initial Release | Active Support Until | Security Support Until
+| Branch | Beta Release | Initial Release | Active Support Until | Security Support Until *
 |--|--|--|--|--|
-|2.15  | 27 Sep 2019 | 8 Oct 2019 | 2.16 Stable Release | TBD
-|2.16  | 30 Jan 2020 | TBD | TBD | TBD **
-|3.0   | 27 Jan 2020 | 3 Feb 2020* | TBD | TBD
+|2.15  | 27 Sep 2019 | 8 Oct 2019 | 8 Oct 2019 | 8 Oct 2019
+|2.16  | 30 Jan 2020 | 13 Feb 2020 | 15 June 2020 | 15 December 2020
+|3.0   | 27 Jan 2020 | 15 June 2020 | 15 June 2021 | 15 December 2021
 
-** = Security Support for 2.16 will only be provided for Mautic itself, not for core dependencies that are EOL like Symfony 2.8.
+* = Security Support for 2.16 will only be provided for Mautic itself, not for core dependencies that are EOL like Symfony 2.8.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Adds the "needs triage" label to new issues (just added that label to this PR so you can see what it looks like). Also updates SECURITY.md with updated dates.