### PR TITLE
Fix failed send mail to contact campaign action when CC or BCC are incorrectly formatted

### DIFF
--- a/app/bundles/EmailBundle/Model/SendEmailToContact.php
+++ b/app/bundles/EmailBundle/Model/SendEmailToContact.php
@@ -288,8 +288,8 @@ class SendEmailToContact
     }
 
     /**
-     * @param bool   $hasBadEmail
-     * @param string $errorMessages
+     * @param bool  $hasBadEmail
+     * @param array $errorMessages
      *
      * @throws FailedToSendToContactException
      */
@@ -298,6 +298,8 @@ class SendEmailToContact
         if (null === $errorMessages) {
             // Clear the errors so it doesn't stop the next send
             $errorMessages = implode('; ', (array) $this->mailer->getErrors());
+        } elseif (is_array($errorMessages)) {
+            $errorMessages = implode('; ', $errorMessages);
         }
 
         $this->errorMessages[$this->contact['id']]  = $errorMessages;


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.0
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

This addresses an issue where exception handing in "Send email to contact" campaign action didn't work correctly when an incorrectly formatted CC or BCC is configured in the email.

Current behaviour: The campaign action does show as executed in the contacts timeline but the email was not sent. 
Expected behaviour: The campaign shows as failed and the error message can be retrieved.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create an email with "test@test.com; test2@test.com" in the BCC field under Advanced
3. Create a segment, new campagin and an campaign action using the previously created segment and email
4. Create a contact and add it to the segment
5. Trigger the campaign
6. Check the contacts' history: The campaign action should be marked as failed and the mailer error is shown

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
