### PR TITLE
M4 API fixes

### DIFF
--- a/app/bundles/LeadBundle/Tracker/Factory/DeviceDetectorFactory/DeviceDetectorFactory.php
+++ b/app/bundles/LeadBundle/Tracker/Factory/DeviceDetectorFactory/DeviceDetectorFactory.php
@@ -27,6 +27,6 @@ final class DeviceDetectorFactory implements DeviceDetectorFactoryInterface
      */
     public function create($userAgent)
     {
-        return new DeviceDetector($userAgent);
+        return new DeviceDetector((string) $userAgent);
     }
 }

--- a/app/bundles/PointBundle/Controller/Api/TriggerApiController.php
+++ b/app/bundles/PointBundle/Controller/Api/TriggerApiController.php
@@ -38,7 +38,7 @@ class TriggerApiController extends CommonApiController
     protected function preSaveEntity(&$entity, $form, $parameters, $action = 'edit')
     {
         $method            = $this->request->getMethod();
-        $triggerEventModel = $this->getModel('point.triggerEvent');
+        $triggerEventModel = $this->getModel('point.triggerevent');
         $isNew             = false;
 
         // Set timestamps
@@ -100,7 +100,7 @@ class TriggerApiController extends CommonApiController
      */
     protected function createTriggerEventEntityForm($entity)
     {
-        return $this->getModel('point.triggerEvent')->createForm(
+        return $this->getModel('point.triggerevent')->createForm(
             $entity,
             $this->get('form.factory'),
             null,

--- a/app/bundles/PointBundle/Controller/TriggerController.php
+++ b/app/bundles/PointBundle/Controller/TriggerController.php
@@ -365,7 +365,7 @@ class TriggerController extends FormController
 
                         //delete entities
                         if (count($deletedEvents)) {
-                            $this->getModel('point.triggerEvent')->deleteEntities($deletedEvents);
+                            $this->getModel('point.triggerevent')->deleteEntities($deletedEvents);
                         }
 
                         $this->addFlash('mautic.core.notice.updated', [

--- a/app/bundles/WebhookBundle/Form/Type/WebhookType.php
+++ b/app/bundles/WebhookBundle/Form/Type/WebhookType.php
@@ -134,7 +134,6 @@ class WebhookType extends AbstractType
             ChoiceType::class,
             [
                 'choices' => [
-                    'mautic.core.form.default'                                  => '',
                     'mautic.webhook.config.event.orderby.chronological'         => Criteria::ASC,
                     'mautic.webhook.config.event.orderby.reverse.chronological' => Criteria::DESC,
                 ],
@@ -143,7 +142,7 @@ class WebhookType extends AbstractType
                     'class'   => 'form-control',
                     'tooltip' => 'mautic.webhook.config.event.orderby.tooltip',
                 ],
-                'placeholder' => '',
+                'placeholder' => 'mautic.core.form.default',
                 'required'    => false,
             ]
         );

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -183,6 +183,7 @@ $container->loadFromExtension('oneup_uploader', [
 //FOS Rest for API
 $container->loadFromExtension('fos_rest', [
     'routing_loader' => false,
+    'body_listener'  => true,
     'view'           => [
         'formats' => [
             'json' => true,


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" 
| Bug fix?                               | yes
| New feature?                           |no
| Deprecations?                          |no
| BC breaks?                             | no
| Automated tests included?              | no (tested by api library)

### Description:
This PR fixes some of the issues with failing API tests: 

#### All API tests with a body were failing

All of the API tests that post JSON are failing since upgrading the FOS rest bundle to v3 because the json is not getting parsed and injected into Symfony's request. It looks like they disabled the body listener by default and so this PR re-enables it. 

There’s a note in v3 upgrade `The default value of the fos_rest.body_listener option has been changed from enabled to disabled.` https://github.com/FriendsOfSymfony/FOSRestBundle/blob/3.x/UPGRADING-3.0.md. 

This was fixed by setting body_listener to true in the fos_rest config. 

#### Point Trigger endpoints were failing

The point trigger endpoints were hitting the error `mautic.point.model.triggerEvent is not a registered container key.` This is because the container became case sensitive in Symfony 4. Thus the use of ModelFactory::getModel must use `point.triggerevent` instead of `point.triggerEvent` because TriggerEventModel is registered as `mautic.point.model.triggerevent`.

#### Mautic\Tests\Api\ContactsTest::testGetActivityAdvanced

```
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'page.hit'
+'oops Missing'
```
This was related to the API test hitting up the tracking pixel to log an event to the page hits table. But an exception was encountered because a useragent wasn't set for the curl request but DeviceDetector now required a string $userAgent causing an exception for the tracking pixel. This was fixed by type casting the user agent to string in the DeviceDetectorFactory class.

#### Mautic\Tests\Api\WebhooksTest::testCreateWithUndefinedOrderDir
```
The response has unexpected status code (400).

Response: {"errors":[{"code":400,"message":"eventsOrderbyDir: The value you selected is not a valid choice.","details":{"eventsOrderbyDir":["The value you selected is not a valid choice."]}}]}
```
Symfony 4 hard codes constraint's `strict` feature to true which used to be false by default. This meant that `'' !== null` causing validation to fail if the choices array had an empty string value such as https://github.com/mautic/mautic/blob/67340a64826bbf9e8b857a0aae4ccf808a19cb1b/app/bundles/WebhookBundle/Form/Type/WebhookType.php#L137.

Empty values now need to be set as the form's `placeholder` to pass validation. 

### Steps to test this PR:
* Load up [this PR](https://mautibox.com)
* Run the API library tests
