### PR TITLE
Fix ConsoleErrorListener

### DIFF
--- a/app/bundles/CoreBundle/EventListener/ConsoleErrorListener.php
+++ b/app/bundles/CoreBundle/EventListener/ConsoleErrorListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2014 Mautic Contributors. All rights reserved
  * @author      Mautic
@@ -43,7 +45,7 @@ class ConsoleErrorListener
             $exception->getMessage(),
             $exception->getFile(),
             $exception->getLine(),
-            $command->getName(),
+            empty($command) ? 'UNKNOWN' : $command->getName(),
             $trace
         );
 

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/ConsoleErrorListenerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/ConsoleErrorListenerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Unit\EventListener;
+
+use Mautic\CoreBundle\EventListener\ConsoleErrorListener;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ConsoleErrorListenerTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var MockObject|LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var MockObject|InputInterface
+     */
+    private $input;
+
+    /**
+     * @var MockObject|OutputInterface
+     */
+    private $output;
+
+    private ?ConsoleErrorListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->logger   = $this->createMock(LoggerInterface::class);
+        $this->input    = $this->createMock(InputInterface::class);
+        $this->output   = $this->createMock(OutputInterface::class);
+
+        $this->listener = new ConsoleErrorListener($this->logger);
+    }
+
+    /**
+     * Should not throw an error when command is null.
+     */
+    public function testConsoleErrorWithNullCommand()
+    {
+        define('MAUTIC_ENV', 'dev');
+
+        $event = new ConsoleErrorEvent(
+            $this->input,
+            $this->output,
+            new \Exception('Example exception'),
+            null
+        );
+
+        $this->logger->expects($this->once())
+            ->method('notice');
+
+        $this->listener->onConsoleError($event);
+    }
+}

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/ConsoleErrorListenerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/ConsoleErrorListenerTest.php
@@ -44,8 +44,6 @@ class ConsoleErrorListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testConsoleErrorWithNullCommand()
     {
-        define('MAUTIC_ENV', 'dev');
-
         $event = new ConsoleErrorEvent(
             $this->input,
             $this->output,

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -38,6 +38,7 @@
     <env name="MAXMIND_LICENSE_KEY" value=""/>
     <env name="KERNEL_CLASS" value="AppKernel" />
     <const name="IS_PHPUNIT" value="true"/>
+    <const name="MAUTIC_ENV" value="test"/>
     <server name="KERNEL_DIR" value="app"/>
     <server name="APP_DEBUG" value="0"/>
   </php>


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | features
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #9848 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

Fixes #9848 by simply checking if an `$command` object is not null (in the reported case it was null)

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. @RCheesley since it's a one-line fix, can you simply copy the line to the appropriate file in the PR that you're testing? That should allow you to finish your testing!

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
