### PR TITLE
Fix: Quote regular expression characters for multiselect segment filter

### DIFF
--- a/app/bundles/LeadBundle/Segment/Decorator/BaseDecorator.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/BaseDecorator.php
@@ -131,7 +131,7 @@ class BaseDecorator implements FilterDecoratorInterface
                 $filter = (array) $filter;
 
                 foreach ($filter as $key => $value) {
-                    $filter[$key] = sprintf('(([|]|^)%s([|]|$))', $value);
+                    $filter[$key] = sprintf('(([|]|^)%s([|]|$))', preg_quote($value, '/'));
                 }
 
                 return $filter;


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging for features or enhancements / 3.0 for bug fixes <!-- see below -->
| Bug fix?                               | yes/no
| New feature?                           | yes/no
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | yes/no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
If mutlir select value contains special characters like `()`, then you're able to use segment filter.

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create contact custom mutli select field  with values
- First (1)
- Second (2)
3. Then create contact and select both options for that field
4. Then create segment with filter  "First (1)"
5. Expect contact include to segment, but nope.
6. After PR should works properly
7. Try If any other multiselect filters works too

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
