### PR TITLE
Add DDEV first-run experience 🚀

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -16,4 +16,6 @@ composer_version: "1"
 webimage_extra_packages: [php7.4-imap]
 hooks:
   post-start:
+    # Fix line endings on Windows
+    - exec: sed -i -e 's/\r$//' ./.ddev/mautic-setup.sh
     - exec: "./.ddev/mautic-setup.sh"

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,0 +1,19 @@
+name: mautic
+type: php
+docroot: ""
+php_version: "7.4"
+webserver_type: apache-fpm
+router_http_port: "80"
+router_https_port: "443"
+xdebug_enabled: false
+additional_hostnames: []
+additional_fqdns: []
+mariadb_version: "10.3"
+mysql_version: ""
+provider: default
+use_dns_when_possible: true
+composer_version: "1"
+webimage_extra_packages: [php7.4-imap]
+hooks:
+  post-start:
+    - exec: "./.ddev/mautic-setup.sh"

--- a/.ddev/local.config.php.dist
+++ b/.ddev/local.config.php.dist
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Parameter overrides for DDEV.
+ */
+$parameters = [
+    'api_enabled'           => true,
+    'api_enable_basic_auth' => true,
+    'db_driver'             => 'pdo_mysql',
+    'db_host'               => 'db',
+    'db_table_prefix'       => null,
+    'db_port'               => 3306,
+    'db_name'               => 'db',
+    'db_user'               => 'db',
+    'db_password'           => 'db',
+    'admin_email'           => 'mautic@ddev.local',
+    'admin_password'        => 'mautic',
+];

--- a/.ddev/mautic-setup.sh
+++ b/.ddev/mautic-setup.sh
@@ -23,6 +23,7 @@ setup_mautic() {
     printf "🌐 To open MailHog for seeing all emails that Mautic sent, go to https://${DDEV_HOSTNAME}:8026 in your browser.\n"
     printf "🚀 Run \"ddev exec composer test\" to run PHPUnit tests.\n"
     printf "🚀 Run \"ddev exec bin/console COMMAND\" (like mautic:segments:update) to use the Mautic CLI. For an overview of all available CLI commands, go to https://mau.tc/cli\n"
+    printf "🔴 If you want to stop the instance, simply run \"ddev stop\".\n"
     tput sgr0
 }
 

--- a/.ddev/mautic-setup.sh
+++ b/.ddev/mautic-setup.sh
@@ -17,12 +17,12 @@ setup_mautic() {
 
     tput setaf 2
     printf "All done! Here's some useful information:\n"
-    printf "🔒 The default login is admin/mautic!\n"
+    printf "🔒 The default login is admin/mautic\n"
     printf "🌐 To open the Mautic instance, go to https://${DDEV_HOSTNAME} in your browser.\n"
     printf "🌐 To open PHPMyAdmin for managing the database, go to https://${DDEV_HOSTNAME}:8037 in your browser.\n"
     printf "🌐 To open MailHog for seeing all emails that Mautic sent, go to https://${DDEV_HOSTNAME}:8026 in your browser.\n"
     printf "🚀 Run \"ddev exec composer test\" to run PHPUnit tests.\n"
-    printf "🚀 Run \"ddev exec bin/console COMMAND (like mautic:segments:update) to use the Mautic CLI. For an overview of all available CLI commands, go to https://mau.tc/cli\n"
+    printf "🚀 Run \"ddev exec bin/console COMMAND\" (like mautic:segments:update) to use the Mautic CLI. For an overview of all available CLI commands, go to https://mau.tc/cli\n"
     tput sgr0
 }
 

