### PR TITLE
Suppress Generic error on inocuous stage change

### DIFF
--- a/app/bundles/StageBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/CampaignSubscriber.php
@@ -80,6 +80,8 @@ class CampaignSubscriber implements EventSubscriberInterface
                 $stageChange = true;
             } elseif (!$leadStage) {
                 $stageChange = true;
+            } else {
+                return $event->setFailed();
             }
         }
 


### PR DESCRIPTION
Is expected that stages don't change in decreasing direction so suppress the
error message entirely.

<!--
Any PR related to Mautic 2 issues is not relavant anymore, please consider upgrading your code to the Mautic 3 series (staging/3.0 branch).
-->
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | staging for features or enhancements / 3.2 for bug fixes <!-- see below -->
| Bug fix?                               | yes
| New feature?                           |no
| Deprecations?                          |None
| BC breaks?                             | No
| Automated tests included?              | No
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the staging branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

Stage change events fail with "Generic error" when the contact stage is > then the new stage. This is the expected behavior but the "Generic error" message is misleading. I faced this problem and talk a little about in the [slack](https://mautic.slack.com/archives/C02GEN0SG/p1605816149414600)

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to reproduce the error:
To reproduce the generic error just

1. Create two stages, A, B with B weight > than A weight
2. Create a contact and set it's stage to B
3. Create a campaign, add a sole change stage action and set stage to A
4. Add the contact to the campaign and run `mautic:campaign:trigger` command
5. Checkout the contact events log, there is a Generic error 
<img width="781" alt="image" src="https://user-images.githubusercontent.com/392820/99738029-5abadc80-2aa8-11eb-9638-207525d4d404.png">


#### Steps to test this PR:
1. Load up this PR
2. Reproduce the exactly the same steps above

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


Side note on tests:

I didn't included any automated test, how/where can I do it?

Regards,
