### PR TITLE
Campaign action bug

### DIFF
--- a/app/bundles/LeadBundle/Helper/CustomFieldHelper.php
+++ b/app/bundles/LeadBundle/Helper/CustomFieldHelper.php
@@ -53,9 +53,11 @@ class CustomFieldHelper
     }
 
     /**
-     * Transform field value based on type.
+     * @param mixed $value This value can be at least array, string, null and maybe others
+     *
+     * @return mixed|string|null
      */
-    public static function fieldValueTransfomer(array $field, ?string $value)
+    public static function fieldValueTransfomer(array $field, $value)
     {
         if (null === $value) {
             // do not transform null values

--- a/app/bundles/LeadBundle/Helper/CustomFieldHelper.php
+++ b/app/bundles/LeadBundle/Helper/CustomFieldHelper.php
@@ -32,18 +32,21 @@ class CustomFieldHelper
      */
     public static function fixValueType($type, $value)
     {
-        if (!is_null($value)) {
-            switch ($type) {
-                case self::TYPE_NUMBER:
-                    $value = (float) $value;
-                    break;
-                case self::TYPE_BOOLEAN:
-                    $value = (bool) $value;
-                    break;
-                case self::TYPE_SELECT:
-                    $value = (string) $value;
-                    break;
-            }
+        if (null === $value) {
+            // do not transform null values
+            return null;
+        }
+
+        switch ($type) {
+            case self::TYPE_NUMBER:
+                $value = (float) $value;
+                break;
+            case self::TYPE_BOOLEAN:
+                $value = (bool) $value;
+                break;
+            case self::TYPE_SELECT:
+                $value = (string) $value;
+                break;
         }
 
         return $value;
@@ -54,11 +57,21 @@ class CustomFieldHelper
      */
     public static function fieldValueTransfomer(array $field, ?string $value)
     {
+        if (null === $value) {
+            // do not transform null values
+            return null;
+        }
+
         $type = $field['type'];
         switch ($type) {
             case 'datetime':
             case 'date':
             case 'time':
+                // Not sure if this happens anywhere but just in case do not transform empty strings
+                if ('' === $value) {
+                    return null;
+                }
+
                 $dtHelper = new DateTimeHelper($value, null, 'local');
                 switch ($type) {
                     case 'datetime':

--- a/app/bundles/LeadBundle/Helper/CustomFieldHelper.php
+++ b/app/bundles/LeadBundle/Helper/CustomFieldHelper.php
@@ -51,11 +51,8 @@ class CustomFieldHelper
 
     /**
      * Transform field value based on type.
-     *
-     * @param $field
-     * @param $value
      */
-    public static function fieldValueTransfomer($field, $value)
+    public static function fieldValueTransfomer(array $field, ?string $value)
     {
         $type = $field['type'];
         switch ($type) {
@@ -82,11 +79,8 @@ class CustomFieldHelper
 
     /**
      * Transform all fields values.
-     *
-     * @param $fields
-     * @param $values
      */
-    public static function fieldsValuesTransformer($fields, $values)
+    public static function fieldsValuesTransformer(array $fields, array $values)
     {
         foreach ($values as $alias => &$value) {
             if (!empty($fields[$alias])) {

--- a/app/bundles/LeadBundle/Tests/Helper/CustomFieldHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/CustomFieldHelperTest.php
@@ -52,20 +52,24 @@ class CustomFieldHelperTest extends \PHPUnit\Framework\TestCase
     public function testFieldsValuesTransformerWithoutRelativesDates()
     {
         $values = [
-            'customdate'     => '2020-11-01',
-            'customdatetime' => '2020-11-02 23:59:00',
-            'customtime'     => '23:59:00',
+            'customdate'         => '2020-11-01',
+            'customdatetime'     => '2020-11-02 23:59:00',
+            'customtime'         => '23:59:00',
+            'customnulldatetime' => null,
         ];
 
         $fields = [
-            'customdate'=> [
+            'customdate'         => [
                 'type' => 'date',
             ],
-            'customdatetime'=> [
+            'customdatetime'     => [
                 'type' => 'datetime',
             ],
-            'customtime'=> [
+            'customtime'         => [
                 'type' => 'time',
+            ],
+            'customnulldatetime' => [
+                'type' => 'datetime',
             ],
         ];
 
@@ -75,27 +79,66 @@ class CustomFieldHelperTest extends \PHPUnit\Framework\TestCase
     public function testFieldsValuesTransformerWithRelativesDates()
     {
         $values = [
-            'customdate'     => '-1 day',
-            'customdatetime' => '-1 day',
-            'customtime'     => '-20 minutes',
+            'customdate'         => '-1 day',
+            'customdatetime'     => '-1 day',
+            'customtime'         => '-20 minutes',
+            'customnulldatetime' => null,
         ];
 
         $fields = [
-            'customdate'=> [
+            'customdate'         => [
                 'type' => 'date',
             ],
-            'customdatetime'=> [
+            'customdatetime'     => [
                 'type' => 'datetime',
             ],
-            'customtime'=> [
+            'customtime'         => [
                 'type' => 'time',
+            ],
+            'customnulldatetime' => [
+                'type' => 'datetime',
             ],
         ];
 
         $expected = [
-            'customdate'     => (new DateTimeHelper('-1 day'))->getString('Y-m-d'),
-            'customdatetime' => (new DateTimeHelper('-1 day'))->getString('Y-m-d H:i:s'),
-            'customtime'     => (new DateTimeHelper('-20 minutes'))->getString('H:i:s'),
+            'customdate'         => (new DateTimeHelper('-1 day'))->getString('Y-m-d'),
+            'customdatetime'     => (new DateTimeHelper('-1 day'))->getString('Y-m-d H:i:s'),
+            'customtime'         => (new DateTimeHelper('-20 minutes'))->getString('H:i:s'),
+            'customnulldatetime' => null,
+        ];
+
+        $this->assertSame($expected, CustomFieldHelper::fieldsValuesTransformer($fields, $values));
+    }
+
+    public function testFieldsValuesWithNullsOrEmptyStringsAreNotTransformedToRelativesDates()
+    {
+        $values = [
+            'customdate'        => null,
+            'customdatetime'    => null,
+            'customtime'        => null,
+            'customemptystring' => '',
+        ];
+
+        $fields = [
+            'customdate'        => [
+                'type' => 'date',
+            ],
+            'customdatetime'    => [
+                'type' => 'datetime',
+            ],
+            'customtime'        => [
+                'type' => 'time',
+            ],
+            'customemptystring' => [
+                'type' => 'datetime',
+            ],
+        ];
+
+        $expected = [
+            'customdate'        => null,
+            'customdatetime'    => null,
+            'customtime'        => null,
+            'customemptystring' => null,
         ];
 
         $this->assertSame($expected, CustomFieldHelper::fieldsValuesTransformer($fields, $values));

--- a/app/bundles/LeadBundle/Tests/Helper/CustomFieldHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/CustomFieldHelperTest.php
@@ -143,4 +143,35 @@ class CustomFieldHelperTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame($expected, CustomFieldHelper::fieldsValuesTransformer($fields, $values));
     }
+
+    public function testFieldsValuesTransformerForDifferingValueTypes()
+    {
+        $fields = [
+            'select'      => [
+                'type' => 'select',
+            ],
+            'multiselect' => [
+                'type' => 'multiselect',
+            ],
+            'number'      => [
+                'type' => 'number',
+            ],
+            'string'      => [
+                'type' => 'text',
+            ],
+            'boolean'     => 0,
+        ];
+
+        $values = [
+            'select'      => 'string',
+            'multiselect' => [
+                'array',
+            ],
+            'number'      => 100,
+            'string'      => 'string',
+            'boolean'     => 0,
+        ];
+
+        $this->assertSame($values, CustomFieldHelper::fieldsValuesTransformer($fields, $values));
+    }
 }

--- a/app/bundles/LeadBundle/Tests/Helper/CustomFieldHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/CustomFieldHelperTest.php
@@ -159,7 +159,9 @@ class CustomFieldHelperTest extends \PHPUnit\Framework\TestCase
             'string'      => [
                 'type' => 'text',
             ],
-            'boolean'     => 0,
+            'boolean'     => [
+                'type' => 'boolean',
+            ],
         ];
 
         $values = [


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.2
| Bug fix?                               | yes
| New feature?                           |no
| Deprecations?                          |no
| BC breaks?                             |no
| Automated tests included?              | yes
| Related user documentation PR URL      | n/a
| Related developer documentation PR URL | n/a
| Issue(s) addressed                     | Fixes #9528


#### Description:

This fixes #9528 to prevent the campaign update contact action from updating date/time fields with today's date when they weren't supposed to be (including the last active and attribution dates). 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create two custom fields that are date or datetime.
3. Create a campaign with an "update contact" action and set one of the fields to "yesterday" and leave the other empty
4. Let the campaign run and look at the contact's profile audit log tab
5. Notice that the field with "yesterday" should have yesterday's date but the field that should have remained blank is still blank and last active and attribution date was not touched.

