### PR TITLE
Symfony expects true/false for CheckboxType

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -5,6 +5,7 @@
 *   Symfony 4
     *   Symfony deprecations were removed or refactored [https://github.com/symfony/symfony/blob/4.4/UPGRADE-4.0.md](https://github.com/symfony/symfony/blob/4.4/UPGRADE-4.0.md)
     *   Services are now private by default in Symfony 4. Mautic has a "hack" to register its own services as public but dependency injection should be preferred for Commands, Controllers, and services. Some Symfony services may no longer be available to the Controller via the Container.
+    *   \Mautic\CoreBundle\Form\Type\YesNoButtonGroupType now uses false/true values which Symfony 4 will convert to empty values for No in the UI. This shouldn't cause issues for most unless the field is using a NotBlank constraint, which is no longer valid, or submitting a form via a functional test with 0 as the value of a YesNoButtonGroupType field. 
 *   Packages removed
     *   debril/rss-atom-bundle removed
     *   egeloen/ordered-form-bundle removed

--- a/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
+++ b/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
@@ -47,12 +47,12 @@ class MessageApiController extends CommonApiController
             foreach ($channels as $channelType => $channel) {
                 if (!isset($params['channels'][$channelType])) {
                     $params['channels'][$channelType] = [
-                        'isEnabled' => 0,
+                        'isEnabled' => false,
                         'channel'   => $channelType,
                     ];
                 } else {
                     $params['channels'][$channelType]['channel']   = $channelType;
-                    $params['channels'][$channelType]['isEnabled'] = (int) $params['channels'][$channelType]['isEnabled'];
+                    $params['channels'][$channelType]['isEnabled'] = (bool) $params['channels'][$channelType]['isEnabled'];
                 }
             }
         }

--- a/app/bundles/CoreBundle/Form/Type/YesNoButtonGroupType.php
+++ b/app/bundles/CoreBundle/Form/Type/YesNoButtonGroupType.php
@@ -54,7 +54,7 @@ class YesNoButtonGroupType extends AbstractType
                         return null;
                     }
 
-                    return (is_string($choiceKey) && !is_numeric($choiceKey)) ? $choiceKey : (int) $choiceKey;
+                    return (is_string($choiceKey) && !is_numeric($choiceKey)) ? $choiceKey : (bool) $choiceKey;
                 },
                 'expanded'          => true,
                 'multiple'          => false,
@@ -63,9 +63,9 @@ class YesNoButtonGroupType extends AbstractType
                 'placeholder'       => false,
                 'required'          => false,
                 'no_label'          => 'mautic.core.form.no',
-                'no_value'          => 0,
+                'no_value'          => false,
                 'yes_label'         => 'mautic.core.form.yes',
