### PR TITLE
Update Travis to Bionic 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ before_install:
   - mysql --version
   - mysql -e 'DROP DATABASE IF EXISTS mautictest;'
   - mysql -e 'CREATE DATABASE mautictest;'
+  - mysql -e 'DROP USER IF EXISTS travis@localhost;'
+  - mysql -e 'CREATE USER travis@localhost;'
   - mysql -e 'GRANT ALL ON *.* TO travis@localhost;' || true
 
   # increase memory limit for all PHP processes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: php
 
 services:
@@ -9,7 +9,7 @@ notifications:
     on_success: never
 
 php:
-  - 7.2
+  - 7.2.33
   - 7.3
 
 cache:
@@ -48,7 +48,7 @@ script:
 jobs:
   include:
     - stage: test
-      php: 7.2
+      php: 7.2.33
       env: DB=mariadb
       addons:
         mariadb: '10.2'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
   - mysql --version
   - mysql -e 'DROP DATABASE IF EXISTS mautictest;'
   - mysql -e 'CREATE DATABASE mautictest;'
+  - mysql -e 'GRANT ALL ON *.* TO travis@localhost;' || true
 
   # increase memory limit for all PHP processes
   - echo "memory_limit=4G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: focal
+dist: bionic
 language: php
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: focal
 language: php
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ notifications:
     on_success: never
 
 php:
-  - 7.2.33
+  - 7.2
   - 7.3
 
 cache:
@@ -21,9 +21,7 @@ before_install:
   - mysql --version
   - mysql -e 'DROP DATABASE IF EXISTS mautictest;'
   - mysql -e 'CREATE DATABASE mautictest;'
-  - mysql -e 'DROP USER IF EXISTS travis@localhost;'
-  - mysql -e 'CREATE USER travis@localhost;'
-  - mysql -e 'GRANT ALL ON *.* TO travis@localhost;' || true
+  - mysql -u root -e 'CREATE USER IF NOT EXISTS travis@localhost; GRANT ALL ON *.* TO travis@localhost;'
 
   # increase memory limit for all PHP processes
   - echo "memory_limit=4G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
@@ -51,7 +49,7 @@ script:
 jobs:
   include:
     - stage: test
-      php: 7.2.33
+      php: 7.2
       env: DB=mariadb
       addons:
         mariadb: '10.2'

--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -266,7 +266,7 @@ class InstallCommand extends ContainerAwareCommand
         $allParams  = $installer->localConfigParameters();
 
         // Initialize DB and admin params from local.php
