### PR TITLE
Adding functional test to ensure a multiselect field can be created

### DIFF
--- a/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerFunctionalTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Controller\Api;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
+{
+    public function testCreatingMultiselectField()
+    {
+        $payload = [
+            'label'               => 'Shops (TB)',
+            'alias'               => 'shops',
+            'type'                => 'multiselect',
+            'isPubliclyUpdatable' => true,
+            'isUniqueIdentifier'  => false,
+            'properties'          => [
+                'list' => [
+                    ['label' => 'label1', 'value' => 'value1'],
+                    ['label' => 'label2', 'value' => 'value2'],
+                ],
+            ],
+        ];
+
+        $this->client->request(Request::METHOD_POST, '/api/fields/contact/new', $payload);
+        $clientResponse = $this->client->getResponse();
+        $fieldResponse  = json_decode($clientResponse->getContent(), true);
+
+        Assert::assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        Assert::assertTrue($fieldResponse['field']['isPublished']);
+        Assert::assertGreaterThan(0, $fieldResponse['field']['id']);
+        Assert::assertSame($payload['label'], $fieldResponse['field']['label']);
+        Assert::assertSame($payload['alias'], $fieldResponse['field']['alias']);
+        Assert::assertSame($payload['type'], $fieldResponse['field']['type']);
+        Assert::assertSame($payload['isPubliclyUpdatable'], $fieldResponse['field']['isPubliclyUpdatable']);
+        Assert::assertSame($payload['isUniqueIdentifier'], $fieldResponse['field']['isUniqueIdentifier']);
+        Assert::assertSame($payload['properties'], $fieldResponse['field']['properties']);
+
+        // Cleanup
+        $this->client->request(Request::METHOD_DELETE, '/api/fields/contact/'.$fieldResponse['field']['id'].'/delete', $payload);
+        $clientResponse = $this->client->getResponse();
+        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.2
| Bug fix?                               | no
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | /
| Related developer documentation PR URL | https://developer.mautic.org/#create-field
| Issue(s) addressed                     | https://github.com/mautic/mautic/issues/9481

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

This PR is just adding a functional test that confirms https://github.com/mautic/mautic/issues/9481 is not an issue. No code changes to production files were made.

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Just ensure that Github actions are passing

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
