### PR TITLE
Fix  cache key contains reserved characters with API limiter

### DIFF
--- a/app/bundles/ApiBundle/EventListener/RateLimitGenerateKeySubscriber.php
+++ b/app/bundles/ApiBundle/EventListener/RateLimitGenerateKeySubscriber.php
@@ -40,7 +40,7 @@ class RateLimitGenerateKeySubscriber implements EventSubscriberInterface
 
     public function onGenerateKey(GenerateKeyEvent $event)
     {
-        $suffix = $this->coreParametersHelper->get('site_url');
+        $suffix = rawurlencode($this->coreParametersHelper->get('site_url'));
         $event->addToKey($suffix);
     }
 }


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging for features or enhancements / 3.0 for bug fixes <!-- see below -->
| Bug fix?                               | yes/no
| New feature?                           | yes/no
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | yes/no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | fixes https://github.com/mautic/mautic/issues/9014

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

This fixed issue reported https://github.com/mautic/mautic/issues/9014
If API limiter is enabled, then cache key contains site url with reserved characters for it. This PR fixed it

#### Steps to test this PR:

Code review should be enought.


1. Load up [this PR](https://mautibox.com)
2. Enable API limiter - add to local php and clear cache

```
    'api_rate_limiter_limit' => 100000,
    'api_rate_limiter_cache' => array(
        'adapter' => 'cache.adapter.filesystem'
    ),
```
3. Try make Oauth2 authentification and then call to API - any hook
4. Without fix should return error 
`
[2020-09-24 12:56:35] mautic.CRITICAL: Uncaught PHP Exception Symfony\Component\Cache\Exception\InvalidArgumentException: "Cache key "*.api.Mjg1YzY0ODdiMDI0ZGMyNTlkZTYwNWZkYjgyYTYwMTRjY2U5MTA1Y2NhOWJkZWUxNjUxNDIxY2E4ODRmMWUwOQ.https://our.mautic.url" contains reserved characters {}()/\@:." at /path/to/mautic/vendor/symfony/cache/CacheItem.php line 168 {"exception":"[object] (Symfony\\Component\\Cache\\Exception\\InvalidArgumentException(code: 0): Cache key \"*.api.Mjg1YzY0ODdiMDI0ZGMyNTlkZTYwNWZkYjgyYTYwMTRjY2U5MTA1Y2NhOWJkZWUxNjUxNDIxY2E4ODRmMWUwOQ.https://yyy200420-1.automation.webmecanik.com\" contains reserved characters {}()/\\@:. at`


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
