### PR TITLE
Skip DNC reason query if not needed

### DIFF
--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
+use PHPUnit\Framework\Assert;
+use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
+use Symfony\Component\HttpFoundation\Request;
+
+final class EmailControllerFunctionalTest extends MauticMysqlTestCase
+{
+    /**
+     * Ensure there is no query for DNC reasons if there are no contacts who received the email
+     * because it loads the whole DNC table if no contact IDs are provided. It can lead to
+     * memory limit error if the DNC table is big.
+     */
+    public function testProfileEmailDetailPageForUnsentEmail()
+    {
+        $segment = new LeadList();
+        $segment->setName('Segment A');
+        $segment->setAlias('segment-a');
+        $email = new Email();
+        $email->setName('Email A');
+        $email->setSubject('Email A Subject');
+        $email->setEmailType('list');
+        $email->addList($segment);
+        $this->em->persist($segment);
+        $this->em->persist($email);
+        $this->em->flush();
+
+        $this->client->enableProfiler();
+        $this->client->request(Request::METHOD_GET, "/s/emails/view/{$email->getId()}");
+
+        $profile = $this->client->getProfile();
+
+        /** @var DoctrineDataCollector $dbCollector */
+        $dbCollector = $profile->getCollector('db');
+        $queries     = $dbCollector->getQueries();
+        $prefix      = $this->container->getParameter('mautic.db_table_prefix');
+
+        $dncQueries = array_filter(
+            $queries['default'],
+            function (array $query) use ($prefix) {
+                return "SELECT l.id, dnc.reason FROM {$prefix}lead_donotcontact dnc LEFT JOIN {$prefix}leads l ON l.id = dnc.lead_id WHERE dnc.channel = :channel" === $query['sql'];
+            }
+        );
+
+        Assert::assertCount(0, $dncQueries);
+    }
+
+    /**
+     * On the other hand there should be the query for DNC reasons if there are contacts who received the email.
+     */
+    public function testProfileEmailDetailPageForSentEmail()
+    {
+        $segment = new LeadList();
+        $segment->setName('Segment A');
+        $segment->setAlias('segment-a');
+        $email = new Email();
+        $email->setName('Email A');
+        $email->setSubject('Email A Subject');
+        $email->setEmailType('list');
+        $email->addList($segment);
+        $contact = new Lead();
+        $contact->setEmail('john@doe.email');
+        $emailStat = new Stat();
+        $emailStat->setEmail($email);
+        $emailStat->setLead($contact);
+        $emailStat->setEmailAddress($contact->getEmail());
+        $emailStat->setDateSent(new \DateTime());
+        $this->em->persist($segment);
+        $this->em->persist($email);
+        $this->em->persist($contact);
+        $this->em->persist($emailStat);
+        $this->em->flush();
+
+        $this->client->enableProfiler();
+        $this->client->request(Request::METHOD_GET, "/s/emails/view/{$email->getId()}");
+
+        $profile = $this->client->getProfile();
+
+        /** @var DoctrineDataCollector $dbCollector */
+        $dbCollector = $profile->getCollector('db');
+        $queries     = $dbCollector->getQueries();
+        $prefix      = $this->container->getParameter('mautic.db_table_prefix');
+
+        $dncQueries = array_filter(
+            $queries['default'],
+            function (array $query) use ($prefix) {
+                return "SELECT l.id, dnc.reason FROM {$prefix}lead_donotcontact dnc LEFT JOIN {$prefix}leads l ON l.id = dnc.lead_id WHERE (dnc.channel = :channel) AND (l.id IN (1))" === $query['sql'];
+            }
+        );
+
+        Assert::assertCount(1, $dncQueries);
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -24,6 +24,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class EmailControllerFunctionalTest extends MauticMysqlTestCase
 {
+    protected $clientOptions = ['debug' => true];
+
     /**
      * Ensure there is no query for DNC reasons if there are no contacts who received the email
      * because it loads the whole DNC table if no contact IDs are provided. It can lead to
@@ -33,6 +35,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
     {
         $segment = new LeadList();
         $segment->setName('Segment A');
+        $segment->setPublicName('Segment A');
         $segment->setAlias('segment-a');
         $email = new Email();
         $email->setName('Email A');
@@ -70,6 +73,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
     {
         $segment = new LeadList();
         $segment->setName('Segment A');
+        $segment->setPublicName('Segment A');
         $segment->setAlias('segment-a');
         $email = new Email();
         $email->setName('Email A');

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -105,8 +105,8 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
 
         $dncQueries = array_filter(
             $queries['default'],
-            function (array $query) use ($prefix) {
-                return "SELECT l.id, dnc.reason FROM {$prefix}lead_donotcontact dnc LEFT JOIN {$prefix}leads l ON l.id = dnc.lead_id WHERE (dnc.channel = :channel) AND (l.id IN (1))" === $query['sql'];
+            function (array $query) use ($prefix, $contact) {
+                return "SELECT l.id, dnc.reason FROM {$prefix}lead_donotcontact dnc LEFT JOIN {$prefix}leads l ON l.id = dnc.lead_id WHERE (dnc.channel = :channel) AND (l.id IN ({$contact->getId()}))" === $query['sql'];
             }
         );
 

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -110,6 +110,6 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
             }
         );
 
-        Assert::assertCount(1, $dncQueries);
+        Assert::assertCount(1, $dncQueries, 'DNC query not found. '.var_export($queries, true));
     }
 }

--- a/app/bundles/LeadBundle/Controller/EntityContactsTrait.php
+++ b/app/bundles/LeadBundle/Controller/EntityContactsTrait.php
@@ -117,7 +117,7 @@ trait EntityContactsTrait
 
         // Get DNC for the contact
         $dnc = [];
-        if ($dncChannel) {
+        if ($dncChannel && $count > 0) {
             $dnc = $this->getDoctrine()->getManager()->getRepository('MauticLeadBundle:DoNotContact')->getChannelList(
                 $dncChannel,
                 array_keys($contacts['results'])


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.0
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

On email detail page load we get queries to fetch contacts that received the email and add information if they were marked as Do Not Contact (DNC). This works correctly if there are some contacts in the email_stats table. We found out that if the email was not sent yet and there are lots of rows in the DNC table then it will throw this error when accessing the email detail page:

```
PHP Fatal error:  Allowed memory size of 536870912 bytes exhausted (tried to allocate 20480 bytes) in vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php on line 167
```

That's because if we do not provide any contact IDs to the DNC query then it will query for all rows:
```sql
SELECT l.id, dnc.reason FROM lead_donotcontact dnc LEFT JOIN leads l ON l.id = dnc.lead_id WHERE dnc.channel = 'email'
```
This will obviously end up with a memory limit error when there are over 1M rows. When the email is sent to a contact then the query looks like this:
```sql
SELECT l.id, dnc.reason FROM lead_donotcontact dnc LEFT JOIN leads l ON l.id = dnc.lead_id WHERE (dnc.channel = 'email') AND (l.id IN (1))
```
So it will return as many rows as how many contacts were sent the email and has a DNC record.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. This is hard to reproduce as the error will appear when there are over 1M rows in the DNC table.

#### Steps to test this PR:
1. Ensure the email detail page is visible for new email and also if you sent the email to a segment then the contacts will show up on the email detail page.
2. There are functional tests that ensure that the problematic SQL query gets skipped for new emails and will get executed for sent emails.

#### Other areas of Mautic that may be affected by the change:
1. The same method to generate the list of contacts is used on other detail pages like SMS, campaign, marketing message.
