### PR TITLE
Fix mobile notifications

### DIFF
--- a/app/bundles/NotificationBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/CampaignSubscriber.php
@@ -183,6 +183,12 @@ class CampaignSubscriber implements EventSubscriberInterface
         $event->setChannel('notification', $notification->getId());
 
         // If for some reason the call failed, tell mautic to try again by return false
+
+        $responseBody = json_decode($response->body, true);
+        if (is_array($responseBody) && isset($responseBody['errors'][0])) {
+            return $event->setFailed($responseBody['errors'][0]);
+        }
+
         if (200 !== $response->code) {
             return $event->setResult(false);
         }

--- a/app/bundles/NotificationBundle/Form/Type/MobileNotificationDetailsType.php
+++ b/app/bundles/NotificationBundle/Form/Type/MobileNotificationDetailsType.php
@@ -11,6 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 class MobileNotificationDetailsType extends AbstractType
 {
@@ -53,7 +54,8 @@ class MobileNotificationDetailsType extends AbstractType
                         'class'   => 'form-control',
                         'tooltip' => 'mautic.notification.form.mobile.ios_subtitle.tooltip',
                     ],
-                    'required' => false,
+                    'required'    => true,
+                    'constraints' => new NotBlank(),
                 ]
             );
             $builder->add(

--- a/app/bundles/NotificationBundle/Tests/Form/Type/MobileNotificationDetailsTypeTest.php
+++ b/app/bundles/NotificationBundle/Tests/Form/Type/MobileNotificationDetailsTypeTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use Mautic\CoreBundle\Form\Type\ButtonGroupType;
+use Mautic\CoreBundle\Form\Type\SortableListType;
+use Mautic\NotificationBundle\Form\Type\MobileNotificationDetailsType;
+use Mautic\PluginBundle\Entity\Integration;
+use Mautic\PluginBundle\Helper\IntegrationHelper;
+use Mautic\PluginBundle\Integration\AbstractIntegration;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class MobileNotificationDetailsTypeTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var MockObject|FormBuilderInterface
+     */
+    protected $formBuilder;
+
+    /**
+     * @var MobileNotificationDetailsType
+     */
+    protected $form;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $featureSettings = [
+            'platforms' => [
+                'ios',
+            ],
+        ];
+
+        $integration = $this->createMock(Integration::class);
+        $integration->method('getFeatureSettings')->willReturn($featureSettings);
+
+        $abstractIntegration = $this->createMock(AbstractIntegration::class);
+        $abstractIntegration->method('getIntegrationSettings')->willReturn($integration);
+
+        $integrationHelper    = $this->createMock(IntegrationHelper::class);
+        $integrationHelper->method('getIntegrationObject')->with('OneSignal')->willReturn($abstractIntegration);
+
+        $this->form = new MobileNotificationDetailsType($integrationHelper);
+
+        $this->formBuilder = $this->createMock(FormBuilderInterface::class);
+        $this->formBuilder->method('create')->willReturnSelf();
+    }
+
+    public function testBuildForm(): void
+    {
+        $options = [];
+
+        $this->formBuilder->expects($this->exactly(8))
+            ->method('add')
+            ->withConsecutive(
+                [
+                    'additional_data',
+                    SortableListType::class,
+                    [
+                        'required'        => false,
+                        'label'           => 'mautic.notification.tab.data',
+                        'option_required' => false,
+                        'with_labels'     => true,
+                    ],
+                ],
+                [
+                    'ios_subtitle',
+                    TextType::class,
+                    [
+                        'label' => 'mautic.notification.form.mobile.ios_subtitle',
+                        'attr'  => [
+                            'class'   => 'form-control',
+                            'tooltip' => 'mautic.notification.form.mobile.ios_subtitle.tooltip',
+                        ],
+                        'required'    => true,
+                        'constraints' => new NotBlank(),
+                    ],
+                ],
+                [
+                    'ios_sound',
+                    TextType::class,
+                    [
+                        'label' => 'mautic.notification.form.mobile.ios_sound',
+                        'attr'  => [
+                            'class'   => 'form-control',
+                            'tooltip' => 'mautic.notification.form.mobile.ios_sound.tooltip',
+                        ],
+                        'required' => false,
+                    ],
+                ],
+                [
+                    'ios_badges',
+                    ButtonGroupType::class,
+                    [
+                        'choices' => [
+                            'mautic.notification.form.mobile.ios_badges.set'       => 'SetTo',
+                            'mautic.notification.form.mobile.ios_badges.increment' => 'Increase',
+                        ],
+                        'attr'              => [
+                            'tooltip' => 'mautic.notification.form.mobile.ios_badges.tooltip',
+                        ],
+                        'label'       => 'mautic.notification.form.mobile.ios_badges',
+                        'empty_data'  => 'None',
+                        'required'    => false,
+                        'placeholder' => 'mautic.notification.form.mobile.ios_badges.placeholder',
+                        'expanded'    => true,
+                        'multiple'    => false,
+                    ],
+                ],
+                [
+                    'ios_badgeCount',
+                    IntegerType::class,
+                    [
+                        'label' => 'mautic.notification.form.mobile.ios_badgecount',
+                        'attr'  => [
+                            'class'        => 'form-control',
+                            'tooltip'      => 'mautic.notification.form.mobile.ios_badgecount.tooltip',
+                            'data-show-on' => '{"mobile_notification_mobileSettings_ios_badges_placeholder":""}',
+                        ],
+                        'required' => false,
+                    ],
+                ],
+                [
+                    'ios_contentAvailable',
+                    CheckboxType::class,
+                    [
+                        'label' => 'mautic.notification.form.mobile.ios_contentavailable',
+                        'attr'  => [
+                            'tooltip' => 'mautic.notification.form.mobile.ios_contentavailable.tooltip',
+                        ],
+                        'required' => false,
+                    ],
+                ],
+                [
+                    'ios_media',
+                    FileType::class,
+                    [
+                        'label' => 'mautic.notification.form.mobile.ios_media',
+                        'attr'  => [
+                            'tooltip' => 'mautic.notification.form.mobile.ios_media.tooltip',
+                        ],
+                        'required' => false,
+                    ],
+                ],
+                [
+                    'ios_mutableContent',
+                    CheckboxType::class,
+                    [
+                        'label' => 'mautic.notification.form.mobile.ios_mutablecontent',
+                        'attr'  => [
+                            'tooltip' => 'mautic.notification.form.mobile.mutablecontent.tooltip',
+                        ],
+                        'required' => false,
+                    ],
+                ]
+            );
+
+        $this->form->buildForm($this->formBuilder, $options);
+    }
+}

