### PR TITLE
Bump minimum MySQL version to 5.7

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -1156,7 +1156,7 @@ return [
         'db_user'                         => '',
         'db_password'                     => '',
         'db_table_prefix'                 => '',
-        'db_server_version'               => '5.5',
+        'db_server_version'               => '5.7',
         'locale'                          => 'en_US',
         'secret_key'                      => '',
         'dev_hosts'                       => [],

--- a/app/bundles/CoreBundle/Doctrine/Provider/VersionProvider.php
+++ b/app/bundles/CoreBundle/Doctrine/Provider/VersionProvider.php
@@ -23,7 +23,7 @@ final class VersionProvider implements VersionProviderInterface
      *
      * @see app/bundles/CoreBundle/Config/config.php and look for 'db_server_version'.
      */
-    const DEFAULT_CONFIG_VERSION = '5.5';
+    const DEFAULT_CONFIG_VERSION = '5.7';
 
     /**
      * @var Connection

--- a/app/bundles/CoreBundle/Tests/Unit/Doctrine/Provider/VersionProviderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Doctrine/Provider/VersionProviderTest.php
@@ -74,7 +74,7 @@ class VersionProviderTest extends \PHPUnit\Framework\TestCase
     {
         $this->coreParametersHelper->expects($this->once())
             ->method('getParameter')
-            ->willReturn('5.5');
+            ->willReturn('5.7');
 
         $this->connection->expects($this->once())
             ->method('executeQuery')


### PR DESCRIPTION
Mautic 3 introduced a version bump for MySQL to 5.7 (see https://github.com/mautic/mautic/blob/staging/UPGRADE-3.0.md#backwards-compatibility-breaking-changes), but it was never enforced in the code.

This is now leading to the following error:
```
11:16:32 ERROR     [console] Error thrown while running command "mautic:plugins:reload". Message: "Unknown database type json requested, Doctrine\DBAL\Platforms\MySqlPlatform may not support it." ["exception" => Doctrine\DBAL\DBALException { …},"command" => "mautic:plugins:reload","message" => "Unknown database type json requested, Doctrine\DBAL\Platforms\MySqlPlatform may not support it."]
```

As described in https://github.com/laravel/framework/issues/15772#issuecomment-685945057, the solution is to bump the `server_version` in the Doctrine config to 5.7 as well.

This bug is currently blocking the following things:
- Mautic API library to GH Actions https://github.com/mautic/api-library/pull/231 (I temporarily applied the patch in this PR to the one in `api-library`, and can confirm it fixes the issue https://github.com/mautic/api-library/pull/231/commits/fa9a7554ea4888fb6f5993591bc3707e58ee49c7
- Automatically testing a Mautic upgrade in our CI release job: https://github.com/mautic/mautic/runs/1442983812?check_suite_focus=true

We can't reliably release 3.2 if this fix is not in.