### PR TITLE
Add MariaDB to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: trusty
 language: php
 
 services:
@@ -11,9 +11,6 @@ notifications:
 php:
   - 7.2
   - 7.3
-
-addons:
-  mariadb: '10.2'
 
 env:
   - DB=mysql
@@ -50,6 +47,11 @@ script:
 jobs:
   include:
     - stage: test
+      name: MariaDB
+      env: DB=mariadb
+      addons:
+        mariadb: '10.2'
+    -
       name: PHPSTAN
       script: composer phpstan
     -

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,21 @@ php:
   - 7.2
   - 7.3
 
+addons:
+  mariadb: '10.2'
+
+env:
+  - DB=mysql
+  - DB=mariadb
+
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_install:
   # Create mautictest database
+  - mysql --version
+  - mysql -e 'DROP DATABASE IF EXISTS mautictest;'
   - mysql -e 'CREATE DATABASE mautictest;'
 
   # increase memory limit for all PHP processes

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,12 +42,17 @@ script:
 
 jobs:
   include:
-    - {}
+    - stage: test
+      php: 7.2
       env: DB=mariadb
       addons:
         mariadb: '10.2'
     - 
-      stage: test
+      php: 7.3
+      env: DB=mariadb
+      addons:
+        mariadb: '10.2'
+    - 
       name: PHPSTAN
       script: composer phpstan
     -

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ php:
   - 7.2
   - 7.3
 
-env:
-  - DB=mysql
-  - DB=mariadb
-
 cache:
   directories:
     - $HOME/.composer/cache
@@ -46,12 +42,12 @@ script:
 
 jobs:
   include:
-    - stage: test
-      name: MariaDB
+    - name: MariaDB
       env: DB=mariadb
       addons:
         mariadb: '10.2'
-    -
+    - 
+      stage: test
       name: PHPSTAN
       script: composer phpstan
     -

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ php:
   - 7.2
   - 7.3
 
-env:
-  - DB=mysql
-  - DB=mariadb
-
 cache:
   directories:
     - $HOME/.composer/cache
@@ -46,7 +42,8 @@ script:
 
 jobs:
   include:
-    - env: DB=mariadb
+    - {}
+      env: DB=mariadb
       addons:
         mariadb: '10.2'
     - 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ php:
   - 7.2
   - 7.3
 
+env:
+  - DB=mysql
+  - DB=mariadb
+
 cache:
   directories:
     - $HOME/.composer/cache
@@ -42,8 +46,7 @@ script:
 
 jobs:
   include:
-    - name: MariaDB
-      env: DB=mariadb
+    - env: DB=mariadb
       addons:
         mariadb: '10.2'
     - 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 language: php
 
 services:


### PR DESCRIPTION
This PR adds MariaDB to the Travis config. This should ensure that Mautic will become and remains compatible with MariaDB. MariaDB version 10.2 equals MySQL 5.7 so should be the minimum version for Mautic 3.

If all Travis tests pass, that should be enough to confirm this PR is working as expected.

Closes #8929 