### PR TITLE
Lead Event Log Generated Columns

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -568,6 +568,9 @@ return [
                     'mautic.lead.model.list',
                 ],
             ],
+            'mautic.leadlist.generated_columns.subscriber' => [
+                'class'     => \Mautic\LeadBundle\EventListener\LeadEventLogGeneratedColumnSubscriber::class,
+            ],
         ],
         'forms' => [
             'mautic.form.type.lead' => [
@@ -1103,6 +1106,7 @@ return [
                     'mautic.lead.model.lead_segment_service',
                     'mautic.lead.segment.stat.chart.query.factory',
                     'request_stack',
+                    'mautic.generated.columns.provider',
                 ],
             ],
             'mautic.lead.repository.lead_segment_filter_descriptor' => [

--- a/app/bundles/LeadBundle/EventListener/LeadEventLogGeneratedColumnSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadEventLogGeneratedColumnSubscriber.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Mautic\LeadBundle\EventListener;
+
+use Mautic\CoreBundle\CoreEvents;
+use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumn;
+use Mautic\CoreBundle\Event\GeneratedColumnsEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class LeadEventLogGeneratedColumnSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            CoreEvents::ON_GENERATED_COLUMNS_BUILD => ['onGeneratedColumnsBuild', 0],
+        ];
+    }
+
+    public function onGeneratedColumnsBuild(GeneratedColumnsEvent $event): void
+    {
+        $event->addGeneratedColumn($this->buildGeneratedColumn('hour', 'DATETIME', '%Y-%m-%d %H:00', 'H'));
+        $event->addGeneratedColumn($this->buildGeneratedColumn('day', 'DATE', '%Y-%m-%d', 'd', true));
+        $event->addGeneratedColumn($this->buildGeneratedColumn('week', 'CHAR(7)', '%Y %U', 'W'));
+        $event->addGeneratedColumn($this->buildGeneratedColumn('month', 'CHAR(7)', '%Y-%m', 'm'));
+        $event->addGeneratedColumn($this->buildGeneratedColumn('year', 'YEAR', '%Y', 'Y'));
+    }
+
+    private function buildGeneratedColumn(string $name, string $type, string $format, string $unit, bool $filterDateColumn = false): GeneratedColumn
+    {
+        $columnName      = 'generated_date_added_'.$name;
+        $generatedColumn = new GeneratedColumn('lead_event_log', $columnName, $type, 'DATE_FORMAT(date_added, "'.$format.'")');
+        $generatedColumn->prependIndexColumn('id');
+        $generatedColumn->setOriginalDateColumn('date_added', $unit);
+        $generatedColumn->setStored(true);
+
+        if ($filterDateColumn) {
+            $generatedColumn->setFilterDateColumn($columnName);
+        } else {
+            $generatedColumn->addIndexColumn('date_added');
+        }
+
+        return $generatedColumn;
+    }
+}

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -13,6 +13,7 @@ namespace Mautic\LeadBundle\Model;
 
 use Doctrine\DBAL\DBALException;
 use Mautic\CategoryBundle\Model\CategoryModel;
+use Mautic\CoreBundle\Doctrine\Provider\GeneratedColumnsProviderInterface;
 use Mautic\CoreBundle\Helper\Chart\BarChart;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\CoreBundle\Helper\Chart\LineChart;
@@ -75,13 +76,19 @@ class ListModel extends FormModel
      */
     private $requestStack;
 
