### PR TITLE
Fix handling of empty reasoncode in DNC API

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -410,7 +410,19 @@ class LeadApiController extends CommonApiController
         if ($channelId) {
             $channel = [$channel => $channelId];
         }
-        $reason   = (int) $this->request->request->get('reason');
+
+        // If no reason is set, default to 3 (manual)
+        $reason = (int) $this->request->request->get('reason', DoNotContact::MANUAL);
+
+        // If a reason is set, but it's empty or 0, show an error.
+        if (0 === $reason) {
+            return $this->returnError(
+                'Invalid reason code given',
+                Response::HTTP_BAD_REQUEST,
+                'Reason code needs to be an integer and higher than 0.'
+            );
+        }
+
         $comments = InputHelper::clean($this->request->request->get('comments'));
 
         /** @var \Mautic\LeadBundle\Model\DoNotContact $doNotContact */


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.1
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #9076 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
This PR fixes the bug that's described in #9076

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com) (you can either test with your local instance or with Mautibox)
2. Have the API enabled and a Contact in Mautic (enabled by default in Mautibox: URL is TODO and Basic Auth credentials are admin/mautic
3. Do a POST request (e.g. with Postman) to YOUR_MAUTIC_URL/api/contacts/YOUR_CONTACT_ID/dnc/email/add (empty body). The created entity should have a `reason` key with value 3 (manual):
```JSON
        "doNotContact": [
            {
                "id": 4,
                "dateAdded": "2020-09-21T11:36:53+00:00",
                "reason": 3,
                "comments": "",
                "channel": "email"
            }
        ],
```
4. Do the same POST request, but this time with an empty reason code in the POST body:
  ```JSON
  {
    "reason": 0
  }
  ```
  this should give you the following error:
  ```JSON
  {
    "errors": [
        {
            "code": 400,
            "message": "Invalid reason code given",
            "details": "Reason code needs to be an integer and higher than 0."
        }
    ]
  }
  ```

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
