### PR TITLE
Add composer.json and composer.lock to release zip archive

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -104,7 +104,7 @@
         Require all denied
     </FilesMatch>
 
-    # Deny access via HTTP requests to composers files.
+    # Deny access via HTTP requests to composer files.
     <FilesMatch "^(composer\.json|composer\.lock)$">
         Require all denied
     </FilesMatch>
@@ -123,7 +123,7 @@
         Deny from all
     </FilesMatch>
 
-    # Deny access via HTTP requests to all PHP files.
+    # Deny access via HTTP requests to composer files
     <FilesMatch "^(composer\.json|composer\.lock)$">
         Order deny,allow
         Deny from all

--- a/.htaccess
+++ b/.htaccess
@@ -104,6 +104,11 @@
         Require all denied
     </FilesMatch>
 
+    # Deny access via HTTP requests to composers files.
+    <FilesMatch "^(composer\.json|composer\.lock)$">
+        Require all denied
+    </FilesMatch>
+
     # Except those whitelisted bellow.
     <FilesMatch "^(index|index_dev|filemanager|upgrade)\.php$">
         Require all granted
@@ -114,6 +119,12 @@
 <IfModule !authz_core_module>
     # Deny access via HTTP requests to all PHP files.
     <FilesMatch "\.php$">
+        Order deny,allow
+        Deny from all
+    </FilesMatch>
+
+    # Deny access via HTTP requests to all PHP files.
+    <FilesMatch "^(composer\.json|composer\.lock)$">
         Order deny,allow
         Deny from all
     </FilesMatch>

--- a/build/exclude_files.txt
+++ b/build/exclude_files.txt
@@ -26,8 +26,6 @@ bin/security-checker
 bin/simple-phpunit
 build/*
 codeception.yml
-composer.json
-composer.lock
 deleted_files.txt
 index_dev.php
 modified_files.txt


### PR DESCRIPTION

| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging
| Bug fix?                               | no
| New feature?                           | yes
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | https://github.com/mautic/docker-mautic/pull/101

Some plugins requires php composer dependencies, so impossible to install them correctly because composer.json and composer.lock are not exists in official docker images.
The PR adds files to future releases.
Example plugins:
https://github.com/mautic/composer-plugin
https://github.com/rmuilwijk/MauticFBAdsLeadAdsBundle