### PR TITLE
Exclude issues with a bounty from stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,7 @@ daysUntilClose: 14
 exemptLabels:
   - security
   - legacy
+  - bounty
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
This is a PR relating to how the Stalebot marks issues as stale.

We should exclude bounty issues from being closed automatically - this PR addresses that.