### PR TITLE
Fix migration 20191017140848, run PHPSTAN on migration files

### DIFF
--- a/app/migrations/Version20191017140848.php
+++ b/app/migrations/Version20191017140848.php
@@ -10,8 +10,8 @@
 
 namespace Mautic\Migrations;
 
-use Doctrine\DBAL\Migrations\SkipMigrationException;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\SkipMigration;
 use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
 
 /**
@@ -20,14 +20,14 @@ use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
 class Version20191017140848 extends AbstractMauticMigration
 {
     /**
-     * @throws SkipMigrationException
+     * @throws SkipMigration
      * @throws \Doctrine\DBAL\Schema\SchemaException
      */
     public function preUp(Schema $schema): void
     {
         $smsStatsTable = $schema->getTable(MAUTIC_TABLE_PREFIX.'sms_message_stats');
         if ($smsStatsTable->hasColumn('is_failed') && $smsStatsTable->hasColumn('details')) {
-            throw new SkipMigrationException('Schema includes this migration');
+            throw new SkipMigration('Schema includes this migration');
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "psr-4": {
             "Mautic\\": "app/bundles/",
             "MauticPlugin\\": "plugins/",
-            "Mautic\\Middleware\\": "app/middlewares/"
+            "Mautic\\Middleware\\": "app/middlewares/",
+            "Mautic\\Migrations\\": "app/migrations/"
         },
         "files": [
             "app/AppKernel.php",
@@ -156,7 +157,7 @@
             "@auto-scripts"
         ],
         "test": "bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist",
-        "phpstan": "bin/phpstan analyse app/bundles plugins",
+        "phpstan": "bin/phpstan analyse app/bundles app/migrations plugins",
         "cs": "bin/php-cs-fixer fix -v --dry-run --diff",
         "fixcs": "bin/php-cs-fixer fix -v",
         "rector": "bin/rector process --config rector.yaml"


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.2
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | N/A
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #9479 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

Running PHPSTAN on `app/migrations` results in the following exception:

```
 ------ -------------------------------------------------------------------------------
  Line   app/migrations/Version20191017140848.php
 ------ -------------------------------------------------------------------------------
  30     Instantiated class Doctrine\DBAL\Migrations\SkipMigrationException not found.
 ------ -------------------------------------------------------------------------------
```

This bug was introduced by https://github.com/mautic/mautic/pull/7879 and wasn't caught by our testing pipeline. This is because PHPSTAN wasn't running on migration files. Bug reported in https://github.com/mautic/mautic/issues/9479.

This PR does the following:
- Run PHPSTAN on all migrations moving forward (preventing these kinds of bugs in the future)
- Fix the problematic migration (20191017140848)

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

A code review should be sufficient, but if you really want to test:

(also see https://github.com/mautic/mautic/issues/9479)

1. Install a clean Mautic 3.2.0 (the version that introduced this bug!)
2. Update Mautic either through the UI or the CLI to 3.2.1 --> the problem shows up

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
