### PR TITLE
Send JSON Webhooks in campaigns when content-type of application/json is included in the header

### DIFF
--- a/app/bundles/WebhookBundle/Helper/CampaignHelper.php
+++ b/app/bundles/WebhookBundle/Helper/CampaignHelper.php
@@ -93,7 +93,7 @@ class CampaignHelper
             case 'put':
             case 'patch':
                 $headers = array_change_key_case($headers);
-                if ('application/json' == strtolower($headers['content-type'])) {
+                if (array_key_exists('content-type', $headers) && 'application/json' == strtolower($headers['content-type'])) {
                     $payload                 = json_encode($payload);
                 }
                 $response = $this->connector->$method($url, $payload, $headers, $timeout);

--- a/app/bundles/WebhookBundle/Helper/CampaignHelper.php
+++ b/app/bundles/WebhookBundle/Helper/CampaignHelper.php
@@ -93,8 +93,7 @@ class CampaignHelper
             case 'put':
             case 'patch':
                 $headers = array_change_key_case($headers);
-                if (!array_key_exists('content-type', $headers) || 'application/json' == strtolower($headers['content-type'])) {
-                    $headers['content-type'] = 'application/json';
+                if ('application/json' == strtolower($headers['content-type'])) {
                     $payload                 = json_encode($payload);
                 }
                 $response = $this->connector->$method($url, $payload, $headers, $timeout);

--- a/app/bundles/WebhookBundle/Helper/CampaignHelper.php
+++ b/app/bundles/WebhookBundle/Helper/CampaignHelper.php
@@ -41,7 +41,6 @@ class CampaignHelper
      */
     public function fireWebhook(array $config, Lead $contact)
     {
-        // dump($config);die;
         $payload = $this->getPayload($config, $contact);
         $headers = $this->getHeaders($config, $contact);
         $url     = rawurldecode(TokenHelper::findLeadTokens($config['url'], $this->getContactValues($contact), true));

--- a/app/bundles/WebhookBundle/Helper/CampaignHelper.php
+++ b/app/bundles/WebhookBundle/Helper/CampaignHelper.php
@@ -92,6 +92,11 @@ class CampaignHelper
             case 'post':
             case 'put':
             case 'patch':
+                $headers = array_change_key_case($headers);
+                if (!array_key_exists('content-type', $headers) || 'application/json' == strtolower($headers['content-type'])) {
+                    $headers['content-type'] = 'application/json';
+                    $payload                 = json_encode($payload);
+                }
                 $response = $this->connector->$method($url, $payload, $headers, $timeout);
                 break;
             case 'delete':

--- a/app/bundles/WebhookBundle/Tests/Helper/CampaignHelperTest.php
+++ b/app/bundles/WebhookBundle/Tests/Helper/CampaignHelperTest.php
@@ -72,7 +72,7 @@ class CampaignHelperTest extends \PHPUnit\Framework\TestCase
 
         $this->connector->expects($this->once())
             ->method('post')
-            ->with('https://mautic.org', ['test'  => 'tee', 'email' => 'john@doe.email', 'IP' => '127.0.0.1,127.0.0.2'], ['test' => 'tee', 'company' => 'Mautic'], 10)
+            ->with('https://mautic.org', json_encode(['test'  => 'tee', 'email' => 'john@doe.email', 'IP' => '127.0.0.1,127.0.0.2']), ['test' => 'tee', 'company' => 'Mautic', 'content-type' => 'application/json'], 10)
             ->willReturn((object) ['code' => 200]);
 
         $this->campaignHelper->fireWebhook($config, $this->contact);

--- a/app/bundles/WebhookBundle/Tests/Helper/CampaignHelperTest.php
+++ b/app/bundles/WebhookBundle/Tests/Helper/CampaignHelperTest.php
@@ -72,6 +72,20 @@ class CampaignHelperTest extends \PHPUnit\Framework\TestCase
 
         $this->connector->expects($this->once())
             ->method('post')
+            ->with('https://mautic.org', ['test'  => 'tee', 'email' => 'john@doe.email', 'IP' => '127.0.0.1,127.0.0.2'], ['test' => 'tee', 'company' => 'Mautic'], 10)
+            ->willReturn((object) ['code' => 200]);
+
+        $this->campaignHelper->fireWebhook($config, $this->contact);
+    }
+
+    public function testFireWebhookWithPostJson()
+    {
+        $config      = $this->provideSampleConfig('post');
+        $expectedUrl = 'https://mautic.org?test=tee&email=john%40doe.email&IP=127.0.0.1%2C127.0.0.2';
+
+        $config      = $this->provideSampleConfig('post', 'application/json');
+        $this->connector->expects($this->once())
+            ->method('post')
             ->with('https://mautic.org', json_encode(['test'  => 'tee', 'email' => 'john@doe.email', 'IP' => '127.0.0.1,127.0.0.2']), ['test' => 'tee', 'company' => 'Mautic', 'content-type' => 'application/json'], 10)
             ->willReturn((object) ['code' => 200]);
 
@@ -89,9 +103,9 @@ class CampaignHelperTest extends \PHPUnit\Framework\TestCase
         $this->campaignHelper->fireWebhook($this->provideSampleConfig(), $this->contact);
     }
 
-    private function provideSampleConfig($method = 'get')
+    private function provideSampleConfig($method = 'get', $type = 'application/x-www-form-urlencoded')
     {
-        return [
+        $sample = [
             'url'             => 'https://mautic.org',
             'method'          => $method,
             'timeout'         => 10,
@@ -124,5 +138,14 @@ class CampaignHelperTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
         ];
+        if ('application/json' == $type) {
+            array_push($sample['headers']['list'],
+            [
+                'label' => 'content-type',
+                'value' => 'application/json',
+            ]);
+        }
+
+        return $sample;
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL |  https://docs.mautic.org/en/campaigns/campaign-events#send-a-webhook
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |  fixes #8375
| BC breaks? | no
| Deprecations? | no

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
In a campaign, fix the "Send a Webhook" for services requiring a JSON Payload, by adding a conversion to JSON if the head 'content-type' is set to 'application/json'

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1.  Cf #7869
2. 

#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Cf #7869

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
