### PR TITLE
Fix Citrix segment filter

### DIFF
--- a/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
+++ b/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
@@ -169,7 +169,7 @@ class LeadSubscriber implements EventSubscriberInterface
                         'label'      => $this->translator->trans('plugin.citrix.event.'.$product.'.registration'),
                         'properties' => [
                             'type' => 'select',
-                            'list' => array_flip($eventNamesWithAny),
+                            'list' => $eventNamesWithAny,
                         ],
                         'operators' => [
                             $this->translator->trans('mautic.core.operator.in')    => 'in',
@@ -186,7 +186,7 @@ class LeadSubscriber implements EventSubscriberInterface
                     'label'      => $this->translator->trans('plugin.citrix.event.'.$product.'.attendance'),
                     'properties' => [
                         'type' => 'select',
-                        'list' => array_flip($eventNamesWithAny),
+                        'list' => $eventNamesWithAny,
                     ],
                     'operators' => [
                         $this->translator->trans('mautic.core.operator.in')    => 'in',
@@ -202,7 +202,7 @@ class LeadSubscriber implements EventSubscriberInterface
                     'label'      => $this->translator->trans('plugin.citrix.event.'.$product.'.no.attendance'),
                     'properties' => [
                         'type' => 'select',
-                        'list' => array_flip($eventNamesWithoutAny),
+                        'list' => $eventNamesWithoutAny,
                     ],
                     'operators' => [
                         $this->translator->trans('mautic.core.operator.in') => 'in',


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging for features or enhancements / 3.0 for bug fixes <!-- see below -->
| Bug fix?                               | yes/no
| New feature?                           | yes/no
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | yes/no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

Segment filters for Citrix services are wrong in M3 due array_flip changes. This PR fixed it



<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Setup Citrix plugin and Go To Webinar https://docs.mautic.org/en/plugins/citrix
3. Sync  data `php bin/console mautic:citrix:sync`
4. Go to segment and try Webinars segment filter
5. Without fix you see wrong filters, after fix are correct

Before:

![image](https://user-images.githubusercontent.com/462477/94436363-a635c600-019c-11eb-9f05-e11168736a62.png)

After

![image](https://user-images.githubusercontent.com/462477/94437215-ba2df780-019d-11eb-814f-a7e1bda05c99.png)

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
