### PR TITLE
[staging] Downgrade Composer to 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,9 @@ before_install:
   # Turn off XDebug extension
   - phpenv config-rm xdebug.ini || true
 
+  # Temp downgrade Composer to v1 (see https://github.com/mautic/mautic/pull/9315 for details)
+  - composer self-update --1
+
   # Install dependencies in parallel
   - travis_retry composer global require hirak/prestissimo
 


### PR DESCRIPTION
CI is failing because Composer 2.0 was released yesterday: https://blog.packagist.com/composer-2-0-is-now-available/

This PR downgrades Composer to 1.10 until we can support Composer 2.0 (see https://github.com/mautic/mautic/pull/9315 for that).