### PR TITLE
Allow 0% coverage on Codecov patch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,12 @@ comment:
     layout: "reach, diff, flags, files"
     behavior: default
     require_changes: true
+
+coverage:
+  status:
+    patch:
+      default:
+        # PRs against files that have 0% coverage can remain
+        # at 0% coverage, as long as the project's total
+        # coverage (e.g. 36%) doesn't decrease.
+        target: 0%


### PR DESCRIPTION
This PR enhances Codecov behavior by allowing 0% coverage on `codecov/patch`.

Example: [this PR](https://github.com/mautic/mautic/pull/9390) makes changes to `app/bundles/LeadBundle/Form/Type/LeadImportType.php`, [a file that currently has 0% test coverage](https://codecov.io/gh/mautic/mautic/src/staging/app/bundles/LeadBundle/Form/Type/LeadImportType.php).

Said PR doesn't decrease the project's overall coverage, but because the project's coverage is currently `31.54%`, Codecov expects that file (`LeadImportType.php`), to also have at least `31.54%` coverage. 

From https://docs.codecov.io/docs/commit-status#patch-status:

> The `codecov/patch` status **only** measures lines adjusted in the pull request or single commit, if the commit is not in a pull request. This status provides an indication on how well the pull request is tested.


![image](https://user-images.githubusercontent.com/17739158/99823289-7c719d80-2b54-11eb-851a-9e081d94f3b8.png)
