### PR TITLE
Change Amazon port form 2587 to 587

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonTransport.php
@@ -34,7 +34,7 @@ class AmazonTransport extends \Swift_SmtpTransport implements CallbackTransportI
      */
     public function __construct($region, $otherRegion, $port, AmazonCallback $amazonCallback)
     {
-        $port                 = $port ?: 2587;
+        $port                 = $port ?: 587;
         $host                 = $this->buildHost($region, $otherRegion);
         $this->amazonCallback = $amazonCallback;
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.1 <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Issue(s) addressed                     | Fixes #9212

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

This was changed from 587 to 2587 by #3857.
But due to the above issue and Google Cloud has also [open port 587](https://googlecloudplatform.uservoice.com/forums/302595-compute-engine/suggestions/10079937-send-and-receive-email-using-tcp-smtp-imap-ports), I think it is necessary to bring it back to 587.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
