### PR TITLE
Imports not completing

### DIFF
--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -377,6 +377,7 @@ class ImportModel extends FormModel
             }
 
             if ($errorMessage) {
+                // Log the error first
                 $import->increaseIgnoredCount();
                 $this->logDebug('Line '.$lineNumber.' error: '.$errorMessage, $import);
                 if (!$this->em->isOpen()) {

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -378,7 +378,7 @@ class ImportModel extends FormModel
 
             if ($errorMessage) {
                 if (!$this->em->isOpen()) {
-                    // Something bad has happened if the entity manager is closed.
+                    // Something bad must have happened if the entity manager is closed.
                     // We will not be able to save any entities.
                     throw new ORMException($errorMessage);
                 }

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -380,6 +380,7 @@ class ImportModel extends FormModel
                 if (!$this->em->isOpen()) {
                     // Something bad must have happened if the entity manager is closed.
                     // We will not be able to save any entities.
+                    $this->logDebug('Line '.$lineNumber.' error: '.$errorMessage, $import);
                     throw new ORMException($errorMessage);
                 }
                 $import->increaseIgnoredCount();

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -377,6 +377,11 @@ class ImportModel extends FormModel
             }
 
             if ($errorMessage) {
+                if (!$this->em->isOpen()) {
+                    // Something bad has happened if the entity manager is closed.
+                    // We will not be able to save any entities.
+                    throw new ORMException($errorMessage);
+                }
                 $import->increaseIgnoredCount();
                 $this->logImportRowError($eventLog, $errorMessage);
                 $this->logDebug('Line '.$lineNumber.' error: '.$errorMessage, $import);

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -379,7 +379,7 @@ class ImportModel extends FormModel
             if ($errorMessage) {
                 $import->increaseIgnoredCount();
                 $this->logDebug('Line '.$lineNumber.' error: '.$errorMessage, $import);
-                if ($this->em->isOpen()) {
+                if (!$this->em->isOpen()) {
                     // Something bad must have happened if the entity manager is closed.
                     // We will not be able to save any entities.
                     throw new ORMException($errorMessage);

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -377,15 +377,15 @@ class ImportModel extends FormModel
             }
 
             if ($errorMessage) {
-                if (!$this->em->isOpen()) {
+                $import->increaseIgnoredCount();
+                $this->logDebug('Line '.$lineNumber.' error: '.$errorMessage, $import);
+                if ($this->em->isOpen()) {
                     // Something bad must have happened if the entity manager is closed.
                     // We will not be able to save any entities.
-                    $this->logDebug('Line '.$lineNumber.' error: '.$errorMessage, $import);
                     throw new ORMException($errorMessage);
                 }
-                $import->increaseIgnoredCount();
+                // This should be called only if the entity manager is open
                 $this->logImportRowError($eventLog, $errorMessage);
-                $this->logDebug('Line '.$lineNumber.' error: '.$errorMessage, $import);
             } else {
                 $this->leadEventLogRepo->saveEntity($eventLog);
             }

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1558,7 +1558,7 @@ class LeadModel extends FormModel
             }
 
             if (null !== $company) {
-                $this->companyModel->addLeadToCompany($company, $lead);
+                $this->companyModel->addLeadToCompany([$company['id']], $lead);
             }
 
             if ($eventLog) {

--- a/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
@@ -386,6 +386,7 @@ class ImportModelTest extends StandardImportTestHelper
 
     public function testItLogsDBErrorIfTheEntityManagerIsClosed(): void
     {
+        $this->generateSmallCSV();
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
         $entityManager = $this->getEntityManagerMock();
 
@@ -406,8 +407,6 @@ class ImportModelTest extends StandardImportTestHelper
         $importModel->process($import, new Progress());
         $import->end();
 
-        Assert::assertSame(0, $import->getInsertedCount());
-        Assert::assertSame(1, $import->getIgnoredCount());
         Assert::assertSame(Import::FAILED, $import->getStatus());
     }
 }

--- a/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2016 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -20,10 +22,11 @@ use Mautic\LeadBundle\Exception\ImportFailedException;
 use Mautic\LeadBundle\Helper\Progress;
 use Mautic\LeadBundle\Model\ImportModel;
 use Mautic\LeadBundle\Tests\StandardImportTestHelper;
+use PHPUnit\Framework\Assert;
 
 class ImportModelTest extends StandardImportTestHelper
 {
-    public function testInitEventLog()
+    public function testInitEventLog(): void
     {
         $userId   = 4;
         $userName = 'John Doe';
@@ -36,15 +39,15 @@ class ImportModelTest extends StandardImportTestHelper
             ->setOriginalFile($fileName);
         $log = $model->initEventLog($entity, $line);
 
-        $this->assertInstanceOf(LeadEventLog::class, $log);
-        $this->assertSame($userId, $log->getUserId());
-        $this->assertSame($userName, $log->getUserName());
-        $this->assertSame('lead', $log->getBundle());
-        $this->assertSame('import', $log->getObject());
-        $this->assertSame(['line' => $line, 'file' => $fileName], $log->getProperties());
+        Assert::assertInstanceOf(LeadEventLog::class, $log);
+        Assert::assertSame($userId, $log->getUserId());
+        Assert::assertSame($userName, $log->getUserName());
+        Assert::assertSame('lead', $log->getBundle());
+        Assert::assertSame('import', $log->getObject());
+        Assert::assertSame(['line' => $line, 'file' => $fileName], $log->getProperties());
     }
 
-    public function testProcess()
+    public function testProcess(): void
     {
         $model  = $this->initImportModel();
         $entity = $this->initImportEntity();
@@ -52,13 +55,13 @@ class ImportModelTest extends StandardImportTestHelper
         $model->process($entity, new Progress());
         $entity->end();
 
-        $this->assertEquals(100, $entity->getProgressPercentage());
-        $this->assertSame(4, $entity->getInsertedCount());
-        $this->assertSame(2, $entity->getIgnoredCount());
-        $this->assertSame(Import::IMPORTED, $entity->getStatus());
+        Assert::assertEquals(100, $entity->getProgressPercentage());
+        Assert::assertSame(4, $entity->getInsertedCount());
+        Assert::assertSame(2, $entity->getIgnoredCount());
+        Assert::assertSame(Import::IMPORTED, $entity->getStatus());
     }
 
-    public function testCheckParallelImportLimitWhenMore()
+    public function testCheckParallelImportLimitWhenMore(): void
     {
         $entity = $this->initImportEntity();
         $model  = $this->getMockBuilder(ImportModel::class)
@@ -85,10 +88,10 @@ class ImportModelTest extends StandardImportTestHelper
 
         $result = $model->checkParallelImportLimit();
 
-        $this->assertFalse($result);
+        Assert::assertFalse($result);
     }
 
-    public function testCheckParallelImportLimitWhenEqual()
+    public function testCheckParallelImportLimitWhenEqual(): void
     {
         $entity = $this->initImportEntity();
         $model  = $this->getMockBuilder(ImportModel::class)
@@ -115,10 +118,10 @@ class ImportModelTest extends StandardImportTestHelper
 
         $result = $model->checkParallelImportLimit();
 
-        $this->assertFalse($result);
+        Assert::assertFalse($result);
     }
 
-    public function testCheckParallelImportLimitWhenLess()
+    public function testCheckParallelImportLimitWhenLess(): void
     {
         $entity = $this->initImportEntity();
         $model  = $this->getMockBuilder(ImportModel::class)
@@ -145,10 +148,10 @@ class ImportModelTest extends StandardImportTestHelper
 
         $result = $model->checkParallelImportLimit();
 
-        $this->assertTrue($result);
+        Assert::assertTrue($result);
     }
 
-    public function testBeginImportWhenParallelLimitHit()
+    public function testBeginImportWhenParallelLimitHit(): void
     {
         $model = $this->getMockBuilder(ImportModel::class)
             ->setMethods(['checkParallelImportLimit', 'setGhostImportsAsFailed', 'saveEntity', 'getParallelImportLimit'])
@@ -176,15 +179,15 @@ class ImportModelTest extends StandardImportTestHelper
             // This is expected
         }
 
-        $this->assertEquals(0, $entity->getProgressPercentage());
-        $this->assertSame(0, $entity->getInsertedCount());
-        $this->assertSame(0, $entity->getIgnoredCount());
-        $this->assertSame(Import::DELAYED, $entity->getStatus());
+        Assert::assertEquals(0, $entity->getProgressPercentage());
+        Assert::assertSame(0, $entity->getInsertedCount());
+        Assert::assertSame(0, $entity->getIgnoredCount());
+        Assert::assertSame(Import::DELAYED, $entity->getStatus());
 
         $model->expects($this->never())->method('saveEntity');
     }
 
-    public function testBeginImportWhenDatabaseException()
+    public function testBeginImportWhenDatabaseException(): void
     {
         $model = $this->getMockBuilder(ImportModel::class)
             ->setMethods(['checkParallelImportLimit', 'setGhostImportsAsFailed', 'saveEntity', 'logDebug', 'process'])
@@ -213,15 +216,15 @@ class ImportModelTest extends StandardImportTestHelper
             // This is expected
         }
 
-        $this->assertEquals(0, $entity->getProgressPercentage());
-        $this->assertSame(0, $entity->getInsertedCount());
-        $this->assertSame(0, $entity->getIgnoredCount());
-        $this->assertSame(Import::DELAYED, $entity->getStatus());
+        Assert::assertEquals(0, $entity->getProgressPercentage());
+        Assert::assertSame(0, $entity->getInsertedCount());
+        Assert::assertSame(0, $entity->getIgnoredCount());
+        Assert::assertSame(Import::DELAYED, $entity->getStatus());
 
         $model->expects($this->never())->method('saveEntity');
     }
 
-    public function testIsEmptyCsvRow()
+    public function testIsEmptyCsvRow(): void
     {
         $model    = $this->initImportModel();
         $testData = [
@@ -252,7 +255,7 @@ class ImportModelTest extends StandardImportTestHelper
         ];
 
         foreach ($testData as $test) {
-            $this->assertSame(
+            Assert::assertSame(
                 $test['res'],
                 $model->isEmptyCsvRow($test['row']),
                 'Failed on row '.var_export($test['row'], true)
@@ -260,7 +263,7 @@ class ImportModelTest extends StandardImportTestHelper
         }
     }
 
-    public function testTrimArrayValues()
+    public function testTrimArrayValues(): void
     {
         $model    = $this->initImportModel();
         $testData = [
@@ -279,7 +282,7 @@ class ImportModelTest extends StandardImportTestHelper
         ];
 
         foreach ($testData as $test) {
-            $this->assertSame(
+            Assert::assertSame(
                 $test['res'],
                 $model->trimArrayValues($test['row']),
                 'Failed on row '.var_export($test['row'], true)
@@ -287,7 +290,7 @@ class ImportModelTest extends StandardImportTestHelper
         }
     }
 
-    public function testHasMoreValuesThanColumns()
+    public function testHasMoreValuesThanColumns(): void
     {
         $model    = $this->initImportModel();
         $columns  = 3;
@@ -316,16 +319,16 @@ class ImportModelTest extends StandardImportTestHelper
 
         foreach ($testData as $test) {
             $res = $model->hasMoreValuesThanColumns($test['row'], $columns);
-            $this->assertSame(
+            Assert::assertSame(
                 $test['res'],
                 $res,
                 'Failed on row '.var_export($test['row'], true)
             );
-            $this->assertSame($test['mod'], $test['row']);
+            Assert::assertSame($test['mod'], $test['row']);
         }
     }
 
-    public function testLimit()
+    public function testLimit(): void
     {
         $model = $this->initImportModel();
 
@@ -346,27 +349,27 @@ class ImportModelTest extends StandardImportTestHelper
         $progress = new Progress();
         // Each batch should have the last line imported recorded as limit + 1
         $model->process($import, $progress, 100);
-        $this->assertEquals(101, $import->getLastLineImported());
+        Assert::assertEquals(101, $import->getLastLineImported());
         $model->process($import, $progress, 100);
-        $this->assertEquals(201, $import->getLastLineImported());
+        Assert::assertEquals(201, $import->getLastLineImported());
         $model->process($import, $progress, 100);
-        $this->assertEquals(301, $import->getLastLineImported());
+        Assert::assertEquals(301, $import->getLastLineImported());
         $model->process($import, $progress, 100);
-        $this->assertEquals(401, $import->getLastLineImported());
+        Assert::assertEquals(401, $import->getLastLineImported());
         $model->process($import, $progress, 100);
-        $this->assertEquals(501, $import->getLastLineImported());
+        Assert::assertEquals(501, $import->getLastLineImported());
         $model->process($import, $progress, 100);
 
         // 512 is an empty line in the CSV
-        $this->assertEquals(512, $import->getLastLineImported());
+        Assert::assertEquals(512, $import->getLastLineImported());
 
         // Excluding the header but including the empty row in 512, there are 511 rows
-        $this->assertEquals(511, $import->getProcessedRows());
+        Assert::assertEquals(511, $import->getProcessedRows());
 
         $import->end();
     }
 
-    public function testMacLineEndings()
+    public function testMacLineEndings(): void
     {
         $oldCsv = self::$csvPath;
 

--- a/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
@@ -387,7 +387,7 @@ class ImportModelTest extends StandardImportTestHelper
     public function testItLogsDBErrorIfTheEntityManagerIsClosed(): void
     {
         $this->generateSmallCSV();
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher    = $this->createMock(EventDispatcherInterface::class);
         $entityManager = $this->getEntityManagerMock();
 
         $entityManager->expects($this->any())

--- a/app/bundles/LeadBundle/Tests/StandardImportTestHelper.php
+++ b/app/bundles/LeadBundle/Tests/StandardImportTestHelper.php
@@ -148,6 +148,10 @@ abstract class StandardImportTestHelper extends CommonMocks
                 )
             );
 
+        $entityManager->expects($this->any())
+            ->method('isOpen')
+            ->willReturn(true);
+
         $leadModel = $this->getMockBuilder(LeadModel::class)
             ->disableOriginalConstructor()
             ->getMock();


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
It's not possible to import some csv files.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make sure you are on MySQL 5.7. 
2. Try to import contacts from this file [import-not-completing.zip](https://github.com/mautic/mautic/files/6437629/import-not-completing.zip)  in your newly created instance.
3. Make sure that you mapped all the fields from the csv fields to CS fields: First Name, Last Name, Email, Company Name.
4. The import will stuck.

#### Steps to test this PR:
1. Repeat steps 1-3 from "Steps to reproduce the bug".
2. You should be able to import all the contacts.

#### Other areas of Mautic that may be affected by the change:
1. Only import functionality should be affected.

#### List deprecations along with the new alternative:
No

#### List backwards compatibility breaks:
No