### PR TITLE
Allow URL shortener for emails

### DIFF
--- a/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
@@ -318,9 +318,9 @@ class BuilderSubscriber implements EventSubscriberInterface
         foreach ($trackables as $token => $trackable) {
             $url = ($trackable instanceof Trackable)
                 ?
-                $this->pageTrackableModel->generateTrackableUrl($trackable, $clickthrough, false, $utmTags)
+                $this->pageTrackableModel->generateTrackableUrl($trackable, $clickthrough, true, $utmTags)
                 :
-                $this->pageRedirectModel->generateRedirectUrl($trackable, $clickthrough, false, $utmTags);
+                $this->pageRedirectModel->generateRedirectUrl($trackable, $clickthrough, true, $utmTags);
 
             $event->addToken($token, $url);
         }

--- a/app/bundles/PageBundle/Model/RedirectModel.php
+++ b/app/bundles/PageBundle/Model/RedirectModel.php
@@ -78,7 +78,7 @@ class RedirectModel extends FormModel
             ['redirectId' => $redirect->getRedirectId()],
             true,
             $clickthrough,
-            $shortenUrl
+            $utmTags
         );
 
         if (!empty($utmTags)) {


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.3
| Bug fix?                               | no
| New feature?                           | deliverability improvement
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Issue(s) addressed                     | Fixes #2357


#### The Problem
Mautic generates long tracking links. For me, it's **287** characters.
Some content spam filters will flag and penalize you for including large HTTP URLs. It is recommended that there are no links over **120** characters. Taken from [here](https://app.mailgenius.com/)
![image](https://user-images.githubusercontent.com/1675033/126485756-e4b6fe28-32e9-405d-9dd2-3babb4923154.png)

#### Description:

As it was mentioned [here](https://github.com/mautic/mautic/issues/2357#issuecomment-241510396), URL shortener on your own domain can fix this issue.
This PR adds URL shortening support in emails if the `URL shortener` is specified in settings:
![image](https://user-images.githubusercontent.com/1675033/126485213-a0302b11-57a5-431b-810d-da24878d3f10.png)

