### PR TITLE
Fix campaign trigger scheduled day/hour

### DIFF
--- a/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
@@ -361,7 +361,7 @@ class EventExecutioner
             );
 
             // Check if we need to schedule this if it is not an inactivity check
-            if (!$isInactive && $this->scheduler->shouldSchedule($executionDate, $this->executionDate)) {
+            if (!$isInactive && $this->scheduler->shouldScheduleEvent($event, $executionDate, $this->executionDate)) {
                 if ($childrenCounter) {
                     $childrenCounter->advanceTotalScheduled($contacts->count());
                 }

--- a/app/bundles/CampaignBundle/Executioner/InactiveExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/InactiveExecutioner.php
@@ -337,7 +337,7 @@ class InactiveExecutioner implements ExecutionerInterface
                 ' to be executed on '.$eventExecutionDate->format('Y-m-d H:i:s e')
             );
 
-            if ($this->scheduler->shouldScheduleForInactive($event, $eventExecutionDate, $executionDate)) {
+            if ($this->scheduler->shouldScheduleEvent($event, $eventExecutionDate, $executionDate)) {
                 $childrenCounter->advanceTotalScheduled($contacts->count());
                 $this->scheduler->schedule($event, $eventExecutionDate, $contacts, true);
 

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
@@ -315,7 +315,7 @@ class EventScheduler
         return $executionDate > $now;
     }
 
-    public function shouldScheduleForInactive(Event $event, \DateTime $executionDate, \DateTime $now): bool
+    public function shouldScheduleEvent(Event $event, \DateTime $executionDate, \DateTime $now): bool
     {
         if (null !== $event) {
             $eventProperties = $event->getProperties();

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
@@ -318,8 +318,7 @@ class EventScheduler
     public function shouldScheduleEvent(Event $event, \DateTime $executionDate, \DateTime $now): bool
     {
         if (null !== $event) {
-            $eventProperties = $event->getProperties();
-            if (!empty($eventProperties['triggerRestrictedDaysOfWeek'])) {
+            if ($this->intervalScheduler->isContactSpecificExecutionDateRequired($event)) {
                 // Event has days in week specified. Needs to be recalculated to the next day configured
                 return true;
             }

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -160,7 +160,7 @@ class Interval implements ScheduleModeInterface
         }
 
         // Restrict just for daily scheduling
-        if ('d' !== $event->getTriggerIntervalUnit()) {
+        if (!in_array($event->getTriggerIntervalUnit(), ['d', 'm', 'y'])) {
             return false;
         }
 

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -119,21 +119,17 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         $date  = new \DateTime();
         $now   = clone $date;
         $event = new Event();
+        $event->setTriggerIntervalUnit('d');
+        $event->setTriggerMode(Event::TRIGGER_MODE_INTERVAL);
 
         $this->assertFalse($this->scheduler->shouldScheduleEvent($event, $date, $now));
 
-        $event->setProperties([
-            'triggerRestrictedDaysOfWeek' => [],
-        ]);
+        $event->setTriggerRestrictedDaysOfWeek([]);
 
         $this->assertFalse($this->scheduler->shouldScheduleEvent($event, $date, $now));
 
-        $event->setProperties([
-            'triggerRestrictedDaysOfWeek' => [
-                0 => 1,
-                1 => 2,
-            ],
-        ]);
+        $event->setTriggerRestrictedStartHour('23:00');
+        $event->setTriggerRestrictedStopHour('23:30');
 
         $this->assertTrue($this->scheduler->shouldScheduleEvent($event, $date, $now));
 

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -120,13 +120,13 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         $now   = clone $date;
         $event = new Event();
 
-        $this->assertFalse($this->scheduler->shouldScheduleForInactive($event, $date, $now));
+        $this->assertFalse($this->scheduler->shouldScheduleEvent($event, $date, $now));
 
         $event->setProperties([
             'triggerRestrictedDaysOfWeek' => [],
         ]);
 
-        $this->assertFalse($this->scheduler->shouldScheduleForInactive($event, $date, $now));
+        $this->assertFalse($this->scheduler->shouldScheduleEvent($event, $date, $now));
 
         $event->setProperties([
             'triggerRestrictedDaysOfWeek' => [
@@ -135,11 +135,11 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
             ],
         ]);
 
-        $this->assertTrue($this->scheduler->shouldScheduleForInactive($event, $date, $now));
+        $this->assertTrue($this->scheduler->shouldScheduleEvent($event, $date, $now));
 
         $date->add(new \DateInterval('P2D'));
         $event = new Event();
-        $this->assertTrue($this->scheduler->shouldScheduleForInactive($event, $date, $now));
+        $this->assertTrue($this->scheduler->shouldScheduleEvent($event, $date, $now));
     }
 
     public function testGetExecutionDateForInactivity()


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging for features or enhancements / 3.0 for bug fixes <!-- see below -->
| Bug fix?                               | yes/no
| New feature?                           | yes/no
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | yes/no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
This PR is based on https://github.com/mautic/mautic/pull/8874 already merged in repo.
We noticed in some cases actions were not scheduled but executed.

Steps to reproduce:

1. Create campaign with conditions and action after condition

![image](https://user-images.githubusercontent.com/462477/87791877-543efe80-c843-11ea-87a6-19cf3ffe0bbd.png)

2. Schedule action  run today 0 days from 23:00 to 23:30 for example

![image](https://user-images.githubusercontent.com/462477/87792007-8b151480-c843-11ea-8c40-a44529dfb117.png)

3. Run campaign and action is triggered now even If you enable schedule


#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat all steps and check if action was scheduled properly

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
