### PR TITLE
Update DB server version for Mautic 2 > 3 upgrade

### DIFF
--- a/upgrade_v3.php
+++ b/upgrade_v3.php
@@ -1582,6 +1582,12 @@ function update_local_config()
     if (array_key_exists('mailer_spool_path', $parameters)) {
         $parameters['mailer_spool_path'] = str_replace('%kernel.root_dir%/spool', '%kernel.root_dir%/../var/spool', $parameters['mailer_spool_path']);
     }
+    
+    // MySQL minimum version was bumped to 5.7 in Mautic 3
+    // https://github.com/mautic/mautic/pull/9437
+    if (array_key_exists('db_server_version', $parameters)) {
+        $parameters['db_server_version'] = '5.7';
+    }
 
     // Write updated config to local.php
     $result = file_put_contents($filename, "<?php\n" . '$parameters = ' . var_export($parameters, true) . ';');


### PR DESCRIPTION
**THIS FIX IS FOR MAUTIC 2.16**

Related to https://github.com/mautic/mautic/pull/9437

Mautic 3 bumped the minimum MySQL version to 5.7, but we forgot to update the `db_server_version` config as can be seen in the PR above. This PR helps people who still haven't upgraded from Mautic 2 to 3 by setting the correct `db_server_version`, preventing potential issues.

**How to test this PR:**
- Download the 2.16.3 installation package from https://github.com/mautic/mautic/releases/download/2.16.3/2.16.3.zip and unzip it. DON'T INSTALL MAUTIC YET
- Overwrite `upgrade_v3.php` with the one from this PR: https://github.com/mautic/mautic/blob/f0348f794dd80816b81e7b22f50b76baecd97578/upgrade_v3.php
- Install Mautic
- Open the Configuration screen and click "Save and close"
- Open `app/config/local.php`. You should see a `db_server_version` parameter:

```PHP
<?php
$parameters = array(
    ....

    'db_server_version' => '5.5.5-10.2.34-MariaDB-1:10.2.34+maria~bionic-log',
    
    ....
);
```

- You should see an update notification in Mautic's UI: I've already made sure that folks now go directly to 3.2 instead of 3.0.1 (https://updates.mautic.org/upgrade-configs/m2-to-m3.json). If you don't see a notification yet, run `php app/console mautic:update:find` to check for updates.
- Run the upgrade either through the UI or by running `php app/console mautic:update:apply` in a terminal.
- Go back to your `app/config/local.php`, the `db_server_version` should now be 5.7.