-    public function __construct(CategoryModel $categoryModel, CoreParametersHelper $coreParametersHelper, ContactSegmentService $leadSegment, SegmentChartQueryFactory $segmentChartQueryFactory, RequestStack $requestStack)
+    /**
+     * @var GeneratedColumnsProviderInterface
+     */
+    private $generatedColumnsProvider;
+
+    public function __construct(CategoryModel $categoryModel, CoreParametersHelper $coreParametersHelper, ContactSegmentService $leadSegment, SegmentChartQueryFactory $segmentChartQueryFactory, RequestStack $requestStack, GeneratedColumnsProviderInterface $generatedColumnsProvider)
     {
         $this->categoryModel            = $categoryModel;
         $this->coreParametersHelper     = $coreParametersHelper;
         $this->leadSegmentService       = $leadSegment;
         $this->segmentChartQueryFactory = $segmentChartQueryFactory;
         $this->requestStack             = $requestStack;
+        $this->generatedColumnsProvider = $generatedColumnsProvider;
     }
 
     /**
@@ -1177,6 +1184,7 @@ class ListModel extends FormModel
     {
         $chart    = new LineChart($unit, $dateFrom, $dateTo, $dateFormat);
         $query    = new SegmentContactsLineChartQuery($this->em->getConnection(), $dateFrom, $dateTo, $filter);
+        $query->setGeneratedColumnProvider($this->generatedColumnsProvider);
 
         // added line everytime
         $chart->setDataset($this->translator->trans('mautic.lead.segments.contacts.added'), $this->segmentChartQueryFactory->getContactsAdded($query));

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types=1);
+namespace Mautic\LeadBundle\Tests\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadEventLog;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\ListLead;
+use Symfony\Component\HttpFoundation\Response;
+
+class ListControllerTest extends MauticMysqlTestCase
+{
+    private function createContacts(): array
+    {
+        $contact1 = new Lead();
+        $contact1->setFirstname('Kane');
+        $contact1->setLastname('Williamson');
+        $contact1->setEmail('kane.williamson@test.com');
+        $contact2 = new Lead();
+        $contact2->setFirstname('Jacques');
+        $contact2->setLastname('Kallis');
+        $contact2->setEmail('jacques.kallis@test.com');
+        $this->em->persist($contact1);
+        $this->em->persist($contact2);
+        $this->em->flush();
+        return [$contact1, $contact2];
+    }
+
+    private function addContactsToSegment(array $contacts, string $segmentName): LeadList
+    {
+        $filters = [
+            'glue'       => 'and',
+            'field'      => 'company',
+            'object'     => 'lead',
+            'type'       => 'text',
+            'operator'   => 'contains',
+            'properties' => [
+                'filter' => 'Acquia',
+            ],
+            'filter'  => 'Acquia',
+            'display' => null,
+        ];
+        $segment = new LeadList();
+        $segment->setName($segmentName);
+        $segment->setAlias(strtolower($segmentName));
+        $segment->isPublished(true);
+        $segment->setDateAdded(new \DateTime());
+        $segment->setFilters($filters);
+        $segment->setIsGlobal(true);
+        $segment->setIsPreferenceCenter(false);
+        $this->em->persist($segment);
+        foreach ($contacts as $contact) {
+            $segmentContacts = new ListLead();
+            $segmentContacts->setList($segment);
+            $segmentContacts->setLead($contact);
+            $segmentContacts->setDateAdded(new \DateTime());
+            $segmentContacts->setManuallyAdded(0);
+            $segmentContacts->setManuallyRemoved(0);
+            $this->em->persist($segmentContacts);
+        }
+        $this->em->flush();
+
+        return $segment;
+    }
+
+    public function testSegmentViewGraph(): void
+    {
+        $payload = ['daterange' => [
+            'date_from' => 'Feb 1, 2021',
+            'date_to'   => 'Jun 4, 2021',
+        ],
+        ];
+        $contacts = $this->createContacts();
+        $segment  = $this->addContactsToSegment($contacts, 'SegmentTest');
+
+        foreach ($contacts as $contact) {
+            $leadEventLog = new LeadEventLog();
+            $leadEventLog->setLead($contact);
+            $leadEventLog->setAction('added');
+            $leadEventLog->setObject('segment');
+            $leadEventLog->setObjectId($segment->getId());
+            $leadEventLog->setBundle('lead');
+            $leadEventLog->setDateAdded(new \DateTime('2021-02-24 11:56:38'));
+            $this->em->persist($leadEventLog);
+        }
+        $this->em->flush();
+
+        $crawler  = $this->client->request('POST', sprintf('/s/segments/view/%d', $segment->getId()), $payload);
+        $response = $this->client->getResponse();
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $canvas        = $crawler->filter('canvas');
+        $daysLeadAdded = json_decode($canvas->text(), true)['datasets'][0]['data'][0];
+        // 2 Leads were added in February
+        self::assertSame(2, $daysLeadAdded);
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features"
| Bug fix?                               | no
| New feature?                           | yes
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

Create generated columns with preformated dates on the lead_event_log table. Optimize the query that generates the chart to use the generated columns.

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Check if the chart (Contacts in time) for segment is shown correctly.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
