### PR TITLE
Update asset category ID in GitHub Action release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,5 +279,5 @@ jobs:
         "${{ secrets.MAUTIC_INSTANCE_USER }}" \
         "${{ secrets.MAUTIC_INSTANCE_PASSWORD }}" \
         "${{ env.MAUTIC_VERSION }}" \
-        2 \
+        4 \
         "${{ github.workspace }}/${{ env.MAUTIC_VERSION }}.zip"


### PR DESCRIPTION
The category ID has changed with the new Mautic instance!

No testing required just review of GitHub Actions workflow.