### PR TITLE
Cors allow headers authorization

### DIFF
--- a/app/middlewares/CORSMiddleware.php
+++ b/app/middlewares/CORSMiddleware.php
@@ -26,7 +26,7 @@ class CORSMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterf
      */
     protected $corsHeaders = [
         'Access-Control-Allow-Origin'      => '*',
-        'Access-Control-Allow-Headers'     => 'Origin, X-Requested-With, Content-Type',
+        'Access-Control-Allow-Headers'     => 'Origin, X-Requested-With, Content-Type, Authorization',
         'Access-Control-Allow-Methods'     => 'PUT, GET, POST, DELETE, OPTIONS',
         'Access-Control-Allow-Credentials' => 'true',
         'Access-Control-Max-Age'           => 10 * 60 * 60, // 10 min, max age for Chrome


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | yes
| New feature? | 
| Automated tests included? | no
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://forum.mautic.org/t/how-to-connect-to-mautic-api-from-javascript-with-basic-auth/14238/2
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fixes the problem, that JavaScript libraries can not authenticate if a browser enforces CORS (default). More details:
https://forum.mautic.org/t/how-to-connect-to-mautic-api-from-javascript-with-basic-auth/14238/2

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. run
```
curl -s -I -X  --location --request OPTIONS 'http://localhost/api/contacts/1' \
--header 'Access-Control-Request-Headers: origin, content-type, accept, authorization' \
--header 'Origin: http://localhost'
```
2. Response will not contain access-control-allow-headers `Authorization`
```
access-control-allow-headers: Origin, X-Requested-With, Content-Type
access-control-allow-methods: PUT, GET, POST, DELETE, OPTIONS
access-control-allow-credentials: true
```

#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Run curl from 1 again
3. Check that Authorization is present
```
Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Authorization
Access-Control-Allow-Methods: PUT, GET, POST, DELETE, OPTIONS
Access-Control-Allow-Credentials: true
```
#### List deprecations along with the new alternative:
1. none

#### List backwards compatibility breaks:
1. none
