### PR TITLE
Fixes mautic/issues/9187 - Migration to increase field length for remo…

### DIFF
--- a/app/migrations/Version20201228041109.php
+++ b/app/migrations/Version20201228041109.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   <year> Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        https://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\SkipMigration;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+final class Version20201228041109 extends AbstractMauticMigration
+{
+    /**
+     * @throws SkipMigrationException
+     */
+    public function preUp(Schema $schema): void
+    {
+        //Not doing anything to throw SkipMigration here.
+        //It is ok if the migration is already run and if the data types are LONGTEXT already
+        //And if the alter statement changes it to LONGTEXT again
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Changes remote_path and original_file_name columns to Longtext
+        $this->addSql("ALTER TABLE {$this->prefix}assets MODIFY remote_path LONGTEXT ");
+        $this->addSql("ALTER TABLE {$this->prefix}assets MODIFY original_file_name LONGTEXT ");
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Changes remote_path and original_file_name columns to earlier VARCHAR(191)
+        // Rolling back causes any long URLs or Filenames with more than 191 chars to be trimmed.
+        $this->addSql("UPDATE {$this->prefix}assets SET remote_path = left(remote_path,191)");
+        $this->addSql("UPDATE {$this->prefix}assets SET original_file_name = left(remote_path,191)");
+        $this->addSql("ALTER TABLE {$this->prefix}assets MODIFY remote_path VARCHAR(191) DEFAULT '' ");
+        $this->addSql("ALTER TABLE {$this->prefix}assets MODIFY original_file_name VARCHAR(191) DEFAULT '' ");
+    }
+}


### PR DESCRIPTION
closes https://github.com/mautic/mautic/issues/9187

| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.2
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | not applicable
| Related developer documentation PR URL | not applicable
| Issue(s) addressed                     | Fixes #9187

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
Allows long URLs (more than 191 chars) for remote assers. 

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Add a remote asset with a really long url. If you don't have one such, you can try the below with 2500+ Characters- 
`https://www.mautic.org/sites/default/files/content-images/Mautic_Logo_RGB_LB_39.png?random=RdkfEXkKJoYZojXeEqhXFTxgfCWrdiyiq2sPmPMDatuHgGsEdJA5QlfoHWCWJnc4goI3X3iR2BU9IRelxLzoyHcKa3pDEkdVtyp966c6pXWDtepAJg8EvcAvbsiNonyLsKVEvKv0QWFrEo4hMyR8ST7XAG7tlC1gFtnuhz5oRCPQy0akLjQ0guZr8khdyjjLtXY3DMzsTdlsx3OpMBHL5rihTxyfPrXcbBL3HW1O4hO8oMoPoagtlZXiYTQvPCnZJHJIhyd6VZztp3Uol41kWvyjbCxqKPqBOCS9jnt1DsH99PzNdJVJhw8XJwKQZ0SbPHSt439GmKfFhmbdHU78KPMwbiPYOBf90anedRUEoij86uez14GDnZbrPwGRPc2ft8SuVyF7a7gInF0DZfAwUPmTdWBOAsgK5YzKA3yJWuBI6BxQzlm9vnQb1cBQCHMm6L5fiBzxTTCJLQMSA173xIf9XCqsltBPFTXmeXFYyBCOO7ROPBa18FNejIIOA71AQR8TNFJSRhhSWEZO4PXfopXvuKce50I2Xx73QttdRkDejwE2AcFdFXdFH4lnphExmP0zms9dAylOms2oPkLnt6goqWISsob05KzNZ8tfrVoZ26eXrCCdDj94iGjYcZnnAc5UGHaIva7QyIOAUSHTYk9AlhDs1bV7I6etz7iw9FKt3smNJRbuW70sgbPBOiP48nHZZTuFcm5mBCvgbkhdPVxVlIIVXL3Ma0XKN2Hon0sk9WbdcXyNoPbTXaacAbOroTB4fcIiksUSr1iPpo3De7KI6YVYd7mJfwY0BYA3g1tZTT4CdqP3cLrgwjb8vsBLD4WopDkte6SAM09mu4YwXIOF6bt1ctXefqPKoSh2bzdpLORQlthO0NQSf8Ma9UY42OWmQAzRGRsfDYi2tVrzasmci1lhdaqOoOOv7ldlZMmBjYbeNi0dlc8b4bFTuKF6fGNaGhzQ4znD45ByQ2TN2xrywMChO2fKJpZKvTs4tB0haGP7FkH24a23XPz0uv45ZzosSUURSnqST0jFd2BDYDC6fxD4HIJ3seFesDugKm3yX2qXm7H4q4YizzP6Ht0pPLVASrMgAgQtf4YDNAQ6WE5QEdjMNbYmy2m65FpoL9e8gweoYFO6UrpfI3SShKvsJQ7nFSyRRfOUXunCjh0USBJZpvkUQbYDp3PAytodLseECI3hERomadTGU8gWzpeFFwqoF95UYUtLjgLr0CHn38pGgT5qaXJPcmqjapg1nvZIUqU5rwojKDpw8pNMYqJ1VryACXS4f40dkfXCG9JAUlwCnXxkwv1nzuqt6O11N0pPkhWb70G6zOnmXL8YdfLbQHOZj0MlYTzJevrLWtWuGwhLEnwakcc2n8c4g9kpWCjC2dsLQ0jy7Ougz7K7vPLqCZcqDrnptDU6kGELluOr1sNarEfWsteBICq6v46F5YtIDLhjLvyith5yiwomWspzKeaHYpA1FlIRVjMzKcMpWh0DbzwYyDHaxBo84APhX3bUFH3O8KNUezksW5HsNwZ3y0n6AGucnM23XkCmKu2ldVXVpLiAa2fQzEyd1brbrljP0DulZz1KoQnrgabgc3FjFVRBxAcA8I7Ik0wifYqUZxgkBDvmSHel3x2wXT9M9dx4bXjxxFcyAiulsTEwsndQkO1hRmaT8GxgRqtw2rRYw1LpGGkIbcEYGeyR8pgXNLOtLyw76XPHsy5cxspoLUzB2PYGFFapiarYpi4ERbv1Yd36YQmlZJSNvRUggnQ3ZLYyfgytN0wkhBnE1cbRt29Fy08FKtQcRAWi0HZcFcGUYqRdVnB08b72TEh1AhsiGilPV7tbprCLIdbiE7wn5DWDPWbIrHgDE9hyUYX7AJzJtFogZYxqIcagLaCWyrg98CqUji0in5kwHvkBFaLoVLA4gcgysgOTHMEnOKogrjplDv4RHB7iRDrt9wEcsJTYjzzMVnOkIcoOk7z7VqRx8iywymTR1gHbnwlQp2uxIT9BKDvOHLuYqYnSEHGBuCOLyQ82BGZGYWKdt8cHhlZkD4OAtUR5k3uzTCUfaGRwrzCKWFdG1ErCxJn0yQ8soT915ZA5sGWOzLQsnjlapVSVWBaAHWqhJZCgvjiwezjfdJyN3MTSJEZtMaBJ9KkZjpCDURDmCtSW4l5LLvrErTYefJzAgvqoUFA1mJdoD6BaCUXUq7zsujCp3S1sFetbCdt589WM8adDxz6A1xkJJRABXQ8JvWTsUpqmKVOdyQh5YIKVvVaUkT4Rw00MU5afLMZAqjjM57tInovdMOBXMwhhQ2OOatqx2sg7MafnQd1uu0dNWVp6Tym7T9dCQJFVjLzqHiYmQAMNEaNyfitXJtoDVOzqVlM23sUCP8VjbDAzzUd5239hUrhkcF5V8uoeBFbcuyhDwXoY8Yljx6SSX5HFjzXqUpoxsIAghvAyHTxxGM2U4aTd0elO4LOhEQ2yCmC7z7BUvazlaErHcHyBdw9QO2GluHOb
`

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
