### PR TITLE
Cache required fields to memory

### DIFF
--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Helper/FieldHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Helper/FieldHelper.php
@@ -60,6 +60,11 @@ class FieldHelper
     /**
      * @var array
      */
+    private $requiredFieldList = [];
+
+    /**
+     * @var array
+     */
     private $syncFields = [];
 
     /**
@@ -184,6 +189,10 @@ class FieldHelper
 
     public function getRequiredFields(string $object): array
     {
+        if (isset($this->requiredFieldList[$object])) {
+            return $this->requiredFieldList[$object];
+        }
+
         $requiredFields = $this->fieldModel->getFieldList(
             false,
             false,
@@ -196,7 +205,9 @@ class FieldHelper
 
         // We don't use unique identifier field for companies.
         if ('company' === $object) {
-            return $requiredFields;
+            $this->requiredFieldList[$object] = $requiredFields;
+
+            return $this->requiredFieldList[$object];
         }
 
         $uniqueIdentifierFields = $this->fieldModel->getUniqueIdentifierFields(
@@ -206,6 +217,8 @@ class FieldHelper
             ]
         );
 
-        return array_merge($requiredFields, $uniqueIdentifierFields);
+        $this->requiredFieldList[$object] = array_merge($requiredFields, $uniqueIdentifierFields);
+
+        return $this->requiredFieldList[$object];
     }
 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Helper/FieldHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Helper/FieldHelperTest.php
@@ -151,6 +151,12 @@ class FieldHelperTest extends TestCase
             ['some fields', 'some unique fields'],
             $this->fieldHelper->getRequiredFields('lead')
         );
+
+        // Call it for the second time to ensure the result was cached,
+        $this->assertSame(
+            ['some fields', 'some unique fields'],
+            $this->fieldHelper->getRequiredFields('lead')
+        );
     }
 
     public function testGetRequiredFieldsForCompany(): void
@@ -162,6 +168,12 @@ class FieldHelperTest extends TestCase
         $this->fieldModel->expects($this->never())
             ->method('getUniqueIdentifierFields');
 
+        $this->assertSame(
+            ['some fields'],
+            $this->fieldHelper->getRequiredFields('company')
+        );
+
+        // Call it for the second time to ensure the result was cached,
         $this->assertSame(
             ['some fields'],
             $this->fieldHelper->getRequiredFields('company')


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.2
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
[//]: # ( Required: )
#### Description:

We are fetching the field list for every changed object and for every changed value of each object. Let's cache it and make the query only once per sync.

The repeated query:
```sql
 SELECT m0_.is_published AS is_published_0, m0_.date_added AS date_added_1, m0_.created_by AS created_by_2, m0_.created_by_user AS created_by_user_3, m0_.date_modified AS date_modified_4, m0_.modified_by AS modified_by_5, m0_.modified_by_user AS modified_by_user_6, m0_.checked_out AS checked_out_7, m0_.checked_out_by AS checked_out_by_8, m0_.checked_out_by_user AS checked_out_by_user_9, m0_.id AS id_10, m0_.label AS label_11, m0_.alias AS alias_12, m0_.type AS type_13, m0_.field_group AS field_group_14, m0_.default_value AS default_value_15, m0_.is_required AS is_required_16, m0_.is_fixed AS is_fixed_17, m0_.is_visible AS is_visible_18, m0_.is_short_visible AS is_short_visible_19, m0_.is_listable AS is_listable_20, m0_.is_publicly_updatable AS is_publicly_updatable_21, m0_.is_unique_identifer AS is_unique_identifer_22, m0_.is_index AS is_index_23, m0_.char_length_limit AS char_length_limit_24, m0_.field_order AS field_order_25, m0_.object AS object_26, m0_.properties AS properties_27, m0_.column_is_not_created AS column_is_not_created_28, m0_.original_is_published_value AS original_is_published_value_29 FROM mautic_lead_fields m0_ WHERE m0_.is_published = 1 AND m0_.is_required = 1 AND m0_.object = 'company' ORDER BY m0_.field_order ASC", 1259, MSG_DONTWAIT, NULL, 0)
```

The command: `bin/console mautic:integrations:sync [Any integration name here]`

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. You'd need some tracing tool like Tideways or Blackfire to get a list of SQL queries during code execution. If you can build such trace then you'll see that the query above is repeating many times during the sync.

#### Steps to test this PR:
1. As there is no community SRM integration to test this with at the moment, please code review only.

#### Other areas of Mautic that may be affected by the change:
1. Any sync of an integration built on the IntegrationsBundle