### PR TITLE
Add GrapesJs builder as default builder

### DIFF
--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -658,10 +658,10 @@ class ThemeHelper
             $builderName = $builder->getName();
         } catch (IntegrationNotFoundException $exception) {
             // Assume legacy builder
-            $builderName = 'legacy';
+            $builderName = 'grapesjsbuilder';
         }
 
-        $builderRequested = $config['builder'] ?? 'legacy';
+        $builderRequested = $config['builder'] ?? null;
 
         return $builderName === $builderRequested;
     }

--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -661,7 +661,7 @@ class ThemeHelper
             $builderName = 'grapesjsbuilder';
         }
 
-        $builderRequested = $config['builder'] ?? null;
+        $builderRequested = $config['builder'] ?? 'grapesjsbuilder';
 
         return $builderName === $builderRequested;
     }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes/no
| New feature?                           | yes/no
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | yes/no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
This PR require changes on plugin side https://github.com/mautic/plugin-grapesjs-builder/pull/79

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Clone Mautic locally
2. cd to the plugins directory
2. Remove the GrapesJS plugin and clone this repo: https://github.com/mautic/plugin-grapesjs-builder into the folder `GrapesJsBuilderBundle` - can be done using `gh repo clone mautic/plugin-grapesjs-builder GrapesJsBuilderBundle` if you have GitHub CLI installed
3. cd into the `GrapesJsBuilderBundle` directory
3. Apply the PR https://github.com/mautic/plugin-grapesjs-builder/pull/79 - can be done using `gh pr checkout 79` if you have GitHub CLI installed
2. cd back to Mautic's root directory
2. Apply this PR - can be done using `gh pr checkout 9935` if you have GitHub CLI installed
3. GrapesJs should now be the default builder without additional changes being needed (enable/disable)...

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
