### PR TITLE
[WIP] PHP 8 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['7.4']
+        php-versions: ['7.4', '8.0']
         db-types: ['mysql', 'mariadb']
   
     name: PHPUnit ${{ matrix.php-versions }} ${{ matrix.db-types }}

--- a/app/composer.json
+++ b/app/composer.json
@@ -72,7 +72,7 @@
     "friendsofsymfony/oauth-server-bundle": "dev-doctrine-fix",
     "willdurand/oauth-server-bundle": "dev-release-0.0.4",
     "jms/serializer-bundle": "^3.8.0",
-    "joomla/filter": "~1.3.5",
+    "joomla/filter": "1.x-dev",
     "oneup/uploader-bundle": "^3.1.0",
     "mrclay/minify": "2.2.0",
     "jbroadway/urlify": "^1.0",

--- a/app/composer.json
+++ b/app/composer.json
@@ -90,7 +90,7 @@
     "simshaun/recurr": "^3.0",
     "ramsey/uuid": "^3.7",
     "sendgrid/sendgrid": "~6.0",
-    "noxlogic/ratelimit-bundle": "^1.11",
+    "noxlogic/ratelimit-bundle": "^1.17",
     "knplabs/knp-menu-bundle": "^3.0",
     "guzzlehttp/oauth-subscriber": "^0.5.0",
     "helios-ag/fm-elfinder-bundle": "^10.1",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "description": "Mautic Open Source Distribution",
   "require": {
     "composer/installers": "^1.11",
-    "mautic/core-lib": "self.version",
+    "mautic/core-lib": "*",
     "mautic/grapes-js-builder-bundle": "dev-mautic3x"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "symfony/var-dumper": "~4.4.0",
     "symfony/browser-kit": "~4.4.0",
     "symfony/dom-crawler": "~4.4.0",
-    "mautic/transifex": "^4.0",
+    "mautic/transifex": "^4.1",
     "http-interop/http-factory-guzzle": "^1.0",
     "webfactory/exceptions-bundle": "~4.3",
     "friendsofphp/php-cs-fixer": "~2.16.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b84a15e9e61bb3654a2a5deda1e51b19",
+    "content-hash": "9f60b2e01aac821aa7ffe07062daaddb",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -5040,11 +5040,11 @@
         },
         {
             "name": "mautic/core-lib",
-            "version": "3.3.x-dev",
+            "version": "3.2.x-dev",
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "46d67c6e1c198932503700e04dfc06e74678e4e9"
+                "reference": "f5660cc67f1e86a6b927f11cc713b9d76cfc0906"
             },
             "require": {
                 "aws/aws-sdk-php": "~3.0",
@@ -5080,7 +5080,7 @@
                 "matomo/device-detector": "^4.0",
                 "misd/phone-number-bundle": "^1.1",
                 "mrclay/minify": "2.2.0",
-                "noxlogic/ratelimit-bundle": "^1.11",
+                "noxlogic/ratelimit-bundle": "^1.17",
                 "oneup/uploader-bundle": "^3.1.0",
                 "php": ">=7.4.0 <8.1",
                 "php-amqplib/rabbitmq-bundle": "^2.5.1",
@@ -16743,7 +16743,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "mautic/core-lib": 20,
         "mautic/grapes-js-builder-bundle": 20
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9f60b2e01aac821aa7ffe07062daaddb",
+    "content-hash": "05c8771e59208f1bb2ef6a095477cba9",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.180.0",
+            "version": "3.180.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "761d06d3d320bd1a0114f9d937eccd1613e1913b"
+                "reference": "88b91af651a9affd384b184332a4d52d69ab7c81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/761d06d3d320bd1a0114f9d937eccd1613e1913b",
-                "reference": "761d06d3d320bd1a0114f9d937eccd1613e1913b",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/88b91af651a9affd384b184332a4d52d69ab7c81",
+                "reference": "88b91af651a9affd384b184332a4d52d69ab7c81",
                 "shasum": ""
             },
             "require": {
@@ -92,9 +92,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.180.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.180.2"
             },
