### PR TITLE
Fixing the search for columns composed of more words

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -14,6 +14,7 @@ namespace Mautic\CoreBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\ExpressionBuilder;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
+use Doctrine\DBAL\Query\QueryBuilder as DbalQueryBuilder;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Query;
@@ -1036,8 +1037,8 @@ class CommonRepository extends EntityRepository
     }
 
     /**
-     * @param \Doctrine\ORM\QueryBuilder $q
-     * @param object                     $filter
+     * @param DbalQueryBuilder|QueryBuilder $q
+     * @param object                        $filter
      *
      * @return array
      */
@@ -1048,16 +1049,19 @@ class CommonRepository extends EntityRepository
         $returnParameter = true; //returning a parameter that is not used will lead to a Doctrine error
         $expr            = false;
         $prefix          = $this->getTableAlias();
+        $isDbalQB        = $q instanceof DbalQueryBuilder;
 
         switch ($command) {
             case $this->translator->trans('mautic.core.searchcommand.ispublished'):
             case $this->translator->trans('mautic.core.searchcommand.ispublished', [], null, 'en_US'):
-                $expr            = $q->expr()->eq("$prefix.isPublished", ":$unique");
+                $column          = $isDbalQB ? 'is_published' : 'isPublished';
+                $expr            = $q->expr()->eq("{$prefix}.{$column}", ":{$unique}");
                 $forceParameters = [$unique => true];
                 break;
             case $this->translator->trans('mautic.core.searchcommand.isunpublished'):
             case $this->translator->trans('mautic.core.searchcommand.isunpublished', [], null, 'en_US'):
-                $expr            = $q->expr()->eq("$prefix.isPublished", ":$unique");
+                $column          = $isDbalQB ? 'is_published' : 'isPublished';
+                $expr            = $q->expr()->eq("{$prefix}.{$column}", ":{$unique}");
                 $forceParameters = [$unique => false];
                 break;
             case $this->translator->trans('mautic.core.searchcommand.isuncategorized'):
@@ -1070,7 +1074,8 @@ class CommonRepository extends EntityRepository
                 break;
             case $this->translator->trans('mautic.core.searchcommand.ismine'):
             case $this->translator->trans('mautic.core.searchcommand.ismine', [], null, 'en_US'):
-                $expr            = $q->expr()->eq("$prefix.createdBy", ":$unique");
+                $column          = $isDbalQB ? 'created_by' : 'createdBy';
+                $expr            = $q->expr()->eq("{$prefix}.{$column}", ":{$unique}");
                 $forceParameters = [$unique => $this->currentUser->getId()];
                 break;
             case $this->translator->trans('mautic.core.searchcommand.category'):
@@ -1093,7 +1098,7 @@ class CommonRepository extends EntityRepository
                 if (false === $catPrefix) {
                     $catPrefix = 'c';
                 }
-                $expr           = $q->expr()->like("{$catPrefix}.alias", ":$unique");
+                $expr           = $q->expr()->like("{$catPrefix}.alias", ":{$unique}");
                 $filter->strict = true;
                 break;
             case $this->translator->trans('mautic.core.searchcommand.ids'):

--- a/app/bundles/CoreBundle/Tests/Functional/Entity/CommonRepositoryTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Entity/CommonRepositoryTest.php
@@ -25,4 +25,20 @@ class CommonRepositoryTest extends MauticMysqlTestCase
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
         $this->assertContains('is:mine', $this->client->getResponse()->getContent());
     }
+
+    public function testIsMineSearchCommandDoesntCauseExceptionDueToBadDQLForCompanies()
+    {
+        $this->client->request('GET', 's/companies?search=is:mine');
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertContains('is:mine', $this->client->getResponse()->getContent());
+    }
+
+    public function testIsPublishedSearchCommandDoesntCauseExceptionDueToBadDQLForEmails()
+    {
+        $this->client->request('GET', 's/emails?search=is:published');
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertContains('is:published', $this->client->getResponse()->getContent());
+    }
 }


### PR DESCRIPTION


<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.0 for bug fixes <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | Fixes #8120

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

The method used for special search commands can get both DBAL and ORM query builders. It was ready only for the ORM builders. Companies use DBAL for some reason so it failed.

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Go to companies list view and add `is:mine` to the search box. You'll get the 500 response.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
