### PR TITLE
API and Tracking configuration - check that the options exist

### DIFF
--- a/app/bundles/ApiBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/ApiBundle/EventListener/ConfigSubscriber.php
@@ -44,8 +44,10 @@ class ConfigSubscriber implements EventSubscriberInterface
     public function onConfigSave(ConfigEvent $event)
     {
         // Symfony craps out with integer for firewall settings
-        $data                          = $event->getConfig('apiconfig');
-        $data['api_enable_basic_auth'] = (bool) $data['api_enable_basic_auth'];
-        $event->setConfig($data, 'apiconfig');
+        $data = $event->getConfig('apiconfig');
+        if (isset($data['api_enable_basic_auth'])) {
+            $data['api_enable_basic_auth'] = (bool) $data['api_enable_basic_auth'];
+            $event->setConfig($data, 'apiconfig');
+        }
     }
 }

--- a/app/bundles/ApiBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ApiBundle/Form/Type/ConfigType.php
@@ -29,7 +29,7 @@ class ConfigType extends AbstractType
             YesNoButtonGroupType::class,
             [
                 'label' => 'mautic.api.config.form.api.enabled',
-                'data'  => (bool) $options['data']['api_enabled'],
+                'data'  => isset($options['data']['api_enabled']) ? (bool) $options['data']['api_enabled'] : false,
                 'attr'  => [
                     'tooltip' => 'mautic.api.config.form.api.enabled.tooltip',
                 ],
@@ -41,7 +41,7 @@ class ConfigType extends AbstractType
             YesNoButtonGroupType::class,
             [
                 'label' => 'mautic.api.config.form.api.basic_auth_enabled',
-                'data'  => (bool) $options['data']['api_enable_basic_auth'],
+                'data'  => isset($options['data']['api_enable_basic_auth']) ? (bool) $options['data']['api_enable_basic_auth'] : false,
                 'attr'  => [
                     'tooltip' => 'mautic.api.config.form.api.basic_auth.tooltip',
                 ],

--- a/app/bundles/ApiBundle/Tests/EventListener/ConfigSubscriberTest.php
+++ b/app/bundles/ApiBundle/Tests/EventListener/ConfigSubscriberTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * @copyright   2017 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\ApiBundle\Tests\EventListener;
+
+use Mautic\ApiBundle\EventListener\ConfigSubscriber;
+use Mautic\ConfigBundle\Event\ConfigEvent;
+use Mautic\CoreBundle\Tests\CommonMocks;
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+class ConfigSubscriberTest extends CommonMocks
+{
+    public function testWithUnsetApiBasicAuthSetting()
+    {
+        /**
+         * We need a config array where api_enable_basic_auth is not set
+         * (for example, in a hosted environment where customers are not allowed
+         * to enable basic auth on the API). Saving the config shouldn't throw
+         * any undefined notices/warnings in that case.
+         */
+        $config = ['apiconfig' => []];
+
+        $subscriber  = new ConfigSubscriber();
+        $configEvent = new ConfigEvent($config, new ParameterBag());
+
+        $subscriber->onConfigSave($configEvent);
+
+        $this->assertEquals($config, $configEvent->getConfig());
+    }
+
+    public function testWithIntegerApiBasicAuthSetting()
+    {
+        // Make sure the subscriber converts an integer value to boolean.
+        $config = [
+            'apiconfig' => [
+                'api_enable_basic_auth' => 1,
+            ],
+        ];
+
+        $fixedConfig = [
+            'api_enable_basic_auth' => true,
+        ];
+
+        $subscriber  = new ConfigSubscriber();
+        $configEvent = new ConfigEvent($config, new ParameterBag());
+
+        $subscriber->onConfigSave($configEvent);
+
+        $this->assertEquals($fixedConfig, $configEvent->getConfig('apiconfig'));
+    }
+}

--- a/app/bundles/PageBundle/Form/Type/ConfigTrackingPageType.php
+++ b/app/bundles/PageBundle/Form/Type/ConfigTrackingPageType.php
@@ -121,7 +121,7 @@ class ConfigTrackingPageType extends AbstractType
             YesNoButtonGroupType::class,
             [
                 'label' => 'mautic.page.config.form.tracking.anonymize.ip.enabled',
-                'data' => isset($options['data']['google_analytics_anonymize_ip']) ? (bool) $options['data']['google_analytics_anonymize_ip'] : false,
+                'data'  => isset($options['data']['google_analytics_anonymize_ip']) ? (bool) $options['data']['google_analytics_anonymize_ip'] : false,
                 'attr'  => [
                     'tooltip' => 'mautic.page.config.form.tracking.anonymize.ip.enabled.tooltip',
                 ],

--- a/app/bundles/PageBundle/Form/Type/ConfigTrackingPageType.php
+++ b/app/bundles/PageBundle/Form/Type/ConfigTrackingPageType.php
@@ -36,7 +36,7 @@ class ConfigTrackingPageType extends AbstractType
             YesNoButtonGroupType::class,
             [
                 'label' => 'mautic.page.config.form.anonymize_ip',
-                'data'  => (bool) $options['data']['anonymize_ip'],
+                'data'  => isset($options['data']['anonymize_ip']) ? (bool) $options['data']['anonymize_ip'] : false,
                 'attr'  => [
                     'tooltip' => 'mautic.page.config.form.anonymize_ip.tooltip',
                 ],
@@ -73,7 +73,7 @@ class ConfigTrackingPageType extends AbstractType
             YesNoButtonGroupType::class,
             [
                 'label' => 'mautic.page.config.form.tracking.trackingpage.enabled',
-                'data'  => (bool) $options['data']['facebook_pixel_trackingpage_enabled'],
+                'data'  => isset($options['data']['facebook_pixel_trackingpage_enabled']) ? (bool) $options['data']['facebook_pixel_trackingpage_enabled'] : false,
             ]
         );
 
@@ -82,7 +82,7 @@ class ConfigTrackingPageType extends AbstractType
             YesNoButtonGroupType::class,
             [
                 'label' => 'mautic.page.config.form.tracking.landingpage.enabled',
-                'data'  => (bool) $options['data']['facebook_pixel_landingpage_enabled'],
+                'data'  => isset($options['data']['facebook_pixel_landingpage_enabled']) ? (bool) $options['data']['facebook_pixel_landingpage_enabled'] : false,
             ]
         );
 
@@ -103,7 +103,7 @@ class ConfigTrackingPageType extends AbstractType
             YesNoButtonGroupType::class,
             [
                 'label' => 'mautic.page.config.form.tracking.trackingpage.enabled',
-                'data'  => (bool) $options['data']['google_analytics_trackingpage_enabled'],
+                'data'  => isset($options['data']['google_analytics_trackingpage_enabled']) ? (bool) $options['data']['google_analytics_trackingpage_enabled'] : false,
             ]
         );
 
@@ -112,7 +112,7 @@ class ConfigTrackingPageType extends AbstractType
             YesNoButtonGroupType::class,
             [
                 'label' => 'mautic.page.config.form.tracking.landingpage.enabled',
-                'data'  => (bool) $options['data']['google_analytics_landingpage_enabled'],
+                'data'  => isset($options['data']['google_analytics_landingpage_enabled']) ? (bool) $options['data']['google_analytics_landingpage_enabled'] : false,
             ]
         );
 
