### PR TITLE
Update Stalebot messages

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,7 +11,7 @@ exemptLabels:
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.
+  This issue or PR has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. If you would like to keep it open please let us know by replying and confirming that this is still relevant to the latest version of Mautic and we will try to get to it as soon as we can. Thank you for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: >
-  This issue has been automatically closed because it has not had recent activity. If the reported issue persists, please create a new issue and link back to this one for reference.  Thank you for your contributions.
+  This issue or PR has been automatically closed because it has not had recent activity. In the case of issues, if it persists in the latest version of Mautic, please create a new issue and link back to this one for reference.  With PRs if you wish to pick up the PR and update it so that it can be considered for a future release, please comment and we will re-open it. Thank you for your contributions.


### PR DESCRIPTION
This relates to the Stalebot we use to manage issues and PRs which have not been active.

The bot now covers both PRs and issues so I have updated the wording to reflect that.

Testing is not needed, just review for typos and the like :) 