### PR TITLE
Fix email resending bugs

### DIFF
--- a/app/bundles/EmailBundle/Command/ProcessEmailQueueCommand.php
+++ b/app/bundles/EmailBundle/Command/ProcessEmailQueueCommand.php
@@ -94,7 +94,7 @@ EOT
                     $file = $failedFile->getRealPath();
 
                     $lockedtime = filectime($file);
-                    if (!(time() - $lockedtime) > $timeout) {
+                    if (!((time() - $lockedtime) > $timeout)) {
                         //the file is not old enough to be resent yet
                         continue;
                     }

--- a/app/bundles/EmailBundle/Command/ProcessEmailQueueCommand.php
+++ b/app/bundles/EmailBundle/Command/ProcessEmailQueueCommand.php
@@ -122,6 +122,7 @@ EOT
 
                         try {
                             $transport->send($message);
+                            $tryAgain = false;
                         } catch (\Swift_TransportException $e) {
                             if ($dispatcher->hasListeners(EmailEvents::EMAIL_FAILED)) {
                                 $event = new QueueEmailEvent($message);


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

There are 2 bugs in the ProcessEmailQueueCommand this PR is intended to fix. 
Both bugs are related to how mautic handles failed emails when using file spool. 

The first one is a wrongly negated condition. The condition probably originates from Swiftmailer's code (Swift_FileSpool::recover()) but got wrongly negated. 

```
if (!(time() - $lockedtime) > $timeout) {
```

In its current form not the comparison, but the subtraction gets negated. Current time minus lockedtime is usually a positive integer. Negating a positive integer results in zero which will never be more than `$timeout` (unless timeout is negative, lol)

AS a result the email sender process doesn't wait `$timeout` seconds before trying to resend the messages.


The second bug is a tricky one.
If a message ever remains with `.sending` extension (probably due to some error during sending), the recovery algorythm resends it via the transport. But the fact whether the resend was successful or not does not have any affect on the `$tryAgain` variable and in the end a file with `.tryagain` extension will remain in place. Next time the process does the same (resulting in multiple successful sends) until the `EMAIL_RESEND` event handler eventually runs out of retry count.

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Set up a wrong email transport with file spooling
3. Try to send email (check if `.sending` file remained in the spool directory)
4. Fix the email transport
5. Try to run `mautic:emails:send` command again
6. With each run the process will ignore `clear-timeout` command parameter or `mautic.mailer_spool_clear_timeout` config parameter
7. With reach subsequent run the message will be send successfully, but the file will remain with `.tryagain` extension.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
