### PR TITLE
Fix failing test 🚀

### DIFF
--- a/app/bundles/CoreBundle/Tests/Unit/Helper/MaxMindDoNotSellDownloadHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/MaxMindDoNotSellDownloadHelperTest.php
@@ -42,7 +42,7 @@ final class MaxMindDoNotSellDownloadHelperTest extends \PHPUnit\Framework\TestCa
             ->willReturn(self::TEMP_TEST_FILE);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $filename = self::TEMP_TEST_FILE;
 

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/MaxMindDoNotSellDownloadHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/MaxMindDoNotSellDownloadHelperTest.php
@@ -31,7 +31,7 @@ final class MaxMindDoNotSellDownloadHelperTest extends \PHPUnit\Framework\TestCa
      */
     private $coreParametersHelperMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->loggerMock               = $this->createMock(LoggerInterface::class);
         $this->httpClientMock           = $this->createMock(HttpClientInterface::class);


### PR DESCRIPTION
https://github.com/mautic/mautic/pull/8647 was merged right after the PHPUnit 8 merge, so it's missing the `void` return type that became mandatory in PHPUnit 8 🤓 this PR fixes that!