### PR TITLE
Delete campaign event log using query instead on delete cascade

### DIFF
--- a/app/bundles/CampaignBundle/CampaignEvents.php
+++ b/app/bundles/CampaignBundle/CampaignEvents.php
@@ -54,7 +54,7 @@ final class CampaignEvents
      *
      * @var string
      */
-    const ON_CAMPAIGN_DELETE = 'mautic.on_campaign_delete';
+    public const ON_CAMPAIGN_DELETE = 'mautic.on_campaign_delete';
 
     /**
      * The mautic.campaign_on_build event is dispatched before displaying the campaign builder form to allow adding of custom actions.
@@ -112,7 +112,7 @@ final class CampaignEvents
      *
      * @var string
      */
-    const ON_EVENT_DELETE = 'mautic.on_event_delete';
+    public const ON_EVENT_DELETE = 'mautic.on_event_delete';
 
     /**
      * The mautic.on_after_events_delete event is dispatched when a campaign events are deleted.
@@ -121,7 +121,7 @@ final class CampaignEvents
      *
      * @var string
      */
-    const ON_AFTER_EVENTS_DELETE = 'mautic.on_after_events_delete';
+    public const ON_AFTER_EVENTS_DELETE = 'mautic.on_after_events_delete';
 
     /**
      * The mautic.campaign_on_event_executed_batch event is dispatched when a batch of campaign events are executed.

--- a/app/bundles/CampaignBundle/CampaignEvents.php
+++ b/app/bundles/CampaignBundle/CampaignEvents.php
@@ -48,6 +48,15 @@ final class CampaignEvents
     public const CAMPAIGN_POST_DELETE = 'mautic.campaign_post_delete';
 
     /**
+     * The mautic.on_campaign_delete event is dispatched when a campaign is deleted.
+     *
+     * The event listener receives a Mautic\CampaignBundle\Event\DeleteCampaign instance.
+     *
+     * @var string
+     */
+    const ON_CAMPAIGN_DELETE = 'mautic.on_campaign_delete';
+
+    /**
      * The mautic.campaign_on_build event is dispatched before displaying the campaign builder form to allow adding of custom actions.
      *
      * The event listener receives a
@@ -95,6 +104,24 @@ final class CampaignEvents
      * @var string
      */
     public const ON_EVENT_EXECUTED = 'mautic.campaign_on_event_executed';
+
+    /**
+     * The mautic.on_event_delete event is dispatched when a campaign events are deleted.
+     *
+     * The event listener receives a Mautic\CampaignBundle\Event\DeleteEvent instance.
+     *
+     * @var string
+     */
+    const ON_EVENT_DELETE = 'mautic.on_event_delete';
+
+    /**
+     * The mautic.on_after_events_delete event is dispatched when a campaign events are deleted.
+     *
+     * The event listener receives a Mautic\CampaignBundle\Event\DeleteEvent instance.
+     *
+     * @var string
+     */
+    const ON_AFTER_EVENTS_DELETE = 'mautic.on_after_events_delete';
 
     /**
      * The mautic.campaign_on_event_executed_batch event is dispatched when a batch of campaign events are executed.

--- a/app/bundles/CampaignBundle/Command/CampaignDeleteEventLogsCommand.php
+++ b/app/bundles/CampaignBundle/Command/CampaignDeleteEventLogsCommand.php
@@ -20,17 +20,8 @@ class CampaignDeleteEventLogsCommand extends Command
      */
     public const COMMAND_NAME = 'mautic:campaign:delete-event-logs';
 
-    private LeadEventLogRepository $leadEventLogRepository;
-
-    private CampaignModel $campaignModel;
-
-    private EventModel $eventModel;
-
-    public function __construct(LeadEventLogRepository $leadEventLogRepository, CampaignModel $campaignModel, EventModel $eventModel)
+    public function __construct(private LeadEventLogRepository $leadEventLogRepository, private CampaignModel $campaignModel, private EventModel $eventModel)
     {
-        $this->leadEventLogRepository = $leadEventLogRepository;
-        $this->campaignModel          = $campaignModel;
-        $this->eventModel             = $eventModel;
         parent::__construct();
     }
 

--- a/app/bundles/CampaignBundle/Command/CampaignDeleteEventLogsCommand.php
+++ b/app/bundles/CampaignBundle/Command/CampaignDeleteEventLogsCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Command;
+
+use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
+use Mautic\CampaignBundle\Model\CampaignModel;
+use Mautic\CampaignBundle\Model\EventModel;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CampaignDeleteEventLogsCommand extends Command
+{
+    /**
+     * @var string
+     */
+    public const COMMAND_NAME = 'mautic:campaign:delete-event-logs';
+
+    private LeadEventLogRepository $leadEventLogRepository;
+
+    private CampaignModel $campaignModel;
+
+    private EventModel $eventModel;
+
+    public function __construct(LeadEventLogRepository $leadEventLogRepository, CampaignModel $campaignModel, EventModel $eventModel)
+    {
+        $this->leadEventLogRepository = $leadEventLogRepository;
+        $this->campaignModel          = $campaignModel;
+        $this->eventModel             = $eventModel;
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setName(self::COMMAND_NAME)
+            ->setDescription('Delete campaign event logs')
+            ->addArgument(
+                'campaign_event_ids',
+                InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
+                'Campaign event ids to delete event logs.'
+            )
+            ->addOption(
+                '--campaign-id',
+                '-i',
+                InputOption::VALUE_OPTIONAL,
+                'Delete campaign also otherwise will delete event and event log only.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $eventIds   = $input->getArgument('campaign_event_ids');
+        $campaignId = (int) $input->getOption('campaign-id');
+
+        if (!empty($campaignId)) {
+            $this->leadEventLogRepository->removeEventLogsByCampaignId($campaignId);
+            $this->eventModel->deleteEventsByCampaignId($campaignId);
+            $campaign = $this->campaignModel->getEntity($campaignId);
+            $this->campaignModel->deleteCampaign($campaign);
+        } elseif (!empty($eventIds)) {
+            $this->leadEventLogRepository->removeEventLogs($eventIds);
+            $this->eventModel->deleteEventsByEventIds($eventIds);
+        }
+
+        return 0;
+    }
+}

--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -378,8 +378,9 @@ return [
         ],
     ],
     'parameters' => [
-        'campaign_time_wait_on_event_false' => 'PT1H',
-        'campaign_use_summary'              => 0,
-        'campaign_by_range'                 => 0,
+        'campaign_time_wait_on_event_false'       => 'PT1H',
+        'campaign_use_summary'                    => 0,
+        'campaign_by_range'                       => 0,
+        'delete_campaign_event_log_in_background' => false,
     ],
 ];

