### PR TITLE
Adding the Connection: Close response header only when the request is made using HTTP/1.1.

### DIFF
--- a/app/bundles/CoreBundle/Helper/TrackingPixelHelper.php
+++ b/app/bundles/CoreBundle/Helper/TrackingPixelHelper.php
@@ -49,12 +49,13 @@ class TrackingPixelHelper
 
         //check to ses if request is a POST
         if ('GET' == $request->getMethod()) {
+            if('HTTP/1.1' == $request->getProtocolVersion())
             $response->headers->set('Connection', 'close');
 
             //return 1x1 pixel transparent gif
             $response->headers->set('Content-Type', 'image/gif');
             //avoid cache time on browser side
-            $response->headers->set('Content-Length', '42');
+            $response->headers->set('Content-Length', '43');
             $response->headers->set('Cache-Control', 'private, no-cache, no-cache=Set-Cookie, proxy-revalidate');
             $response->headers->set('Expires', 'Wed, 11 Jan 2000 12:59:00 GMT');
             $response->headers->set('Last-Modified', 'Wed, 11 Jan 2006 12:59:00 GMT');

--- a/app/bundles/CoreBundle/Helper/TrackingPixelHelper.php
+++ b/app/bundles/CoreBundle/Helper/TrackingPixelHelper.php
@@ -49,8 +49,9 @@ class TrackingPixelHelper
 
         //check to ses if request is a POST
         if ('GET' == $request->getMethod()) {
-            if('HTTP/1.1' == $request->getProtocolVersion())
-            $response->headers->set('Connection', 'close');
+            if ('HTTP/1.1' == $request->getProtocolVersion()) {
+                $response->headers->set('Connection', 'close');
+            }
 
             //return 1x1 pixel transparent gif
             $response->headers->set('Content-Type', 'image/gif');


### PR DESCRIPTION
Adding the Connection: Close response header only when the request is made using HTTP/1.1.

| Q                                      | A
| -------------------------------------- | ---
| Branch?                                |  3.2 for bug fixes 
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #9077  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
Responding with Connection: Close to a HTTP/2 request is non-conformant, and will generate warnings/errors on Safari , this PR prevents having this error.
Fixes https://github.com/mautic/mautic/issues/9077

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com) 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
