### PR TITLE
Fix memory limit message in InstallBundle

### DIFF
--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -63,6 +63,13 @@ class CheckStep implements StepInterface
     public $site_url;
 
     /**
+     * Recommended minimum memory limit for Mautic.
+     *
+     * @var string
+     */
+    public static $memory_limit = '512M';
+
+    /**
      * @param Configurator $configurator Configurator service
      * @param string       $kernelRoot   Kernel root path
      * @param RequestStack $requestStack Request stack
@@ -228,7 +235,7 @@ class CheckStep implements StepInterface
         }
 
         $memoryLimit    = FileHelper::convertPHPSizeToBytes(ini_get('memory_limit'));
-        $suggestedLimit = FileHelper::convertPHPSizeToBytes('512M');
+        $suggestedLimit = FileHelper::convertPHPSizeToBytes(self::$memory_limit);
         if ($memoryLimit < $suggestedLimit) {
             $messages[] = 'mautic.install.memory.limit';
         }

--- a/app/bundles/InstallBundle/Translations/en_US/messages.ini
+++ b/app/bundles/InstallBundle/Translations/en_US/messages.ini
@@ -55,7 +55,7 @@ mautic.install.function.sessionstart="Install and enable the <strong>session</st
 mautic.install.function.simplexml="Install and enable the <strong>SimpleXML</strong> extension."
 mautic.install.function.tokengetall="Install and enable the <strong>Tokenizer</strong> extension."
 mautic.install.function.xml="Install and enable the <strong>XML</strong> extension."
-mautic.install.memory.limit="The <strong>memory_limit</strong> setting in your PHP configuration is lower than the suggested minimum limit of 128MB. Mautic can have performance issues with large datasets without sufficient memory."
+mautic.install.memory.limit="The <strong>memory_limit</strong> setting in your PHP configuration is lower than the suggested minimum limit of %min_memory_limit%. Mautic can have performance issues with large datasets without sufficient memory."
 mautic.install.heading.check.environment="Mautic Installation - Environment Check"
 mautic.install.heading.configured="Mautic is installed! Visit <a href='https://www.mautic.org/getting-started' target='_blank'>Getting Started</a> for the next steps."
 mautic.install.heading.database.configuration="Mautic Installation - Database Setup"

--- a/app/bundles/InstallBundle/Views/Install/check.html.php
+++ b/app/bundles/InstallBundle/Views/Install/check.html.php
@@ -8,6 +8,9 @@
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
+
+use Mautic\InstallBundle\Configurator\Step\CheckStep;
+
 if ('index' == $tmpl) {
     $view->extend('MauticInstallBundle:Install:content.html.php');
 }
@@ -87,6 +90,9 @@ if ('index' == $tmpl) {
                                 <?php break;
                             case 'mautic.install.php.version.has.only.security.support': ?>
                                 <li class="list-group-item"><?php echo $view['translator']->trans($message, ['%phpversion%' => PHP_VERSION]); ?></li>
+                                <?php break;
+                            case 'mautic.install.memory.limit': ?>
+                                <li class="list-group-item"><?php echo $view['translator']->trans($message, ['%min_memory_limit%' => CheckStep::$memory_limit]); ?></li>
                                 <?php break;
                             default: ?>
                                 <li class="list-group-item"><?php echo $view['translator']->trans($message); ?></li>


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | fixes #8932 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Set the PHP `memory_limit` in your environment to `256M`, probably in the `php.ini` file
2. Open the Mautic 3 installer and see the warning that you should have at least `128M`. This is a display error; it actually checks if the `memory_limit` is 512M+

#### Steps to test this PR:
1. Repeat the steps above, the warning should show 512M as the recommended minimum instead of 128M.
