### PR TITLE
add getProjectDir() function to Kernel

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -315,6 +315,14 @@ class AppKernel extends Kernel
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getProjectDir(): string
+    {
+        return dirname(__DIR__);
+    }
+
+    /**
      * Get local config file.
      */
     public function getLocalConfigFile(): string


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | Fixes #8940 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Fixes issues with `open_basedir` in Mautic 3's production package. See #8940 for details. This fix is based on a comment made by one of Symfony's contributors at https://symfony.com/blog/new-in-symfony-3-3-a-simpler-way-to-get-the-project-root-directory:

> If you are not deploying the composer.json file, override the getProjectDir() method in your Kernel.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. See #8940 
2. 

#### Steps to test this PR:
1. Repeat the steps in #8940 (for example, copy the new code in this PR manually, it's a small snippet)
2. 

#### List deprecations along with the new alternative:
1. N/A
2. 

#### List backwards compatibility breaks:
1. N/A
2. 
