### PR TITLE
Add workflow for automatic replies on closed issues

### DIFF
--- a/.github/workflows/closed-issue-reply.yaml
+++ b/.github/workflows/closed-issue-reply.yaml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: aws-actions/closed-issue-message@v1
-          with:
+        with:
           # These inputs are both required
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           message: |
-              ### ⚠️ COMMENT VISIBILITY WARNING ⚠️ 
-              Hi there! Comments on closed issues are hard for our team to see. 
-              If this issue is continuing with the [lastest stable version of Mautic](https://www.mautic.org/mautic-releases), please open a new issue that references this one.                                     
+            ### ⚠️COMMENT VISIBILITY WARNING⚠️
+            Comments on closed issues are hard for our team to see.
+            If this issue is continuing with the [lastest stable version of Mautic](https://www.mautic.org/mautic-releases), please open a new issue that references this one.

--- a/.github/workflows/closed-issue-reply.yaml
+++ b/.github/workflows/closed-issue-reply.yaml
@@ -1,0 +1,16 @@
+name: Closed Issue Reply
+on:
+    issues:
+       types: [closed]
+jobs:
+    auto_comment:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: aws-actions/closed-issue-message@v1
+            with:
+            # These inputs are both required
+            repo-token: "${{ secrets.GITHUB_TOKEN }}"
+            message: |
+              ### ⚠️ COMMENT VISIBILITY WARNING ⚠️ 
+              Hi there! Comments on closed issues are hard for our team to see. 
+              If this issue is continuing with the [lastest stable version of Mautic](https://www.mautic.org/mautic-releases), please open a new issue that references this one.                                     

--- a/.github/workflows/closed-issue-reply.yaml
+++ b/.github/workflows/closed-issue-reply.yaml
@@ -1,16 +1,16 @@
-name: Closed Issue Reply
+name: Closed Issue Message
 on:
-    issues:
-       types: [closed]
+  issues:
+    types: [closed]
 jobs:
-    auto_comment:
-        runs-on: ubuntu-latest
-        steps:
-        - uses: aws-actions/closed-issue-message@v1
-            with:
-            # These inputs are both required
-            repo-token: "${{ secrets.GITHUB_TOKEN }}"
-            message: |
+  auto_comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/closed-issue-message@v1
+          with:
+          # These inputs are both required
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          message: |
               ### ⚠️ COMMENT VISIBILITY WARNING ⚠️ 
               Hi there! Comments on closed issues are hard for our team to see. 
               If this issue is continuing with the [lastest stable version of Mautic](https://www.mautic.org/mautic-releases), please open a new issue that references this one.                                     


### PR DESCRIPTION
We often get folk replying to closed issues - sometimes these are years old and we do not necessarily notice the replies.

This adds a GitHub Actions workflow if someone replies to an issue which is closed, telling them that they should create a new issue rather than reply to the closed issue.

It uses this action: https://github.com/aws-actions/closed-issue-message

Message would appear something like this:

![image](https://user-images.githubusercontent.com/2930593/125481356-d943cc29-7f37-4b39-9986-ebeaba7a966b.png)

Code review should be sufficient as this doesn't impact Mautic itself.