### PR TITLE
Fix to Email Sending Issue with SparkPost

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
@@ -262,7 +262,7 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
         ];
 
         if (!empty($message['headers'])) {
-            $content['headers'] = $message['headers'];
+            $content['headers'] = array_map('strval', $message['headers']);
         }
 
         // Sparkpost will set parts regardless if they are empty or not


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relevant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                |  3.0
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | #8621 


Description: 
This issue happen when you use Sparkpost, Swift Mail throws an exception and the emails are not sent. 

Steps to re-produce: 

1. Select sparkpost
2. Send a campaign email or segment email and send
3. You will get the following error


`mautic.ERROR: [MAIL ERROR] content.headers json dictionary value has type 'number' when expecting type 'string' Log data: !! content.headers json dictionary value has type 'number' when expecting type 'string' (code: 0) (send); victorcampuzano@XXXXXXXXXXXXXXX.com {"exception":"[object] (Swift_TransportException(code: 0): content.headers json dictionary value has type 'number' when expecting type 'string'\nLog data:\n!! content.headers json dictionary value has type 'number' when expecting type 'string' (code: 0) at`