### PR TITLE
Several improvements to Mautic 3 upgrade script

### DIFF
--- a/upgrade_v3.php
+++ b/upgrade_v3.php
@@ -899,19 +899,17 @@ if (!IN_CLI) {
 
     final_cleanup_files();
 
-    writeToLog("Do you want to remove the backup files? We recommend first checking in a browser whether Mautic 3 works as expected. Type \"yes\" to remove: ");
+    echo "Do you want to remove the backup files? We recommend first checking in a browser whether Mautic 3 works as expected. Type \"yes\" to remove:\n";
     $handle = fopen("php://stdin", "r");
     $line = fgets($handle);
     if (trim($line) != "yes") {
-        writeToLog(
-            "Ok, we won't do anything for now. "
+        echo "Ok, we won't do anything for now. "
             . "Please note that upgrade_v3.php will remain (publicly) available until you choose to remove the backup files using this script! "
-            . "Run this script again to be prompted to delete backup files."
-        );
+            . "Run this script again to be prompted to delete backup files.\n";
         exit;
     }
     fclose($handle);
-    writeToLog("\nThank you, continuing...");
+    echo "\nThank you, continuing...\n";
 
     removeBackupFilesAndExit();
 

--- a/upgrade_v3.php
+++ b/upgrade_v3.php
@@ -12,7 +12,7 @@
  */
 @ini_set('display_errors', 'Off');
 
-if (stristr(PHP_OS, 'WIN')) {
+if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
     define('IS_WINDOWS', true);
 }
 

--- a/upgrade_v3.php
+++ b/upgrade_v3.php
@@ -347,7 +347,7 @@ function runPreUpgradeChecks()
     if (file_exists(__DIR__ . '/composer.json')) {
         $preUpgradeWarnings[] = 'You seem to have installed Mautic by cloning from GitHub. '
             . 'We don\'t support upgrading with the upgrade script in this scenario. '
-            . 'Proceed at your own risk or reinstall with the official package at <a target="_blank" href="https://www.mautic.org/download">https://www.mautic.org/download</a>';
+            . 'Proceed at your own risk or reinstall with the official package at <a target="_blank" href="https://github.com/mautic/mautic/releases/tag/2.16.3">https://github.com/mautic/mautic/releases/tag/2.16.3</a>';
     }
 
     return [


### PR DESCRIPTION
[//]: # ( Required: )
#### Description:

Adds/changes the following things in the M3 upgrade script:

- [x] Look into open_basedir issue https://github.com/mautic/mautic/pull/8824#issuecomment-640285227 --> this is a M3 issue, not an upgrade script issue. See https://github.com/mautic/mautic/issues/8940 for details.
- [x] Add pre-upgrade check for when instance has >=10000 contacts, then recommend to do CLI instead of UI upgrade
- [x] Change pre-upgrade check so that we check for MariaDB 10.2 or higher instead of 10.1
- [x] Add pre-upgrade check for `composer.json` (if that file is present, the user has installed Mautic by cloning from GitHub)
- [x] Send database version (e.g. 5.7.14) to stats server

#### Steps to test this PR:
1. Clone this PR locally. If you already have a Mautic 2.16.3-beta installation in this folder, you're ready to test, and if not, [download the ZIP package for this PR from here](https://github.com/dennisameling/mautic/releases/download/2.16.3-beta-8942/2.16.3-beta.zip) and do a fresh installation.
2. If you can upgrade without issues, you're basically good to go. However, if you want to test for all the cases mentioned above, follow the steps below.
3. (optional) Tests per item above:
- Instance >=10000 contacts: you can open Mautic, add 2 contacts, go to `upgrade_v3.php` and change `if ($count_leads >= 10000)` to `if ($count_leads >= 2)`. If you want to _actually_ create 10000 contacts, you might try [this approach](https://stackoverflow.com/a/22988639/4337765).
- MariaDB >= 10.2: if you use DDEV for local development, you can change the database version dynamically by adding e.g. `mariadb_version: 10.1` to your `.ddev/config.yaml`. See the [DDEV docs](https://ddev.readthedocs.io/en/stable/users/extend/database_types/) for details.
- `composer.json`: add an empty `composer.json` file to the root of your Mautic installation. The warning will now be triggered.
- Send database version to stats server: this has been tested and works as expected. If you want to test yourself, it would involve setting up a local [`statsapp`](https://github.com/mautic/statsapp) instance which is quite a lot of work 🙈 