### PR TITLE
Fix cache key contains reserved characters with API limiter (3.1 re-PR)

### DIFF
--- a/app/bundles/ApiBundle/EventListener/RateLimitGenerateKeySubscriber.php
+++ b/app/bundles/ApiBundle/EventListener/RateLimitGenerateKeySubscriber.php
@@ -40,7 +40,7 @@ class RateLimitGenerateKeySubscriber implements EventSubscriberInterface
 
     public function onGenerateKey(GenerateKeyEvent $event)
     {
-        $suffix = $this->coreParametersHelper->get('site_url');
+        $suffix = rawurlencode($this->coreParametersHelper->get('site_url'));
         $event->addToKey($suffix);
     }
 }


### PR DESCRIPTION
New PR for https://github.com/mautic/mautic/pull/9237 which targets the `3.1` branch instead of `staging`, which was selected incorrectly.

The other PR was already approved, so this one is good to merge.