### PR TITLE
fix timeline on sms

### DIFF
--- a/app/bundles/SmsBundle/Entity/StatRepository.php
+++ b/app/bundles/SmsBundle/Entity/StatRepository.php
@@ -140,7 +140,7 @@ class StatRepository extends CommonRepository
             );
         } else {
             $query->select(
-                's.sms_id, s.id, s.date_sent as dateSent, e.name, e.name as sms_name, s.is_failed as isFailed, s.list_id, l.name as list_name, s.tracking_hash as idHash, s.lead_id, s.details'
+                's.sms_id, s.id, s.date_sent as dateSent, e.name, e.name as sms_name, e.message, e.sms_type as type, s.is_failed as isFailed, s.list_id, l.name as list_name, s.tracking_hash as idHash, s.lead_id, s.details'
             )
                 ->leftJoin('s', MAUTIC_TABLE_PREFIX.'lead_lists', 'l', 's.list_id = l.id');
         }

--- a/app/bundles/SmsBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/LeadSubscriber.php
@@ -99,7 +99,6 @@ class LeadSubscriber implements EventSubscriberInterface
                 if ('failed' == $state or 'sent' == $state) { //this is to get the correct column for date dateSent
                     $dateSent = 'sent';
                 }
-                $status=($stat['isFailed']) ? 'Failed' : 'Success';
 
                 $contactId = $stat['lead_id'];
                 unset($stat['lead_id']);
@@ -113,7 +112,6 @@ class LeadSubscriber implements EventSubscriberInterface
                         'extra'      => [
                             'stat'   => $stat,
                             'type'   => $state,
-                            'status' => $status,
                         ],
                         'contentTemplate' => 'MauticSmsBundle:SubscribedEvents\Timeline:index.html.php',
                         'icon'            => ('read' == $state) ? 'fa-message-o' : 'fa-commenting',

--- a/app/bundles/SmsBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/LeadSubscriber.php
@@ -99,6 +99,7 @@ class LeadSubscriber implements EventSubscriberInterface
                 if ('failed' == $state or 'sent' == $state) { //this is to get the correct column for date dateSent
                     $dateSent = 'sent';
                 }
+                $status=($stat['isFailed']) ? 'Failed' : 'Success';
 
                 $contactId = $stat['lead_id'];
                 unset($stat['lead_id']);
@@ -110,8 +111,9 @@ class LeadSubscriber implements EventSubscriberInterface
                         'eventType'  => $eventTypeName,
                         'timestamp'  => $stat['date'.ucfirst($dateSent)],
                         'extra'      => [
-                            'stat' => $stat,
-                            'type' => $state,
+                            'stat'   => $stat,
+                            'type'   => $state,
+                            'status' => $status,
                         ],
                         'contentTemplate' => 'MauticSmsBundle:SubscribedEvents\Timeline:index.html.php',
                         'icon'            => ('read' == $state) ? 'fa-message-o' : 'fa-commenting',

--- a/app/bundles/SmsBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/SmsBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -47,7 +47,13 @@ if ($item = ((isset($event['extra'])) ? $event['extra']['stat'] : false)):
 <?php else: ?>
 <dl class="dl-horizontal">
     <dt><?php echo $view['translator']->trans('mautic.sms.timeline.status'); ?></dt>
-    <dd><?php echo $view['translator']->trans($event['extra']['status']); ?></dd>
+    <dd>
+        <?php if (!empty($item['is_failed'])): ?>
+            <?php echo $view['translator']->trans('mautic.email.stat.failed'); ?>
+        <?php else: ?>
+            <?php echo $view['translator']->trans('mautic.email.send'); ?>
+        <?php endif; ?>
+    </dd>
     <dt><?php echo $view['translator']->trans('mautic.sms.timeline.type'); ?></dt>
     <dd><?php echo $view['translator']->trans($item['type']); ?></dd>
 </dl>

--- a/app/bundles/SmsBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/SmsBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -40,21 +40,21 @@ if ($item = ((isset($event['extra'])) ? $event['extra']['stat'] : false)):
     </p>
 <?php endif; ?>
 
-<?php if ($errors): ?>
+<?php if (isset($errors)): ?>
 <p class="text-danger mt-0 mb-10">
     <i class="fa fa-warning"></i> <?php echo $view['translator']->trans('mautic.campaign.event.last_error').': '.$errors; ?>
 </p>
 <?php else: ?>
 <dl class="dl-horizontal">
     <dt><?php echo $view['translator']->trans('mautic.sms.timeline.status'); ?></dt>
-    <dd><?php echo $view['translator']->trans($data['status']); ?></dd>
+    <dd><?php echo $view['translator']->trans($event['extra']['status']); ?></dd>
     <dt><?php echo $view['translator']->trans('mautic.sms.timeline.type'); ?></dt>
-    <dd><?php echo $view['translator']->trans($data['type']); ?></dd>
+    <dd><?php echo $view['translator']->trans($item['type']); ?></dd>
 </dl>
 <div class="small">
     <hr />
     <strong><?php echo $view['translator']->trans('mautic.sms.timeline.content.heading'); ?></strong>
     <br />
-    <?php echo $data['content']; ?>
+    <?php echo $item['message']; ?>
 </div>
 <?php endif; ?>


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.2 for bug fixes <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| Automated tests included?              | no
| Issue(s) addressed                     | Fixes #9577 
<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
This PR fixes issue #9577 . which create error on logs and return sms sent event with blank data
<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. open lead timeline that has sms event on history.
3. content of sms should apear inside and no error on console.

![image](https://user-images.githubusercontent.com/67871785/104206861-b9f9f500-5438-11eb-9c8c-85d68477fefe.png)


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
