### PR TITLE
Fix - SAML - use username (optional) in attributes mapper

### DIFF
--- a/app/bundles/UserBundle/Security/SAML/User/UserMapper.php
+++ b/app/bundles/UserBundle/Security/SAML/User/UserMapper.php
@@ -61,7 +61,9 @@ class UserMapper implements UsernameMapperInterface
         if (isset($attributes['email'])) {
             $user->setEmail($attributes['email']);
             $user->setUsername($attributes['email']);
-        } elseif (isset($attributes['username'])) {
+        }
+
+        if (isset($attributes['username']) && !empty($attributes['username'])) {
             $user->setUsername($attributes['username']);
         }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

In User/Authentication Settings - SAML SSO Settings is ignored attribute mapping for **Username (optional)**
Condition in code is designed way, that Username cannot be never used since Email is required attribute.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Set up SAML with Username attribute mapping - see docs [here](https://docs.mautic.org/en/authentication) for instructions
2. Log in with new account using SSO
3. Username is email

#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Set up SAML with Username attribute mapping
3. Log in with new account using SSO
4. Username is username
