### PR TITLE
Links with self reference (#) and UTM break links

### DIFF
--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -444,6 +444,12 @@ class PublicController extends CommonFormController
         // Ensure the URL does not have encoded ampersands
         $url = str_replace('&amp;', '&', $redirect->getUrl());
 
+        $fragment = false;
+        if (false !== strpos($url, '#')) {
+            $fragment = '#'.parse_url($url, PHP_URL_FRAGMENT);
+            $url      = str_replace($fragment, '', $url);
+        }
+
         // Get query string
         $query = $this->request->query->all();
 
@@ -454,6 +460,10 @@ class PublicController extends CommonFormController
         // Tak on anything left to the URL
         if (count($query)) {
             $url = UrlHelper::appendQueryToUrl($url, http_build_query($query));
+        }
+
+        if ($fragment) {
+            $url .= $fragment;
         }
 
         // If the IP address is not trackable, it means it came form a configured "do not track" IP or a "do not track" user agent


### PR DESCRIPTION
<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging 
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #9399... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create an email with a link that contains a self-reference (#), like (#link)
3. Add UTM Codes to the email
4. Send the email
5. You will get an email with the wrong link, what you get
``https://example.com/url#link?utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content``
The correct link must be
``https://example.com/url?utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content#link``

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
