### PR TITLE
Add release note generation logic to GitHub Actions

### DIFF
--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -1,0 +1,7 @@
+changelog:
+  repository: mautic/mautic
+  sections:
+  - title: "Enhancements"
+    labels: ["enhancement", "feature"]
+  - title: "Bugs"
+    labels: ["bug", "regression"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,31 @@ jobs:
 
         echo "IS_PRERELEASE=${PRERELEASE}" >> $GITHUB_ENV
 
+    - name: "Try generating the release notes"
+      run: |
+        # Version as indicated in the metadata, e.g., 3.2.5-rc
+        METADATA_VERSION=$(jq -r '.version' app/release_metadata.json)
+
+        # We only need the first part of the version, e.g. 3.2.5, for the milestone recognition. Split on the dash (-) character.
+        METADATA_ARRAY=(${METADATA_VERSION//-/ })
+        POTENTIAL_MILESTONE=${METADATA_ARRAY[0]}
+
+        echo "Will try to create changelog based on milestone ${POTENTIAL_MILESTONE} if it exists..."
+
+        # In case the Jar below fails, fall back to a default text
+        echo "MAUTIC_CHANGELOG=\"**Based on Mautic's version number (${POTENTIAL_MILESTONE}), we tried finding a milestone with the same name. We couldn't find it though. Make sure it exists (and re-run GitHub Actions) or add a changelog manually!**\"" >> $GITHUB_ENV
+
+        # Download changelog generator
+        wget -q https://github.com/spring-io/github-changelog-generator/releases/download/v0.0.5/github-changelog-generator.jar
+
+        # Copy of release-notes.yml to root folder needed, since the Jar can't read from hidden folders anymore (bug): https://github.com/Decathlon/release-notes-generator-action/pull/21
+        cp ./.github/release-notes.yml ./release-notes.yml
+        java -jar ./github-changelog-generator.jar --spring.config.location="./release-notes.yml" ${POTENTIAL_MILESTONE} mautic-changelog.txt
+
+        echo 'MAUTIC_CHANGELOG<<EOF' >> $GITHUB_ENV
+        cat mautic-changelog.txt >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
@@ -72,7 +97,7 @@ jobs:
         draft: true
         prerelease: ${{ env.IS_PRERELEASE }}
         body: |
-          TODO add release notes here!
+          ${{ env.MAUTIC_CHANGELOG }}
 
           ${{ env.MAUTIC_SHA1_CONTENTS }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,11 +80,13 @@ jobs:
 
         # Copy of release-notes.yml to root folder needed, since the Jar can't read from hidden folders anymore (bug): https://github.com/Decathlon/release-notes-generator-action/pull/21
         cp ./.github/release-notes.yml ./release-notes.yml
-        java -jar ./github-changelog-generator.jar --spring.config.location="./release-notes.yml" ${POTENTIAL_MILESTONE} mautic-changelog.txt
+        java -jar ./github-changelog-generator.jar --spring.config.location="./release-notes.yml" ${POTENTIAL_MILESTONE} mautic-changelog.txt || true
 
-        echo 'MAUTIC_CHANGELOG<<EOF' >> $GITHUB_ENV
-        cat mautic-changelog.txt >> $GITHUB_ENV
-        echo 'EOF' >> $GITHUB_ENV
+        if [[ -f mautic-changelog.txt ]]; then
+          echo 'MAUTIC_CHANGELOG<<EOF' >> $GITHUB_ENV
+          cat mautic-changelog.txt >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+        fi
 
     - name: Create Release
       id: create_release


### PR DESCRIPTION
Generates the release notes automatically in the GitHub Actions release step! :)

Let's give this a shot for the 3.3.0 release. **Make sure you have moved PRs/issues out of the milestone that aren't relevant first!**.

This uses the following changelog generator under the hood: https://github.com/spring-io/github-changelog-generator - you can edit the `.github/release-notes.yml` file as you like if you want to change the formatting. See https://github.com/spring-io/github-changelog-generator#customizing-sections for all possible options.

@RCheesley are the labels I selected in `.github/release-notes.yml` correct and complete? Please note that PRs which don't have any of these labels won't be included in the release notes.

Example based on the `3.2.5` milestone:

```
## Bugs

- Fix dashboard query performance [#9520](https://github.com/mautic/mautic/pull/9520)
- Focus items in dynamic web content [#9519](https://github.com/mautic/mautic/pull/9519)
- Fix absolute url in pages [#9515](https://github.com/mautic/mautic/pull/9515)
- Fix gated video showing play button above form (Issue #9431) [#9476](https://github.com/mautic/mautic/pull/9476)
- Update db_server_version on existing Mautic instances [#9458](https://github.com/mautic/mautic/pull/9458)
- Check for country/city presence before use. [#9410](https://github.com/mautic/mautic/pull/9410)
- Plugins Not Loading + Database type Error [#9200](https://github.com/mautic/mautic/issues/9200)
- Fix: Report when use Contact Point Log as data source and filter by Segment  [#8746](https://github.com/mautic/mautic/pull/8746)
- Fix input format for onesignal. [#8605](https://github.com/mautic/mautic/pull/8605)
- Fixed batch delete response inconsistencies [#7815](https://github.com/mautic/mautic/pull/7815)

## :heart: Contributors

We'd like to thank all the contributors who worked on this release!

- [@alanhartless](https://github.com/alanhartless)
- [@hluchas](https://github.com/hluchas)
- [@dennisameling](https://github.com/dennisameling)
- [@dev-marcel](https://github.com/dev-marcel)
- [@crasx](https://github.com/crasx)
- [@gabepri](https://github.com/gabepri)
- [@kuzmany](https://github.com/kuzmany)
- [@letharion](https://github.com/letharion)
```