### PR TITLE
Fix transliterate without intl extensions

### DIFF
--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -513,6 +513,6 @@ class InputHelper
             return $trans->transliterate($value);
         }
 
-        return \URLify::transliterate($value);
+        return \URLify::transliterate((string) $value);
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/InputHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/InputHelperTest.php
@@ -149,4 +149,16 @@ class InputHelperTest extends \PHPUnit\Framework\TestCase
             InputHelper::filename('29NIDJi  dsfjh(#*RO85T784šěíáčýžěé+ěšéřář', 'txt')
         );
     }
+
+    public function testTransliterate()
+    {
+        $tests = [
+            'custom test' => 'custom test',
+            'čusťom test' => 'custom test',
+            null          => '',
+        ];
+        foreach ($tests as $input=>$expected) {
+            $this->assertEquals(InputHelper::transliterate($input), $expected);
+        }
+    }
 }


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging for features or enhancements / 3.0 for bug fixes <!-- see below -->
| Bug fix?                               | yes/no
| New feature?                           | yes/no
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | yes/no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #9016

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

Create new form is not possible if php-intl extension missing in PHP due transliterate
https://github.com/mautic/mautic/blob/0ec78b81cb88be9db3bc4ae69f3c85f1abb6b5c5/app/bundles/FormBundle/Entity/Form.php#L847

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Disable php-intl extension in PHP
2. Try create form
3. You should see error 

`[2020-08-04 09:39:31] mautic.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Type error: Argument 1 passed to URLify::transliterate() must be of the type string, null given, called in /path/app/bundles/CoreBundle/Helper/InputHelper.php on line 516" at /path/vendor/jbroadway/urlify/URLify.php line 360 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Type error: Argument 1 passed to URLify::transliterate() must be of the type string, null given, called in /path/app/bundles/CoreBundle/Helper/InputHelper.php on line 516 at /path/vendor/jbroadway/urlify/URLify.php:360)"} []
`
4. This PR fixed it

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
