### PR TITLE
Refactoring theme helper

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -640,10 +640,16 @@ return [
                 // When removing, remove also the ricardofiorani/guzzle-psr18-adapter dependency.
                 'class' => \RicardoFiorani\GuzzlePsr18Adapter\Client::class,
             ],
+            /* @deprecated to be removed in Mautic 4. Use 'mautic.filesystem' instead. */
             'symfony.filesystem' => [
                 'class' => \Symfony\Component\Filesystem\Filesystem::class,
             ],
-
+            'mautic.filesystem' => [
+                'class' => \Mautic\CoreBundle\Helper\Filesystem::class,
+            ],
+            'symfony.finder' => [
+                'class' => \Symfony\Component\Finder\Finder::class,
+            ],
             // Error handler
             'mautic.core.errorhandler.subscriber' => [
                 'class'     => 'Mautic\CoreBundle\EventListener\ErrorHandlingListener',
@@ -828,12 +834,14 @@ return [
                 ],
             ],
             'mautic.helper.theme' => [
-                'class'     => 'Mautic\CoreBundle\Helper\ThemeHelper',
+                'class'     => \Mautic\CoreBundle\Helper\ThemeHelper::class,
                 'arguments' => [
                     'mautic.helper.paths',
                     'mautic.helper.templating',
                     'translator',
                     'mautic.helper.core_parameters',
+                    'mautic.filesystem',
+                    'symfony.finder',
                 ],
                 'methodCalls' => [
                     'setDefaultTheme' => [

--- a/app/bundles/CoreBundle/Helper/Filesystem.php
+++ b/app/bundles/CoreBundle/Helper/Filesystem.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Helper;
+
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
+
+/**
+ * Extends Symfony's filesystem but adding the readFile method that we need to abstract for unit tests.
+ * Using file_get_contents() directly makes unit testing impossible.
+ *
+ * @see https://github.com/symfony/filesystem/pull/4
+ */
+class Filesystem extends SymfonyFilesystem
+{
+    /**
+     * Read file and return contents.
+     *
+     * @throws Exception\IOException
+     */
+    public function readFile(string $filename): string
+    {
+        if (false === $source = @file_get_contents($filename)) {
+            throw new IOException(sprintf('Failed to read "%s" because source file could not be opened for reading.', $filename), 0, null, $filename);
+        }
+
+        return $source;
+    }
+}

--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -11,9 +11,11 @@
 
 namespace Mautic\CoreBundle\Helper;
 
-use Mautic\CoreBundle\Exception as MauticException;
+use Mautic\CoreBundle\Exception\BadConfigurationException;
+use Mautic\CoreBundle\Exception\FileExistsException;
+use Mautic\CoreBundle\Exception\FileNotFoundException;
+use Mautic\CoreBundle\Helper\Filesystem;
 use Mautic\CoreBundle\Templating\Helper\ThemeHelper as TemplatingThemeHelper;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Templating\TemplateReference;
@@ -90,14 +92,29 @@ class ThemeHelper
     private $coreParametersHelper;
 
     /**
-     * ThemeHelper constructor.
+     * @var Filesystem
      */
-    public function __construct(PathsHelper $pathsHelper, TemplatingHelper $templatingHelper, TranslatorInterface $translator, CoreParametersHelper $coreParametersHelper)
-    {
+    private $filesystem;
+
+    /**
+     * @var Finder
+     */
+    private $finder;
+
+    public function __construct(
+        PathsHelper $pathsHelper,
+        TemplatingHelper $templatingHelper,
+        TranslatorInterface $translator,
+        CoreParametersHelper $coreParametersHelper,
+        Filesystem $filesystem,
+        Finder $finder
+    ) {
         $this->pathsHelper          = $pathsHelper;
         $this->templatingHelper     = $templatingHelper;
         $this->translator           = $translator;
         $this->coreParametersHelper = $coreParametersHelper;
+        $this->filesystem           = clone $filesystem;
+        $this->finder               = clone $finder;
     }
 
     /**
@@ -119,12 +136,12 @@ class ThemeHelper
     }
 
     /**
-     * @param $themeName
+     * @param string $themeName
      *
      * @return TemplatingThemeHelper
      *
-     * @throws MauticException\BadConfigurationException
-     * @throws MauticException\FileNotFoundException
+     * @throws BadConfigurationException
+     * @throws FileNotFoundException
      */
     public function createThemeHelper($themeName)
     {
@@ -136,17 +153,17 @@ class ThemeHelper
     }
 
     /**
-     * @param $newName
+     * @param string $newName
      *
      * @return string
      */
     private function getDirectoryName($newName)
     {
-        return InputHelper::filename($newName);
+        return InputHelper::filename(str_replace(' ', '-', $newName));
     }
 
     /**
-     * @param $theme
+     * @param string $theme
      *
      * @return bool
      */
@@ -154,47 +171,45 @@ class ThemeHelper
     {
         $root    = $this->pathsHelper->getSystemPath('themes', true).'/';
         $dirName = $this->getDirectoryName($theme);
-        $fs      = new Filesystem();
 
-        return $fs->exists($root.$dirName);
+        return $this->filesystem->exists($root.$dirName);
     }
 
     /**
-     * @param $theme
-     * @param $newName
+     * @param string      $theme      original theme dir name
+     * @param string      $newName
+     * @param string|null $newDirName if not set then it will be generated from the $newName param
      *
-     * @throws MauticException\FileExistsException
-     * @throws MauticException\FileNotFoundException
+     * @throws FileExistsException
+     * @throws FileNotFoundException
      */
-    public function copy($theme, $newName)
+    public function copy($theme, $newName, $newDirName = null)
     {
         $root   = $this->pathsHelper->getSystemPath('themes', true).'/';
         $themes = $this->getInstalledThemes();
 
         //check to make sure the theme exists
         if (!isset($themes[$theme])) {
-            throw new MauticException\FileNotFoundException($theme.' not found!');
+            throw new FileNotFoundException($theme.' not found!');
         }
 
-        $dirName = $this->getDirectoryName($newName);
+        $dirName = $this->getDirectoryName($newDirName ?? $newName);
 
-        $fs = new Filesystem();
-
-        if ($fs->exists($root.$dirName)) {
-            throw new MauticException\FileExistsException("$dirName already exists");
+        if ($this->filesystem->exists($root.$dirName)) {
+            throw new FileExistsException("$dirName already exists");
         }
 
-        $fs->mirror($root.$theme, $root.$dirName);
+        $this->filesystem->mirror($root.$theme, $root.$dirName);
 
         $this->updateConfig($root.$dirName, $newName);
     }
 
     /**
-     * @param $theme
-     * @param $newName
+     * @param string $theme
+     * @param string $newName
      *
-     * @throws MauticException\FileNotFoundException
-     * @throws MauticException\FileExistsException
+     * @throws FileNotFoundException
+     * @throws FileExistsException
      */
     public function rename($theme, $newName)
     {
@@ -203,26 +218,24 @@ class ThemeHelper
 
         //check to make sure the theme exists
         if (!isset($themes[$theme])) {
-            throw new MauticException\FileNotFoundException($theme.' not found!');
+            throw new FileNotFoundException($theme.' not found!');
         }
 
         $dirName = $this->getDirectoryName($newName);
 
-        $fs = new Filesystem();
-
-        if ($fs->exists($root.$dirName)) {
-            throw new MauticException\FileExistsException("$dirName already exists");
+        if ($this->filesystem->exists($root.$dirName)) {
+            throw new FileExistsException("$dirName already exists");
         }
 
-        $fs->rename($root.$theme, $root.$dirName);
+        $this->filesystem->rename($root.$theme, $root.$dirName);
 
         $this->updateConfig($root.$theme, $dirName);
     }
 
     /**
-     * @param $theme
+     * @param string $theme
      *
-     * @throws MauticException\FileNotFoundException
+     * @throws FileNotFoundException
      */
     public function delete($theme)
     {
@@ -231,29 +244,29 @@ class ThemeHelper
 
         //check to make sure the theme exists
         if (!isset($themes[$theme])) {
-            throw new MauticException\FileNotFoundException($theme.' not found!');
+            throw new FileNotFoundException($theme.' not found!');
         }
 
-        $fs = new Filesystem();
-        $fs->remove($root.$theme);
+        $this->filesystem->remove($root.$theme);
     }
 
     /**
      * Updates the theme configuration and converts
      * it to json if still using php array.
-     *
-     * @param $themePath
-     * @param $newName
      */
-    private function updateConfig($themePath, $newName)
+    private function updateConfig(string $themePath, string $newName): void
     {
-        if (file_exists($themePath.'/config.json')) {
-            $config = json_decode(file_get_contents($themePath.'/config.json'), true);
+        $configJsonPath = "{$themePath}/config.json";
+
+        if ($this->filesystem->exists($configJsonPath)) {
+            $config = json_decode($this->filesystem->readFile($configJsonPath), true);
+        } else {
+            throw new FileNotFoundException("File {$configJsonPath} was not found and so the theme config cannot be updated with new name of {$newName}");
         }
 
         $config['name'] = $newName;
 
-        file_put_contents($themePath.'/config.json', json_encode($config));
+        $this->filesystem->dumpFile($configJsonPath, json_encode($config));
     }
 
     /**
@@ -316,18 +329,17 @@ class ThemeHelper
     public function getInstalledThemes($specificFeature = 'all', $extended = false, $ignoreCache = false, $includeDirs = true)
     {
         if (empty($this->themes[$specificFeature]) || $ignoreCache) {
-            $dir    = $this->pathsHelper->getSystemPath('themes', true);
-            $finder = new Finder();
-            $finder->directories()->depth('0')->ignoreDotFiles(true)->in($dir);
+            $dir = $this->pathsHelper->getSystemPath('themes', true);
+            $this->finder->directories()->depth('0')->ignoreDotFiles(true)->in($dir);
 
             $this->themes[$specificFeature]     = [];
             $this->themesInfo[$specificFeature] = [];
-            foreach ($finder as $theme) {
-                if (!file_exists($theme->getRealPath().'/config.json')) {
+            foreach ($this->finder as $theme) {
+                if (!$this->filesystem->exists($theme->getRealPath().'/config.json')) {
                     continue;
                 }
 
-                $config = json_decode(file_get_contents($theme->getRealPath().'/config.json'), true);
+                $config = json_decode($this->filesystem->readFile($theme->getRealPath().'/config.json'), true);
 
                 if ('all' === $specificFeature || (isset($config['features']) && in_array($specificFeature, $config['features']))) {
                     $this->themes[$specificFeature][$theme->getBasename()]               = $config['name'];
@@ -360,15 +372,15 @@ class ThemeHelper
      *
      * @return TemplatingThemeHelper
      *
-     * @throws MauticException\FileNotFoundException
-     * @throws MauticException\BadConfigurationException
+     * @throws FileNotFoundException
+     * @throws BadConfigurationException
      */
     public function getTheme($theme = 'current', $throwException = false)
     {
         if (empty($this->themeHelpers[$theme])) {
             try {
                 $this->themeHelpers[$theme] = $this->createThemeHelper($theme);
-            } catch (MauticException\FileNotFoundException $e) {
+            } catch (FileNotFoundException $e) {
                 if (!$throwException) {
                     // theme wasn't found so just use the first available
                     $themes = $this->getInstalledThemes();
@@ -385,7 +397,7 @@ class ThemeHelper
                                 $found = true;
                                 break;
                             }
-                        } catch (MauticException\FileNotFoundException $e) {
+                        } catch (FileNotFoundException $e) {
                             continue;
                         }
                     }
@@ -408,13 +420,13 @@ class ThemeHelper
      *
      * @return bool
      *
-     * @throws MauticException\FileNotFoundException
+     * @throws FileNotFoundException
      * @throws \Exception
      */
     public function install($zipFile)
     {
-        if (false === file_exists($zipFile)) {
-            throw new MauticException\FileNotFoundException();
+        if (false === $this->filesystem->exists($zipFile)) {
+            throw new FileNotFoundException();
         }
 
         if (false === class_exists('ZipArchive')) {
@@ -476,7 +488,7 @@ class ThemeHelper
         }
 
         if ($missingFiles = array_diff($requiredFiles, $foundRequiredFiles)) {
-            throw new MauticException\FileNotFoundException($this->translator->trans('mautic.core.theme.missing.files', ['%files%' => implode(', ', $missingFiles)], 'validators'));
+            throw new FileNotFoundException($this->translator->trans('mautic.core.theme.missing.files', ['%files%' => implode(', ', $missingFiles)], 'validators'));
         }
 
         // Extract the archive file now
@@ -539,20 +551,19 @@ class ThemeHelper
         $themePath = $this->pathsHelper->getSystemPath('themes', true).'/'.$themeName;
         $tmpPath   = $this->pathsHelper->getSystemPath('cache', true).'/tmp_'.$themeName.'.zip';
         $zipper    = new \ZipArchive();
-        $finder    = new Finder();
 
-        if (file_exists($tmpPath)) {
-            @unlink($tmpPath);
+        if ($this->filesystem->exists($tmpPath)) {
+            $this->filesystem->remove($tmpPath);
         }
 
         $archive = $zipper->open($tmpPath, \ZipArchive::CREATE);
 
-        $finder->files()->in($themePath);
+        $$this->finder->files()->in($themePath);
 
         if (true !== $archive) {
             throw new \Exception($this->getExtractError($archive));
         } else {
-            foreach ($finder as $file) {
+            foreach ($$this->finder as $file) {
                 $filePath  = $file->getRealPath();
                 $localPath = $file->getRelativePathname();
                 $zipper->addFile($filePath, $localPath);
@@ -566,8 +577,8 @@ class ThemeHelper
     }
 
     /**
-     * @throws MauticException\BadConfigurationException
-     * @throws MauticException\FileNotFoundException
+     * @throws BadConfigurationException
+     * @throws FileNotFoundException
      */
     private function findThemeWithTemplate(EngineInterface $templating, TemplateReference $template)
     {

--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -558,12 +558,12 @@ class ThemeHelper
 
         $archive = $zipper->open($tmpPath, \ZipArchive::CREATE);
 
-        $$this->finder->files()->in($themePath);
+        $this->finder->files()->in($themePath);
 
         if (true !== $archive) {
             throw new \Exception($this->getExtractError($archive));
         } else {
-            foreach ($$this->finder as $file) {
+            foreach ($this->finder as $file) {
                 $filePath  = $file->getRealPath();
                 $localPath = $file->getRelativePathname();
                 $zipper->addFile($filePath, $localPath);

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
@@ -13,36 +13,45 @@ namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Exception\FileNotFoundException;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\Filesystem;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Helper\TemplatingHelper;
 use Mautic\CoreBundle\Helper\ThemeHelper;
 use Mautic\CoreBundle\Templating\TemplateNameParser;
 use Mautic\CoreBundle\Templating\TemplateReference;
-use Symfony\Component\Filesystem\Filesystem;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Templating\DelegatingEngine;
+use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class ThemeHelperTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var PathsHelper|\PHPUnit\Framework\MockObject\MockObject
+     * @var PathsHelper|MockObject
      */
     private $pathsHelper;
 
     /**
-     * @var TemplatingHelper|\PHPUnit\Framework\MockObject\MockObject
+     * @var TemplatingHelper|MockObject
      */
     private $templatingHelper;
 
     /**
-     * @var TranslatorInterface|\PHPUnit\Framework\MockObject\MockObject
+     * @var TranslatorInterface|MockObject
      */
     private $translator;
 
     /**
-     * @var CoreParametersHelper|\PHPUnit\Framework\MockObject\MockObject
+     * @var CoreParametersHelper|MockObject
      */
     private $coreParameterHelper;
+
+    /**
+     * @var ThemeHelper
+     */
+    private $themeHelper;
 
     protected function setUp(): void
     {
@@ -53,6 +62,15 @@ class ThemeHelperTest extends \PHPUnit\Framework\TestCase
         $this->coreParameterHelper->method('get')
             ->with('theme_import_allowed_extensions')
             ->willReturn(['json', 'twig', 'css', 'js', 'htm', 'html', 'txt', 'jpg', 'jpeg', 'png', 'gif']);
+
+        $this->themeHelper = new ThemeHelper(
+            $this->pathsHelper,
+            $this->templatingHelper,
+            $this->translator,
+            $this->coreParameterHelper,
+            new Filesystem(),
+            new Finder()
+        );
     }
 
     public function testExceptionThrownWithMissingConfig()
@@ -72,7 +90,7 @@ class ThemeHelperTest extends \PHPUnit\Framework\TestCase
                 }
             );
 
-        $this->getThemeHelper()->install(__DIR__.'/resource/themes/missing-config.zip');
+        $this->themeHelper->install(__DIR__.'/resource/themes/missing-config.zip');
     }
 
     public function testExceptionThrownWithMissingMessage()
@@ -92,7 +110,7 @@ class ThemeHelperTest extends \PHPUnit\Framework\TestCase
                 }
             );
 
-        $this->getThemeHelper()->install(__DIR__.'/resource/themes/missing-message.zip');
+        $this->themeHelper->install(__DIR__.'/resource/themes/missing-message.zip');
     }
 
     public function testExceptionThrownWithMissingFeature()
@@ -112,7 +130,7 @@ class ThemeHelperTest extends \PHPUnit\Framework\TestCase
                 }
             );
 
-        $this->getThemeHelper()->install(__DIR__.'/resource/themes/missing-feature.zip');
+        $this->themeHelper->install(__DIR__.'/resource/themes/missing-feature.zip');
     }
 
     public function testThemeIsInstalled()
@@ -124,7 +142,7 @@ class ThemeHelperTest extends \PHPUnit\Framework\TestCase
             ->with('themes', true)
             ->willReturn(__DIR__.'/resource/themes');
 
-        $this->getThemeHelper()->install(__DIR__.'/resource/themes/good-tmp.zip');
+        $this->themeHelper->install(__DIR__.'/resource/themes/good-tmp.zip');
 
         $this->assertFileExists(__DIR__.'/resource/themes/good-tmp');
 
@@ -176,10 +194,9 @@ class ThemeHelperTest extends \PHPUnit\Framework\TestCase
                 }
             );
 
-        $themeHelper = $this->getThemeHelper();
-        $themeHelper->setDefaultTheme('nature');
+        $this->themeHelper->setDefaultTheme('nature');
 
-        $template = $themeHelper->checkForTwigTemplate(':goldstar:page.html.twig');
+        $template = $this->themeHelper->checkForTwigTemplate(':goldstar:page.html.twig');
         $this->assertEquals(':nature:page.html.twig', $template);
     }
 
@@ -233,20 +250,189 @@ class ThemeHelperTest extends \PHPUnit\Framework\TestCase
                 }
             );
 
-        $themeHelper = $this->getThemeHelper();
-        $themeHelper->setDefaultTheme('nature');
+        $this->themeHelper->setDefaultTheme('nature');
 
-        $template = $themeHelper->checkForTwigTemplate(':goldstar:page.html.twig');
+        $template = $this->themeHelper->checkForTwigTemplate(':goldstar:page.html.twig');
         $this->assertNotEquals(':nature:page.html.twig', $template);
         $this->assertNotEquals(':goldstar:page.html.twig', $template);
         $this->assertStringContainsString(':page.html.twig', $template);
     }
 
-    /**
-     * @return ThemeHelper
-     */
-    private function getThemeHelper()
+    public function testCopyWithNoNewDirName(): void
     {
-        return new ThemeHelper($this->pathsHelper, $this->templatingHelper, $this->translator, $this->coreParameterHelper);
+        $themeHelper = new ThemeHelper(
+            new class() extends PathsHelper {
+                public function __construct()
+                {
+                }
+
+                public function getSystemPath($name, $fullPath = false)
+                {
+                    Assert::assertSame('themes', $name);
+
+                    return '/path/to/themes';
+                }
+            },
+            new class() extends TemplatingHelper {
+                public function __construct()
+                {
+                }
+            },
+            new class() extends Translator {
+                public function __construct()
+                {
+                }
+            },
+            new class() extends CoreParametersHelper {
+                public function __construct()
+                {
+                }
+            },
+            new class() extends Filesystem {
+                public function __construct()
+                {
+                }
+
+                public function exists($files)
+                {
+                    if ('/path/to/themes/new-theme-name' === $files) {
+                        return false;
+                    }
+
+                    return true;
+                }
+
+                public function mirror($originDir, $targetDir, ?\Traversable $iterator = null, $options = [])
+                {
+                    Assert::assertSame('/path/to/themes/origin-template-dir', $originDir);
+                    Assert::assertSame('/path/to/themes/new-theme-name', $targetDir);
+                }
+
+                public function readFile(string $filename): string
+                {
+                    Assert::assertStringEndsWith('/config.json', $filename);
+
+                    return '{"name":"Origin Theme"}';
+                }
+
+                public function dumpFile($filename, $content)
+                {
+                    Assert::assertSame('/path/to/themes/new-theme-name/config.json', $filename);
+                    Assert::assertSame('{"name":"New Theme Name"}', $content);
+                }
+            },
+            new class() extends Finder {
+                private $dirs = [];
+
+                public function __construct()
+                {
+                }
+
+                public function in($dirs)
+                {
+                    $this->dirs = [
+                        new \SplFileInfo('origin-template-dir'),
+                    ];
+
+                    return $this;
+                }
+
+                public function getIterator()
+                {
+                    return new \ArrayIterator($this->dirs);
+                }
+            }
+        );
+
+        $themeHelper->copy('origin-template-dir', 'New Theme Name');
+    }
+
+    public function testCopyWithNewDirName(): void
+    {
+        $themeHelper = new ThemeHelper(
+            new class() extends PathsHelper {
+                public function __construct()
+                {
+                }
+
+                public function getSystemPath($name, $fullPath = false)
+                {
+                    Assert::assertSame('themes', $name);
+
+                    return '/path/to/themes';
+                }
+            },
+            new class() extends TemplatingHelper {
+                public function __construct()
+                {
+                }
+            },
+            new class() extends Translator {
+                public function __construct()
+                {
+                }
+            },
+            new class() extends CoreParametersHelper {
+                public function __construct()
+                {
+                }
+            },
+            new class() extends Filesystem {
+                public function __construct()
+                {
+                }
+
+                public function exists($files)
+                {
+                    if ('/path/to/themes/requested-theme-dir' === $files) {
+                        return false;
+                    }
+
+                    return true;
+                }
+
+                public function mirror($originDir, $targetDir, ?\Traversable $iterator = null, $options = [])
+                {
+                    Assert::assertSame('/path/to/themes/origin-template-dir', $originDir);
+                    Assert::assertSame('/path/to/themes/requested-theme-dir', $targetDir);
+                }
+
+                public function readFile(string $filename): string
+                {
+                    Assert::assertStringEndsWith('/config.json', $filename);
+
+                    return '{"name":"Origin Theme"}';
+                }
+
+                public function dumpFile($filename, $content)
+                {
+                    Assert::assertSame('/path/to/themes/requested-theme-dir/config.json', $filename);
+                    Assert::assertSame('{"name":"New Theme Name"}', $content);
+                }
+            },
+            new class() extends Finder {
+                private $dirs = [];
+
+                public function __construct()
+                {
+                }
+
+                public function in($dirs)
+                {
+                    $this->dirs = [
+                        new \SplFileInfo('origin-template-dir'),
+                    ];
+
+                    return $this;
+                }
+
+                public function getIterator()
+                {
+                    return new \ArrayIterator($this->dirs);
+                }
+            }
+        );
+
+        $themeHelper->copy('origin-template-dir', 'New Theme Name', 'requested-theme-dir');
     }
 }


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.0 for bug fixes <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | yes
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

The goal was to enable to set directory name in a separate parameter to the `copy()` method. As generating it from the theme name may not be always what we want. Also to provide greater test coverage to the TestHelper. However this task was not possible without refactoring.

The ThemeHelper class was not fully testable as it was creating instances of `Filesystem` and `Finder` classes instead of providing those helpers via dependency injection so those could be mocked.

So I created 2 new services for those Symfony helpers and even created Mautic's own `Filesystem` helper by extending Symfony's `Filesystem` and adding the `readFile()` method to our implementation so we could use this one helper to manipulate files and folders. Symfony's version doesn't have that method for wrong reasons. Se need an abstraction above the native PHP methods that manipulate files so we could mock outputs in unit tests. 

As we now have our own `Filesystem` helper I have deprecated Symfony's helper.

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Go to Themes
3. Clone a theme. Ensure it's visible in the list of Themes as well as in the Email form page.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
