### PR TITLE
Migration may run in wrong order

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadField.php
+++ b/app/bundles/LeadBundle/Entity/LeadField.php
@@ -209,10 +209,12 @@ class LeadField extends FormEntity
 
         $builder->createField('columnIsNotCreated', 'boolean')
             ->columnName('column_is_not_created')
+            ->option('default', false)
             ->build();
 
         $builder->createField('originalIsPublishedValue', 'boolean')
             ->columnName('original_is_published_value')
+            ->option('default', false)
             ->build();
     }
 

--- a/app/migrations/Version20180702014364.php
+++ b/app/migrations/Version20180702014364.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * @package     Mautic
+ * @copyright   2019 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+class Version20180702014364 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        if (!$schema->getTable($this->prefix.'lead_fields')->hasColumn('column_is_not_created')) {
+            throw new SkipMigrationException('Schema does not need this migration');
+        }
+
+        if (false === $schema->getTable($this->prefix.'lead_fields')->getColumn('column_is_not_created')->getDefault()) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql("ALTER TABLE {$this->prefix}lead_fields MODIFY column_is_not_created TINYINT(1) NOT NULL DEFAULT 0");
+    }
+}

--- a/app/migrations/Version20180702014364.php
+++ b/app/migrations/Version20180702014364.php
@@ -20,7 +20,7 @@ final class Version20180702014364 extends AbstractMauticMigration
             throw new SkipMigration('Schema does not need this migration');
         }
 
-        if (false === $schema->getTable($this->prefix.'lead_fields')->getColumn('column_is_not_created')->getDefault()) {
+        if ('0' === $schema->getTable($this->prefix.'lead_fields')->getColumn('column_is_not_created')->getDefault()) {
             throw new SkipMigration('Schema includes this migration');
         }
     }

--- a/app/migrations/Version20180702014364.php
+++ b/app/migrations/Version20180702014364.php
@@ -1,42 +1,31 @@
 <?php
 
-/*
- * @package     Mautic
- * @copyright   2019 Mautic Contributors. All rights reserved.
- * @author      Mautic
- * @link        http://mautic.org
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
+declare(strict_types=1);
 
 namespace Mautic\Migrations;
 
-use Doctrine\DBAL\Migrations\SkipMigrationException;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\SkipMigration;
 use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
 
-class Version20180702014364 extends AbstractMauticMigration
+final class Version20180702014364 extends AbstractMauticMigration
 {
     /**
-     * @param Schema $schema
-     *
-     * @throws SkipMigrationException
+     * @throws SkipMigration
      * @throws \Doctrine\DBAL\Schema\SchemaException
      */
-    public function preUp(Schema $schema)
+    public function preUp(Schema $schema): void
     {
         if (!$schema->getTable($this->prefix.'lead_fields')->hasColumn('column_is_not_created')) {
-            throw new SkipMigrationException('Schema does not need this migration');
+            throw new SkipMigration('Schema does not need this migration');
         }
 
         if (false === $schema->getTable($this->prefix.'lead_fields')->getColumn('column_is_not_created')->getDefault()) {
-            throw new SkipMigrationException('Schema includes this migration');
+            throw new SkipMigration('Schema includes this migration');
         }
     }
 
-    /**
-     * @param Schema $schema
-     */
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         $this->addSql("ALTER TABLE {$this->prefix}lead_fields MODIFY column_is_not_created TINYINT(1) NOT NULL DEFAULT 0");
     }

--- a/app/migrations/Version20180702014365.php
+++ b/app/migrations/Version20180702014365.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * @package     Mautic
+ * @copyright   2019 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+class Version20180702014365 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        if (!$schema->getTable($this->prefix.'lead_fields')->hasColumn('original_is_published_value')) {
+            throw new SkipMigrationException('Schema does not need this migration');
+        }
+
+        if (false === $schema->getTable($this->prefix.'lead_fields')->getColumn('original_is_published_value')->getDefault()) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql("ALTER TABLE {$this->prefix}lead_fields MODIFY original_is_published_value TINYINT(1) NOT NULL DEFAULT 0");
+    }
+}

--- a/app/migrations/Version20180702014365.php
+++ b/app/migrations/Version20180702014365.php
@@ -1,42 +1,31 @@
 <?php
 
-/*
- * @package     Mautic
- * @copyright   2019 Mautic Contributors. All rights reserved.
- * @author      Mautic
- * @link        http://mautic.org
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
+declare(strict_types=1);
 
 namespace Mautic\Migrations;
 
-use Doctrine\DBAL\Migrations\SkipMigrationException;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\SkipMigration;
 use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
 
-class Version20180702014365 extends AbstractMauticMigration
+final class Version20180702014365 extends AbstractMauticMigration
 {
     /**
-     * @param Schema $schema
-     *
-     * @throws SkipMigrationException
+     * @throws SkipMigration
      * @throws \Doctrine\DBAL\Schema\SchemaException
      */
-    public function preUp(Schema $schema)
+    public function preUp(Schema $schema): void
     {
         if (!$schema->getTable($this->prefix.'lead_fields')->hasColumn('original_is_published_value')) {
-            throw new SkipMigrationException('Schema does not need this migration');
+            throw new SkipMigration('Schema does not need this migration');
         }
 
         if (false === $schema->getTable($this->prefix.'lead_fields')->getColumn('original_is_published_value')->getDefault()) {
-            throw new SkipMigrationException('Schema includes this migration');
+            throw new SkipMigration('Schema includes this migration');
         }
     }
 
-    /**
-     * @param Schema $schema
-     */
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         $this->addSql("ALTER TABLE {$this->prefix}lead_fields MODIFY original_is_published_value TINYINT(1) NOT NULL DEFAULT 0");
     }

--- a/app/migrations/Version20180702014365.php
+++ b/app/migrations/Version20180702014365.php
@@ -20,7 +20,7 @@ final class Version20180702014365 extends AbstractMauticMigration
             throw new SkipMigration('Schema does not need this migration');
         }
 
-        if (false === $schema->getTable($this->prefix.'lead_fields')->getColumn('original_is_published_value')->getDefault()) {
+        if ('0' === $schema->getTable($this->prefix.'lead_fields')->getColumn('original_is_published_value')->getDefault()) {
             throw new SkipMigration('Schema includes this migration');
         }
     }


### PR DESCRIPTION


[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

It happened to us that one migration that is adding new rows to the lead_field table (20180702145735) is run after a migration that is adding 2 new columns with no default value (20180921144421) and so the query breaks as MySql doesn't know what value to put there for the new row. This PR adds new migration before the problematic migration and adds default values for those fields. Another failing migration did not have permission classes generated before it was used. That another issue with 2 PR merged that did not know about each other changes.



[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Run `app/console doctrine:migrations:migrate`. You may see this error:
```
Migration 20180702145735 failed during Execution. Error An exception occurred while executing 'INSERT INTO `mautic_lead_fields` (`is_published`, `label`, `alias`, `type`, `field_group`, `default_value`, `is_required`, `is_fixed`, `is_visible`, `is_short_visible`, `is_listable`, `is_publicly_updatable`, `is_unique_identifer`, `field_order`, `properties`, `object`) 
VALUES 
    (1, 'Date Last Active', 'last_active', 'datetime', 'core', NULL , 0, 1, 1, 0, 1, 0, 0, 24, 'a:0:{}', 'lead')':
SQLSTATE[HY000]: General error: 1364 Field 'column_is_not_created' doesn't have a default value
```

If it's not reproducible then just test the migrations. It will not harm to have them in.

#### Steps to test this PR:
1. Run the migration command again. It should execute all SQL queries smoothly


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10213"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

