### PR TITLE
Improve query performance

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -185,7 +185,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
      */
     public function getContactIdsByEmails(array $emails): array
     {
-        $result =  $this->getEntityManager()
+        $result = $this->getEntityManager()
             ->createQuery("
                 SELECT c.id 
                 FROM Mautic\LeadBundle\Entity\Lead c

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -12,6 +12,7 @@
 namespace Mautic\LeadBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Mautic\CoreBundle\Entity\CommonRepository;
@@ -175,6 +176,30 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
         }
 
         return $contacts;
+    }
+
+    /**
+     * @param string[] $emails
+     *
+     * @return int[]|array
+     */
+    public function getContactIdsByEmails(array $emails): array
+    {
+        $result =  $this->getEntityManager()
+            ->createQuery("
+                SELECT c.id 
+                FROM Mautic\LeadBundle\Entity\Lead c
+                WHERE c.email IN (:emails)
+            ")
+            ->setParameter(':emails', $emails, Connection::PARAM_STR_ARRAY)
+            ->getArrayResult();
+
+        return array_map(
+            function ($row) {
+                return (int) $row['id'];
+            },
+            $result
+        );
     }
 
     /**


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.1 for bug fixes
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | -
| Related developer documentation PR URL | -
| Issue(s) addressed                     | -

#### Description:
Discovered slow query in some circumstances when syncing contact with integration. 

#### Steps to test this PR:
Let's assume that integration is supporting lead and contacts separately as Salesforce do.
0. Load up [this PR](https://mautibox.com)
1. Create contact
2. Run the sync to some integration
3. Run the sync (it's important to run it twice)
4. Convert the lead to contact in your integration
5. Run the sync
6. Check the mautic_sunc_object_mapping table that the Mautic contact has 2 rows. One for Lead, one for Contact and the Lead row is is marked as deleted.

Should look like this with different `internal_object_id`
![Snímek obrazovky 2020-09-02 v 15 43 18](https://user-images.githubusercontent.com/12815758/91991323-0c146680-ed33-11ea-99d5-e4157e2b7683.png)