-                'yes_value'         => 1,
+                'yes_value'         => true,
             ]
         );
     }

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -66,8 +66,8 @@ class LeadControllerTest extends MauticMysqlTestCase
             [
                 'leadlist[name]'               => 'Segment 1',
                 'leadlist[alias]'              => 'segment-1',
-                'leadlist[isGlobal]'           => '0',
-                'leadlist[isPreferenceCenter]' => '0',
+                'leadlist[isGlobal]'           => '',
+                'leadlist[isPreferenceCenter]' => '',
                 'leadlist[isPublished]'        => '1',
                 'leadlist[publicName]'         => 'Segment 1',
                 'leadlist[category]'           => '1',

--- a/app/bundles/ReportBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ReportBundle/Form/Type/ConfigType.php
@@ -20,20 +20,19 @@ class ConfigType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('csv_always_enclose', YesNoButtonGroupType::class, [
-            'label'      => 'mautic.config.tab.form.csv_always_enclose',
-            'label_attr' => ['class' => 'control-label'],
-            'attr'       => [
-                'class'   => 'form-control',
-                'tooltip' => 'mautic.config.tab.form.csv_always_enclose.tooltip',
+        $builder->add(
+            'csv_always_enclose',
+            YesNoButtonGroupType::class,
+            [
+                'label'      => 'mautic.config.tab.form.csv_always_enclose',
+                'label_attr' => ['class' => 'control-label'],
+                'attr'       => [
+                    'class'   => 'form-control',
+                    'tooltip' => 'mautic.config.tab.form.csv_always_enclose.tooltip',
                 ],
-            'data'        => isset($options['data']['csv_always_enclose']) ? (bool) $options['data']['csv_always_enclose'] : false,
-            'constraints' => [
-                new NotBlank([
-                    'message' => 'mautic.core.value.required',
-                ]),
-            ],
-        ]);
+                'data'       => isset($options['data']['csv_always_enclose']) ? (bool) $options['data']['csv_always_enclose'] : false,
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" 
| Bug fix?                               | yes
| New feature?                           |no
| Deprecations?                          |no
| BC breaks?                             |no
| Automated tests included?              | no  (but functional and API tests should cover this change)
| Related user documentation PR URL      | na
| Related developer documentation PR URL | na
| Issue(s) addressed                     | https://mautic.atlassian.net/secure/RapidBoard.jspa?rapidView=26&projectKey=TPROD&modal=detail&selectedIssue=TPROD-223

#### Description:

One of the API tests started to fail with the Symfony Forms version bump to 4.4.21, specifically with the addition of this code https://github.com/symfony/form/compare/v4.4.20...v4.4.21#diff-bb5d9d94844af7f842e5b6aa429a8a0141316e527f0c4bd31d3a140adfc7c581R145. 

```
1) Mautic\Tests\Api\MessagesTest::testBatchEndpoints
The response has unexpected status code (500).

Response: {"errors":[{"message":"An exception occurred while executing \u0027UPDATE message_channels SET channel_id = ?, is_enabled = ? WHERE id = ?\u0027 with params [\u00225\u0022, null, 14]:\n\nSQLSTATE[23000]: Integrity constraint violation: 1048 Column \u0027is_enabled\u0027 cannot be null","code":500,"type":null}],"trace":[{"namespace":"","short_class":"","class":"","type":"","function":"","file":"\/var\/www\/html\/mautic\/vendor\/doctrine\/dbal\/lib\/Doctrine\/DBAL\/Driver\/AbstractMySQLDriver.php","line":125,"args":[]},{"namespace":"Doctrine\\DBAL\\Driver","short_class":"AbstractMySQLDriver","class":"Doctrine\\DBAL\\Driver\\AbstractMySQLDriver","type":"-\u003E","function":"convertException","file":"\/var\/www\/html\/mautic\/vendor\/doctrine\/dbal\/lib\/Doctrine\/DBAL\/DBALException.php","line":182,"args":[]},{"namespace":"Doctrine\\DBAL","short_class":"DBALException","class":"Doctrine\\DBAL\\DBALException","type":"::","function":"wrapException","file":"\/var\/www\/html\/mautic\/vendor\/d...

Failed asserting that false is true.

/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:89
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:104
/home/runner/work/api-library/api-library/tests/Api/MessagesTest.php:74
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:284
/home/runner/work/api-library/api-library/tests/Api/MessagesTest.php:126
```

It seems that prior to 4.4.21, our YesNoButtonGroupType returning integers for values worked but now fails because of the above change leading to isEnabled being set as null. YesNoButtonGroupType is getting proxied as RadioType when resolved by Symfony forms which inherits CheckboxType and according to [Symfony docs](https://symfony.com/doc/4.4/reference/forms/types/checkbox.html), should have boolean values. Switching the values of YesNoButtonGroupType from integers to booleans caused the API test to pass. Yes/No toggles in the UI also continue to work. 

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Browse the UI and toggle the Yes/No buttons in various forms (typically used for published/enabled states). Changing the state, saving, and editing should repopulate the correct state. 
3. API functional tests should pass (the 5 tests that failed always fail on my local) 
<img width="1183" alt="Screen Shot 2021-04-23 at 11 54 04 PM" src="https://user-images.githubusercontent.com/63312/115947752-5ea3be00-a48f-11eb-96ef-4a6e3a339c4e.png">
4. Test the Configuration can be saved and manipulated
4. Create a batch of messages via the API: `POST /api/messages/batch/new` (change channelId to be the ID of an Email and SMS that exists in your Mautic)
```
[
    {
        "name": "API message",
        "description": "Marketing message created via API unit test",
        "channels": {
            "email": {
                "channel": "email",
                "channelId": 27,
                "isEnabled": false
            },
            "sms": {
                "channel": "sms",
                "channelId": 17,
                "isEnabled": true
            }
        }
    },
    {
        "name": "API message",
        "description": "Marketing message created via API unit test",
        "channels": {
            "email": {
                "channel": "email",
                "channelId": 27,
                "isEnabled": false
            },
            "sms": {
                "channel": "sms",
                 "channelId": 17,
                "isEnabled": true
            }
        }
    },
    {
        "name": "API message",
        "description": "Marketing message created via API unit test",
        "channels": {
            "email": {
                "channel": "email",
                "channelId": 27,
                "isEnabled": false
            },
            "sms": {
                "channel": "sms",
                "channelId": 17,
                "isEnabled": true
            }
        }
    }
]
```

Then try to PATCH by switching the isEnabled of each channel and adding the message ID:
`PATCH /api/messages/batch/edit`
```
[
    {
        "id": 97,
        "name": "API message",
        "description": "Marketing message created via API unit test",
        "channels": {
            "email": {
                "channel": "email",
                "channelId": 27,
                "isEnabled": true
            },
            "sms": {
                "channel": "sms",
                "channelId": 17,
                "isEnabled": false
            }
        }
    },
    {
        "id": 98,
        "name": "API message",
        "description": "Marketing message created via API unit test",
        "channels": {
            "email": {
                "channel": "email",
                "channelId": 27,
                "isEnabled": true
            },
            "sms": {
                "channel": "sms",
                 "channelId": 17,
                "isEnabled": false
            }
        }
    },
    {
        "id": 99,
        "name": "API message",
        "description": "Marketing message created via API unit test",
        "channels": {
            "email": {
                "channel": "email",
                "channelId": 27,
                "isEnabled": true
            },
            "sms": {
                "channel": "sms",
                "channelId": 17,
                "isEnabled": false
            }
        }
    }
]
```
Then try PUT as well
`PUT /api/messages/batch/edit`
```
[
    {
        "id": 97,
        "isPublished": true,
        "name": "API message",
        "description": "Marketing message created via API unit test",
        "channels": {
            "email": {
                "channel": "email",
                "channelId": 27,
                "isEnabled": true
            },
            "sms": {
                "channel": "sms",
                "channelId": 17,
                "isEnabled": false
            }
        }
    },
    {
        "id": 98,
        "name": "API message",
        "description": "Marketing message created via API unit test",
        "channels": {
            "email": {
                "channel": "email",
                "channelId": 27,
                "isEnabled": true
            },
            "sms": {
                "channel": "sms",
                 "channelId": 17,
                "isEnabled": false
            }
        }
    },
    {
        "id": 99,
        "name": "API message",
        "description": "Marketing message created via API unit test",
        "channels": {
            "email": {
                "channel": "email",
                "channelId": 27,
                "isEnabled": true
            },
            "sms": {
                "channel": "sms",
                "channelId": 17,
                "isEnabled": false
            }
        }
    }
]
```

Finally, try using 0/1 instead of true/false. 

#### BC Breaks:
This changes causes Symfony to render the value of the No button as empty. This shouldn't cause any issues for most. But if they happen to be using a NotBlank constraints on the YesNoButtonGroupType, as found in this PR, it will fail because the submission will have an empty value (it shouldn't be required to start with because the buttons default to No). It also means that some functional tests that may have previously submitted 0 as the value will value as an invalid value. 
