### PR TITLE
Fix Codecov badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![codecov](https://codecov.io/gh/mautic/mautic/branch/feature/graph/badge.svg)](https://codecov.io/gh/mautic/mautic)
+[![codecov](https://codecov.io/gh/mautic/mautic/branch/features/graph/badge.svg)](https://codecov.io/gh/mautic/mautic)
 
 Mautic Introduction
 ===========


### PR DESCRIPTION
Not related to Mautic itself, but rather fixes a typo in the Codecov badge URL