### PR TITLE
Php 7 unit test fix

### DIFF
--- a/app/bundles/CoreBundle/Tests/Unit/Helper/InputHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/InputHelperTest.php
@@ -169,7 +169,7 @@ class InputHelperTest extends TestCase
     /**
      * @dataProvider urlProvider
      */
-    public function testUrlSanitization(string $inputUrl, $outputUrl, bool $ignoreFragment = false): void
+    public function testUrlSanitization(string $inputUrl, string $outputUrl, bool $ignoreFragment = false): void
     {
         $cleanedUrl = InputHelper::url($inputUrl, false, null, null, [], $ignoreFragment);
 

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/InputHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/InputHelperTest.php
@@ -169,7 +169,7 @@ class InputHelperTest extends TestCase
     /**
      * @dataProvider urlProvider
      */
-    public function testUrlSanitization(string $inputUrl, string $outputUrl, bool $ignoreFragment = false): void
+    public function testUrlSanitization(string $inputUrl, $outputUrl, bool $ignoreFragment = false): void
     {
         $cleanedUrl = InputHelper::url($inputUrl, false, null, null, [], $ignoreFragment);
 
@@ -191,7 +191,11 @@ class InputHelperTest extends TestCase
         yield ['http://user:password@www.mautic.org', 'http://user:password@www.mautic.org'];
 
         // user and password have tags stripped
-        yield ['http://<img>:<img>@www.mautic.org', 'http://:@www.mautic.org'];
+        // PHP 7.3.26 changed behavior for this type of URL but in either case, the <img> tag is sanitized
+        $sanitizedUrl = (\version_compare(PHP_VERSION, '7.3.25', '>=')) ?
+            'http://&#60;img&#62;:&#60;img&#62;@www.mautic.org' :
+            'http://:@www.mautic.org';
+        yield ['http://<img>:<img>@www.mautic.org', $sanitizedUrl];
 
         // host is cleaned (should have the whole url go through ::clean() because it's not recognized as a valid host
         yield ['http://<img/src="doesnotexist.jpg">', 'http://&#60;img/src=&#34;doesnotexist.jpg&#34;&#62;'];

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/InputHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/InputHelperTest.php
@@ -192,7 +192,7 @@ class InputHelperTest extends TestCase
 
         // user and password have tags stripped
         // PHP 7.3.26 changed behavior for this type of URL but in either case, the <img> tag is sanitized
-        $sanitizedUrl = (\version_compare(PHP_VERSION, '7.3.25', '>=')) ?
+        $sanitizedUrl = (\version_compare(PHP_VERSION, '7.3.26', '>=')) ?
             'http://&#60;img&#62;:&#60;img&#62;@www.mautic.org' :
             'http://:@www.mautic.org';
         yield ['http://<img>:<img>@www.mautic.org', $sanitizedUrl];


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | no (only affects tests)
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
#### Description:
Looks like PHP 7.3.26 changed behavior for validating a URL that has tags in the username or password which is causing our tests to fail. This addresses the test. There is no need to change the behavior of the code because the URL is sanitized regardless of PHP version. 

#### Steps to test this PR:
1. Tests should pass

