### PR TITLE
Check if tag name matches version in metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,17 @@ jobs:
     - name: Get tag name
       run: echo "MAUTIC_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
+    - name: Check if tag name matches version in release_metadata.json
+      run: |
+        METADATA_VERSION=$(jq -r '.version' app/release_metadata.json)
+
+        if [[ "${{ env.MAUTIC_VERSION }}" != "$METADATA_VERSION" ]]; then
+          echo "❌ ERROR: tag name (${{ env.MAUTIC_VERSION }}) doesn't match version in app/release_metadata.json ($METADATA_VERSION). Please ensure that both versions match!"
+          exit 1
+        else
+          echo "✔ Tag name (${{ env.MAUTIC_VERSION }}) and the version in app/release_metadata.json ($METADATA_VERSION) match. Great!"
+        fi
+
     - name: Install dependencies
       # Force Composer to v1.10
       run: |


### PR DESCRIPTION
## Background

When creating a release for Mautic, the tag name and the version in `app/release_metadata.json` need to be exactly the same, otherwise the build process will error with something like

> Error: ENOENT: no such file or directory, stat './build/packages/3.2.2.zip'

An example where this happened was [this run](https://github.com/mautic/mautic/runs/1588261003?check_suite_focus=true), where the tag name was `3.2.2` and the version in `release_metadata.json` was `3.2.2-rc`. 

## What this PR does

This PR adds a check to the beginning of the release process where it shows a more user-friendly error in case this scenario happens:

> ❌ ERROR: tag name (3.2.2) doesn't match version in app/release_metadata.json (3.2.2-rc). Please ensure that both versions match!

Or it will just confirm that all is OK:

> ✔ Tag name (3.2.2-rc) and the version in app/release_metadata.json (3.2.2-rc) match. Great!