### PR TITLE
Avoid sending big substitutions to Sendgrid and fix Substitutions are limited to 50000 bytes per personalization block

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailPersonalization.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailPersonalization.php
@@ -51,7 +51,11 @@ class SendGridMailPersonalization
             }
 
             foreach ($metadata[$recipientEmail]['tokens'] as $token => $value) {
-                $personalization->addSubstitution($token, (string) $value);
+                $v = (string)$value;
+                if (strlen($v) > 10000) {
+                    continue;
+                }
+                $personalization->addSubstitution($token, $v);
             }
 
             $mail->addPersonalization($personalization);


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.3
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
>

Probably fixes these issues:
https://forum.mautic.org/t/email-sending-error-substitutions-are-limited-to-10000-bytes-per-personalization-block/12036
https://forum.mautic.org/t/mautic-cant-send-email-with-sendgrid-api-need-help-with-cron-jobs/14902
https://forum.mautic.org/t/mautic-is-not-triggering-crons-and-email-campaigns-are-not-firing-on-time/14582

#### Description:

Mautic sends the email tokens to Sendgrid as substitutions. I don't know the exact reason, but everything works without issues when the substitutions are shorter than 50000 bytes.
If the substitutions exceed this amount I get the error **Substitutions are limited to 50000 bytes per personalization block**
In my case, it's 50000 bytes, in other cased I have found on the Internet the limit is even smaller - 10000 bytes.
I propose this solution: Mautic should skip the token if its size is bigger than 10000 symbols.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Set up Mautic configuration to use SendGrid api key.
3. Create an email
4. Create an email content variation >10KB
5. Try to send a sample email and get an error from SendGrid

Expected Result: Email was sent without issues
Actual: You get an error: Substitutions are limited to 50000 bytes per personalization block.