### PR TITLE
Fix auto-update script for GrapesJS

### DIFF
--- a/.github/workflows/build-grapesjs-assets.yml
+++ b/.github/workflows/build-grapesjs-assets.yml
@@ -30,7 +30,6 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:
-        path: 'Assets/library/js/dist'
         commit-message: 'Auto-update GrapesJS generated JS dist files'
         title: 'Update GrapesJS generated JS dist files'
         delete-branch: true

--- a/plugins/GrapesJsBuilderBundle/.gitignore
+++ b/plugins/GrapesJsBuilderBundle/.gitignore
@@ -1,10 +1,2 @@
-.*
-!.babelrc
-!.eslintrc
-!.prettierignore
-!.prettierrc
-!.gitignore
-!.htaccess
-!.gitkeep
-!Assets/library/js/dist
 vendor/*
+node_modules/*

--- a/plugins/GrapesJsBuilderBundle/package-lock.json
+++ b/plugins/GrapesJsBuilderBundle/package-lock.json
@@ -12,10 +12,6 @@
         "grapesjs": "^0.16.44",
         "grapesjs-mjml": "^0.4.2",
         "grapesjs-parser-postcss": "^0.1.1",
-<<<<<<< Updated upstream
-=======
-        "grapesjs-plugin-ckeditor": "^0.0.10",
->>>>>>> Stashed changes
         "grapesjs-preset-mautic": "github:mautic/grapesjs-preset-mautic#master",
         "grapesjs-preset-newsletter": "^0.2.20",
         "grapesjs-preset-webpage": "^0.1.11"


### PR DESCRIPTION
- Fixes the GH Actions workflow
- Fixes .gitignore (also excludes `node_modules` from NodeJS now, which is similar to the `vendor` folder in PHP and shouldn't be committed)
- Fixes `package-lock.json` which got corrupted by some earlier commit back when the plugin was in its own repo

Example PR generated by this workflow: https://github.com/dennisameling/mautic/pull/6