### PR TITLE
Report filters like and notLike expression with wildcards by default

### DIFF
--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -435,6 +435,9 @@ final class MauticReportBuilder implements ReportBuilderInterface
                             case 'email':
                             case 'url':
                                 switch ($exprFunction) {
+                                    case 'like':
+                                    case 'notLike':
+                                        $filter['value'] = false === strpos($filter['value'], '%') ? '%'.$filter['value'].'%' : $filter['value'];
                                     case 'startsWith':
                                         $exprFunction    = 'like';
                                         $filter['value'] = $filter['value'].'%';

--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -438,6 +438,7 @@ final class MauticReportBuilder implements ReportBuilderInterface
                                     case 'like':
                                     case 'notLike':
                                         $filter['value'] = false === strpos($filter['value'], '%') ? '%'.$filter['value'].'%' : $filter['value'];
+                                        break;
                                     case 'startsWith':
                                         $exprFunction    = 'like';
                                         $filter['value'] = $filter['value'].'%';


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | features for 4.0
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
This just add the same behaviour like we use in segment filters and dynamics content filters. 
For like and notLike add wildcards If not exists

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create reports for contacts
3. Add filter to like or notLike wiht some strings what are you expect do you see in report
4. Without PR you don't see related results
5. After PR you see expected results

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
