### PR TITLE
Enable code coverage report on plugins and middlewares

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -27,11 +27,18 @@
     <filter>
         <whitelist>
             <directory>bundles</directory>
+            <directory>./../plugins</directory>
+            <directory>middlewares</directory>
             <exclude>
                 <directory>bundles/*Bundle/Config</directory>
                 <directory>bundles/*Bundle/Tests</directory>
                 <directory>bundles/*Bundle/Translations</directory>
                 <directory>bundles/*Bundle/Views</directory>
+                <directory>plugins/*Bundle/Config</directory>
+                <directory>plugins/*Bundle/Tests</directory>
+                <directory>plugins/*Bundle/Translations</directory>
+                <directory>plugins/*Bundle/Views</directory>
+                <directory>middlewares/Tests</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -34,10 +34,10 @@
                 <directory>bundles/*Bundle/Tests</directory>
                 <directory>bundles/*Bundle/Translations</directory>
                 <directory>bundles/*Bundle/Views</directory>
-                <directory>plugins/*Bundle/Config</directory>
-                <directory>plugins/*Bundle/Tests</directory>
-                <directory>plugins/*Bundle/Translations</directory>
-                <directory>plugins/*Bundle/Views</directory>
+                <directory>./../plugins/*Bundle/Config</directory>
+                <directory>./../plugins/*Bundle/Tests</directory>
+                <directory>./../plugins/*Bundle/Translations</directory>
+                <directory>./../plugins/*Bundle/Views</directory>
                 <directory>middlewares/Tests</directory>
             </exclude>
         </whitelist>


### PR DESCRIPTION
Currently, PHPUnit only generates code coverage reports for Mautic's core bundles. However, the CI also runs tests on plugins + middleware, so they should be included in the code coverage report as well.

![image](https://user-images.githubusercontent.com/17739158/87859456-6dc07300-c935-11ea-96b7-9f740f6b86d0.png)

**It's expected that this PR will decrease coverage significantly, since we're adding new code (plugins + middleware) to the code coverage report.**