### PR TITLE
Downgrade Composer to v1 on 2.16 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ before_install:
 
   # turn off XDebug
   - phpenv config-rm xdebug.ini || return
+  
+  # Downgrade Composer to v1 (see https://github.com/mautic/mautic/pull/9315 for details)
+  - composer self-update --1
 
   # install dependencies in parallel
   - travis_retry composer global require hirak/prestissimo


### PR DESCRIPTION
Currently, Travis is failing on the 2.16 branch since Composer was updated to v2 a few days ago.
This PR downgrades to Composer v1, similar to #9315, to get CI up and running again.

![image](https://user-images.githubusercontent.com/17739158/97782874-5a5baf80-1b94-11eb-92d0-80f30a6032bc.png)