--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -17,6 +17,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 class Campaign extends FormEntity implements PublishStatusIconAttributesInterface
 {
+    public const TABLE_NAME = 'campaigns';
     /**
      * @var int
      */
@@ -41,6 +42,11 @@ class Campaign extends FormEntity implements PublishStatusIconAttributesInterfac
      * @var \DateTimeInterface|null
      */
     private $publishDown;
+
+    /**
+     * @Groups({"campaign:read", "campaign:write"})
+     */
+    public ?\DateTimeInterface $deleted;
 
     /**
      * @var \Mautic\CategoryBundle\Entity\Category|null
@@ -97,7 +103,7 @@ class Campaign extends FormEntity implements PublishStatusIconAttributesInterfac
     {
         $builder = new ClassMetadataBuilder($metadata);
 
-        $builder->setTable('campaigns')
+        $builder->setTable(self::TABLE_NAME)
             ->setCustomRepositoryClass(CampaignRepository::class);
 
         $builder->addIdColumns();
@@ -139,6 +145,7 @@ class Campaign extends FormEntity implements PublishStatusIconAttributesInterfac
             ->build();
 
         $builder->addNamedField('allowRestart', 'boolean', 'allow_restart');
+        $builder->addNullableField('deleted', 'datetime');
     }
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
@@ -326,7 +333,12 @@ class Campaign extends FormEntity implements PublishStatusIconAttributesInterfac
 
     public function getRootEvents(): ArrayCollection
     {
-        $criteria = Criteria::create()->where(Criteria::expr()->isNull('parent'));
+        $criteria = Criteria::create()->where(
+            Criteria::expr()->andX(
+                Criteria::expr()->isNull('parent'),
+                Criteria::expr()->isNull('deleted')
+            )
+        );
         $events   = $this->getEvents()->matching($criteria);
 
         // Doctrine loses the indexBy mapping definition when using matching so we have to manually reset them.
@@ -579,6 +591,17 @@ class Campaign extends FormEntity implements PublishStatusIconAttributesInterfac
         $this->allowRestart = $allowRestart;
 
         return $this;
+    }
+
+    public function setDeleted(?\DateTimeInterface $deleted): void
+    {
+        $this->isChanged('deleted', $deleted);
+        $this->deleted = $deleted;
+    }
+
+    public function isDeleted(): bool
+    {
+        return !is_null($this->deleted);
     }
 
     /**

--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -43,10 +43,7 @@ class Campaign extends FormEntity implements PublishStatusIconAttributesInterfac
      */
     private $publishDown;
 
-    /**
-     * @Groups({"campaign:read", "campaign:write"})
-     */
-    public ?\DateTimeInterface $deleted;
+    public ?\DateTimeInterface $deleted = null;
 
     /**
      * @var \Mautic\CategoryBundle\Entity\Category|null
@@ -195,6 +192,7 @@ class Campaign extends FormEntity implements PublishStatusIconAttributesInterfac
                     'events',
                     'publishUp',
                     'publishDown',
+                    'deleted'
                 ]
             )
             ->build();

--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -192,7 +192,7 @@ class Campaign extends FormEntity implements PublishStatusIconAttributesInterfac
                     'events',
                     'publishUp',
                     'publishDown',
-                    'deleted'
+                    'deleted',
                 ]
             )
             ->build();

--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -19,9 +19,8 @@ class CampaignRepository extends CommonRepository
 
     public function getEntities(array $args = [])
     {
-        $q = $this->getEntityManager()
-            ->createQueryBuilder()
-            ->select($this->getTableAlias().', cat')
+        $q = $this->getEntityManager()->createQueryBuilder();
+        $q->select($this->getTableAlias().', cat')
             ->from(\Mautic\CampaignBundle\Entity\Campaign::class, $this->getTableAlias(), $this->getTableAlias().'.id')
             ->leftJoin($this->getTableAlias().'.category', 'cat');
 
@@ -32,33 +31,27 @@ class CampaignRepository extends CommonRepository
         if (!empty($args['joinForms'])) {
             $q->leftJoin($this->getTableAlias().'.forms', 'f');
         }
-
+        $q->where($q->expr()->isNull($this->getTableAlias().'.deleted'));
         $args['qb'] = $q;
 
         return parent::getEntities($args);
     }
 
-    /**
-     * @param object $entity
-     * @param bool   $flush
-     */
-    public function deleteEntity($entity, $flush = true): void
+    public function setCampaignAsDeleted(int $campaignId): void
     {
-        // Null parents of associated events first
-        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $q->update(MAUTIC_TABLE_PREFIX.'campaign_events')
-            ->set('parent_id', ':null')
-            ->setParameter('null', null)
-            ->where('campaign_id = '.$entity->getId())
-            ->executeStatement();
+        $dateTime = (new \DateTime())->format('Y-m-d H:i:s');
 
-        // Delete events
-        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $q->delete(MAUTIC_TABLE_PREFIX.'campaign_events')
-            ->where('campaign_id = '.$entity->getId())
-            ->executeStatement();
+        $this->getEntityManager()->getConnection()->update(
+            MAUTIC_TABLE_PREFIX.Event::TABLE_NAME,
+            ['deleted'     => $dateTime],
+            ['campaign_id' => $campaignId]
+        );
 
-        parent::deleteEntity($entity, $flush);
+        $this->getEntityManager()->getConnection()->update(
+            MAUTIC_TABLE_PREFIX.Campaign::TABLE_NAME,
+            ['deleted'   => $dateTime, 'is_published' => 0],
+            ['id'        => $campaignId]
+        );
     }
 
     /**

--- a/app/bundles/CampaignBundle/Entity/Event.php
+++ b/app/bundles/CampaignBundle/Entity/Event.php
@@ -3,6 +3,7 @@
 namespace Mautic\CampaignBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Mapping as ORM;
 use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
@@ -11,6 +12,8 @@ use Mautic\LeadBundle\Entity\Lead as Contact;
 
 class Event implements ChannelInterface
 {
+    public const TABLE_NAME = 'campaign_events';
+
     public const TYPE_DECISION  = 'decision';
 
     public const TYPE_ACTION    = 'action';
@@ -156,6 +159,8 @@ class Event implements ChannelInterface
      */
     private $changes = [];
 
+    private ?\DateTimeInterface $deleted = null;
+
     public function __construct()
     {
         $this->log      = new ArrayCollection();
@@ -177,7 +182,7 @@ class Event implements ChannelInterface
     {
         $builder = new ClassMetadataBuilder($metadata);
 
-        $builder->setTable('campaign_events')
+        $builder->setTable(self::TABLE_NAME)
             ->setCustomRepositoryClass(\Mautic\CampaignBundle\Entity\EventRepository::class)
             ->addIndex(['type', 'event_type'], 'campaign_event_search')
             ->addIndex(['event_type'], 'campaign_event_type')
@@ -199,6 +204,8 @@ class Event implements ChannelInterface
             ->build();
 
         $builder->addField('properties', 'array');
+
+        $builder->addNullableField('deleted', 'datetime');
 
         $builder->createField('triggerDate', 'datetime')
             ->columnName('trigger_date')
@@ -272,7 +279,6 @@ class Event implements ChannelInterface
         $builder->createOneToMany('log', 'LeadEventLog')
             ->mappedBy('event')
             ->cascadePersist()
-            ->cascadeRemove()
             ->fetchExtraLazy()
             ->build();
 
@@ -418,8 +424,6 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Get id.
-     *
      * @return int
      */
     public function getId()
@@ -433,8 +437,6 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Set order.
-     *
      * @param int $order
      *
      * @return Event
@@ -449,8 +451,6 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Get order.
-     *
      * @return int
      */
     public function getOrder()
@@ -459,8 +459,6 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Set properties.
-     *
      * @param array $properties
      *
      * @return Event
@@ -475,8 +473,6 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Get properties.
-     *
      * @return array
      */
     public function getProperties()
@@ -485,8 +481,6 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Set campaign.
-     *
      * @return Event
      */
     public function setCampaign(Campaign $campaign)
@@ -497,8 +491,6 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Get campaign.
-     *
      * @return \Mautic\CampaignBundle\Entity\Campaign
      */
     public function getCampaign()
@@ -507,8 +499,6 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Set type.
-     *
      * @param string $type
      *
      * @return Event
@@ -522,8 +512,6 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Get type.
-     *
      * @return string
      */
     public function getType()
@@ -537,8 +525,6 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Set description.
-     *
      * @param string $description
      *
      * @return Event
@@ -552,8 +538,6 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Get description.
-     *
      * @return string
      */
     public function getDescription()
@@ -562,8 +546,6 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Set name.
-     *
      * @param string $name
      *
      * @return Event
@@ -577,8 +559,6 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Get name.
-     *
      * @return string
      */
     public function getName()
@@ -587,8 +567,6 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Add log.
-     *
      * @return Event
      */
     public function addLog(LeadEventLog $log)
@@ -607,8 +585,6 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Get log.
-     *
      * @return \Doctrine\Common\Collections\Collection
      */
     public function getLog()
@@ -658,15 +634,17 @@ class Event implements ChannelInterface
     }
 
     /**
-     * @return ArrayCollection|Event[]
+     * @return ArrayCollection<int,Event>|Collection<(int|string), mixed>
      */
     public function getChildren()
     {
-        return $this->children;
+        $criteria = Criteria::create()->where(Criteria::expr()->isNull('deleted'));
+
+        return $this->children->matching($criteria);
     }
 
     /**
-     * @return ArrayCollection|Event[]
+     * @return ArrayCollection<int,Event>
      */
     public function getPositiveChildren()
     {
@@ -676,7 +654,7 @@ class Event implements ChannelInterface
     }
 
     /**
-     * @return ArrayCollection|Event[]
+     * @return ArrayCollection<int,Event>
      */
     public function getNegativeChildren()
     {
@@ -686,7 +664,9 @@ class Event implements ChannelInterface
     }
 
     /**
-     * @return ArrayCollection
+     * @param string $type
+     *
+     * @return ArrayCollection<int,Event>
      */
     public function getChildrenByType($type)
     {
@@ -696,7 +676,9 @@ class Event implements ChannelInterface
     }
 
     /**
-     * @return ArrayCollection
+     * @param string $type
+     *
+     * @return ArrayCollection<int,Event>
      */
     public function getChildrenByEventType($type)
     {
@@ -728,9 +710,7 @@ class Event implements ChannelInterface
     }
 
     /**
-     * Get parent.
-     *
-     * @return \Mautic\CampaignBundle\Entity\Event
+     * @return ?Event
      */
     public function getParent()
     {
@@ -738,7 +718,7 @@ class Event implements ChannelInterface
     }
 
     /**
-     * @return mixed
+     * @return \DateTime|null
      */
     public function getTriggerDate()
     {
@@ -746,7 +726,7 @@ class Event implements ChannelInterface
     }
 
     /**
-     * @param mixed $triggerDate
+     * @param \DateTime|null $triggerDate
      */
     public function setTriggerDate($triggerDate): void
     {
@@ -1049,5 +1029,23 @@ class Event implements ChannelInterface
         $this->isChanged('triggerRestrictedDaysOfWeek', $triggerRestrictedDaysOfWeek);
 
         return $this;
+    }
+
+    public function setDeleted(?\DateTimeInterface $deleted): Event
+    {
+        $this->isChanged('deleted', $deleted);
+        $this->deleted = $deleted;
+
+        return $this;
+    }
+
+    public function getDeleted(): ?\DateTimeInterface
+    {
+        return $this->deleted;
+    }
+
+    public function isDeleted(): bool
+    {
+        return !is_null($this->deleted);
     }
 }

--- a/app/bundles/CampaignBundle/Entity/Event.php
+++ b/app/bundles/CampaignBundle/Entity/Event.php
@@ -183,7 +183,7 @@ class Event implements ChannelInterface
         $builder = new ClassMetadataBuilder($metadata);
 
         $builder->setTable(self::TABLE_NAME)
-            ->setCustomRepositoryClass(\Mautic\CampaignBundle\Entity\EventRepository::class)
+            ->setCustomRepositoryClass(EventRepository::class)
             ->addIndex(['type', 'event_type'], 'campaign_event_search')
             ->addIndex(['event_type'], 'campaign_event_type')
             ->addIndex(['channel', 'channel_id'], 'campaign_event_channel');
@@ -491,7 +491,7 @@ class Event implements ChannelInterface
     }
 
     /**
-     * @return \Mautic\CampaignBundle\Entity\Campaign
+     * @return Campaign
      */
     public function getCampaign()
     {
@@ -585,7 +585,7 @@ class Event implements ChannelInterface
     }
 
     /**
-     * @return \Doctrine\Common\Collections\Collection
+     * @return Collection
      */
     public function getLog()
     {
@@ -718,7 +718,7 @@ class Event implements ChannelInterface
     }
 
     /**
-     * @return \DateTime|null
+     * @return mixed
      */
     public function getTriggerDate()
     {

--- a/app/bundles/CampaignBundle/Entity/EventRepository.php
+++ b/app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CampaignBundle\Entity;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ArrayParameterType;
 use Mautic\CoreBundle\Entity\CommonRepository;
 
 /**
@@ -113,7 +113,7 @@ class EventRepository extends CommonRepository
         $q = $this->getEntityManager()->createQueryBuilder();
 
         $q->select('e')
-            ->from(\Mautic\CampaignBundle\Entity\Event::class, 'e', 'e.id')
+            ->from(Event::class, 'e', 'e.id')
             ->where(
                 $q->expr()->eq('IDENTITY(e.parent)', (int) $parentId)
             );
@@ -145,7 +145,7 @@ class EventRepository extends CommonRepository
     {
         $q = $this->getEntityManager()->createQueryBuilder();
         $q->select('e, IDENTITY(e.parent)')
-            ->from(\Mautic\CampaignBundle\Entity\Event::class, 'e', 'e.id')
+            ->from(Event::class, 'e', 'e.id')
             ->where(
                 $q->expr()->eq('IDENTITY(e.campaign)', (int) $campaignId)
             )
@@ -178,7 +178,7 @@ class EventRepository extends CommonRepository
             ->from(MAUTIC_TABLE_PREFIX.Event::TABLE_NAME, 'e')
             ->where($q->expr()->eq('e.campaign_id', $campaignId));
 
-        return array_column($q->execute()->fetchAllAssociative(), 'id');
+        return array_column($q->executeQuery()->fetchAllAssociative(), 'id');
     }
 
     /**
@@ -256,7 +256,7 @@ class EventRepository extends CommonRepository
         $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->delete(Event::class, 'e')
             ->where($qb->expr()->in('e.id', ':event_ids'))
-            ->setParameter('event_ids', $eventIds, Connection::PARAM_INT_ARRAY)
+            ->setParameter('event_ids', $eventIds, ArrayParameterType::INTEGER)
             ->getQuery()
             ->execute();
     }
@@ -274,7 +274,7 @@ class EventRepository extends CommonRepository
             ->where(
                 $qb->expr()->in('id', $eventIds)
             )
-            ->execute();
+            ->executeStatement();
     }
 
     public function getTableAlias(): string
@@ -300,7 +300,7 @@ class EventRepository extends CommonRepository
         $q = $this->getEntityManager()->createQueryBuilder();
 
         $q->select('e')
-            ->from(\Mautic\CampaignBundle\Entity\Event::class, 'e', 'e.id')
+            ->from(Event::class, 'e', 'e.id')
             ->where('e.channel = :channel')
             ->setParameter('channel', $channel);
 
@@ -325,7 +325,7 @@ class EventRepository extends CommonRepository
     {
         $q = $this->getEntityManager()->createQueryBuilder()
             ->select('e, c, l')
-            ->from(\Mautic\CampaignBundle\Entity\Event::class, 'e')
+            ->from(Event::class, 'e')
             ->join('e.campaign', 'c')
             ->join('e.log', 'l');
 

--- a/app/bundles/CampaignBundle/Entity/EventRepository.php
+++ b/app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\CampaignBundle\Entity;
 
+use Doctrine\DBAL\Connection;
 use Mautic\CoreBundle\Entity\CommonRepository;
 
 /**
@@ -43,6 +44,9 @@ class EventRepository extends CommonRepository
     }
 
     /**
+     * @param int    $contactId
+     * @param string $type
+     *
      * @return array
      */
     public function getContactPendingEvents($contactId, $type)
@@ -77,7 +81,9 @@ class EventRepository extends CommonRepository
             ->where(
                 $q->expr()->andX(
                     $q->expr()->eq('c.isPublished', 1),
+                    $q->expr()->isNull('c.deleted'),
                     $q->expr()->eq('e.type', ':type'),
+                    $q->expr()->isNull('e.deleted'),
                     $q->expr()->eq('IDENTITY(l.lead)', ':contactId'),
                     $q->expr()->eq('l.manuallyRemoved', 0),
                     $q->expr()->notIn('e.id', $eventQb->getDQL()),
@@ -95,6 +101,10 @@ class EventRepository extends CommonRepository
 
     /**
      * Get array of events by parent.
+     *
+     * @param int         $parentId
+     * @param string|null $decisionPath
+     * @param string|null $eventType
      *
      * @return array
      */
@@ -125,7 +135,13 @@ class EventRepository extends CommonRepository
         return $q->getQuery()->getArrayResult();
     }
 
-    public function getCampaignEvents($campaignId): array
+    /**
+     * @param int  $campaignId
+     * @param bool $ignoreDeleted
+     *
+     * @return array<int,mixed[]>
+     */
+    public function getCampaignEvents($campaignId, $ignoreDeleted = true): array
     {
         $q = $this->getEntityManager()->createQueryBuilder();
         $q->select('e, IDENTITY(e.parent)')
@@ -134,6 +150,10 @@ class EventRepository extends CommonRepository
                 $q->expr()->eq('IDENTITY(e.campaign)', (int) $campaignId)
             )
             ->orderBy('e.order', \Doctrine\Common\Collections\Criteria::ASC);
+
+        if ($ignoreDeleted) {
+            $q->andWhere($q->expr()->isNull('e.deleted'));
+        }
 
         $results = $q->getQuery()->getArrayResult();
 
@@ -146,6 +166,19 @@ class EventRepository extends CommonRepository
         unset($results);
 
         return $events;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getCampaignEventIds(int $campaignId): array
+    {
+        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        $q->select('e.id')
+            ->from(MAUTIC_TABLE_PREFIX.Event::TABLE_NAME, 'e')
+            ->where($q->expr()->eq('e.campaign_id', $campaignId));
+
+        return array_column($q->execute()->fetchAllAssociative(), 'id');
     }
 
     /**
@@ -186,6 +219,8 @@ class EventRepository extends CommonRepository
 
     /**
      * Null event parents in preparation for deleI'lting a campaign.
+     *
+     * @param int $campaignId
      */
     public function nullEventParents($campaignId): void
     {
@@ -198,6 +233,8 @@ class EventRepository extends CommonRepository
 
     /**
      * Null event parents in preparation for deleting events from a campaign.
+     *
+     * @param string[] $events
      */
     public function nullEventRelationships($events): void
     {
@@ -209,6 +246,35 @@ class EventRepository extends CommonRepository
                 $qb->expr()->in('parent_id', $events)
             )
             ->executeStatement();
+    }
+
+    /**
+     * @param string[] $eventIds
+     */
+    public function deleteEvents(array $eventIds): void
+    {
+        $qb = $this->getEntityManager()->createQueryBuilder();
+        $qb->delete(Event::class, 'e')
+            ->where($qb->expr()->in('e.id', ':event_ids'))
+            ->setParameter('event_ids', $eventIds, Connection::PARAM_INT_ARRAY)
+            ->getQuery()
+            ->execute();
+    }
+
+    /**
+     * @param string[] $eventIds
+     */
+    public function setEventsAsDeleted(array $eventIds): void
+    {
+        $dateTime = (new \DateTime())->format('Y-m-d H:i:s');
+        $qb       = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        $qb->update(MAUTIC_TABLE_PREFIX.Event::TABLE_NAME)
+            ->set('deleted', ':deleted')
+            ->setParameter('deleted', $dateTime)
+            ->where(
+                $qb->expr()->in('id', $eventIds)
+            )
+            ->execute();
     }
 
     public function getTableAlias(): string

--- a/app/bundles/CampaignBundle/Entity/LeadEventLog.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLog.php
@@ -10,6 +10,7 @@ use Mautic\LeadBundle\Entity\Lead as LeadEntity;
 
 class LeadEventLog implements ChannelInterface
 {
+    public const TABLE_NAME = 'campaign_lead_event_log';
     /**
      * @var string|null
      */
@@ -101,7 +102,7 @@ class LeadEventLog implements ChannelInterface
     {
         $builder = new ClassMetadataBuilder($metadata);
 
-        $builder->setTable('campaign_lead_event_log')
+        $builder->setTable(self::TABLE_NAME)
             ->setCustomRepositoryClass(\Mautic\CampaignBundle\Entity\LeadEventLogRepository::class)
             ->addIndex(['is_scheduled', 'lead_id'], 'campaign_event_upcoming_search')
             ->addIndex(['campaign_id', 'is_scheduled', 'trigger_date'], 'campaign_event_schedule_counts')
@@ -117,7 +118,7 @@ class LeadEventLog implements ChannelInterface
 
         $builder->createManyToOne('event', 'Event')
             ->inversedBy('log')
-            ->addJoinColumn('event_id', 'id', false, false, 'CASCADE')
+            ->addJoinColumn('event_id', 'id', false, false)
             ->build();
 
         $builder->addLead(false, 'CASCADE');

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -3,11 +3,9 @@
 namespace Mautic\CampaignBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\ParameterType;
-use Doctrine\DBAL\Types\Type;
 use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
 use Mautic\CoreBundle\Entity\CommonRepository;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
@@ -21,7 +19,7 @@ class LeadEventLogRepository extends CommonRepository
     use TimelineTrait;
     use ContactLimiterTrait;
     use ReplicaConnectionTrait;
-    const LOG_DELETE_BATCH_SIZE = 5000;
+    public const LOG_DELETE_BATCH_SIZE = 5000;
 
     public function getEntities(array $args = [])
     {
@@ -621,7 +619,7 @@ SQL;
         $table_name    = $this->getTableName();
         $sql           = "DELETE FROM {$table_name} WHERE campaign_id = (?) LIMIT ".self::LOG_DELETE_BATCH_SIZE;
         $conn          = $this->getEntityManager()->getConnection();
-        while ($conn->executeQuery($sql, [$campaignId], [ParameterType::INTEGER])->rowCount()) {
+        while ($conn->executeQuery($sql, [$campaignId], [ArrayParameterType::INTEGER])->rowCount()) {
         }
     }
 
@@ -633,7 +631,7 @@ SQL;
         $table_name    = $this->getTableName();
         $sql           = "DELETE FROM {$table_name} WHERE event_id IN (?) ORDER BY event_id ASC LIMIT ".self::LOG_DELETE_BATCH_SIZE;
         $conn          = $this->getEntityManager()->getConnection();
-        while ($conn->executeQuery($sql, [$eventIds], [Connection::PARAM_INT_ARRAY])->rowCount()) {
+        while ($conn->executeQuery($sql, [$eventIds], [ArrayParameterType::INTEGER])->rowCount()) {
         }
     }
 }

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -619,7 +619,7 @@ SQL;
         $table_name    = $this->getTableName();
         $sql           = "DELETE FROM {$table_name} WHERE campaign_id = (?) LIMIT ".self::LOG_DELETE_BATCH_SIZE;
         $conn          = $this->getEntityManager()->getConnection();
-        while ($conn->executeQuery($sql, [$campaignId], [ArrayParameterType::INTEGER])->rowCount()) {
+        while ($conn->executeQuery($sql, [$campaignId], [Types::INTEGER])->rowCount()) {
         }
     }
 

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -5,6 +5,9 @@ namespace Mautic\CampaignBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Types\Type;
 use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
 use Mautic\CoreBundle\Entity\CommonRepository;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
@@ -18,6 +21,7 @@ class LeadEventLogRepository extends CommonRepository
     use TimelineTrait;
     use ContactLimiterTrait;
     use ReplicaConnectionTrait;
+    const LOG_DELETE_BATCH_SIZE = 5000;
 
     public function getEntities(array $args = [])
     {
@@ -449,7 +453,9 @@ class LeadEventLogRepository extends CommonRepository
                 $q->expr()->andX(
                     $q->expr()->in('o.id', $ids),
                     $q->expr()->eq('o.isScheduled', 1),
-                    $q->expr()->eq('c.isPublished', 1)
+                    $q->expr()->eq('c.isPublished', 1),
+                    $q->expr()->isNull('c.deleted'),
+                    $q->expr()->isNull('e.deleted')
                 )
             );
 
@@ -610,18 +616,24 @@ SQL;
             ->executeStatement();
     }
 
-    /**
-     * Removes logs by event_id.
-     * It uses batch processing for removing
-     * large quantities of records.
-     *
-     * @param int $eventId
-     */
-    public function removeEventLogs($eventId): void
+    public function removeEventLogsByCampaignId(int $campaignId): void
     {
-        $conn = $this->_em->getConnection();
-        $conn->delete(MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', [
-            'event_id' => (int) $eventId,
-        ]);
+        $table_name    = $this->getTableName();
+        $sql           = "DELETE FROM {$table_name} WHERE campaign_id = (?) LIMIT ".self::LOG_DELETE_BATCH_SIZE;
+        $conn          = $this->getEntityManager()->getConnection();
+        while ($conn->executeQuery($sql, [$campaignId], [ParameterType::INTEGER])->rowCount()) {
+        }
+    }
+
+    /**
+     * @param string[] $eventIds
+     */
+    public function removeEventLogs(array $eventIds): void
+    {
+        $table_name    = $this->getTableName();
+        $sql           = "DELETE FROM {$table_name} WHERE event_id IN (?) ORDER BY event_id ASC LIMIT ".self::LOG_DELETE_BATCH_SIZE;
+        $conn          = $this->getEntityManager()->getConnection();
+        while ($conn->executeQuery($sql, [$eventIds], [Connection::PARAM_INT_ARRAY])->rowCount()) {
+        }
     }
 }

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -619,7 +619,9 @@ SQL;
         $table_name    = $this->getTableName();
         $sql           = "DELETE FROM {$table_name} WHERE campaign_id = (?) LIMIT ".self::LOG_DELETE_BATCH_SIZE;
         $conn          = $this->getEntityManager()->getConnection();
-        while ($conn->executeQuery($sql, [$campaignId], [Types::INTEGER])->rowCount()) {
+        $deleteEntries = true;
+        while ($deleteEntries) {
+            $deleteEntries = $conn->executeQuery($sql, [$campaignId], [Types::INTEGER])->rowCount();
         }
     }
 
@@ -631,7 +633,9 @@ SQL;
         $table_name    = $this->getTableName();
         $sql           = "DELETE FROM {$table_name} WHERE event_id IN (?) ORDER BY event_id ASC LIMIT ".self::LOG_DELETE_BATCH_SIZE;
         $conn          = $this->getEntityManager()->getConnection();
-        while ($conn->executeQuery($sql, [$eventIds], [ArrayParameterType::INTEGER])->rowCount()) {
+        $deleteEntries = true;
+        while ($deleteEntries) {
+            $deleteEntries = $conn->executeQuery($sql, [$eventIds], [ArrayParameterType::INTEGER])->rowCount();
         }
     }
 }

