### PR TITLE
fixed the contact import is not merging with several uniquely identified fields

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -194,8 +194,12 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
 
         // loop through the fields and
         foreach ($uniqueFieldsWithData as $col => $val) {
-            $q->orWhere("l.$col = :".$col)
-                ->setParameter($col, $val);
+            if (is_null($val)) {
+                $q->andWhere("l.$col IS NULL");
+            } else {
+                $q->andWhere("l.$col = :".$col)
+                    ->setParameter($col, $val);
+            }
         }
 
         // if we have a lead ID lets use it

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -968,7 +968,7 @@ class LeadModel extends FormModel
 
         foreach ($cleanFields as $group) {
             foreach ($group as $key => $field) {
-                if (array_key_exists($key, $uniqueFields) && !empty($field['value'])) {
+                if (array_key_exists($key, $uniqueFields)) {
                     $uniqueFieldData[$key] = $field['value'];
                 }
             }


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | fixes #8948
| BC breaks? | N
| Deprecations? | N 

#### Description:
Fixes a contact import merging based on more than one uniquely identified fields.

## Steps to Reproduce Issue

1. Add a new custom field with the label **unique_field_1** and set _Is Unique Identifier_ to _Yes_
2. Add a new custom field with the label **unique_field_2** and set _Is Unique Identifier_ to _Yes_
3. Edit the **Email** field and set _Is Unique Identifier_ to _No_
4. Edit the **Company Email** field and set _Is Unique Identifier_ to _No_
5. Create a simple CSV file that has at least the following columns and rows:

email|unique_field_1|unique_field_2
------------ | ------------- | -------------
1@example.com|1|1
2@example.com|1|2
3@example.com|1|3
4@example.com|1|4

6. Import the CSV into Contacts
7. Once imported, Mautic will indicate that only 1 new contact was created and 3 of them were merged.

## Steps to Test PR
1. Use the same Mautic field configuration and CSV used in the Steps to Reproduce Issue, i.e., steps 1-5.
2. Remove the Contact added in the Steps to Reproduce Issue (optional)
3. Import the CSV into Contacts
4. Once imported, Mautic will indicate that 4 new contacts were created.
    If Step 2 was skipped, then it should indicate 1 contact was merged and 3 new contacts were created.