### PR TITLE
Revert back allowCampaignForm for modify tags action

### DIFF
--- a/app/bundles/LeadBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/FormSubscriber.php
@@ -111,12 +111,13 @@ class FormSubscriber implements EventSubscriberInterface
         ]);
 
         $event->addSubmitAction('lead.addutmtags', [
-            'group'       => 'mautic.lead.lead.submitaction',
-            'label'       => 'mautic.lead.lead.events.addutmtags',
-            'description' => 'mautic.lead.lead.events.addutmtags_descr',
-            'formType'    => ActionAddUtmTagsType::class,
-            'formTheme'   => 'MauticLeadBundle:FormTheme\\ActionAddUtmTags',
-            'eventName'   => FormEvents::ON_EXECUTE_SUBMIT_ACTION,
+            'group'             => 'mautic.lead.lead.submitaction',
+            'label'             => 'mautic.lead.lead.events.addutmtags',
+            'description'       => 'mautic.lead.lead.events.addutmtags_descr',
+            'formType'          => ActionAddUtmTagsType::class,
+            'formTheme'         => 'MauticLeadBundle:FormTheme\\ActionAddUtmTags',
+            'eventName'         => FormEvents::ON_EXECUTE_SUBMIT_ACTION,
+            'allowCampaignForm' => true,
         ]);
 
         $event->addSubmitAction('lead.remove_do_not_contact', [


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging for features or enhancements / 3.0 for bug fixes <!-- see below -->
| Bug fix?                               | yes/no
| New feature?                           | yes/no
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | yes/no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

Looks like Modify contact's tags form action was removed  from campaign type forms during the 3.0 refactoring https://github.com/mautic/mautic/pull/8186/files#diff-d647d0b9d02e66866f835c3ef364b17cL88
This PR added it back

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Check If Modify contact's tags are back in form action in campaign forms.
3. Test it works by previewing the form with UTM tags (e.g. http://example.com/s/forms/preview/3?utm_campaign=Promotion&utm_medium=Social&utm_source=Facebook) and checking that the UTM tags are being captured by looking at the contact activity logs