### PR TITLE
Fix pagination for integrations

### DIFF
--- a/app/bundles/PluginBundle/Controller/AjaxController.php
+++ b/app/bundles/PluginBundle/Controller/AjaxController.php
@@ -114,9 +114,8 @@ class AjaxController extends CommonAjaxController
                     if ('_' == substr($idPrefix, -1)) {
                         $idPrefix = substr($idPrefix, 0, -1);
                     }
-
-                    $html                 = preg_replace('/'.$formType.'\[(.*?)\]/', $prefix.'[$1]', $html);
-                    $html                 = str_replace($formType, $idPrefix, $html);
+                    $html                 = preg_replace('/'.$form->getName().'\[(.*?)\]/', $prefix.'[$1]', $html);
+                    $html                 = str_replace($form->getName(), $idPrefix, $html);
                     $dataArray['success'] = 1;
                     $dataArray['html']    = $html;
                 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
While I worked on Hubspot integration for M3 I noticed fields matching pagination not working.
This PR fixed this error:


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Setup integration (for example Hubspot)
2. Try pagination in  Contact Matching
3. You should see error 

> Uncaught PHP Exception Symfony\Component\Debug\Exception\ContextErrorException: "PHP Warning - preg_replace(): Compilation failed: unknown property name after \P or \p at offset 8" at app\bundles\PluginBundle\Controller\AjaxController.php line 118

#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Pagination should working properly
