### PR TITLE
Refactor Webhook::removeQueue to not depend on ORM

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -60,6 +60,14 @@
 
     * `mautic.http.connector` has been removed in favor of `mautic.http.client`. See the example above on how to use it in your class constructors.
 
-*   Plugins
+*   PluginBundle
     * If you extend `AbstractIntegration` and use the method `makeRequest`, including `$options['return_raw']`, you will now get `\Psr\Http\Message\ResponseInterface` as the response type (was `\Joomla\CMS\Http\Response`)
     * If you're listening on the `Mautic\PluginBundle\PluginEvents::PLUGIN_ON_INTEGRATION_RESPONSE` event, `PluginIntegrationRequestEvent->getResponse()` now returns `\Psr\Http\Message\ResponseInterface` as the type (was not explicitly defined)
+
+*   WebhookBundle
+    * \Mautic\WebhookBundle\Entity\Webhook::getQueues() removed and there is no replacement
+    * \Mautic\WebhookBundle\Entity\Webhook::addQueues() removed and there is no replacement
+    * \Mautic\WebhookBundle\Entity\Webhook::addQueue() removed and there is no replacement
+    * \Mautic\WebhookBundle\Entity\Webhook::removeQueue() removed and there is no replacement
+
+    

--- a/app/bundles/WebhookBundle/Entity/Webhook.php
+++ b/app/bundles/WebhookBundle/Entity/Webhook.php
@@ -63,11 +63,6 @@ class Webhook extends FormEntity
     /**
      * @var ArrayCollection
      */
-    private $queues;
-
-    /**
-     * @var ArrayCollection
-     */
     private $logs;
 
     /**
@@ -99,7 +94,6 @@ class Webhook extends FormEntity
     public function __construct()
     {
         $this->events = new ArrayCollection();
-        $this->queues = new ArrayCollection();
         $this->logs   = new ArrayCollection();
     }
 
@@ -117,14 +111,6 @@ class Webhook extends FormEntity
             ->orphanRemoval()
             ->setIndexBy('event_type')
             ->mappedBy('webhook')
-            ->cascadePersist()
-            ->cascadeMerge()
-            ->cascadeDetach()
-            ->build();
-
-        $builder->createOneToMany('queues', 'WebhookQueue')
-            ->mappedBy('webhook')
-            ->fetchExtraLazy()
             ->cascadePersist()
             ->cascadeMerge()
             ->cascadeDetach()
@@ -446,49 +432,6 @@ class Webhook extends FormEntity
     public function getEventsOrderbyDir()
     {
         return $this->eventsOrderbyDir;
-    }
-
-    /**
-     * @return ArrayCollection
-     */
-    public function getQueues()
-    {
-        return $this->queues;
-    }
-
-    /**
-     * @return $this
-     */
-    public function addQueues($queues)
-    {
-        $this->queues = $queues;
-
-        /** @var \Mautic\WebhookBundle\Entity\WebhookQueue $queue */
-        foreach ($queues as $queue) {
-            $queue->setWebhook($this);
-        }
-
-        return $this;
-    }
-
-    /**
-     * @return $this
-     */
-    public function addQueue(WebhookQueue $queue)
-    {
-        $this->queues[] = $queue;
-
-        return $this;
-    }
-
-    /**
-     * @return $this
-     */
-    public function removeQueue(WebhookQueue $queue)
-    {
-        $this->queues->removeElement($queue);
-
-        return $this;
     }
 
     /**

--- a/app/bundles/WebhookBundle/Entity/WebhookQueue.php
+++ b/app/bundles/WebhookBundle/Entity/WebhookQueue.php
@@ -52,7 +52,6 @@ class WebhookQueue
             ->setCustomRepositoryClass(WebhookQueueRepository::class);
         $builder->addId();
         $builder->createManyToOne('webhook', 'Webhook')
-            ->inversedBy('queues')
             ->addJoinColumn('webhook_id', 'id', false, false, 'CASCADE')
             ->build();
         $builder->addNullableField('dateAdded', Type::DATETIME, 'date_added');

--- a/app/bundles/WebhookBundle/Tests/Entity/WebhookTest.php
+++ b/app/bundles/WebhookBundle/Tests/Entity/WebhookTest.php
@@ -39,7 +39,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
 
     public function testTriggersFromApiAreStoredAsEvents(): void
     {
-        $webhook = new Webhook();
+        $webhook  = new Webhook();
         $triggers = [
             'mautic.company_post_save',
             'mautic.company_post_delete',

--- a/app/bundles/WebhookBundle/Tests/Entity/WebhookTest.php
+++ b/app/bundles/WebhookBundle/Tests/Entity/WebhookTest.php
@@ -12,6 +12,7 @@
 namespace Mautic\WebhookBundle\Tests\Entity;
 
 use Mautic\WebhookBundle\Entity\Webhook;
+use PHPUnit\Framework\Assert;
 
 class WebhookTest extends \PHPUnit\Framework\TestCase
 {
@@ -34,5 +35,25 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         $webhook = new Webhook();
         $webhook->setDateModified((new \DateTime())->modify('-2 hours'));
         $this->assertTrue($webhook->wasModifiedRecently());
+    }
+
+    public function testTriggersFromApiAreStoredAsEvents(): void
+    {
+        $webhook = new Webhook();
+        $triggers = [
+            'mautic.company_post_save',
+            'mautic.company_post_delete',
+            'mautic.lead_channel_subscription_changed',
+        ];
+
+        $webhook->setTriggers($triggers);
+
+        $events = $webhook->getEvents();
+        Assert::assertCount(3, $events);
+
+        foreach ($events as $key => $event) {
+            Assert::assertEquals($event->getEventType(), $triggers[$key]);
+            Assert::assertSame($webhook, $event->getWebhook());
+        }
     }
 }

--- a/app/bundles/WebhookBundle/Tests/Functional/WebhookFunctionalTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/WebhookFunctionalTest.php
@@ -50,6 +50,7 @@ class WebhookFunctionalTest extends MauticMysqlTestCase
                 Assert::assertSame('://whatever.url', $request->getUri()->getPath());
                 $jsonPayload = json_decode($request->getBody()->getContents(), true);
                 Assert::assertCount(3, $jsonPayload['mautic.lead_post_save_new']);
+                Assert::assertNotEmpty($request->getHeader('Webhook-Signature'));
 
                 ++$this->sendRequestCounter;
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | 
| Related developer documentation PR URL |
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
Refactor away from PersistantCollection::removeElement where the collection is EXTRA_LAZY and scale is expected to support upgrading to Doctrine ORM 2.7.0+ due to BC changes implemented in 2.7.1 that loads the entire collection into RAM before deleting an element. See https://github.com/mautic/mautic/pull/8772 and https://github.com/doctrine/orm/pull/7940#issuecomment-617275249

https://github.com/mautic/mautic/blob/d638a8db6b58bab76073546ca7de19821e6629fe/app/bundles/WebhookBundle/Entity/Webhook.php#L489 used in https://github.com/mautic/mautic/blob/a60afc74ac0ef94a57e47c250a2c742639230fc6/app/bundles/WebhookBundle/Model/WebhookModel.php#L311 needs to be refactored to delete the related data via code rather than depending on the ORM considering how big queued events can be.

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create webhook with some events, execute event to fire the webhook.
3. Execute `mautic:webhooks:process`.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
