### PR TITLE
Fix segment email stats graph

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -741,8 +741,8 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
 
         /** @var \Mautic\PageBundle\Entity\TrackableRepository $trackableRepo */
         $trackableRepo = $this->em->getRepository('MauticPageBundle:Trackable');
-        $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);
-        $key   = ($listCount > 1) ? 1 : 0;
+        $query         = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);
+        $key           = ($listCount > 1) ? 1 : 0;
 
         if ($listCount > 1) {
             $sentCounts         = $statRepo->getSentCount($emailIds, $lists->getKeys(), $query);
@@ -777,7 +777,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             }
         }
 
-        if($listCount) {
+        if ($listCount) {
             $combined = [
                 $statRepo->getSentCount($emailIds, null, $query),
                 $statRepo->getReadCount($emailIds, null, $query),
@@ -793,7 +793,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
                     $combined,
                     0
                 );
-            }else{
+            } else {
                 $chart->setDataset(
                     $lists->first()->getName(),
                     $combined,

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -746,20 +746,20 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);
             $key   = ($listCount > 1) ? 1 : 0;
 
-            $sentCounts         = $statRepo->getSentCount($emailIds, $lists->getKeys(), $query);
-            $readCounts         = $statRepo->getReadCount($emailIds, $lists->getKeys(), $query);
-            $failedCounts       = $statRepo->getFailedCount($emailIds, $lists->getKeys(), $query);
-            $clickCounts        = $trackableRepo->getCount('email', $emailIds, $lists->getKeys(), $query, false, 'DISTINCT ph.lead_id');
-            $unsubscribedCounts = $dncRepo->getCount('email', $emailIds, DoNotContact::UNSUBSCRIBED, $lists->getKeys(), $query);
-            $bouncedCounts      = $dncRepo->getCount('email', $emailIds, DoNotContact::BOUNCED, $lists->getKeys(), $query);
+            $sentCounts         = $statRepo->getSentCount($emailIds, null, $query);
+            $readCounts         = $statRepo->getReadCount($emailIds, null, $query);
+            $failedCounts       = $statRepo->getFailedCount($emailIds, null, $query);
+            $clickCounts        = $trackableRepo->getCount('email', $emailIds, null, $query, false, 'DISTINCT ph.lead_id');
+            $unsubscribedCounts = $dncRepo->getCount('email', $emailIds, DoNotContact::UNSUBSCRIBED, null, $query);
+            $bouncedCounts      = $dncRepo->getCount('email', $emailIds, DoNotContact::BOUNCED, null, $query);
 
             foreach ($lists as $l) {
-                $sentCount         = isset($sentCounts[$l->getId()]) ? $sentCounts[$l->getId()] : 0;
-                $readCount         = isset($readCounts[$l->getId()]) ? $readCounts[$l->getId()] : 0;
-                $failedCount       = isset($failedCounts[$l->getId()]) ? $failedCounts[$l->getId()] : 0;
-                $clickCount        = isset($clickCounts[$l->getId()]) ? $clickCounts[$l->getId()] : 0;
-                $unsubscribedCount = isset($unsubscribedCounts[$l->getId()]) ? $unsubscribedCounts[$l->getId()] : 0;
-                $bouncedCount      = isset($bouncedCounts[$l->getId()]) ? $bouncedCounts[$l->getId()] : 0;
+                $sentCount         = $sentCounts;
+                $readCount         = $readCounts;
+                $failedCount       = $failedCounts;
+                $clickCount        = $clickCounts;
+                $unsubscribedCount = $unsubscribedCounts;
+                $bouncedCount      = $bouncedCounts;
 
                 $chart->setDataset(
                     $l->getName(),

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -754,12 +754,12 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             $bouncedCounts      = $dncRepo->getCount('email', $emailIds, DoNotContact::BOUNCED, null, $query);
 
             foreach ($lists as $l) {
-                $sentCount         = $sentCounts;
-                $readCount         = $readCounts;
-                $failedCount       = $failedCounts;
-                $clickCount        = $clickCounts;
-                $unsubscribedCount = $unsubscribedCounts;
-                $bouncedCount      = $bouncedCounts;
+                $sentCount         = isset($sentCounts[$l->getId()]) ? $sentCounts[$l->getId()] : 0;
+                $readCount         = isset($readCounts[$l->getId()]) ? $readCounts[$l->getId()] : 0;
+                $failedCount       = isset($failedCounts[$l->getId()]) ? $failedCounts[$l->getId()] : 0;
+                $clickCount        = isset($clickCounts[$l->getId()]) ? $clickCounts[$l->getId()] : 0;
+                $unsubscribedCount = isset($unsubscribedCounts[$l->getId()]) ? $unsubscribedCounts[$l->getId()] : 0;
+                $bouncedCount      = isset($bouncedCounts[$l->getId()]) ? $bouncedCounts[$l->getId()] : 0;
 
                 $chart->setDataset(
                     $l->getName(),

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -615,7 +615,7 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
 
     private function getEmailListStats(ArrayCollection $lists)
     {
-        $trackableRepo  = $this->createMock(TrackableRepository::class);
+        $trackableRepo    = $this->createMock(TrackableRepository::class);
         $doNotContactRepo = $this->createMock(DoNotContactRepository::class);
 
         $this->entityManager->expects($this->any())
@@ -629,7 +629,6 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
                     ]
                 )
             );
-
 
         $this->emailEntity->method('getLists')->willReturn($lists);
 

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -11,6 +11,8 @@
 
 namespace Mautic\EmailBundle\Tests\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
 use Mautic\ChannelBundle\Entity\MessageRepository;
 use Mautic\ChannelBundle\Model\MessageQueueModel;
@@ -33,15 +35,18 @@ use Mautic\EmailBundle\Model\SendEmailToContact;
 use Mautic\EmailBundle\MonitoredEmail\Mailbox;
 use Mautic\EmailBundle\Stat\StatHelper;
 use Mautic\LeadBundle\Entity\CompanyRepository;
+use Mautic\LeadBundle\Entity\DoNotContactRepository;
 use Mautic\LeadBundle\Entity\FrequencyRuleRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadDevice;
+use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\DoNotContact;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Mautic\LeadBundle\Tracker\DeviceTracker;
 use Mautic\PageBundle\Entity\RedirectRepository;
+use Mautic\PageBundle\Entity\TrackableRepository;
 use Mautic\PageBundle\Model\TrackableModel;
 use Mautic\UserBundle\Model\UserModel;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -49,6 +54,10 @@ use Symfony\Component\HttpFoundation\Request;
 
 class EmailModelTest extends \PHPUnit\Framework\TestCase
 {
+    const SEGMENT_A = 'segment A';
+
+    const SEGMENT_B = 'segment B';
+
     private $ipLookupHelper;
     private $themeHelper;
     private $mailboxHelper;
@@ -572,5 +581,66 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
         $this->emailModel->setDispatcher($this->createMock(EventDispatcher::class));
 
         $this->emailModel->hitEmail($stat, $request);
+    }
+
+    public function testGetEmailListStatsOneSegment()
+    {
+        $list = $this->createMock(LeadList::class);
+        $list->method('getName')->willReturn(self::SEGMENT_A);
+
+        $lists = new ArrayCollection([$list]);
+
+        $result = $this->getEmailListStats($lists);
+
+        self::assertCount(1, $result['datasets']);
+        self::assertEquals(self::SEGMENT_A, $result['datasets'][0]['label']);
+    }
+
+    public function testGetEmailListStatsTwoSegments()
+    {
+        $list = $this->createMock(LeadList::class);
+        $list->method('getName')->willReturn(self::SEGMENT_A);
+
+        $list2 = $this->createMock(LeadList::class);
+        $list2->method('getName')->willReturn(self::SEGMENT_B);
+
+        $lists = new ArrayCollection([$list, $list2]);
+
+        $result = $this->getEmailListStats($lists);
+
+        self::assertCount(3, $result['datasets']);
+        self::assertEquals(self::SEGMENT_A, $result['datasets'][1]['label']);
+        self::assertEquals(self::SEGMENT_B, $result['datasets'][2]['label']);
+    }
+
+    private function getEmailListStats(ArrayCollection $lists)
+    {
+        $trackableRepo  = $this->createMock(TrackableRepository::class);
+        $doNotContactRepo = $this->createMock(DoNotContactRepository::class);
+
+        $this->entityManager->expects($this->any())
+            ->method('getRepository')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['MauticEmailBundle:Stat', $this->statRepository],
+                        ['MauticLeadBundle:DoNotContact', $doNotContactRepo],
+                        ['MauticPageBundle:Trackable', $trackableRepo],
+                    ]
+                )
+            );
+
+
+        $this->emailEntity->method('getLists')->willReturn($lists);
+
+        $connection   = $this->createMock(Connection::class);
+        $this->entityManager->method('getConnection')->willReturn($connection);
+
+        $dateFromObject = new \DateTime('now');
+        $dateToObject   = new \DateTime('-1 month');
+
+        $this->emailEntity->method('getLists')->willReturn($lists);
+
+        return $this->emailModel->getEmailListStats($this->emailEntity, true, $dateFromObject, $dateToObject);
     }
 }


### PR DESCRIPTION
closes https://github.com/mautic/mautic/issues/9727

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
We noticed segment email details stats are different like same data from reports. In segment email Mautic show data what expect contacts are members of email segment. If contact is removed from segment by filter, then is not count in data. 
This PR changed it.
If you use one segment for sent to email - we count data from email_stats (not related to current membership state)
If you're using two and more segments, then data are count same like before, but all combinated data are count from email_stats table (not related to current membership state)

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create 3 contact - Contact A, Contact B, Contact C
3. Create 3 segments: Segment A, Segment B and Segment C
4. Segment B add filter - include Segment A membership and exclude Unsubscribed
4. Add 3 contacts to segment A and rebuild segments membership
5. In this moment you have 3 segments, and Segment A and Segments B has 3 contacts
6. Create segment email with Segment B and Segment C
7. Send segment email
8. Open email from Contact A and Contact B and unsubscribe Contact B from email
9. Rebuild segments
10. Go to emails detail and see no unsubscribe in graph stats
11. After PR you should see 1 unsubscribed in combinated data
12. Remove Segment C from email 
13. Go to email detail and see graph. You should see 1 unsubscribed in Segment B data


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
