### PR TITLE
Fix IpLookupHelper bug

### DIFF
--- a/app/bundles/ApiBundle/Form/Type/ClientType.php
+++ b/app/bundles/ApiBundle/Form/Type/ClientType.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * @copyright   2014 Mautic Contributors. All rights reserved
  * @author      Mautic

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * @copyright   2014 Mautic Contributors. All rights reserved
  * @author      Mautic

--- a/app/bundles/CategoryBundle/Model/CategoryModel.php
+++ b/app/bundles/CategoryBundle/Model/CategoryModel.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * @copyright   2014 Mautic Contributors. All rights reserved
  * @author      Mautic

--- a/app/bundles/CoreBundle/Helper/IpLookupHelper.php
+++ b/app/bundles/CoreBundle/Helper/IpLookupHelper.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * @copyright   2016 Mautic Contributors. All rights reserved
  * @author      Mautic

--- a/app/bundles/CoreBundle/Helper/IpLookupHelper.php
+++ b/app/bundles/CoreBundle/Helper/IpLookupHelper.php
@@ -180,7 +180,7 @@ class IpLookupHelper
             $ipAddress->setDoNotTrackList($doNotTrack);
 
             if ($ipAddress->isTrackable() && $request) {
-                $userAgent = $request->headers->get('User-Agent');
+                $userAgent = $request->headers->get('User-Agent', '');
                 foreach ($this->doNotTrackBots as $bot) {
                     if (false !== strpos($userAgent, $bot)) {
                         $doNotTrack[] = $ip;

--- a/app/bundles/CoreBundle/Menu/MenuHelper.php
+++ b/app/bundles/CoreBundle/Menu/MenuHelper.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * @copyright   2014 Mautic Contributors. All rights reserved
  * @author      Mautic

--- a/app/bundles/CoreBundle/Templating/Helper/SecurityHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/SecurityHelper.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * @copyright   2014 Mautic Contributors. All rights reserved
  * @author      Mautic

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * @copyright   2014 Mautic Contributors. All rights reserved
  * @author      Mautic

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * @copyright   2018 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * @copyright   2014 Mautic Contributors. All rights reserved
  * @author      Mautic

--- a/app/bundles/LeadBundle/Tracker/ContactTracker.php
+++ b/app/bundles/LeadBundle/Tracker/ContactTracker.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * @copyright   2017 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.

--- a/app/bundles/LeadBundle/Tracker/Service/ContactTrackingService/ContactTrackingService.php
+++ b/app/bundles/LeadBundle/Tracker/Service/ContactTrackingService/ContactTrackingService.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * @copyright   2016 Mautic Contributors. All rights reserved
  * @author      Mautic

--- a/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingService.php
+++ b/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingService.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * @copyright   2016 Mautic Contributors. All rights reserved
  * @author      Mautic

--- a/app/bundles/NotificationBundle/Helper/NotificationHelper.php
+++ b/app/bundles/NotificationBundle/Helper/NotificationHelper.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * @copyright   2016 Mautic Contributors. All rights reserved
  * @author      Mautic

--- a/app/bundles/PageBundle/Helper/TrackingHelper.php
+++ b/app/bundles/PageBundle/Helper/TrackingHelper.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * @copyright   2016 Mautic Contributors. All rights reserved
  * @author      Mautic


### PR DESCRIPTION
I enabled PHP `strict_types` on a few files in https://github.com/mautic/mautic/pull/9667, including the IpLookupHelper. While Mautic's tests passed, there is one test that is now failing in the API Library:

https://github.com/mautic/api-library/pull/235/checks?check_run_id=1898895191

```
Response: {"errors":[{"message":"Type error: strpos() expects parameter 1 to be string, null given","code":500,"type":null}],"trace":[{"namespace":"","short_class":"","class":"","type":"","function":"","file":"\/var\/www\/html\/mautic\/app\/bundles\/CoreBundle\/Helper\/IpLookupHelper.php","line":185,"args":[]},{"namespace":"","short_class":"","class":"","type":"","function":"strpos","file":"\/var\/www\/html\/mautic\/app\/bundles\/CoreBundle\/Helper\/IpLookupHelper.php","line":185,"args":[]},{"namespace":"Mautic\\CoreBundle\\Helper","short_class":"IpLookupHelper","class":"Mautic\\CoreBundle\\Helper\\IpLookupHelper","type":"-\u003E","function":"getIpAddress","file":"\/var\/www\/html\/mautic\/app\/bundles\/PointBundle\/Controller\/Api\/PointApiController.php","line":97,"args":[]},{"namespace":"Mautic\\PointBundle\\Controller\\Api","short_class":"PointApiController","class":"Mautic\\PointBundle\\Controller\\Api\\PointApiController","type":"-\u003E","function":"logApiPointChange","file":"\/var\/www\/...
```

**Background**
`$request->headers->get()` returns `null` by default, while `strpos()` under it requires a string. Without `strict_types`, PHP quietly converts `null` to an empty string, but now, it throws an error instead. This PR sets the default output of `$request->headers->get()` to an empty string `''` instead of `null`, fixing this issue.