### PR TITLE
Fix API form tag action save

### DIFF
--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -212,6 +212,7 @@ class FormApiController extends CommonApiController
 
         // Add actions from the request
         if (!empty($parameters['actions']) && is_array($parameters['actions'])) {
+            $actions = [];
             foreach ($parameters['actions'] as &$actionParams) {
                 if (empty($actionParams['id'])) {
                     $actionParams['id'] = 'new'.hash('sha1', uniqid(mt_rand()));
@@ -232,12 +233,13 @@ class FormApiController extends CommonApiController
 
                     return $this->returnError($msg, Response::HTTP_BAD_REQUEST);
                 }
+                $actions[] = $actionForm->getNormData();
             }
 
             // Save the form first and new actions so that new fields are available to actions.
             // Using the repository function to not trigger the listeners twice.
             $this->model->getRepository()->saveEntity($entity);
-            $this->model->setActions($entity, $parameters['actions']);
+            $this->model->setActions($entity, $actions);
         }
 
         // Remove actions which weren't in the PUT request

--- a/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerFunctionalTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Mautic\FormBundle\Tests\Controller\Api;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class FormApiControllerFunctionalTest extends MauticMysqlTestCase
+{
+    public function testFormWorkflow()
+    {
+        $payload = [
+            'name'        => 'Form API test',
+            'formType'    => 'standalone',
+            'isPublished' => true,
+            'description' => 'Functional API test',
+            'fields'      => [
+                [
+                    'label'     => 'Email',
+                    'alias'     => 'email',
+                    'type'      => 'text',
+                    'leadField' => 'email',
+                ],
+            ],
+        ];
+
+        // Create:
+        $this->client->request('POST', '/api/forms/new', $payload);
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+
+        if (!empty($response['errors'][0])) {
+            $this->fail($response['errors'][0]['code'].': '.$response['errors'][0]['message']);
+        }
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), 'Return code must be 201.');
+
+        $formId = $response['form']['id'];
+        $this->assertGreaterThan(0, $formId);
+        $this->assertEquals($payload['name'], $response['form']['name']);
+        $this->assertEquals($payload['formType'], $response['form']['formType']);
+        $this->assertEquals($payload['isPublished'], $response['form']['isPublished']);
+        $this->assertEquals($payload['description'], $response['form']['description']);
+        $this->assertIsArray($response['form']['fields']);
+        $this->assertCount(count($payload['fields']), $response['form']['fields']);
+        for ($i = 0; $i < count($payload['fields']); ++$i) {
+            $this->assertEquals($payload['fields'][$i]['label'], $response['form']['fields'][$i]['label']);
+            $this->assertEquals($payload['fields'][$i]['alias'], $response['form']['fields'][$i]['alias']);
+            $this->assertEquals($payload['fields'][$i]['type'], $response['form']['fields'][$i]['type']);
+            $this->assertEquals($payload['fields'][$i]['leadField'], $response['form']['fields'][$i]['leadField']);
+        }
+
+        // Edit:
+        $this->client->request('PATCH', "/api/forms/{$formId}/edit", ['name' => 'Form API renamed']);
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertSame($formId, $response['form']['id'], 'ID of the created form does not match with the edited one.');
+        $this->assertEquals('Form API renamed', $response['form']['name']);
+        $this->assertEquals($payload['formType'], $response['form']['formType']);
+        $this->assertEquals($payload['isPublished'], $response['form']['isPublished']);
+        $this->assertEquals($payload['description'], $response['form']['description']);
+        $this->assertIsArray($response['form']['fields']);
+        $this->assertCount(count($payload['fields']), $response['form']['fields']);
+        for ($i = 0; $i < count($payload['fields']); ++$i) {
+            $this->assertEquals($payload['fields'][$i]['label'], $response['form']['fields'][$i]['label']);
+            $this->assertEquals($payload['fields'][$i]['alias'], $response['form']['fields'][$i]['alias']);
+            $this->assertEquals($payload['fields'][$i]['type'], $response['form']['fields'][$i]['type']);
+            $this->assertEquals($payload['fields'][$i]['leadField'], $response['form']['fields'][$i]['leadField']);
+        }
+
+        // Get:
+        $this->client->request('GET', "/api/forms/{$formId}");
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertSame($formId, $response['form']['id'], 'ID of the created form does not match with the fetched one.');
+        $this->assertEquals('Form API renamed', $response['form']['name']);
+        $this->assertEquals($payload['formType'], $response['form']['formType']);
+        $this->assertEquals($payload['isPublished'], $response['form']['isPublished']);
+        $this->assertEquals($payload['description'], $response['form']['description']);
+        $this->assertIsArray($response['form']['fields']);
+        $this->assertCount(count($payload['fields']), $response['form']['fields']);
+        for ($i = 0; $i < count($payload['fields']); ++$i) {
+            $this->assertEquals($payload['fields'][$i]['label'], $response['form']['fields'][$i]['label']);
+            $this->assertEquals($payload['fields'][$i]['alias'], $response['form']['fields'][$i]['alias']);
+            $this->assertEquals($payload['fields'][$i]['type'], $response['form']['fields'][$i]['type']);
+            $this->assertEquals($payload['fields'][$i]['leadField'], $response['form']['fields'][$i]['leadField']);
+        }
+
+        // Delete:
+        $this->client->request('DELETE', "/api/forms/{$formId}/delete");
+        $clientResponse = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+
+        // Get (ensure it's deleted):
+        $this->client->request('GET', "/api/forms/{$formId}");
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+
+        $this->assertSame(404, $clientResponse->getStatusCode());
+        $this->assertSame(404, $response['errors'][0]['code']);
+    }
+
+    public function testFormWithChangeTagsAction()
+    {
+        // Create tag:
+        $tag1Payload = ['tag' => 'add this'];
+        $tag2Payload = ['tag' => 'remove this'];
+
+        $this->client->request('POST', '/api/tags/new', $tag1Payload);
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+        $tag1Id         = $response['tag']['id'];
+
+        $this->client->request('POST', '/api/tags/new', $tag2Payload);
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+        $tag2Id         = $response['tag']['id'];
+
+        $payload = [
+            'name'        => 'Form API test',
+            'formType'    => 'standalone',
+            'isPublished' => true,
+            'description' => 'Functional API test',
+            'fields'      => [
+                [
+                    'label'     => 'lab',
+                    'alias'     => 'email',
+                    'type'      => 'text',
+                    'leadField' => 'email',
+                ],
+            ],
+            'actions' => [
+                [
+                    'name'        => 'Add tags to contact',
+                    'description' => 'action description',
+                    'type'        => 'lead.changetags',
+                    'order'       => 1,
+                    'properties'  => [
+                        'add_tags'    => [$tag1Id],
+                        'remove_tags' => [$tag2Id],
+                    ],
+                ],
+            ],
+        ];
+
+        // Create form with lead.changetags action:
+        $this->client->request('POST', '/api/forms/new', $payload);
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+
+        if (!empty($response['errors'][0])) {
+            $this->fail($response['errors'][0]['code'].': '.$response['errors'][0]['message']);
+        }
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), 'Return code must be 201.');
+
+        $formId = $response['form']['id'];
+        $this->assertGreaterThan(0, $formId);
+        $this->assertEquals($payload['name'], $response['form']['name']);
+        $this->assertEquals($payload['formType'], $response['form']['formType']);
+        $this->assertEquals($payload['isPublished'], $response['form']['isPublished']);
+        $this->assertEquals($payload['description'], $response['form']['description']);
+        $this->assertIsArray($response['form']['fields']);
+        $this->assertCount(count($payload['fields']), $response['form']['fields']);
+        for ($i = 0; $i < count($payload['fields']); ++$i) {
+            $this->assertEquals($payload['fields'][$i]['label'], $response['form']['fields'][$i]['label']);
+            $this->assertEquals($payload['fields'][$i]['alias'], $response['form']['fields'][$i]['alias']);
+            $this->assertEquals($payload['fields'][$i]['type'], $response['form']['fields'][$i]['type']);
+            $this->assertEquals($payload['fields'][$i]['leadField'], $response['form']['fields'][$i]['leadField']);
+        }
+        $this->assertIsArray($response['form']['actions']);
+        $this->assertCount(count($payload['actions']), $response['form']['actions']);
+        $this->assertEquals($payload['actions'][0]['name'], $response['form']['actions'][0]['name']);
+        $this->assertEquals($payload['actions'][0]['description'], $response['form']['actions'][0]['description']);
+        $this->assertEquals($payload['actions'][0]['type'], $response['form']['actions'][0]['type']);
+        $this->assertEquals($payload['actions'][0]['order'], $response['form']['actions'][0]['order']);
+        $this->assertIsArray($response['form']['actions'][0]['properties']['add_tags']);
+        $this->assertIsArray($response['form']['actions'][0]['properties']['remove_tags']);
+        $this->assertEquals($tag1Payload['tag'], $response['form']['actions'][0]['properties']['add_tags'][0]);
+        $this->assertEquals($tag2Payload['tag'], $response['form']['actions'][0]['properties']['remove_tags'][0]);
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.0
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no

#### Description:
Form action properties are not properly normalized when added/modified through API and tag id is stored in database instead of name. In result the user who submits the form receives tag with id as name.

#### Steps to reproduce bug
1. Create tag using POST `/api/tags/new` with data:
```
{
    "tag": "my tag"
}
```
2. Create new form using POST `/api/forms/new` endpoint with action `lead.changetags` and use previously created tag id:
```
{
	"name": "Test",
	"formType": "standalone",
	"description": "API test",
	"fields": [{
			"label": "Email",
			"alias": "email",
			"type": "text",
			"leadField": "email"
		}
	],
	"actions": [{
			"name": "Add tags to contact",
			"description": "",
			"type": "lead.changetags",
			"order": 0,
			"properties": {
				"add_tags": [1],
				"remove_tags": []
			}
		}
	]
}
```
3. Submit this form
4. Created contact has tag with name "1" instead of "my tag"

#### Steps test this PR
Repeat steps to reproduce after applying this PR.