### PR TITLE
Add readme for Tag Manager repo

### DIFF
--- a/plugins/MauticTagManagerBundle/README.md
+++ b/plugins/MauticTagManagerBundle/README.md
@@ -1,0 +1,3 @@
+## Tag management user interface for Mautic
+
+All issues and pull requests should be made against https://github.com/mautic/mautic.


### PR DESCRIPTION
This PR does not require review, it is just adding a readme file for the Tag Manager repository.