### PR TITLE
populate doNotContact field in webhooks - rebased #7293 for Mautic 3

### DIFF
--- a/app/bundles/LeadBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/WebhookSubscriber.php
@@ -117,6 +117,7 @@ class WebhookSubscriber implements EventSubscriberInterface
                 'userList',
                 'publishDetails',
                 'ipAddress',
+                'doNotContactList',
                 'tagList',
             ]
         );
@@ -138,6 +139,7 @@ class WebhookSubscriber implements EventSubscriberInterface
                 'userList',
                 'publishDetails',
                 'ipAddress',
+                'doNotContactList',
                 'tagList',
             ]
         );
@@ -156,6 +158,7 @@ class WebhookSubscriber implements EventSubscriberInterface
                 'leadDetails',
                 'userList',
                 'publishDetails',
+                'doNotContactList',
                 'ipAddress',
             ]
         );
@@ -176,6 +179,7 @@ class WebhookSubscriber implements EventSubscriberInterface
                 'userList',
                 'publishDetails',
                 'ipAddress',
+                'doNotContactList',
                 'tagList',
             ]
         );

--- a/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberTest.php
@@ -122,6 +122,7 @@ class WebhookSubscriberTest extends \PHPUnit\Framework\TestCase
                     'userList',
                     'publishDetails',
                     'ipAddress',
+                    'doNotContactList',
                     'tagList',
                 ]
             );


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging
| Bug fix?                               | no
| New feature?                           | yes
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | Not required
| Related developer documentation PR URL | Not required
| Issue(s) addressed                     | No issue raised

#### Description:

This is a direct copy of #7293 - details from the original PR are below:

doNotContact elements in webhooks are empty. This PR properly populates this field in the webhook data.

#### Steps to reproduce the bug:
1. Create a contact and untick the email channel in their preferences so that they have the DNC flag for that channel
1. Go to [https://webhook.site/](https://webhook.site/) and grab the unique URL
1. Create webhook in Mautic and check "Contact Updated Event", "Contact subscription change", "Contact point change" and "Contact deleted"
1. Trigger each of those webhooks for a contact in the DNC list (eg update the contact, change their segments, change points, delete contact)
1. Check webhook's payload on  [https://webhook.site/](https://webhook.site/), notice that the doNotContact elements are empty:

![screenshot-webhook site-2020 07 31-14_00_01](https://user-images.githubusercontent.com/2930593/89037392-435bb600-d336-11ea-8197-4c51ff44b9e5.png)

#### Steps to test this PR:
1. Create a contact and untick the email channel in their preferences so that they have the DNC flag for that channel
1. Go to [https://webhook.site/](https://webhook.site/) and grab the unique URL
1. Create webhook in Mautic and check "Contact Updated Event", "Contact subscription change", "Contact point change" and "Contact deleted"
1. Trigger each of those webhooks for the contact you created above (eg update the contact, change their segments, change points, delete contact)
1. Check webhook's payload on  [https://webhook.site/](https://webhook.site/), notice that the doNotContact elements are no longer empty:

![screenshot-webhook site-2020 07 31-14_00_30](https://user-images.githubusercontent.com/2930593/89037405-49ea2d80-d336-11ea-88a9-1b590c9987bd.png)
