### PR TITLE
Add release note generation logic to GitHub Actions

### DIFF
--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -1,0 +1,7 @@
+changelog:
+  repository: mautic/mautic
+  sections:
+  - title: "Enhancements"
+    labels: ["enhancement", "feature"]
+  - title: "Bugs"
+    labels: ["bug", "regression"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,29 @@ jobs:
 
         echo "IS_PRERELEASE=${PRERELEASE}" >> $GITHUB_ENV
 
+    - name: "Try generating the release notes"
+      run: |
+        # Version as indicated in the metadata, e.g., 3.2.5-rc
+        METADATA_VERSION=$(jq -r '.version' app/release_metadata.json)
+
+        # We only need the first part of the version, e.g. 3.2.5, for the milestone recognition. Split on the dash (-) character.
+        METADATA_ARRAY=(${METADATA_VERSION//-/ })
+        POSSIBLE_MILESTONE=${METADATA_ARRAY[0]}
+
+        # In case the Jar below fails, fall back to a default text
+        echo "MAUTIC_CHANGELOG=\"**Based on Mautic's version number (${POSSIBLE_MILESTONE}), we tried finding a milestone with the same name. We couldn't find it though. Make sure it exists (and re-run GitHub Actions) or add a changelog manually!**\"" >> $GITHUB_ENV
+
+        # Download changelog generator
+        wget https://github.com/spring-io/github-changelog-generator/releases/download/v0.0.5/github-changelog-generator.jar
+
+        # Copy of release-notes.yml to root folder needed, since the Jar can't read from hidden folders anymore (bug): https://github.com/Decathlon/release-notes-generator-action/pull/21
+        cp ./.github/release-notes.yml ./release-notes.yml
+        java -jar ./github-changelog-generator.jar --spring.config.location="./release-notes.yml" ${POSSIBLE_MILESTONE} mautic-changelog.txt
+
+        echo 'MAUTIC_CHANGELOG<<EOF' >> $GITHUB_ENV
+        cat mautic-changelog.txt >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
@@ -72,7 +95,7 @@ jobs:
         draft: true
         prerelease: ${{ env.IS_PRERELEASE }}
         body: |
-          TODO add release notes here!
+          ${{ env.MAUTIC_CHANGELOG }}
 
           ${{ env.MAUTIC_SHA1_CONTENTS }}
 

--- a/.github/workflows/temp-release-notes.yml
+++ b/.github/workflows/temp-release-notes.yml
@@ -1,0 +1,33 @@
+name: test
+on:
+  push:
+  pull_request:
+
+jobs:
+  release:
+    name: Create draft release
+    runs-on: ubuntu-latest
+    steps:
+      run: |
+        # Version as indicated in the metadata, e.g., 3.2.5-rc
+        METADATA_VERSION=$(jq -r '.version' app/release_metadata.json)
+
+        # We only need the first part of the version, e.g. 3.2.5, for the milestone recognition. Split on the dash (-) character.
+        METADATA_ARRAY=(${METADATA_VERSION//-/ })
+        POSSIBLE_MILESTONE=${METADATA_ARRAY[0]}
+
+        # In case the Jar below fails, fall back to a default text
+        echo "MAUTIC_CHANGELOG=\"**Based on Mautic's version number (${POSSIBLE_MILESTONE}), we tried finding a milestone with the same name. We couldn't find it though. Make sure it exists (and re-run GitHub Actions) or add a changelog manually!**\"" >> $GITHUB_ENV
+
+        # Download changelog generator
+        wget https://github.com/spring-io/github-changelog-generator/releases/download/v0.0.5/github-changelog-generator.jar
+
+        # Copy of release-notes.yml to root folder needed, since the Jar can't read from hidden folders anymore (bug): https://github.com/Decathlon/release-notes-generator-action/pull/21
+        cp ./.github/release-notes.yml ./release-notes.yml
+        java -jar ./github-changelog-generator.jar --spring.config.location="./release-notes.yml" ${POSSIBLE_MILESTONE} mautic-changelog.txt
+
+        echo 'MAUTIC_CHANGELOG<<EOF' >> $GITHUB_ENV
+        cat mautic-changelog.txt >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+
+        echo ${{ env.MAUTIC_CHANGELOG }}


### PR DESCRIPTION
Generates the release notes automatically in the GitHub Actions release step! :)

Will add better docs later. Let's try it for the 3.3.0 release.