### PR TITLE
Fix saving email without existing template

### DIFF
--- a/app/bundles/AssetBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/FormSubscriber.php
@@ -19,7 +19,7 @@ use Mautic\AssetBundle\Model\AssetModel;
 use Mautic\CoreBundle\Exception\BadConfigurationException;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\TemplatingHelper;
-use Mautic\CoreBundle\Helper\ThemeHelper;
+use Mautic\CoreBundle\Helper\ThemeHelperInterface;
 use Mautic\CoreBundle\Templating\Helper\AnalyticsHelper;
 use Mautic\CoreBundle\Templating\Helper\AssetsHelper;
 use Mautic\FormBundle\Entity\Form;
@@ -53,7 +53,7 @@ class FormSubscriber implements EventSubscriberInterface
     private $assetsHelper;
 
     /**
-     * @var ThemeHelper
+     * @var ThemeHelperInterface
      */
     private $themeHelper;
 
@@ -72,7 +72,7 @@ class FormSubscriber implements EventSubscriberInterface
         TranslatorInterface $translator,
         AnalyticsHelper $analyticsHelper,
         AssetsHelper $assetsHelper,
-        ThemeHelper $themeHelper,
+        ThemeHelperInterface $themeHelper,
         TemplatingHelper $templatingHelper,
         CoreParametersHelper $coreParametersHelper
     ) {

--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -1174,6 +1174,7 @@ return [
         'image_path'                      => 'media/images',
         'tmp_path'                        => '%kernel.root_dir%/../var/tmp',
         'theme'                           => 'blank',
+        'blank_theme'                     => 'blank',
         'theme_import_allowed_extensions' => ['json', 'twig', 'css', 'js', 'htm', 'html', 'txt', 'jpg', 'jpeg', 'png', 'gif'],
         'db_driver'                       => 'pdo_mysql',
         'db_host'                         => '127.0.0.1',

--- a/app/bundles/CoreBundle/Controller/ThemeController.php
+++ b/app/bundles/CoreBundle/Controller/ThemeController.php
@@ -13,7 +13,7 @@ namespace Mautic\CoreBundle\Controller;
 
 use Mautic\CoreBundle\Form\Type\ThemeUploadType;
 use Mautic\CoreBundle\Helper\InputHelper;
-use Mautic\CoreBundle\Helper\ThemeHelper;
+use Mautic\CoreBundle\Helper\ThemeHelperInterface;
 use Mautic\IntegrationsBundle\Helper\BuilderIntegrationsHelper;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -41,7 +41,7 @@ class ThemeController extends FormController
             return $this->accessDenied();
         }
 
-        /** @var ThemeHelper $themeHelper */
+        /** @var ThemeHelperInterface $themeHelper */
         $themeHelper = $this->container->get('mautic.helper.theme');
         /** @var BuilderIntegrationsHelper $builderIntegrationsHelper */
         $builderIntegrationsHelper    = $this->container->get('mautic.integrations.helper.builder_integrations');

--- a/app/bundles/CoreBundle/Form/Type/ThemeListType.php
+++ b/app/bundles/CoreBundle/Form/Type/ThemeListType.php
@@ -11,7 +11,7 @@
 
 namespace Mautic\CoreBundle\Form\Type;
 
-use Mautic\CoreBundle\Helper\ThemeHelper;
+use Mautic\CoreBundle\Helper\ThemeHelperInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
@@ -23,14 +23,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ThemeListType extends AbstractType
 {
     /**
-     * @var ThemeHelper
+     * @var ThemeHelperInterface
      */
     private $themeHelper;
 
     /**
      * ThemeListType constructor.
      */
-    public function __construct(ThemeHelper $helper)
+    public function __construct(ThemeHelperInterface $helper)
     {
         $this->themeHelper = $helper;
     }

--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -22,7 +22,7 @@ use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Templating\TemplateReference;
 use Symfony\Component\Translation\TranslatorInterface;
 
-class ThemeHelper
+class ThemeHelper implements ThemeHelperInterface
 {
     /**
      * @var PathsHelper
@@ -674,5 +674,14 @@ class ThemeHelper
         }
 
         return in_array($builderName, $builderRequested);
+    }
+
+    public function getCurrentTheme(string $template, string $specificFeature): string
+    {
+        if (!in_array($template, array_keys($this->getInstalledThemes($specificFeature)))) {
+            return $this->coreParametersHelper->get('blank_theme');
+        }
+
+        return $template;
     }
 }

--- a/app/bundles/CoreBundle/Helper/ThemeHelperInterface.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelperInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Mautic\CoreBundle\Helper;
+
+interface ThemeHelperInterface
+{
+    public function getDefaultThemes();
+
+    public function setDefaultTheme($defaultTheme);
+
+    public function createThemeHelper($themeName);
+
+    public function exists($theme);
+
+    public function copy($theme, $newName, $newDirName = null);
+
+    public function rename($theme, $newName);
+
+    public function delete($theme);
+
+    public function getOptionalSettings();
+
+    public function checkForTwigTemplate($template);
+
+    public function getInstalledThemes($specificFeature = 'all', $extended = false, $ignoreCache = false, $includeDirs = true);
+
+    public function getTheme($theme = 'current', $throwException = false);
+
+    public function install($zipFile);
+
+    public function getExtractError($archive);
+
+    public function zip($themeName);
+
+    public function getCurrentTheme(string $template, string $specificFeature): string;
+}

--- a/app/bundles/CoreBundle/Templating/TemplateReference.php
+++ b/app/bundles/CoreBundle/Templating/TemplateReference.php
@@ -12,7 +12,7 @@
 namespace Mautic\CoreBundle\Templating;
 
 use Mautic\CoreBundle\Helper\PathsHelper;
-use Mautic\CoreBundle\Helper\ThemeHelper;
+use Mautic\CoreBundle\Helper\ThemeHelperInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference as BaseTemplateReference;
 
 class TemplateReference extends BaseTemplateReference
@@ -23,7 +23,7 @@ class TemplateReference extends BaseTemplateReference
     protected $themeOverride;
 
     /**
-     * @var ThemeHelper
+     * @var ThemeHelperInterface
      */
     protected $themeHelper;
 
@@ -32,7 +32,7 @@ class TemplateReference extends BaseTemplateReference
      */
     protected $pathsHelper;
 
-    public function setThemeHelper(ThemeHelper $themeHelper)
+    public function setThemeHelper(ThemeHelperInterface $themeHelper)
     {
         $this->themeHelper = $themeHelper;
     }

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
@@ -18,7 +18,7 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\Filesystem;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Helper\TemplatingHelper;
-use Mautic\CoreBundle\Helper\ThemeHelper;
+use Mautic\CoreBundle\Helper\ThemeHelperInterface;
 use Mautic\CoreBundle\Templating\TemplateNameParser;
 use Mautic\CoreBundle\Templating\TemplateReference;
 use Mautic\IntegrationsBundle\Exception\IntegrationNotFoundException;
@@ -61,7 +61,7 @@ class ThemeHelperTest extends TestCase
     private $builderIntegrationsHelper;
 
     /**
-     * @var ThemeHelper
+     * @var ThemeHelperInterface
      */
     private $themeHelper;
 

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -313,6 +313,7 @@ return [
                     'doctrine.orm.entity_manager',
                     'mautic.stage.model.stage',
                     'mautic.helper.core_parameters',
+                    'mautic.helper.theme',
                 ],
             ],
             'mautic.form.type.email.utm_tags' => [

--- a/app/bundles/EmailBundle/Form/Type/EmailType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailType.php
@@ -24,6 +24,7 @@ use Mautic\CoreBundle\Form\Type\SortableListType;
 use Mautic\CoreBundle\Form\Type\ThemeListType;
 use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\ThemeHelperInterface;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\FormBundle\Form\Type\FormListType;
 use Mautic\LeadBundle\Form\Type\LeadListType;
@@ -65,16 +66,23 @@ class EmailType extends AbstractType
 
     private CoreParametersHelper $coreParametersHelper;
 
+    /**
+     * @var ThemeHelperInterface
+     */
+    private $themeHelper;
+
     public function __construct(
         TranslatorInterface $translator,
         EntityManager $entityManager,
         StageModel $stageModel,
-        CoreParametersHelper $coreParametersHelper
+        CoreParametersHelper $coreParametersHelper,
+        ThemeHelperInterface $themeHelper
     ) {
         $this->translator           = $translator;
         $this->em                   = $entityManager;
         $this->stageModel           = $stageModel;
         $this->coreParametersHelper = $coreParametersHelper;
+        $this->themeHelper          = $themeHelper;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -209,6 +217,10 @@ class EmailType extends AbstractType
             ]
         );
 
+        $template = $options['data']->getTemplate() ? $options['data']->getTemplate() : $this->coreParametersHelper->get('theme_email_default');
+        // If theme does not exist, set empty
+        $template = $this->themeHelper->getCurrentTheme($template, 'email');
+
         $builder->add(
             'template',
             ThemeListType::class,
@@ -218,7 +230,7 @@ class EmailType extends AbstractType
                     'class'   => 'form-control not-chosen hidden',
                     'tooltip' => 'mautic.email.form.template.help',
                 ],
-                'data' => $options['data']->getTemplate() ? $options['data']->getTemplate() : $this->coreParametersHelper->get('theme_email_default'),
+                'data' => $template,
             ]
         );
 

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -22,7 +22,7 @@ use Mautic\CoreBundle\Helper\Chart\LineChart;
 use Mautic\CoreBundle\Helper\Chart\PieChart;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
