### PR TITLE
Fix "Update Now" button on update page for M3

### DIFF
--- a/app/bundles/CoreBundle/Helper/UpdateHelper.php
+++ b/app/bundles/CoreBundle/Helper/UpdateHelper.php
@@ -211,13 +211,14 @@ class UpdateHelper
                 // If the kill switch is activated for the upgrade, we don't offer the upgrade to the user.
                 if (isset($m3Update->killSwitchActivated) && $m3Update->killSwitchActivated === false) {
                     $m3Data = [
-                        'error'            => false,
-                        'message'          => 'mautic.core.updater.update.available',
-                        'version'          => $m3Update->version,
-                        'announcement'     => $m3Update->announcement,
-                        'package'          => $m3Update->mautic3downloadUrl,
-                        'checkedTime'      => time(),
-                        'isMautic3Upgrade' => true,
+                        'error'             => false,
+                        'message'           => 'mautic.core.updater.update.available',
+                        'version'           => $m3Update->version,
+                        'announcement'      => $m3Update->announcement,
+                        'package'           => $m3Update->mautic3downloadUrl,
+                        'checkedTime'       => time(),
+                        'isMautic3Upgrade'  => true,
+                        'mautic3UpgradeUrl' => $this->coreParametersHelper->getParameter('site_url').'/upgrade_v3.php',
                     ];
 
                     file_put_contents($m3CacheFile, json_encode($m3Data));

--- a/app/bundles/CoreBundle/Views/Update/index.html.php
+++ b/app/bundles/CoreBundle/Views/Update/index.html.php
@@ -47,7 +47,11 @@ $view['slots']->set('headerTitle', $view['translator']->trans('mautic.core.updat
                             </tbody>
                         </table>
                         <div class="text-right">
-                            <button class="btn btn-primary" onclick="Mautic.processUpdate('update-panel', 1, '<?php echo base64_encode(json_encode([])); ?>');"><?php echo $view['translator']->trans('mautic.core.update.now'); ?></button>
+                            <?php if (isset($updateData['isMautic3Upgrade']) && $updateData['isMautic3Upgrade'] === true) { ?>
+                                <a class="btn btn-primary" href="<?php echo $updateData['mautic3UpgradeUrl'] ?>"><?php echo $view['translator']->trans('mautic.core.update.now'); ?></a>
+                            <?php } else { ?>
+                                <button class="btn btn-primary" onclick="Mautic.processUpdate('update-panel', 1, '<?php echo base64_encode(json_encode([])); ?>');"><?php echo $view['translator']->trans('mautic.core.update.now'); ?></button>
+                            <?php } ?>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Very painful bug. Sorry sorry sorry.

Test instructions:
- Download 2.16.3 new package: https://github.com/mautic/mautic/releases/download/2.16.3/2.16.3.zip
- Do a fresh install just to be sure
- Open `https://YOUR_MAUTIC_URL/s/update`, then hover over the "Update now" button. You should see in the corner of your browser a URL that ends with `upgrade_v3.php`. That's good and exactly what this fix does!