### PR TITLE
Fix field merge condition for merging contacts

### DIFF
--- a/app/bundles/LeadBundle/Deduplicate/ContactMerger.php
+++ b/app/bundles/LeadBundle/Deduplicate/ContactMerger.php
@@ -182,7 +182,14 @@ class ContactMerger
             }
 
             try {
-                $defaultValue = ArrayHelper::getValue('default_value', $winner->getField($field));
+                $fromValue    = empty($oldestFields[$field]) ? 'empty' : $oldestFields[$field];
+                $fieldDetails = $winner->getField($field);
+
+                if (false === $fieldDetails) {
+                    throw new ValueNotMergeableException($fromValue, false);
+                }
+
+                $defaultValue = ArrayHelper::getValue('default_value', $fieldDetails);
                 $newValue     = MergeValueHelper::getMergeValue(
                     $newestFields[$field],
                     $oldestFields[$field],
@@ -192,7 +199,6 @@ class ContactMerger
                 );
                 $winner->addUpdatedField($field, $newValue);
 
-                $fromValue = empty($oldestFields[$field]) ? 'empty' : $oldestFields[$field];
                 $this->logger->debug("CONTACT: Updated {$field} from {$fromValue} to {$newValue} for {$winner->getId()}");
             } catch (ValueNotMergeableException $exception) {
                 $this->logger->info("CONTACT: {$field} is not mergeable for {$winner->getId()} - {$exception->getMessage()}");

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -12,7 +12,6 @@
 namespace Mautic\LeadBundle\Tests\Deduplicate;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Mautic\CampaignBundle\Executioner\Scheduler\Mode\DateTime;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\LeadBundle\Deduplicate\ContactMerger;
 use Mautic\LeadBundle\Deduplicate\Exception\SameContactException;
@@ -687,7 +686,7 @@ class ContactMergerTest extends \PHPUnit\Framework\TestCase
 
     public function testMergeFieldWithEmptyFieldData()
     {
-        $loser = $this->createMock(Lead::class);
+        $loser  = $this->createMock(Lead::class);
         $winner = $this->createMock(Lead::class);
 
         $loser->expects($this->exactly(2))
@@ -702,7 +701,7 @@ class ContactMergerTest extends \PHPUnit\Framework\TestCase
             ->method('getId')
             ->willReturn(1);
 
-        $loser->expects($this->exactly(1))
+        $loser->expects($this->once())
             ->method('getId')
             ->willReturn(2);
 


### PR DESCRIPTION
Based on https://github.com/mautic/mautic/pull/7722

3 cherry-picks applied instead of 4. This one https://github.com/mautic/mautic/pull/7722/commits/ebf4340978c6687dcdf26c72f96e68e54392d6a7 seems to be already in staging now..

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
There is a bug probably when merging contacts and code expects array and gets false from \Mautic\LeadBundle\Entity\CustomFieldEntityTrait::getField().

When merging to community I discovered many differences between community and cloud code, so this became enhancement and sinc.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. We don't know, but reported by our customer and fixed by this.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Test contact merge

