### PR TITLE
Fix click on page events

### DIFF
--- a/app/bundles/CalendarBundle/Controller/DefaultController.php
+++ b/app/bundles/CalendarBundle/Controller/DefaultController.php
@@ -147,7 +147,7 @@ class DefaultController extends FormController
         return $this->delegateView([
             'viewParameters' => [
                 'form'   => $this->setFormTheme($form, $event->getContentTemplate()),
-                'tokens' => $builderComponents[$source.'Tokens'],
+                'tokens' => $builderComponents['tokens'],
                 'entity' => $entity,
                 'model'  => $model,
             ],

--- a/app/bundles/PageBundle/EventListener/CalendarSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/CalendarSubscriber.php
@@ -17,6 +17,7 @@ use Mautic\CalendarBundle\Event\CalendarGeneratorEvent;
 use Mautic\CalendarBundle\Event\EventGeneratorEvent;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
+use Mautic\PageBundle\Form\Type\PagePublishDatesType;
 use Mautic\PageBundle\Model\PageModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -153,7 +154,7 @@ class CalendarSubscriber implements EventSubscriberInterface
         $event->setModel($this->pageModel);
         $event->setEntity($entity);
         $event->setContentTemplate('MauticPageBundle:SubscribedEvents\Calendar:modal.html.php');
-        $event->setFormName('page_publish_dates');
+        $event->setFormName(PagePublishDatesType::class);
         $event->setAccess($this->security->hasEntityAccess(
             'page:pages:viewown', 'page:pages:viewother', $entity->getCreatedBy()));
     }

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -272,6 +272,7 @@ class PageModel extends FormModel
 
         if (!empty($options['formName'])) {
             $formClass = $options['formName'];
+            unset($options['formName']);
         }
 
         if (!empty($action)) {


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.3
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no

#### Description:

When you create a landing page and set Publish up date, it shows event in the calendar, if you click the event on the calendar you get error message as shown on the image.
![mautic-calendar](https://user-images.githubusercontent.com/18140846/110492492-88c53a80-80f2-11eb-8277-b286228d82b6.png)

This pull request fixes that.


#### Steps to test this PR:
1. Create landing page & set Publish at date to some value
2.  Go to Calendar
3. Try to click on the event you created.
