### PR TITLE
An attempt to optimize the code coverage report generation only for 1 PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,10 @@ before_install:
   - export SYMFONY_ENV="test"
 
 install:
-  # Needed only to run test coverage.
-  - pecl install pcov
   - composer install
 
   # Clobber is needed because PCOV normally only works with PHPUnit 8+. Needed only to run test coverage.
-  - if [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]; then bin/pcov clobber; fi
+  - if [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]; then pecl install pcov && composer require --dev pcov/clobber && bin/pcov clobber; fi
 
 script:
   - if [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]; 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,15 +40,14 @@ install:
   # Clobber is needed because PCOV normally only works with PHPUnit 8+. Needed only to run test coverage.
   - if [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]; then bin/pcov clobber; fi
 
+script:
+  - if [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]; 
+    then composer test -- --coverage-clover=coverage.xml && bash <(curl -s https://codecov.io/bash); 
+    else composer test; fi
+
 jobs:
   include:
     - stage: test
-      name: PHPUNIT
-      script:
-        - if [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]; 
-          then composer test -- --coverage-clover=coverage.xml && bash <(curl -s https://codecov.io/bash); 
-          else composer test; fi
-    -
       name: PHPSTAN
       script: composer phpstan
     -

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
 
 install:
   # Needed only to run test coverage.
-  - if [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]; then pecl install pcov; fi
+  - pecl install pcov
   - composer install
 
   # Clobber is needed because PCOV normally only works with PHPUnit 8+. Needed only to run test coverage.

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,18 +33,24 @@ before_install:
   - export SYMFONY_ENV="test"
 
 install:
-  - pecl install pcov
+  # Needed only to run test coverage.
+  - if [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]; then pecl install pcov; fi
   - composer install
 
-  # Clobber is needed because PCOV normally only works with PHPUnit 8+
-  - bin/pcov clobber
-
-script:
-  - composer test
+  # Clobber is needed because PCOV normally only works with PHPUnit 8+. Needed only to run test coverage.
+  - if [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]; then bin/pcov clobber; fi
 
 jobs:
   include:
     - stage: test
+      name: PHPSTAN
+      script: if [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]; 
+        then 
+          composer test -- --coverage-clover=coverage.xml && bash <(curl -s https://codecov.io/bash); 
+        else 
+          composer test;
+      fi
+    -
       name: PHPSTAN
       script: composer phpstan
     -
@@ -53,6 +59,3 @@ jobs:
     -
       name: CS Fixer
       script: bin/php-cs-fixer fix --config=.php_cs -v --dry-run --using-cache=no --show-progress=dots --diff $(git diff -- '*.php' --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,11 @@ install:
 jobs:
   include:
     - stage: test
-      name: PHPSTAN
-      script: if [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]; 
-        then 
-          composer test -- --coverage-clover=coverage.xml && bash <(curl -s https://codecov.io/bash); 
-        else 
-          composer test;
-      fi
+      name: PHPUNIT
+      script:
+        - if [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]; 
+          then composer test -- --coverage-clover=coverage.xml && bash <(curl -s https://codecov.io/bash); 
+          else composer test; fi
     -
       name: PHPSTAN
       script: composer phpstan

--- a/composer.json
+++ b/composer.json
@@ -129,8 +129,7 @@
         "friendsofphp/php-cs-fixer": "~2.16.1",
         "liip/test-fixtures-bundle": "^1.6",
         "phpstan/phpstan": "^0.12.3",
-        "rector/rector-prefixed": "0.6.13",
-        "pcov/clobber": "^2.0"
+        "rector/rector-prefixed": "0.6.13"
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -155,7 +155,7 @@
             "php -r \"if(file_exists('./.git')&&file_exists('./build/hooks/pre-commit'.(PHP_OS=='WINNT'?'.win':''))){copy('./build/hooks/pre-commit'.(PHP_OS=='WINNT'?'.win':''),'./.git/hooks/pre-commit');}\"",
             "php -r \"if(file_exists('./.git/hooks/pre-commit')&&(PHP_OS!='WINNT')){chmod('./.git/hooks/pre-commit',0755);}\""
         ],
-        "test": "bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --coverage-clover=coverage.xml",
+        "test": "bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist",
         "phpstan": "bin/phpstan analyse app/bundles plugins",
         "cs": "bin/php-cs-fixer fix -v --dry-run --diff",
         "fixcs": "bin/php-cs-fixer fix -v",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53e80cbffebf718bd38ae821718900d3",
+    "content-hash": "e8a46baf1a0661f6fca1401be29683ab",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -12500,88 +12500,6 @@
             "time": "2020-01-17T21:11:47+00:00"
         },
         {
-            "name": "nikic/php-parser",
-            "version": "v4.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "53c2753d756f5adb586dca79c2ec0e2654dd9463"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/53c2753d756f5adb586dca79c2ec0e2654dd9463",
-                "reference": "53c2753d756f5adb586dca79c2ec0e2654dd9463",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.0"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "0.0.5",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "time": "2020-06-03T07:24:19+00:00"
-        },
-        {
-            "name": "pcov/clobber",
-            "version": "v2.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/krakjoe/pcov-clobber.git",
-                "reference": "4c30759e912e6e5d5bf833fb3d77b5bd51709f05"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/krakjoe/pcov-clobber/zipball/4c30759e912e6e5d5bf833fb3d77b5bd51709f05",
-                "reference": "4c30759e912e6e5d5bf833fb3d77b5bd51709f05",
-                "shasum": ""
-            },
-            "require": {
-                "ext-pcov": "^1.0",
-                "nikic/php-parser": "^4.2"
-            },
-            "bin": [
-                "bin/pcov"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "pcov\\Clobber\\": "src/pcov/clobber"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "time": "2019-10-29T05:03:37+00:00"
-        },
-        {
             "name": "phar-io/manifest",
             "version": "1.0.3",
             "source": {
@@ -14496,6 +14414,5 @@
         "ext-zip": "^1.15",
         "ext-imap": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform-dev": []
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Let's generate the CodeCov report only once per build (only for one PHP version) and save some CO2 ;)

Other issue this PR is solving is that you can continue using `composer test` without generating the code coverage report. It helps me greatly with my workflow.

#### Steps to test this PR:
1. Check Travis. It should not generate the CodeCov report for PHP 7.2 tests, but it should generate it for PHP 7.3

Note: I have no idea why the test coverage is decreased for this PR when it does not edit any PHP file...