### PR TITLE
fixed #9896, disable regex check for ::1

### DIFF
--- a/app/bundles/CoreBundle/Entity/IpAddress.php
+++ b/app/bundles/CoreBundle/Entity/IpAddress.php
@@ -200,7 +200,9 @@ class IpAddress
                     return false;
                 }
 
-                if (preg_match('/'.str_replace('.', '\\.', $ip).'/', $this->ipAddress)) {
+				// disable regex check for entry ::1
+				// https://github.com/mautic/mautic/issues/9896
+                if (preg_match('/'.str_replace('.', '\\.', $ip).'/', $this->ipAddress) && $ip != "::1") {
                     return false;
                 }
             }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | features
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | -
| Related developer documentation PR URL | -
| Issue(s) addressed                     | Fixes #9896 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
disable *preg_match* check for doNotTrack() entry *::1* (= ipv6 localhost)
