### PR TITLE
Add DNS check

### DIFF
--- a/app/bundles/EmailBundle/EventListener/CampaignConditionSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignConditionSubscriber.php
@@ -58,7 +58,7 @@ class CampaignConditionSubscriber implements EventSubscriberInterface
     public function onCampaignTriggerCondition(CampaignExecutionEvent $event)
     {
         try {
-            $this->validator->validate($event->getLead()->getEmail());
+            $this->validator->validate($event->getLead()->getEmail(), true);
         } catch (InvalidEmailException $exception) {
             return $event->setResult(false);
         }


### PR DESCRIPTION
Adds a DNS check (clone of #9144 with author's permission)

| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.1 
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Issue(s) addressed                     | Fixes #9131 

## Description

The campaign condition 'Has valid email address' always returned positive results, regardless if the email address is valid or not. Several tests were attempted with invalid WHOIS, non-existent MX DNS record, and nonexistent email account (on a valid domain with valid MX record)

## Steps to reproduce

(Copied from #9131)

1. Create a test campaign, with a 'test segment'. (see example screenshot).
2. Add 'Has valid email address' condition to campaign.
3. Wire up +5/-5 contact points, to be able to test.
4. Add a contact with correctly formatted email address but with non-existent domain - e.g. test@test123testinvalid.com (verify domain has no WHOIS record by using an online WHOIS tool).
6. Update contact points to 100, so points can be subtracted from.
7. Add contact to test segment / or to test campaign.
8. Observe condition 'Has valid email address' always returning positive results. See the contact's history log and the contact points wrongly increasing.

<img width="502" alt="91310493-3b1a5d80-e7b2-11ea-83f8-98a1541d5592" src="https://user-images.githubusercontent.com/2930593/93668305-7a6f5d80-fa83-11ea-9869-472fa61934bf.png">

## Steps to test this PR:
1. Load up this PR
2. Follow steps above. Previously used to pass, now it should fail.
