### PR TITLE
Fix OAuth1 database migration

### DIFF
--- a/app/migrations/Version20210609191822.php
+++ b/app/migrations/Version20210609191822.php
@@ -30,8 +30,8 @@ final class Version20210609191822 extends AbstractMauticMigration
     public function up(Schema $schema): void
     {
         foreach ($this->tables as $table) {
-            if ($schema->hasTable($table)) {
-                $schema->dropTable($table);
+            if ($schema->hasTable($this->prefix . $table)) {
+                $schema->dropTable($this->prefix . $table);
             }
         }
     }

--- a/app/migrations/Version20210609191822.php
+++ b/app/migrations/Version20210609191822.php
@@ -17,14 +17,22 @@ use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
 
 final class Version20210609191822 extends AbstractMauticMigration
 {
+    private $tables = [
+        'oauth1_access_tokens',
+        'oauth1_consumers',
+        'oauth1_nonces',
+        'oauth1_request_tokens'
+    ];
+
     /**
-     * Mautic 4 removed OAuth1 support, so we drop those tables.
+     * Mautic 4 removed OAuth1 support, so we drop those tables if they exist.
      */
     public function up(Schema $schema): void
     {
-        $schema->dropTable('oauth1_access_tokens');
-        $schema->dropTable('oauth1_consumers');
-        $schema->dropTable('oauth1_nonces');
-        $schema->dropTable('oauth1_request_tokens');
+        foreach ($this->tables as $table) {
+            if ($schema->hasTable($table)) {
+                $schema->dropTable($table);
+            }
+        }
     }
 }

--- a/app/migrations/Version20210609191822.php
+++ b/app/migrations/Version20210609191822.php
@@ -21,7 +21,7 @@ final class Version20210609191822 extends AbstractMauticMigration
         'oauth1_access_tokens',
         'oauth1_consumers',
         'oauth1_nonces',
-        'oauth1_request_tokens'
+        'oauth1_request_tokens',
     ];
 
     /**
@@ -30,8 +30,8 @@ final class Version20210609191822 extends AbstractMauticMigration
     public function up(Schema $schema): void
     {
         foreach ($this->tables as $table) {
-            if ($schema->hasTable($this->prefix . $table)) {
-                $schema->dropTable($this->prefix . $table);
+            if ($schema->hasTable($this->prefix.$table)) {
+                $schema->dropTable($this->prefix.$table);
             }
         }
     }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | features
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | N/A
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #10232 

#### Description:

Upgrading from the last v3 to 4rc when you are using a database prefix gives a schema error relating to oauth1

##### Steps to reproduce

- Install Mautic 3.x with a database prefix in use

mkdir mautic3test && cd mautic3test
ddev config --webserver-type=apache-fpm --php-version=7.4 && ddev start
wget https://github.com/mautic/mautic/releases/download/3.3.3/3.3.3.zip
unzip -q 3.3.3.zip
ddev exec php bin/console mautic:install https://mautic3test.ddev.site \
        --mailer_from_name="DDEV" --mailer_from_email="mautic@ddev.local" \
        --mailer_transport="smtp" --mailer_host="localhost" --mailer_port="1025" \
	--db_driver="pdo_mysql" --db_host="db" --db_port="3306" --db_name="db" --db_user="db" --db_password="db" --db_prefix="mau_" \
        --db_backup_tables="false" --admin_email="admin@mautic.local" --admin_password="mautic"

- Upgrade to 4rc via command line update
- Migrate db schema via command line
- Notice the following schema error when trying to upgrade to 4rc which appears related to oauth1 removal

```
[2021-07-05 12:11:14] mautic.NOTICE: Doctrine\DBAL\Schema\SchemaException: There is no table with name 'mauticdb.oauth1_access_tokens' in the schema. (uncaught exception) at /config/www/mautic/vendor/doctrine/dbal/lib/Doctrine/DBAL/Schema/SchemaException.php line 34 while running console command `doctrine:migrations:migrate`

[2021-07-05 12:11:14] mautic.WARNING: Command `doctrine:migrations:migrate` exited with status code 10

[2021-07-05 12:11:14] mautic.WARNING: Command `mautic:update:apply` exited with status code 1
Trying to apply the db schema manually give me the following;

root@b9f9bdad51e7:/config/www/mautic# php bin/console doctrine:migrations:migrate
                                                         
WARNING! You are about to execute a database migration that could result in schema changes and data loss. Are you sure you wish to continue? (y/n)y
Migrating up to 20210609191822 from 20210502162314

  ++ migrating 20210609191822

Migration 20210609191822 failed during Execution. Error There is no table with name 'mauticdb.oauth1_access_tokens' in the schema.

In SchemaException.php line 34:
                                                                              
  There is no table with name 'mauticdb.oauth1_access_tokens' in the schema.
```

#### Steps to test this PR:
1. Install Mautic 3.x with a database prefix
2. Attempt to update, you'll see the error
3. Overwrite app/migrations/Version20210609191822.php in your system with the contents from https://raw.githubusercontent.com/mautic/mautic/c82906165979691b3b7c0b707f66525a653ffe23/app/migrations/Version20210609191822.php
4.Try again with php bin/console doctrine:migrations:migrate. The migration should then succeed and remove tables starting with oauth1_ from your database. 