-        foreach ($allParams as $opt => $value) {
+        foreach ((array) $allParams as $opt => $value) {
             if (0 === strpos($opt, 'db_')) {
                 $dbParams[substr($opt, 3)] = $value;
             } elseif (0 === strpos($opt, 'admin_')) {

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
@@ -5,6 +5,10 @@ namespace Mautic\PageBundle\Tests\Controller;
 use Doctrine\DBAL\Connection;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 class PageControllerTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 
 /**
  * @runTestsInSeparateProcesses
- * @preserveGlobalState enabled
+ * @preserveGlobalState disabled
  */
 class PageControllerTest extends MauticMysqlTestCase
 {

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 
 /**
  * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
+ * @preserveGlobalState enabled
  */
 class PageControllerTest extends MauticMysqlTestCase
 {

--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -434,7 +434,7 @@ final class MauticReportBuilder implements ReportBuilderInterface
                             case 'boolean':
                                 if ((int) $filter['value'] > 1) {
                                     // Ignore the "reset" value of "2"
-                                    continue 2;
+                                    break 2;
                                 }
 
                                 $queryBuilder->setParameter($paramName, $filter['value'], 'boolean');

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -46,5 +46,6 @@
     <php>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
         <env name="MAXMIND_LICENSE_KEY" value=""/>
+        <server name="KERNEL_DIR" value="app" />
     </php>
 </phpunit>

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -15,7 +15,7 @@
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>bundles/*Bundle/Tests</directory>
-            <exclude>bundles/LeadBundle/Tests</directory>
+            <exclude>bundles/LeadBundle/Tests</exclude>
         </testsuite>
         <testsuite name="Plugin tests">
             <directory>./../plugins/*Bundle/Tests</directory>

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -15,7 +15,7 @@
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>bundles/*Bundle/Tests</directory>
-            <exclude>bundles/LeadBundle/Tests/Segment/ContactSegmentServiceFunctionalTest.php</exclude>
+            <exclude>bundles/LeadBundle/Tests/Segment</exclude>
         </testsuite>
         <testsuite name="Plugin tests">
             <directory>./../plugins/*Bundle/Tests</directory>

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -8,7 +8,7 @@
     convertErrorsToExceptions   = "true"
     convertNoticesToExceptions  = "true"
     convertWarningsToExceptions = "true"
-    processIsolation            = "true"
+    processIsolation            = "false"
     stopOnFailure               = "false"
     bootstrap                   = "autoload.php" >
 

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -15,7 +15,7 @@
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>bundles/*Bundle/Tests</directory>
-            <exclude>bundles/LeadBundle/Tests</exclude>
+            <exclude>bundles/LeadBundle/Tests/Segment/ContactSegmentServiceFunctionalTest.php</exclude>
         </testsuite>
         <testsuite name="Plugin tests">
             <directory>./../plugins/*Bundle/Tests</directory>

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -8,14 +8,13 @@
     convertErrorsToExceptions   = "true"
     convertNoticesToExceptions  = "true"
     convertWarningsToExceptions = "true"
-    processIsolation            = "false"
+    processIsolation            = "true"
     stopOnFailure               = "false"
     bootstrap                   = "autoload.php" >
 
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>bundles/*Bundle/Tests</directory>
-            <exclude>bundles/LeadBundle/Tests/Segment</exclude>
         </testsuite>
         <testsuite name="Plugin tests">
             <directory>./../plugins/*Bundle/Tests</directory>

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -15,6 +15,7 @@
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>bundles/*Bundle/Tests</directory>
+            <exclude>bundles/LeadBundle/Tests</directory>
         </testsuite>
         <testsuite name="Plugin tests">
             <directory>./../plugins/*Bundle/Tests</directory>

--- a/plugins/MauticCrmBundle/Tests/Pipedrive/Controller/PipedriveControllerTest.php
+++ b/plugins/MauticCrmBundle/Tests/Pipedrive/Controller/PipedriveControllerTest.php
@@ -6,7 +6,7 @@ use MauticPlugin\MauticCrmBundle\Tests\Pipedrive\PipedriveTest;
 
 /**
  * @runTestsInSeparateProcesses
- * @preserveGlobalState enabled
+ * @preserveGlobalState disabled
  */
 class PipedriveControllerTest extends PipedriveTest
 {

--- a/plugins/MauticCrmBundle/Tests/Pipedrive/Controller/PipedriveControllerTest.php
+++ b/plugins/MauticCrmBundle/Tests/Pipedrive/Controller/PipedriveControllerTest.php
@@ -4,6 +4,10 @@ namespace MauticPlugin\MauticCrmBundle\Tests\Pipedrive\Controller;
 
 use MauticPlugin\MauticCrmBundle\Tests\Pipedrive\PipedriveTest;
 
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 class PipedriveControllerTest extends PipedriveTest
 {
     public function testWithoutIntegration()

--- a/plugins/MauticCrmBundle/Tests/Pipedrive/Controller/PipedriveControllerTest.php
+++ b/plugins/MauticCrmBundle/Tests/Pipedrive/Controller/PipedriveControllerTest.php
@@ -6,7 +6,7 @@ use MauticPlugin\MauticCrmBundle\Tests\Pipedrive\PipedriveTest;
 
 /**
  * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
+ * @preserveGlobalState enabled
  */
 class PipedriveControllerTest extends PipedriveTest
 {


### PR DESCRIPTION
It is with great enthusiasm that I bring to you this PR that updates Travis from Ubuntu 14.04 (Trusty) to Ubuntu 18.04 (Bionic). This unblocks several innovations, like [PHP 7.4 support](https://github.com/mautic/mautic/pull/8447) 🚀 

## TL;DR

Updates Travis to Ubuntu 18.04 and enables PHPUnit's `processIsolation` feature. This is because some tests were interfering with each other. Only downside is that the tests run slower now than before.

## Details

Continuation of https://github.com/mautic/mautic/pull/9088 (accidentally removed all commits with a wrong rebase)

20-30 hours were spent on issues with this upgrade, several people looked into it including from Acquia. Here's a [summary](https://github.com/mautic/mautic/issues/9072#issuecomment-703167030) of my findings:

 `PageControllerTest` and `PipedriveControllerTest` seem to be failing because some other test(s) in other bundles earlier in the process break something (e.g. a request config/DB thing/etc.). If I run both bundle tests (`PageBundle/Tests` and `MauticCrmBundle/Tests`) separately, the issue isn't there 🤷‍♂️ 

After a lot of digging, it looks like some test(s) in the `LeadBundle` is/are the culprit. I first suspected `Segment` tests to be the issue, but in the end that didn't seem to be the case. When I started excluding more and more tests from the LeadBundle (e.g. https://github.com/dennisameling/mautic/pull/2/commits/4ecbe42d6efc71e074a3a5703e119e4a8a470f19), tests started to pass. That's how I in the end came to suspect the `Segment` tests.

I tried with GitHub Actions (27 runs in total 🤯) because it was 3x as fast as my local machine, and didn't have the drawback that I had to wait for previous tests to finish (like Travis has). That way I could run multiple tests runs in parallel, excluding potential causes for this problem.

- ⚠️ when running PageBundle tests separately, there is no problem: https://github.com/dennisameling/mautic/runs/1203188077?check_suite_focus=true
  - when only running all tests in app/bundles, the problem starts to show up ❌ : https://github.com/dennisameling/mautic/runs/1203183342?check_suite_focus=true --> this might mean that another Bundle is very likely to be causing the issues. Maybe it has to do something with `MauticMysqlTestCase`?
  - when running only **LeadBundle** and **PageBundle** tests, the problem appears as well ❌ : https://github.com/dennisameling/mautic/runs/1203210285?check_suite_focus=true
  - when running only **EmailBundle** and **PageBundle** tests, the problem isn't there anymore ✔️ : https://github.com/dennisameling/mautic/runs/1203240450?check_suite_focus=true
  - when running **all tests except LeadBundle**, the problem isn't there anymore ✔️ : https://github.com/dennisameling/mautic/pull/2/checks?check_run_id=1203511164 https://github.com/dennisameling/mautic/blob/ba8b5aabce07cdd2566e79aa6977412bb003f8a9/app/phpunit.xml.dist
  - after a lot of trial and error, the **Segment** tests in the **LeadBundle** seem to be the culprit 🕵🏼‍♂️ ❌ : https://github.com/dennisameling/mautic/runs/1203628134 --> **UPDATE: doesn't seem to be the actual culprit.**

**~If someone wants to continue working on this and/or help troubleshooting, I'm working in this PR:~ (FIXED IT ✅ ) https://github.com/mautic/mautic/pull/9266**

In the future we'll very likely be able to disable `processIsolation` again, as all plugins will be moved to the [Mautic Marketplace](https://github.com/mautic/mautic/pull/8257) as soon as it's released. Also, the `LeadBundle` might see a refactoring in the future, which will make it easier to debug things.

## Next steps after this PR
1. Add [PHP 7.4 support](https://github.com/mautic/mautic/pull/8447)
2. [Upgrade to PHPUnit 8](https://github.com/mautic/mautic/pull/9244) + remove dependency on Clobber
3. [Explore Paratest](https://github.com/mautic/mautic/pull/8682) to run PHPUnit tests in parallel, which should speed up the whole process