### PR TITLE
Fix crash when getting a field that is missing column if more missing

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -360,7 +360,7 @@ class LeadFieldRepository extends CommonRepository
         $qb = $this->createQueryBuilder($this->getTableAlias());
         $qb->where($qb->expr()->eq("{$this->getTableAlias()}.columnIsNotCreated", 1));
         $qb->orderBy("{$this->getTableAlias()}.dateAdded", 'ASC');
-        $qb->getMaxResults(1);
+        $qb->setMaxResults(1);
 
         return $qb->getQuery()->getOneOrNullResult();
     }

--- a/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
@@ -15,8 +15,11 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Portability\Statement;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query;
+use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -245,5 +248,60 @@ class LeadFieldRepositoryTest extends \PHPUnit\Framework\TestCase
             ->willReturn(['id' => 456]);
 
         $this->assertTrue($this->repository->compareDateValue($contactId, $fieldAlias, $value));
+    }
+
+    public function testGetFieldThatIsMissingColumnWhenMutlipleColumsMissing()
+    {
+        $queryBuilder = $this->createMock(\Doctrine\ORM\QueryBuilder::class);
+
+        $this->entityManager->method('createQueryBuilder')
+            ->willReturn($queryBuilder);
+
+        $queryBuilder->expects(self::once())
+            ->method('select')
+            ->willReturnSelf();
+
+        $queryBuilder->expects(self::once())
+            ->method('from')
+            ->willReturnSelf();
+
+        $expr = $this->createMock(Query\Expr::class);
+        $queryBuilder->expects(self::once())
+            ->method('expr')
+            ->willReturn($expr);
+
+        $comparison= $this->createMock(Query\Expr\Comparison::class);
+        $expr->expects(self::once())
+            ->method('eq')
+            ->willReturn($comparison);
+
+        $queryBuilder->expects(self::once())
+            ->method('where')
+            ->with($comparison)
+            ->willReturnSelf();
+
+        $queryBuilder->expects(self::once())
+            ->method('orderBy')
+            ->willReturnSelf();
+
+        $queryBuilder->expects(self::once())
+            ->method('setMaxResults')
+            ->with(1)
+            ->willReturnSelf();
+
+        $query = $this->createMock(AbstractQuery::class);
+        $queryBuilder->expects(self::once())
+            ->method('getQuery')
+            ->willReturn($query);
+
+        $leadField = $this->createMock(LeadField::class);
+        $query->expects(self::once())
+            ->method('getOneOrNullResult')
+            ->willReturn($leadField);
+
+        self::assertSame(
+            $leadField,
+            $this->repository->getFieldThatIsMissingColumn()
+        );
     }
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | from "3.3.0" up to "features"
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | 
| Related developer documentation PR URL |
| Issue(s) addressed                     |

#### Description:
When multiple custom fields are added at once, then `mautic:custom-field:create-column` command fails on generic error
```
In AbstractQuery.php line 804:
                                                                                   
  More than one result was found for query although one row or none was expected.
```
Mautic method, responsible for this, already expects that. Just uses invalid single-result-limitation.

#### Steps to test this PR:
1.
```php
        $model = $modelFactory->getModel('lead.field');

        $field1 = new LeadField();
        $field1->setName('Just some column')
            ->setAlias('just_some_column')
        $field1->setGroup('core');
        $field1->setColumnIsNotCreated();
        /** sadly @see \Mautic\LeadBundle\Field\Command\CreateCustomFieldCommand::execute requires author */
        $field1->setCreatedBy(1);
        $model->saveEntity($field1);

        $field2 = new LeadField();
        $field2->setName('Just another column')
            ->setAlias('just_another_column')
        $field2->setGroup('core');
        $field2->setColumnIsNotCreated();
        /** sadly @see \Mautic\LeadBundle\Field\Command\CreateCustomFieldCommand::execute requires author */
        $field2->setCreatedBy(1);
        $model->saveEntity($field2);
```
2.
```php
bin/console mautic:custom-field:create-column
```