### PR TITLE
POST data is being forwarded as an array but not accepted

### DIFF
--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -826,7 +826,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
                 case 'PUT':
                 case 'PATCH':
                     $result = $client->request($method, $url, [
-                        \GuzzleHttp\RequestOptions::BODY    => $parameters,
+                        \GuzzleHttp\RequestOptions::FORM_PARAMS => $parameters,
                         \GuzzleHttp\RequestOptions::HEADERS => $headers,
                         \GuzzleHttp\RequestOptions::TIMEOUT => $timeout,
                     ]);


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
-->
| Issue(s) addressed                     | 
Right now when authorizing to a Dynamics CRM instance, an error comes back from Guzzle as the data that is being passed is an array, while the BODY request option from Guzzle no longer accepts an array. Changing this to form_params makes sure that Guzzle now does accept the original payload.

See https://docs.guzzlephp.org/en/stable/request-options.html#form-params -> Describes that it accepts arrays
https://docs.guzzlephp.org/en/stable/request-options.html#body -> Only accepts strings


#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Try to connect with Dynamics
3. See it fail
4. Apply this patch
5. Connect with Dynamics
6. See it work

