### PR TITLE
Shell verbosity restored in tests

### DIFF
--- a/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
+++ b/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
@@ -53,6 +53,8 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
             $this->prepareDatabase();
         }
 
+        $this->restoreShellVerbosity();
+
         parent::tearDown();
     }
 
@@ -206,5 +208,18 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
             file_put_contents($sqlDumpFile, $file);
         }
         fclose($f);
+    }
+
+    /**
+     * Restores the shell verbosity that might be set by Symfony console globally.
+     *
+     * @see \Symfony\Component\Console\Application::configureIO()
+     */
+    private function restoreShellVerbosity(): void
+    {
+        $defaultVerbosity=0;
+        putenv('SHELL_VERBOSITY='.$defaultVerbosity);
+        $_ENV['SHELL_VERBOSITY']    = $defaultVerbosity;
+        $_SERVER['SHELL_VERBOSITY'] = $defaultVerbosity;
     }
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features"
| Bug fix?                               | no
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | 
| Related developer documentation PR URL |
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
This PR fixes shell verbosity within functional tests. If there is a functional test that sets a shell verbosity, the verbosity value is set to the global state and is never restored.
