### PR TITLE
Legacy email builder apply button fix

### DIFF
--- a/app/bundles/EmailBundle/Form/Type/EmailType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailType.php
@@ -64,12 +64,14 @@ class EmailType extends AbstractType
 
     public function __construct(
         TranslatorInterface $translator,
-        EntityManager $entityManager,
-        StageModel $stageModel
+        EntityManagerInterface $entityManager,
+        StageModel $stageModel,
+        CoreParametersHelper $coreParametersHelper
     ) {
-        $this->translator = $translator;
-        $this->em         = $entityManager;
-        $this->stageModel = $stageModel;
+        $this->translator           = $translator;
+        $this->em                   = $entityManager;
+        $this->stageModel           = $stageModel;
+        $this->coreParametersHelper = $coreParametersHelper;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)

--- a/app/bundles/EmailBundle/Tests/Form/Type/EmailTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/EmailTypeTest.php
@@ -13,6 +13,7 @@ namespace Mautic\EmailBundle\Tests\Form\Type;
 
 use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Form\Type\EmailType;
 use Mautic\StageBundle\Model\StageModel;
@@ -51,14 +52,16 @@ class EmailTypeTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->translator    = $this->createMock(TranslatorInterface::class);
-        $this->entityManager = $this->createMock(EntityManager::class);
-        $this->stageModel    = $this->createMock(StageModel::class);
-        $this->formBuilder   = $this->createMock(FormBuilderInterface::class);
-        $this->form          = new EmailType(
+        $this->translator           = $this->createMock(TranslatorInterface::class);
+        $this->entityManager        = $this->createMock(EntityManager::class);
+        $this->stageModel           = $this->createMock(StageModel::class);
+        $this->formBuilder          = $this->createMock(FormBuilderInterface::class);
+        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+        $this->form                 = new EmailType(
             $this->translator,
             $this->entityManager,
-            $this->stageModel
+            $this->stageModel,
+            $this->coreParametersHelper
         );
 
         $this->formBuilder->method('create')->willReturnSelf();
@@ -70,7 +73,7 @@ class EmailTypeTest extends \PHPUnit\Framework\TestCase
             'data' => new Email(),
         ];
 
-        $this->formBuilder->expects($this->at(46))
+        $this->formBuilder->expects($this->at(47))
             ->method('add')
             ->with(
                 'buttons',

--- a/app/bundles/EmailBundle/Tests/Form/Type/EmailTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/EmailTypeTest.php
@@ -48,6 +48,11 @@ class EmailTypeTest extends \PHPUnit\Framework\TestCase
      */
     private $form;
 
+    /**
+     * @var CoreParametersHelper
+     */
+    private $coreParametersHelper;
+
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The Apply button in the legacy Email Builder stopped working properly. 

The problem was in the form name that was passed to the JS method.

[//]: # ( As applicable: )
1. Go to the legacy Email Builder.
2. Click the Apply button in the email builder itself.
3. It will save the changes, but it won't open the email builder again. You will end up in the form.

#### Steps to test this PR:
1. Load up this PR
2. Click the Apply button in the legacy email builder again.
3. It will save the changes and opens the builder again after save.