### PR TITLE
Re-enable the fos_rest.body_listener to parse json requests

### DIFF
--- a/app/config/config.php
+++ b/app/config/config.php
@@ -183,6 +183,7 @@ $container->loadFromExtension('oneup_uploader', [
 //FOS Rest for API
 $container->loadFromExtension('fos_rest', [
     'routing_loader' => false,
+    'body_listener'  => true,
     'view'           => [
         'formats' => [
             'json' => true,


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" 
| Bug fix?                               | yes
| New feature?                           |no
| Deprecations?                          |no
| BC breaks?                             | no
| Automated tests included?              | no (tested by api library)

#### Description:
All of the API tests that post JSON are failing since upgrading the FOS rest bundle to v3 because the json is not getting parsed and injected into Symfony's request. It looks like they disabled the body listener by default and so this PR re-enables it. 

There’s a note in v3 upgrade `The default value of the fos_rest.body_listener option has been changed from enabled to disabled.` https://github.com/FriendsOfSymfony/FOSRestBundle/blob/3.x/UPGRADING-3.0.md

#### Steps to test this PR:
* Load up [this PR](https://mautibox.com)
* Use the API to create something with a JSON body 
```
curl --location --request POST 'https://your-mautic.com/api/segments/new' \
--header 'Content-Type: application/json' \
--data-raw '{
    "name": "Some new segment test"
}'
```
* The segment should be created with the given name without a validation error that name is required.
