### PR TITLE
Fix failed send mail to contact campaign action when CC or BCC are incorrectly formatted

### DIFF
--- a/app/bundles/EmailBundle/Model/SendEmailToContact.php
+++ b/app/bundles/EmailBundle/Model/SendEmailToContact.php
@@ -288,8 +288,8 @@ class SendEmailToContact
     }
 
     /**
-     * @param bool   $hasBadEmail
-     * @param string $errorMessages
+     * @param bool  $hasBadEmail
+     * @param array $errorMessages
      *
      * @throws FailedToSendToContactException
      */
@@ -298,6 +298,8 @@ class SendEmailToContact
         if (null === $errorMessages) {
             // Clear the errors so it doesn't stop the next send
             $errorMessages = implode('; ', (array) $this->mailer->getErrors());
+        } elseif (is_array($errorMessages)) {
+            $errorMessages = implode('; ', $errorMessages);
         }
 
         $this->errorMessages[$this->contact['id']]  = $errorMessages;

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
@@ -725,4 +725,77 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         $errorMessages = $model->getErrors();
         $this->assertCount(1, $errorMessages);
     }
+
+    /**
+     * @testdox Test that sending an email with invalid Bcc address is handled
+     *
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::setContact()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::send()
+     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::failContact()
+     */
+    public function testThatInvalidBccFailureIsHandled()
+    {
+        defined('MAUTIC_ENV') or define('MAUTIC_ENV', 'test');
+
+        $mockFactory = $this->getMockBuilder(MauticFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockFactory->method('getParameter')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['mailer_return_path', false, null],
+                        ['mailer_spool_type', false, 'memory'],
+                    ]
+                )
+            );
+        $mockFactory->method('getLogger')
+            ->willReturn(
+                new NullLogger()
+            );
+
+        $swiftMailer = new \Swift_Mailer(new BatchTransport());
+
+        $mailHelper = new MailHelper($mockFactory, $swiftMailer, ['nobody@nowhere.com' => 'No Body']);
+
+        $statRepository = $this->getMockBuilder(StatRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dncModel = $this->getMockBuilder(DoNotContact::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $statHelper = new StatHelper($statRepository);
+
+        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
+
+        $emailMock = $this->getMockBuilder(Email::class)
+            ->getMock();
+        $emailMock
+            ->expects($this->any())
+            ->method('getId')
+            ->will($this->returnValue(1));
+
+        // Set invalid BCC (should use comma as separator)
+        $emailMock
+            ->expects($this->any())
+            ->method('getBccAddress')
+            ->willReturn('test@mautic.com; test@mautic.com');
+
+        $model->setEmail($emailMock);
+
+        $stat = new Stat();
+        $stat->setEmail($emailMock);
+
+        $this->expectException(FailedToSendToContactException::class);
+        $this->expectExceptionMessage('Address in mailbox given [test@mautic.com; test@mautic.com] does not comply with RFC 2822, 3.6.2.');
+
+        // Send should trigger the FailedToSendToContactException
+        $model->setContact($this->contacts[0])->send();
+    }
 }


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

This addresses an issue where exception handing in "Send email to contact" campaign action didn't work correctly when an incorrectly formatted CC or BCC is configured in the email.

Current behaviour: The campaign action does show as executed in the contacts timeline but the email was not sent. 
Expected behaviour: The campaign shows as failed and the error message can be retrieved.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create an email with "test@test.com; test2@test.com" in the BCC field under Advanced
3. Create a segment, new campagin and an campaign action using the previously created segment and email
4. Create a contact and add it to the segment
5. Trigger the campaign
6. Check the contacts' history: The campaign action should be marked as failed and the mailer error is shown

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
