### PR TITLE
Avoid sending big substitutions to Sendgrid and fix Substitutions are limited to 50000 bytes per personalization block

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailPersonalization.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailPersonalization.php
@@ -55,7 +55,11 @@ class SendGridMailPersonalization
             }
 
             foreach ($metadata[$recipientEmail]['tokens'] as $token => $value) {
-                $personalization->addSubstitution($token, (string) $value);
+                $v = (string)$value;
+                if (strlen($v) > 10000) {
+                    continue;
+                }
+                $personalization->addSubstitution($token, $v);
             }
 
             $mail->addPersonalization($personalization);


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "1.6"
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
>

Probably fixes issues these issues:
https://forum.mautic.org/t/email-sending-error-substitutions-are-limited-to-10000-bytes-per-personalization-block/12036
https://forum.mautic.org/t/mautic-cant-send-email-with-sendgrid-api-need-help-with-cron-jobs/14902
https://forum.mautic.org/t/mautic-is-not-triggering-crons-and-email-campaigns-are-not-firing-on-time/14582

#### Description:

Mautic sends the email tokens to Sendgrid as substitutions. I don't know the exact reason, but all is okay unless it's shorter than 50000 bytes.
If it's bigger I get the error **Substitutions are limited to 50000 bytes per personalization block**
In my case it's 50000, in others is 10000.
I propose this solution: Skip the token if it's bigger than 10000 symbols.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Setup Mautic configuration to SendGrid api key.
3. Create an email
4. Create a variation >10KB
5. Try to send an example

Expected: Email was send
Actual: An error: Substitutions are limited to 50000 bytes per personalization block.
