### PR TITLE
Allow plugin create own deduplicate logic 

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -810,6 +810,7 @@ return [
                     'mautic.lead.model.field',
                     'mautic.lead.merger',
                     'mautic.lead.repository.lead',
+                    'event_dispatcher',
                 ],
             ],
             'mautic.lead.helper.primary_company' => [

--- a/app/bundles/LeadBundle/Deduplicate/ContactDeduper.php
+++ b/app/bundles/LeadBundle/Deduplicate/ContactDeduper.php
@@ -184,8 +184,6 @@ class ContactDeduper
     }
 
     /**
-     * @param array $queryFields
-     *
      * @return array
      *
      * @throws NotHandledDuplicationByPlugin

--- a/app/bundles/LeadBundle/Event/DuplicateContactsEvent.php
+++ b/app/bundles/LeadBundle/Event/DuplicateContactsEvent.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Event;
+
+class DuplicateContactsEvent extends \Mautic\ChannelBundle\Event\ChannelEvent
+{
+    /**
+     * @var array
+     */
+    private $fields;
+
+    /**
+     * @var array
+     */
+    private $duplicates = [];
+
+    private $handledByPlugin = false;
+
+    /**
+     * CheckForDuplicateContactsEvent constructor.
+     *
+     * @param array $fields
+     */
+    public function __construct(array $fields)
+    {
+        $this->fields = $fields;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFields()
+    {
+        return $this->fields;
+    }
+
+    /**
+     * @param array $fields
+     */
+    public function setFields($fields)
+    {
+        $this->fields = $fields;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDuplicates()
+    {
+        return $this->duplicates;
+    }
+
+    /**
+     * @param array $duplicates
+     */
+    public function setDuplicates($duplicates)
+    {
+        $this->handledByPlugin = true;
+        $this->duplicates      = $duplicates;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHandledByPlugin()
+    {
+        return $this->handledByPlugin;
+    }
+}

--- a/app/bundles/LeadBundle/Event/DuplicateContactsEvent.php
+++ b/app/bundles/LeadBundle/Event/DuplicateContactsEvent.php
@@ -27,8 +27,6 @@ class DuplicateContactsEvent extends \Mautic\ChannelBundle\Event\ChannelEvent
 
     /**
      * CheckForDuplicateContactsEvent constructor.
-     *
-     * @param array $fields
      */
     public function __construct(array $fields)
     {

--- a/app/bundles/LeadBundle/Exception/NotHandledDuplicationByPlugin.php
+++ b/app/bundles/LeadBundle/Exception/NotHandledDuplicationByPlugin.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Exception;
+
+class NotHandledDuplicationByPlugin extends \Exception
+{
+}

--- a/app/bundles/LeadBundle/LeadEvents.php
+++ b/app/bundles/LeadBundle/LeadEvents.php
@@ -592,6 +592,16 @@ final class LeadEvents
     const ON_CLICKTHROUGH_IDENTIFICATION = 'mautic.clickthrough_contact_identification';
 
     /**
+     * The mautic.check_for_duplicate_contact event is dispatched when deduplicate for contact is execute
+     * URL.
+     *
+     * The event listener receives a Mautic\LeadBundle\Event\CheckForDuplicateContactsEvent instance.
+     *
+     * @var string
+     */
+    const CHECK_FOR_DUPLICATE_CONTACTS_EVENT = 'mautic.check_for_duplicate_contact';
+
+    /**
      * The mautic.lead_field_pre_add_column event is dispatched before adding a new column to lead_fields table.
      *
      * The event listener receives a

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactDeduperTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactDeduperTest.php
@@ -16,6 +16,7 @@ use Mautic\LeadBundle\Deduplicate\ContactMerger;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Model\FieldModel;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class ContactDeduperTest extends \PHPUnit\Framework\TestCase
 {
@@ -34,6 +35,11 @@ class ContactDeduperTest extends \PHPUnit\Framework\TestCase
      */
     private $leadRepository;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $dispatcher;
+
     protected function setUp(): void
     {
         $this->fieldModel = $this->getMockBuilder(FieldModel::class)
@@ -45,6 +51,10 @@ class ContactDeduperTest extends \PHPUnit\Framework\TestCase
             ->getMock();
 
         $this->leadRepository = $this->getMockBuilder(LeadRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->dispatcher = $this->getMockBuilder(EventDispatcher::class)
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -160,7 +170,8 @@ class ContactDeduperTest extends \PHPUnit\Framework\TestCase
         return new ContactDeduper(
             $this->fieldModel,
             $this->contactMerger,
-            $this->leadRepository
+            $this->leadRepository,
+            $this->dispatcher
         );
     }
 }

--- a/app/bundles/LeadBundle/Tests/Event/DuplicateContactsEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/DuplicateContactsEventTest.php
@@ -24,10 +24,9 @@ class DuplicateContactsEventTest extends \PHPUnit\Framework\TestCase
         $event  = new DuplicateContactsEvent($fields);
         $this->assertSame($event->getFields(), $fields);
 
-        $duplicates = ['duplicate1', 'duplicate2' ];
+        $duplicates = ['duplicate1', 'duplicate2'];
         $event->setDuplicates($duplicates);
         $this->assertSame($event->getDuplicates(), $duplicates);
         $this->assertTrue($event->isHandledByPlugin());
-
     }
 }

--- a/app/bundles/LeadBundle/Tests/Event/DuplicateContactsEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/DuplicateContactsEventTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Event;
+
+use Mautic\CategoryBundle\Entity\Category;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Event\DuplicateContactsEvent;
+use Mautic\LeadBundle\Event\LeadListEvent;
+
+class DuplicateContactsEventTest extends \PHPUnit\Framework\TestCase
+{
+    public function testConstructGettersSetters()
+    {
+        $fields = ['field1', 'field2'];
+        $event  = new DuplicateContactsEvent($fields);
+        $this->assertSame($event->getFields(), $fields);
+
+        $duplicates = ['duplicate1', 'duplicate2' ];
+        $event->setDuplicates($duplicates);
+        $this->assertSame($event->getDuplicates(), $duplicates);
+        $this->assertTrue($event->isHandledByPlugin());
+
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes/no
| New feature?                           | yes/no
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | yes/no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Follow up to https://github.com/mautic/mautic/pull/7502

Common `mautic:contacts:deduplicate` already deduplicate contacts by unique fields from configurations. But sometimes we need custom check for duplications (for example based on firstname/lastname/phone). This PR added dispatcher to checkForDuplicateContacts method allow load duplicate contacts by plugin. 
This allow also create own command (for example `mautic:contacts:deduplicate:custom`) along with core one. 


#### Steps to test this PR:
1. Install and setup MauticCustomDeduplicateBundle https://github.com/mtcextendee/mautic-custom-deduplicate-bundle
2. Choose in plugins settings:
firstname, lastname, phone
and not empty email
3. Create two contacts without email but with same firstname, lastname, and phone.
4. Run `php app/console mautic:contacts:deduplicate:custom`
5. See If contacts were merged
6. Then create two contacts again
7. Go to Mautic > Contacts
8. Run Custom deduplicate from menu
![image](https://user-images.githubusercontent.com/462477/57359025-f7dc4b80-7176-11e9-94ed-eb0dee9e0c24.png)
9. Wait and then see If you have at least two notification in notification area (started, finished)
![image](https://user-images.githubusercontent.com/462477/57359081-12aec000-7177-11e9-92ff-e77991f0e875.png)
10. Check If contacts were merged

