### PR TITLE
Added time part support for datetime fields to segment filters (e.g -1 hour)

### DIFF
--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateRelativeInterval.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateRelativeInterval.php
@@ -96,7 +96,7 @@ class DateRelativeInterval implements FilterDecoratorInterface
         $date->modify($this->originalValue);
 
         $operator = $this->getOperator($contactSegmentFilterCrate);
-        $format   = 'Y-m-d';
+        $format   = $this->dateOptionParameters->hasTimePart() ? 'Y-m-d H:i:s' : 'Y-m-d';
         if ('like' === $operator || 'notLike' === $operator) {
             $format .= '%';
         }

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/TimezoneResolver.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/TimezoneResolver.php
@@ -47,7 +47,7 @@ class TimezoneResolver
          */
         $timezone = $hasTimePart ? 'UTC' : $this->coreParametersHelper->get('default_timezone', 'UTC');
 
-        $date = new \DateTime('midnight today', new \DateTimeZone($timezone));
+        $date = new \DateTime($hasTimePart ? 'now' : 'midnight today', new \DateTimeZone($timezone));
 
         return new DateTimeHelper($date, null, $timezone);
     }

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateRelativeIntervalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateRelativeIntervalTest.php
@@ -109,6 +109,32 @@ class DateRelativeIntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers \Mautic\LeadBundle\Segment\Decorator\Date\Other\DateRelativeInterval::getParameterValue
      */
+    public function testGetParameterValueMinusHourWithGreaterOperator()
+    {
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
+
+        $date = new DateTimeHelper('2018-03-02', null, 'local');
+
+        $timezoneResolver->method('getDefaultDate')
+            ->with()
+            ->willReturn($date);
+
+        $filter = [
+            'operator' => '>',
+            'type' => 'datetime',
+        ];
+        $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
+
+        $filterDecorator = new DateRelativeInterval($dateDecorator, '-1 hour', $dateOptionParameters);
+
+        $this->assertEquals('2018-03-01 23:00:00', $filterDecorator->getParameterValue($contactSegmentFilterCrate));
+    }
+
+    /**
+     * @covers \Mautic\LeadBundle\Segment\Decorator\Date\Other\DateRelativeInterval::getParameterValue
+     */
     public function testGetParameterValueMinusMonthWithNotEqualOperator()
     {
         $dateDecorator    = $this->createMock(DateDecorator::class);


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | no
| New feature?                           | yes
| Deprecations?                          | no
| BC breaks?                             | Hopefully no
| Automated tests included?              | yes
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

Segment filters don't allow filtering the datetime fields on hour or minute level, e.g specify less than 1 hour ago. They truncate the `YYYY-MM-DD hh:mm:ss` value to `YYYY-MM-DD`. So it only possible to filter by day or month or year, like yesterday or -1 day.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create a custom field of DateTime type
3. Create a segment and add to filter the date field with less than "-1 hour" value
4. Create a contact, set the date field value to 2 hours ago
5. run `bin/console mautic:segments:update`

Expected: the contact is added to the segment
Actual: the contact is not added because segment filters truncate the `YYYY-MM-DD hh:mm:ss` value to `YYYY-MM-DD`

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
