### PR TITLE
Fix Code Mode block for non valid HTML

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -271,11 +271,57 @@ Mautic.keepPreviewAlive = function(iframeId, slot) {
     window.setInterval(function() {
         if (codeChanged) {
             var value = (Mautic.builderCodeMirror)?Mautic.builderCodeMirror.getValue():'';
+            Mautic.setCodeModeSlotContent(slot, value);
             Mautic.livePreviewInterval = Mautic.updateIframeContent(iframeId, value, slot);
             codeChanged = false;
         }
     }, 2000);
 };
+
+Mautic.isValidHtml = function (html) {
+    var doc = document.createElement('div');
+    doc.innerHTML = html;
+    return (doc.innerHTML === html);
+}
+
+Mautic.setCodeModeSlotContent = function (slot, content) {
+    if (Mautic.isValidHtml(content)) {
+        slot.removeAttr('encode');
+    } else {
+        slot.attr('encode', btoa(content));
+    }
+}
+
+Mautic.geCodeModetSlotContent = function (slot) {
+    var html = slot.html();
+    if (slot.attr('encode')) {
+        html = atob(slot.attr('encode'));
+    }
+    return html;
+}
+
+Mautic.prepareCodeModeBlocksBeforeSave = function(themeHtml) {
+    var parser = new DOMParser();
+    var el = parser.parseFromString(themeHtml, "text/html");
+    var $b = mQuery(el);
+    var codeBlocks = {};
+
+    $b.find('#codemodeHtmlContainer,.codemodeHtmlContainer').each(function (index) {
+        var html = mQuery(this).html();
+        if (mQuery(this).attr('encode')) {
+            html = atob(mQuery(this).attr('encode'));
+            var token = '{CODEMODEBLOCK'+index+'}';
+            codeBlocks[token] = html;
+        }
+    })
+
+    themeHtml = Mautic.domToString($b);
+    for (codeBlock in codeBlocks) {
+        themeHtml = themeHtml.replace(codeBlock, codeBlocks[codeBlock]);
+    }
+
+    return themeHtml;
+}
 
 Mautic.killLivePreview = function() {
     window.clearInterval(Mautic.livePreviewInterval);
@@ -577,7 +623,9 @@ Mautic.sanitizeHtmlBeforeSave = function(htmlContent) {
     var customHtml = Mautic.domToString(htmlContent).replace(/url\(&quot;(.+)&quot;\)/g, 'url(\'$1\')');
 
     // Convert dynamic slot definitions into tokens
-    return Mautic.convertDynamicContentSlotsToTokens(customHtml);
+    customHtml = Mautic.convertDynamicContentSlotsToTokens(customHtml);
+
+    return Mautic.prepareCodeModeBlocksBeforeSave(customHtml);
 };
 
 /**
@@ -1418,8 +1466,10 @@ Mautic.initSlotListeners = function() {
                             extraKeys: {"Ctrl-Space": "autocomplete"},
                             lineWrapping: true,
                         });
-                        Mautic.builderCodeMirror.getDoc().setValue(slot.find('#codemodeHtmlContainer,.codemodeHtmlContainer').html());
-                        Mautic.keepPreviewAlive(null, slot.find('#codemodeHtmlContainer,.codemodeHtmlContainer'));
+                        var elem = slot.find('#codemodeHtmlContainer,.codemodeHtmlContainer');
+                        html = Mautic.geCodeModetSlotContent(elem);
+                        Mautic.builderCodeMirror.getDoc().setValue(html);
+                        Mautic.keepPreviewAlive(null, elem);
                     }
                     break;
                 }

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -312,6 +312,7 @@ Mautic.prepareCodeModeBlocksBeforeSave = function(themeHtml) {
             html = atob(mQuery(this).attr('encode'));
             var token = '{CODEMODEBLOCK'+index+'}';
             codeBlocks[token] = html;
+            mQuery(this).html(token);
         }
     })
 

--- a/app/bundles/CoreBundle/Assets/js/4.builder.js
+++ b/app/bundles/CoreBundle/Assets/js/4.builder.js
@@ -286,16 +286,16 @@ Mautic.isValidHtml = function (html) {
 
 Mautic.setCodeModeSlotContent = function (slot, content) {
     if (Mautic.isValidHtml(content)) {
-        slot.removeAttr('encode');
+        slot.removeAttr('data-encode');
     } else {
-        slot.attr('encode', btoa(content));
+        slot.attr('data-encode', btoa(content));
     }
 }
 
 Mautic.geCodeModetSlotContent = function (slot) {
     var html = slot.html();
-    if (slot.attr('encode')) {
-        html = atob(slot.attr('encode'));
+    if (slot.attr('data-encode')) {
+        html = atob(slot.attr('data-encode'));
     }
     return html;
 }
@@ -308,8 +308,8 @@ Mautic.prepareCodeModeBlocksBeforeSave = function(themeHtml) {
 
     $b.find('#codemodeHtmlContainer,.codemodeHtmlContainer').each(function (index) {
         var html = mQuery(this).html();
-        if (mQuery(this).attr('encode')) {
-            html = atob(mQuery(this).attr('encode'));
+        if (mQuery(this).attr('data-encode')) {
+            html = atob(mQuery(this).attr('data-encode'));
             var token = '{CODEMODEBLOCK'+index+'}';
             codeBlocks[token] = html;
             mQuery(this).html(token);


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Noticed If we use non valid HTML in Code Block, the builder broke it.

If you're using RSS Bundle for Mautic  https://github.com/ChrisRAoW/mautic-rss-to-email-bundle and use table layout

```
{feed url="https://www.webmecanik.com/feed/"}
  <table>
    <tr>
      {feeditems count="3"}
        <td>
          <h3>{feeditem:title}</h3>
          <p><small>{feeditem:date format="d-m-Y H:i"}</small></p>
          <p>{feeditem:description}</p>
          <p><img src="{feeditem:image}"></p>
        </td>
      {/feeditems}
    </tr>
  </table>
{/feed}
```

Mautic builder broke it to:


```
{feed url="https://www.webmecanik.com/feed/"}
{feeditems count="3"}
    {/feeditems}
  <table><tbody><tr><td>
        <h3>{feeditem:title}</h3>
        <p><small>{feeditem:date format="d-m-Y H:i"}</small></p>
        <p>{feeditem:description}</p>
        <p><img src="{feeditem:image}"></p>
  </td></tr></tbody></table>
{/feed}
```

This PR make html validation of code mode block, If is not valid encode html content, store to data attribute of code mode block and then on save paste that code on search/replace.



[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Install 
2. Create email and create code mode slot with this content


```
{feed url="https://www.webmecanik.com/feed/"}
  <table>
    <tr>
      {feeditems count="3"}
        <td>
          <h3>{feeditem:title}</h3>
          <p><small>{feeditem:date format="d-m-Y H:i"}</small></p>
          <p>{feeditem:description}</p>
          <p><img src="{feeditem:image}"></p>
        </td>
      {/feeditems}
    </tr>
  </table>
{/feed}
```
2. Unselect code mode slot and then select again. Should see broken code and broken email preview

```
{feed url="https://www.webmecanik.com/feed/"}
{feeditems count="3"}
    {/feeditems}
  <table><tbody><tr><td>
        <h3>{feeditem:title}</h3>
        <p><small>{feeditem:date format="d-m-Y H:i"}</small></p>
        <p>{feeditem:description}</p>
        <p><img src="{feeditem:image}"></p>
  </td></tr></tbody></table>
{/feed}
```



#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Repeat all steps
3. You should see correct code and email preview
