### PR TITLE
[BUGFIX] added parenthesis for filter String

### DIFF
--- a/plugins/MauticTagManagerBundle/Views/Tag/list.html.php
+++ b/plugins/MauticTagManagerBundle/Views/Tag/list.html.php
@@ -125,7 +125,7 @@ $listCommand = $view['translator']->trans('mautic.tagmanager.tag.searchcommand.l
                     <td class="visible-md visible-lg">
                         <a class="label label-primary" href="<?php echo $view['router']->path(
                             'mautic_contact_index',
-                            ['search' => $view['translator']->trans('mautic.tagmanager.lead.searchcommand.list').':'.$item->getTag()]
+                            ['search' => $view['translator']->trans('mautic.tagmanager.lead.searchcommand.list').':"'.$item->getTag().'"']
                         ); ?>" data-toggle="ajax"<?php echo (0 == $tagsCount[$item->getId()]) ? 'disabled=disabled' : ''; ?>>
                             <?php echo $view['translator']->transChoice(
                                 'mautic.lead.list.viewleads_count',


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" 
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Issue(s) addressed                     | Fixes #10119



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
The issue was with having a space in the tag name and the filter was not using double quotes to search for the phrase, so it couldn't find it. 
<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Edit a contact and add a tag containing a whitespace 
3. Open the tagmanager 
4. In the row of the corresponding tag click on "view contacts"
5. The contact with the tag should now be displayed. Also, in the filter field, the tag is displayed surrounded by double quotes

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
