### PR TITLE
BUG FIX create table "email_stats" | 1054 Unknown column ‘-’ in ‘generated column function’ when (...)

### DIFF
--- a/app/bundles/EmailBundle/EventListener/GeneratedColumnSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/GeneratedColumnSubscriber.php
@@ -32,7 +32,7 @@ class GeneratedColumnSubscriber implements EventSubscriberInterface
 
     public function onGeneratedColumnsBuild(GeneratedColumnsEvent $event): void
     {
-        $sentDate = new GeneratedColumn('email_stats', 'generated_sent_date', 'DATE', 'CONCAT(YEAR(date_sent), "-", LPAD(MONTH(date_sent), 2, "0"), "-", LPAD(DAY(date_sent), 2, "0"))');
+        $sentDate = new GeneratedColumn('email_stats', 'generated_sent_date', 'DATE', "CONCAT(YEAR(date_sent), '-', LPAD(MONTH(date_sent), 2, '0'), '-', LPAD(DAY(date_sent), 2, '0'))");
         $sentDate->addIndexColumn('email_id');
         $sentDate->setOriginalDateColumn('date_sent', 'd');
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for features or enhancements / 3.2 for bug fixes <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #9388  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

the problem are here:

`generated_sent_date DATE AS (CONCAT(YEAR(date_sent), "-", LPAD(MONTH(date_sent), 2, "0"), "-", LPAD(DAY(date_sent), 2, "0"))) COMMENT '(DC2Type:generated)',` 
fix quotes, from double quotes (") to simple quotes (’)

`generated_sent_date DATE AS (CONCAT(YEAR(date_sent), '-', LPAD(MONTH(date_sent), 2, '0'), '-', LPAD(DAY(date_sent), 2, '0'))) COMMENT '(DC2Type:generated)',` 

You can create table with this code:
https://forum.mautic.org/t/sql-syntax-errors-mautic-3-1-1/16555/6
https://forum.mautic.org/t/column-not-found-1054-unknown-column-in-generated-column-function-when-upgrading-from-3-0-2-to-3-1/15869/5

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. begin new installation.
2. follow standard steps.
3. when installation try create table "email_stats", you will receive error, unless you use this bug fix.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
