### PR TITLE
Fix multiple forms on pages

### DIFF
--- a/app/bundles/FormBundle/Views/Builder/script.html.php
+++ b/app/bundles/FormBundle/Views/Builder/script.html.php
@@ -29,5 +29,7 @@ $scriptSrc = str_replace('/index_dev.php', '', $scriptSrc);
         var MauticLang   = {
             'submittingMessage': "<?php echo $view['translator']->trans('mautic.form.submission.pleasewait'); ?>"
         }
+    }else if (typeof MauticSDK != 'undefined') {
+        MauticSDK.onLoad();
     }
 </script>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | Fixes https://github.com/mautic/mautic/issues/7062
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
We noticed when using more forms on page, sometimes forms wasn't initialized. 
 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create 3 forms with field with enabled validation
2. Insert all 3 forms your custom page
3. Open the page and try submit all 3 forms
4. Shouldn't work validation for one of them
5. If validation works, then try reload page and try again submit forms

![image](https://user-images.githubusercontent.com/462477/85308409-79915480-b4b1-11ea-9e5d-a540c6683730.png)


#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Repeat all steps and everything should works properly