### PR TITLE
Functional tests improvements

### DIFF
--- a/app/bundles/CoreBundle/Test/Hooks/ExecuteTestAfterExtension.php
+++ b/app/bundles/CoreBundle/Test/Hooks/ExecuteTestAfterExtension.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Test\Hooks;
+
+use PHPUnit\Framework\TestFailure;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Runner\AfterTestHook;
+use PHPUnit\Runner\BeforeTestHook;
+
+/**
+ * This extension allows you to run an arbitrary test after every test in the current suite which is
+ * extremely helpful when hunting down a functional test that causes your test fail.
+ * When your test fails, the execution is stopped immediately and the name of problematic test is written to STDOUT.
+ *
+ * Example of usage: `MAUTIC_TEST_EXECUTE_TEST_AFTER="Fully\\Qualified\\Class\\NameTest" bin/phpunit`.
+ */
+class ExecuteTestAfterExtension implements AfterTestHook, BeforeTestHook
+{
+    public function executeAfterTest(string $test, float $time): void
+    {
+        $testClass = getenv('MAUTIC_TEST_EXECUTE_TEST_AFTER');
+
+        if (false === $testClass) {
+            return;
+        }
+
+        $testSuite = new TestSuite();
+        $testSuite->addTestSuite($testClass);
+        $result = $testSuite->run();
+
+        if (!$result->wasSuccessful()) {
+            $failures = array_map(function (TestFailure $testFailure) {
+                return $testFailure->getExceptionAsString();
+            }, array_merge($result->failures(), $result->errors()));
+
+            exit(sprintf('The previous test was: "%s". Your test errored with: %s', $test, implode(PHP_EOL, $failures)));
+        }
+    }
+
+    public function executeBeforeTest(string $test): void
+    {
+        // Without implementing this method the method self::executeAfterTest() is never invoked. There must be a bug in PHPUnit 7.5.20.
+    }
+}

--- a/app/bundles/CoreBundle/Test/Hooks/ExecuteTestAfterExtension.php
+++ b/app/bundles/CoreBundle/Test/Hooks/ExecuteTestAfterExtension.php
@@ -25,7 +25,7 @@ use PHPUnit\Runner\BeforeTestHook;
  *
  * Example of usage: `MAUTIC_TEST_EXECUTE_TEST_AFTER="Fully\\Qualified\\Class\\NameTest" bin/phpunit`.
  */
-class ExecuteTestAfterExtension implements AfterTestHook, BeforeTestHook
+class ExecuteTestAfterExtension implements AfterTestHook
 {
     public function executeAfterTest(string $test, float $time): void
     {
@@ -46,10 +46,5 @@ class ExecuteTestAfterExtension implements AfterTestHook, BeforeTestHook
 
             exit(sprintf('The previous test was: "%s". Your test errored with: %s', $test, implode(PHP_EOL, $failures)));
         }
-    }
-
-    public function executeBeforeTest(string $test): void
-    {
-        // Without implementing this method the method self::executeAfterTest() is never invoked. There must be a bug in PHPUnit 7.5.20.
     }
 }

--- a/app/bundles/CoreBundle/Test/Hooks/ExecuteTestAfterExtension.php
+++ b/app/bundles/CoreBundle/Test/Hooks/ExecuteTestAfterExtension.php
@@ -16,7 +16,6 @@ namespace Mautic\CoreBundle\Test\Hooks;
 use PHPUnit\Framework\TestFailure;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Runner\AfterTestHook;
-use PHPUnit\Runner\BeforeTestHook;
 
 /**
  * This extension allows you to run an arbitrary test after every test in the current suite which is

--- a/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
+++ b/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
@@ -186,7 +186,8 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
      */
     private function createDatabase()
     {
-        $this->runCommand('doctrine:database:create', ['--if-not-exists' => true]);
+        $this->runCommand('doctrine:database:drop', ['--if-exists' => true, '--force' => true]);
+        $this->runCommand('doctrine:database:create');
         $this->runCommand('doctrine:schema:create');
     }
 

--- a/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
+++ b/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
@@ -186,27 +186,8 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
      */
     private function createDatabase()
     {
-        $this->runCommand(
-            'doctrine:database:drop',
-            [
-                '--env'   => 'test',
-                '--force' => true,
-            ]
-        );
-
-        $this->runCommand(
-            'doctrine:database:create',
-            [
-                '--env' => 'test',
-            ]
-        );
-
-        $this->runCommand(
-            'doctrine:schema:create',
-            [
-                '--env' => 'test',
-            ]
-        );
+        $this->runCommand('doctrine:database:create', ['--if-not-exists' => true]);
+        $this->runCommand('doctrine:schema:create');
     }
 
     /**

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -48,4 +48,7 @@
   <listeners>
     <listener class="\Mautic\CoreBundle\Test\Listeners\CleanupListener" />
   </listeners>
+  <extensions>
+    <extension class="\Mautic\CoreBundle\Test\Hooks\ExecuteTestAfterExtension" />
+  </extensions>
 </phpunit>


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | features
| Bug fix?                               | no
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      |
| Related developer documentation PR URL |
| Issue(s) addressed                     | 

#### Description:
This PR introduces some improvements for functional test.
1. A PHPUnit extension that helps hunt down a functional test that causes your test fail.
2. `Mautic\CoreBundle\Test\AbstractMauticTestCase::runCommand()` made stricter which helps find out a root cause of a failing test easier.

#### Steps to test this PR:
1. All tests are passing.
2. Test that `ExecuteTestAfterExtension` works as expected. See [its PHPDoc](https://github.com/fedys/mautic/blob/5a609d3e45a693d20fa8cca08dd929cfadb36194/app/bundles/CoreBundle/Test/Hooks/ExecuteTestAfterExtension.php#L21-L28).

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10212"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

