### PR TITLE
Add GrapesJS daily dist update script

### DIFF
--- a/.github/workflows/build-grapesjs-assets.yml
+++ b/.github/workflows/build-grapesjs-assets.yml
@@ -1,0 +1,36 @@
+name: Build JS files for dist folder
+
+on:
+  # Allow manually triggering this workflow
+  workflow_dispatch:
+  schedule:
+    # Run every day at 10 AM UTC
+    - cron: '0 10 * * *'
+
+defaults:
+  run:
+    working-directory: plugins/GrapesJsBuilderBundle
+
+jobs:
+  build-js:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+    - name: Install dependencies
+      run: npm install
+    - name: Build JS dist files
+      run: npm run build
+
+    # Checks if the JS files have been updated as a result of the NPM build,
+    # and creates a PR if necessary.
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        path: 'Assets/library/js/dist'
+        commit-message: 'Auto-update GrapesJS generated JS dist files'
+        title: 'Update GrapesJS generated JS dist files'
+        delete-branch: true


### PR DESCRIPTION
As discussed in https://github.com/mautic/mautic/issues/9995#issuecomment-835367486, adds a workflow to automatically build GrapesJS production files

Unfortunately, we can only test this after having merged this PR by triggering this workflow manually (it also runs daily at 10AM UTC)