### PR TITLE
Avoid increment twice for campaign jump to events

### DIFF
--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -223,7 +223,6 @@ return [
                     'monolog.logger.mautic',
                     'mautic.campaign.scheduler',
                     'mautic.campaign.helper.removed_contact_tracker',
-                    'mautic.campaign.repository.lead',
                 ],
             ],
             'mautic.campaign.executioner.kickoff'     => [

--- a/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
@@ -183,12 +183,6 @@ class EventExecutioner
                 $jumpLogs[$key] = $this->eventLogger->fetchRotationAndGenerateLogsFromContacts($event, $config, $contacts, $isInactive);
             }
 
-            // Increment the campaign rotation for the given contacts and current campaign
-            $this->leadRepository->incrementCampaignRotationForContacts(
-                $contacts->getKeys(),
-                $jumpEvents->first()->getCampaign()->getId()
-            );
-
             // Process the jump to events
             foreach ($jumpLogs as $key => $logs) {
                 $this->executeLogs($jumpEvents->get($key), $logs, $childrenCounter);

--- a/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
@@ -6,7 +6,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\FailedLeadEventLog;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
-use Mautic\CampaignBundle\Entity\LeadRepository;
 use Mautic\CampaignBundle\EventCollector\Accessor\Exception\TypeNotFoundException;
 use Mautic\CampaignBundle\EventCollector\EventCollector;
 use Mautic\CampaignBundle\EventListener\CampaignActionJumpToEventSubscriber;
@@ -37,7 +36,6 @@ class EventExecutioner
         private LoggerInterface $logger,
         private EventScheduler $scheduler,
         private RemovedContactTracker $removedContactTracker,
-        private LeadRepository $leadRepository
     ) {
         // Be sure that all events are compared using the exact same \DateTime
         $this->executionDate = new \DateTime();

--- a/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
@@ -199,7 +199,8 @@ class EventExecutionerTest extends \PHPUnit\Framework\TestCase
             )
             ->willReturn(new EvaluatedContacts());
 
-        $this->leadRepository->expects($this->once())
+        // This should not be called because the rotation is already incremented in the subscriber
+        $this->leadRepository->expects($this->never())
             ->method('incrementCampaignRotationForContacts');
 
         $this->getEventExecutioner()->executeEventsForContacts($events, $contacts);

--- a/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
@@ -220,7 +220,6 @@ class EventExecutionerTest extends \PHPUnit\Framework\TestCase
             $this->logger,
             $this->eventScheduler,
             $this->removedContactTracker,
-            $this->leadRepository
         );
     }
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | features
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | 
| Related developer documentation PR URL |
| Issue(s) addressed                     | 

#### Description:
This PR is a follow-up to https://github.com/mautic/mautic/pull/7129. After merging [that PR](https://github.com/mautic/mautic/pull/7129) we found out that the `mautic_campaign_leads.rotation` field is incremented twice when a _jump to event_ is set to be executed **immediately**. This PR fixes that.

#### Steps to reproduce the bug:
1. Create a new campaign following the schema bellow:
![schema](https://user-images.githubusercontent.com/6388925/123803117-49fb0080-d8ec-11eb-836c-f36e8264239c.png)
2. Execute `bin/console mautic:campaigns:rebuild` followed by `bin/console mautic:campaigns:trigger`.
3. Find the related record in the `mautic_campaign_leads` table. The value of the `rotation` columns is `7` which is incorrect.

#### Steps to test this PR:
1. Follow the steps 1.-2. above.
2. Find the related record in the `mautic_campaign_leads` table. The value of the `rotation` columns is `4` which is an expected value.
