### PR TITLE
Add more mime types to import csv validation

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/LeadImportType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadImportType.php
@@ -35,7 +35,7 @@ class LeadImportType extends AbstractType
                 'constraints' => [
                     new File(
                         [
-                            'mimeTypes'        => ['text/csv', 'text/plain'],
+                            'mimeTypes'        => ['text/csv', 'text/plain', 'text/*', 'application/octet-stream'],
                             'mimeTypesMessage' => 'mautic.core.invalid_file_type',
                         ]
                     ),

--- a/app/bundles/LeadBundle/Form/Type/LeadImportType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadImportType.php
@@ -35,7 +35,7 @@ class LeadImportType extends AbstractType
                 'constraints' => [
                     new File(
                         [
-                            'mimeTypes'        => ['text/csv', 'text/plain', 'text/*', 'application/octet-stream'],
+                            'mimeTypes'        => ['text/*', 'application/octet-stream'],
                             'mimeTypesMessage' => 'mautic.core.invalid_file_type',
                         ]
                     ),


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging for features or enhancements / 3.2 for bug fixes <!-- see below -->
| Bug fix?                               | yes/no
| New feature?                           | yes/no
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | yes/no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
We noticed in last days two reported csv files, which cannot pass mime types validation during make import contacts.
I've made some research and tests, I found some dicssution 
https://stackoverflow.com/questions/16234859/what-is-the-mime-types-to-upload-csv-file
In conclusion mime can return more types, If detect some leters or combination of letters.
In our cases csv return application/octet-stream and text/x-Algol68 

This is reason why I've added to validation:

- application/octet-stream
- text/*


<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Try upload import file and check If import works like before

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
