### PR TITLE
Add no_superfluous_phpdoc_tags to CS fixer configuration

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -14,6 +14,7 @@ return PhpCsFixer\Config::create()
             'align_double_arrow' => true,
             'align_equals'       => true,
         ],
+        'no_superfluous_phpdoc_tags' => false,
         'phpdoc_to_comment' => false,
         'ordered_imports'   => true,
         'array_syntax'      => [


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
While I commit few PRs to M3 CS fixer remove annotations on class properties. Happen few times and was discuss here https://github.com/mautic/mautic/pull/8809#pullrequestreview-438093164 (@escopecz @dennisameling )

I noticed `no_superfluous_phpdoc_tags`  param to CS fixer config false flag stop doing that.

From docs https://cs.symfony.com/ I don't know what is the correct setup, but false flag works for me. Any idea how to improve it? 

> no_superfluous_phpdoc_tags [@Symfony, @PhpCsFixer]
> 
> Removes @param, @return and @var tags that don’t provide any useful information.
> 
> Configuration options:
> 
> allow_mixed (bool): whether type mixed without description is allowed (true) or considered superfluous (false); defaults to false
> allow_unused_params (bool): whether param annotation without actual signature is allowed (true) or considered superfluous (false); defaults to false
> remove_inheritdoc (bool): remove @inheritDoc tags; defaults to false


#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Just code review