### PR TITLE
Increase calendar result limit from 100 to 1000 (workaround for issue 9964)

### DIFF
--- a/app/bundles/LeadBundle/EventListener/CalendarSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CalendarSubscriber.php
@@ -72,7 +72,7 @@ class CalendarSubscriber implements EventSubscriberInterface
             ->setParameter('start', $dates['start_date'])
             ->setParameter('end', $dates['end_date'])
             ->setFirstResult(0)
-            ->setMaxResults(100);
+            ->setMaxResults(1000);
 
         $results = $query->execute()->fetchAll();
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes (workaround)
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #9964 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

This is a workaround to fix #9964 . The real solution would be to create a calendar-specific configuration option to dynamically increase the number of events - or to remove the limit completely.

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Create more than 100 notes happening within 30 days (default calendar view)
2. Calendar is missing some entries
3. Increase `setMaxResults` in mautic/app/bundles/LeadBundle/EventListener/CalendarSubscriber.php
4. Calendar now shows all the entries

