### PR TITLE
Add Constructor to StopSubscriber.php

### DIFF
--- a/app/bundles/SmsBundle/EventListener/StopSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/StopSubscriber.php
@@ -27,7 +27,7 @@ class StopSubscriber implements EventSubscriberInterface
     /**
      * StopSubscriber constructor.
      */
-    public function __construct($doNotContactModel)
+    public function __construct(DoNotContactModel $doNotContactModel)
     {
         $this->doNotContactModel         = $doNotContactModel;
     }

--- a/app/bundles/SmsBundle/EventListener/StopSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/StopSubscriber.php
@@ -25,6 +25,14 @@ class StopSubscriber implements EventSubscriberInterface
     private $doNotContactModel;
 
     /**
+     * StopSubscriber constructor.
+     */
+    public function __construct($doNotContactModel)
+    {
+        $this->doNotContactModel         = $doNotContactModel;
+    }
+
+    /**
      * @return array
      */
     public static function getSubscribedEvents()

--- a/app/bundles/SmsBundle/Tests/EventListener/StopSubscriberTest.php
+++ b/app/bundles/SmsBundle/Tests/EventListener/StopSubscriberTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\SmsBundle\Tests\EventListener;
+
+use Mautic\LeadBundle\Entity\DoNotContact;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\DoNotContact as DoNotContactModel;
+use Mautic\SmsBundle\Event\ReplyEvent;
+use Mautic\SmsBundle\EventListener\StopSubscriber;
+
+class StopSubscriberTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|DoNotContact
+     */
+    private $doNotContactModel;
+
+    protected function setUp()
+    {
+        $this->doNotContactModel = $this->createMock(DoNotContactModel::class);
+    }
+
+    public function testLeadAddedToDNC()
+    {
+        $lead = new Lead();
+        $lead->setId(1);
+        $event = new ReplyEvent($lead, 'stop');
+
+        $this->doNotContactModel->expects($this->once())
+        ->method('addDncForContact')
+        ->with(1, 'sms', DoNotContact::UNSUBSCRIBED);
+
+        $this->StopSubscriber()->onReply($event);
+    }
+
+    /**
+     * @return StopSubscriber
+     */
+    private function StopSubscriber()
+    {
+        return new StopSubscriber($this->doNotContactModel);
+    }
+}


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.1
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #9153... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

To reproduce the issue:

1. Configure Twilio to send SMS ([Setup Plugin Docs](https://docs.mautic.org/en/plugins/twilio) | [Send SMS docs](https://docs.mautic.org/en/channels/marketing-messages/sms))
2. Configure Twilio to send replies back to Mautic.
3. Send SMS with the word Stop, to unsubscribe a contact
4. Exception is raised

Log errors
[2020-08-28 16:13:56] mautic.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Call to a member function addDncForContact() on null" at app/bundles/SmsBundle/EventListener/StopSubscriber.php line 46 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Call to a member function addDncForContact() on null at /usr/www/users/bigbrain/mailing.uppstart.com/app/bundles/SmsBundle/EventListener/StopSubscriber.php:46)"} [] 

To test the PR, follow the steps above and the error should not be thrown

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
