### PR TITLE
Sanitizing select aliases during generating report query

### DIFF
--- a/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
+++ b/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\ReportBundle\Tests\Builder;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Mautic\ChannelBundle\Helper\ChannelListHelper;
+use Mautic\ReportBundle\Builder\MauticReportBuilder;
+use Mautic\ReportBundle\Entity\Report;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+final class MauticReportBuilderTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var MockObject|EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var MockObject|Connection
+     */
+    private $connection;
+
+    /**
+     * @var MockObject|QueryBuilder
+     */
+    private $queryBuilder;
+
+    /**
+     * @var MockObject|ChannelListHelper
+     */
+    private $channelListHelper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dispatcher        = $this->createMock(EventDispatcherInterface::class);
+        $this->connection        = $this->createMock(Connection::class);
+        $this->queryBuilder      = new QueryBuilder($this->connection);
+        $this->channelListHelper = $this->createMock(ChannelListHelper::class);
+
+        $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilder);
+    }
+
+    public function testColumnSanitization(): void
+    {
+        $report = new Report();
+        $report->setColumns(['a.b', 'b.c']);
+        $builder = $this->buildBuilder($report);
+        $query   = $builder->getQuery([
+            'columns' => ['a.b' => [], 'b.c' => []],
+        ]);
+        Assert::assertSame('SELECT `a`.`b`, `b`.`c`', $query->getSql());
+    }
+
+    private function buildBuilder(Report $report): MauticReportBuilder
+    {
+        return new MauticReportBuilder(
+            $this->dispatcher,
+            $this->connection,
+            $report,
+            $this->channelListHelper
+        );
+    }
+}


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.0
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

We must sanitize the table aliases as they might be auto generated. Aliases like "8e296a06" makes MySql to think it is a number. Expects param in format "table_alias.column_name".

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Cannot be easily reproduced as the issue occurred on a report with autogenerated table alias names.

#### Steps to test this PR:
1. Ensure that the reports still load the values as before this change.

