### PR TITLE
Fixed mysql 8.0.16 Incorrect DATETIME value: ''

### DIFF
--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilter.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilter.php
@@ -182,6 +182,11 @@ class ContactSegmentFilter
         return $this->contactSegmentFilterCrate->isBooleanType();
     }
 
+    public function isColumnTypeDate(): bool
+    {
+        return $this->contactSegmentFilterCrate->isDateType();
+    }
+
     /**
      * @return mixed
      */

--- a/app/bundles/LeadBundle/Segment/Query/Filter/BaseFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/BaseFilterQueryBuilder.php
@@ -65,21 +65,18 @@ class BaseFilterQueryBuilder implements FilterQueryBuilderInterface
 
         switch ($filterOperator) {
             case 'empty':
-                $expression = new CompositeExpression(CompositeExpression::TYPE_OR,
-                    [
-                        $queryBuilder->expr()->isNull('l.'.$filter->getField()),
-                        $queryBuilder->expr()->eq('l.'.$filter->getField(), $queryBuilder->expr()->literal('')),
-                    ]
-                );
+                $parts = [$queryBuilder->expr()->isNull('l.'.$filter->getField())];
+                if (!$filter->isColumnTypeDate()) {
+                    $parts[] = $queryBuilder->expr()->eq('l.'.$filter->getField(), $queryBuilder->expr()->literal(''));
+                }
+                $expression = new CompositeExpression(CompositeExpression::TYPE_OR, $parts);
                 break;
             case 'notEmpty':
-                $expression = new CompositeExpression(CompositeExpression::TYPE_AND,
-                    [
-                        $queryBuilder->expr()->isNotNull('l.'.$filter->getField()),
-                        $queryBuilder->expr()->neq('l.'.$filter->getField(), $queryBuilder->expr()->literal('')),
-                    ]
-                );
-
+                $parts = [$queryBuilder->expr()->isNotNull('l.'.$filter->getField())];
+                if (!$filter->isColumnTypeDate()) {
+                    $parts[] = $queryBuilder->expr()->neq('l.'.$filter->getField(), $queryBuilder->expr()->literal(''));
+                }
+                $expression = new CompositeExpression(CompositeExpression::TYPE_AND, $parts);
                 break;
             case 'neq':
                 $expression = $queryBuilder->expr()->orX(


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "3.3"
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Issue(s) addressed                     | Fixes #8198

#### Description:

This was a breaking change introduced in MySQL 8.0.16 but not treated as such, mautic works on 8.0.15 and earlier
Discussion here: https://bugs.mysql.com/bug.php?id=93513

#### Steps to test this PR:
1. Create a segment
2.  Add filter on a DateTime field with condition empty (or not empty)
3. Create a contact with empty (or not empty) DateTime field 
4. run `bin/console mautic:segments:update`
Expected: contact is added to segment
Actual: Got an error `Incorrect DATETIME value: ''`

