### PR TITLE
Salesforce - truncate activity name to 80 characters

### DIFF
--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -258,7 +258,7 @@ class SalesforceApi extends CrmApi
                     $body = [
                         $namespace.'ActivityDate__c' => $record['dateAdded']->format('c'),
                         $namespace.'Description__c'  => $record['description'],
-                        'Name'                       => $record['name'],
+                        'Name'                       => substr($record['name'], 0, 80),
                         $namespace.'Mautic_url__c'   => $records['leadUrl'],
                         $namespace.'ReferenceId__c'  => $record['id'].'-'.$sfId,
                     ];


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Salesforce activities sync https://docs.mautic.org/en/plugins/salesforce stop working If activity name has more like 80 characters. And it happend in many cases for us, for example Page hit. 

Because we are not able to extend this limit (hardcoded limit by Salesforce), this PR truncates the activity name.

![image](https://user-images.githubusercontent.com/462477/86602211-a0b44f80-bfa2-11ea-95b8-9453d718f3d5.png)


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
Instead wasting time, just code review should be enoght.

1. Setup the Salesforce integration https://docs.mautic.org/en/plugins/salesforce (make sure to set up Mautic's Custom Object in Salesforce or you'll get errors!)
2. In the Salesforce integration settings, make sure to add "Page hit" to the "Events to include in the activity sync":
![image](https://user-images.githubusercontent.com/17739158/87857100-56c55500-c924-11ea-998c-7873589a3b4c.png)
3. Create a landing page in Mautic with a very long name (80+ characters)
4. Make sure a contact has a "Page Hit" event on that page:
![image](https://user-images.githubusercontent.com/17739158/87857113-7197c980-c924-11ea-9b9a-a27c9a9a6971.png)
5. Sync contacts with Salesforce (`bin/console mautic:integration:synccontacts -i Salesforce --env=dev`)
6. Sync events with Salesforce (`php bin/console mautic:integration:pushactivity -i Salesforce --env=dev`)
7. Activity is not synced. If you are on dev mode, you can check logs ans see error in log

![image](https://user-images.githubusercontent.com/462477/86602572-1c160100-bfa3-11ea-98ed-501ed689f96d.png)


#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Repeat all steps and activity should synced
