### PR TITLE
Replacing deprecated at() calls in unit tests

### DIFF
--- a/app/bundles/AssetBundle/EventListener/DetermineWinnerSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/DetermineWinnerSubscriber.php
@@ -11,7 +11,7 @@
 
 namespace Mautic\AssetBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\AssetBundle\AssetEvents;
 use Mautic\AssetBundle\Entity\Download;
 use Mautic\CoreBundle\Event\DetermineWinnerEvent;
@@ -22,7 +22,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 class DetermineWinnerSubscriber implements EventSubscriberInterface
 {
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $em;
 
@@ -31,7 +31,7 @@ class DetermineWinnerSubscriber implements EventSubscriberInterface
      */
     private $translator;
 
-    public function __construct(EntityManager $em, TranslatorInterface $translator)
+    public function __construct(EntityManagerInterface $em, TranslatorInterface $translator)
     {
         $this->em         = $em;
         $this->translator = $translator;

--- a/app/bundles/AssetBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2019 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -11,16 +13,24 @@
 
 namespace Mautic\AssetBundle\Tests\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\AssetBundle\Entity\DownloadRepository;
 use Mautic\AssetBundle\EventListener\DetermineWinnerSubscriber;
 use Mautic\CoreBundle\Event\DetermineWinnerEvent;
 use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var MockObject|EntityManagerInterface
+     */
     private $em;
+
+    /**
+     * @var MockObject|TranslatorInterface
+     */
     private $translator;
 
     /**
@@ -32,7 +42,7 @@ class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->em         = $this->createMock(EntityManager::class);
+        $this->em         = $this->createMock(EntityManagerInterface::class);
         $this->translator = $this->createMock(TranslatorInterface::class);
         $this->subscriber = new DetermineWinnerSubscriber($this->em, $this->translator);
     }
@@ -65,13 +75,8 @@ class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
                 ],
         ];
 
-        $this->translator->expects($this->at(0))
-            ->method('trans')
-            ->willReturn($transDownloads);
-
-        $this->translator->expects($this->at(1))
-            ->method('trans')
-            ->willReturn($transHits);
+        $this->translator->method('trans')
+            ->willReturnOnConsecutiveCalls($transDownloads, $transHits);
 
         $this->em->expects($this->once())
             ->method('getRepository')

--- a/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/DecisionDispatcherTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/DecisionDispatcherTest.php
@@ -42,13 +42,16 @@ class DecisionDispatcherTest extends \PHPUnit\Framework\TestCase
      */
     private $config;
 
-    private DecisionDispatcher $decisionDispatcher;
+    /**
+     * @var DecisionDispatcher
+     */
+    private $decisionDispatcher;
 
     protected function setUp(): void
     {
-        $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
-        $this->legacyDispatcher = $this->createMock(LegacyEventDispatcher::class);
-        $this->config = $this->createMock(DecisionAccessor::class);
+        $this->dispatcher         = $this->createMock(EventDispatcherInterface::class);
+        $this->legacyDispatcher   = $this->createMock(LegacyEventDispatcher::class);
+        $this->config             = $this->createMock(DecisionAccessor::class);
         $this->decisionDispatcher = new DecisionDispatcher($this->dispatcher, $this->legacyDispatcher);
     }
 

--- a/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/DecisionDispatcherTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/DecisionDispatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -20,39 +22,39 @@ use Mautic\CampaignBundle\EventCollector\Accessor\Event\DecisionAccessor;
 use Mautic\CampaignBundle\Executioner\Dispatcher\DecisionDispatcher;
 use Mautic\CampaignBundle\Executioner\Dispatcher\LegacyEventDispatcher;
 use Mautic\CampaignBundle\Executioner\Result\EvaluatedContacts;
-use PHPUnit\Framework\MockObject\MockBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class DecisionDispatcherTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var MockBuilder|EventDispatcherInterface
+     * @var MockObject|EventDispatcherInterface
      */
     private $dispatcher;
 
     /**
-     * @var MockBuilder|LegacyEventDispatcher
+     * @var MockObject|LegacyEventDispatcher
      */
     private $legacyDispatcher;
 
+    /**
+     * @var MockObject|DecisionAccessor
+     */
+    private $config;
+
+    private DecisionDispatcher $decisionDispatcher;
+
     protected function setUp(): void
     {
-        $this->dispatcher = $this->getMockBuilder(EventDispatcherInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->legacyDispatcher = $this->getMockBuilder(LegacyEventDispatcher::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->legacyDispatcher = $this->createMock(LegacyEventDispatcher::class);
+        $this->config = $this->createMock(DecisionAccessor::class);
+        $this->decisionDispatcher = new DecisionDispatcher($this->dispatcher, $this->legacyDispatcher);
     }
 
-    public function testDecisionEventIsDispatched()
+    public function testDecisionEventIsDispatched(): void
     {
-        $config = $this->getMockBuilder(DecisionAccessor::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $config->expects($this->once())
+        $this->config->expects($this->once())
             ->method('getEventName')
             ->willReturn('something');
 
@@ -63,16 +65,12 @@ class DecisionDispatcherTest extends \PHPUnit\Framework\TestCase
             ->method('dispatch')
             ->with('something', $this->isInstanceOf(DecisionEvent::class));
 
-        $this->getEventDispatcher()->dispatchRealTimeEvent($config, new LeadEventLog(), null);
+        $this->decisionDispatcher->dispatchRealTimeEvent($this->config, new LeadEventLog(), null);
     }
 
-    public function testDecisionEvaluationEventIsDispatched()
+    public function testDecisionEvaluationEventIsDispatched(): void
     {
-        $config = $this->getMockBuilder(DecisionAccessor::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $config->expects($this->never())
+        $this->config->expects($this->never())
             ->method('getEventName');
 
         $this->legacyDispatcher->expects($this->once())
@@ -82,27 +80,15 @@ class DecisionDispatcherTest extends \PHPUnit\Framework\TestCase
             ->method('dispatch')
             ->with(CampaignEvents::ON_EVENT_DECISION_EVALUATION, $this->isInstanceOf(DecisionEvent::class));
 
-        $this->getEventDispatcher()->dispatchEvaluationEvent($config, new LeadEventLog());
+        $this->decisionDispatcher->dispatchEvaluationEvent($this->config, new LeadEventLog());
     }
 
-    public function testDecisionResultsEventIsDispatched()
+    public function testDecisionResultsEventIsDispatched(): void
     {
-        $config = $this->getMockBuilder(DecisionAccessor::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->dispatcher->expects($this->at(0))
+        $this->dispatcher->expects($this->once())
             ->method('dispatch')
             ->with(CampaignEvents::ON_EVENT_DECISION_EVALUATION_RESULTS, $this->isInstanceOf(DecisionResultsEvent::class));
 
-        $this->getEventDispatcher()->dispatchDecisionResultsEvent($config, new ArrayCollection([new LeadEventLog()]), new EvaluatedContacts());
-    }
-
-    /**
-     * @return DecisionDispatcher
-     */
-    public function getEventDispatcher()
-    {
-        return new DecisionDispatcher($this->dispatcher, $this->legacyDispatcher);
+        $this->decisionDispatcher->dispatchDecisionResultsEvent($this->config, new ArrayCollection([new LeadEventLog()]), new EvaluatedContacts());
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Executioner/RealTimeExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/RealTimeExecutionerTest.php
@@ -214,16 +214,12 @@ class RealTimeExecutionerTest extends \PHPUnit\Framework\TestCase
             ->method('getExecutionDateTime')
             ->willReturn(new \DateTime());
 
-        $this->eventScheduler->expects($this->at(1))
+        $this->eventScheduler->expects($this->exactly(2))
             ->method('shouldSchedule')
-            ->willReturn(true);
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $this->eventScheduler->expects($this->once())
             ->method('scheduleForContact');
-
-        $this->eventScheduler->expects($this->at(3))
-            ->method('shouldSchedule')
-            ->willReturn(false);
 
         // This is how we know if the test failed/passed
         $this->executioner->expects($this->once())
@@ -361,16 +357,12 @@ class RealTimeExecutionerTest extends \PHPUnit\Framework\TestCase
             ->method('getExecutionDateTime')
             ->willReturn(new \DateTime());
 
-        $this->eventScheduler->expects($this->at(1))
+        $this->eventScheduler->expects($this->exactly(2))
             ->method('shouldSchedule')
-            ->willReturn(true);
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $this->eventScheduler->expects($this->once())
             ->method('scheduleForContact');
-
-        $this->eventScheduler->expects($this->at(3))
-            ->method('shouldSchedule')
-            ->willReturn(false);
 
         $this->executioner->expects($this->once())
             ->method('executeEventsForContact');

--- a/app/bundles/CategoryBundle/Tests/Model/ContactActionModelTest.php
+++ b/app/bundles/CategoryBundle/Tests/Model/ContactActionModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic Contributors. All rights reserved
  * @author      Mautic
@@ -14,21 +16,22 @@ namespace Mautic\CategoryBundle\Tests\Model;
 use Mautic\CategoryBundle\Model\ContactActionModel;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ContactActionModelTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var Lead
      */
     private $contactMock5;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var Lead
      */
     private $contactMock6;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var MockObject|LeadModel
      */
     private $contactModelMock;
 
@@ -39,8 +42,8 @@ class ContactActionModelTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->contactMock5     = $this->createMock(Lead::class);
-        $this->contactMock6     = $this->createMock(Lead::class);
+        $this->contactMock5     = new Lead();
+        $this->contactMock6     = new Lead();
         $this->contactModelMock = $this->createMock(LeadModel::class);
         $this->actionModel      = new ContactActionModel($this->contactModelMock);
     }
@@ -50,22 +53,17 @@ class ContactActionModelTest extends \PHPUnit\Framework\TestCase
         $contacts   = [5, 6];
         $categories = [4, 5];
 
-        $this->contactModelMock->expects($this->at(0))
+        $this->contactModelMock->expects($this->once())
             ->method('getLeadsByIds')
             ->with($contacts)
             ->willReturn([$this->contactMock5, $this->contactMock6]);
 
-        $this->contactModelMock->expects($this->at(1))
+        $this->contactModelMock->expects($this->exactly(2))
             ->method('canEditContact')
-            ->with($this->contactMock5)
-            ->willReturn(false);
+            ->withConsecutive([$this->contactMock5], [$this->contactMock6])
+            ->willReturnOnConsecutiveCalls(false, true);
 
-        $this->contactModelMock->expects($this->at(2))
-            ->method('canEditContact')
-            ->with($this->contactMock6)
-            ->willReturn(true);
-
-        $this->contactModelMock->expects($this->at(3))
+        $this->contactModelMock->expects($this->once())
             ->method('addToCategory')
             ->with($this->contactMock6);
 
@@ -77,27 +75,22 @@ class ContactActionModelTest extends \PHPUnit\Framework\TestCase
         $contacts   = [5, 6];
         $categories = [1, 2];
 
-        $this->contactModelMock->expects($this->at(0))
+        $this->contactModelMock->expects($this->once())
             ->method('getLeadsByIds')
             ->with($contacts)
             ->willReturn([$this->contactMock5, $this->contactMock6]);
 
-        $this->contactModelMock->expects($this->at(1))
+        $this->contactModelMock->expects($this->exactly(2))
             ->method('canEditContact')
-            ->with($this->contactMock5)
-            ->willReturn(false);
+            ->withConsecutive([$this->contactMock5], [$this->contactMock6])
+            ->willReturnOnConsecutiveCalls(false, true);
 
-        $this->contactModelMock->expects($this->at(2))
-            ->method('canEditContact')
-            ->with($this->contactMock6)
-            ->willReturn(true);
-
-        $this->contactModelMock->expects($this->at(3))
+        $this->contactModelMock->expects($this->once())
             ->method('getLeadCategories')
             ->with($this->contactMock6)
             ->willReturn([45, 2]);
 
-        $this->contactModelMock->expects($this->at(4))
+        $this->contactModelMock->expects($this->once())
             ->method('removeFromCategories')
             ->with([1 => 2]);
 
@@ -109,73 +102,46 @@ class ContactActionModelTest extends \PHPUnit\Framework\TestCase
         $contacts   = [5, 6];
         $categories = [1, 2];
 
-        $this->contactModelMock->expects($this->at(0))
+        $this->contactModelMock->expects($this->once())
             ->method('getLeadsByIds')
             ->with($contacts)
             ->willReturn([$this->contactMock5, $this->contactMock6]);
 
-        // Loop 1
-        $this->contactModelMock->expects($this->at(1))
+        $this->contactModelMock->expects($this->exactly(2))
             ->method('canEditContact')
-            ->with($this->contactMock5)
+            ->withConsecutive([$this->contactMock5], [$this->contactMock6])
             ->willReturn(true);
 
-        $this->contactModelMock->expects($this->at(2))
+        $this->contactModelMock->expects($this->exactly(2))
             ->method('addToCategory')
-            ->with($this->contactMock5, $categories);
-
-        // Loop 2
-        $this->contactModelMock->expects($this->at(3))
-            ->method('canEditContact')
-            ->with($this->contactMock6)
-            ->willReturn(true);
-
-        $this->contactModelMock->expects($this->at(4))
-            ->method('addToCategory')
-            ->with($this->contactMock6, $categories);
+            ->withConsecutive([$this->contactMock5, $categories], [$this->contactMock6, $categories]);
 
         $this->actionModel->addContactsToCategories($contacts, $categories);
     }
 
-    public function testRemoveContactsFromCategories()
+    public function testRemoveContactsFromCategories(): void
     {
         $contacts   = [5, 6];
         $categories = [1, 2];
 
-        $this->contactModelMock->expects($this->at(0))
+        $this->contactModelMock->expects($this->once())
             ->method('getLeadsByIds')
             ->with($contacts)
             ->willReturn([$this->contactMock5, $this->contactMock6]);
 
-        // Loop 1
-        $this->contactModelMock->expects($this->at(1))
+        $this->contactModelMock->expects($this->exactly(2))
             ->method('canEditContact')
-            ->with($this->contactMock5)
+            ->withConsecutive([$this->contactMock5], [$this->contactMock6])
             ->willReturn(true);
 
-        $this->contactModelMock->expects($this->at(2))
+        $this->contactModelMock->expects($this->exactly(2))
             ->method('getLeadCategories')
-            ->with($this->contactMock5)
-            ->willReturn([1, 2]);
+            ->withConsecutive([$this->contactMock5], [$this->contactMock6])
+            ->willReturnOnConsecutiveCalls([1, 2], [2, 3]);
 
-        $this->contactModelMock->expects($this->at(3))
+        $this->contactModelMock->expects($this->exactly(2))
             ->method('removeFromCategories')
-            ->with($categories);
-
-        // Loop 2
-        $this->contactModelMock->expects($this->at(4))
-            ->method('canEditContact')
-            ->with($this->contactMock6)
-            ->willReturn(true);
-
-        $this->contactModelMock->expects($this->at(5))
-            ->method('getLeadCategories')
-            ->with($this->contactMock6)
-            ->willReturn([2, 3]);
-
-        $this->contactModelMock->expects($this->at(6))
-            ->method('removeFromCategories')
-            ->with([2]);
+            ->withConsecutive([$categories], [[2]]);
 
         $this->actionModel->removeContactsFromCategories($contacts, $categories);
     }

--- a/app/bundles/ChannelBundle/Tests/Model/ChannelActionModelTest.php
+++ b/app/bundles/ChannelBundle/Tests/Model/ChannelActionModelTest.php
@@ -175,7 +175,7 @@ class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
         $contacts           = [5];
         $subscribedChannels = []; // Unsubscribe contact from missing
 
-        $this->contactModelMock->expects($this->once(0))
+        $this->contactModelMock->expects($this->once())
             ->method('getLeadsByIds')
             ->with($contacts)
             ->willReturn([$this->contactMock5]);

--- a/app/bundles/ChannelBundle/Tests/Model/ChannelActionModelTest.php
+++ b/app/bundles/ChannelBundle/Tests/Model/ChannelActionModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic Contributors. All rights reserved
  * @author      Mautic
@@ -16,32 +18,33 @@ use Mautic\LeadBundle\Entity\DoNotContact as DNC;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\DoNotContact;
 use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var MockObject
      */
     private $contactMock5;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var MockObject
      */
     private $contactMock6;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var MockObject
      */
     private $contactModelMock;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var MockObject
      */
     private $doNotContactMock;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var MockObject
      */
     private $translatorMock;
 
@@ -52,6 +55,8 @@ class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->contactMock5     = $this->createMock(Lead::class);
         $this->contactMock6     = $this->createMock(Lead::class);
         $this->contactModelMock = $this->createMock(LeadModel::class);
@@ -66,23 +71,18 @@ class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
         $this->contactMock5->method('getId')->willReturn(5);
     }
 
-    public function testUpdateEntityAccess()
+    public function testUpdateEntityAccess(): void
     {
         $contacts = [5, 6];
 
-        $this->contactModelMock->expects($this->at(0))
+        $this->contactModelMock->expects($this->once())
             ->method('getLeadsByIds')
             ->with($contacts)
             ->willReturn([$this->contactMock5, $this->contactMock6]);
 
-        $this->contactModelMock->expects($this->at(1))
+        $this->contactModelMock->expects($this->exactly(2))
             ->method('canEditContact')
-            ->with($this->contactMock5)
-            ->willReturn(false);
-
-        $this->contactModelMock->expects($this->at(2))
-            ->method('canEditContact')
-            ->with($this->contactMock6)
+            ->withConsecutive([$this->contactMock5], [$this->contactMock6])
             ->willReturn(false);
 
         $this->contactModelMock->expects($this->never())
@@ -91,23 +91,23 @@ class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
         $this->actionModel->update($contacts, [], [], '');
     }
 
-    public function testSubscribeContactToEmailChannel()
+    public function testSubscribeContactToEmailChannel(): void
     {
         $contacts           = [5];
         $subscribedChannels = ['email', 'sms']; // Subscribe contact to these channels
 
-        $this->contactModelMock->expects($this->at(0))
+        $this->contactModelMock->expects($this->once())
             ->method('getLeadsByIds')
             ->with($contacts)
             ->willReturn([$this->contactMock5]);
 
-        $this->contactModelMock->expects($this->at(1))
+        $this->contactModelMock->expects($this->once())
             ->method('canEditContact')
             ->with($this->contactMock5)
             ->willReturn(true);
 
         // Contact is already subscribed to the SMS channel but not to email
-        $this->contactModelMock->expects($this->at(2))
+        $this->contactModelMock->expects($this->once())
             ->method('getContactChannels')
             ->with($this->contactMock5)
             ->willReturn(['sms' => 'sms']);
@@ -121,7 +121,7 @@ class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
             ->method('removeDncForContact')
             ->with(5, 'email');
 
-        $this->contactModelMock->expects($this->at(3))
+        $this->contactModelMock->expects($this->once())
             ->method('getPreferenceChannels')
             ->willReturn(['Email' => 'email', 'Text Message' => 'sms']);
 
@@ -131,23 +131,23 @@ class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
         $this->actionModel->update($contacts, $subscribedChannels);
     }
 
-    public function testSubscribeContactWhoUnsubscribedToEmailChannel()
+    public function testSubscribeContactWhoUnsubscribedToEmailChannel(): void
     {
         $contacts           = [5];
         $subscribedChannels = ['email', 'sms']; // Subscribe contact to these channels
 
-        $this->contactModelMock->expects($this->at(0))
+        $this->contactModelMock->expects($this->once())
             ->method('getLeadsByIds')
             ->with($contacts)
             ->willReturn([$this->contactMock5]);
 
-        $this->contactModelMock->expects($this->at(1))
+        $this->contactModelMock->expects($this->once())
             ->method('canEditContact')
             ->with($this->contactMock5)
             ->willReturn(true);
 
         // Contact is already subscribed to the SMS channel but not to email
-        $this->contactModelMock->expects($this->at(2))
+        $this->contactModelMock->expects($this->once())
             ->method('getContactChannels')
             ->with($this->contactMock5)
             ->willReturn(['sms' => 'sms']);
@@ -160,7 +160,7 @@ class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
         $this->doNotContactMock->expects($this->never())
             ->method('removeDncForContact');
 
-        $this->contactModelMock->expects($this->at(3))
+        $this->contactModelMock->expects($this->once())
             ->method('getPreferenceChannels')
             ->willReturn(['Email' => 'email', 'Text Message' => 'sms']);
 
@@ -170,22 +170,22 @@ class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
         $this->actionModel->update($contacts, $subscribedChannels);
     }
 
-    public function testUnsubscribeContactFromSmsChannel()
+    public function testUnsubscribeContactFromSmsChannel(): void
     {
         $contacts           = [5];
         $subscribedChannels = []; // Unsubscribe contact from missing
 
-        $this->contactModelMock->expects($this->at(0))
+        $this->contactModelMock->expects($this->once(0))
             ->method('getLeadsByIds')
             ->with($contacts)
             ->willReturn([$this->contactMock5]);
 
-        $this->contactModelMock->expects($this->at(1))
+        $this->contactModelMock->expects($this->once())
             ->method('canEditContact')
             ->with($this->contactMock5)
             ->willReturn(true);
 
-        $this->contactModelMock->expects($this->at(2))
+        $this->contactModelMock->expects($this->once())
             ->method('getContactChannels')
             ->with($this->contactMock5)
             ->willReturn(['sms' => 'sms']);
@@ -193,24 +193,15 @@ class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
         $this->doNotContactMock->expects($this->never())
             ->method('isContactable');
 
-        $this->contactModelMock->expects($this->at(3))
+        $this->contactModelMock->expects($this->once())
             ->method('getPreferenceChannels')
             ->willReturn(['Email' => 'email', 'Text Message' => 'sms']);
 
-        $this->doNotContactMock->expects($this->at(0))
+        $this->doNotContactMock->expects($this->exactly(2))
             ->method('addDncForContact')
-            ->with(
-                5,
-                'email',
-                DNC::MANUAL
-            );
-
-        $this->doNotContactMock->expects($this->at(1))
-            ->method('addDncForContact')
-            ->with(
-                5,
-                'sms',
-                DNC::MANUAL
+            ->withConsecutive(
+                [5, 'email', DNC::MANUAL],
+                [5, 'sms', DNC::MANUAL]
             );
 
         $this->actionModel->update($contacts, $subscribedChannels);

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/EncryptionHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/EncryptionHelperTest.php
@@ -95,20 +95,20 @@ class EncryptionHelperTest extends \PHPUnit\Framework\TestCase
             ->method('isSupported')
             ->willReturn(false);
 
-        $this->secondaryCipherMock->expects($this->once(0))
+        $this->secondaryCipherMock->expects($this->once())
             ->method('isSupported')
             ->willReturn(true);
 
-        $this->coreParametersHelperMock->expects($this->once(0))
+        $this->coreParametersHelperMock->expects($this->once())
             ->method('get')
             ->with('mautic.secret_key')
             ->willReturn($this->key);
 
-        $this->secondaryCipherMock->expects($this->once(1))
+        $this->secondaryCipherMock->expects($this->once())
             ->method('getRandomInitVector')
             ->willReturn($initVector);
 
-        $this->secondaryCipherMock->expects($this->once(2))
+        $this->secondaryCipherMock->expects($this->once())
             ->method('encrypt')
             ->with(serialize($secretMessage), $this->key, $initVector)
             ->willReturn($encryptedMessage);

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/EncryptionHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/EncryptionHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2017 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -16,179 +18,210 @@ use Mautic\CoreBundle\Helper\EncryptionHelper;
 use Mautic\CoreBundle\Security\Cryptography\Cipher\Symmetric\OpenSSLCipher;
 use Mautic\CoreBundle\Security\Cryptography\Cipher\Symmetric\SymmetricCipherInterface;
 use Mautic\CoreBundle\Security\Exception\Cryptography\Symmetric\InvalidDecryptionException;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class EncryptionHelperTest extends \PHPUnit\Framework\TestCase
 {
-    /** @var \PHPUnit\Framework\MockObject\MockObject */
+    /**
+     * @var MockObject|CoreParametersHelper
+     */
     private $coreParametersHelperMock;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject */
+    /**
+     * @var MockObject|OpenSSLCipher
+     */
     private $mainCipherMock;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject */
+    /**
+     * @var MockObject|SymmetricCipherInterface
+     */
     private $secondaryCipherMock;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     private $key = 'totallySecretKeyHere';
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->coreParametersHelperMock = $this->createMock(CoreParametersHelper::class);
         $this->mainCipherMock           = $this->createMock(OpenSSLCipher::class);
         $this->secondaryCipherMock      = $this->createMock(SymmetricCipherInterface::class);
     }
 
-    public function testEncryptMainSupported()
+    public function testEncryptMainSupported(): void
     {
         $initVector       = 'totallyRandomInitializationVector';
         $secretMessage    = 'totallySecretMessage';
         $encryptedMessage = 'encryptionIsMagical';
         $expectedReturn   = base64_encode($encryptedMessage).'|'.base64_encode($initVector);
 
-        $this->mainCipherMock->expects($this->at(0))
+        $this->mainCipherMock->expects($this->once())
             ->method('isSupported')
             ->willReturn(true);
-        $this->secondaryCipherMock->expects($this->at(0))
+
+        $this->secondaryCipherMock->expects($this->once())
             ->method('isSupported')
             ->willReturn(true);
-        $this->coreParametersHelperMock->expects($this->at(0))
+
+        $this->coreParametersHelperMock->expects($this->once())
             ->method('get')
             ->with('mautic.secret_key')
             ->willReturn($this->key);
 
-        $this->mainCipherMock->expects($this->at(1))
+        $this->mainCipherMock->expects($this->once())
             ->method('getRandomInitVector')
             ->willReturn($initVector);
-        $this->mainCipherMock->expects($this->at(2))
+
+        $this->mainCipherMock->expects($this->once())
             ->method('encrypt')
             ->with(serialize($secretMessage), $this->key, $initVector)
             ->willReturn($encryptedMessage);
+
         $encryptionHelper = $this->getEncryptionHelper();
         $actualReturn     = $encryptionHelper->encrypt($secretMessage);
         $this->assertSame($expectedReturn, $actualReturn);
     }
 
-    public function testEncryptMainNotSupported()
+    public function testEncryptMainNotSupported(): void
     {
         $initVector       = 'totallyRandomInitializationVector';
         $secretMessage    = 'totallySecretMessage';
         $encryptedMessage = 'encryptionIsMagical';
         $expectedReturn   = base64_encode($encryptedMessage).'|'.base64_encode($initVector);
 
-        $this->mainCipherMock->expects($this->at(0))
+        $this->mainCipherMock->expects($this->once())
             ->method('isSupported')
             ->willReturn(false);
-        $this->secondaryCipherMock->expects($this->at(0))
+
+        $this->secondaryCipherMock->expects($this->once(0))
             ->method('isSupported')
             ->willReturn(true);
-        $this->coreParametersHelperMock->expects($this->at(0))
+
+        $this->coreParametersHelperMock->expects($this->once(0))
             ->method('get')
             ->with('mautic.secret_key')
             ->willReturn($this->key);
 
-        $this->secondaryCipherMock->expects($this->at(1))
+        $this->secondaryCipherMock->expects($this->once(1))
             ->method('getRandomInitVector')
             ->willReturn($initVector);
-        $this->secondaryCipherMock->expects($this->at(2))
+
+        $this->secondaryCipherMock->expects($this->once(2))
             ->method('encrypt')
             ->with(serialize($secretMessage), $this->key, $initVector)
             ->willReturn($encryptedMessage);
+
         $encryptionHelper = $this->getEncryptionHelper();
         $actualReturn     = $encryptionHelper->encrypt($secretMessage);
         $this->assertSame($expectedReturn, $actualReturn);
     }
 
-    public function testDecryptMain()
+    public function testDecryptMain(): void
     {
         $toDecrypt      = 'ZW5jcnlwdGlvbklzTWFnaWNhbA==|dG90YWxseVJhbmRvbUluaXRpYWxpemF0aW9uVmVjdG9y';
         $expectedReturn = 'totallySecretMessage';
 
-        $this->mainCipherMock->expects($this->at(0))
+        $this->mainCipherMock->expects($this->once())
             ->method('isSupported')
             ->willReturn(true);
-        $this->secondaryCipherMock->expects($this->at(0))
+
+        $this->secondaryCipherMock->expects($this->once())
             ->method('isSupported')
             ->willReturn(true);
-        $this->coreParametersHelperMock->expects($this->at(0))
+
+        $this->coreParametersHelperMock->expects($this->once())
             ->method('get')
             ->with('mautic.secret_key')
             ->willReturn($this->key);
 
-        $this->mainCipherMock->expects($this->at(1))
+        $this->mainCipherMock->expects($this->once())
             ->method('decrypt')
             ->with('encryptionIsMagical', $this->key, 'totallyRandomInitializationVector')
             ->willReturn('s:20:"totallySecretMessage";');
+
         $encryptionHelper = $this->getEncryptionHelper();
         $actualReturn     = $encryptionHelper->decrypt($toDecrypt);
         $this->assertSame($expectedReturn, $actualReturn);
     }
 
-    public function testDecryptSecondary()
+    public function testDecryptSecondary(): void
     {
         $toDecrypt      = 'ZW5jcnlwdGlvbklzTWFnaWNhbA==|dG90YWxseVJhbmRvbUluaXRpYWxpemF0aW9uVmVjdG9y';
         $expectedReturn = 'totallySecretMessage';
 
-        $this->mainCipherMock->expects($this->at(0))
+        $this->mainCipherMock->expects($this->once())
             ->method('isSupported')
             ->willReturn(true);
-        $this->secondaryCipherMock->expects($this->at(0))
+
+        $this->secondaryCipherMock->expects($this->once())
             ->method('isSupported')
             ->willReturn(true);
-        $this->coreParametersHelperMock->expects($this->at(0))
+
+        $this->coreParametersHelperMock->expects($this->once())
             ->method('get')
             ->with('mautic.secret_key')
             ->willReturn($this->key);
 
-        $this->mainCipherMock->expects($this->at(1))
+        $this->mainCipherMock->expects($this->once())
             ->method('decrypt')
             ->with('encryptionIsMagical', $this->key, 'totallyRandomInitializationVector')
             ->willThrowException(new InvalidDecryptionException());
-        $this->secondaryCipherMock->expects($this->at(1))
+
+        $this->secondaryCipherMock->expects($this->once())
             ->method('decrypt')
             ->with('encryptionIsMagical', $this->key, 'totallyRandomInitializationVector')
             ->willReturn('s:20:"totallySecretMessage";');
+
         $encryptionHelper = $this->getEncryptionHelper();
         $actualReturn     = $encryptionHelper->decrypt($toDecrypt, false);
         $this->assertSame($expectedReturn, $actualReturn);
     }
 
-    public function testDecryptFalse()
+    public function testDecryptFalse(): void
     {
         $toDecrypt = 'ZW5jcnlwdGlvbklzTWFnaWNhbA==|dG90YWxseVJhbmRvbUluaXRpYWxpemF0aW9uVmVjdG9y';
 
-        $this->mainCipherMock->expects($this->at(0))
+        $this->mainCipherMock->expects($this->once())
             ->method('isSupported')
             ->willReturn(true);
-        $this->secondaryCipherMock->expects($this->at(0))
+
+        $this->secondaryCipherMock->expects($this->once())
             ->method('isSupported')
             ->willReturn(true);
-        $this->coreParametersHelperMock->expects($this->at(0))
+
+        $this->coreParametersHelperMock->expects($this->once())
             ->method('get')
             ->with('mautic.secret_key')
             ->willReturn($this->key);
 
-        $this->mainCipherMock->expects($this->at(1))
+        $this->mainCipherMock->expects($this->once())
             ->method('decrypt')
             ->with('encryptionIsMagical', $this->key, 'totallyRandomInitializationVector')
             ->willThrowException(new InvalidDecryptionException());
-        $this->secondaryCipherMock->expects($this->at(1))
+
+        $this->secondaryCipherMock->expects($this->once())
             ->method('decrypt')
             ->with('encryptionIsMagical', $this->key, 'totallyRandomInitializationVector')
             ->willThrowException(new InvalidDecryptionException());
+
         $encryptionHelper = $this->getEncryptionHelper();
         $actualReturn     = $encryptionHelper->decrypt($toDecrypt, false);
         $this->assertFalse($actualReturn);
     }
 
-    public function testMainSupported()
+    public function testMainSupported(): void
     {
-        $this->mainCipherMock->expects($this->at(0))
+        $this->mainCipherMock->expects($this->once())
             ->method('isSupported')
             ->willReturn(true);
-        $this->secondaryCipherMock->expects($this->at(0))
+
+        $this->secondaryCipherMock->expects($this->once())
             ->method('isSupported')
             ->willReturn(false);
-        $this->coreParametersHelperMock->expects($this->at(0))
+
+        $this->coreParametersHelperMock->expects($this->once())
             ->method('get')
             ->with('mautic.secret_key')
             ->willReturn($this->key);
@@ -196,15 +229,17 @@ class EncryptionHelperTest extends \PHPUnit\Framework\TestCase
         $this->getEncryptionHelper();
     }
 
-    public function testSecondarySupported()
+    public function testSecondarySupported(): void
     {
-        $this->mainCipherMock->expects($this->at(0))
+        $this->mainCipherMock->expects($this->once())
             ->method('isSupported')
             ->willReturn(false);
-        $this->secondaryCipherMock->expects($this->at(0))
+
+        $this->secondaryCipherMock->expects($this->once())
             ->method('isSupported')
             ->willReturn(true);
-        $this->coreParametersHelperMock->expects($this->at(0))
+
+        $this->coreParametersHelperMock->expects($this->once())
             ->method('get')
             ->with('mautic.secret_key')
             ->willReturn($this->key);
@@ -212,12 +247,13 @@ class EncryptionHelperTest extends \PHPUnit\Framework\TestCase
         $this->getEncryptionHelper();
     }
 
-    public function testNoneSupported()
+    public function testNoneSupported(): void
     {
-        $this->mainCipherMock->expects($this->at(0))
+        $this->mainCipherMock->expects($this->once())
             ->method('isSupported')
             ->willReturn(false);
-        $this->secondaryCipherMock->expects($this->at(0))
+
+        $this->secondaryCipherMock->expects($this->once())
             ->method('isSupported')
             ->willReturn(false);
 
@@ -225,10 +261,7 @@ class EncryptionHelperTest extends \PHPUnit\Framework\TestCase
         $this->getEncryptionHelper();
     }
 
-    /**
-     * @return EncryptionHelper
-     */
-    private function getEncryptionHelper()
+    private function getEncryptionHelper(): EncryptionHelper
     {
         return new EncryptionHelper(
             $this->coreParametersHelperMock,

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/FilePathResolverTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/FilePathResolverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2015 Mautic Contributors. All rights reserved
  * @author      Mautic
@@ -43,6 +45,7 @@ class FilePathResolverTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->filesystemMock   = $this->createMock(Filesystem::class);
         $this->fileMock         = $this->createMock(UploadedFile::class);
         $this->inputHelper      = new InputHelper();
@@ -51,29 +54,21 @@ class FilePathResolverTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Get correct name if few previous names are taken
-     *
-     * @covers \Mautic\CoreBundle\Helper\FilePathResolver::getUniqueFileName
      */
-    public function testGetUniqueName()
+    public function testGetUniqueName(): void
     {
         $uploadDir     = 'my/upload/dir';
         $extension     = 'jpg';
         $dirtyFileName = 'fileName_x./-u'.$extension;
 
-        $this->filesystemMock->expects($this->at(0))
+        $this->filesystemMock->expects($this->exactly(3))
             ->method('exists')
-            ->with('my/upload/dir/filename_x.jpg')
-            ->willReturn(true);
-
-        $this->filesystemMock->expects($this->at(1))
-            ->method('exists')
-            ->with('my/upload/dir/filename_x-1.jpg')
-            ->willReturn(true);
-
-        $this->filesystemMock->expects($this->at(2))
-            ->method('exists')
-            ->with('my/upload/dir/filename_x-2.jpg')
-            ->willReturn(false);
+            ->withConsecutive(
+                ['my/upload/dir/filename_x.jpg'],
+                ['my/upload/dir/filename_x-1.jpg'],
+                ['my/upload/dir/filename_x-2.jpg']
+            )
+            ->willReturnOnConsecutiveCalls(true, true, false);
 
         $this->fileMock->expects($this->once())
             ->method('getClientOriginalName')
@@ -92,10 +87,8 @@ class FilePathResolverTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Throws an Exception if name cannot be generated
-     *
-     * @covers \Mautic\CoreBundle\Helper\FilePathResolver::getUniqueFileName
      */
-    public function testCouldNotGetUniqueName()
+    public function testCouldNotGetUniqueName(): void
     {
         $uploadDir     = 'my/upload/dir';
         $extension     = 'jpg';
@@ -123,10 +116,8 @@ class FilePathResolverTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox No action is taken when directory already exists
-     *
-     * @covers \Mautic\CoreBundle\Helper\FilePathResolver::createDirectory
      */
-    public function testNoActionIfDirectoryExists()
+    public function testNoActionIfDirectoryExists(): void
     {
         $directory = 'my/directory';
 
@@ -140,10 +131,8 @@ class FilePathResolverTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Create new directory
-     *
-     * @covers \Mautic\CoreBundle\Helper\FilePathResolver::createDirectory
      */
-    public function testCreateNewDirectory()
+    public function testCreateNewDirectory(): void
     {
         $directory = 'my/directory';
 
@@ -161,10 +150,8 @@ class FilePathResolverTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Directory could not be created
-     *
-     * @covers \Mautic\CoreBundle\Helper\FilePathResolver::createDirectory
      */
-    public function testDirectoryCouldNotBeCreated()
+    public function testDirectoryCouldNotBeCreated(): void
     {
         $directory = 'my/directory';
 
@@ -186,10 +173,8 @@ class FilePathResolverTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Successfuly detete file
-     *
-     * @covers \Mautic\CoreBundle\Helper\FilePathResolver::delete
      */
-    public function testDeleteFile()
+    public function testDeleteFile(): void
     {
         $file = 'my/file';
 
@@ -207,10 +192,8 @@ class FilePathResolverTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox File could not be deleted
-     *
-     * @covers \Mautic\CoreBundle\Helper\FilePathResolver::delete
      */
-    public function testCouldNotDeleteFile()
+    public function testCouldNotDeleteFile(): void
     {
         $file = 'my/file';
 
@@ -229,10 +212,8 @@ class FilePathResolverTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox File could not be deleted
-     *
-     * @covers \Mautic\CoreBundle\Helper\FilePathResolver::delete
      */
-    public function testDeleteFileWhichNotExists()
+    public function testDeleteFileWhichNotExists(): void
     {
         $file = 'my/file';
 
@@ -247,7 +228,7 @@ class FilePathResolverTest extends \PHPUnit\Framework\TestCase
         $this->filePathResolver->delete($file);
     }
 
-    public function testMove()
+    public function testMove(): void
     {
         $originalPath = 'my/file';
         $targetPath   = 'my/new/file';

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/Language/InstallerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/Language/InstallerTest.php
@@ -38,11 +38,11 @@ class InstallerTest extends \PHPUnit\Framework\TestCase
         $this->assertFileExists($languagePath.'/config.json');
 
         // did it ignore the php config?
-        $this->assertFileNotExists($languagePath.'/config.php');
+        $this->assertFileDoesNotExist($languagePath.'/config.php');
 
         // did it ignore the extra files?
-        $this->assertFileNotExists($languagePath.'/random.txt');
-        $this->assertFileNotExists($languagePath.'/RandomFolder');
+        $this->assertFileDoesNotExist($languagePath.'/random.txt');
+        $this->assertFileDoesNotExist($languagePath.'/RandomFolder');
 
         // did it create the bundles?
         $this->assertFileExists($languagePath.'/CoreBundle');
@@ -55,12 +55,12 @@ class InstallerTest extends \PHPUnit\Framework\TestCase
         $this->assertFileExists($languagePath.'/CampaignBundle/flashes.ini');
 
         // did it ignore the bundle's extra files?
-        $this->assertFileNotExists($languagePath.'/CoreBundle/random.txt');
+        $this->assertFileDoesNotExist($languagePath.'/CoreBundle/random.txt');
 
         // did the installer cleanup appropriately
         $this->assertFileExists($translationsDirectory.'/tmp/es');
         $installer->cleanup();
-        $this->assertFileNotExists($translationsDirectory.'/tmp/es');
+        $this->assertFileDoesNotExist($translationsDirectory.'/tmp/es');
 
         // cleanup the test
         (new Filesystem())->remove($languagePath);

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php
@@ -34,7 +34,7 @@ class PRedisConnectionHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertIsArray($connInfo);
         $this->assertGreaterThan(1, count($connInfo));
         foreach ($connInfo as $c) {
-            $this->assertRegExp('/^(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:[.](?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}$/', $c['host']);
+            $this->assertMatchesRegularExpression('/^(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:[.](?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}$/', $c['host']);
             $this->assertEquals('tcp', $c['scheme']);
             $this->assertEquals(8888, $c['port']);
             $this->assertEquals('test=car', $c['query']);

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic Inc. All rights reserved
  * @author      Mautic, Inc.
@@ -65,6 +67,7 @@ class ThemeHelperTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->pathsHelper         = $this->createMock(PathsHelper::class);
         $this->templatingHelper    = $this->createMock(TemplatingHelper::class);
         $this->translator          = $this->createMock(TranslatorInterface::class);
@@ -86,7 +89,7 @@ class ThemeHelperTest extends TestCase
         );
     }
 
-    public function testExceptionThrownWithMissingConfig()
+    public function testExceptionThrownWithMissingConfig(): void
     {
         $this->expectException(FileNotFoundException::class);
 
@@ -106,7 +109,7 @@ class ThemeHelperTest extends TestCase
         $this->themeHelper->install(__DIR__.'/resource/themes/missing-config.zip');
     }
 
-    public function testExceptionThrownWithMissingMessage()
+    public function testExceptionThrownWithMissingMessage(): void
     {
         $this->expectException(FileNotFoundException::class);
 
@@ -126,7 +129,7 @@ class ThemeHelperTest extends TestCase
         $this->themeHelper->install(__DIR__.'/resource/themes/missing-message.zip');
     }
 
-    public function testExceptionThrownWithMissingFeature()
+    public function testExceptionThrownWithMissingFeature(): void
     {
         $this->expectException(FileNotFoundException::class);
 
@@ -146,7 +149,7 @@ class ThemeHelperTest extends TestCase
         $this->themeHelper->install(__DIR__.'/resource/themes/missing-feature.zip');
     }
 
-    public function testThemeIsInstalled()
+    public function testThemeIsInstalled(): void
     {
         $fs = new Filesystem();
         $fs->copy(__DIR__.'/resource/themes/good.zip', __DIR__.'/resource/themes/good-tmp.zip');
@@ -162,7 +165,7 @@ class ThemeHelperTest extends TestCase
         $fs->remove(__DIR__.'/resource/themes/good-tmp');
     }
 
-    public function testThemeFallbackToDefaultIfTemplateIsMissing()
+    public function testThemeFallbackToDefaultIfTemplateIsMissing(): void
     {
         $templateNameParser = $this->createMock(TemplateNameParser::class);
         $this->templatingHelper->expects($this->once())
@@ -176,20 +179,13 @@ class ThemeHelperTest extends TestCase
 
         $templating = $this->createMock(DelegatingEngine::class);
 
-        // twig does not exist
-        $templating->expects($this->at(0))
+        $templating->expects($this->exactly(3))
             ->method('exists')
-            ->willReturn(false);
-
-        // php does not exist
-        $templating->expects($this->at(1))
-            ->method('exists')
-            ->willReturn(false);
-
-        // default themes twig exists
-        $templating->expects($this->at(2))
-            ->method('exists')
-            ->willReturn(true);
+            ->willReturnOnConsecutiveCalls(
+                false, // twig does not exist
+                false, // php does not exist
+                true // default themes twig exists
+            );
 
         $this->templatingHelper->expects($this->once())
             ->method('getTemplating')
@@ -213,7 +209,7 @@ class ThemeHelperTest extends TestCase
         $this->assertEquals(':nature:page.html.twig', $template);
     }
 
-    public function testThemeFallbackToNextBestIfTemplateIsMissingForBothRequestedAndDefaultThemes()
+    public function testThemeFallbackToNextBestIfTemplateIsMissingForBothRequestedAndDefaultThemes(): void
     {
         $templateNameParser = $this->createMock(TemplateNameParser::class);
         $this->templatingHelper->expects($this->once())

--- a/app/bundles/CoreBundle/Tests/Unit/Templating/Helper/FormatterHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Templating/Helper/FormatterHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2016 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -17,7 +19,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class FormatterHelperTest extends \PHPUnit\Framework\TestCase
 {
-    public function testStrictHtmlFormatIsRemovingScriptTags()
+    public function testStrictHtmlFormatIsRemovingScriptTags(): void
     {
         $dateHelper = $this->createMock(DateHelper::class);
         $translator = $this->createMock(TranslatorInterface::class);
@@ -32,19 +34,15 @@ class FormatterHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testBooleanFormat()
+    public function testBooleanFormat(): void
     {
         $dateHelper = $this->createMock(DateHelper::class);
         $translator = $this->createMock(TranslatorInterface::class);
 
-        $translator->expects($this->at(0))
+        $translator->expects($this->exactly(2))
             ->method('trans')
-            ->with('mautic.core.yes')
-            ->willReturn('yes');
-        $translator->expects($this->at(1))
-            ->method('trans')
-            ->with('mautic.core.no')
-            ->willReturn('no');
+            ->withConsecutive(['mautic.core.yes'], ['mautic.core.no'])
+            ->willReturnOnConsecutiveCalls('yes', 'no');
 
         $helper = new FormatterHelper($dateHelper, $translator);
 

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/FinalizeUpdateStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/FinalizeUpdateStepTest.php
@@ -90,8 +90,8 @@ class FinalizeUpdateStepTest extends AbstractStepTest
 
         $this->step->execute($this->progressBar, $this->input, $this->output);
 
-        $this->assertFileNotExists(__DIR__.'/resources/upgrade.php');
-        $this->assertFileNotExists(__DIR__.'/resources/lastUpdateCheck.txt');
+        $this->assertFileDoesNotExist(__DIR__.'/resources/upgrade.php');
+        $this->assertFileDoesNotExist(__DIR__.'/resources/lastUpdateCheck.txt');
 
         $this->assertEquals($updateSuccessfulKey, trim($this->progressBar->getMessage()));
     }
@@ -127,7 +127,7 @@ class FinalizeUpdateStepTest extends AbstractStepTest
 
         $this->step->execute($this->progressBar, $this->input, $this->output);
 
-        $this->assertFileNotExists(__DIR__.'/resources/upgrade.php');
-        $this->assertFileNotExists(__DIR__.'/resources/lastUpdateCheck.txt');
+        $this->assertFileDoesNotExist(__DIR__.'/resources/upgrade.php');
+        $this->assertFileDoesNotExist(__DIR__.'/resources/lastUpdateCheck.txt');
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/InstallNewFilesStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/InstallNewFilesStepTest.php
@@ -82,7 +82,7 @@ class InstallNewFilesStepTest extends AbstractStepTest
         $this->step->execute($this->progressBar, $this->input, $this->output);
 
         $this->assertFileExists($resourcePath.'/update');
-        $this->assertFileNotExists($resourcePath.'/update-test.zip');
+        $this->assertFileDoesNotExist($resourcePath.'/update-test.zip');
 
         // Cleanup
         $filesystem = new Filesystem();
@@ -118,7 +118,7 @@ class InstallNewFilesStepTest extends AbstractStepTest
         $this->step->execute($this->progressBar, $this->input, $this->output);
 
         $this->assertFileExists($resourcePath.'/update');
-        $this->assertFileNotExists($resourcePath.'/update-test.zip');
+        $this->assertFileDoesNotExist($resourcePath.'/update-test.zip');
 
         // Cleanup
         $filesystem = new Filesystem();

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/RemoveDeletedFilesStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/RemoveDeletedFilesStepTest.php
@@ -74,8 +74,8 @@ class RemoveDeletedFilesStepTest extends AbstractStepTest
 
         $step->execute($this->progressBar, $this->input, $this->output);
 
-        $this->assertFileNotExists($resourcePath.'/delete_me.txt');
-        $this->assertFileNotExists($resourcePath.'/deleted_files.txt');
+        $this->assertFileDoesNotExist($resourcePath.'/delete_me.txt');
+        $this->assertFileDoesNotExist($resourcePath.'/deleted_files.txt');
     }
 
     public function testNonExistentFileIsIgnored()
@@ -83,7 +83,7 @@ class RemoveDeletedFilesStepTest extends AbstractStepTest
         $resourcePath = __DIR__.'/resources';
         file_put_contents($resourcePath.'/deleted_files.txt', '["delete_me.txt"]');
 
-        $this->assertFileNotExists($resourcePath.'/delete_me.txt');
+        $this->assertFileDoesNotExist($resourcePath.'/delete_me.txt');
 
         $this->pathsHelper->method('getRootPath')
             ->willReturn($resourcePath);
@@ -98,7 +98,7 @@ class RemoveDeletedFilesStepTest extends AbstractStepTest
         $this->logger->expects($this->never())
             ->method('error');
 
-        $this->assertFileNotExists($resourcePath.'/deleted_files.txt');
+        $this->assertFileDoesNotExist($resourcePath.'/deleted_files.txt');
     }
 
     private function getStep(): RemoveDeletedFilesStep

--- a/app/bundles/CoreBundle/Tests/Unit/Validator/FileUploadValidatorTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Validator/FileUploadValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2015 Mautic Contributors. All rights reserved
  * @author      Mautic
@@ -19,15 +21,10 @@ class FileUploadValidatorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @testdox Check that extension is valid
-     *
-     * @covers \Mautic\CoreBundle\Validator\FileUploadValidator::checkExtension
      */
-    public function testValidExtension()
+    public function testValidExtension(): void
     {
-        $translatorMock = $this->getMockBuilder(TranslatorInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $translatorMock = $this->createMock(TranslatorInterface::class);
         $translatorMock->expects($this->never())
             ->method('trans');
 
@@ -45,15 +42,10 @@ class FileUploadValidatorTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Check that extension is not valid
-     *
-     * @covers \Mautic\CoreBundle\Validator\FileUploadValidator::checkExtension
      */
-    public function testInvalidExtension()
+    public function testInvalidExtension(): void
     {
-        $translatorMock = $this->getMockBuilder(TranslatorInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $translatorMock = $this->createMock(TranslatorInterface::class);
         $translatorMock->expects($this->once())
             ->method('trans')
             ->willReturn('Extension is not allowed');
@@ -75,15 +67,10 @@ class FileUploadValidatorTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Check file size is ok
-     *
-     * @covers \Mautic\CoreBundle\Validator\FileUploadValidator::checkFileSize
      */
-    public function testFileSizeIsOk()
+    public function testFileSizeIsOk(): void
     {
-        $translatorMock = $this->getMockBuilder(TranslatorInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $translatorMock = $this->createMock(TranslatorInterface::class);
         $translatorMock->expects($this->never())
             ->method('trans');
 
@@ -98,15 +85,10 @@ class FileUploadValidatorTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Check file size bigger than allowed one
-     *
-     * @covers \Mautic\CoreBundle\Validator\FileUploadValidator::checkFileSize
      */
-    public function testFileSizeIsBiggerThanAllowed()
+    public function testFileSizeIsBiggerThanAllowed(): void
     {
-        $translatorMock = $this->getMockBuilder(TranslatorInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $translatorMock = $this->createMock(TranslatorInterface::class);
         $translatorMock->expects($this->once())
             ->method('trans')
             ->willReturn('File size limit exceeded');
@@ -125,22 +107,13 @@ class FileUploadValidatorTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Test concat message from validators
-     *
-     * @covers \Mautic\CoreBundle\Validator\FileUploadValidator::validate
      */
-    public function testBadExtensionAndBadSize()
+    public function testBadExtensionAndBadSize(): void
     {
-        $translatorMock = $this->getMockBuilder(TranslatorInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $translatorMock->expects($this->at(0))
+        $translatorMock = $this->createMock(TranslatorInterface::class);
+        $translatorMock->expects($this->exactly(2))
             ->method('trans')
-            ->willReturn('Extension is not allowed');
-
-        $translatorMock->expects($this->at(1))
-            ->method('trans')
-            ->willReturn('File size limit exceeded');
+            ->willReturnOnConsecutiveCalls('Extension is not allowed', 'File size limit exceeded');
 
         $fileUploadValidator = new FileUploadValidator($translatorMock);
 

--- a/app/bundles/DashboardBundle/Controller/DashboardController.php
+++ b/app/bundles/DashboardBundle/Controller/DashboardController.php
@@ -320,8 +320,11 @@ class DashboardController extends AbstractFormController
         }
 
         $name = $this->getNameFromRequest();
+
+        /** @var DashboardModel $dashboardModel */
+        $dashboardModel = $this->getModel('dashboard');
         try {
-            $this->getModel('dashboard')->saveSnapshot($name);
+            $dashboardModel->saveSnapshot($name);
             $type = 'notice';
             $msg  = $this->translator->trans('mautic.dashboard.notice.save', [
                 '%name%'    => $name,

--- a/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerTest.php
+++ b/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -18,6 +20,7 @@ use Mautic\CoreBundle\Templating\Engine\PhpEngine;
 use Mautic\DashboardBundle\Controller\DashboardController;
 use Mautic\DashboardBundle\Dashboard\Widget;
 use Mautic\DashboardBundle\Model\DashboardModel;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,15 +32,54 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class DashboardControllerTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var MockObject|Request
+     */
     private $requestMock;
+
+    /**
+     * @var MockObject|CorePermissions
+     */
     private $securityMock;
+
+    /**
+     * @var MockObject|TranslatorInterface
+     */
     private $translatorMock;
+
+    /**
+     * @var MockObject|ModelFactory
+     */
     private $modelFactoryMock;
+
+    /**
+     * @var MockObject|DashboardModel
+     */
     private $dashboardModelMock;
+
+    /**
+     * @var MockObject|RouterInterface
+     */
     private $routerMock;
+
+    /**
+     * @var MockObject|Session
+     */
     private $sessionMock;
+
+    /**
+     * @var MockObject|FlashBag
+     */
     private $flashBagMock;
+
+    /**
+     * @var MockObject|Container
+     */
     private $containerMock;
+
+    /**
+     * @var DashboardController
+     */
     private $controller;
 
     protected function setUp(): void
@@ -61,7 +103,7 @@ class DashboardControllerTest extends \PHPUnit\Framework\TestCase
         $this->sessionMock->method('getFlashBag')->willReturn($this->flashBagMock);
     }
 
-    public function testSaveWithGetWillCallAccessDenied()
+    public function testSaveWithGetWillCallAccessDenied(): void
     {
         $this->requestMock->expects($this->once())
             ->method('isMethod')
@@ -72,7 +114,7 @@ class DashboardControllerTest extends \PHPUnit\Framework\TestCase
             ->method('isXmlHttpRequest')
             ->willReturn(false);
 
-        $this->containerMock->expects($this->at(0))
+        $this->containerMock->expects($this->once())
             ->method('get')
             ->with('mautic.security')
             ->willReturn($this->securityMock);
@@ -81,7 +123,7 @@ class DashboardControllerTest extends \PHPUnit\Framework\TestCase
         $this->controller->saveAction();
     }
 
-    public function testSaveWithPostNotAjaxWillCallAccessDenied()
+    public function testSaveWithPostNotAjaxWillCallAccessDenied(): void
     {
         $this->requestMock->expects($this->once())
             ->method('isMethod')
@@ -91,12 +133,12 @@ class DashboardControllerTest extends \PHPUnit\Framework\TestCase
         $this->requestMock->method('isXmlHttpRequest')
             ->willReturn(false);
 
-        $this->containerMock->expects($this->at(0))
+        $this->containerMock->expects($this->once())
             ->method('get')
             ->with('mautic.security')
             ->willReturn($this->securityMock);
 
-        $this->translatorMock->expects($this->at(0))
+        $this->translatorMock->expects($this->once())
             ->method('trans')
             ->with('mautic.core.url.error.401');
 
@@ -104,7 +146,7 @@ class DashboardControllerTest extends \PHPUnit\Framework\TestCase
         $this->controller->saveAction();
     }
 
-    public function testSaveWithPostAjaxWillSave()
+    public function testSaveWithPostAjaxWillSave(): void
     {
         $this->requestMock->expects($this->once())
             ->method('isMethod')
@@ -114,40 +156,37 @@ class DashboardControllerTest extends \PHPUnit\Framework\TestCase
         $this->requestMock->method('isXmlHttpRequest')
             ->willReturn(true);
 
-        $this->requestMock->expects($this->at(2))
-            ->method('get')
-            ->with('name')
-            ->willReturn('mockName');
+        $this->requestMock->method('get')
+            ->withConsecutive(['name'])
+            ->willReturnOnConsecutiveCalls('mockName');
 
-        $this->containerMock->expects($this->at(0))
+        $this->containerMock->expects($this->exactly(3))
             ->method('get')
-            ->with('mautic.model.factory')
-            ->willReturn($this->modelFactoryMock);
-
-        $this->containerMock->expects($this->at(1))
-            ->method('get')
-            ->with('router')
-            ->willReturn($this->routerMock);
-
-        $this->containerMock->expects($this->at(2))
-            ->method('get')
-            ->with('router')
-            ->willReturn($this->routerMock);
+            ->withConsecutive(
+                ['mautic.model.factory'],
+                ['router'],
+                ['router']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->modelFactoryMock,
+                $this->routerMock,
+                $this->routerMock
+            );
 
         $this->routerMock->expects($this->any())
             ->method('generate')
             ->willReturn('https://some.url');
 
-        $this->modelFactoryMock->expects($this->at(0))
+        $this->modelFactoryMock->expects($this->once())
             ->method('getModel')
             ->with('dashboard')
             ->willReturn($this->dashboardModelMock);
 
-        $this->dashboardModelMock->expects($this->at(0))
+        $this->dashboardModelMock->expects($this->once())
             ->method('saveSnapshot')
             ->with('mockName');
 
-        $this->translatorMock->expects($this->at(0))
+        $this->translatorMock->expects($this->once())
             ->method('trans')
             ->with('mautic.dashboard.notice.save');
 
@@ -156,7 +195,7 @@ class DashboardControllerTest extends \PHPUnit\Framework\TestCase
         $this->controller->saveAction();
     }
 
-    public function testSaveWithPostAjaxWillNotBeAbleToSave()
+    public function testSaveWithPostAjaxWillNotBeAbleToSave(): void
     {
         $this->requestMock->expects($this->once())
             ->method('isMethod')
@@ -170,31 +209,31 @@ class DashboardControllerTest extends \PHPUnit\Framework\TestCase
             ->method('generate')
             ->willReturn('https://some.url');
 
-        $this->requestMock->expects($this->at(2))
-            ->method('get')
-            ->with('name')
-            ->willReturn('mockName');
+        $this->requestMock->method('get')
+            ->withConsecutive(['name'])
+            ->willReturnOnConsecutiveCalls('mockName');
 
-        $this->containerMock->expects($this->at(0))
+        $this->containerMock->expects($this->exactly(2))
             ->method('get')
-            ->with('mautic.model.factory')
-            ->willReturn($this->modelFactoryMock);
+            ->withConsecutive(
+                ['mautic.model.factory'],
+                ['router']
+            )
+            ->willReturn(
+                $this->modelFactoryMock,
+                $this->routerMock
+            );
 
-        $this->containerMock->expects($this->at(1))
-            ->method('get')
-            ->with('router')
-            ->willReturn($this->routerMock);
-
-        $this->modelFactoryMock->expects($this->at(0))
+        $this->modelFactoryMock->expects($this->once())
             ->method('getModel')
             ->with('dashboard')
             ->willReturn($this->dashboardModelMock);
 
-        $this->dashboardModelMock->expects($this->at(0))
+        $this->dashboardModelMock->expects($this->once())
             ->method('saveSnapshot')
             ->will($this->throwException(new IOException('some error message')));
 
-        $this->translatorMock->expects($this->at(0))
+        $this->translatorMock->expects($this->once())
             ->method('trans')
             ->with('mautic.dashboard.error.save');
 
@@ -242,6 +281,11 @@ class DashboardControllerTest extends \PHPUnit\Framework\TestCase
         $widgetId        = '1';
         $widget          = new \Mautic\DashboardBundle\Entity\Widget();
         $renderedContent = 'lfsadkdhfůasfjds';
+        $engine          = $this->createMock(PhpEngine::class);
+
+        $engine->expects(self::once())
+            ->method('render')
+            ->willReturn($renderedContent);
 
         $this->requestMock->method('isXmlHttpRequest')
             ->willReturn(true);
@@ -255,25 +299,18 @@ class DashboardControllerTest extends \PHPUnit\Framework\TestCase
             ->with((int) $widgetId)
             ->willReturn($widget);
 
-        $this->containerMock->expects(self::at(0))
+        $this->containerMock->expects(self::exactly(2))
             ->method('get')
-            ->with('mautic.dashboard.widget')
-            ->willReturn($widgetService);
+            ->withConsecutive(
+                ['mautic.dashboard.widget'],
+                ['templating']
+            )
+            ->willReturnOnConsecutiveCalls($widgetService, $engine);
 
         $this->containerMock->expects(self::once())
             ->method('has')
             ->with('templating')
             ->willReturn(true);
-
-        $engine = $this->createMock(PhpEngine::class);
-        $engine->expects(self::once())
-            ->method('render')
-            ->willReturn($renderedContent);
-
-        $this->containerMock->expects(self::at(2))
-            ->method('get')
-            ->with('templating')
-            ->willReturn($engine);
 
         $response = $this->controller->widgetAction($widgetId);
 

--- a/app/bundles/DashboardBundle/Tests/Model/DashboardModelTest.php
+++ b/app/bundles/DashboardBundle/Tests/Model/DashboardModelTest.php
@@ -16,6 +16,7 @@ namespace Mautic\DashboardBundle\Tests\Model;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\DashboardBundle\Model\DashboardModel;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
@@ -69,33 +70,34 @@ class DashboardModelTest extends TestCase
 
     public function testGetDefaultFilterFromSession(): void
     {
-        $dateFrom = '-1 month';
+        $dateFromStr = '-1 month';
+        $dateFrom    = new \DateTime($dateFromStr);
+        $dateTo      = new \DateTime();
 
         $this->coreParametersHelper->expects(self::once())
             ->method('get')
-            ->with('default_daterange_filter', $dateFrom)
-            ->willReturn($dateFrom);
+            ->with('default_daterange_filter', $dateFromStr)
+            ->willReturn($dateFromStr);
 
-        $dateFrom = new \DateTime($dateFrom);
-        $this->session->expects(self::at(0))
+        $this->session->expects($this->exactly(2))
             ->method('get')
-            ->with('mautic.daterange.form.from')
-            ->willReturn($dateFrom->format(\DateTimeInterface::ATOM));
-
-        $dateTo = new \DateTime();
-        $this->session->expects(self::at(1))
-            ->method('get')
-            ->with('mautic.daterange.form.to')
-            ->willReturn($dateTo->format(\DateTimeInterface::ATOM));
+            ->withConsecutive(
+                ['mautic.daterange.form.from'],
+                ['mautic.daterange.form.to']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $dateFrom->format(\DateTimeInterface::ATOM),
+                $dateTo->format(\DateTimeInterface::ATOM)
+            );
 
         $filter = $this->model->getDefaultFilter();
 
-        self::assertSame(
+        Assert::assertSame(
             $dateFrom->format(\DateTimeInterface::ATOM),
             $filter['dateFrom']->format(\DateTimeInterface::ATOM)
         );
 
-        self::assertSame(
+        Assert::assertSame(
             $dateTo->format(\DateTimeInterface::ATOM),
             $filter['dateTo']->format(\DateTimeInterface::ATOM)
         );

--- a/app/bundles/DynamicContentBundle/Tests/Helper/DynamicContentHelperTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Helper/DynamicContentHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2017 Mautic Contributors. All rights reserved
  * @author      Mautic
@@ -18,49 +20,51 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class DynamicContentHelperTest extends \PHPUnit\Framework\TestCase
 {
-    public function testGetDwcBySlotNameWithPublished()
+    public function testGetDwcBySlotNameWithPublished(): void
     {
         $mockModel = $this->getMockBuilder(DynamicContentModel::class)
             ->disableOriginalConstructor()
             ->setMethods(['getEntities'])
             ->getMock();
 
-        $mockModel->expects($this->at(0))
+        $mockModel->expects($this->exactly(2))
             ->method('getEntities')
-            ->with([
-                'filter' => [
-                    'where' => [
-                        [
-                            'col'  => 'e.slotName',
-                            'expr' => 'eq',
-                            'val'  => 'test',
+            ->withConsecutive(
+                [
+                    [
+                        'filter' => [
+                            'where' => [
+                                [
+                                    'col'  => 'e.slotName',
+                                    'expr' => 'eq',
+                                    'val'  => 'test',
+                                ],
+                                [
+                                    'col'  => 'e.isPublished',
+                                    'expr' => 'eq',
+                                    'val'  => 1,
+                                ],
+                            ],
                         ],
-                        [
-                            'col'  => 'e.isPublished',
-                            'expr' => 'eq',
-                            'val'  => 1,
-                        ],
+                        'ignore_paginator' => true,
                     ],
                 ],
-                'ignore_paginator' => true,
-            ])
-            ->willReturn(true);
-
-        $mockModel->expects($this->at(1))
-            ->method('getEntities')
-            ->with([
-                'filter' => [
-                    'where' => [
-                        [
-                            'col'  => 'e.slotName',
-                            'expr' => 'eq',
-                            'val'  => 'secondtest',
+                [
+                    [
+                        'filter' => [
+                            'where' => [
+                                [
+                                    'col'  => 'e.slotName',
+                                    'expr' => 'eq',
+                                    'val'  => 'secondtest',
+                                ],
+                            ],
                         ],
+                        'ignore_paginator' => true,
                     ],
-                ],
-                'ignore_paginator' => true,
-            ])
-            ->willReturn(false);
+                ]
+            )
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $realTimeExecutioner = $this->createMock(RealTimeExecutioner::class);
         $mockDispatcher      = $this->createMock(EventDispatcher::class);

--- a/app/bundles/EmailBundle/EventListener/DetermineWinnerSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/DetermineWinnerSubscriber.php
@@ -11,17 +11,19 @@
 
 namespace Mautic\EmailBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Event\DetermineWinnerEvent;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\PageBundle\Entity\Hit;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class DetermineWinnerSubscriber implements EventSubscriberInterface
 {
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $em;
 
@@ -30,7 +32,7 @@ class DetermineWinnerSubscriber implements EventSubscriberInterface
      */
     private $translator;
 
-    public function __construct(EntityManager $em, TranslatorInterface $translator)
+    public function __construct(EntityManagerInterface $em, TranslatorInterface $translator)
     {
         $this->em         = $em;
         $this->translator = $translator;
@@ -57,7 +59,7 @@ class DetermineWinnerSubscriber implements EventSubscriberInterface
         $children   = $parameters['children'];
 
         /** @var \Mautic\EmailBundle\Entity\StatRepository $repo */
-        $repo = $this->em->getRepository('MauticEmailBundle:Stat');
+        $repo = $this->em->getRepository(Stat::class);
         /** @var Email $parent */
         $ids       = $parent->getRelatedEntityIds();
         $startDate = $parent->getVariantStartDate();
@@ -151,9 +153,9 @@ class DetermineWinnerSubscriber implements EventSubscriberInterface
         $children   = $parameters['children'];
 
         /** @var \Mautic\PageBundle\Entity\HitRepository $pageRepo */
-        $pageRepo = $this->em->getRepository('MauticPageBundle:Hit');
+        $pageRepo = $this->em->getRepository(Hit::class);
         /** @var \Mautic\EmailBundle\Entity\StatRepository $emailRepo */
-        $emailRepo = $this->em->getRepository('MauticEmailBundle:Stat');
+        $emailRepo = $this->em->getRepository(Stat::class);
         /** @var Email $parent */
         $ids = $parent->getRelatedEntityIds();
 

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
@@ -169,7 +169,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertSame('Email Stat with tracking hash tracking_hash_123 was not found', $responseData['errors'][0]['message']);
     }
 
-    public function testReplyAction()
+    public function testReplyAction(): void
     {
         $trackingHash = 'tracking_hash_123';
 
@@ -199,7 +199,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         // Check that the email reply was created correctly.
         $this->assertSame('1', $fetchedReplyData['total']);
         $this->assertSame($stat->getId(), $fetchedReplyData['stats'][0]['stat_id']);
-        $this->assertRegExp('/api-[a-z0-9]*/', $fetchedReplyData['stats'][0]['message_id']);
+        $this->assertMatchesRegularExpression('/api-[a-z0-9]*/', $fetchedReplyData['stats'][0]['message_id']);
 
         // Get the email stat that was just updated from the stat API.
         $statQuery = ['where' => [['col' => 'id', 'expr' => 'eq', 'val' => $stat->getId()]]];
@@ -210,6 +210,6 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertSame('1', $fetchedStatData['total']);
         $this->assertSame($stat->getId(), $fetchedStatData['stats'][0]['id']);
         $this->assertSame('1', $fetchedStatData['stats'][0]['is_read']);
-        $this->assertRegExp('/\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}/', $fetchedStatData['stats'][0]['date_read']);
+        $this->assertMatchesRegularExpression('/\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}/', $fetchedStatData['stats'][0]['date_read']);
     }
 }

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -19,6 +21,7 @@ use Mautic\EmailBundle\Controller\EmailController;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Form\Form;
@@ -30,19 +33,74 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class EmailControllerTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var MockObject|TranslatorInterface
+     */
     private $translatorMock;
+
+    /**
+     * @var MockObject|Session
+     */
     private $sessionMock;
+
+    /**
+     * @var MockObject|ModelFactory
+     */
     private $modelFactoryMock;
+
+    /**
+     * @var MockObject|Container
+     */
     private $containerMock;
+
+    /**
+     * @var MockObject|Router
+     */
     private $routerMock;
+
+    /**
+     * @var MockObject|EmailModel
+     */
     private $modelMock;
+
+    /**
+     * @var MockObject|Email
+     */
     private $emailMock;
+
+    /**
+     * @var MockObject|FlashBag
+     */
     private $flashBagMock;
+
+    /**
+     * @var EmailController
+     */
     private $controller;
+
+    /**
+     * @var MockObject|CorePermissions
+     */
     private $corePermissionsMock;
+
+    /**
+     * @var MockObject|UserHelper
+     */
     private $helperUserMock;
+
+    /**
+     * @var MockObject|FormFactory
+     */
     private $formFactoryMock;
+
+    /**
+     * @var MockObject|Form
+     */
     private $formMock;
+
+    /**
+     * @var MockObject|DelegatingEngine
+     */
     private $templatingMock;
 
     protected function setUp(): void
@@ -70,32 +128,22 @@ class EmailControllerTest extends \PHPUnit\Framework\TestCase
         $this->controller->setRequest(new Request());
     }
 
-    public function testSendActionWhenNoEntityFound()
+    public function testSendActionWhenNoEntityFound(): void
     {
-        $this->containerMock->expects($this->at(0))
+        $this->containerMock->expects($this->exactly(3))
             ->method('get')
-            ->with('mautic.model.factory')
-            ->willReturn($this->modelFactoryMock);
+            ->withConsecutive(['mautic.model.factory'], ['session'], ['router'])
+            ->willReturnOnConsecutiveCalls($this->modelFactoryMock, $this->sessionMock, $this->routerMock);
 
-        $this->modelFactoryMock->expects($this->at(0))
+        $this->modelFactoryMock->expects($this->once())
             ->method('getModel')
             ->with('email')
             ->willReturn($this->modelMock);
 
-        $this->modelMock->expects($this->at(0))
+        $this->modelMock->expects($this->once())
             ->method('getEntity')
             ->with(5)
             ->willReturn(null);
-
-        $this->containerMock->expects($this->at(1))
-            ->method('get')
-            ->with('session')
-            ->willReturn($this->sessionMock);
-
-        $this->containerMock->expects($this->at(2))
-            ->method('get')
-            ->with('router')
-            ->willReturn($this->routerMock);
 
         $this->routerMock->expects($this->any())
             ->method('generate')
@@ -108,32 +156,22 @@ class EmailControllerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(302, $response->getStatusCode());
     }
 
-    public function testSendActionWhenEnityFoundButNotPublished()
+    public function testSendActionWhenEnityFoundButNotPublished(): void
     {
-        $this->containerMock->expects($this->at(0))
+        $this->containerMock->expects($this->exactly(3))
             ->method('get')
-            ->with('mautic.model.factory')
-            ->willReturn($this->modelFactoryMock);
+            ->withConsecutive(['mautic.model.factory'], ['session'], ['router'])
+            ->willReturnOnConsecutiveCalls($this->modelFactoryMock, $this->sessionMock, $this->routerMock);
 
-        $this->modelFactoryMock->expects($this->at(0))
+        $this->modelFactoryMock->expects($this->once())
             ->method('getModel')
             ->with('email')
             ->willReturn($this->modelMock);
 
-        $this->modelMock->expects($this->at(0))
+        $this->modelMock->expects($this->once())
             ->method('getEntity')
             ->with(5)
             ->willReturn($this->emailMock);
-
-        $this->containerMock->expects($this->at(1))
-            ->method('get')
-            ->with('session')
-            ->willReturn($this->sessionMock);
-
-        $this->containerMock->expects($this->at(2))
-            ->method('get')
-            ->with('router')
-            ->willReturn($this->routerMock);
 
         $this->routerMock->expects($this->any())
             ->method('generate')
@@ -150,43 +188,47 @@ class EmailControllerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(302, $response->getStatusCode());
     }
 
-    public function testThatExampleEmailsHaveTestStringInTheirSubject()
+    public function testThatExampleEmailsHaveTestStringInTheirSubject(): void
     {
         $this->emailMock->expects($this->once())
             ->method('setSubject')
             ->with($this->stringStartsWith(EmailController::EXAMPLE_EMAIL_SUBJECT_PREFIX));
 
-        $this->containerMock->expects($this->at(0))
+        $this->containerMock->expects($this->exactly(6))
             ->method('get')
-            ->with('mautic.model.factory')
-            ->willReturn($this->modelFactoryMock);
+            ->withConsecutive(
+                ['mautic.model.factory'],
+                ['mautic.security'],
+                ['router'],
+                ['mautic.helper.user'],
+                ['form.factory'],
+                ['templating']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->modelFactoryMock,
+                $this->corePermissionsMock,
+                $this->routerMock,
+                $this->helperUserMock,
+                $this->formFactoryMock,
+                $this->templatingMock
+            );
 
-        $this->modelFactoryMock->expects($this->at(0))
+        $this->modelFactoryMock->expects($this->once())
             ->method('getModel')
             ->with('email')
             ->willReturn($this->modelMock);
 
-        $this->modelMock->expects($this->at(0))
+        $this->modelMock->expects($this->once())
             ->method('getEntity')
             ->with(1)
             ->willReturn($this->emailMock);
 
-        $this->containerMock->expects($this->at(1))
-            ->method('get')
-            ->with('mautic.security')
-            ->willReturn($this->corePermissionsMock);
-
-        $this->corePermissionsMock->expects($this->at(0))
+        $this->corePermissionsMock->expects($this->once())
             ->method('hasEntityAccess')
             ->with('email:emails:viewown', 'email:emails:viewother', null)
             ->willReturn(true);
 
-        $this->containerMock->expects($this->at(2))
-            ->method('get')
-            ->with('router')
-            ->willReturn($this->routerMock);
-
-        $this->routerMock->expects($this->at(0))
+        $this->routerMock->expects($this->once())
             ->method('generate')
             ->with('mautic_email_action', [
                 'objectAction' => 'sendExample',
@@ -194,21 +236,11 @@ class EmailControllerTest extends \PHPUnit\Framework\TestCase
             ], 1)
             ->willReturn('someUrl');
 
-        $this->containerMock->expects($this->at(3))
-            ->method('get')
-            ->with('mautic.helper.user')
-            ->willReturn($this->helperUserMock);
-
-        $this->helperUserMock->expects($this->at(0))
+        $this->helperUserMock->expects($this->once())
             ->method('getUser')
             ->willReturn(new User(false));
 
-        $this->containerMock->expects($this->at(4))
-            ->method('get')
-            ->with('form.factory')
-            ->willReturn($this->formFactoryMock);
-
-        $this->formFactoryMock->expects($this->at(0))
+        $this->formFactoryMock->expects($this->once())
             ->method('create')
             ->with('Mautic\EmailBundle\Form\Type\ExampleSendType',
                 [
@@ -224,15 +256,10 @@ class EmailControllerTest extends \PHPUnit\Framework\TestCase
             )
             ->willReturn($this->formMock);
 
-        $this->containerMock->expects($this->at(5))
+        $this->containerMock->expects($this->once())
             ->method('has')
             ->with('templating')
             ->willReturn(true);
-
-        $this->containerMock->expects($this->at(6))
-            ->method('get')
-            ->with('templating')
-            ->willReturn($this->templatingMock);
 
         $this->templatingMock->expects($this->once())
             ->method('render')

--- a/app/bundles/EmailBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2019 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -11,17 +13,27 @@
 
 namespace Mautic\EmailBundle\Tests\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Event\DetermineWinnerEvent;
 use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\EventListener\DetermineWinnerSubscriber;
+use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\HitRepository;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var MockObject|EntityManagerInterface
+     */
     private $em;
+
+    /**
+     * @var MockObject|TranslatorInterface
+     */
     private $translator;
 
     /**
@@ -33,7 +45,7 @@ class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->em         = $this->createMock(EntityManager::class);
+        $this->em         = $this->createMock(EntityManagerInterface::class);
         $this->translator = $this->createMock(TranslatorInterface::class);
         $this->subscriber = new DetermineWinnerSubscriber($this->em, $this->translator);
     }
@@ -150,13 +162,9 @@ class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
                 'opened'
             );
 
-        $this->em->expects($this->at(0))
-            ->method('getRepository')
-            ->willReturn($pageRepoMock);
-
-        $this->em->expects($this->at(1))
-            ->method('getRepository')
-            ->willReturn($emailRepoMock);
+        $this->em->method('getRepository')
+            ->withConsecutive([Hit::class], [Stat::class])
+            ->willReturnOnConsecutiveCalls($pageRepoMock, $emailRepoMock);
 
         $parentMock->expects($this->once())
             ->method('getRelatedEntityIds')

--- a/app/bundles/EmailBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -218,25 +220,22 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $queryBuilderMock->method('execute')->willReturn($statementMock);
 
-        $eventMock->expects($this->at(0))
+        $eventMock->expects($this->once())
             ->method('getRequestedGraphs')
             ->willReturn(['mautic.email.graph.pie.read.ingored.unsubscribed.bounced']);
 
-        $eventMock->expects($this->at(1))
-            ->method('checkContext')
-            ->with(['email.stats', 'emails'])
+        $eventMock->method('checkContext')
+            ->withConsecutive(
+                [['email.stats', 'emails']],
+                ['emails']
+            )
             ->willReturn(true);
 
-        $eventMock->expects($this->at(2))
-            ->method('checkContext')
-            ->with('emails')
-            ->willReturn(true);
-
-        $eventMock->expects($this->at(3))
+        $eventMock->expects($this->once())
             ->method('getQueryBuilder')
             ->willReturn($queryBuilderMock);
 
-        $eventMock->expects($this->at(4))
+        $eventMock->expects($this->once())
             ->method('getOptions')
             ->willReturn(['chartQuery' => $chartQueryMock, 'translator' => $translatorMock]);
 

--- a/app/bundles/EmailBundle/Tests/Form/Type/EmailTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/EmailTypeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2020 Mautic Contributors. All rights reserved
  * @author      Mautic
@@ -17,6 +19,7 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Form\Type\EmailType;
 use Mautic\StageBundle\Model\StageModel;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -72,32 +75,24 @@ class EmailTypeTest extends \PHPUnit\Framework\TestCase
         $this->formBuilder->method('create')->willReturnSelf();
     }
 
-    public function testBuildForm()
+    public function testBuildForm(): void
     {
-        $options = [
-            'data' => new Email(),
-        ];
+        $options = ['data' => new Email()];
+        $names   = [];
 
-        $this->formBuilder->expects($this->at(47))
-            ->method('add')
+        $this->formBuilder->method('add')
             ->with(
-                'buttons',
-                FormButtonsType::class,
-                [
-                    'pre_extra_buttons' => [
-                        [
-                            'name'  => 'builder',
-                            'label' => 'mautic.core.builder',
-                            'attr'  => [
-                                'class'   => 'btn btn-default btn-dnd btn-nospin text-primary btn-builder',
-                                'icon'    => 'fa fa-cube',
-                                'onclick' => "Mautic.launchBuilder('emailform', 'email');",
-                            ],
-                        ],
-                    ],
-                ]
+                $this->callback(
+                    function ($name) use (&$names) {
+                        $names[] = $name;
+
+                        return true;
+                    }
+                )
             );
 
         $this->form->buildForm($this->formBuilder, $options);
+
+        Assert::assertContains('buttons', $names);
     }
 }

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Callback/SendGridApiCallbackTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Callback/SendGridApiCallbackTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2014 Mautic Contributors. All rights reserved
  * @author      Mautic
@@ -18,15 +20,11 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SendGridApiCallbackTest extends \PHPUnit\Framework\TestCase
 {
-    public function testSupportedEvents()
+    public function testSupportedEvents(): void
     {
-        $transportCallback = $this->getMockBuilder(TransportCallback::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $transportCallback   = $this->createMock(TransportCallback::class);
         $sendGridApiCallback = new SendGridApiCallback($transportCallback);
-
-        $payload = [
+        $payload             = [
             [
                 'email'         => 'example5@test.com',
                 'timestamp'     => '1512130989',
@@ -67,13 +65,12 @@ class SendGridApiCallbackTest extends \PHPUnit\Framework\TestCase
 
         $request = new Request(['query'], $payload);
 
-        $transportCallback->expects($this->at(0))
+        $transportCallback->expects($this->exactly(2))
             ->method('addFailureByAddress')
-            ->with('example6@test.com', '500 unknown recipient', DoNotContact::BOUNCED);
-
-        $transportCallback->expects($this->at(1))
-            ->method('addFailureByAddress')
-            ->with('example7@test.com', 'Bounced Address', DoNotContact::BOUNCED);
+            ->withConsecutive(
+                ['example6@test.com', '500 unknown recipient', DoNotContact::BOUNCED],
+                ['example7@test.com', 'Bounced Address', DoNotContact::BOUNCED]
+            );
 
         $sendGridApiCallback->processCallbackRequest($request);
     }

--- a/app/bundles/EmailBundle/Tests/Validator/MultipleEmailsValidValidatorTest.php
+++ b/app/bundles/EmailBundle/Tests/Validator/MultipleEmailsValidValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2016 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -20,15 +22,10 @@ use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 class MultipleEmailsValidValidatorTest extends \PHPUnit\Framework\TestCase
 {
-    public function testNoEmailsProvided()
+    public function testNoEmailsProvided(): void
     {
-        $emailValidatorMock = $this->getMockBuilder(EmailValidator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $constraintMock = $this->getMockBuilder(Constraint::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $emailValidatorMock = $this->createMock(EmailValidator::class);
+        $constraintMock     = $this->createMock(Constraint::class);
 
         $emailValidatorMock->expects($this->never())
             ->method('validate');
@@ -38,23 +35,14 @@ class MultipleEmailsValidValidatorTest extends \PHPUnit\Framework\TestCase
         $multipleEmailsValidValidator->validate(null, $constraintMock);
     }
 
-    public function testValidEmails()
+    public function testValidEmails(): void
     {
-        $emailValidatorMock = $this->getMockBuilder(EmailValidator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $emailValidatorMock = $this->createMock(EmailValidator::class);
+        $constraintMock     = $this->createMock(Constraint::class);
 
-        $constraintMock = $this->getMockBuilder(Constraint::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $emailValidatorMock->expects($this->at(0))
+        $emailValidatorMock->expects($this->exactly(2))
             ->method('validate')
-            ->with('john@don.com');
-
-        $emailValidatorMock->expects($this->at(1))
-            ->method('validate')
-            ->with('don@john.com');
+            ->withConsecutive(['john@don.com'], ['don@john.com']);
 
         $multipleEmailsValidValidator = new MultipleEmailsValidValidator($emailValidatorMock);
 
@@ -62,32 +50,17 @@ class MultipleEmailsValidValidatorTest extends \PHPUnit\Framework\TestCase
         $multipleEmailsValidValidator->validate($emails, $constraintMock);
     }
 
-    public function testNotValidEmails()
+    public function testNotValidEmails(): void
     {
-        $emailValidatorMock = $this->getMockBuilder(EmailValidator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $emailValidatorMock                      = $this->createMock(EmailValidator::class);
+        $constraintMock                          = $this->createMock(Constraint::class);
+        $executionContextInterfaceMock           = $this->createMock(ExecutionContextInterface::class);
+        $constraintViolationBuilderInterfaceMock = $this->createMock(ConstraintViolationBuilderInterface::class);
 
-        $constraintMock = $this->getMockBuilder(Constraint::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $executionContextInterfaceMock = $this->getMockBuilder(ExecutionContextInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $constraintViolationBuilderInterfaceMock = $this->getMockBuilder(ConstraintViolationBuilderInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $emailValidatorMock->expects($this->at(0))
+        $emailValidatorMock->expects($this->exactly(2))
             ->method('validate')
-            ->with('john@don.com');
-
-        $emailValidatorMock->expects($this->at(1))
-            ->method('validate')
-            ->with('xxx')
-            ->willThrowException(new InvalidEmailException('xxx'));
+            ->withConsecutive(['john@don.com'], ['xxx'])
+            ->willReturn(null, $this->throwException(new InvalidEmailException('xxx')));
 
         $executionContextInterfaceMock->expects($this->once())
             ->method('buildViolation')

--- a/app/bundles/FormBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2019 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -15,11 +17,19 @@ use Mautic\CoreBundle\Event\DetermineWinnerEvent;
 use Mautic\FormBundle\Entity\SubmissionRepository;
 use Mautic\FormBundle\EventListener\DetermineWinnerSubscriber;
 use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var MockObject|SubmissionRepository
+     */
     private $submissionRepository;
+
+    /**
+     * @var MockObject|TranslatorInterface
+     */
     private $translator;
 
     /**
@@ -61,13 +71,8 @@ class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->translator->expects($this->at(0))
-            ->method('trans')
-            ->willReturn($transSubmissions);
-
-        $this->translator->expects($this->at(1))
-            ->method('trans')
-            ->willReturn($transHits);
+        $this->translator->method('trans')
+            ->willReturnOnConsecutiveCalls($transSubmissions, $transHits);
 
         $parentMock->expects($this->any())
             ->method('isPublished')

--- a/app/bundles/FormBundle/Tests/Model/DeleteFormTest.php
+++ b/app/bundles/FormBundle/Tests/Model/DeleteFormTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2014 Mautic Contributors. All rights reserved
  * @author      Mautic
@@ -31,61 +33,24 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class DeleteFormTest extends FormTestAbstract
 {
-    public function testDelete()
+    public function testDelete(): void
     {
-        $requestStack = $this
-            ->getMockBuilder(RequestStack::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $templatingHelperMock = $this
-            ->getMockBuilder(TemplatingHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $themeHelper = $this
-            ->getMockBuilder(ThemeHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $formActionModel = $this
-            ->getMockBuilder(ActionModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $formFieldModel = $this
-            ->getMockBuilder(FieldModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $fieldHelper = $this
-            ->getMockBuilder(FormFieldHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $leadFieldModel = $this
-            ->getMockBuilder(LeadFieldModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $formUploaderMock = $this
-            ->getMockBuilder(FormUploader::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $contactTracker = $this->createMock(ContactTracker::class);
-
-        $columnSchemaHelper = $this
-            ->getMockBuilder(ColumnSchemaHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $tableSchemaHelper = $this
-            ->getMockBuilder(TableSchemaHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $formModel = new FormModel(
+        $requestStack         = $this->createMock(RequestStack::class);
+        $templatingHelperMock = $this->createMock(TemplatingHelper::class);
+        $themeHelper          = $this->createMock(ThemeHelper::class);
+        $formActionModel      = $this->createMock(ActionModel::class);
+        $formFieldModel       = $this->createMock(FieldModel::class);
+        $fieldHelper          = $this->createMock(FormFieldHelper::class);
+        $leadFieldModel       = $this->createMock(LeadFieldModel::class);
+        $formUploaderMock     = $this->createMock(FormUploader::class);
+        $contactTracker       = $this->createMock(ContactTracker::class);
+        $columnSchemaHelper   = $this->createMock(ColumnSchemaHelper::class);
+        $tableSchemaHelper    = $this->createMock(TableSchemaHelper::class);
+        $entityManager        = $this->createMock(EntityManager::class);
+        $dispatcher           = $this->createMock(EventDispatcher::class);
+        $formRepository       = $this->createMock(FormRepository::class);
+        $form                 = $this->createMock(Form::class);
+        $formModel            = new FormModel(
             $requestStack,
             $templatingHelperMock,
             $themeHelper,
@@ -99,30 +64,10 @@ class DeleteFormTest extends FormTestAbstract
             $tableSchemaHelper
         );
 
-        $dispatcher = $this
-            ->getMockBuilder(EventDispatcher::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $dispatcher->expects($this->at(0))
+        $dispatcher->expects($this->exactly(2))
             ->method('hasListeners')
-            ->with('mautic.form_pre_delete')
+            ->withConsecutive(['mautic.form_pre_delete'], ['mautic.form_post_delete'])
             ->willReturn(false);
-
-        $dispatcher->expects($this->at(1))
-            ->method('hasListeners')
-            ->with('mautic.form_post_delete')
-            ->willReturn(false);
-
-        $entityManager = $this
-            ->getMockBuilder(EntityManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $formRepository = $this
-            ->getMockBuilder(FormRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
 
         $entityManager->expects($this->once())
             ->method('getRepository')
@@ -130,11 +75,6 @@ class DeleteFormTest extends FormTestAbstract
 
         $formModel->setDispatcher($dispatcher);
         $formModel->setEntityManager($entityManager);
-
-        $form = $this
-            ->getMockBuilder(Form::class)
-            ->disableOriginalConstructor()
-            ->getMock();
 
         $form->expects($this->exactly(2))
             ->method('getId')

--- a/app/bundles/FormBundle/Tests/Model/FormUploaderTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormUploaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2014 Mautic Contributors. All rights reserved
  * @author      Mautic
@@ -29,45 +31,28 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Uploader uploads files correctly
-     *
-     * @covers \Mautic\FormBundle\Helper\FormUploader::uploadFiles
      */
-    public function testSuccessfulUploadFiles()
+    public function testSuccessfulUploadFiles(): void
     {
-        $fileUploaderMock = $this->getMockBuilder(FileUploader::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $fileUploaderMock         = $this->createMock(FileUploader::class);
+        $coreParametersHelperMock = $this->createMock(CoreParametersHelper::class);
+        $formUploader             = new FormUploader($fileUploaderMock, $coreParametersHelperMock);
+        $file1Mock                = $this->createMock(UploadedFile::class);
+        $file2Mock                = $this->createMock(UploadedFile::class);
+        $form1Mock                = $this->createMock(Form::class);
+        $field1Mock               = $this->createMock(Field::class);
+        $form2Mock                = $this->createMock(Form::class);
+        $field2Mock               = $this->createMock(Field::class);
 
-        $coreParametersHelperMock = $this->getMockBuilder(CoreParametersHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $coreParametersHelperMock->expects($this->exactly(2))
             ->method('get')
             ->with('form_upload_dir')
             ->willReturn($this->uploadDir);
 
-        $formUploader = new FormUploader($fileUploaderMock, $coreParametersHelperMock);
-
-        $file1Mock = $this->getMockBuilder(UploadedFile::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $file2Mock = $this->getMockBuilder(UploadedFile::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $form1Mock = $this->getMockBuilder(Form::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $form1Mock->expects($this->once())
             ->method('getId')
             ->with()
             ->willReturn($this->formId1);
-
-        $field1Mock = $this->getMockBuilder(Field::class)
-            ->disableOriginalConstructor()
-            ->getMock();
 
         $field1Mock->expects($this->once())
             ->method('getId')
@@ -84,18 +69,10 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
             ->with()
             ->willReturn('file1');
 
-        $form2Mock = $this->getMockBuilder(Form::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $form2Mock->expects($this->once())
             ->method('getId')
             ->with()
             ->willReturn($this->formId2);
-
-        $field2Mock = $this->getMockBuilder(Field::class)
-            ->disableOriginalConstructor()
-            ->getMock();
 
         $field2Mock->expects($this->once())
             ->method('getId')
@@ -122,15 +99,10 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
         $path1 = $this->uploadDir.'/1/fieldId1';
         $path2 = $this->uploadDir.'/2/fieldId2';
 
-        $fileUploaderMock->expects($this->at(0))
+        $fileUploaderMock->expects($this->exactly(2))
             ->method('upload')
-            ->with($path1, $file1Mock)
-            ->willReturn('upload1.jpg');
-
-        $fileUploaderMock->expects($this->at(1))
-            ->method('upload')
-            ->with($path2, $file2Mock)
-            ->willReturn('upload2.txt');
+            ->withConsecutive([$path1, $file1Mock], [$path2, $file2Mock])
+            ->willReturnOnConsecutiveCalls('upload1.jpg', 'upload2.txt');
 
         $formUploader->uploadFiles($filesToUpload, $submission);
 
@@ -145,45 +117,28 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Uploader delete uploaded file if anz error occures
-     *
-     * @covers \Mautic\FormBundle\Helper\FormUploader::uploadFiles
      */
-    public function testUploadFilesWithError()
+    public function testUploadFilesWithError(): void
     {
-        $fileUploaderMock = $this->getMockBuilder(FileUploader::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $fileUploaderMock         = $this->createMock(FileUploader::class);
+        $coreParametersHelperMock = $this->createMock(CoreParametersHelper::class);
+        $formUploader             = new FormUploader($fileUploaderMock, $coreParametersHelperMock);
+        $file1Mock                = $this->createMock(UploadedFile::class);
+        $file2Mock                = $this->createMock(UploadedFile::class);
+        $form1Mock                = $this->createMock(Form::class);
+        $field1Mock               = $this->createMock(Field::class);
+        $form2Mock                = $this->createMock(Form::class);
+        $field2Mock               = $this->createMock(Field::class);
 
-        $coreParametersHelperMock = $this->getMockBuilder(CoreParametersHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $coreParametersHelperMock->expects($this->exactly(2))
             ->method('get')
             ->with('form_upload_dir')
             ->willReturn($this->uploadDir);
 
-        $formUploader = new FormUploader($fileUploaderMock, $coreParametersHelperMock);
-
-        $file1Mock = $this->getMockBuilder(UploadedFile::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $file2Mock = $this->getMockBuilder(UploadedFile::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $form1Mock = $this->getMockBuilder(Form::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $form1Mock->expects($this->once())
             ->method('getId')
             ->with()
             ->willReturn($this->formId1);
-
-        $field1Mock = $this->getMockBuilder(Field::class)
-            ->disableOriginalConstructor()
-            ->getMock();
 
         $field1Mock->expects($this->once())
             ->method('getId')
@@ -200,18 +155,10 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
             ->with()
             ->willReturn('file1');
 
-        $form2Mock = $this->getMockBuilder(Form::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $form2Mock->expects($this->once())
             ->method('getId')
             ->with()
             ->willReturn($this->formId2);
-
-        $field2Mock = $this->getMockBuilder(Field::class)
-            ->disableOriginalConstructor()
-            ->getMock();
 
         $field2Mock->expects($this->once())
             ->method('getId')
@@ -238,15 +185,10 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
         $path1 = $this->uploadDir.'/1/fieldId1';
         $path2 = $this->uploadDir.'/2/fieldId2';
 
-        $fileUploaderMock->expects($this->at(0))
+        $fileUploaderMock->expects($this->exactly(2))
             ->method('upload')
-            ->with($path1, $file1Mock)
-            ->willReturn('upload1.jpg');
-
-        $fileUploaderMock->expects($this->at(1))
-            ->method('upload')
-            ->with($path2, $file2Mock)
-            ->willThrowException(new FileUploadException());
+            ->withConsecutive([$path1, $file1Mock], [$path2, $file2Mock])
+            ->willReturnOnConsecutiveCalls('upload1.jpg', $this->throwException(new FileUploadException()));
 
         $fileUploaderMock->expects($this->once())
             ->method('delete')
@@ -268,14 +210,10 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Uploader do nothing if no files for upload provided
-     *
-     * @covers \Mautic\FormBundle\Helper\FormUploader::uploadFiles
      */
-    public function testNoFilesUploadFiles()
+    public function testNoFilesUploadFiles(): void
     {
-        $fileUploaderMock = $this->getMockBuilder(FileUploader::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $fileUploaderMock = $this->createMock(FileUploader::class);
 
         $fileUploaderMock->expects($this->never())
             ->method('upload');
@@ -283,9 +221,7 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
         $fileUploaderMock->expects($this->never())
             ->method('delete');
 
-        $coreParametersHelperMock = $this->getMockBuilder(CoreParametersHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $coreParametersHelperMock = $this->createMock(CoreParametersHelper::class);
 
         $formUploader = new FormUploader($fileUploaderMock, $coreParametersHelperMock);
 
@@ -297,35 +233,25 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Uploader returs correct path for file
-     *
-     * @covers \Mautic\FormBundle\Helper\FormUploader::getCompleteFilePath
      */
-    public function testGetCompleteFilePath()
+    public function testGetCompleteFilePath(): void
     {
-        $fileUploaderMock = $this->getMockBuilder(FileUploader::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $fileUploaderMock = $this->createMock(FileUploader::class);
 
-        $coreParametersHelperMock = $this->getMockBuilder(CoreParametersHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $coreParametersHelperMock = $this->createMock(CoreParametersHelper::class);
         $coreParametersHelperMock->expects($this->once())
             ->method('get')
             ->with('form_upload_dir')
             ->willReturn($this->uploadDir);
 
-        $formMock = $this->getMockBuilder(Form::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $formMock = $this->createMock(Form::class);
 
         $formMock->expects($this->once())
             ->method('getId')
             ->with()
             ->willReturn($this->formId1);
 
-        $fieldMock = $this->getMockBuilder(Field::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $fieldMock = $this->createMock(Field::class);
 
         $fieldMock->expects($this->once())
             ->method('getId')
@@ -346,22 +272,16 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Uploader delete files correctly
-     *
-     * @covers \Mautic\FormBundle\Helper\FormUploader::deleteAllFilesOfFormField
      */
-    public function testDeleteAllFilesOfFormField()
+    public function testDeleteAllFilesOfFormField(): void
     {
-        $fileUploaderMock = $this->getMockBuilder(FileUploader::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $fileUploaderMock = $this->createMock(FileUploader::class);
 
         $fileUploaderMock->expects($this->once())
             ->method('delete')
             ->with($this->uploadDir.'/1/fieldId1');
 
-        $coreParametersHelperMock = $this->getMockBuilder(CoreParametersHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $coreParametersHelperMock = $this->createMock(CoreParametersHelper::class);
         $coreParametersHelperMock->expects($this->once())
             ->method('get')
             ->with('form_upload_dir')
@@ -369,18 +289,14 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
 
         $formUploader = new FormUploader($fileUploaderMock, $coreParametersHelperMock);
 
-        $formMock = $this->getMockBuilder(Form::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $formMock = $this->createMock(Form::class);
 
         $formMock->expects($this->once())
             ->method('getId')
             ->with()
             ->willReturn($this->formId1);
 
-        $fieldMock = $this->getMockBuilder(Field::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $fieldMock = $this->createMock(Field::class);
 
         $fieldMock->expects($this->once())
             ->method('getId')
@@ -400,37 +316,24 @@ class FormUploaderTest extends \PHPUnit\Framework\TestCase
         $formUploader->deleteAllFilesOfFormField($fieldMock);
     }
 
-    public function testDeleteFilesOfForm()
+    public function testDeleteFilesOfForm(): void
     {
-        $fileUploaderMock = $this->getMockBuilder(FileUploader::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $fileUploaderMock         = $this->createMock(FileUploader::class);
+        $formMock                 = $this->createMock(Form::class);
+        $coreParametersHelperMock = $this->createMock(CoreParametersHelper::class);
 
         $fileUploaderMock
             ->method('delete')
             ->with($this->uploadDir.'/1');
 
-        $coreParametersHelperMock = $this->getMockBuilder(CoreParametersHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $coreParametersHelperMock->expects($this->exactly(2))
             ->method('get')
             ->with('form_upload_dir')
             ->willReturn($this->uploadDir);
 
-        $formMock = $this->getMockBuilder(Form::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $formMock->expects($this->at(0))
+        $formMock->expects($this->exactly(2))
             ->method('getId')
-            ->with()
-            ->willReturn($this->formId1);
-
-        $formMock->expects($this->at(1))
-            ->method('getId')
-            ->with()
-            ->willReturn(null);
+            ->willReturnOnConsecutiveCalls($this->formId1, null);
 
         $formUploader = new FormUploader($fileUploaderMock, $coreParametersHelperMock);
         $formUploader->deleteFilesOfForm($formMock);

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
@@ -138,26 +138,6 @@ class LeadSubscriberTest extends TestCase
         $this->subscriber->onLeadPostSave($this->leadEvent);
     }
 
-    public function testOnLeadCompanyChange(): void
-    {
-        $leadId      = 3;
-        $companyName = 'Dell';
-
-        $lead = $this->createMock(Lead::class);
-        $lead->expects($this->once())
-            ->method('getCompany')
-            ->willReturn($companyName);
-        $lead->expects($this->once())
-            ->method('getId')
-            ->willReturn($leadId);
-
-        $this->leadEvent->expects($this->once())
-            ->method('getLead')
-            ->willReturn($lead);
-
-        $this->subscriber->onLeadPostSave($this->leadEvent);
-    }
-
     public function testOnLeadPostSaveNoAction(): void
     {
         $fieldChanges = [];

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
@@ -101,7 +101,7 @@ class LeadSubscriberTest extends TestCase
     public function testOnLeadPostSaveAnonymousLead(): void
     {
         $lead = $this->createMock(Lead::class);
-        $lead->expects($this->at(0))
+        $lead->expects($this->once())
             ->method('isAnonymous')
             ->willReturn(true);
         $lead->expects($this->never())
@@ -120,7 +120,7 @@ class LeadSubscriberTest extends TestCase
     public function testOnLeadPostSaveLeadObjectSyncNotEnabled(): void
     {
         $lead = $this->createMock(Lead::class);
-        $lead->expects($this->at(0))
+        $lead->expects($this->once())
             ->method('isAnonymous')
             ->willReturn(false);
         $lead->expects($this->never())
@@ -144,10 +144,10 @@ class LeadSubscriberTest extends TestCase
         $companyName = 'Dell';
 
         $lead = $this->createMock(Lead::class);
-        $lead->expects($this->at(0))
+        $lead->expects($this->once())
             ->method('getCompany')
             ->willReturn($companyName);
-        $lead->expects($this->at(0))
+        $lead->expects($this->once())
             ->method('getId')
             ->willReturn($leadId);
 
@@ -163,7 +163,7 @@ class LeadSubscriberTest extends TestCase
         $fieldChanges = [];
 
         $lead = $this->createMock(Lead::class);
-        $lead->expects($this->at(0))
+        $lead->expects($this->once())
             ->method('isAnonymous')
             ->willReturn(false);
         $lead->expects($this->once())
@@ -199,7 +199,7 @@ class LeadSubscriberTest extends TestCase
         $objectType = Lead::class;
 
         $lead = $this->createMock(Lead::class);
-        $lead->expects($this->at(0))
+        $lead->expects($this->once())
             ->method('isAnonymous')
             ->willReturn(false);
         $lead->expects($this->once())
@@ -236,7 +236,7 @@ class LeadSubscriberTest extends TestCase
         $objectType = Lead::class;
 
         $lead = $this->createMock(Lead::class);
-        $lead->expects($this->at(0))
+        $lead->expects($this->once())
             ->method('isAnonymous')
             ->willReturn(false);
         $lead->expects($this->once())
@@ -275,7 +275,7 @@ class LeadSubscriberTest extends TestCase
         $objectType = Lead::class;
 
         $lead = $this->createMock(Lead::class);
-        $lead->expects($this->at(0))
+        $lead->expects($this->once())
             ->method('isAnonymous')
             ->willReturn(false);
         $lead->expects($this->once())

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
@@ -444,17 +444,18 @@ class LeadSubscriberTest extends TestCase
             ->willReturn($enabledIntegrations);
 
         $fieldNames = [];
+        $values     = [];
+        $valueDAOs  = [];
         $i          = 0;
         foreach ($fieldChanges as $fieldName => [$oldValue, $newValue]) {
-            $valueDao = new EncodedValueDAO($objectType, (string) $newValue);
-
-            $this->variableExpresserHelper->expects($this->at($i))
-                ->method('encodeVariable')
-                ->with($newValue)
-                ->willReturn($valueDao);
-
+            $values[]     = [$newValue];
+            $valueDAOs[]  = new EncodedValueDAO($objectType, (string) $newValue);
             $fieldNames[] = $fieldName;
         }
+
+        $this->variableExpresserHelper->method('encodeVariable')
+                ->withConsecutive(...$values)
+                ->willReturn(...$valueDAOs);
 
         $this->fieldChangeRepository->expects($this->once())
             ->method('deleteEntitiesForObjectByColumnName')

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Form/Type/IntegrationSyncSettingsObjectFieldTypeTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Form/Type/IntegrationSyncSettingsObjectFieldTypeTest.php
@@ -68,47 +68,46 @@ final class IntegrationSyncSettingsObjectFieldTypeTest extends \PHPUnit\Framewor
         $field->method('isToIntegrationSyncEnabled')->willReturn(true);
         $field->method('isToMauticSyncEnabled')->willReturn(true);
 
-        $this->formBuilder->expects($this->at(0))
+        $this->formBuilder->expects($this->exactly(2))
             ->method('add')
-            ->with(
-                'mappedField',
-                ChoiceType::class,
+            ->withConsecutive(
                 [
-                    'label'          => false,
-                    'choices'        => [
-                        'Mautic Field A' => 'mautic_field_a',
-                        'Mautic Field B' => 'mautic_field_b',
+                    'mappedField',
+                    ChoiceType::class,
+                    [
+                        'label'          => false,
+                        'choices'        => [
+                            'Mautic Field A' => 'mautic_field_a',
+                            'Mautic Field B' => 'mautic_field_b',
+                        ],
+                        'required'       => true,
+                        'placeholder'    => '',
+                        'error_bubbling' => false,
+                        'attr'           => [
+                            'class'            => 'form-control integration-mapped-field',
+                            'data-placeholder' => $options['placeholder'],
+                            'data-object'      => $options['object'],
+                            'data-integration' => $options['integration'],
+                            'data-field'       => 'Integration Field A',
+                        ],
                     ],
-                    'required'       => true,
-                    'placeholder'    => '',
-                    'error_bubbling' => false,
-                    'attr'           => [
-                        'class'            => 'form-control integration-mapped-field',
-                        'data-placeholder' => $options['placeholder'],
-                        'data-object'      => $options['object'],
-                        'data-integration' => $options['integration'],
-                        'data-field'       => 'Integration Field A',
-                    ],
-                ]
-            );
-
-        $this->formBuilder->expects($this->at(1))
-            ->method('add')
-            ->with(
-                'syncDirection',
-                ChoiceType::class,
+                ],
                 [
-                    'choices' => [
-                        'mautic.integration.sync_direction_integration' => ObjectMappingDAO::SYNC_TO_INTEGRATION,
-                        'mautic.integration.sync_direction_mautic'      => ObjectMappingDAO::SYNC_TO_MAUTIC,
-                    ],
-                    'label'      => false,
-                    'empty_data' => ObjectMappingDAO::SYNC_TO_INTEGRATION,
-                    'attr'       => [
-                        'class'            => 'integration-sync-direction',
-                        'data-object'      => 'Object A',
-                        'data-integration' => 'Integration A',
-                        'data-field'       => 'Integration Field A',
+                    'syncDirection',
+                    ChoiceType::class,
+                    [
+                        'choices' => [
+                            'mautic.integration.sync_direction_integration' => ObjectMappingDAO::SYNC_TO_INTEGRATION,
+                            'mautic.integration.sync_direction_mautic'      => ObjectMappingDAO::SYNC_TO_MAUTIC,
+                        ],
+                        'label'      => false,
+                        'empty_data' => ObjectMappingDAO::SYNC_TO_INTEGRATION,
+                        'attr'       => [
+                            'class'            => 'integration-sync-direction',
+                            'data-object'      => 'Object A',
+                            'data-integration' => 'Integration A',
+                            'data-field'       => 'Integration Field A',
+                        ],
                     ],
                 ]
             );

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Notification/Helper/UserNotificationHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Notification/Helper/UserNotificationHelperTest.php
@@ -19,33 +19,34 @@ use Mautic\IntegrationsBundle\Sync\Notification\Helper\UserHelper;
 use Mautic\IntegrationsBundle\Sync\Notification\Helper\UserNotificationHelper;
 use Mautic\IntegrationsBundle\Sync\Notification\Writer;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class UserNotificationHelperTest extends TestCase
 {
     /**
-     * @var Writer|\PHPUnit\Framework\MockObject\MockObject
+     * @var Writer|MockObject
      */
     private $writer;
 
     /**
-     * @var UserHelper|\PHPUnit\Framework\MockObject\MockObject
+     * @var UserHelper|MockObject
      */
     private $userHelper;
 
     /**
-     * @var OwnerProvider|\PHPUnit\Framework\MockObject\MockObject
+     * @var OwnerProvider|MockObject
      */
     private $ownerProvider;
 
     /**
-     * @var RouteHelper|\PHPUnit\Framework\MockObject\MockObject
+     * @var RouteHelper|MockObject
      */
     private $routeHelper;
 
     /**
-     * @var TranslatorInterface|\PHPUnit\Framework\MockObject\MockObject
+     * @var TranslatorInterface|MockObject
      */
     private $translator;
 
@@ -80,13 +81,12 @@ class UserNotificationHelperTest extends TestCase
         $this->userHelper->expects($this->never())
             ->method('getAdminUsers');
 
-        $this->translator->expects($this->at(0))
+        $this->translator->expects($this->exactly(2))
             ->method('trans')
-            ->with('mautic.integration.sync.user_notification.header', $this->anything())
-            ->willReturn('test');
-        $this->translator->expects($this->at(1))
-            ->method('trans')
-            ->with('mautic.integration.sync.user_notification.sync_error', $this->anything())
+            ->withConsecutive(
+                ['mautic.integration.sync.user_notification.header', $this->anything()],
+                ['mautic.integration.sync.user_notification.sync_error', $this->anything()]
+            )
             ->willReturn('test');
 
         $this->writer->expects($this->once())
@@ -109,13 +109,12 @@ class UserNotificationHelperTest extends TestCase
             ->method('getAdminUsers')
             ->willReturn([1]);
 
-        $this->translator->expects($this->at(0))
+        $this->translator->expects($this->exactly(2))
             ->method('trans')
-            ->with('mautic.integration.sync.user_notification.header', $this->anything())
-            ->willReturn('test');
-        $this->translator->expects($this->at(1))
-            ->method('trans')
-            ->with('mautic.integration.sync.user_notification.sync_error', $this->anything())
+            ->withConsecutive(
+                ['mautic.integration.sync.user_notification.header', $this->anything()],
+                ['mautic.integration.sync.user_notification.sync_error', $this->anything()]
+            )
             ->willReturn('test');
 
         $this->writer->expects($this->once())

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Notification/Helper/UserSummaryNotificationHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Notification/Helper/UserSummaryNotificationHelperTest.php
@@ -19,33 +19,34 @@ use Mautic\IntegrationsBundle\Sync\Notification\Helper\UserHelper;
 use Mautic\IntegrationsBundle\Sync\Notification\Helper\UserSummaryNotificationHelper;
 use Mautic\IntegrationsBundle\Sync\Notification\Writer;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class UserSummaryNotificationHelperTest extends TestCase
 {
     /**
-     * @var Writer|\PHPUnit\Framework\MockObject\MockObject
+     * @var Writer|MockObject
      */
     private $writer;
 
     /**
-     * @var UserHelper|\PHPUnit\Framework\MockObject\MockObject
+     * @var UserHelper|MockObject
      */
     private $userHelper;
 
     /**
-     * @var OwnerProvider|\PHPUnit\Framework\MockObject\MockObject
+     * @var OwnerProvider|MockObject
      */
     private $ownerProvider;
 
     /**
-     * @var RouteHelper|\PHPUnit\Framework\MockObject\MockObject
+     * @var RouteHelper|MockObject
      */
     private $routeHelper;
 
     /**
-     * @var TranslatorInterface|\PHPUnit\Framework\MockObject\MockObject
+     * @var TranslatorInterface|MockObject
      */
     private $translator;
 
@@ -89,21 +90,14 @@ class UserSummaryNotificationHelperTest extends TestCase
         $this->userHelper->expects($this->never())
             ->method('getAdminUsers');
 
-        $this->translator->expects($this->at(0))
+        $this->translator->expects($this->exactly(4))
             ->method('trans')
-            ->with('mautic.integration.sync.user_notification.header', $this->anything())
-            ->willReturn('test');
-        $this->translator->expects($this->at(1))
-            ->method('trans')
-            ->with('test', $this->anything())
-            ->willReturn('test');
-        $this->translator->expects($this->at(2))
-            ->method('trans')
-            ->with('mautic.integration.sync.user_notification.header', $this->anything())
-            ->willReturn('test');
-        $this->translator->expects($this->at(3))
-            ->method('trans')
-            ->with('test', $this->anything())
+            ->withConsecutive(
+                ['mautic.integration.sync.user_notification.header', $this->anything()],
+                ['test', $this->anything()],
+                ['mautic.integration.sync.user_notification.header', $this->anything()],
+                ['test', $this->anything()]
+            )
             ->willReturn('test');
 
         $this->writer->expects($this->exactly(2))
@@ -135,21 +129,14 @@ class UserSummaryNotificationHelperTest extends TestCase
             ->method('getAdminUsers')
             ->willReturn([1]);
 
-        $this->translator->expects($this->at(0))
+        $this->translator->expects($this->exactly(4))
             ->method('trans')
-            ->with('mautic.integration.sync.user_notification.header', $this->anything())
-            ->willReturn('test');
-        $this->translator->expects($this->at(1))
-            ->method('trans')
-            ->with('test', $this->anything())
-            ->willReturn('test');
-        $this->translator->expects($this->at(2))
-            ->method('trans')
-            ->with('mautic.integration.sync.user_notification.header', $this->anything())
-            ->willReturn('test');
-        $this->translator->expects($this->at(3))
-            ->method('trans')
-            ->with('test', $this->anything())
+            ->withConsecutive(
+                ['mautic.integration.sync.user_notification.header', $this->anything()],
+                ['test', $this->anything()],
+                ['mautic.integration.sync.user_notification.header', $this->anything()],
+                ['test', $this->anything()]
+            )
             ->willReturn('test');
 
         $this->writer->expects($this->exactly(2))

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilderTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilderTest.php
@@ -31,6 +31,7 @@ use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ReportBuilder\Parti
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -39,27 +40,27 @@ class PartialObjectReportBuilderTest extends TestCase
     private const INTEGRATION_NAME = 'Test';
 
     /**
-     * @var FieldChangeRepository|\PHPUnit\Framework\MockObject\MockObject
+     * @var FieldChangeRepository|MockObject
      */
     private $fieldChangeRepository;
 
     /**
-     * @var FieldHelper|\PHPUnit\Framework\MockObject\MockObject
+     * @var FieldHelper|MockObject
      */
     private $fieldHelper;
 
     /**
-     * @var EventDispatcherInterface|\PHPUnit\Framework\MockObject\MockObject
+     * @var EventDispatcherInterface|MockObject
      */
     private $dispatcher;
 
     /**
-     * @var FieldBuilder|\PHPUnit\Framework\MockObject\MockObject
+     * @var FieldBuilder|MockObject
      */
     private $fieldBuilder;
 
     /**
-     * @var ObjectProvider|\PHPUnit\Framework\MockObject\MockObject
+     * @var ObjectProvider|MockObject
      */
     private $objectProvider;
 
@@ -97,7 +98,7 @@ class PartialObjectReportBuilderTest extends TestCase
         $requestObject->addField('firstname');
         $requestDAO->addObject($requestObject);
 
-        $this->fieldBuilder->expects($this->at(0))
+        $this->fieldBuilder->expects($this->once())
             ->method('buildObjectField')
             ->with('email', $this->anything(), $requestObject, MauticSyncDataExchange::NAME)
             ->willReturn(
@@ -188,7 +189,7 @@ class PartialObjectReportBuilderTest extends TestCase
         $requestObject->addField('companyname');
         $requestDAO->addObject($requestObject);
 
-        $this->fieldBuilder->expects($this->at(0))
+        $this->fieldBuilder->expects($this->once())
             ->method('buildObjectField')
             ->with('email', $this->anything(), $requestObject, MauticSyncDataExchange::NAME)
             ->willReturn(

--- a/app/bundles/LeadBundle/Tests/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/LeadSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2017 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -132,9 +134,7 @@ class LeadSubscriberTest extends CommonMocks
             $this->router
         );
 
-        $leadEvent = $this->getMockBuilder(LeadEvent::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $leadEvent = $this->createMock(LeadEvent::class);
 
         $leadEvent->expects($this->exactly(2))
             ->method('getLead')
@@ -194,23 +194,16 @@ class LeadSubscriberTest extends CommonMocks
             'contactId'  => $leadEventLog['lead_id'],
         ];
 
-        $leadEvent = new LeadTimelineEvent(
-            $lead
-        );
+        $leadEvent = new LeadTimelineEvent($lead);
+        $repo      = $this->createMock(LeadEventLogRepository::class);
 
-        $repo = $this->getMockBuilder(LeadEventLogRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $repo->expects($this->at(0))
+        $repo->expects($this->exactly(2))
             ->method('getEvents')
-            ->with($lead, 'lead', 'api-single', null, $leadEvent->getQueryOptions())
-            ->will($this->returnValue($logs));
-
-        $repo->expects($this->at(1))
-            ->method('getEvents')
-            ->with($lead, 'lead', 'api-batch', null, $leadEvent->getQueryOptions())
-            ->will($this->returnValue(['total' => 0, 'results' => []]));
+            ->withConsecutive(
+                [$lead, 'lead', 'api-single', null, $leadEvent->getQueryOptions()],
+                [$lead, 'lead', 'api-batch', null, $leadEvent->getQueryOptions()]
+            )
+            ->willReturnOnConsecutiveCalls($logs, ['total' => 0, 'results' => []]);
 
         $this->entityManager->method('getRepository')
             ->with(LeadEventLog::class)

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -28,7 +28,6 @@ use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\CompanyReportData;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Report\FieldsBuilder;
-use Mautic\LeadBundle\Segment\Query\Expression\CompositeExpression;
 use Mautic\LeadBundle\Segment\Query\Expression\ExpressionBuilder;
 use Mautic\ReportBundle\Entity\Report;
 use Mautic\ReportBundle\Event\ReportBuilderEvent;
@@ -38,7 +37,6 @@ use Mautic\ReportBundle\Event\ReportGraphEvent;
 use Mautic\ReportBundle\Helper\ReportHelper;
 use Mautic\StageBundle\Model\StageModel;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
 {
@@ -349,16 +347,19 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testNotRelevantContextBuilder()
     {
-        $this->reportBuilderEventMock->expects($this->at(0))
-            ->method('checkContext')
-            ->with([
-                'leads',
-                'lead.pointlog',
-                'contact.attribution.multi',
-                'contact.attribution.first',
-                'contact.attribution.last',
-                'contact.frequencyrules',
-            ])->willReturn(false);
+        $this->reportBuilderEventMock->method('checkContext')
+            ->withConsecutive(
+                [
+                    [
+                        'leads',
+                        'lead.pointlog',
+                        'contact.attribution.multi',
+                        'contact.attribution.first',
+                        'contact.attribution.last',
+                        'contact.frequencyrules',
+                    ],
+                ]
+            )->willReturn(false);
 
         $this->reportBuilderEventMock->expects($this->never())
             ->method('addTable');
@@ -368,19 +369,22 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testNotRelevantContextGenerate()
     {
-        $this->reportGeneratorEventMock->expects($this->at(0))
-            ->method('checkContext')
-            ->with(['leads',
-            'lead.pointlog',
-            'contact.attribution.multi',
-            'contact.attribution.first',
-            'contact.attribution.last',
-            'contact.frequencyrules',
-            ])->willReturn(false);
-
-        $this->reportGeneratorEventMock->expects($this->at(1))
-            ->method('checkContext')
-            ->with(['companies'])->willReturn(false);
+        $this->reportBuilderEventMock->method('checkContext')
+            ->withConsecutive(
+                [
+                    [
+                        'leads',
+                        'lead.pointlog',
+                        'contact.attribution.multi',
+                        'contact.attribution.first',
+                        'contact.attribution.last',
+                        'contact.frequencyrules',
+                    ],
+                ],
+                [
+                    ['companies'],
+                ]
+            )->willReturn(false);
 
         $this->reportGeneratorEventMock->expects($this->never())
             ->method('getQueryBuilder');
@@ -831,16 +835,19 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
      */
     public function testReportGenerate($event)
     {
-        $this->reportGeneratorEventMock->expects($this->at(0))
-        ->method('checkContext')
-        ->with(['leads',
-        'lead.pointlog',
-        'contact.attribution.multi',
-        'contact.attribution.first',
-        'contact.attribution.last',
-        'contact.frequencyrules',
-        ])
-        ->willReturn(true);
+        $this->reportBuilderEventMock->method('checkContext')
+            ->withConsecutive(
+                [
+                    [
+                        'leads',
+                        'lead.pointlog',
+                        'contact.attribution.multi',
+                        'contact.attribution.first',
+                        'contact.attribution.last',
+                        'contact.frequencyrules',
+                    ],
+                ]
+            )->willReturn(true);
 
         $this->reportGeneratorEventMock->expects($this->once())
             ->method('getContext')

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -369,7 +369,7 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testNotRelevantContextGenerate()
     {
-        $this->reportBuilderEventMock->method('checkContext')
+        $this->reportGeneratorEventMock->method('checkContext')
             ->withConsecutive(
                 [
                     [
@@ -833,9 +833,9 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider eventDataProvider
      */
-    public function testReportGenerate($event)
+    public function testReportGenerate($context)
     {
-        $this->reportBuilderEventMock->method('checkContext')
+        $this->reportGeneratorEventMock->method('checkContext')
             ->withConsecutive(
                 [
                     [
@@ -851,7 +851,7 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $this->reportGeneratorEventMock->expects($this->once())
             ->method('getContext')
-            ->willReturn($event);
+            ->willReturn($context);
 
         $this->reportGeneratorEventMock->expects($this->once())
             ->method('getQueryBuilder')

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportUtmTagSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportUtmTagSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -23,7 +25,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class ReportUtmTagSubscriberTest extends \PHPUnit\Framework\TestCase
 {
-    public function testNotRelevantContextBuilder()
+    public function testNotRelevantContextBuilder(): void
     {
         $fieldsBuilderMock      = $this->createMock(FieldsBuilder::class);
         $companyReportDataMock  = $this->createMock(CompanyReportData::class);
@@ -41,7 +43,7 @@ class ReportUtmTagSubscriberTest extends \PHPUnit\Framework\TestCase
         $reportUtmTagSubscriber->onReportBuilder($reportBuilderEventMock);
     }
 
-    public function testNotRelevantContextGenerate()
+    public function testNotRelevantContextGenerate(): void
     {
         $fieldsBuilderMock        = $this->createMock(FieldsBuilder::class);
         $companyReportDataMock    = $this->createMock(CompanyReportData::class);
@@ -59,7 +61,7 @@ class ReportUtmTagSubscriberTest extends \PHPUnit\Framework\TestCase
         $reportUtmTagSubscriber->onReportGenerate($reportGeneratorEventMock);
     }
 
-    public function testReportBuilder()
+    public function testReportBuilder(): void
     {
         $translatorMock        = $this->createMock(TranslatorInterface::class);
         $channelListHelperMock = $this->createMock(ChannelListHelper::class);
@@ -142,7 +144,7 @@ class ReportUtmTagSubscriberTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expected, $reportBuilderEvent->getTables());
     }
 
-    public function testReportGenerateNoJoinedTables()
+    public function testReportGenerateNoJoinedTables(): void
     {
         if (!defined('MAUTIC_TABLE_PREFIX')) {
             define('MAUTIC_TABLE_PREFIX', '');
@@ -159,7 +161,7 @@ class ReportUtmTagSubscriberTest extends \PHPUnit\Framework\TestCase
         $reportUtmTagSubscriber->onReportGenerate($reportGeneratorEventMock);
     }
 
-    public function testReportGenerateWithUsers()
+    public function testReportGenerateWithUsers(): void
     {
         if (!defined('MAUTIC_TABLE_PREFIX')) {
             define('MAUTIC_TABLE_PREFIX', '');
@@ -169,22 +171,22 @@ class ReportUtmTagSubscriberTest extends \PHPUnit\Framework\TestCase
         $reportUtmTagSubscriber   = $this->getReportUtmTagSubscriber();
         $queryBuilderMock         = $this->getQueryBuilderMock();
 
-        $reportGeneratorEventMock->expects($this->at(1))
+        $reportGeneratorEventMock->expects($this->once())
             ->method('getQueryBuilder')
             ->willReturn($queryBuilderMock);
 
-        $reportGeneratorEventMock->expects($this->at(2))
+        $reportGeneratorEventMock->expects($this->exactly(2))
             ->method('usesColumn')
-            ->with(['u.first_name', 'u.last_name'])
+            ->withConsecutive(
+                [['u.first_name', 'u.last_name']],
+                ['i.ip_address']
+            )
             ->willReturn(true);
 
         $reportUtmTagSubscriber->onReportGenerate($reportGeneratorEventMock);
     }
 
-    /**
-     * @return ReportUtmTagSubscriber
-     */
-    private function getReportUtmTagSubscriber()
+    private function getReportUtmTagSubscriber(): ReportUtmTagSubscriber
     {
         $fieldsBuilderMock      = $this->createMock(FieldsBuilder::class);
         $companyReportDataMock  = $this->createMock(CompanyReportData::class);
@@ -200,7 +202,7 @@ class ReportUtmTagSubscriberTest extends \PHPUnit\Framework\TestCase
     {
         $reportGeneratorEventMock = $this->createMock(ReportGeneratorEvent::class);
 
-        $reportGeneratorEventMock->expects($this->at(0))
+        $reportGeneratorEventMock->expects($this->once())
             ->method('checkContext')
             ->with(['lead.utmTag'])
             ->willReturn(true);
@@ -215,14 +217,13 @@ class ReportUtmTagSubscriberTest extends \PHPUnit\Framework\TestCase
     {
         $queryBuilderMock = $this->createMock(QueryBuilder::class);
 
-        $queryBuilderMock->expects($this->at(0))
+        $queryBuilderMock->expects($this->once())
             ->method('from')
             ->with(MAUTIC_TABLE_PREFIX.'lead_utmtags', 'utm')
             ->willReturn($queryBuilderMock);
 
-        $queryBuilderMock->expects($this->at(1))
-            ->method('leftJoin')
-            ->with('utm', MAUTIC_TABLE_PREFIX.'leads', 'l', 'l.id = utm.lead_id')
+        $queryBuilderMock->method('leftJoin')
+            ->withConsecutive(['utm', MAUTIC_TABLE_PREFIX.'leads', 'l', 'l.id = utm.lead_id'])
             ->willReturn($queryBuilderMock);
 
         return $queryBuilderMock;

--- a/app/bundles/LeadBundle/Tests/Helper/ContactRequestHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/ContactRequestHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -23,53 +25,56 @@ use Mautic\LeadBundle\Helper\ContactRequestHelper;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Monolog\Logger;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class ContactRequestHelperTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|LeadModel
+     * @var MockObject|LeadModel
      */
     private $leadModel;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|ContactTracker
+     * @var MockObject|ContactTracker
      */
     private $contactTracker;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|CoreParametersHelper
+     * @var MockObject|CoreParametersHelper
      */
     private $coreParametersHelper;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|IpLookupHelper
+     * @var MockObject|IpLookupHelper
      */
     private $ipLookupHelper;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|EventDispatcher
+     * @var MockObject|EventDispatcher
      */
     private $dispatcher;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|RequestStack
+     * @var MockObject|RequestStack
      */
     private $requestStack;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|Logger
+     * @var MockObject|Logger
      */
     private $logger;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|Lead
+     * @var MockObject|Lead
      */
     private $trackedContact;
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->leadModel            = $this->createMock(LeadModel::class);
         $this->contactTracker       = $this->createMock(ContactTracker::class);
         $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
@@ -77,8 +82,8 @@ class ContactRequestHelperTest extends \PHPUnit\Framework\TestCase
         $this->requestStack         = $this->createMock(RequestStack::class);
         $this->logger               = $this->createMock(Logger::class);
         $this->dispatcher           = $this->createMock(EventDispatcher::class);
+        $this->trackedContact       = $this->createMock(Lead::class);
 
-        $this->trackedContact = $this->createMock(Lead::class);
         $this->trackedContact->method('getId')
             ->willReturn(1);
 
@@ -92,7 +97,7 @@ class ContactRequestHelperTest extends \PHPUnit\Framework\TestCase
             ->willReturn(new IpAddress());
     }
 
-    public function testEventDoesNotIdentifyContact()
+    public function testEventDoesNotIdentifyContact(): void
     {
         $query = [
             'ct' => [
@@ -100,7 +105,7 @@ class ContactRequestHelperTest extends \PHPUnit\Framework\TestCase
                 'channel' => [
                     'email' => 1,
                 ],
-                'stat'    => 'abc123',
+                'stat' => 'abc123',
             ],
         ];
 
@@ -122,7 +127,7 @@ class ContactRequestHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($this->trackedContact->getId(), $helper->getContactFromQuery($query)->getId());
     }
 
-    public function testEventIdentifiesContact()
+    public function testEventIdentifiesContact(): void
     {
         $query = [
             'ct' => [
@@ -152,7 +157,7 @@ class ContactRequestHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($contact === $foundContact);
     }
 
-    public function testLandingPageClickthroughIdentifiesLeadIfEnabled()
+    public function testLandingPageClickthroughIdentifiesLeadIfEnabled(): void
     {
         $this->coreParametersHelper->expects($this->once())
             ->method('get')
@@ -195,9 +200,9 @@ class ContactRequestHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($lead->getId(), $helper->getContactFromQuery($query)->getId());
     }
 
-    public function testLandingPageClickthroughDoesNotIdentifyLeadIfDisabled()
+    public function testLandingPageClickthroughDoesNotIdentifyLeadIfDisabled(): void
     {
-        $this->coreParametersHelper->expects($this->at(0))
+        $this->coreParametersHelper->expects($this->once())
             ->method('get')
             ->with('track_by_tracking_url')
             ->willReturn(false);
@@ -227,10 +232,7 @@ class ContactRequestHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($this->trackedContact->getId(), $helper->getContactFromQuery($query)->getId());
     }
 
-    /**
-     * @return ContactRequestHelper
-     */
-    private function getContactRequestHelper()
+    private function getContactRequestHelper(): ContactRequestHelper
     {
         return new ContactRequestHelper(
             $this->leadModel,

--- a/app/bundles/LeadBundle/Tests/Model/SegmentActionModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/SegmentActionModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2018 Mautic Contributors. All rights reserved
  * @author      Mautic
@@ -14,21 +16,22 @@ namespace Mautic\LeadBundle\Tests\Model;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Model\SegmentActionModel;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class SegmentActionModelTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var MockObject
      */
     private $contactMock5;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var MockObject
      */
     private $contactMock6;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var MockObject
      */
     private $contactModelMock;
 
@@ -45,137 +48,104 @@ class SegmentActionModelTest extends \PHPUnit\Framework\TestCase
         $this->actionModel         = new SegmentActionModel($this->contactModelMock);
     }
 
-    public function testAddContactsToSegmentsEntityAccess()
+    public function testAddContactsToSegmentsEntityAccess(): void
     {
         $contacts = [5, 6];
         $segments = [4, 5];
 
-        $this->contactModelMock->expects($this->at(0))
+        $this->contactModelMock->expects($this->once())
             ->method('getLeadsByIds')
             ->with($contacts)
             ->willReturn([$this->contactMock5, $this->contactMock6]);
 
-        $this->contactModelMock->expects($this->at(1))
+        $this->contactModelMock->expects($this->exactly(2))
             ->method('canEditContact')
-            ->with($this->contactMock5)
-            ->willReturn(false);
+            ->withConsecutive([$this->contactMock5], [$this->contactMock6])
+            ->willReturnOnConsecutiveCalls(false, true);
 
-        $this->contactModelMock->expects($this->at(2))
-            ->method('canEditContact')
-            ->with($this->contactMock6)
-            ->willReturn(true);
-
-        $this->contactModelMock->expects($this->at(3))
+        $this->contactModelMock->expects($this->once())
             ->method('addToLists')
             ->with($this->contactMock6, $segments);
 
-        $this->contactModelMock->expects($this->at(4))
+        $this->contactModelMock->expects($this->once())
             ->method('saveEntities')
             ->with([$this->contactMock5, $this->contactMock6]);
 
         $this->actionModel->addContacts($contacts, $segments);
     }
 
-    public function testRemoveContactsFromSementsEntityAccess()
+    public function testRemoveContactsFromSementsEntityAccess(): void
     {
         $contacts = [5, 6];
         $segments = [1, 2];
 
-        $this->contactModelMock->expects($this->at(0))
+        $this->contactModelMock->expects($this->once())
             ->method('getLeadsByIds')
             ->with($contacts)
             ->willReturn([$this->contactMock5, $this->contactMock6]);
 
-        $this->contactModelMock->expects($this->at(1))
+        $this->contactModelMock->expects($this->exactly(2))
             ->method('canEditContact')
-            ->with($this->contactMock5)
-            ->willReturn(false);
+            ->withConsecutive([$this->contactMock5], [$this->contactMock6])
+            ->willReturnOnConsecutiveCalls(false, true);
 
-        $this->contactModelMock->expects($this->at(2))
-            ->method('canEditContact')
-            ->with($this->contactMock6)
-            ->willReturn(true);
-
-        $this->contactModelMock->expects($this->at(3))
+        $this->contactModelMock->expects($this->once())
             ->method('removeFromLists')
             ->with($this->contactMock6, $segments);
 
-        $this->contactModelMock->expects($this->at(4))
+        $this->contactModelMock->expects($this->once())
             ->method('saveEntities')
             ->with([$this->contactMock5, $this->contactMock6]);
 
         $this->actionModel->removeContacts($contacts, $segments);
     }
 
-    public function testAddContactsToSegments()
+    public function testAddContactsToSegments(): void
     {
         $contacts = [5, 6];
         $segments = [1, 2];
 
-        $this->contactModelMock->expects($this->at(0))
+        $this->contactModelMock->expects($this->once())
             ->method('getLeadsByIds')
             ->with($contacts)
             ->willReturn([$this->contactMock5, $this->contactMock6]);
 
-        // Loop 1
-        $this->contactModelMock->expects($this->at(1))
+        $this->contactModelMock->expects($this->exactly(2))
             ->method('canEditContact')
-            ->with($this->contactMock5)
+            ->withConsecutive([$this->contactMock5], [$this->contactMock6])
             ->willReturn(true);
 
-        $this->contactModelMock->expects($this->at(2))
+        $this->contactModelMock->expects($this->exactly(2))
             ->method('addToLists')
-            ->with($this->contactMock5, $segments);
+            ->withConsecutive([$this->contactMock5, $segments], [$this->contactMock6, $segments]);
 
-        // Loop 2
-        $this->contactModelMock->expects($this->at(3))
-            ->method('canEditContact')
-            ->with($this->contactMock6)
-            ->willReturn(true);
-
-        $this->contactModelMock->expects($this->at(4))
-            ->method('addToLists')
-            ->with($this->contactMock6, $segments);
-
-        $this->contactModelMock->expects($this->at(5))
+        $this->contactModelMock->expects($this->once())
             ->method('saveEntities')
             ->with([$this->contactMock5, $this->contactMock6]);
 
         $this->actionModel->addContacts($contacts, $segments);
     }
 
-    public function testRemoveContactsFromCategories()
+    public function testRemoveContactsFromCategories(): void
     {
         $contacts = [5, 6];
         $segments = [1, 2];
 
-        $this->contactModelMock->expects($this->at(0))
+        $this->contactModelMock->expects($this->once())
             ->method('getLeadsByIds')
             ->with($contacts)
             ->willReturn([$this->contactMock5, $this->contactMock6]);
 
-        // Loop 1
-        $this->contactModelMock->expects($this->at(1))
+        $this->contactModelMock->expects($this->exactly(2))
             ->method('canEditContact')
-            ->with($this->contactMock5)
+            ->withConsecutive([$this->contactMock5], [$this->contactMock6])
             ->willReturn(true);
 
-        $this->contactModelMock->expects($this->at(2))
+        $this->contactModelMock->expects($this->exactly(2))
             ->method('removeFromLists')
-            ->with($this->contactMock5, $segments);
+            ->withConsecutive([$this->contactMock5, $segments], [$this->contactMock6]);
 
-        // Loop 2
-        $this->contactModelMock->expects($this->at(3))
-            ->method('canEditContact')
-            ->with($this->contactMock6)
-            ->willReturn(true);
-
-        $this->contactModelMock->expects($this->at(4))
-            ->method('removeFromLists')
-            ->with($this->contactMock6)
-            ->willReturn($this->contactMock6, $segments);
-
-        $this->contactModelMock->expects($this->at(5))
+        $this->contactModelMock->expects($this->once())
             ->method('saveEntities')
             ->with([$this->contactMock5, $this->contactMock6]);
 

--- a/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2017 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -24,6 +26,7 @@ use Mautic\LeadBundle\Tracker\ContactTracker;
 use Mautic\LeadBundle\Tracker\DeviceTracker;
 use Mautic\LeadBundle\Tracker\Service\ContactTrackingService\ContactTrackingServiceInterface;
 use Monolog\Logger;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -31,32 +34,32 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class ContactTrackerTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var LeadRepository
+     * @var MockObject|LeadRepository
      */
     private $leadRepositoryMock;
 
     /**
-     * @var ContactTrackingServiceInterface
+     * @var MockObject|ContactTrackingServiceInterface
      */
     private $contactTrackingServiceMock;
 
     /**
-     * @var DeviceTracker
+     * @var MockObject|DeviceTracker
      */
     private $deviceTrackerMock;
 
     /**
-     * @var CorePermissions
+     * @var MockObject|CorePermissions
      */
     private $securityMock;
 
     /**
-     * @var Logger
+     * @var MockObject|Logger
      */
     private $loggerMock;
 
     /**
-     * @var IpLookupHelper
+     * @var MockObject|IpLookupHelper
      */
     private $ipLookupHelperMock;
 
@@ -66,64 +69,40 @@ class ContactTrackerTest extends \PHPUnit\Framework\TestCase
     private $requestStack;
 
     /**
-     * @var CoreParametersHelper
+     * @var MockObject|CoreParametersHelper
      */
     private $coreParametersHelperMock;
 
     /**
-     * @var EventDispatcher
+     * @var MockObject|EventDispatcher
      */
     private $dispatcherMock;
 
     /**
-     * @var FieldModel
+     * @var MockObject|FieldModel
      */
     private $leadFieldModelMock;
 
     protected function setUp(): void
     {
-        $this->leadRepositoryMock = $this->getMockBuilder(LeadRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->leadRepositoryMock         = $this->createMock(LeadRepository::class);
+        $this->contactTrackingServiceMock = $this->createMock(ContactTrackingServiceInterface::class);
+        $this->deviceTrackerMock          = $this->createMock(DeviceTracker::class);
+        $this->securityMock               = $this->createMock(CorePermissions::class);
+        $this->coreParametersHelperMock   = $this->createMock(CoreParametersHelper::class);
+        $this->dispatcherMock             = $this->createMock(EventDispatcher::class);
+        $this->leadFieldModelMock         = $this->createMock(FieldModel::class);
+        $this->loggerMock                 = $this->createMock(Logger::class);
+        $this->ipLookupHelperMock         = $this->createMock(IpLookupHelper::class);
+        $this->requestStack               = new RequestStack();
 
-        $this->contactTrackingServiceMock = $this->getMockBuilder(ContactTrackingServiceInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->deviceTrackerMock = $this->getMockBuilder(DeviceTracker::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->securityMock = $this->getMockBuilder(CorePermissions::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $this->securityMock->method('isAnonymous')
             ->willReturn(true);
 
-        $this->loggerMock = $this->getMockBuilder(Logger::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->ipLookupHelperMock = $this->getMockBuilder(IpLookupHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->requestStack = new RequestStack();
-        $request            = new Request();
-        $this->requestStack->push($request);
-
-        $this->coreParametersHelperMock = $this->getMockBuilder(CoreParametersHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->dispatcherMock = $this->getMockBuilder(EventDispatcher::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->leadFieldModelMock = $this->createMock(FieldModel::class);
+        $this->requestStack->push(new Request());
     }
 
-    public function testSystemContactIsUsedOverTrackedContact()
+    public function testSystemContactIsUsedOverTrackedContact(): void
     {
         $contactTracker = $this->getContactTracker();
 
@@ -142,7 +121,7 @@ class ContactTrackerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($lead2->getEmail(), $contactTracker->getContact()->getEmail());
     }
 
-    public function testContactIsTrackedByDevice()
+    public function testContactIsTrackedByDevice(): void
     {
         $contactTracker = $this->getContactTracker();
 
@@ -172,7 +151,7 @@ class ContactTrackerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('test@test.com', $contact->getFieldValue('email'));
     }
 
-    public function testContactIsTrackedByOldCookie()
+    public function testContactIsTrackedByOldCookie(): void
     {
         $contactTracker = $this->getContactTracker();
 
@@ -191,7 +170,7 @@ class ContactTrackerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('test@test.com', $contact->getEmail());
     }
 
-    public function testContactIsTrackedByIp()
+    public function testContactIsTrackedByIp(): void
     {
         $contactTracker = $this->getContactTracker();
 
@@ -222,7 +201,7 @@ class ContactTrackerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('test@test.com', $contact->getEmail());
     }
 
-    public function testNewContactIsCreated()
+    public function testNewContactIsCreated(): void
     {
         $contactTracker = $this->getContactTracker();
 
@@ -253,7 +232,7 @@ class ContactTrackerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(true, $contact->isNewlyCreated());
     }
 
-    public function testEventIsDispatchedWithChangeOfContact()
+    public function testEventIsDispatchedWithChangeOfContact(): void
     {
         $contactTracker = $this->getContactTracker();
 
@@ -281,25 +260,19 @@ class ContactTrackerTest extends \PHPUnit\Framework\TestCase
             ->willReturn(true);
 
         $leadDevice1 = new LeadDevice();
-        $leadDevice1->setTrackingId('abc123');
-        $this->deviceTrackerMock->expects($this->at(0))
-            ->method('getTrackedDevice')
-            ->willReturn($leadDevice1);
-
         $leadDevice2 = new LeadDevice();
+
+        $leadDevice1->setTrackingId('abc123');
         $leadDevice2->setTrackingId('def456');
-        $this->deviceTrackerMock->expects($this->at(2))
-            ->method('getTrackedDevice')
-            ->willReturn($leadDevice2);
+
+        $this->deviceTrackerMock->method('getTrackedDevice')
+            ->willReturnOnConsecutiveCalls($leadDevice1, $leadDevice2);
 
         $contactTracker->setTrackedContact($lead);
         $contactTracker->setTrackedContact($lead2);
     }
 
-    /**
-     * @return ContactTracker
-     */
-    private function getContactTracker()
+    private function getContactTracker(): ContactTracker
     {
         return new ContactTracker(
             $this->leadRepositoryMock,

--- a/app/bundles/LeadBundle/Tests/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2017 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -19,41 +21,39 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadDevice;
 use Mautic\LeadBundle\Entity\LeadDeviceRepository;
 use Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingService;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-/**
- * Class CompanyModelTest.
- */
 final class DeviceTrackingServiceTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var MockObject
      */
     private $cookieHelperMock;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var MockObject
      */
     private $entityManagerMock;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var MockObject
      */
     private $randomHelperMock;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var MockObject
      */
     private $leadDeviceRepositoryMock;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var MockObject
      */
     private $requestStackMock;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var MockObject
      */
     private $security;
 
@@ -67,19 +67,16 @@ final class DeviceTrackingServiceTest extends \PHPUnit\Framework\TestCase
         $this->security                    = $this->createMock(CorePermissions::class);
     }
 
-    public function testIsTrackedTrue()
+    public function testIsTrackedTrue(): void
     {
-        // Parameters
-        $trackingId = 'randomTrackingId';
-
-        // __construct()
+        $trackingId  = 'randomTrackingId';
         $requestMock = $this->createMock(Request::class);
-        $this->requestStackMock->expects($this->at(0))
+
+        $this->requestStackMock->expects($this->once())
             ->method('getCurrentRequest')
             ->willReturn($requestMock);
 
-        // getTrackedIdentifier()
-        $this->cookieHelperMock->expects($this->at(0))
+        $this->cookieHelperMock->expects($this->once())
             ->method('getCookie')
             ->with('mautic_device_id', null)
             ->willReturn($trackingId);
@@ -89,28 +86,24 @@ final class DeviceTrackingServiceTest extends \PHPUnit\Framework\TestCase
             ->method('isAnonymous')
             ->willReturn(true);
 
-        $this->leadDeviceRepositoryMock->expects($this->at(0))
+        $this->leadDeviceRepositoryMock->expects($this->once())
             ->method('getByTrackingId')
             ->with($trackingId)
             ->willReturn($leadDeviceMock);
 
-        $deviceTrackingService = $this->getDeviceTrackingService();
-        $this->assertTrue($deviceTrackingService->isTracked());
+        $this->assertTrue($this->getDeviceTrackingService()->isTracked());
     }
 
-    public function testIsTrackedFalse()
+    public function testIsTrackedFalse(): void
     {
-        // Parameters
-        $trackingId = 'randomTrackingId';
-
-        // __construct()
+        $trackingId  = 'randomTrackingId';
         $requestMock = $this->createMock(Request::class);
-        $this->requestStackMock->expects($this->at(0))
+
+        $this->requestStackMock->expects($this->once())
             ->method('getCurrentRequest')
             ->willReturn($requestMock);
 
-        // getTrackedIdentifier()
-        $this->cookieHelperMock->expects($this->at(0))
+        $this->cookieHelperMock->expects($this->once())
             ->method('getCookie')
             ->with('mautic_device_id', null)
             ->willReturn($trackingId);
@@ -119,63 +112,57 @@ final class DeviceTrackingServiceTest extends \PHPUnit\Framework\TestCase
             ->method('isAnonymous')
             ->willReturn(true);
 
-        $this->leadDeviceRepositoryMock->expects($this->at(0))
+        $this->leadDeviceRepositoryMock->expects($this->once())
             ->method('getByTrackingId')
             ->with($trackingId)
             ->willReturn(null);
 
-        $deviceTrackingService = $this->getDeviceTrackingService();
-        $this->assertFalse($deviceTrackingService->isTracked());
+        $this->assertFalse($this->getDeviceTrackingService()->isTracked());
     }
 
-    public function testGetTrackedDeviceCookie()
+    public function testGetTrackedDeviceCookie(): void
     {
-        // Parameters
-        $trackingId = 'randomTrackingId';
-
-        // __construct()
-        $requestMock = $this->createMock(Request::class);
-        $this->requestStackMock->expects($this->at(0))
-            ->method('getCurrentRequest')
-            ->willReturn($requestMock);
-
-        // getTrackedIdentifier()
-        $this->cookieHelperMock->expects($this->at(0))
-            ->method('getCookie')
-            ->with('mautic_device_id', null)
-            ->willReturn($trackingId);
-
-        $this->security->expects($this->once())
-            ->method('isAnonymous')
-            ->willReturn(true);
-
+        $trackingId     = 'randomTrackingId';
         $leadDeviceMock = $this->createMock(LeadDevice::class);
-        $this->leadDeviceRepositoryMock->expects($this->at(0))
+        $requestMock    = $this->createMock(Request::class);
+
+        $this->requestStackMock->expects($this->once())
+            ->method('getCurrentRequest')
+            ->willReturn($requestMock);
+
+        $this->cookieHelperMock->expects($this->once())
+            ->method('getCookie')
+            ->with('mautic_device_id', null)
+            ->willReturn($trackingId);
+
+        $this->security->expects($this->once())
+            ->method('isAnonymous')
+            ->willReturn(true);
+
+        $this->leadDeviceRepositoryMock->expects($this->once())
             ->method('getByTrackingId')
             ->with($trackingId)
             ->willReturn($leadDeviceMock);
 
-        $deviceTrackingService = $this->getDeviceTrackingService();
-        $this->assertSame($leadDeviceMock, $deviceTrackingService->getTrackedDevice());
+        $this->assertSame($leadDeviceMock, $this->getDeviceTrackingService()->getTrackedDevice());
     }
 
-    public function testGetTrackedDeviceGetFromRequest()
+    public function testGetTrackedDeviceGetFromRequest(): void
     {
-        // Parameters
-        $trackingId = 'randomTrackingId';
+        $trackingId     = 'randomTrackingId';
+        $requestMock    = $this->createMock(Request::class);
+        $leadDeviceMock = $this->createMock(LeadDevice::class);
 
-        // __construct()
-        $requestMock = $this->createMock(Request::class);
-        $this->requestStackMock->expects($this->at(0))
+        $this->requestStackMock->expects($this->once())
             ->method('getCurrentRequest')
             ->willReturn($requestMock);
 
-        // getTrackedIdentifier()
-        $this->cookieHelperMock->expects($this->at(0))
+        $this->cookieHelperMock->expects($this->once())
             ->method('getCookie')
             ->with('mautic_device_id', null)
             ->willReturn(null);
-        $requestMock->expects($this->at(0))
+
+        $requestMock->expects($this->once())
             ->method('get')
             ->with('mautic_device_id', null)
             ->willReturn($trackingId);
@@ -184,30 +171,28 @@ final class DeviceTrackingServiceTest extends \PHPUnit\Framework\TestCase
             ->method('isAnonymous')
             ->willReturn(true);
 
-        $leadDeviceMock = $this->createMock(LeadDevice::class);
-        $this->leadDeviceRepositoryMock->expects($this->at(0))
+        $this->leadDeviceRepositoryMock->expects($this->once())
             ->method('getByTrackingId')
             ->with($trackingId)
             ->willReturn($leadDeviceMock);
 
-        $deviceTrackingService = $this->getDeviceTrackingService();
-        $this->assertSame($leadDeviceMock, $deviceTrackingService->getTrackedDevice());
+        $this->assertSame($leadDeviceMock, $this->getDeviceTrackingService()->getTrackedDevice());
     }
 
-    public function testGetTrackedDeviceNoTrackingId()
+    public function testGetTrackedDeviceNoTrackingId(): void
     {
-        // __construct()
         $requestMock = $this->createMock(Request::class);
-        $this->requestStackMock->expects($this->at(0))
+
+        $this->requestStackMock->expects($this->once())
             ->method('getCurrentRequest')
             ->willReturn($requestMock);
 
-        // getTrackedIdentifier()
-        $this->cookieHelperMock->expects($this->at(0))
+        $this->cookieHelperMock->expects($this->once())
             ->method('getCookie')
             ->with('mautic_device_id', null)
             ->willReturn(null);
-        $requestMock->expects($this->at(0))
+
+        $requestMock->expects($this->once())
             ->method('get')
             ->with('mautic_device_id', null)
             ->willReturn(null);
@@ -219,8 +204,7 @@ final class DeviceTrackingServiceTest extends \PHPUnit\Framework\TestCase
         $this->leadDeviceRepositoryMock->expects($this->never())
             ->method('getByTrackingId');
 
-        $deviceTrackingService = $this->getDeviceTrackingService();
-        $this->assertNull($deviceTrackingService->getTrackedDevice());
+        $this->assertNull($this->getDeviceTrackingService()->getTrackedDevice());
     }
 
     public function testGetTrackedDeviceNoRequest()
@@ -232,22 +216,18 @@ final class DeviceTrackingServiceTest extends \PHPUnit\Framework\TestCase
     /**
      * Test tracking device with already tracked current device.
      */
-    public function testTrackCurrentDeviceAlreadyTracked()
+    public function testTrackCurrentDeviceAlreadyTracked(): void
     {
-        // Parameters
         $leadDeviceMock        = $this->createMock(LeadDevice::class);
         $trackingId            = 'randomTrackingId';
         $trackedLeadDeviceMock = $this->createMock(LeadDevice::class);
 
-        // __construct()
         $requestMock = $this->createMock(Request::class);
-        $this->requestStackMock->expects($this->at(0))
+        $this->requestStackMock->expects($this->once())
             ->method('getCurrentRequest')
             ->willReturn($requestMock);
 
-        // getTrackedDevice()
-        // getTrackedIdentifier()
-        $this->cookieHelperMock->expects($this->at(0))
+        $this->cookieHelperMock->expects($this->once())
             ->method('getCookie')
             ->with('mautic_device_id', null)
             ->willReturn($trackingId);
@@ -256,36 +236,32 @@ final class DeviceTrackingServiceTest extends \PHPUnit\Framework\TestCase
             ->method('isAnonymous')
             ->willReturn(true);
 
-        $this->leadDeviceRepositoryMock->expects($this->at(0))
+        $this->leadDeviceRepositoryMock->expects($this->once())
             ->method('getByTrackingId')
             ->with($trackingId)
             ->willReturn($trackedLeadDeviceMock);
 
         $deviceTrackingService = $this->getDeviceTrackingService();
-        $returnedLeadDevice    = $deviceTrackingService->trackCurrentDevice($leadDeviceMock, false);
-        $this->assertInstanceOf(LeadDevice::class, $returnedLeadDevice);
+
+        $this->assertInstanceOf(LeadDevice::class, $deviceTrackingService->trackCurrentDevice($leadDeviceMock, false));
     }
 
     /**
      * Test tracking device with already tracked current device, replace existing tracking.
      */
-    public function testTrackCurrentDeviceAlreadyTrackedReplaceExistingTracking()
+    public function testTrackCurrentDeviceAlreadyTrackedReplaceExistingTracking(): void
     {
-        // Parameters
         $leadDeviceMock           = $this->createMock(LeadDevice::class);
-        $trackingId               = 'randomTrackingId';
         $trackedLeadDeviceMock    = $this->createMock(LeadDevice::class);
+        $requestMock              = $this->createMock(Request::class);
+        $trackingId               = 'randomTrackingId';
         $uniqueTrackingIdentifier = '1234567890abcdefghij123';
 
-        // __construct()
-        $requestMock = $this->createMock(Request::class);
-        $this->requestStackMock->expects($this->at(0))
+        $this->requestStackMock->expects($this->once())
             ->method('getCurrentRequest')
             ->willReturn($requestMock);
 
-        // getTrackedDevice()
-        // getTrackedIdentifier()
-        $this->cookieHelperMock->expects($this->at(0))
+        $this->cookieHelperMock->expects($this->once())
             ->method('getCookie')
             ->with('mautic_device_id', null)
             ->willReturn($trackingId);
@@ -294,76 +270,63 @@ final class DeviceTrackingServiceTest extends \PHPUnit\Framework\TestCase
             ->method('isAnonymous')
             ->willReturn(true);
 
-        $this->leadDeviceRepositoryMock->expects($this->at(0))
-            ->method('getByTrackingId')
-            ->with($trackingId)
-            ->willReturn($trackedLeadDeviceMock);
+        $this->leadDeviceRepositoryMock->method('getByTrackingId')
+            ->withConsecutive([$trackingId])
+            ->willReturnOnConsecutiveCalls($trackedLeadDeviceMock);
 
-        // getUniqueTrackingIdentifier()
-        $this->randomHelperMock->expects($this->at(0))
+        $this->randomHelperMock->expects($this->once())
             ->method('generate')
             ->with(23)
             ->willReturn($uniqueTrackingIdentifier);
 
-        $this->entityManagerMock->expects($this->at(0))
+        $this->entityManagerMock->expects($this->once())
             ->method('persist')
             ->with($leadDeviceMock);
 
         // index 0-3 for leadDeviceRepository::findOneBy
-        $leadDeviceMock->expects($this->at(4))
-            ->method('getTrackingId')
-            ->willReturn(null);
-        $leadDeviceMock->expects($this->at(5))
+        $leadDeviceMock->method('getTrackingId')
+            ->willReturnOnConsecutiveCalls(null, $uniqueTrackingIdentifier);
+
+        $leadDeviceMock->expects($this->once())
             ->method('setTrackingId')
             ->with($uniqueTrackingIdentifier)
             ->willReturn($leadDeviceMock);
-        $leadDeviceMock->expects($this->at(6))
-            ->method('getTrackingId')
-            ->willReturn($uniqueTrackingIdentifier);
+
         $leadDeviceMock->expects($this->exactly(2))
             ->method('getLead')
             ->willReturn(new Lead());
-        $this->cookieHelperMock->expects($this->at(1))
-            ->method('setCookie')
-            ->with('mautic_device_id', $uniqueTrackingIdentifier, 31536000);
+
+        $this->cookieHelperMock->method('setCookie')
+            ->withConsecutive(['mautic_device_id', $uniqueTrackingIdentifier, 31536000]);
 
         $deviceTrackingService = $this->getDeviceTrackingService();
-        $returnedLeadDevice    = $deviceTrackingService->trackCurrentDevice($leadDeviceMock, true);
-        $this->assertInstanceOf(LeadDevice::class, $returnedLeadDevice);
+        $this->assertInstanceOf(LeadDevice::class, $deviceTrackingService->trackCurrentDevice($leadDeviceMock, true));
     }
 
     /**
      * Test tracking device without already tracked current device.
      */
-    public function testTrackCurrentDeviceNotTrackedYet()
+    public function testTrackCurrentDeviceNotTrackedYet(): void
     {
-        // Parameters
         $leadDeviceMock           = $this->createMock(LeadDevice::class);
         $uniqueTrackingIdentifier = '1234567890abcdefghij123';
+        $requestMock              = $this->createMock(Request::class);
 
-        // __construct()
-        $requestMock = $this->createMock(Request::class);
-        $this->requestStackMock->expects($this->at(0))
+        $this->requestStackMock->expects($this->once())
             ->method('getCurrentRequest')
             ->willReturn($requestMock);
 
-        // getTrackedDevice()
-        $this->cookieHelperMock->expects($this->at(0))
+        $this->cookieHelperMock->expects($this->once())
             ->method('getCookie')
             ->with('mautic_device_id', null)
             ->willReturn(null);
 
-        $requestMock->expects($this->at(0))
+        $requestMock->expects($this->once())
             ->method('get')
             ->with('mautic_device_id', null)
             ->willReturn(null);
 
-        $leadDeviceMock->expects($this->at(0))
-            ->method('getTrackingId')
-            ->willReturn(null);
-
-        // getUniqueTrackingIdentifier()
-        $this->randomHelperMock->expects($this->at(0))
+        $this->randomHelperMock->expects($this->once())
             ->method('generate')
             ->with(23)
             ->willReturn($uniqueTrackingIdentifier);
@@ -373,33 +336,36 @@ final class DeviceTrackingServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn(true);
 
         // index 0-3 for leadDeviceRepository::findOneBy
-        $leadDeviceMock->expects($this->at(4))
-            ->method('getTrackingId')
-            ->willReturn(null);
-        $leadDeviceMock->expects($this->at(5))
+        $leadDeviceMock->method('getTrackingId')
+            ->willReturnOnConsecutiveCalls(null, $uniqueTrackingIdentifier);
+
+        $leadDeviceMock->expects($this->once())
             ->method('setTrackingId')
             ->with($uniqueTrackingIdentifier)
             ->willReturn($leadDeviceMock);
-        $leadDeviceMock->expects($this->at(6))
-            ->method('getTrackingId')
-            ->willReturn($uniqueTrackingIdentifier);
+
         $leadDeviceMock->expects($this->exactly(2))
             ->method('getLead')
             ->willReturn(new Lead());
 
-        $this->cookieHelperMock->expects($this->at(1))
-            ->method('setCookie')
-            ->with('mautic_device_id', $uniqueTrackingIdentifier, 31536000);
+        $this->cookieHelperMock->method('setCookie')
+            ->withConsecutive(['mautic_device_id', $uniqueTrackingIdentifier, 31536000]);
+
+        $this->entityManagerMock->expects($this->once())
+            ->method('persist')
+            ->with($leadDeviceMock);
+
+        $this->entityManagerMock->expects($this->once())
+            ->method('flush');
 
         $deviceTrackingService = $this->getDeviceTrackingService();
-        $returnedLeadDevice    = $deviceTrackingService->trackCurrentDevice($leadDeviceMock, false);
-        $this->assertInstanceOf(LeadDevice::class, $returnedLeadDevice);
+        $this->assertInstanceOf(LeadDevice::class, $deviceTrackingService->trackCurrentDevice($leadDeviceMock, false));
     }
 
     /**
      * Test that a user is not tracked.
      */
-    public function testUserIsNotTracked()
+    public function testUserIsNotTracked(): void
     {
         $this->leadDeviceRepositoryMock->expects($this->never())
             ->method('getByTrackingId');
@@ -411,10 +377,7 @@ final class DeviceTrackingServiceTest extends \PHPUnit\Framework\TestCase
         $this->getDeviceTrackingService()->getTrackedDevice();
     }
 
-    /**
-     * @return DeviceTrackingService
-     */
-    private function getDeviceTrackingService()
+    private function getDeviceTrackingService(): DeviceTrackingService
     {
         return new DeviceTrackingService(
             $this->cookieHelperMock,

--- a/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingService.php
+++ b/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingService.php
@@ -152,10 +152,7 @@ final class DeviceTrackingService implements DeviceTrackingServiceInterface
         $this->cookieHelper->deleteCookie('mtc_sid');
     }
 
-    /**
-     * @return string|null
-     */
-    private function getTrackedIdentifier()
+    private function getTrackedIdentifier(): ?string
     {
         $request = $this->requestStack->getCurrentRequest();
 
@@ -176,10 +173,7 @@ final class DeviceTrackingService implements DeviceTrackingServiceInterface
         return $deviceTrackingId;
     }
 
-    /**
-     * @return string
-     */
-    private function getUniqueTrackingIdentifier()
+    private function getUniqueTrackingIdentifier(): string
     {
         do {
             $generatedIdentifier = $this->randomHelper->generate(23);

--- a/app/bundles/PageBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2019 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -16,11 +18,19 @@ use Mautic\CoreBundle\Event\DetermineWinnerEvent;
 use Mautic\PageBundle\Entity\HitRepository;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\EventListener\DetermineWinnerSubscriber;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var MockObject|HitRepository
+     */
     private $hitRepository;
+
+    /**
+     * @var MockObject|TranslatorInterface
+     */
     private $translator;
 
     /**
@@ -88,13 +98,8 @@ class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
             ->method('hasTranslations')
             ->willReturn(true);
 
-        $transChildren->expects($this->at(0))
-            ->method('getKeys')
-            ->willReturn([2]);
-
-        $transChildren->expects($this->at(1))
-            ->method('getKeys')
-            ->willReturn([4]);
+        $transChildren->method('getKeys')
+            ->willReturnOnConsecutiveCalls([2], [4]);
 
         $parentMock->expects($this->any())
             ->method('getTranslationChildren')

--- a/app/bundles/ReportBundle/Tests/Form/Type/ReportTypeTest.php
+++ b/app/bundles/ReportBundle/Tests/Form/Type/ReportTypeTest.php
@@ -81,27 +81,29 @@ final class ReportTypeTest extends \PHPUnit\Framework\TestCase
         $this->reportModel->method('getFilterList')
             ->willReturn($filterList);
 
-        $this->reportModel->method('getColumnList')
-            ->with('assets') // This is the confirmation that the source was selected properly.
+        $this->reportModel->expects($this->exactly(2))
+            ->method('getColumnList')
+            ->with($this->equalTo('assets')) // This is the confirmation that the source was selected properly.
             ->willReturn($columnList);
 
         $this->reportModel->method('getGraphList')
             ->willReturn($graphList);
 
-        $this->formBuilder->expects($this->at(14))
-            ->method('addEventListener')
-            ->with(
-                FormEvents::PRE_SET_DATA,
-                $this->callback(
-                    function (callable $listener) use ($report) {
-                        /** @var FormInterface $form */
-                        $form = $this->createMock(FormInterface::class);
-                        $formEvent = new FormEvent($form, $report);
-                        $listener($formEvent);
+        $this->formBuilder->method('addEventListener')
+            ->withConsecutive(
+                [
+                    FormEvents::PRE_SET_DATA,
+                    $this->callback(
+                        function (callable $listener) use ($report) {
+                            /** @var FormInterface $form */
+                            $form = $this->createMock(FormInterface::class);
+                            $formEvent = new FormEvent($form, $report);
+                            $listener($formEvent);
 
-                        return true;
-                    }
-                )
+                            return true;
+                        }
+                    ),
+                ]
             );
 
         $this->reportType->buildForm($this->formBuilder, $data);

--- a/app/bundles/WebhookBundle/Tests/Model/WebhookModelTest.php
+++ b/app/bundles/WebhookBundle/Tests/Model/WebhookModelTest.php
@@ -155,7 +155,7 @@ class WebhookModelTest extends TestCase
                 return null;
             });
 
-        $this->entityManagerMock->expects($this->at(0))
+        $this->entityManagerMock->expects($this->once())
             ->method('getRepository')
             ->with(WebhookQueue::class)
             ->willReturn($queueRepositoryMock);

--- a/plugins/MauticCrmBundle/Tests/Api/SalesforceApiTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/SalesforceApiTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2017 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -19,17 +21,12 @@ class SalesforceApiTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @testdox Test that a locked record request is retried up to 3 times
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::analyzeResponse()
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::processError()
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::checkIfLockedRequestShouldBeRetried()
      */
-    public function testRecordLockedErrorIsRetriedThreeTimes()
+    public function testRecordLockedErrorIsRetriedThreeTimes(): void
     {
-        $integration = $this->getMockBuilder(SalesforceIntegration::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $integration = $this->createMock(SalesforceIntegration::class);
+        $message     = 'unable to obtain exclusive access to this record or 1 records: 70137000000Ugy3AAC';
 
-        $message = 'unable to obtain exclusive access to this record or 1 records: 70137000000Ugy3AAC';
         $integration->expects($this->exactly(3))
             ->method('makeRequest')
             ->willReturn(
@@ -54,42 +51,27 @@ class SalesforceApiTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Test that a locked record request is retried up to 3 times with last one being successful so no exception should be thrown
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::analyzeResponse()
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::processError()
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::checkIfLockedRequestShouldBeRetried()
      */
-    public function testRecordLockedErrorIsRetriedThreeTimesWithLastOneSuccessful()
+    public function testRecordLockedErrorIsRetriedThreeTimesWithLastOneSuccessful(): void
     {
-        $integration = $this->getMockBuilder(SalesforceIntegration::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $integration = $this->createMock(SalesforceIntegration::class);
+        $message     = 'unable to obtain exclusive access to this record or 1 records: 70137000000Ugy3AAC';
 
-        $message = 'unable to obtain exclusive access to this record or 1 records: 70137000000Ugy3AAC';
-        $integration->expects($this->at(1))
+        $integration->expects($this->exactly(3))
             ->method('makeRequest')
-            ->willReturn(
+            ->willReturnOnConsecutiveCalls(
                 [
                     [
                         'errorCode' => 'UNABLE_TO_LOCK_ROW',
                         'message'   => $message,
                     ],
-                ]
-            );
-
-        $integration->expects($this->at(2))
-            ->method('makeRequest')
-            ->willReturn(
+                ],
                 [
                     [
                         'errorCode' => 'UNABLE_TO_LOCK_ROW',
                         'message'   => $message,
                     ],
-                ]
-            );
-
-        $integration->expects($this->at(3))
-            ->method('makeRequest')
-            ->willReturn(
+                ],
                 [
                     [
                         'success' => true,
@@ -108,36 +90,28 @@ class SalesforceApiTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Test that a locked record request is retried 2 times with 3rd being successful
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::analyzeResponse()
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::processError()
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::checkIfLockedRequestShouldBeRetried()
      */
-    public function testRecordLockedErrorIsRetriedTwoTimesWithThirdSuccess()
+    public function testRecordLockedErrorIsRetriedTwoTimesWithThirdSuccess(): void
     {
-        $integration = $this->getMockBuilder(SalesforceIntegration::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $integration = $this->createMock(SalesforceIntegration::class);
+        $message     = 'unable to obtain exclusive access to this record or 1 records: 70137000000Ugy3AAC';
 
-        $message = 'unable to obtain exclusive access to this record or 1 records: 70137000000Ugy3AAC';
-        $integration->expects($this->at(1))
+        $integration->expects($this->exactly(2))
             ->method('makeRequest')
-            ->willReturn(
+            ->willReturnOnConsecutiveCalls(
                 [
                     [
                         'errorCode' => 'UNABLE_TO_LOCK_ROW',
                         'message'   => $message,
                     ],
-                ]
-            );
-        $integration->expects($this->at(0))
-            ->method('makeRequest')
-            ->willReturn(
+                ],
                 [
                     [
                         ['success' => true],
                     ],
                 ]
             );
+
         $api = new SalesforceApi($integration);
 
         try {
@@ -149,20 +123,15 @@ class SalesforceApiTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Test that a session expired should attempt a refresh before failing
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::analyzeResponse()
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::processError()
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::revalidateSession()
      */
-    public function testSessionExpiredIsRefreshed()
+    public function testSessionExpiredIsRefreshed(): void
     {
-        $integration = $this->getMockBuilder(SalesforceIntegration::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $integration = $this->createMock(SalesforceIntegration::class);
+        $message     = 'Session expired';
 
         $integration->expects($this->exactly(2))
             ->method('authCallback');
 
-        $message = 'Session expired';
         $integration->expects($this->exactly(2))
             ->method('makeRequest')
             ->willReturn(
@@ -186,36 +155,25 @@ class SalesforceApiTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Test that a session expired should attempt a refresh but not throw an exception if successful on second request
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::analyzeResponse()
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::processError()
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::revalidateSession()
      */
-    public function testSessionExpiredIsRefreshedWithoutThrowingExceptionOnSecondRequestWithSuccess()
+    public function testSessionExpiredIsRefreshedWithoutThrowingExceptionOnSecondRequestWithSuccess(): void
     {
-        $integration = $this->getMockBuilder(SalesforceIntegration::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $integration = $this->createMock(SalesforceIntegration::class);
+        $message     = 'Session expired';
 
         $integration->expects($this->once())
             ->method('authCallback');
 
-        $message = 'Session expired';
-
         // Test again but both attempts should fail resulting in
-        $integration->expects($this->at(1))
+        $integration->expects($this->exactly(2))
             ->method('makeRequest')
-            ->willReturn(
+            ->willReturnOnConsecutiveCalls(
                 [
                     [
                         'errorCode' => 'INVALID_SESSION_ID',
                         'message'   => $message,
                     ],
-                ]
-            );
-
-        $integration->expects($this->at(2))
-            ->method('makeRequest')
-            ->willReturn(
+                ],
                 [
                     ['success' => true],
                 ]
@@ -232,16 +190,12 @@ class SalesforceApiTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Test that an exception is thrown for all other errors
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::analyzeResponse()
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::processError()
      */
-    public function testErrorDoesNotRetryRequest()
+    public function testErrorDoesNotRetryRequest(): void
     {
-        $integration = $this->getMockBuilder(SalesforceIntegration::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $integration = $this->createMock(SalesforceIntegration::class);
+        $message     = 'Fatal error';
 
-        $message = 'Fatal error';
         $integration->expects($this->exactly(1))
             ->method('makeRequest')
             ->willReturn(
@@ -266,10 +220,8 @@ class SalesforceApiTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Test that a backslash and a single quote are escaped for SF queries
-     *
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::escapeQueryValue()
      */
-    public function testCompanyQueryIsEscapedCorrectly()
+    public function testCompanyQueryIsEscapedCorrectly(): void
     {
         $integration = $this->getMockBuilder(SalesforceIntegration::class)
             ->disableOriginalConstructor()
@@ -315,10 +267,8 @@ class SalesforceApiTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Test that a backslash and a single quote are escaped for SF queries
-     *
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::escapeQueryValue()
      */
-    public function testContactQueryIsEscapedCorrectly()
+    public function testContactQueryIsEscapedCorrectly(): void
     {
         $integration = $this->getMockBuilder(SalesforceIntegration::class)
             ->disableOriginalConstructor()
@@ -359,10 +309,8 @@ class SalesforceApiTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Test that a backslash and a single quote are escaped for SF queries
-     *
-     * @covers \MauticPlugin\MauticCrmBundle\Api\SalesforceApi::escapeQueryValue()
      */
-    public function testLeadQueryIsEscapedCorrectly()
+    public function testLeadQueryIsEscapedCorrectly(): void
     {
         $integration = $this->getMockBuilder(SalesforceIntegration::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" 
| Bug fix?                               | yes/no
| New feature?                           | yes/no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | https://mautic.atlassian.net/browse/TPROD-161

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

After the PHPUNIT upgrade our test reports were showing warning in many tests. This PR refactors the tests that were using `at()` method to something else to get cleaner test reports.

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. There was no change in the production code. So just check the GitHub Actions phpunit report.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
