### PR TITLE
Added the table prefix to the lead_list_leads table

### DIFF
--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -569,7 +569,7 @@ class CampaignRepository extends CommonRepository
             ->leftJoin('c', MAUTIC_TABLE_PREFIX.'campaign_leads', 'cl', 'cl.campaign_id = c.id AND cl.manually_removed = 0')
             ->leftJoin(
                 'cl',
-                '(SELECT lll.lead_id AS ll, lll.lead_id FROM'.MAUTIC_TABLE_PREFIX.'lead_lists_leads lll WHERE lll.leadlist_id = '.$segmentId
+                '(SELECT lll.lead_id AS ll, lll.lead_id FROM '.MAUTIC_TABLE_PREFIX.'lead_lists_leads lll WHERE lll.leadlist_id = '.$segmentId
                     .' AND lll.manually_removed = 0)',
                 't',
                 't.lead_id = cl.lead_id'

--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -567,9 +567,10 @@ class CampaignRepository extends CommonRepository
         $q->select('c.id, c.name, ROUND(IFNULL(COUNT(DISTINCT t.lead_id)/COUNT(DISTINCT cl.lead_id)*100, 0),1) segmentCampaignShare');
         $q->from(MAUTIC_TABLE_PREFIX.'campaigns', 'c')
             ->leftJoin('c', MAUTIC_TABLE_PREFIX.'campaign_leads', 'cl', 'cl.campaign_id = c.id AND cl.manually_removed = 0')
-            ->leftJoin('cl',
-                '(SELECT lll.lead_id AS ll, lll.lead_id FROM lead_lists_leads lll WHERE lll.leadlist_id = '.$segmentId
-                .' AND lll.manually_removed = 0)',
+            ->leftJoin(
+                'cl',
+                '(SELECT lll.lead_id AS ll, lll.lead_id FROM'.MAUTIC_TABLE_PREFIX.'lead_lists_leads lll WHERE lll.leadlist_id = '.$segmentId
+                    .' AND lll.manually_removed = 0)',
                 't',
                 't.lead_id = cl.lead_id'
             );


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.2
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | N/A
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
While checking the logs of our Mautic instance I came across this error: 

> [2021-01-27 13:56:51] mautic.CRITICAL: Uncaught PHP Exception Doctrine\DBAL\Exception\TableNotFoundException: "An exception occurred while executing 'SELECT c.id, c.name, ROUND(IFNULL(COUNT(DISTINCT t.lead_id)/COUNT(DISTINCT cl.lead_id)*100, 0),1) segmentCampaignShare FROM mautic_campaigns c LEFT JOIN mautic_campaign_leads cl ON cl.campaign_id = c.id AND cl.manually_removed = 0 LEFT JOIN (SELECT lll.lead_id AS ll, lll.lead_id FROM lead_lists_leads lll WHERE lll.leadlist_id = 177 AND lll.manually_removed = 0) t ON t.lead_id = cl.lead_id WHERE c.id IN (168, 166, 165, 163, 161, 160, 154, 153, 141, 135) GROUP BY c.id':  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'mautic.lead_lists_leads' doesn't exist" at /MAUTICDIR/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php line 53 {"exception":"[object] (Doctrine\\DBAL\\Exception\\TableNotFoundException(code: 0): An exception occurred while executing 'SELECT c.id, c.name, ROUND(IFNULL(COUNT(DISTINCT t.lead_id)/COUNT(DISTINCT cl.lead_id)*100, 0),1) segmentCampaignShare FROM mautic_campaigns c LEFT JOIN mautic_campaign_leads cl ON cl.campaign_id = c.id AND cl.manually_removed = 0 LEFT JOIN (SELECT lll.lead_id AS ll, lll.lead_id FROM lead_lists_leads lll WHERE lll.leadlist_id = 177 AND lll.manually_removed = 0) t ON t.lead_id = cl.lead_id WHERE c.id IN (168, 166, 165, 163, 161, 160, 154, 153, 141, 135) GROUP BY c.id':\n\nSQLSTATE[42S02]: Base table or view not found: 1146 Table 'mautic.lead_lists_leads' doesn't exist at /MAUTICDIR/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:53, Doctrine\\DBAL\\Driver\\PDOException(code: 42S02): SQLSTATE[42S02]: Base table or view not found: 1146 Table 'mautic.lead_lists_leads' doesn't exist at /MAUTICDIR/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:106, PDOException(code: 42S02): SQLSTATE[42S02]: Base table or view not found: 1146 Table 'mautic.lead_lists_leads' doesn't exist at /MAUTICDIR/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:104)"} []

It appeared one table in the function did not get the prefix appended to it. Therefore the Campaign share for a segment would not render if you use a prefix in the database. It would just show `%`.

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Setup your instance with a table prefix
3. Create a campaign
4. Create a segment
5. After the Campaign share is calculated one of two things will happen (for me this sometimes takes a reload, but other times it appears after a few seconds)
5.1. If no contacts are in the segment or no contacts of the segment are in campaigns the list will be cleared
5.2. If a contact is in a campaign and in this segment a percentage will show

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
