### PR TITLE
Fix mysqli issue with Mautic 3 DB migrations

### DIFF
--- a/app/migrations/Version20191219155630.php
+++ b/app/migrations/Version20191219155630.php
@@ -32,61 +32,55 @@ final class Version20191219155630 extends AbstractMauticMigration
 
     public function up(Schema $schema): void
     {
-        $sql = <<<SQL
-# Dump of table mautic_sync_object_field_change_report
-# ------------------------------------------------------------
+        $this->addSql(
+            "# Dump of table mautic_sync_object_field_change_report
+            # ------------------------------------------------------------
 
-CREATE TABLE `{$this->prefix}sync_object_field_change_report` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `integration` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
-  `object_id` int(11) NOT NULL,
-  `object_type` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
-  `modified_at` datetime NOT NULL COMMENT '(DC2Type:datetime)',
-  `column_name` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
-  `column_type` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
-  `column_value` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `{$this->prefix}object_composite_key` (`object_type`,`object_id`,`column_name`),
-  KEY `{$this->prefix}integration_object_composite_key` (`integration`,`object_type`,`object_id`,`column_name`),
-  KEY `{$this->prefix}integration_object_type_modification_composite_key` (`integration`,`object_type`,`modified_at`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+            CREATE TABLE `{$this->prefix}sync_object_field_change_report` (
+            `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+            `integration` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
+            `object_id` int(11) NOT NULL,
+            `object_type` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
+            `modified_at` datetime NOT NULL COMMENT '(DC2Type:datetime)',
+            `column_name` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
+            `column_type` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
+            `column_value` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
+            PRIMARY KEY (`id`),
+            KEY `{$this->prefix}object_composite_key` (`object_type`,`object_id`,`column_name`),
+            KEY `{$this->prefix}integration_object_composite_key` (`integration`,`object_type`,`object_id`,`column_name`),
+            KEY `{$this->prefix}integration_object_type_modification_composite_key` (`integration`,`object_type`,`modified_at`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci"
+        );
 
-
-
-# Dump of table mautic_sync_object_mapping
-# ------------------------------------------------------------
-
-CREATE TABLE `{$this->prefix}sync_object_mapping` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `date_created` datetime NOT NULL COMMENT '(DC2Type:datetime)',
-  `integration` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
-  `internal_object_name` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
-  `integration_reference_id` varchar(191) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `internal_object_id` int(11) NOT NULL,
-  `integration_object_name` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
-  `integration_object_id` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
-  `last_sync_date` datetime NOT NULL COMMENT '(DC2Type:datetime)',
-  `internal_storage` longtext COLLATE utf8_unicode_ci NOT NULL COMMENT '(DC2Type:json_array)',
-  `is_deleted` tinyint(1) NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `{$this->prefix}internal_object` (`integration`,`internal_object_name`,`internal_object_id`),
-  KEY `{$this->prefix}object_match` (`integration`,`internal_object_name`,`integration_object_name`),
-  KEY `{$this->prefix}integration_last_sync_date` (`integration`,`last_sync_date`),
-  KEY `{$this->prefix}integration_object` (`integration`,`integration_object_name`,`integration_object_id`,`integration_reference_id`),
-  KEY `{$this->prefix}integration_reference` (`integration`,`integration_object_name`,`integration_reference_id`,`integration_object_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
-SQL;
-
-        $this->addSql($sql);
+        $this->addSql(
+            "# Dump of table mautic_sync_object_mapping
+            # ------------------------------------------------------------
+            
+            CREATE TABLE `{$this->prefix}sync_object_mapping` (
+            `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+            `date_created` datetime NOT NULL COMMENT '(DC2Type:datetime)',
+            `integration` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
+            `internal_object_name` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
+            `integration_reference_id` varchar(191) COLLATE utf8_unicode_ci DEFAULT NULL,
+            `internal_object_id` int(11) NOT NULL,
+            `integration_object_name` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
+            `integration_object_id` varchar(191) COLLATE utf8_unicode_ci NOT NULL,
+            `last_sync_date` datetime NOT NULL COMMENT '(DC2Type:datetime)',
+            `internal_storage` longtext COLLATE utf8_unicode_ci NOT NULL COMMENT '(DC2Type:json_array)',
+            `is_deleted` tinyint(1) NOT NULL,
+            PRIMARY KEY (`id`),
+            KEY `{$this->prefix}internal_object` (`integration`,`internal_object_name`,`internal_object_id`),
+            KEY `{$this->prefix}object_match` (`integration`,`internal_object_name`,`integration_object_name`),
+            KEY `{$this->prefix}integration_last_sync_date` (`integration`,`last_sync_date`),
+            KEY `{$this->prefix}integration_object` (`integration`,`integration_object_name`,`integration_object_id`,`integration_reference_id`),
+            KEY `{$this->prefix}integration_reference` (`integration`,`integration_object_name`,`integration_reference_id`,`integration_object_id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci"
+        );
     }
 
     public function down(Schema $schema): void
     {
-        $sql = <<<SQL
-DROP TABLE `{$this->prefix}sync_object_field_change_report`;
-DROP TABLE `{$this->prefix}sync_object_mapping`;
-SQL;
-
-        $this->addSql($sql);
+        $this->addSql("DROP TABLE `{$this->prefix}sync_object_field_change_report`");
+        $this->addSql("DROP TABLE `{$this->prefix}sync_object_mapping`");
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | Closes #8946 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This PR fixes Mautic 3 DB migration errors with the `mysqli` driver, which was reported in #8946.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Follow the steps mentioned in #8946 (option 1 is the easiest & fastest to test)
2. 

#### Steps to test this PR:
1. Clone this PR locally, e.g. with the GitHub CLI `gh pr checkout 8961`
2. Repeat the steps in #8946, the rollback should now succeed without errors
3. Run `bin/console doctrine:migrations:migrate --no-interaction` to make sure your installation is up-to-date with DB migrations again.
