### PR TITLE
Fix tracking pixel `mtracking.gif`

### DIFF
--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -746,8 +746,10 @@ class PageModel extends FormModel
         $query['page_url'] = $this->getPageUrl($request, $page);
 
         // get all params from the url (actual url or passed in as page_url)
-        $queryUrl = $this->getQueryFromUrl($query['page_url']);
-        $query    = \array_merge($queryUrl, $query);
+        if (!empty($query['page_url'])) {
+            $queryUrl = $this->getQueryFromUrl($query['page_url']);
+            $query    = \array_merge($queryUrl, $query);
+        }
 
         // Process clickthrough if applicable
         if (!empty($query['ct'])) {

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
@@ -19,6 +19,7 @@ use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Templating\Helper\AnalyticsHelper;
 use Mautic\CoreBundle\Templating\Helper\AssetsHelper;
+use Mautic\CoreBundle\Test\AbstractMauticTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Helper\PrimaryCompanyHelper;
 use Mautic\LeadBundle\Model\LeadModel;
@@ -32,7 +33,6 @@ use Mautic\PageBundle\Helper\TrackingHelper;
 use Mautic\PageBundle\Model\PageModel;
 use Mautic\PageBundle\Model\RedirectModel;
 use Mautic\PageBundle\PageEvents;
-use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Logger;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -41,13 +41,13 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Router;
 
-class PublicControllerTest extends TestCase
+class PublicControllerTest extends AbstractMauticTestCase
 {
     /** @var PublicControllerTest */
     private $controller;
 
     /** @var Container */
-    private $container;
+    private $internalContainer;
 
     /** @var Logger */
     private $logger;
@@ -83,7 +83,7 @@ class PublicControllerTest extends TestCase
     {
         $this->controller           = new PublicController();
         $this->request              = new Request();
-        $this->container            = $this->createMock(Container::class);
+        $this->internalContainer    = $this->createMock(Container::class);
         $this->logger               = $this->createMock(Logger::class);
         $this->modelFactory         = $this->createMock(ModelFactory::class);
         $this->redirectModel        = $this->createMock(RedirectModel::class);
@@ -94,7 +94,7 @@ class PublicControllerTest extends TestCase
         $this->pageModel            = $this->createMock(PageModel::class);
         $this->primaryCompanyHelper = $this->createMock(PrimaryCompanyHelper::class);
 
-        $this->controller->setContainer($this->container);
+        $this->controller->setContainer($this->internalContainer);
         $this->controller->setRequest($this->request);
 
         parent::setUp();
@@ -348,7 +348,7 @@ class PublicControllerTest extends TestCase
             ->method('getContactFromRequest')
             ->will($this->returnCallback($getContactFromRequestCallback));
 
-        $this->container->expects($this->exactly(6))
+        $this->internalContainer->expects($this->exactly(6))
             ->method('get')
             ->withConsecutive(
                 ['monolog.logger.mautic'],
@@ -464,5 +464,12 @@ class PublicControllerTest extends TestCase
             ],
             $json['events']
         );
+    }
+
+    public function testTrackingImageAction()
+    {
+        $this->client->request('GET', '/mtracking.gif?url=http%3A%2F%2Fmautic.org');
+
+        $this->assertResponseStatusCodeSame(200);
     }
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | features
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #9982 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

A bug was introduced in the [tracking pixel](https://docs.mautic.org/en/contacts/manage-contacts/contact-monitoring#tracking-pixel) in https://github.com/mautic/mautic/pull/9265. This [is causing the API library tests to fail](https://github.com/mautic/api-library/runs/2533984860?check_suite_focus=true).

This PR fixes the tracking pixel by adding a small `if` block together with an automated test to prevent issues in the future.

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up this PR locally
2. Access `/index_dev.php/mtracking.gif?url=http%3A%2F%2Fmautic.org`, ideally through Postman. You should now get a 200 OK response instead of a 500 Server Error

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
