### PR TITLE
Set INT(11) on lead_lists migration

### DIFF
--- a/app/migrations/Version20210104171005.php
+++ b/app/migrations/Version20210104171005.php
@@ -31,7 +31,7 @@ final class Version20210104171005 extends AbstractMauticMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql("ALTER TABLE {$this->prefix}lead_lists ADD category_id INT UNSIGNED DEFAULT NULL");
+        $this->addSql("ALTER TABLE {$this->prefix}lead_lists ADD category_id INT(11) UNSIGNED DEFAULT NULL");
         $this->addSql("ALTER TABLE {$this->prefix}lead_lists ADD CONSTRAINT FK_6EC1522A12469DE2 FOREIGN KEY (category_id) REFERENCES {$this->prefix}categories (id) ON DELETE SET NULL");
         $this->addSql("CREATE INDEX IDX_6EC1522A12469DE2 ON {$this->prefix}lead_lists (category_id)");
     }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | features
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | N/A
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #9709

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

I have no clue how this failed in the first place since the migration ran successfully on my test instance with MariaDB 10.2.

However, this will fix things for the original reported. 

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up this PR locally
2. Run `php bin/console doctrine:migrations:migrate 20201207140911` to rollback to the previous version
3. Run `php bin/console doctrine:migrations:migrate 20210104171005` to run the affected migration again, it should finish without any issues

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
