### PR TITLE
Run composer test command with 4G

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -156,7 +156,7 @@
         "post-update-cmd": [
             "@auto-scripts"
         ],
-        "test": "bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist",
+        "test": "bin/phpunit -d memory_limit=3G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist",
         "phpstan": "bin/phpstan analyse app/bundles app/migrations plugins",
         "cs": "bin/php-cs-fixer fix -v --dry-run --diff",
         "fixcs": "bin/php-cs-fixer fix -v",

--- a/composer.json
+++ b/composer.json
@@ -156,7 +156,7 @@
         "post-update-cmd": [
             "@auto-scripts"
         ],
-        "test": "bin/phpunit -d memory_limit=3G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist",
+        "test": "bin/phpunit -d memory_limit=4G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist",
         "phpstan": "bin/phpstan analyse app/bundles app/migrations plugins",
         "cs": "bin/php-cs-fixer fix -v --dry-run --diff",
         "fixcs": "bin/php-cs-fixer fix -v",


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

We develop Mautic in a container with 512MB memory limit to ensure our code does not need more. But PHPUNIT does. Setting the memory limit to $GB when the `composer test` command runs.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to run `composer test` with memory limit lower than 1GB. It will fail in the middle with a memory limit error.

#### Steps to test this PR:
1. Try to run `composer test` with memory limit lower than 1GB. It will finish all the tests.

#### Other areas of Mautic that may be affected by the change:
1. None
