### PR TITLE
Enable code coverage reports with Codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .php_cs.cache
 /.env
 /composer.phar
+/coverage.xml
 
 /app/bootstrap*
 /app/console

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ before_install:
 install:
   - pecl install pcov
   - composer install
+
+  # Clobber is needed because PCOV normally only works with PHPUnit 8+
   - bin/pcov clobber
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,3 +49,6 @@ jobs:
     -
       name: CS Fixer
       script: bin/php-cs-fixer fix --config=.php_cs -v --dry-run --using-cache=no --show-progress=dots --diff $(git diff -- '*.php' --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - echo "memory_limit=4G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
   # turn off XDebug
-  - phpenv config-rm xdebug.ini || return
+  #- phpenv config-rm xdebug.ini || return
 
   # install dependencies in parallel
   - travis_retry composer global require hirak/prestissimo

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ before_install:
   # increase memory limit for all PHP processes
   - echo "memory_limit=4G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
-  # turn off XDebug
-  #- phpenv config-rm xdebug.ini || return
-
   # install dependencies in parallel
   - travis_retry composer global require hirak/prestissimo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ before_install:
   # increase memory limit for all PHP processes
   - echo "memory_limit=4G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
+  # turn off XDebug
+  - phpenv config-rm xdebug.ini || return
+
   # install dependencies in parallel
   - travis_retry composer global require hirak/prestissimo
 
@@ -30,6 +33,7 @@ before_install:
   - export SYMFONY_ENV="test"
 
 install:
+  - pecl install pcov
   - composer install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
 install:
   - pecl install pcov
   - composer install
+  - bin/pcov clobber
 
 script:
   - composer test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![codecov](https://codecov.io/gh/dennisameling/mautic/branch/test-codecov/graph/badge.svg)](https://codecov.io/gh/dennisameling/mautic)
+[![codecov](https://codecov.io/gh/mautic/mautic/branch/staging/graph/badge.svg)](https://codecov.io/gh/mautic/mautic)
 
 Mautic Introduction
 ===========

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![codecov](https://codecov.io/gh/dennisameling/mautic/branch/test-codecov/graph/badge.svg)](https://codecov.io/gh/dennisameling/mautic)
+
 Mautic Introduction
 ===========
 ![Mautic](.github/readme_image.png "Mautic Open Source Marketing Automation")

--- a/build/exclude_files.txt
+++ b/build/exclude_files.txt
@@ -6,6 +6,7 @@
 .gitignore
 .php_cs
 .travis.yml
+codecov.yml
 Gruntfile.js
 README.md
 UPGRADE*.md

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+comment:
+    layout: "reach, diff, flags, files"
+    behavior: default
+    require_changes: true

--- a/composer.json
+++ b/composer.json
@@ -154,7 +154,7 @@
             "php -r \"if(file_exists('./.git')&&file_exists('./build/hooks/pre-commit'.(PHP_OS=='WINNT'?'.win':''))){copy('./build/hooks/pre-commit'.(PHP_OS=='WINNT'?'.win':''),'./.git/hooks/pre-commit');}\"",
             "php -r \"if(file_exists('./.git/hooks/pre-commit')&&(PHP_OS!='WINNT')){chmod('./.git/hooks/pre-commit',0755);}\""
         ],
-        "test": "bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --coverage-clover=coverage.xml",
+        "test": "bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --coverage-clover=coverage.xml --filter CampaignBundle",
         "phpstan": "bin/phpstan analyse app/bundles plugins",
         "cs": "bin/php-cs-fixer fix -v --dry-run --diff",
         "fixcs": "bin/php-cs-fixer fix -v",

--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,8 @@
         "friendsofphp/php-cs-fixer": "~2.16.1",
         "liip/test-fixtures-bundle": "^1.6",
         "phpstan/phpstan": "^0.12.3",
-        "rector/rector-prefixed": "0.6.13"
+        "rector/rector-prefixed": "0.6.13",
+        "pcov/clobber": "^2.0"
     },
     "repositories": [
         {
@@ -154,7 +155,7 @@
             "php -r \"if(file_exists('./.git')&&file_exists('./build/hooks/pre-commit'.(PHP_OS=='WINNT'?'.win':''))){copy('./build/hooks/pre-commit'.(PHP_OS=='WINNT'?'.win':''),'./.git/hooks/pre-commit');}\"",
             "php -r \"if(file_exists('./.git/hooks/pre-commit')&&(PHP_OS!='WINNT')){chmod('./.git/hooks/pre-commit',0755);}\""
         ],
-        "test": "bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --coverage-clover=coverage.xml --filter CampaignBundle",
+        "test": "bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --coverage-clover=coverage.xml",
         "phpstan": "bin/phpstan analyse app/bundles plugins",
         "cs": "bin/php-cs-fixer fix -v --dry-run --diff",
         "fixcs": "bin/php-cs-fixer fix -v",

--- a/composer.json
+++ b/composer.json
@@ -154,7 +154,7 @@
             "php -r \"if(file_exists('./.git')&&file_exists('./build/hooks/pre-commit'.(PHP_OS=='WINNT'?'.win':''))){copy('./build/hooks/pre-commit'.(PHP_OS=='WINNT'?'.win':''),'./.git/hooks/pre-commit');}\"",
             "php -r \"if(file_exists('./.git/hooks/pre-commit')&&(PHP_OS!='WINNT')){chmod('./.git/hooks/pre-commit',0755);}\""
         ],
-        "test": "bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist",
+        "test": "bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --coverage-clover=coverage.xml",
         "phpstan": "bin/phpstan analyse app/bundles plugins",
         "cs": "bin/php-cs-fixer fix -v --dry-run --diff",
         "fixcs": "bin/php-cs-fixer fix -v",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8a46baf1a0661f6fca1401be29683ab",
+    "content-hash": "53e80cbffebf718bd38ae821718900d3",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -12498,6 +12498,88 @@
                 "object graph"
             ],
             "time": "2020-01-17T21:11:47+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "53c2753d756f5adb586dca79c2ec0e2654dd9463"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/53c2753d756f5adb586dca79c2ec0e2654dd9463",
+                "reference": "53c2753d756f5adb586dca79c2ec0e2654dd9463",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "0.0.5",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2020-06-03T07:24:19+00:00"
+        },
+        {
+            "name": "pcov/clobber",
+            "version": "v2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/krakjoe/pcov-clobber.git",
+                "reference": "4c30759e912e6e5d5bf833fb3d77b5bd51709f05"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/krakjoe/pcov-clobber/zipball/4c30759e912e6e5d5bf833fb3d77b5bd51709f05",
+                "reference": "4c30759e912e6e5d5bf833fb3d77b5bd51709f05",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pcov": "^1.0",
+                "nikic/php-parser": "^4.2"
+            },
+            "bin": [
+                "bin/pcov"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "pcov\\Clobber\\": "src/pcov/clobber"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "time": "2019-10-29T05:03:37+00:00"
         },
         {
             "name": "phar-io/manifest",


### PR DESCRIPTION
This PR is not touching Mautic as a product, but rather the CI pipeline. 

After discussion with @RCheesley @npracht ([after initial discussion in the Trello board](https://trello.com/c/I4qWCnQi/34-add-code-coverage-report-to-mautic-repo)), we decided to start by implementing Codecov as the provider that will parse our coverage report XMLs. Given the fact that the lack of code coverage insights is quite a long-lasting and urgent issue, we fast-forwarded this.

If you are reading this and want to suggest a different approach, please do so in the #t-product team [on Slack](https://www.mautic.org/slack).