### PR TITLE
Repair bug API access to list custom fields Mautic v3.0

### DIFF
--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -29,11 +29,11 @@ class FieldController extends FormController
     public function indexAction($page = 1)
     {
         //set some permissions
-        $permissions = $this->get('mautic.security')->isGranted(['lead:fields:full'], 'RETURN_ARRAY');
+        $permissions = $this->get('mautic.security')->isGranted(['lead:fields:view', 'lead:fields:full'], 'RETURN_ARRAY');
 
         $session = $this->get('session');
 
-        if (!$permissions['lead:fields:full']) {
+        if (!$permissions['lead:fields:view'] && !$permissions['lead:fields:full']) {
             return $this->accessDenied();
         }
 

--- a/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
+++ b/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
@@ -30,6 +30,7 @@ class LeadPermissions extends AbstractPermissions
             ],
             'fields' => [
                 'full' => 1024,
+                'view' => 1,
             ],
         ];
         $this->addExtendedPermissions('leads', false);
@@ -71,6 +72,7 @@ class LeadPermissions extends AbstractPermissions
             [
                 'choices' => [
                     'mautic.core.permissions.manage' => 'full',
+                    'mautic.core.permissions.view'   => 'view',
                 ],
                 'label'             => 'mautic.lead.permissions.fields',
                 'data'              => (!empty($data['fields']) ? $data['fields'] : []),

--- a/app/bundles/LeadBundle/Views/Field/list.html.php
+++ b/app/bundles/LeadBundle/Views/Field/list.html.php
@@ -51,9 +51,9 @@ if ('index' == $tmpl) {
                             [
                                 'item'            => $item,
                                 'templateButtons' => [
-                                    'edit'   => true,
-                                    'clone'  => true,
-                                    'delete' => $item->isFixed() ? false : true,
+                                    'edit'   => $permissions['lead:fields:full'],
+                                    'clone'  => $permissions['lead:fields:full'],
+                                    'delete' => $item->isFixed() ? false : $permissions['lead:fields:full'],
                                 ],
                                 'routeBase' => 'contactfield',
                                 'langVar'   => 'lead.field',


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging for features or enhancements / 3.0 for bug fixes <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | 
| BC breaks?                             | 
| Automated tests included?              | no
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | #7045

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

Description:
Listing custom fields via the API currently requires full admin access; even specifying the "Manage" permission for custom fields is insufficient. This PR adds the missing view permission (fixing the admin privilege requirement), and makes it possible to grant only that permission to a role (so you can allow reading the field list without also allowing field management).

**Steps to reproduce the bug:**

1. Create a role without admin privileges, but with "Custom Fields - Manage"
2. Create a user with that role
3. Fetch /a

pi/fields/contact using that user's credentials and see a 403 error

**Steps to test this PR:**

1. Load up this PR
2. Create a role without admin privileges, and either the View or Manage permissions for Custom Fields
3. Fetch /api/fields/contact using that user's credentials and see the field list

I correct PR @pjeby https://github.com/mautic/mautic/pull/7046 to Mautic 3.0 
