### PR TITLE
Correct bug report data without company column but with filters company

### DIFF
--- a/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
@@ -247,7 +247,6 @@ class ReportSubscriber implements EventSubscriberInterface
                 } else {
                     $event->applyDateFilters($qb, 'date_added', 'l');
                 }
-                $event->addCompanyLeftJoin($qb);
                 break;
 
             case self::CONTEXT_LEAD_POINT_LOG:
@@ -378,7 +377,9 @@ class ReportSubscriber implements EventSubscriberInterface
                 break;
         }
 
-        if (!$event->checkContext(self::CONTEXT_COMPANIES) && $this->companyReportData->eventHasCompanyColumns($event)) {
+        if (!$event->checkContext(self::CONTEXT_COMPANIES) &&
+            ($this->companyReportData->eventHasCompanyColumns($event) or $this->companyReportData->eventHasCompanyFilters($event))
+        ) {
             $event->addCompanyLeftJoin($qb);
         }
 

--- a/app/bundles/LeadBundle/Model/CompanyReportData.php
+++ b/app/bundles/LeadBundle/Model/CompanyReportData.php
@@ -73,6 +73,21 @@ class CompanyReportData
     }
 
     /**
+     * @return bool
+     */
+    public function eventHasCompanyFilters(ReportGeneratorEvent $event)
+    {
+        $companyColumns = $this->getCompanyData();
+        foreach ($companyColumns as $key => $column) {
+            if ($event->hasFilter($key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @return array
      */
     private function getCompanyColumns()

--- a/app/bundles/LeadBundle/Model/CompanyReportData.php
+++ b/app/bundles/LeadBundle/Model/CompanyReportData.php
@@ -75,7 +75,7 @@ class CompanyReportData
     /**
      * @return bool
      */
-    public function eventHasCompanyFilters(ReportGeneratorEvent $event)
+    public function eventHasCompanyFilters(ReportGeneratorEvent $event): bool
     {
         $companyColumns = $this->getCompanyData();
         foreach ($companyColumns as $key => $column) {

--- a/app/bundles/LeadBundle/Tests/Model/CompanyReportDataTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/CompanyReportDataTest.php
@@ -165,4 +165,71 @@ class CompanyReportDataTest extends \PHPUnit\Framework\TestCase
 
         $this->assertFalse($result);
     }
+
+    /**
+     * @covers \Mautic\LeadBundle\Model\CompanyReportData::eventHasCompanyFilters
+     */
+    public function testEventHasCompanyFilters()
+    {
+        $fieldModelMock = $this->getMockBuilder(FieldModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $eventMock = $this->getMockBuilder(ReportGeneratorEvent::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $field = new Field();
+        $field->setType('email');
+        $field->setAlias('email');
+        $field->setLabel('Email');
+
+        $fieldModelMock->expects($this->once())
+            ->method('getEntities')
+            ->willReturn([$field]);
+
+        $eventMock->expects($this->once())
+            ->method('hasFilter')
+            ->with('comp.id')
+            ->willReturn(true);
+
+        $companyReportData = new CompanyReportData($fieldModelMock, $this->translator);
+
+        $result = $companyReportData->eventHasCompanyFilters($eventMock);
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @covers \Mautic\LeadBundle\Model\CompanyReportData::eventHasCompanyFilters
+     */
+    public function testEventDoesNotHaveCompanyFilters()
+    {
+        $fieldModelMock = $this->getMockBuilder(FieldModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $eventMock = $this->getMockBuilder(ReportGeneratorEvent::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $field = new Field();
+        $field->setType('email');
+        $field->setAlias('email');
+        $field->setLabel('Email');
+
+        $fieldModelMock->expects($this->once())
+            ->method('getEntities')
+            ->willReturn([$field]);
+
+        $eventMock->expects($this->any())
+            ->method('hasFilter')
+            ->willReturn(false);
+
+        $companyReportData = new CompanyReportData($fieldModelMock, $this->translator);
+
+        $result = $companyReportData->eventHasCompanyFilters($eventMock);
+
+        $this->assertFalse($result);
+    }
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

When we use in the report as Data Source Contacts and we do not select any data from the company and we add filters with the company, we will get an error about the lack of a column, it fixed the error reported by the pull request https://github.com/mautic/mautic/pull/9560 version 3.3.2

![image](https://user-images.githubusercontent.com/39382654/113149568-75117d80-9233-11eb-946f-a81805ec977e.png)

`mautic.CRITICAL: Uncaught PHP Exception Doctrine\DBAL\Exception\InvalidFieldNameException: "An exception occurred while executing 'SELECT DATE_FORMAT(l.date_added, '%Y-%m') AS date, COUNT(*) AS count FROM leads l INNER JOIN lead_lists_leads s ON s.lead_id = l.id AND s.manually_removed = 0 WHERE (s.date_added IS NULL OR (s.date_added BETWEEN ? AND ?)) AND ((s.leadlist_id = ?) OR (comp.id = 2)) GROUP BY DATE_FORMAT(l.date_added, '%Y-%m') ORDER BY DATE_FORMAT(l.date_added, '%Y-%m') ASC LIMIT 5' with params ["2020-08-31 22:00:00", "2021-01-05 08:55:16", "2"]: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'comp.id'`



However, when we use the column's company name, we now get an error

![image](https://user-images.githubusercontent.com/39382654/113150821-c40be280-9234-11eb-9292-7412fb58d4ef.png)

`[2021-03-31 09:26:18] mautic.CRITICAL: Uncaught PHP Exception Doctrine\DBAL\Query\QueryException: "The given alias 'companies_lead' is not unique in FROM and JOIN clause table. The currently registered aliases are: l, s, companies_lead." at /home/www/vendor/doctrine/dbal/lib/Doctrine/DBAL/Query/QueryException.php line 31 {"exception":"[object] (Doctrine\\DBAL\\Query\\QueryException(code: 0): The given alias 'companies_lead' is not unique in FROM and JOIN clause table. The currently registered aliases are: l, s, companies_lead. at /home/www/vendor/doctrine/dbal/lib/Doctrine/DBAL/Query/QueryException.php:31)"} []`

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create report with data source Contacts
3. Add columns company (Company Name)
4. Add filters with company

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
