### PR TITLE
Fix form search after switch language

### DIFF
--- a/app/bundles/FormBundle/Entity/FormRepository.php
+++ b/app/bundles/FormBundle/Entity/FormRepository.php
@@ -107,6 +107,7 @@ class FormRepository extends CommonRepository
 
         switch ($command) {
             case $this->translator->trans('mautic.form.form.searchcommand.isexpired'):
+            case $this->translator->trans('mautic.form.form.searchcommand.isexpired', [], null, 'en_US'):
                 $expr = $q->expr()->andX(
                     $q->expr()->eq('f.isPublished', ":$unique"),
                     $q->expr()->isNotNull('f.publishDown'),
@@ -116,6 +117,7 @@ class FormRepository extends CommonRepository
                 $forceParameters = [$unique => true];
                 break;
             case $this->translator->trans('mautic.form.form.searchcommand.ispending'):
+            case $this->translator->trans('mautic.form.form.searchcommand.ispending', [], null, 'en_US'):
                 $expr = $q->expr()->andX(
                     $q->expr()->eq('f.isPublished', ":$unique"),
                     $q->expr()->isNotNull('f.publishUp'),
@@ -125,6 +127,7 @@ class FormRepository extends CommonRepository
                 $forceParameters = [$unique => true];
                 break;
             case $this->translator->trans('mautic.form.form.searchcommand.hasresults'):
+            case $this->translator->trans('mautic.form.form.searchcommand.hasresults', [], null, 'en_US'):
                 $sq       = $this->getEntityManager()->createQueryBuilder();
                 $subquery = $sq->select('count(s.id)')
                     ->from('MauticFormBundle:Submission', 's')
@@ -139,6 +142,7 @@ class FormRepository extends CommonRepository
                 $expr = $q->expr()->gt(sprintf('(%s)', $subquery), 1);
                 break;
             case $this->translator->trans('mautic.core.searchcommand.name'):
+            case $this->translator->trans('mautic.core.searchcommand.name', [], null, 'en_US'):
                 $expr            = $q->expr()->like('f.name', ':'.$unique);
                 $returnParameter = true;
                 break;


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Switch language for current user to French
2. Go to form, create form with name **test** and form with name **example**
3. Try search in forms by name - for example `name:test`
4. You should see both forms 

#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Should find the form
