### PR TITLE
Fixed #8717

### DIFF
--- a/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/DateHelper.php
@@ -173,7 +173,7 @@ class DateHelper extends Helper
         $dt       = $this->helper->getLocalDateTime();
 
         if ($textDate) {
-            return $this->translator->trans('mautic.core.date.'.$textDate, ['%time%' => $dt->format('g:i a')]);
+            return $this->translator->trans('mautic.core.date.'.$textDate, ['%time%' => $dt->format($this->formats['time'])]);
         } else {
             $interval = $this->helper->getDiff('now', null, true);
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? |  No
| Automated tests included? | No
| Related user documentation PR URL |  n/a
| Related developer documentation PR URL |  n/a
| Issues addressed (#s or URLs) |  #8717 
| BC breaks? |  no
| Deprecations? |  no

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: The format of times of Events dated yesterday/today in the contact detail page ignore the time format preferences. This PR fixes that.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Show a contact page that has changes dated today
2. Note that the time format is 'g:i a' regardless of time settings

#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
