### PR TITLE
Enabling company tokens in webhook campaign action

### DIFF
--- a/app/bundles/WebhookBundle/Config/config.php
+++ b/app/bundles/WebhookBundle/Config/config.php
@@ -115,6 +115,7 @@ return [
                 'class'     => \Mautic\WebhookBundle\Helper\CampaignHelper::class,
                 'arguments' => [
                     'mautic.http.connector',
+                    'mautic.lead.model.company',
                 ],
             ],
             'mautic.webhook.http.client' => [

--- a/app/bundles/WebhookBundle/Helper/CampaignHelper.php
+++ b/app/bundles/WebhookBundle/Helper/CampaignHelper.php
@@ -16,6 +16,7 @@ use Joomla\Http\Http;
 use Mautic\CoreBundle\Helper\AbstractFormFieldHelper;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Helper\TokenHelper;
+use Mautic\LeadBundle\Model\CompanyModel;
 
 class CampaignHelper
 {
@@ -25,15 +26,21 @@ class CampaignHelper
     protected $connector;
 
     /**
+     * @var CompanyModel
+     */
+    protected $companyModel;
+
+    /**
      * Cached contact values in format [contact_id => [key1 => val1, key2 => val1]].
      *
      * @var array
      */
     private $contactsValues = [];
 
-    public function __construct(Http $connector)
+    public function __construct(Http $connector, $companyModel)
     {
-        $this->connector = $connector;
+        $this->connector    = $connector;
+        $this->companyModel = $companyModel;
     }
 
     /**
@@ -136,6 +143,7 @@ class CampaignHelper
         if (empty($this->contactsValues[$contact->getId()])) {
             $this->contactsValues[$contact->getId()]              = $contact->getProfileFields();
             $this->contactsValues[$contact->getId()]['ipAddress'] = $this->ipAddressesToCsv($contact->getIpAddresses());
+            $this->contactsValues[$contact->getId()]['companies'] = $this->companyModel->getRepository()->getCompaniesByLeadId($contact->getId());
         }
 
         return $this->contactsValues[$contact->getId()];

--- a/app/bundles/WebhookBundle/Tests/Helper/CampaignHelperTest.php
+++ b/app/bundles/WebhookBundle/Tests/Helper/CampaignHelperTest.php
@@ -14,13 +14,18 @@ namespace Mautic\WebhookBundle\Tests\Helper;
 use Doctrine\Common\Collections\ArrayCollection;
 use Joomla\Http\Http;
 use Mautic\CoreBundle\Entity\IpAddress;
+use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\WebhookBundle\Helper\CampaignHelper;
 
 class CampaignHelperTest extends \PHPUnit\Framework\TestCase
 {
     private $contact;
     private $connector;
+    private $companyModel;
+    private $companyRepository;
 
     /**
      * @var ArrayCollection
@@ -36,10 +41,22 @@ class CampaignHelperTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->contact        = $this->createMock(Lead::class);
-        $this->connector      = $this->createMock(Http::class);
-        $this->ipCollection   = new ArrayCollection();
-        $this->campaignHelper = new CampaignHelper($this->connector);
+        $this->contact           = $this->createMock(Lead::class);
+        $this->connector         = $this->createMock(Http::class);
+        $this->companyModel      = $this->createMock(CompanyModel::class);
+        $this->ipCollection      = new ArrayCollection();
+        $this->companyRepository = $this->getMockBuilder(CompanyRepository::class)
+        ->disableOriginalConstructor()
+        ->setMethods(['getCompaniesByLeadId'])
+        ->getMock();
+
+        $this->companyRepository->method('getCompaniesByLeadId')
+        ->willReturn([new Company()]);
+
+        $this->companyModel->method('getRepository')
+        ->willReturn($this->companyRepository);
+
+        $this->campaignHelper = new CampaignHelper($this->connector, $this->companyModel);
 
         $this->ipCollection->add((new IpAddress())->setIpAddress('127.0.0.1'));
         $this->ipCollection->add((new IpAddress())->setIpAddress('127.0.0.2'));


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging
| Bug fix?                               | yes
| New feature?                           | yes/no
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | yes/no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #7615

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
This replaces the PR #7625

Company field tokens are premissable in various places within Mautic, but not in Webhook campaign actions. If sending data to a third party system, it's likely you'll need to send company data along with contact data.

This PR includes the company data in the contact data to be parsed by the TokenHelper.


<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create a campaign with a webhook action
3. Within the webhook action, pass a parameter for company zipcode using the token {contactfield=companyzipcode}
4. view payload on the other side of the webhook

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