--- a/.ddev/mautic-setup.sh
+++ b/.ddev/mautic-setup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+setup_mautic() {
+    printf "Installing Mautic Composer dependencies...\n"
+    composer install
+
+    cp ./.ddev/local.config.php.dist ./app/config/local.php
+
+    printf "Installing Mautic...\n"
+    php bin/console mautic:install https://${DDEV_HOSTNAME} \
+        --mailer_from_name="DDEV" --mailer_from_email="mautic@ddev.local" \
+        --mailer_transport="smtp" --mailer_host="localhost" --mailer_port="1025"
+    php bin/console cache:warmup --no-interaction --env=dev
+
+    printf "Enabling plugins...\n"
+    php bin/console mautic:plugins:reload
+
+    tput setaf 2
+    printf "All done! Here's some useful information:\n"
+    printf "🔒 The default login is admin/mautic!\n"
+    printf "🌐 To open the Mautic instance, go to https://${DDEV_HOSTNAME} in your browser.\n"
+    printf "🌐 To open PHPMyAdmin for managing the database, go to https://${DDEV_HOSTNAME}:8037 in your browser.\n"
+    printf "🌐 To open MailHog for seeing all emails that Mautic sent, go to https://${DDEV_HOSTNAME}:8026 in your browser.\n"
+    printf "🚀 Run \"ddev exec composer test\" to run PHPUnit tests.\n"
+    printf "🚀 Run \"ddev exec bin/console COMMAND (like mautic:segments:update) to use the Mautic CLI. For an overview of all available CLI commands, go to https://mau.tc/cli\n"
+    tput sgr0
+}
+
+# Check if the user has indicated their preference for the Mautic installation
+# already (DDEV-managed or self-managed)
+if ! test -f ./.ddev/mautic-preference
+then
+    tput setab 3
+    tput setaf 0
+    printf "Do you want us to set up the Mautic instance for you with the recommended settings for DDEV?\n"
+    printf "If you answer \"no\", you will have to set up the Mautic instance yourself."
+    tput sgr0
+    printf "\nAnswer [yes/no]: "
+    read MAUTIC_PREF
+
+    if [[ $MAUTIC_PREF == "yes" ]]
+    then
+        printf "Okay, setting up your Mautic instance... 🚀\n"
+        echo "ddev-managed" > ./.ddev/mautic-preference
+        setup_mautic
+    else
+        printf "Okay, you'll have to set up the Mautic instance yourself. That's what pros do, right? Good luck! 🚀\n"
+        echo "unmanaged" > ./.ddev/mautic-preference
+    fi
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 !.gitignore
 !.htaccess
 !.gitkeep
+!.ddev
+.ddev/mautic-preference
 .php_cs.cache
 /.env
 /composer.phar

--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -324,10 +324,10 @@ class InstallCommand extends ContainerAwareCommand
                         $output->writeln('Missing optional settings:');
                         $this->handleInstallerErrors($output, $messages['optional']);
 
-                        if (!isset($options['force'])) {
+                        if (empty($options['force'])) {
                             // Ask user to confirm install when optional settings missing
                             $helper   = $this->getHelper('question');
-                            $question = new ConfirmationQuestion('Continue with install anyway? ', false);
+                            $question = new ConfirmationQuestion('Continue with install anyway? [yes/no]', false);
 
                             if (!$helper->ask($input, $output, $question)) {
                                 return -$step;

--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -238,7 +238,7 @@ class CheckStep implements StepInterface
 
         $memoryLimit    = FileHelper::convertPHPSizeToBytes(ini_get('memory_limit'));
         $suggestedLimit = FileHelper::convertPHPSizeToBytes(self::$memory_limit);
-        if ($memoryLimit < $suggestedLimit) {
+        if ($memoryLimit > -1 && $memoryLimit < $suggestedLimit) {
             $messages[] = 'mautic.install.memory.limit';
         }
 

--- a/build/exclude_files.txt
+++ b/build/exclude_files.txt
@@ -1,5 +1,6 @@
 *.git*
 *.idea*
+.ddev/*
 .DS_Store
 .env.dist
 .github/*


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | features
| Bug fix?                               | no
| New feature?                           | yes
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | N/A
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | ⚠️ TO DO!!!
| Issue(s) addressed                     | N/A

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

Adds a first-run experience for DDEV users.
When the user runs `ddev start` for the first time, they will be greeted with the following message:

```
$ ddev start
Do you want us to set up the Mautic instance for you with the recommended settings for DDEV?
If you answer "no", you will have to set up the Mautic instance yourself.
```

After installation, they will see some useful information to get started:

```
All done! Here's some useful information:
🔒 The default login is admin/mautic!
🌐 To open the Mautic instance, go to https://mautic.ddev.site in your browser.
🌐 To open PHPMyAdmin for managing the database, go to https://mautic.ddev.site:8037 in your browser.
🌐 To open MailHog for seeing all emails that Mautic sent, go to https://mautic.ddev.site:8026 in your browser.
🚀 Run "ddev exec composer test" to run PHPUnit tests.
🚀 Run "ddev exec bin/console COMMAND (like mautic:segments:update) to use the Mautic CLI. For an overview of all available CLI commands, go to https://mau.tc/cli
```

In the background, the following happens:
- Setup environment with PHP 7.4, Apache, Composer 1 (until Mautic 4 is released, which will add Composer 2 support)
- Install composer dependencies
- Install Mautic with user admin/mautic, API enabled, database set to db/db/db/db (DDEV default), MailHog for emails

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Checkout this PR locally
2. Run `ddev start` (assuming you have DDEV installed)

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
