### PR TITLE
Fix convertEmbedImages not working

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -945,7 +945,7 @@ class MailHelper
      */
     public function setBody($content, $contentType = 'text/html', $charset = null, $ignoreTrackingPixel = false)
     {
-        if (!$ignoreTrackingPixel && $this->factory->getParameter('mailer_convert_embed_images')) {
+        if ($this->factory->getParameter('mailer_convert_embed_images')) {
             $content = $this->convertEmbedImages($content);
         }
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? |  Y
| New feature? | N
| Automated tests included? |N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | N
| BC breaks? | N
| Deprecations? |N 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fixes convertEmbedImages not workin when using ignoreTrackingPixel==true , this prevented convertEmbedImages working when using "Send Example" functionality in Channels -> Emails. There is no reason to prevent convertEmbedImages working when ignoreTrackingPixel is true


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Enable Convert embed images to Base64  in Email settings
2. Create new Channel Email with Image in it
3. Use "Send Example" button and send email to your email address
4. If you have remote content blocked in your email client you will not see any images loaded, when you check email source you will notice that no images was converted to base64 version.

#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Follow same steps as in "Steps to reproduce the bug" to step 3.
3. You should see embed images loaded with disabled remote content