### PR TITLE
Fix Codecov trigger in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 
 script:
   - if [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]; 
-    then composer test -- --coverage-clover=coverage.xml && bash <(curl -s https://codecov.io/bash); 
+    then composer test -- --coverage-clover=coverage.xml; 
     else composer test; fi
 
 jobs:
@@ -67,3 +67,6 @@ jobs:
     -
       name: CS Fixer
       script: bin/php-cs-fixer fix --config=.php_cs -v --dry-run --using-cache=no --show-progress=dots --diff $(git diff -- '*.php' --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash);


### PR DESCRIPTION
~**This PR depends on https://github.com/mautic/mautic/pull/9308**~ ✅ 

Currently, Codecov is triggered incorrectly in Travis. In the screenshot below you can see that it is triggered three times in a single Travis build:

![image](https://user-images.githubusercontent.com/17739158/96338373-cf57c100-108d-11eb-9b69-8930169aab51.png)

This "bug" was introduced in https://github.com/mautic/mautic/pull/8954.

According to the [official Codecov PHP example](https://github.com/codecov/example-php#travis-setup), Codecov should only be triggered on the `after_success` hook in Travis. This hook is only triggered after all tests have passed, meaning that all code coverage reports from separate runs are in as well at that point. This allows Codecov to run only once and more reliably. This PR restores the behavior that we originally introduced in https://github.com/mautic/mautic/pull/8943.