### PR TITLE
Fix migration for 3.3.0

### DIFF
--- a/app/migrations/Version20210223174702.php
+++ b/app/migrations/Version20210223174702.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2021 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        https://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\SkipMigration;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+final class Version20210223174702 extends AbstractMauticMigration
+{
+    /**
+     * @throws SkipMigration
+     */
+    public function preUp(Schema $schema): void
+    {
+        $idxName = $this->getIdxName();
+        if ($schema->getTable($this->prefix.'lead_lists')->hasIndex($idxName)) {
+            // The category_id column is assumed to have been created with the foreign key and index by Version20210104171005
+            throw new SkipMigration('Schema includes this migration');
+        }
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Fix bad migration from 3.3.0
+        $fkName  = $this->getFkName();
+        $idxName = $this->getIdxName();
+        $table   = $schema->getTable($this->prefix.'lead_lists');
+
+        // fk and idx names may be different based on the table name so remove hard coded names in favor of what Doctrine would dynamically generate
+        $oldFkName  = 'FK_6EC1522A12469DE2';
+        if ($oldFkName !== $fkName && $table->hasForeignKey($oldFkName)) {
+            $this->addSql("ALTER TABLE {$this->prefix}lead_lists DROP FOREIGN KEY $oldFkName");
+        }
+
+        $oldIdxName = 'IDX_6EC1522A12469DE2';
+        if ($oldIdxName !== $idxName && $table->hasIndex($idxName)) {
+            $this->addSql("ALTER TABLE {$this->prefix}lead_lists DROP INDEX $oldIdxName");
+        }
+
+        // Add the new column if it failed for any reason
+        if (!$table->hasColumn('category_id')) {
+            $categoryIdColumn = $schema->getTable("{$this->prefix}categories")->getColumn('id');
+            if ($categoryIdColumn->getUnsigned()) {
+                $this->addSql("ALTER TABLE {$this->prefix}lead_lists ADD category_id INT UNSIGNED DEFAULT NULL");
+            } else {
+                $this->addSql("ALTER TABLE {$this->prefix}lead_lists ADD category_id INT DEFAULT NULL");
+            }
+        }
+
+        // Add the foreign key if it was removed above and/or failed to create due to M2 schema
+        if (!$table->hasForeignKey($fkName)) {
+            $this->addSql(
+                "ALTER TABLE {$this->prefix}lead_lists ADD CONSTRAINT $fkName FOREIGN KEY (category_id) REFERENCES {$this->prefix}categories (id) ON DELETE SET NULL"
+            );
+        }
+
+        // Add the index if it was removed above and/or failed to create due to M2 schema
+        if (!$table->hasIndex($idxName)) {
+            $this->addSql("CREATE INDEX $idxName ON {$this->prefix}lead_lists (category_id)");
+        }
+    }
+
+    private function getFkName(): string
+    {
+        return $this->generatePropertyName('lead_lists', 'fk', ['category_id']);
+    }
+
+    private function getIdxName(): string
+    {
+        return $this->generatePropertyName('lead_lists', 'idx', ['category_id']);
+    }
+}

--- a/app/migrations/Version20210223174702.php
+++ b/app/migrations/Version20210223174702.php
@@ -37,7 +37,7 @@ final class Version20210223174702 extends AbstractMauticMigration
         $table   = $schema->getTable($this->prefix.'lead_lists');
 
         // fk and idx names may be different based on the table name so remove hard coded names in favor of what Doctrine would dynamically generate
-        $oldFkName  = 'FK_6EC1522A12469DE2';
+        $oldFkName = 'FK_6EC1522A12469DE2';
         if ($oldFkName !== $fkName && $table->hasForeignKey($oldFkName)) {
             $this->addSql("ALTER TABLE {$this->prefix}lead_lists DROP FOREIGN KEY $oldFkName");
         }
@@ -49,11 +49,13 @@ final class Version20210223174702 extends AbstractMauticMigration
 
         // Add the new column if it failed for any reason
         if (!$table->hasColumn('category_id')) {
-            $categoryIdColumn = $schema->getTable("{$this->prefix}categories")->getColumn('id');
+            $catTable         = $schema->getTable("{$this->prefix}categories");
+            $categoryIdColumn = $catTable->getColumn('id');
             if ($categoryIdColumn->getUnsigned()) {
                 $this->addSql("ALTER TABLE {$this->prefix}lead_lists ADD category_id INT UNSIGNED DEFAULT NULL");
             } else {
-                $this->addSql("ALTER TABLE {$this->prefix}lead_lists ADD category_id INT DEFAULT NULL");
+                $categoryIdLength = $categoryIdColumn->getLength();
+                $this->addSql("ALTER TABLE {$this->prefix}lead_lists ADD category_id INT($categoryIdLength) DEFAULT NULL");
             }
         }
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | features
| Bug fix?                               | no
| New feature?                           |no
| Deprecations?                          |no
| BC breaks?                             |no
| Automated tests included?              |no
| Related user documentation PR URL      | na
| Related developer documentation PR URL | na
| Issue(s) addressed                     | Fixes #9709

#### Description:
Replacing https://github.com/mautic/mautic/pull/9718 as 9718 seems to be confused with extra commits despite rebasing.

This addresses schema differences for M2 and M3 introduced in https://github.com/mautic/mautic/pull/9544.

@dennisameling confirmed that the unsigned/signed was the real culprit rather than int(11) vs int(10) so that code was removed and https://github.com/mautic/mautic/pull/9714 closed.


#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Preferably run the migrations on a failed upgrade, a M2  installation upgraded to M3, and an installation on M3. All three should work. (I've only tested on a M3 schema as I don't have a M2 schema but tried to manipulate the database to emulate all three scenarios). 

