### PR TITLE
Fixed editor space/backspace bug regarding to buttons and links

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/froala/froala_editor.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/froala/froala_editor.js
@@ -204,6 +204,7 @@
     var initOnA = $.proxy(function () {
       this.$el = this.$oel;
       this.el = this.$el.get(0);
+      this.$wp = $(this);
       this.$el.attr('contenteditable', true).css('outline', 'none').css('display', 'inline-block');
       this.opts.multiLine = false;
       this.opts.toolbarInline = false;


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Issue(s) addressed                     | Fixes #9997

I did some debugging, when profiling the following script seems to be the issue:

froala_editor.js:1093
Several callbacks are implemented, if it can't apply callback it will "return false;" on the action (keydown) you are doing.
the callback it fails on is _mapKeyDown(e)

What i found was that the preventDefault on the following code is triggering:
`if (key_code == $.FE.KEYCODE.BACKSPACE && !ctrlKey(e) && !e.altKey) {
        if  (!editor.placeholder.isVisible()) {
          _backspace(e);
        }
        else {
          e.preventDefault();
          e.stopPropagation();
        }
      }`

What means editor.placeholder.isVisible() returns true.
The code refers to froala_editor.js:5029
`  /* Check if placeholder is visible */
  function isVisible () {
      return !editor.$wp ? true : editor.node.hasClass(editor.$wp.get(0), 'show-placeholder');
  }`

The code returns true when the editor.$wp is undefined/empty etc. (Which it is)
When editing for example a default textfield the editor.$wp is filled with the div.fr-wrapper DOM object.

So i checked where the editor.$wp is filled, there is an FE.prototype._init (froala_editor.js:142) code which is executed when editing an area.
With the text field (DIV element) it the proxy function initOnDefault triggers, with the links and buttons (A element) it does not. Thats why editor.$wp is not filled.

When looking into what triggers initOnDefault i found the following code:
`   // Check on what element it was initialized.
    if (this.opts.editInPopup) editInPopup();
    else if (tag_name == 'TEXTAREA') initOnTextarea();
    else if (tag_name == 'A') initOnA();
    else if (tag_name == 'IMG') initOnImg();
    else if (tag_name == 'BUTTON' || tag_name == 'INPUT') {
      this.opts.editInPopup = true;
      this.opts.toolbarInline = false;
      editInPopup();
    }
    else {
      initOnDefault();
    }`

So initOnA is triggered, in that code $wp is never filled, why this is, i don't know.
When editing froala_editor.js and adding this.$wp = $(this); it works like charm.

I'm not 100% sure we just can edit the froala_editor.js but i can't find new versions online