--- a/app/bundles/NotificationBundle/Views/SubscribedEvents/Timeline/index.html.php
+++ b/app/bundles/NotificationBundle/Views/SubscribedEvents/Timeline/index.html.php
@@ -9,10 +9,11 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 $data = $event['extra']['log']['metadata'];
-if (isset($data['failed'])) {
-    return;
-}
 ?>
+<?php if (isset($data['failed'])): ?>
+    <p class="text-danger mt-0 mb-10"><i class="fa fa-warning"></i> <?php echo $view['translator']->trans('mautic.campaign.event.last_error').': '.$data['reason']; ?></p>
+    <?php return; ?>
+<?php endif; ?>
 
 <dl class="dl-horizontal">
     <dt><?php echo $view['translator']->trans('mautic.notification.timeline.status'); ?></dt>


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes/no
| New feature?                           | yes/no
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | yes/no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
We noticed some issues for mobile notifications

1. Error 

> Notification subtitle must not be null for any languages.

iOS require subtitle, then we add not blank validation

2. Process error in timeline

At the moment error from response is not set to database and not display in timeline. This PR added standard error message to timeline, for example: 

![image](https://user-images.githubusercontent.com/462477/118844547-52aeee80-b8cb-11eb-9f0c-4bb08e686f35.png)

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. You should use mobile notification, what is really hard to setup
3. Then code review is good and basic test for mobile notification (create/edit)

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10062"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

