### PR TITLE
Fix segments list for owners

### DIFF
--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -861,7 +861,7 @@ class ListController extends FormController
         return $this->generateContactsGrid(
             $objectId,
             $page,
-            'lead:lists:viewother',
+            ['lead:leads:viewother', 'lead:leads:viewown'],
             'segment',
             'lead_lists_leads',
             null,

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -465,6 +465,11 @@ class LeadListRepository extends CommonRepository
                 $expr            = $q->expr()->like('l.name', ':'.$unique);
                 $returnParameter = true;
                 break;
+            case $this->translator->trans('mautic.core.searchcommand.ismine'):
+            case $this->translator->trans('mautic.core.searchcommand.ismine', [], null, 'en_US'):
+                $expr            = $q->expr()->eq('l.createdBy', ":$unique");
+                $forceParameters = [$unique => $this->currentUser->getId()];
+                break;
         }
 
         if (!empty($forceParameters)) {
@@ -490,6 +495,7 @@ class LeadListRepository extends CommonRepository
             'mautic.core.searchcommand.ispublished',
             'mautic.core.searchcommand.isunpublished',
             'mautic.core.searchcommand.name',
+            'mautic.core.searchcommand.ismine',
         ];
 
         return array_merge($commands, parent::getSearchCommands());


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
I've noticed issue with display not global segments created by user. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create role with these settings. Expect see just own segments and global segments.

![image](https://user-images.githubusercontent.com/462477/85880881-0b180380-b7dd-11ea-8245-2d887b10c6dc.png)

2. Create user, assign that role and login to Mautic
3. Go to segments, create segment, disable Is Global and save.
4. Go to segments, and see this segment is not in the list of segments

#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Repeat all steps. You should see after login own segments and global segments
