### PR TITLE
Prevent codecov/patch failed check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+coverage:
+    status:
+        patch: off
 comment:
     layout: "reach, diff, flags, files"
     behavior: default


### PR DESCRIPTION
Currently, if someone creates a PR in which the modified file(s) isn't/aren't covered by unit tests at all, the `codecov/patch` check shows up as failed:

![image](https://user-images.githubusercontent.com/17739158/87853978-b284e380-c90e-11ea-8416-08c330322fd5.png)

This PR disables that check. Codecov will still check for changed coverage project-wide, which is the main thing we're interested in currently.