### PR TITLE
Enable MX DNS validation when validating email addresses in a campaign.

### DIFF
--- a/app/bundles/EmailBundle/EventListener/CampaignConditionSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignConditionSubscriber.php
@@ -58,7 +58,7 @@ class CampaignConditionSubscriber implements EventSubscriberInterface
     public function onCampaignTriggerCondition(CampaignExecutionEvent $event)
     {
         try {
-            $this->validator->validate($event->getLead()->getEmail());
+            $this->validator->validate($event->getLead()->getEmail(), true);
         } catch (InvalidEmailException $exception) {
             return $event->setResult(false);
         }


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging (for v3.1.x
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              |  no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #9131

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
#9131

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. In a campaign, test an email address (with invalid domain or non-existent MX record). Previously used to pass, now it should fail. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
