### PR TITLE
Email sender name not changing

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -348,7 +348,7 @@ class MailHelper
                 } elseif (!empty($emailToSend->getFromAddress())) {
                     $this->setFrom($emailToSend->getFromAddress(), $emailToSend->getFromName());
                 } else {
-                    $this->setFrom($this->systemFrom, null);
+                    $this->setFrom($this->from, null);
                 }
             } else {
                 $this->setFrom($this->from, null);


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | features
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Issue(s) addressed                     | Fixes #9751 


#### Description:
Using an already set variable from instead of systemFrom to have the from built for us and avoid additional changes.

#### Steps to reproduce:
Create an email
Change the sender to your desired from name and leave from address empty
Send the email and it will arrive as system default instead of set from name

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create an email
3. Change the sender to your desired from name and leave from address empty
4. Send the email and it should arrive with from name but from email will be system default
5. Additionally when leaving both empty it will be system default
