### PR TITLE
Fix install warnings from #9139

### DIFF
--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -46,7 +46,7 @@ class InstallCommand extends ContainerAwareCommand
             ->addArgument(
                 'step',
                 InputArgument::OPTIONAL,
-                'Install process start index. 0 for requirements check, 1 for database, 2 for admin, 3 for configuration. Each successful step will trigger the next until completion.',
+                'Install process start index. 0 for requirements check, 1 for database, 2 for admin, 3 for configuration, 4 for final step. Each successful step will trigger the next until completion.',
                 0
             )
             ->addOption(
@@ -395,10 +395,26 @@ class InstallCommand extends ContainerAwareCommand
 
                 // no break
             case InstallService::EMAIL_STEP:
-                $output->writeln($step.' - Email configuration and final steps...');
+                $output->writeln($step.' - Email configuration...');
                 $messages = $this->stepAction($installer, $allParams, $step);
                 if (is_array($messages) && !empty($messages)) {
-                    $output->writeln('Errors in email configuration or final migration:');
+                    $output->writeln('Errors in email configuration:');
+                    $this->handleInstallerErrors($output, $messages);
+
+                    $output->writeln('Install canceled');
+
+                    return -$step;
+                }
+                // Keep on with next step
+                $step = InstallService::FINAL_STEP;
+
+                // no break
+            case InstallService::FINAL_STEP:
+                $output->writeln($step.' - Final steps...');
+                $messages = $this->stepAction($installer, $allParams, $step);
+
+                if (is_array($messages) && !empty($messages)) {
+                    $output->writeln('Errors in final migration:');
                     $this->handleInstallerErrors($output, $messages);
 
                     $output->writeln('Install canceled');
@@ -494,15 +510,15 @@ class InstallCommand extends ContainerAwareCommand
                 }
                 $messages = $installer->setupEmailStep($step, $params);
                 break;
-        }
 
-        if (is_bool($messages) && true === $messages) {
-            $siteUrl  = $params['site_url'];
-            $messages = $installer->createFinalConfigStep($siteUrl);
-
-            if (is_bool($messages) && true === $messages) {
-                $installer->finalMigrationStep();
-            }
+            case InstallService::FINAL_STEP:
+                // Save final configuration
+                $siteUrl  = $allParams['site_url'];
+                $messages = $installer->createFinalConfigStep($siteUrl);
+                if (is_bool($messages) && true === $messages) {
+                    $installer->finalMigrationStep();
+                }
+                break;
         }
 
         return $messages;

--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -513,7 +513,7 @@ class InstallCommand extends ContainerAwareCommand
 
             case InstallService::FINAL_STEP:
                 // Save final configuration
-                $siteUrl  = $allParams['site_url'];
+                $siteUrl  = $params['site_url'];
                 $messages = $installer->createFinalConfigStep($siteUrl);
                 if (is_bool($messages) && true === $messages) {
                     $installer->finalMigrationStep();

--- a/app/bundles/InstallBundle/Install/InstallService.php
+++ b/app/bundles/InstallBundle/Install/InstallService.php
@@ -41,6 +41,7 @@ class InstallService
     const DOCTRINE_STEP = 1;
     const USER_STEP     = 2;
     const EMAIL_STEP    = 3;
+    const FINAL_STEP    = 4;
 
     private $configurator;
 


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging
| Bug fix?                               | no
| New feature?                           | yes
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | NA
| Related developer documentation PR URL | NA
| Issue(s) addressed                     | Fixes #9139

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

Simple enhancement to remove `PHP Notice:  Undefined index: site_url` during CLI install from #7395.

Email configuration and final migration are split in 2 separate tasks, instead of checking everytime if final step can be done.
This differs from the web controller behavior but there is no actual modification of the install process (so no risk of regression) and makes the CLI install more flexible.

This enhancement was funded by @Monogramm

#### Steps to test this PR:
Two things will need to be tested with this PR: 
1. the new install command(s)
2. the regular install wizard

##### Mautic install:
1. Load up this PR and user composer to install deps:
```bash
git clone --branch fix/install_warnings git@github.com:Monogramm/mautic.git mautic_install
cd mautic_install
composer install
```
2. Create an initial `local.php` config file with the database parameters. You can also define the mailer properties and admin properties in `local.php` with the same syntax expected by the command line options (do `php bin/console mautic:install --help` for the list of options)
```php
<?php
// Example local.php to test install (to adapt of course)
$parameters = array(
	// Do not set db_driver and mailer_from_name as they are used to assume Mautic is installed
	'db_host' => 'localhost',
	'db_table_prefix' => null,
	'db_port' => 3306,
	'db_name' => 'mautic',
	'db_user' => 'mautic',
	'db_password' => 'mautic',
	'db_backup_tables' => true,
	'db_backup_prefix' => 'bak_',
	'admin_email' => 'admin@yopmail.com',
	'admin_password' => 'mautic',
	'mailer_transport' => null,
	'mailer_host' => null,
	'mailer_port' => null,
	'mailer_user' => null,
	'mailer_password' => null,
	'mailer_api_key' => null,
	'mailer_encryption' => null,
	'mailer_auth_mode' => null,
);

```
3. Execute `php bin/console mautic:install http://your-mautic-domain.com` (see [documentation](https://github.com/mautic/developer-documentation/pull/122/files#diff-860e3ce2541f17effc8aebd6b8cf606bR55))
```
Mautic Install
==============

Parsing options and arguments...
0 - Checking installation requirements...
Missing optional settings:
  - [0] It is recommended to secure your installation with an SSL certificate (https). Starting February 2020 Google Chrome will stop sending third-party cookies in cross-site requests unless the cookies are secure. Tracking will stop working for Mautic instances running on HTTP. Use HTTPS.
  - [1] The <strong>memory_limit</strong> setting in your PHP configuration is lower than the suggested minimum limit of %min_memory_limit%. Mautic can have performance issues with large datasets without sufficient memory.
Ready to Install!
1 - Creating database...
1.1 - Creating schema...
1.2 - Loading fixtures...
2 - Creating admin user...
3 - Email configuration...
4 - Final steps...

================
Install complete
================

```
4. Check install worked properly and the install wizard is not triggered
5. Execute `php bin/console mautic:install` again and verify that nothing happens:
```
> php bin/console mautic:install http://your-mautic-domain.com

Mautic already installed
```

##### Mautic wizard:
1. Load up this PR and user composer to install deps:
```bash
git clone --branch fix/install_warnings git@github.com:Monogramm/mautic.git mautic_install
cd mautic_install
composer install
```
2. Go to your Mautic address and execute install wizard
3. Check install worked properly and the install wizard is not triggered anymore

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