-            "time": "2021-05-03T20:41:22+00:00"
+            "time": "2021-05-05T02:47:28+00:00"
         },
         {
             "name": "bandwidth-throttle/token-bucket",
@@ -3593,21 +3593,21 @@
         },
         {
             "name": "joomla/filter",
-            "version": "1.3.5",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/filter.git",
-                "reference": "ee1d870b5c188056745e1dd3cece21522e2158b8"
+                "reference": "2b476d60a7228ada411aa5d21e361efff76873e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/filter/zipball/ee1d870b5c188056745e1dd3cece21522e2158b8",
-                "reference": "ee1d870b5c188056745e1dd3cece21522e2158b8",
+                "url": "https://api.github.com/repos/joomla-framework/filter/zipball/2b476d60a7228ada411aa5d21e361efff76873e0",
+                "reference": "2b476d60a7228ada411aa5d21e361efff76873e0",
                 "shasum": ""
             },
             "require": {
                 "joomla/string": "~1.3|~2.0",
-                "php": "^5.3.10|~7.0"
+                "php": "^5.3.10|~7.0|^8.0"
             },
             "require-dev": {
                 "joomla/coding-standards": "~2.0@alpha",
@@ -3617,6 +3617,7 @@
             "suggest": {
                 "joomla/language": "Required only if you want to use `OutputFilter::stringURLSafe`."
             },
+            "default-branch": true,
             "type": "joomla-package",
             "extra": {
                 "branch-alias": {
@@ -3643,7 +3644,17 @@
                 "issues": "https://github.com/joomla-framework/filter/issues",
                 "source": "https://github.com/joomla-framework/filter/tree/master"
             },
-            "time": "2018-05-26T15:48:53+00:00"
+            "funding": [
+                {
+                    "url": "https://community.joomla.org/sponsorship-campaigns.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/joomla",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-29T11:15:36+00:00"
         },
         {
             "name": "joomla/string",
@@ -5044,7 +5055,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "f5660cc67f1e86a6b927f11cc713b9d76cfc0906"
+                "reference": "b1e5560ce8d4038af506ea91b0cb229d8fba0fd2"
             },
             "require": {
                 "aws/aws-sdk-php": "~3.0",
@@ -5071,7 +5082,7 @@
                 "ip2location/ip2location-php": "^7.2",
                 "jbroadway/urlify": "^1.0",
                 "jms/serializer-bundle": "^3.8.0",
-                "joomla/filter": "~1.3.5",
+                "joomla/filter": "1.x-dev",
                 "kamermans/guzzle-oauth2-subscriber": "^1.0",
                 "knplabs/gaufrette": "~0.9.0",
                 "knplabs/knp-menu-bundle": "^3.0",
@@ -14077,21 +14088,21 @@
         },
         {
             "name": "mautic/transifex",
-            "version": "4.0.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mautic/Transifex-API.git",
-                "reference": "caa46c645d63b2ef84171d2fce69bb5978827eff"
+                "reference": "5dca817cdc5dd5fd231c07bfe4a8d80038b3efcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mautic/Transifex-API/zipball/caa46c645d63b2ef84171d2fce69bb5978827eff",
-                "reference": "caa46c645d63b2ef84171d2fce69bb5978827eff",
+                "url": "https://api.github.com/repos/mautic/Transifex-API/zipball/5dca817cdc5dd5fd231c07bfe4a8d80038b3efcd",
+                "reference": "5dca817cdc5dd5fd231c07bfe4a8d80038b3efcd",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": "~7.2",
+                "php": "~7.2|^8.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0"
@@ -14132,9 +14143,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mautic/Transifex-API/issues",
-                "source": "https://github.com/mautic/Transifex-API/tree/4.0.0"
+                "source": "https://github.com/mautic/Transifex-API/tree/4.1.0"
             },
-            "time": "2020-01-07T08:33:18+00:00"
+            "time": "2021-04-24T08:21:49+00:00"
         },
         {
             "name": "myclabs/deep-copy",


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | features
| Bug fix?                               | no
| New feature?                           | yes
| Deprecations?                          | no
| BC breaks?                             | TBD
| Automated tests included?              | no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

Building further on the work done in https://github.com/mautic/mautic/pull/9833:

- [ ] `friendsofsymfony/oauth2-php` is not PHP 8.0-ready. Turns out we're lucky and someone just created a PHP 8 PR: https://github.com/FriendsOfSymfony/oauth2-php/pull/125 - looks like no changes are needed on our side apart from just bumping the dependency
- [x] `joomla/filter` already seems to support PHP 8.0 (their test suite runs against it), but it doesn't explicitly declare support in their `composer.json`. Created a PR for that: https://github.com/joomla-framework/filter/pull/46
- [ ] `joomla/string` also needs to explicitly declare support in `composer.json` (will create a PR for that later)
- [x] `noxlogic/ratelimit-bundle` has PHP 8.0 support in progress. Looks like no changes from our side are required apart from updating the dependency when it's ready: https://github.com/jaytaph/RateLimitBundle/pull/113
- [x] `mautic/transifex` already works on PHP 8.0, just had to declare explicit support for it: https://github.com/mautic/Transifex-API/pull/3
- [ ] `friendsofsymfony/oauth-server-bundle` is working on a new major version, but it's not finished yet, so we can't update just yet. However, they have removed PHP templating support in favor of Twig. Since Mautic still heavily relies on PHP templates, we wouldn't be able to update this dependency once we work on PHP 8.0 support. Created a PR to re-add the templating engine: https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/pull/676 - also, @alanhartless created an issue to ask when they will release the new version: https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/issues/682
- [x] `plugin-grapesjs-builder` needs to declare PHP 8 support Done in https://github.com/mautic/mautic/pull/9966
- [ ] Update PHPSTAN + Rector in separate PRs (expect that to be quite a pain! Updating PHPSTAN should be OK but Rector will be painful)

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
