### PR TITLE
Include GrapesJsBuilderBundle in build script for update package

### DIFF
--- a/build/package_release.php
+++ b/build/package_release.php
@@ -90,9 +90,11 @@ if (!isset($args['repackage'])) {
     // Only add deleted files to our list; new and modified files will be covered by the archive
     $deletedFiles  = [];
     $modifiedFiles = [
-        'deleted_files.txt'       => true,
-        'critical_migrations.txt' => true,
-        'upgrade.php'             => true,
+        'deleted_files.txt'              => true,
+        'critical_migrations.txt'        => true,
+        'upgrade.php'                    => true,
+        // Temp fix for GrapesJs builder
+        'plugins/GrapesJsBuilderBundle/' => true,
     ];
 
     // Create a flag to check if the vendors changed


### PR DESCRIPTION
Fixes #9710

The GrapesJsBuilderBundle is missing in `3.3.0-update.zip`:

![image](https://user-images.githubusercontent.com/17739158/108844295-3527fc80-75dc-11eb-9946-e6af4c8994c6.png)

This PR hotfixes that by hardcoding it in the build script

**Some background**

The release script (`build/package_release.php`) basically uses `git diff` to find out all the differences. But since the GrapesJSBundle is ignored by Git due to Mautic's .gitignore file, it's not included in the update package since `git diff` ignores it as well. Yay! Suggestion: use the same package for both the full and the update package, since the difference is literally ~600kB. Then in Mautic 4 we could start using a single package only.

![image](https://user-images.githubusercontent.com/17739158/108844498-7fa97900-75dc-11eb-994c-5a2705155f0f.png)
