### PR TITLE
Fixed impossible statement

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -1525,7 +1525,7 @@ class CommonRepository extends EntityRepository
                             break;
                         case 'isEmpty':
                         case 'isNotEmpty':
-                            if ('empty' === $clause['expr']) {
+                            if ('isEmpty' === $clause['expr']) {
                                 $whereClause = $query->expr()->orX(
                                     $query->expr()->eq($column, $query->expr()->literal('')),
                                     $query->expr()->isNull($column)


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features"<!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | N/A
| Related user documentation PR URL      | N/A <!-- required for new features -->
| Related developer documentation PR URL | N/A <!-- required for developer-facing changes -->
| Issue(s) addressed                     | N/A <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
Since the switch case uses `$clause['expr']` and the case is for `isEmpty` and `isNotEmpty` the if statement inside the case can never be true since we know the value is `isEmpty` or `isNotEmpty`.

The issue is not testable, since it is not really used anywhere. Found while building a new plugin.

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
