### PR TITLE
Fix error dynamic content without variants

### DIFF
--- a/app/bundles/CoreBundle/Form/Type/DynamicContentFilterType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentFilterType.php
@@ -56,8 +56,9 @@ class DynamicContentFilterType extends AbstractType
                             'class' => 'form-control',
                         ],
                     ],
-                    'allow_add'    => true,
-                    'allow_delete' => true,
+                    'option_required' => false,
+                    'allow_add'       => true,
+                    'allow_delete'    => true,
                 ]
             )
         );

--- a/app/bundles/CoreBundle/Form/Type/DynamicListType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicListType.php
@@ -38,8 +38,10 @@ class DynamicListType extends AbstractType
             function (FormEvent $event) {
                 //reorder list in case keys were dynamically removed
                 $data = $event->getData();
-                $data = array_values($data);
-                $event->setData($data);
+                if (is_array($data)) {
+                    $data = array_values($data);
+                    $event->setData($data);
+                }
             }
         );
     }


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging for features or enhancements / 3.0 for bug fixes <!-- see below -->
| Bug fix?                               | yes/no
| New feature?                           | yes/no
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | yes/no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
We've noticed after migration emails cannot be save If contains dynamic content without variants. This was able to create in Mautic2, but after migrate to Mautic2, this dynamic contents return error


<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Try create email with dynamic content without variants
3. Without PR email is not able to save and return error 

`[2020-10-13 09:37:19] mautic.WARNING: PHP Warning - array_values() expects parameter 1 to be array, null given - in file /path/app/bundles/CoreBundle/Form/Type/DynamicListType.php - at line 41 {"event":"[object] (Symfony\\Component\\Form\\FormEvent: {})","data":null} []`

4. With fix works same like in M2

