### PR TITLE
Bump version to 3.0.2 stable

### DIFF
--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.0.2-rc",
-  "stability": "rc",
+  "version": "3.0.2",
+  "stability": "stable",
   "minimum_php_version": "7.2.21",
   "maximum_php_version": "7.3.99",
   "minimum_mautic_version": "3.0.0-alpha",


### PR DESCRIPTION
Bumps the version to 3.0.2 stable in preparation for the release today.