--- a/app/bundles/CampaignBundle/Event/DeleteCampaign.php
+++ b/app/bundles/CampaignBundle/Event/DeleteCampaign.php
@@ -8,11 +8,8 @@ use Mautic\CampaignBundle\Entity\Campaign;
 
 final class DeleteCampaign extends \Symfony\Contracts\EventDispatcher\Event
 {
-    private Campaign $campaign;
-
-    public function __construct(Campaign $campaign)
+    public function __construct(private Campaign $campaign)
     {
-        $this->campaign = $campaign;
     }
 
     public function getCampaign(): Campaign

--- a/app/bundles/CampaignBundle/Event/DeleteCampaign.php
+++ b/app/bundles/CampaignBundle/Event/DeleteCampaign.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Event;
+
+use Mautic\CampaignBundle\Entity\Campaign;
+
+final class DeleteCampaign extends \Symfony\Contracts\EventDispatcher\Event
+{
+    private Campaign $campaign;
+
+    public function __construct(Campaign $campaign)
+    {
+        $this->campaign = $campaign;
+    }
+
+    public function getCampaign(): Campaign
+    {
+        return $this->campaign;
+    }
+}

--- a/app/bundles/CampaignBundle/Event/DeleteEvent.php
+++ b/app/bundles/CampaignBundle/Event/DeleteEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Event;
+
+final class DeleteEvent extends \Symfony\Contracts\EventDispatcher\Event
+{
+    /**
+     * @var string[]
+     */
+    private array $eventIds;
+
+    /**
+     * @param string[] $eventIds
+     */
+    public function __construct(array $eventIds)
+    {
+        $this->eventIds = $eventIds;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getEventIds(): array
+    {
+        return $this->eventIds;
+    }
+}

--- a/app/bundles/CampaignBundle/Event/DeleteEvent.php
+++ b/app/bundles/CampaignBundle/Event/DeleteEvent.php
@@ -7,16 +7,10 @@ namespace Mautic\CampaignBundle\Event;
 final class DeleteEvent extends \Symfony\Contracts\EventDispatcher\Event
 {
     /**
-     * @var string[]
-     */
-    private array $eventIds;
-
-    /**
      * @param string[] $eventIds
      */
-    public function __construct(array $eventIds)
+    public function __construct(private array $eventIds)
     {
-        $this->eventIds = $eventIds;
     }
 
     /**

--- a/app/bundles/CampaignBundle/EventListener/CampaignEventDeleteSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignEventDeleteSubscriber.php
@@ -15,24 +15,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class CampaignEventDeleteSubscriber implements EventSubscriberInterface
 {
-    private CampaignConfig $campaignConfig;
-
-    private LeadEventLogRepository $leadEventLogRepository;
-
-    private CampaignModel $campaignModel;
-
-    private EventModel $eventModel;
-
     public function __construct(
-        LeadEventLogRepository $leadEventLogRepository,
-        CampaignConfig $campaignConfig,
-        CampaignModel $campaignModel,
-        EventModel $eventModel
+        private LeadEventLogRepository $leadEventLogRepository,
+        private CampaignConfig $campaignConfig,
+        private CampaignModel $campaignModel,
+        private EventModel $eventModel
     ) {
-        $this->campaignConfig         = $campaignConfig;
-        $this->leadEventLogRepository = $leadEventLogRepository;
-        $this->campaignModel          = $campaignModel;
-        $this->eventModel             = $eventModel;
     }
 
     public static function getSubscribedEvents(): array

--- a/app/bundles/CampaignBundle/EventListener/CampaignEventDeleteSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignEventDeleteSubscriber.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\EventListener;
+
+use Mautic\CampaignBundle\CampaignEvents;
+use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
+use Mautic\CampaignBundle\Event\DeleteCampaign;
+use Mautic\CampaignBundle\Event\DeleteEvent;
+use Mautic\CampaignBundle\Helper\CampaignConfig;
+use Mautic\CampaignBundle\Model\CampaignModel;
+use Mautic\CampaignBundle\Model\EventModel;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CampaignEventDeleteSubscriber implements EventSubscriberInterface
+{
+    private CampaignConfig $campaignConfig;
+
+    private LeadEventLogRepository $leadEventLogRepository;
+
+    private CampaignModel $campaignModel;
+
+    private EventModel $eventModel;
+
+    public function __construct(
+        LeadEventLogRepository $leadEventLogRepository,
+        CampaignConfig $campaignConfig,
+        CampaignModel $campaignModel,
+        EventModel $eventModel
+    ) {
+        $this->campaignConfig         = $campaignConfig;
+        $this->leadEventLogRepository = $leadEventLogRepository;
+        $this->campaignModel          = $campaignModel;
+        $this->eventModel             = $eventModel;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            CampaignEvents::ON_CAMPAIGN_DELETE => ['onCampaignDelete', 0],
+            CampaignEvents::ON_EVENT_DELETE    => ['onEventDelete', 0],
+        ];
+    }
+
+    public function onCampaignDelete(DeleteCampaign $event): void
+    {
+        if ($this->campaignConfig->shouldDeleteEventLogInBackground()) {
+            return;
+        }
+
+        $campaignId = $event->getCampaign()->getId();
+        $this->leadEventLogRepository->removeEventLogsByCampaignId($campaignId);
+        $this->eventModel->deleteEventsByCampaignId($campaignId);
+        $this->campaignModel->deleteCampaign($event->getCampaign());
+    }
+
+    public function onEventDelete(DeleteEvent $event): void
+    {
+        if ($this->campaignConfig->shouldDeleteEventLogInBackground()) {
+            return;
+        }
+        $eventIds   = $event->getEventIds();
+        $this->leadEventLogRepository->removeEventLogs($eventIds);
+        $this->eventModel->deleteEventsByEventIds($eventIds);
+    }
+}

--- a/app/bundles/CampaignBundle/Executioner/Helper/DecisionHelper.php
+++ b/app/bundles/CampaignBundle/Executioner/Helper/DecisionHelper.php
@@ -43,7 +43,7 @@ class DecisionHelper
         // Check if parent taken path is the path of this event, otherwise exit
         $parentEvent = $event->getParent();
 
-        if (null !== $parentEvent && null !== $event->getDecisionPath()) {
+        if (null !== $parentEvent && !$parentEvent->isDeleted() && null !== $event->getDecisionPath()) {
             $rotation    = $this->leadRepository->getContactRotations([$contact->getId()], $event->getCampaign()->getId());
             $log         = $parentEvent->getLogByContactAndRotation($contact, $rotation);
 

--- a/app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
+++ b/app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
@@ -111,8 +111,9 @@ class InactiveHelper
     {
         $collection = new ArrayCollection();
 
-        /** @var Event $decision */
-        if ($decision = $this->eventRepository->find($decisionId)) {
+        /** @var Event|null $decision */
+        $decision = $this->eventRepository->find($decisionId);
+        if ($decision && !$decision->isDeleted()) {
             $collection->set($decision->getId(), $decision);
         }
 

--- a/app/bundles/CampaignBundle/Executioner/InactiveExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/InactiveExecutioner.php
@@ -128,6 +128,10 @@ class InactiveExecutioner implements ExecutionerInterface
         if (!$this->campaign->isPublished()) {
             throw new NoEventsFoundException();
         }
+
+        if ($this->campaign->isDeleted()) {
+            throw new NoEventsFoundException();
+        }
     }
 
     /**
@@ -185,13 +189,13 @@ class InactiveExecutioner implements ExecutionerInterface
             try {
                 // We need the parent ID of the decision in order to fetch the time the contact executed this event
                 $parentEvent   = $decisionEvent->getParent();
-                $parentEventId = ($parentEvent) ? $parentEvent->getId() : null;
+                $parentEventId = $parentEvent && !$parentEvent->isDeleted() ? $parentEvent->getId() : null;
 
                 // Ge the first batch of contacts
                 $contacts = $this->inactiveContactFinder->getContacts($this->campaign->getId(), $decisionEvent, $this->limiter);
 
                 // Loop over all contacts till we've processed all those applicable for this decision
-                while ($contacts && $contacts->count()) {
+                while ($contacts->count()) {
                     // Get the max contact ID before any are removed
                     $batchMinContactId = max($contacts->getKeys()) + 1;
 

--- a/app/bundles/CampaignBundle/Helper/CampaignConfig.php
+++ b/app/bundles/CampaignBundle/Helper/CampaignConfig.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Helper;
+
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+
+final class CampaignConfig
+{
+    private CoreParametersHelper $coreParametersHelper;
+
+    public function __construct(CoreParametersHelper $coreParametersHelper)
+    {
+        $this->coreParametersHelper = $coreParametersHelper;
+    }
+
+    public function shouldDeleteEventLogInBackground(): bool
+    {
+        return (bool) $this->coreParametersHelper->get('delete_campaign_event_log_in_background', false);
+    }
+}

--- a/app/bundles/CampaignBundle/Helper/CampaignConfig.php
+++ b/app/bundles/CampaignBundle/Helper/CampaignConfig.php
@@ -8,11 +8,8 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 
 final class CampaignConfig
 {
-    private CoreParametersHelper $coreParametersHelper;
-
-    public function __construct(CoreParametersHelper $coreParametersHelper)
+    public function __construct(private CoreParametersHelper $coreParametersHelper)
     {
-        $this->coreParametersHelper = $coreParametersHelper;
     }
 
     public function shouldDeleteEventLogInBackground(): bool

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -61,7 +61,7 @@ class CampaignModel extends CommonFormModel
      */
     public function getRepository()
     {
-        $repo = $this->em->getRepository(\Mautic\CampaignBundle\Entity\Campaign::class);
+        $repo = $this->em->getRepository(Campaign::class);
         $repo->setCurrentUser($this->userHelper->getUser());
 
         return $repo;
@@ -72,7 +72,7 @@ class CampaignModel extends CommonFormModel
      */
     public function getEventRepository()
     {
-        return $this->em->getRepository(\Mautic\CampaignBundle\Entity\Event::class);
+        return $this->em->getRepository(Event::class);
     }
 
     /**
@@ -80,7 +80,7 @@ class CampaignModel extends CommonFormModel
      */
     public function getCampaignLeadRepository()
     {
-        return $this->em->getRepository(\Mautic\CampaignBundle\Entity\Lead::class);
+        return $this->em->getRepository(CampaignLead::class);
     }
 
     /**
@@ -153,7 +153,7 @@ class CampaignModel extends CommonFormModel
     {
         // Null all the event parents for this campaign to avoid database constraints
         $this->getEventRepository()->nullEventParents($entity->getId());
-        $event = $this->dispatchEvent('pre_delete', $entity);
+        $this->dispatchEvent('pre_delete', $entity);
         $this->getRepository()->setCampaignAsDeleted($entity->getId());
 
         $this->dispatcher->dispatch(new Events\DeleteCampaign($entity), CampaignEvents::ON_CAMPAIGN_DELETE);
@@ -167,11 +167,11 @@ class CampaignModel extends CommonFormModel
     }
 
     /**
-     * @throws \Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException
+     * @throws MethodNotAllowedHttpException
      */
     protected function dispatchEvent($action, &$entity, $isNew = false, \Symfony\Contracts\EventDispatcher\Event $event = null): ?\Symfony\Contracts\EventDispatcher\Event
     {
-        if ($entity instanceof \Mautic\CampaignBundle\Entity\Lead) {
+        if ($entity instanceof CampaignLead) {
             return null;
         }
 
@@ -445,7 +445,7 @@ class CampaignModel extends CommonFormModel
                         $entity->addList($this->em->getReference(\Mautic\LeadBundle\Entity\LeadList::class, $id));
                         break;
                     case 'forms':
-                        $entity->addForm($this->em->getReference(\Mautic\FormBundle\Entity\Form::class, $id));
+                        $entity->addForm($this->em->getReference(Form::class, $id));
                         break;
                     default:
                         break;
@@ -460,7 +460,7 @@ class CampaignModel extends CommonFormModel
                         $entity->removeList($this->em->getReference(\Mautic\LeadBundle\Entity\LeadList::class, $id));
                         break;
                     case 'forms':
-                        $entity->removeForm($this->em->getReference(\Mautic\FormBundle\Entity\Form::class, $id));
+                        $entity->removeForm($this->em->getReference(Form::class, $id));
                         break;
                     default:
                         break;
@@ -606,7 +606,7 @@ class CampaignModel extends CommonFormModel
             $leads = array_keys($leads->toArray());
         }
 
-        return $this->em->getRepository(\Mautic\CampaignBundle\Entity\Lead::class)->getLeadDetails($campaignId, $leads);
+        return $this->em->getRepository(CampaignLead::class)->getLeadDetails($campaignId, $leads);
     }
 
     /**
@@ -622,7 +622,7 @@ class CampaignModel extends CommonFormModel
         $campaignId = ($campaign instanceof Campaign) ? $campaign->getId() : $campaign;
         $eventId    = (is_array($event) && isset($event['id'])) ? $event['id'] : $event;
 
-        return $this->em->getRepository(\Mautic\CampaignBundle\Entity\Lead::class)->getLeads($campaignId, $eventId);
+        return $this->em->getRepository(CampaignLead::class)->getLeads($campaignId, $eventId);
     }
 
     public function getCampaignListIds($id): array

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -156,7 +156,7 @@ class CampaignModel extends CommonFormModel
         $event = $this->dispatchEvent('pre_delete', $entity);
         $this->getRepository()->setCampaignAsDeleted($entity->getId());
 
-        $this->dispatcher->dispatch(CampaignEvents::ON_CAMPAIGN_DELETE, new Events\DeleteCampaign($entity));
+        $this->dispatcher->dispatch(new Events\DeleteCampaign($entity), CampaignEvents::ON_CAMPAIGN_DELETE);
     }
 
     public function deleteCampaign(Campaign $campaign): void

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -83,7 +83,7 @@ class EventModel extends FormModel
             // wipe out any references to these events to prevent restraint violations
             $this->getRepository()->nullEventRelationships($deletedKeys);
             $this->getRepository()->setEventsAsDeleted($deletedEvents);
-            $this->dispatcher->dispatch(CampaignEvents::ON_EVENT_DELETE, new DeleteEvent($deletedKeys));
+            $this->dispatcher->dispatch(new DeleteEvent($deletedKeys), CampaignEvents::ON_EVENT_DELETE);
         }
     }
 
@@ -99,7 +99,7 @@ class EventModel extends FormModel
     public function deleteEventsByEventIds(array $eventIds): void
     {
         $this->getRepository()->deleteEvents($eventIds);
-        $this->dispatcher->dispatch(CampaignEvents::ON_AFTER_EVENTS_DELETE, new DeleteEvent($eventIds));
+        $this->dispatcher->dispatch(new DeleteEvent($eventIds), CampaignEvents::ON_AFTER_EVENTS_DELETE);
     }
 
     /**

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -2,10 +2,12 @@
 
 namespace Mautic\CampaignBundle\Model;
 
+use Mautic\CampaignBundle\CampaignEvents;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
+use Mautic\CampaignBundle\Event\DeleteEvent;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\CoreBundle\Helper\Chart\LineChart;
 use Mautic\CoreBundle\Model\FormModel;
@@ -80,13 +82,24 @@ class EventModel extends FormModel
         if (count($deletedEvents)) {
             // wipe out any references to these events to prevent restraint violations
             $this->getRepository()->nullEventRelationships($deletedKeys);
-
-            foreach ($deletedEvents as $eventToDelete) {
-                // delete the events
-                $this->getLeadEventLogRepository()->removeEventLogs($eventToDelete);
-                $this->deleteEntities([$eventToDelete]);
-            }
+            $this->getRepository()->setEventsAsDeleted($deletedEvents);
+            $this->dispatcher->dispatch(CampaignEvents::ON_EVENT_DELETE, new DeleteEvent($deletedKeys));
         }
+    }
+
+    public function deleteEventsByCampaignId(int $campaignId): void
+    {
+        $eventIds = $this->getRepository()->getCampaignEventIds($campaignId);
+        $this->deleteEventsByEventIds($eventIds);
+    }
+
+    /**
+     * @param string[] $eventIds
+     */
+    public function deleteEventsByEventIds(array $eventIds): void
+    {
+        $this->getRepository()->deleteEvents($eventIds);
+        $this->dispatcher->dispatch(CampaignEvents::ON_AFTER_EVENTS_DELETE, new DeleteEvent($eventIds));
     }
 
     /**

--- a/app/bundles/CampaignBundle/Resources/views/Campaign/_builder.html.twig
+++ b/app/bundles/CampaignBundle/Resources/views/Campaign/_builder.html.twig
@@ -32,7 +32,7 @@
               }) -}}
             {% endfor %}
 
-            {% for event in campaignEvents if event.deleted is not empty  %}
+            {% for event in campaignEvents %}
                 {% if event.deleted is not empty %}
                   {% set settings = eventSettings[event.eventType][event.type]|default(null) %}
                   {{- include(settings['template']|default('@MauticCampaign/Event/_generic.html.twig'), {

--- a/app/bundles/CampaignBundle/Resources/views/Campaign/_builder.html.twig
+++ b/app/bundles/CampaignBundle/Resources/views/Campaign/_builder.html.twig
@@ -33,7 +33,7 @@
             {% endfor %}
 
             {% for event in campaignEvents %}
-                {% if event.deleted is not empty %}
+                {% if event.deleted is empty %}
                   {% set settings = eventSettings[event.eventType][event.type]|default(null) %}
                   {{- include(settings['template']|default('@MauticCampaign/Event/_generic.html.twig'), {
                         'event': event,

--- a/app/bundles/CampaignBundle/Resources/views/Campaign/_builder.html.twig
+++ b/app/bundles/CampaignBundle/Resources/views/Campaign/_builder.html.twig
@@ -32,12 +32,14 @@
               }) -}}
             {% endfor %}
 
-            {% for event in campaignEvents %}
-              {% set settings = eventSettings[event.eventType][event.type]|default(null) %}
-              {{- include(settings['template']|default('@MauticCampaign/Event/_generic.html.twig'), {
-                    'event': event,
-                    'campaignId': campaignId,
-              }) -}}
+            {% for event in campaignEvents if event.deleted is not empty  %}
+                {% if event.deleted is not empty %}
+                  {% set settings = eventSettings[event.eventType][event.type]|default(null) %}
+                  {{- include(settings['template']|default('@MauticCampaign/Event/_generic.html.twig'), {
+                        'event': event,
+                        'campaignId': campaignId,
+                  }) -}}
+                {% endif %}
             {% endfor %}
 
             {{- include('@MauticCampaign/Campaign/Builder/_index.html.twig', {

--- a/app/bundles/CampaignBundle/Tests/Command/CampaignDeleteEventLogsCommandFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/CampaignDeleteEventLogsCommandFunctionalTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Tests\Command;
+
+use Mautic\CampaignBundle\Command\CampaignDeleteEventLogsCommand;
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Assert;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\ApplicationTester;
+
+class CampaignDeleteEventLogsCommandFunctionalTest extends MauticMysqlTestCase
+{
+    public function testWithEventIds(): void
+    {
+        $exitCode = $this->createDataAndRunCommand(false);
+        Assert::assertSame(0, $exitCode);
+
+        $campaign = $this->em->getRepository(Campaign::class)->findAll();
+        Assert::assertCount(1, $campaign);
+
+        $eventLogs = $this->em->getRepository(LeadEventLog::class)->findAll();
+        Assert::assertCount(0, $eventLogs);
+    }
+
+    public function testWithCampaignId(): void
+    {
+        $exitCode = $this->createDataAndRunCommand(true);
+
+        Assert::assertSame(0, $exitCode);
+
+        $campaign = $this->em->getRepository(Campaign::class)->findAll();
+        Assert::assertCount(0, $campaign);
+
+        $eventLogs = $this->em->getRepository(LeadEventLog::class)->findAll();
+        Assert::assertCount(0, $eventLogs);
+    }
+
+    private function createApplicationTester(): ApplicationTester
+    {
+        $application = new Application(self::$kernel);
+        $application->setAutoExit(false);
+
+        return new ApplicationTester($application);
+    }
+
+    private function createDataAndRunCommand(bool $usingCampaign): int
+    {
+        $applicationTester = $this->createApplicationTester();
+        $lead              = $this->createLead();
+        $campaign          = $this->createCampaign();
+        $event1            = $this->createEvent('Event 1', $campaign);
+        $event2            = $this->createEvent('Event 2', $campaign);
+        $this->createEventLog($lead, $event1);
+        $this->createEventLog($lead, $event2);
+
+        $commandData = ['command' => CampaignDeleteEventLogsCommand::COMMAND_NAME];
+        if ($usingCampaign) {
+            $commandData['--campaign-id'] = $campaign->getId();
+        } else {
+            $commandData['campaign_event_ids'] = [$event1->getId(), $event2->getId()];
+        }
+
+        $exitCode = $applicationTester->run($commandData);
+
+        return $exitCode;
+    }
+
+    private function createLead(): Lead
+    {
+        $lead = new Lead();
+        $lead->setFirstname('Test');
+        $this->em->persist($lead);
+        $this->em->flush();
+
+        return $lead;
+    }
+
+    private function createCampaign(): Campaign
+    {
+        $campaign = new Campaign();
+        $campaign->setName('My campaign');
+        $this->em->persist($campaign);
+        $this->em->flush();
+
+        return $campaign;
+    }
+
+    private function createEvent(string $name, Campaign $campaign): Event
+    {
+        $event = new Event();
+        $event->setName($name);
+        $event->setCampaign($campaign);
+        $event->setType('email.send');
+        $event->setEventType('action');
+        $this->em->persist($event);
+        $this->em->flush();
+
+        return $event;
+    }
+
+    private function createEventLog(Lead $lead, Event $event): LeadEventLog
+    {
+        $leadEventLog = new LeadEventLog();
+        $leadEventLog->setLead($lead);
+        $leadEventLog->setEvent($event);
+        $this->em->persist($leadEventLog);
+        $this->em->flush();
+
+        return $leadEventLog;
+    }
+}

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
@@ -5,11 +5,16 @@ declare(strict_types=1);
 namespace Mautic\CampaignBundle\Tests\Controller;
 
 use Mautic\CampaignBundle\Command\SummarizeCommand;
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CampaignBundle\Tests\Campaign\AbstractCampaignTest;
+use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class CampaignControllerFunctionalTest extends AbstractCampaignTest
 {
@@ -43,6 +48,7 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTest
         parent::setUp();
         $this->campaignModel      = static::getContainer()->get('mautic.model.factory')->getModel('campaign');
         $this->campaignLeadsLabel = static::getContainer()->get('translator')->trans('mautic.campaign.campaign.leads');
+        $this->configParams['delete_campaign_event_log_in_background'] = false;
     }
 
     public function testCampaignContactCountThroughStatsWithSummary(): void
@@ -248,5 +254,66 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTest
         Assert::assertSame($expectedSuccessPercent.'%', $actionCounts['successPercent']);
         Assert::assertSame($expectedCompleted, (int) $actionCounts['completed']);
         Assert::assertSame($expectedPending, (int) $actionCounts['pending']);
+    }
+
+    public function testDeleteCampaign(): void
+    {
+        $lead              = $this->createLead();
+        $campaign          = $this->createCampaign();
+        $event             = $this->createEvent('Event 1', $campaign);
+        $this->createEventLog($lead, $event, $campaign);
+
+        $this->client->request(Request::METHOD_POST, '/s/campaigns/delete/'.$campaign->getId());
+
+        $response = $this->client->getResponse();
+        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
+
+        $eventLogs = $this->em->getRepository(LeadEventLog::class)->findAll();
+        Assert::assertCount(0, $eventLogs);
+    }
+
+    private function createLead(): Lead
+    {
+        $lead = new Lead();
+        $lead->setFirstname('Test');
+        $this->em->persist($lead);
+        $this->em->flush();
+
+        return $lead;
+    }
+
+    private function createCampaign(): Campaign
+    {
+        $campaign = new Campaign();
+        $campaign->setName('My campaign');
+        $this->em->persist($campaign);
+        $this->em->flush();
+
+        return $campaign;
+    }
+
+    private function createEvent(string $name, Campaign $campaign): Event
+    {
+        $event = new Event();
+        $event->setName($name);
+        $event->setCampaign($campaign);
+        $event->setType('email.send');
+        $event->setEventType('action');
+        $this->em->persist($event);
+        $this->em->flush();
+
+        return $event;
+    }
+
+    private function createEventLog(Lead $lead, Event $event, Campaign $campaign): LeadEventLog
+    {
+        $leadEventLog = new LeadEventLog();
+        $leadEventLog->setLead($lead);
+        $leadEventLog->setEvent($event);
+        $leadEventLog->setCampaign($campaign);
+        $this->em->persist($leadEventLog);
+        $this->em->flush();
+
+        return $leadEventLog;
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
@@ -46,8 +46,8 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTest
         $this->configParams[self::CAMPAIGN_SUMMARY_PARAM] = in_array($this->getName(), $functionForUseSummary);
         $this->configParams[self::CAMPAIGN_RANGE_PARAM]   = in_array($this->getName(), $functionForUseRange);
         parent::setUp();
-        $this->campaignModel      = static::getContainer()->get('mautic.model.factory')->getModel('campaign');
-        $this->campaignLeadsLabel = static::getContainer()->get('translator')->trans('mautic.campaign.campaign.leads');
+        $this->campaignModel                                           = static::getContainer()->get('mautic.model.factory')->getModel('campaign');
+        $this->campaignLeadsLabel                                      = static::getContainer()->get('translator')->trans('mautic.campaign.campaign.leads');
         $this->configParams['delete_campaign_event_log_in_background'] = false;
     }
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Entity/LeadEventLogRepositoryTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Entity/LeadEventLogRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CampaignBundle\Tests\Functional\Entity;
 
+use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Assert;
@@ -15,8 +16,8 @@ class LeadEventLogRepositoryTest extends MauticMysqlTestCase
         $eventId    = random_int(200, 2000);
         $connection = $this->em->getConnection();
 
-        /** @var LeadEventLogRepository $leadEventLogRepository */
-        $leadEventLogRepository = $this->em->getRepository(\Mautic\CampaignBundle\Entity\LeadEventLog::class);
+        $leadEventLogRepository = $this->em->getRepository(LeadEventLog::class);
+        \assert($leadEventLogRepository instanceof LeadEventLogRepository);
 
         $insertStatement = $connection->prepare('INSERT INTO `'.MAUTIC_TABLE_PREFIX.'campaign_lead_event_log` (`event_id`, `lead_id`, `rotation`, `is_scheduled`, `system_triggered`) VALUES (?, ?, ?, ?, ?);');
 
@@ -28,7 +29,7 @@ class LeadEventLogRepositoryTest extends MauticMysqlTestCase
 
         Assert::assertCount(3, $leadEventLogRepository->findAll());
 
-        $leadEventLogRepository->removeEventLogs($eventId);
+        $leadEventLogRepository->removeEventLogs([(string) $eventId]);
 
         Assert::assertCount(0, $leadEventLogRepository->findAll());
     }

--- a/app/bundles/CampaignBundle/Tests/Model/EventModelTest.php
+++ b/app/bundles/CampaignBundle/Tests/Model/EventModelTest.php
@@ -4,16 +4,28 @@ declare(strict_types=1);
 
 namespace Mautic\CampaignBundle\Tests\Model;
 
+use Doctrine\ORM\EntityManager;
+use Mautic\CampaignBundle\CampaignEvents;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Entity\EventRepository;
 use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
+use Mautic\CampaignBundle\Event\DeleteEvent;
 use Mautic\CampaignBundle\Model\EventModel;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class EventModelTest extends TestCase
 {
     /**
-     * @var LeadEventLogRepository
+     * @var EntityManager|MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $leadEventLogRepository;
+    private $entityManagerMock;
+
+    /**
+     * @var EventRepository|MockObject
+     */
+    private $eventRepositoryMock;
 
     /**
      * @var EventModel
@@ -22,23 +34,17 @@ class EventModelTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->eventModel = $this->getMockBuilder(EventModel::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods([
-                'getRepository',
-                'getLeadEventLogRepository',
-                'deleteEntities',
-            ])
-            ->getMock();
-
-        $this->leadEventLogRepository = $this->createMock(LeadEventLogRepository::class);
+        $this->entityManagerMock   = $this->createMock(EntityManager::class);
+        $this->eventRepositoryMock = $this->createMock(EventRepository::class);
+        $this->eventModel          = new EventModel();
     }
 
     public function testThatClonedEventsDoNotAttemptNullingParentInDeleteEvents(): void
     {
-        $this->eventModel->expects($this->exactly(0))
+        $this->entityManagerMock->expects($this->never())
             ->method('getRepository')
-            ->willReturn($this->leadEventLogRepository);
+            ->with(Event::class)
+            ->willReturn($this->eventRepositoryMock);
 
         $currentEvents = [
             'new1',
@@ -50,28 +56,13 @@ class EventModelTest extends TestCase
             'new1',
         ];
 
+        $this->eventModel->setEntityManager($this->entityManagerMock);
         $this->eventModel->deleteEvents($currentEvents, $deletedEvents);
     }
 
     public function testThatItDeletesEventLogs(): void
     {
         $idToDelete = 'old1';
-
-        $this->eventModel->expects($this->once())
-            ->method('getRepository')
-            ->willReturn($this->leadEventLogRepository);
-
-        $this->eventModel->expects($this->once())
-            ->method('getLeadEventLogRepository')
-            ->willReturn($this->leadEventLogRepository);
-
-        $this->leadEventLogRepository->expects($this->once())
-            ->method('removeEventLogs')
-            ->with($idToDelete);
-
-        $this->eventModel->expects($this->once())
-            ->method('deleteEntities')
-            ->with([$idToDelete]);
 
         $currentEvents = [
             'new1',
@@ -82,6 +73,50 @@ class EventModelTest extends TestCase
             $idToDelete,
         ];
 
+        $this->entityManagerMock->method('getRepository')
+            ->with(Event::class)
+            ->willReturn($this->eventRepositoryMock);
+
+        $this->eventRepositoryMock->expects($this->once())
+            ->method('nullEventRelationships')
+            ->with([$idToDelete]);
+
+        $this->eventRepositoryMock->expects($this->once())
+            ->method('setEventsAsDeleted')
+            ->with([1 => $idToDelete]);
+
+        $dispatcherMock = $this->createMock(EventDispatcherInterface::class);
+        $dispatcherMock->expects($this->once())
+            ->method('dispatch')
+            ->with(CampaignEvents::ON_EVENT_DELETE, new DeleteEvent([$idToDelete]));
+
+        $this->eventModel->setEntityManager($this->entityManagerMock);
+        $this->eventModel->setDispatcher($dispatcherMock);
         $this->eventModel->deleteEvents($currentEvents, $deletedEvents);
+    }
+
+    public function testDeleteEventsByCampaignId(): void
+    {
+        /** @var EventModel&MockObject */
+        $mockModel = $this->getMockBuilder(EventModel::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getRepository', 'deleteEventsByEventIds'])
+            ->getMock();
+
+        $mockModel->expects($this->once())
+            ->method('getRepository')
+            ->willReturn($this->eventRepositoryMock);
+
+        $campaignEvents = ['1', '2', '3'];
+
+        $this->eventRepositoryMock->expects($this->once())
+            ->method('getCampaignEventIds')
+            ->with(1)
+            ->willReturn($campaignEvents);
+
+        $mockModel->expects($this->once())->method('deleteEventsByEventIds')
+            ->with($campaignEvents);
+
+        $mockModel->deleteEventsByCampaignId(1);
     }
 }

--- a/app/bundles/InstallBundle/Config/config.php
+++ b/app/bundles/InstallBundle/Config/config.php
@@ -48,8 +48,6 @@ return [
             ],
             'mautic.install.fixture.grape_js' => [
                 'class'     => \Mautic\InstallBundle\InstallFixtures\ORM\GrapesJsData::class,
-                'tag'       => \Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass::FIXTURE_TAG,
-                'arguments' => [],
             ],
         ],
         'other' => [

--- a/app/migrations/Version20210217115150.php
+++ b/app/migrations/Version20210217115150.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\Exception\SkipMigration;
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+final class Version20210217115150 extends AbstractMauticMigration
+{
+    public function preUp(Schema $schema): void
+    {
+        if ($schema->getTable($this->getPrefixedTableName(Campaign::TABLE_NAME))->hasColumn('deleted') &&
+            $schema->getTable($this->getPrefixedTableName(Event::TABLE_NAME))->hasColumn('deleted')
+        ) {
+            throw new SkipMigration('Deleted column already added in tables');
+        }
+    }
+
+    public function up(Schema $schema): void
+    {
+        $schema->getTable($this->getPrefixedTableName(Campaign::TABLE_NAME))
+            ->addColumn('deleted', Types::DATETIME_MUTABLE, ['notnull' => false]);
+
+        $schema->getTable($this->getPrefixedTableName(Event::TABLE_NAME))
+            ->addColumn('deleted', Types::DATETIME_MUTABLE, ['notnull' => false]);
+    }
+
+    private function getPrefixedTableName(string $tableName): string
+    {
+        return $this->prefix.$tableName;
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix?                               | yes, from the bigger data standpoint
| New feature?                           | yes
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | yes
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
On campaign event deletion, event and event history was not deleting properly because on campaign delete, campaign events and event log will be deleted because of on delete cascade in foreign key relationship. 
Now campaign event log table have millions records so due to on delete cascade some time mysql stuck and not able to delete record associated record properly.
<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create a campaign
3. add an event to the campaign
4. Save and close
5. Edit campaign again and delete event
6. Event and event history should be deleted.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10219"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

