### PR TITLE
Use --force option on Mautic CI installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
         mkdir -p ./mautic-testing/var/logs
         cp ./.github/ci-files/local.php ./mautic-testing/app/config/local.php
         cd ./mautic-testing
-        php bin/console mautic:install http://localhost
+        php bin/console mautic:install --force http://localhost
 
     - name: Store log artifacts
       if: ${{ always() }}
@@ -225,7 +225,7 @@ jobs:
         mkdir -p ./mautic-testing/var/logs
         cp ./.github/ci-files/local.php ./mautic-testing/app/config/local.php
         cd ./mautic-testing
-        php bin/console mautic:install http://localhost
+        php bin/console mautic:install --force http://localhost
     
     - name: "Download update package artifact ${{ env.MAUTIC_VERSION }}-update.zip"
       uses: actions/download-artifact@v2


### PR DESCRIPTION
Not related to Mautic itself, but to the release CI pipeline.

Some background: in #9669, we [fixed](https://github.com/mautic/mautic/pull/9669/files#diff-3f4f2585f859179efd379e162d873ca11b7daa63b2b797845700a4af305e3d68R327-R330) the behavior of `php bin/console mautic:install`. It was supposed to ask `Continue with install anyway?` if optional settings are missing, but it didn't. Now it does, but - guess what - it introduces problems in our CI pipeline! 🤯 🤦🏼 

In Mautic's CI, we obviously cannot provide user input in the terminal, so the installation will just stop with:

```
Missing optional settings:
  - [0] It is recommended to secure your installation with an SSL certificate (https). Starting February 2020 Google Chrome will stop sending third-party cookies in cross-site requests unless the cookies are secure. Tracking will stop working for Mautic instances running on HTTP. Use HTTPS.
```

Luckily, we can add a `--force` option to the installation command, which only applies to optional failing checks. This PR does exactly that, fixing CI 🚀 