### PR TITLE
[3.1] Downgrade Composer to 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ before_install:
   # turn off XDebug
   - phpenv config-rm xdebug.ini || return
 
+  # Temp downgrade Composer to v1 (see https://github.com/mautic/mautic/pull/9315 for details)
+  - composer self-update --1
+
   # install dependencies in parallel
   - travis_retry composer global require hirak/prestissimo
 
@@ -36,7 +39,6 @@ before_install:
   - export SYMFONY_ENV="test"
 
 install:
-  - composer self-update --1
   - composer install
 
   # Clobber is needed because PCOV normally only works with PHPUnit 8+. Needed only to run test coverage.

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_install:
   - export SYMFONY_ENV="test"
 
 install:
+  - composer self-update --1
   - composer install
 
   # Clobber is needed because PCOV normally only works with PHPUnit 8+. Needed only to run test coverage.


### PR DESCRIPTION
CI is failing because Composer 2.0 was released yesterday: https://blog.packagist.com/composer-2-0-is-now-available/

This PR downgrades Composer to 1.10 until we can support Composer 2.0 (see https://github.com/mautic/mautic/pull/9315 for that).