@@ -121,7 +121,7 @@ class ConfigTrackingPageType extends AbstractType
             YesNoButtonGroupType::class,
             [
                 'label' => 'mautic.page.config.form.tracking.anonymize.ip.enabled',
-                'data'  => (bool) (isset($options['data']['google_analytics_anonymize_ip']) ? $options['data']['google_analytics_anonymize_ip'] : false),
+                'data' => isset($options['data']['google_analytics_anonymize_ip']) ? (bool) $options['data']['google_analytics_anonymize_ip'] : false,
                 'attr'  => [
                     'tooltip' => 'mautic.page.config.form.tracking.anonymize.ip.enabled.tooltip',
                 ],


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

If we want hide some configuration from API settings, It crash with error. This PR fixed it

> 500 Internal Server Error - PHP Notice - Undefined index: api_enable_basic_auth 

![image](https://user-images.githubusercontent.com/462477/85322423-a00dba80-b4c6-11ea-9382-e7305b0525bc.png)


[//]: # ( As applicable: )
#### Steps to test this PR:
1. Just code review from devs

Or

#### Steps to reproduce this issue:
1. Copy https://gist.github.com/kuzmany/278196d75477bd8c41a5a5773ec31190 to app/config/security_local.php  (this is security file which hide one of switch button from configurations > API)
2. Clear cache
3. Go to configuration - should return error

![image](https://user-images.githubusercontent.com/462477/85322423-a00dba80-b4c6-11ea-9382-e7305b0525bc.png)

Then patch and test again
Try save configuration if everything works properly.