-use Mautic\CoreBundle\Helper\ThemeHelper;
+use Mautic\CoreBundle\Helper\ThemeHelperInterface;
 use Mautic\CoreBundle\Model\AjaxLookupModelInterface;
 use Mautic\CoreBundle\Model\BuilderModelTrait;
 use Mautic\CoreBundle\Model\FormModel;
@@ -73,7 +73,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
     protected $ipLookupHelper;
 
     /**
-     * @var ThemeHelper
+     * @var ThemeHelperInterface
      */
     protected $themeHelper;
 
@@ -164,7 +164,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
 
     public function __construct(
         IpLookupHelper $ipLookupHelper,
-        ThemeHelper $themeHelper,
+        ThemeHelperInterface $themeHelper,
         Mailbox $mailboxHelper,
         MailHelper $mailHelper,
         LeadModel $leadModel,

--- a/app/bundles/EmailBundle/Tests/Form/Type/EmailTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/EmailTypeTest.php
@@ -16,6 +16,7 @@ namespace Mautic\EmailBundle\Tests\Form\Type;
 use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\ThemeHelperInterface;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Form\Type\EmailType;
 use Mautic\StageBundle\Model\StageModel;
@@ -56,6 +57,11 @@ class EmailTypeTest extends \PHPUnit\Framework\TestCase
      */
     private $coreParametersHelper;
 
+    /**
+     * @var ThemeHelperInterface
+     */
+    private $themeHelper;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -65,11 +71,13 @@ class EmailTypeTest extends \PHPUnit\Framework\TestCase
         $this->stageModel           = $this->createMock(StageModel::class);
         $this->formBuilder          = $this->createMock(FormBuilderInterface::class);
         $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+        $this->themeHelper          = $this->createMock(ThemeHelperInterface::class);
         $this->form                 = new EmailType(
             $this->translator,
             $this->entityManager,
             $this->stageModel,
-            $this->coreParametersHelper
+            $this->coreParametersHelper,
+            $this->themeHelper
         );
 
         $this->formBuilder->method('create')->willReturnSelf();
@@ -77,6 +85,12 @@ class EmailTypeTest extends \PHPUnit\Framework\TestCase
 
     public function testBuildForm(): void
     {
+        $this->themeHelper
+            ->expects($this->once())
+            ->method('getCurrentTheme')
+            ->with('blank', 'email')
+            ->willReturn('blank');
+
         $options = ['data' => new Email()];
         $names   = [];
 

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -22,7 +22,7 @@ use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Helper\CacheStorageHelper;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
-use Mautic\CoreBundle\Helper\ThemeHelper;
+use Mautic\CoreBundle\Helper\ThemeHelperInterface;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Translation\Translator;
@@ -68,7 +68,7 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
     private $ipLookupHelper;
 
     /**
-     * @var MockObject|ThemeHelper
+     * @var MockObject|ThemeHelperInterface
      */
     private $themeHelper;
 
@@ -202,7 +202,7 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
 
         $this->ipLookupHelper           = $this->createMock(IpLookupHelper::class);
-        $this->themeHelper              = $this->createMock(ThemeHelper::class);
+        $this->themeHelper              = $this->createMock(ThemeHelperInterface::class);
         $this->mailboxHelper            = $this->createMock(Mailbox::class);
         $this->mailHelper               = $this->createMock(MailHelper::class);
         $this->leadModel                = $this->createMock(LeadModel::class);

--- a/app/bundles/FormBundle/Form/Type/FieldType.php
+++ b/app/bundles/FormBundle/Form/Type/FieldType.php
@@ -21,6 +21,8 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints as Assert;

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -16,7 +16,7 @@ use Mautic\CoreBundle\Doctrine\Helper\ColumnSchemaHelper;
 use Mautic\CoreBundle\Doctrine\Helper\TableSchemaHelper;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\CoreBundle\Helper\TemplatingHelper;
-use Mautic\CoreBundle\Helper\ThemeHelper;
+use Mautic\CoreBundle\Helper\ThemeHelperInterface;
 use Mautic\CoreBundle\Model\FormModel as CommonFormModel;
 use Mautic\FormBundle\Entity\Action;
 use Mautic\FormBundle\Entity\Field;
@@ -51,7 +51,7 @@ class FormModel extends CommonFormModel
     protected $templatingHelper;
 
     /**
-     * @var ThemeHelper
+     * @var ThemeHelperInterface
      */
     protected $themeHelper;
 
@@ -101,7 +101,7 @@ class FormModel extends CommonFormModel
     public function __construct(
         RequestStack $requestStack,
         TemplatingHelper $templatingHelper,
-        ThemeHelper $themeHelper,
+        ThemeHelperInterface $themeHelper,
         ActionModel $formActionModel,
         FieldModel $formFieldModel,
         FormFieldHelper $fieldHelper,

--- a/app/bundles/FormBundle/Tests/Model/DeleteFormTest.php
+++ b/app/bundles/FormBundle/Tests/Model/DeleteFormTest.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\Doctrine\Helper\ColumnSchemaHelper;
 use Mautic\CoreBundle\Doctrine\Helper\TableSchemaHelper;
 use Mautic\CoreBundle\Helper\TemplatingHelper;
-use Mautic\CoreBundle\Helper\ThemeHelper;
+use Mautic\CoreBundle\Helper\ThemeHelperInterface;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\FormBundle\Entity\FormRepository;
 use Mautic\FormBundle\Helper\FormFieldHelper;
@@ -37,7 +37,7 @@ class DeleteFormTest extends FormTestAbstract
     {
         $requestStack         = $this->createMock(RequestStack::class);
         $templatingHelperMock = $this->createMock(TemplatingHelper::class);
-        $themeHelper          = $this->createMock(ThemeHelper::class);
+        $themeHelper          = $this->createMock(ThemeHelperInterface::class);
         $formActionModel      = $this->createMock(ActionModel::class);
         $formFieldModel       = $this->createMock(FieldModel::class);
         $fieldHelper          = $this->createMock(FormFieldHelper::class);

--- a/app/bundles/PageBundle/Config/config.php
+++ b/app/bundles/PageBundle/Config/config.php
@@ -226,6 +226,7 @@ return [
                     'mautic.page.model.page',
                     'mautic.security',
                     'mautic.helper.user',
+                    'mautic.helper.theme',
                 ],
             ],
             'mautic.form.type.pagevariant' => [

--- a/app/bundles/PageBundle/Form/Type/PageType.php
+++ b/app/bundles/PageBundle/Form/Type/PageType.php
@@ -19,6 +19,8 @@ use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
 use Mautic\CoreBundle\Form\Type\ThemeListType;
 use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\ThemeHelperInterface;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\PageBundle\Entity\Page;
@@ -61,16 +63,23 @@ class PageType extends AbstractType
      */
     private $canViewOther = false;
 
+    /**
+     * @var ThemeHelperInterface
+     */
+    private $themeHelper;
+
     public function __construct(
         EntityManager $entityManager,
         PageModel $pageModel,
         CorePermissions $corePermissions,
-        UserHelper $userHelper
+        UserHelper $userHelper,
+        ThemeHelperInterface $themeHelper
     ) {
         $this->em           = $entityManager;
         $this->model        = $pageModel;
         $this->canViewOther = $corePermissions->isGranted('page:pages:viewother');
         $this->user         = $userHelper->getUser();
+        $this->themeHelper  = $themeHelper;
     }
 
     /**
@@ -105,6 +114,10 @@ class PageType extends AbstractType
             ]
         );
 
+        $template = $options['data']->getTemplate() ? $options['data']->getTemplate() : 'blank';
+        // If theme does not exist, set empty
+        $template = $this->themeHelper->getCurrentTheme($template, 'page');
+
         $builder->add(
             'template',
             ThemeListType::class,
@@ -115,7 +128,7 @@ class PageType extends AbstractType
                     'tooltip' => 'mautic.page.form.template.help',
                 ],
                 'placeholder' => 'mautic.core.none',
-                'data'        => $options['data']->getTemplate() ? $options['data']->getTemplate() : 'blank',
+                'data'        => $template,
             ]
         );
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
The problem happens when an email is based on a theme that was removed from code.
<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

- Create a new email template EMAIL-1 based on THANK YOU EMAIL.
- Delete THANK YOU EMAIL from code

Expected Result: Theme should be reset to the default EMPTY theme, after deleing the template theme.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
