### PR TITLE
Update oneup/uploader-bundle to 1.9.4 (security fix)

### DIFF
--- a/app/bundles/CoreBundle/Views/Update/index.html.php
+++ b/app/bundles/CoreBundle/Views/Update/index.html.php
@@ -47,11 +47,15 @@ $view['slots']->set('headerTitle', $view['translator']->trans('mautic.core.updat
                             </tbody>
                         </table>
                         <div class="text-right">
-                            <?php if (isset($updateData['isMautic3Upgrade']) && $updateData['isMautic3Upgrade'] === true) { ?>
+                            <?php if (isset($updateData['isMautic3Upgrade']) && $updateData['isMautic3Upgrade'] === true) {
+    ?>
                                 <a class="btn btn-primary" href="<?php echo $updateData['mautic3UpgradeUrl'] ?>"><?php echo $view['translator']->trans('mautic.core.update.now'); ?></a>
-                            <?php } else { ?>
+                            <?php
+} else {
+        ?>
                                 <button class="btn btn-primary" onclick="Mautic.processUpdate('update-panel', 1, '<?php echo base64_encode(json_encode([])); ?>');"><?php echo $view['translator']->trans('mautic.core.update.now'); ?></button>
-                            <?php } ?>
+                            <?php
+    } ?>
                         </div>
                     </div>
                 </div>

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "friendsofsymfony/oauth-server-bundle": "1.5.2",
         "willdurand/oauth-server-bundle": "0.0.2",
         "jms/serializer-bundle": "~1.1",
-        "oneup/uploader-bundle": "~1.3",
+        "oneup/uploader-bundle": "^1.9.4",
 
         "phpoffice/phpexcel": "1.8.1",
         "joomla/http": "1.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e09408d23624dfd3451cee6e23c5815b",
+    "content-hash": "31c3e40179c18371297f6ef8597723dd",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -3592,17 +3592,17 @@
         },
         {
             "name": "oneup/uploader-bundle",
-            "version": "1.9.3",
+            "version": "1.9.4",
             "target-dir": "Oneup/UploaderBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/1up-lab/OneupUploaderBundle.git",
-                "reference": "d59fcd2e5f675ee83c53965e16d21a942e90a9ef"
+                "reference": "8a6dc57c35e12fbc341e52e401a1d286475ec445"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/1up-lab/OneupUploaderBundle/zipball/d59fcd2e5f675ee83c53965e16d21a942e90a9ef",
-                "reference": "d59fcd2e5f675ee83c53965e16d21a942e90a9ef",
+                "url": "https://api.github.com/repos/1up-lab/OneupUploaderBundle/zipball/8a6dc57c35e12fbc341e52e401a1d286475ec445",
+                "reference": "8a6dc57c35e12fbc341e52e401a1d286475ec445",
                 "shasum": ""
             },
             "require": {
@@ -3663,7 +3663,7 @@
                 "plupload",
                 "upload"
             ],
-            "time": "2020-02-04T10:37:36+00:00"
+            "time": "2020-02-04T12:08:35+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -10853,5 +10853,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "5.6.19"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes (Security) |
| New feature? | No |
| Automated tests included? | No |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | https://github.com/1up-lab/OneupUploaderBundle/security/advisories/GHSA-x8wj-6m73-gfqp |
| BC breaks? | No |
| Deprecations? | No |

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Relative Path Traversal (CWE-23) in chunked uploads. See more here: https://github.com/1up-lab/OneupUploaderBundle/security/advisories/GHSA-x8wj-6m73-gfqp