### PR TITLE
Fix Illegal Address - Enclosing sender name with double quotes

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonApiTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonApiTransport.php
@@ -338,7 +338,7 @@ class AmazonApiTransport extends AbstractTokenArrayTransport implements \Swift_T
             $fromEmail = current(array_keys($from));
             $fromName  = $from[$fromEmail];
 
-            $sesArray['FromEmailAddress'] =  (!empty($fromName)) ? mb_encode_mimeheader($fromName).' <'.$fromEmail.'>' : $fromEmail;
+            $sesArray['FromEmailAddress'] =  (!empty($fromName)) ? '"'.mb_encode_mimeheader($fromName).'" <'.$fromEmail.'>' : $fromEmail;
             $to                           = $message->getTo();
             if (!empty($to)) {
                 $sesArray['Destination']['ToAddresses'] = array_keys($to);
@@ -381,7 +381,7 @@ class AmazonApiTransport extends AbstractTokenArrayTransport implements \Swift_T
                 $toSendMessage                                   = (new \Swift_Message());
                 $toSendMessage->setSubject($tokenizedMessage['subject']);
                 $toSendMessage->setFrom([$tokenizedMessage['from']['email'] => $tokenizedMessage['from']['name']]);
-                $sesArray['FromEmailAddress'] =  (!empty($tokenizedMessage['from']['name'])) ? mb_encode_mimeheader($tokenizedMessage['from']['name']).' <'.$tokenizedMessage['from']['email'].'>' : $tokenizedMessage['from']['email'];
+                $sesArray['FromEmailAddress'] =  (!empty($tokenizedMessage['from']['name'])) ? '"'.mb_encode_mimeheader($tokenizedMessage['from']['name']).'" <'.$tokenizedMessage['from']['email'].'>' : $tokenizedMessage['from']['email'];
                 $toSendMessage->setTo([$recipient]);
                 $sesArray['Destination']['ToAddresses'] = [$recipient];
                 if (isset($tokenizedMessage['text']) && strlen($tokenizedMessage['text']) > 0) {


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.3
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | yes
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/10304

#### Description:

Fixes a bug that leads to illegal address error when sending emails where the sender name has comma, like "test, test"

I don't know the lowest specific version where this problem happens, but he is present at 3.3.3

#### Steps to test this PR:

To simulate the problem:
- Create a new campaign/segment email with the sender name field like this: "Test, test from Brazil" (sender name with comma)
- The other fields could be anything. Does not matter the sender mail too.
- Trigger this email sending to any recipient and the illegal address error should occur

To fix the problem:
- Apply the PR then send the same email
- Now the email should be sent okay with no errors