### PR TITLE
issue-9545-forms-not-prefilling-fixed-regex

### DIFF
--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -221,7 +221,7 @@ class FormFieldHelper extends AbstractFormFieldHelper
                 }
                 break;
             case 'textarea':
-                if (preg_match('/<textarea(.?)*id="mauticform_input_'.$formName.'_'.$alias.'"(.*)?>(.*)?<\/textarea>/i', $formHtml, $match)) {
+                if (preg_match('/<textarea(.*)?id="mauticform_input_'.$formName.'_'.$alias.'"(.*)?>(.*)?<\/textarea>/i', $formHtml, $match)) {
                     $replace  = '<textarea'.$match[1].'id="mauticform_input_'.$formName.'_'.$alias.'"'.$match[2].'>'.$this->sanitizeValue($value).'</textarea>';
                     $formHtml = str_replace($match[0], $replace, $formHtml);
                 }

--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -214,14 +214,14 @@ class FormFieldHelper extends AbstractFormFieldHelper
             case 'url':
             case 'date':
             case 'datetime':
-                if (preg_match('/<input(.*?)id="mauticform_input_'.$formName.'_'.$alias.'"(.*?)value="(.*?)"(.*?)\/>/i', $formHtml, $match)) {
+                if (preg_match('/<input(.*)?id="mauticform_input_'.$formName.'_'.$alias.'"(.*)?value="(.*)?"(.*)?\/?>/i', $formHtml, $match)) {
                     $replace = '<input'.$match[1].'id="mauticform_input_'.$formName.'_'.$alias.'"'.$match[2].'value="'.$this->sanitizeValue($value).'"'
                         .$match[4].'/>';
                     $formHtml = str_replace($match[0], $replace, $formHtml);
                 }
                 break;
             case 'textarea':
-                if (preg_match('/<textarea(.*?)id="mauticform_input_'.$formName.'_'.$alias.'"(.*?)>(.*?)<\/textarea>/i', $formHtml, $match)) {
+                if (preg_match('/<textarea(.?)*id="mauticform_input_'.$formName.'_'.$alias.'"(.*)?>(.*)?<\/textarea>/i', $formHtml, $match)) {
                     $replace  = '<textarea'.$match[1].'id="mauticform_input_'.$formName.'_'.$alias.'"'.$match[2].'>'.$this->sanitizeValue($value).'</textarea>';
                     $formHtml = str_replace($match[0], $replace, $formHtml);
                 }
@@ -236,7 +236,7 @@ class FormFieldHelper extends AbstractFormFieldHelper
                 foreach ($value as $val) {
                     $val = $this->sanitizeValue($val);
                     if (preg_match(
-                        '/<input(.*?)id="mauticform_checkboxgrp_checkbox_'.$alias.'(.*?)"(.*?)value="'.$val.'"(.*?)\/>/i',
+                        '/<input(.*)?id="mauticform_checkboxgrp_checkbox_'.$alias.'(.*)?"(.*)?value="'.$val.'"(.*)?\/?>/i',
                         $formHtml,
                         $match
                     )) {
@@ -248,7 +248,7 @@ class FormFieldHelper extends AbstractFormFieldHelper
                 break;
             case 'radiogrp':
                 $value = $this->sanitizeValue($value);
-                if (preg_match('/<input(.*?)id="mauticform_radiogrp_radio_'.$alias.'(.*?)"(.*?)value="'.$value.'"(.*?)\/>/i', $formHtml, $match)) {
+                if (preg_match('/<input(.*)?id="mauticform_radiogrp_radio_'.$alias.'(.*)?"(.*)?value="'.$value.'"(.*)?\/?>/i', $formHtml, $match)) {
                     $replace = '<input'.$match[1].'id="mauticform_radiogrp_radio_'.$alias.$match[2].'"'.$match[3].'value="'.$value.'"'.$match[4]
                         .' checked />';
                     $formHtml = str_replace($match[0], $replace, $formHtml);


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.2
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | https://docs.mautic.org/en/components/forms/managing-forms
| Related developer documentation PR URL | Documentation update not required
| Issue(s) addressed                     | Fixes #9545

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
The source of this issue seems to be the regex written in `app/bundles/FormBundle/Helper/FormFieldHelper.php`

`if (preg_match('/<input(.*?)id="mauticform_input_'.$formName.'_'.$alias.'"(.*?)value="(.*?)"(.*?)\/>/i', $formHtml, $match)) {`

This tries to match the HTML which is
`<input id="mauticform_input_mauticissues9545_first_name" name="mauticform[first_name]" value="" class="mauticform-input" type="text" />\n`

This seems to have worked in the past, although some regression seems to have caused changed over time to the form HTML markup that has caused the regex to break. 
The current regex works only if
* id is the first param in the input tage
* **value** attribute in the html of the input element comes right after the **id** attribute
* The input tag has a "/" before the closing ">"

**This is failing now because the form markup generated inserts a name attribute between the id and value attributes of the input field markup. Further the "/" before the closing ">" is gone now. ** 

This will likely affect other types of fields than just text as well. 

Fixing the regex accordingly. I have tested the updated regex for Text Field only. I have applied similar change to other fields regex, which might require further testing. 

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Create a form, add fields and save the form. 
2. Open the form url and try to pass values for fields as per https://docs.mautic.org/en/components/forms/managing-forms and check if the values are populating in the form . 
Example: if form url is http://localhost/mauticissues9545-landing-page and if it has a email_address field, try to open http://localhost/mauticissues9545-landing-page?email_address=saitanay@example.com and check if email address is prepopulated


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
