### PR TITLE
Fix datetime picker for contact/company fields

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
@@ -119,7 +119,6 @@ trait EntityFieldsBuildFormTrait
                 case DateType::class:
                 case DateTimeType::class:
                 case TimeType::class:
-                    $attr['data-toggle'] = $type;
                     $opts                = [
                         'required'    => $required,
                         'label'       => $field['label'],
@@ -142,16 +141,19 @@ trait EntityFieldsBuildFormTrait
                     }
 
                     if (DateTimeType::class === $type) {
-                        $opts['model_timezone'] = 'UTC';
-                        $opts['view_timezone']  = date_default_timezone_get();
-                        $opts['format']         = 'yyyy-MM-dd HH:mm:ss';
-                        $opts['with_seconds']   = true;
+                        $opts['attr']['data-toggle'] = 'datetime';
+                        $opts['model_timezone']      = 'UTC';
+                        $opts['view_timezone']       = date_default_timezone_get();
+                        $opts['format']              = 'yyyy-MM-dd HH:mm:ss';
+                        $opts['with_seconds']        = true;
 
                         $opts['data'] = (!empty($value)) ? $dtHelper->toLocalString('Y-m-d H:i:s') : null;
                     } elseif (DateType::class == $type) {
-                        $opts['data'] = (!empty($value)) ? $dtHelper->toLocalString('Y-m-d') : null;
+                        $opts['attr']['data-toggle'] = 'date';
+                        $opts['data']                = (!empty($value)) ? $dtHelper->toLocalString('Y-m-d') : null;
                     } else {
-                        $opts['model_timezone'] = 'UTC';
+                        $opts['attr']['data-toggle'] = 'time';
+                        $opts['model_timezone']      = 'UTC';
                         // $opts['with_seconds']   = true; // @todo figure out why this cause the contact form to fail.
                         $opts['view_timezone']  = date_default_timezone_get();
                         $opts['data']           = (!empty($value)) ? $dtHelper->toLocalString('H:i:s') : null;


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging for features or enhancements / 3.0 for bug fixes <!-- see below -->
| Bug fix?                               | yes/no
| New feature?                           | yes/no
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | yes/no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | fixes https://github.com/mautic/mautic/issues/8958

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
When editing a contacts custom datefield value, I do not get a date popup anymore. This PR fixed it



<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create a date/time contact field
3: Create new contact and notice that there is  date selector finally

