### PR TITLE
Filter out gmail false opens (email is read immediately after it is sent to gmail)

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -478,7 +478,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             $stat = $this->getEmailStatus($stat);
         }
 
-        if (!$stat) {
+        if (!$stat || $this->isUseragentBlacklisted($request->server->get('HTTP_USER_AGENT'))) {
             return;
         }
 
@@ -2373,5 +2373,21 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         }
 
         return $ids;
+    }
+
+    private function isUseragentBlacklisted(?string $useragent): bool
+    {
+        if (null === $useragent) {
+            return false;
+        }
+        $blacklist = [
+            'Chrome/42.0.2311.135', //https://www.gmass.co/blog/false-opens-in-gmail/
+        ];
+        foreach ($blacklist as $blackItem) {
+            if (false !== stripos($useragent, $blackItem)) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "3.3"
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no

#### Description:

I encountered false reads that appeared immediately after Mautic sent an email. The user agent was
```
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246 Mozilla/5.0
```
I found more proves that it's a Gmail bot: [1](https://github.com/ankane/ahoy_email/issues/139), [2](https://www.gmass.co/blog/false-opens-in-gmail/).
Specifically, Gmail has been triggering opens via a bot as soon as an email is received by a Gmail user, and Gmail triggers the open from one of many Google IP addresses with this specific User Agent.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create a user with Gmail email
3. Create a segment, campaign and an email
3. Send an email
Expected: Email is read as soon as the user opens it with enabled images
Actual: Email is read immediately after it is sent

