### PR TITLE
Update ListType.php to show all categories in list showing them (segments, preference center)

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/ListType.php
+++ b/app/bundles/LeadBundle/Form/Type/ListType.php
@@ -113,7 +113,7 @@ class ListType extends AbstractType
             $this->stageChoices[$stage['label']] = $stage['value'];
         }
 
-        $categories = $categoryModel->getLookupResults('global');
+        $categories = $categoryModel->getLookupResults('global', null, 0);
 
         foreach ($categories as $category) {
             $this->categoriesChoices[$category['title']] = $category['id'];


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging
| Bug fix?                               | x
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | https://github.com/mautic/mautic/issues/9169

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
As reported in this issue: https://github.com/mautic/mautic/issues/9169 if you create more than 10 categories, they are not all shown in the segment filter.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create 11 categories
3. Create a segment with filter on category and see we miss 1 result