### PR TITLE
Add support Redis lock system for commands

### DIFF
--- a/app/bundles/CampaignBundle/Command/SummarizeCommand.php
+++ b/app/bundles/CampaignBundle/Command/SummarizeCommand.php
@@ -7,6 +7,7 @@ namespace Mautic\CampaignBundle\Command;
 use Doctrine\DBAL\DBALException;
 use Mautic\CampaignBundle\Model\SummaryModel;
 use Mautic\CoreBundle\Command\ModeratedCommand;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -25,9 +26,10 @@ class SummarizeCommand extends ModeratedCommand
     public function __construct(
         TranslatorInterface $translator,
         SummaryModel $summaryModel,
-        PathsHelper $pathsHelper
+        PathsHelper $pathsHelper,
+        CoreParametersHelper $coreParametersHelper
     ) {
-        parent::__construct($pathsHelper);
+        parent::__construct($pathsHelper, $coreParametersHelper);
 
         $this->translator   = $translator;
         $this->summaryModel = $summaryModel;

--- a/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
@@ -12,6 +12,7 @@ use Mautic\CampaignBundle\Executioner\InactiveExecutioner;
 use Mautic\CampaignBundle\Executioner\KickoffExecutioner;
 use Mautic\CampaignBundle\Executioner\ScheduledExecutioner;
 use Mautic\CoreBundle\Command\ModeratedCommand;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Templating\Helper\FormatterHelper;
 use Mautic\LeadBundle\Helper\SegmentCountCacheHelper;
@@ -76,9 +77,10 @@ class TriggerCampaignCommand extends ModeratedCommand
         FormatterHelper $formatterHelper,
         ListModel $listModel,
         SegmentCountCacheHelper $segmentCountCacheHelper,
-        PathsHelper $pathsHelper
+        PathsHelper $pathsHelper,
+        CoreParametersHelper $coreParametersHelper
     ) {
-        parent::__construct($pathsHelper);
+        parent::__construct($pathsHelper, $coreParametersHelper);
 
         $this->campaignRepository        = $campaignRepository;
         $this->dispatcher                = $dispatcher;

--- a/app/bundles/CampaignBundle/Command/UpdateLeadCampaignsCommand.php
+++ b/app/bundles/CampaignBundle/Command/UpdateLeadCampaignsCommand.php
@@ -21,8 +21,6 @@ class UpdateLeadCampaignsCommand extends ModeratedCommand
 {
     private CampaignRepository $campaignRepository;
 
-    private CoreParametersHelper $coreParametersHelper;
-
     private TranslatorInterface $translator;
     private MembershipBuilder $membershipBuilder;
     private LoggerInterface $logger;

--- a/app/bundles/CampaignBundle/Command/UpdateLeadCampaignsCommand.php
+++ b/app/bundles/CampaignBundle/Command/UpdateLeadCampaignsCommand.php
@@ -7,6 +7,7 @@ use Mautic\CampaignBundle\Entity\CampaignRepository;
 use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
 use Mautic\CampaignBundle\Membership\MembershipBuilder;
 use Mautic\CoreBundle\Command\ModeratedCommand;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Templating\Helper\FormatterHelper;
 use Psr\Log\LoggerInterface;
@@ -19,6 +20,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class UpdateLeadCampaignsCommand extends ModeratedCommand
 {
     private CampaignRepository $campaignRepository;
+
+    private CoreParametersHelper $coreParametersHelper;
+
     private TranslatorInterface $translator;
     private MembershipBuilder $membershipBuilder;
     private LoggerInterface $logger;
@@ -33,7 +37,8 @@ class UpdateLeadCampaignsCommand extends ModeratedCommand
         MembershipBuilder $membershipBuilder,
         LoggerInterface $logger,
         FormatterHelper $formatterHelper,
-        PathsHelper $pathsHelper
+        PathsHelper $pathsHelper,
+        CoreParametersHelper $coreParametersHelper
     ) {
         $this->campaignRepository = $campaignRepository;
         $this->translator         = $translator;
@@ -41,7 +46,7 @@ class UpdateLeadCampaignsCommand extends ModeratedCommand
         $this->logger             = $logger;
         $this->formatterHelper    = $formatterHelper;
 
-        parent::__construct($pathsHelper);
+        parent::__construct($pathsHelper, $coreParametersHelper);
     }
 
     protected function configure()

--- a/app/bundles/ChannelBundle/Command/ProcessMarketingMessagesQueueCommand.php
+++ b/app/bundles/ChannelBundle/Command/ProcessMarketingMessagesQueueCommand.php
@@ -4,6 +4,7 @@ namespace Mautic\ChannelBundle\Command;
 
 use Mautic\ChannelBundle\Model\MessageQueueModel;
 use Mautic\CoreBundle\Command\ModeratedCommand;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -15,12 +16,12 @@ class ProcessMarketingMessagesQueueCommand extends ModeratedCommand
     private TranslatorInterface $translator;
     private MessageQueueModel $messageQueueModel;
 
-    public function __construct(TranslatorInterface $translator, MessageQueueModel $messageQueueModel, PathsHelper $pathsHelper)
+    public function __construct(TranslatorInterface $translator, MessageQueueModel $messageQueueModel, PathsHelper $pathsHelper, CoreParametersHelper $coreParametersHelper)
     {
         $this->translator        = $translator;
         $this->messageQueueModel = $messageQueueModel;
 
-        parent::__construct($pathsHelper);
+        parent::__construct($pathsHelper, $coreParametersHelper);
     }
 
     protected function configure()

--- a/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
+++ b/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
@@ -5,6 +5,7 @@ namespace Mautic\ChannelBundle\Command;
 use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Event\ChannelBroadcastEvent;
 use Mautic\CoreBundle\Command\ModeratedCommand;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,12 +22,12 @@ class SendChannelBroadcastCommand extends ModeratedCommand
     private EventDispatcherInterface $dispatcher;
     private TranslatorInterface $translator;
 
-    public function __construct(TranslatorInterface $translator, EventDispatcherInterface $dispatcher, PathsHelper $pathsHelper)
+    public function __construct(TranslatorInterface $translator, EventDispatcherInterface $dispatcher, PathsHelper $pathsHelper, CoreParametersHelper $coreParametersHelper)
     {
         $this->dispatcher = $dispatcher;
         $this->translator = $translator;
 
-        parent::__construct($pathsHelper);
+        parent::__construct($pathsHelper, $coreParametersHelper);
     }
 
     protected function configure()

--- a/app/bundles/CoreBundle/Command/ModeratedCommand.php
+++ b/app/bundles/CoreBundle/Command/ModeratedCommand.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\CoreBundle\Command;
 
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Console\Command\Command;
@@ -32,6 +33,8 @@ abstract class ModeratedCommand extends Command
     protected $lockExpiration;
     protected $lockFile;
 
+    private CoreParametersHelper $coreParametersHelper;
+
     /**
      * @var Lock
      */
@@ -44,9 +47,10 @@ abstract class ModeratedCommand extends Command
 
     protected PathsHelper $pathsHelper;
 
-    public function __construct(PathsHelper $pathsHelper)
+    public function __construct(PathsHelper $pathsHelper, CoreParametersHelper $coreParametersHelper)
     {
-        $this->pathsHelper = $pathsHelper;
+        $this->pathsHelper          = $pathsHelper;
+        $this->coreParametersHelper = $coreParametersHelper;
 
         parent::__construct();
     }
@@ -187,7 +191,7 @@ abstract class ModeratedCommand extends Command
     {
         switch ($this->moderationMode) {
             case self::MODE_REDIS:
-                $cacheAdapterConfig = $this->getContainer()->get('mautic.helper.core_parameters')->get('cache_adapter_redis');
+                $cacheAdapterConfig = $this->coreParametersHelper->get('cache_adapter_redis');
                 $redisDsn           = $cacheAdapterConfig['dsn'] ?? null;
                 $redisOptions       = $cacheAdapterConfig['options'] ?? [];
                 $redis              = RedisAdapter::createConnection($redisDsn, $redisOptions);

--- a/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
@@ -228,10 +228,6 @@ class ModeratedCommandTest extends TestCase
 
     public function testRedisLock(): void
     {
-        if (!class_exists('\Redis')) {
-            $this->markTestSkipped('Php Redis client not installed');
-        }
-
         $command = new FakeModeratedCommand();
         $command->setContainer($this->container);
 

--- a/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
@@ -226,7 +226,7 @@ class ModeratedCommandTest extends TestCase
         rmdir($runDir);
     }
 
-    public function testRedisLock()
+    public function testRedisLock(): void
     {
         if (!class_exists('\Redis')) {
             $this->markTestSkipped('Php Redis client not installed');
@@ -240,7 +240,10 @@ class ModeratedCommandTest extends TestCase
             ->with('mautic.helper.core_parameters')
             ->willReturnCallback(function (string $key) {
                 return new class() {
-                    public function get()
+                    /**
+                     * @return string[]
+                     */
+                    public function get(): array
                     {
                         return ['dsn' => 'redis://localhost'];
                     }
@@ -261,7 +264,7 @@ class ModeratedCommandTest extends TestCase
                 }
             );
 
-        $this->expectException(\RedisException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $command->run($this->input, $this->output);
     }

--- a/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
@@ -244,7 +244,7 @@ class ModeratedCommandTest extends TestCase
                 return new class() {
                     public function get()
                     {
-                        return ['dns' => 'redis://localhost'];
+                        return ['dsn' => 'redis://localhost'];
                     }
                 };
             });

--- a/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
@@ -249,10 +249,6 @@ class ModeratedCommandTest extends TestCase
                 };
             });
 
-        $this->container->expects($this->once())
-            ->method('getParameter')
-            ->with('cach');
-
         $this->input->method('getOption')
             ->willReturnCallback(
                 function (string $name) {
@@ -267,10 +263,9 @@ class ModeratedCommandTest extends TestCase
                 }
             );
 
-        $command->run($this->input, $this->output);
+        $this->expectException(\RedisException::class);
 
-        // Finish the command
-        $command->forceCompleteRun();
+        $command->run($this->input, $this->output);
     }
 
     private function getFirstFile(Finder $finder): SplFileInfo

--- a/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
@@ -235,8 +235,6 @@ class ModeratedCommandTest extends TestCase
         $command = new FakeModeratedCommand();
         $command->setContainer($this->container);
 
-        $cacheDir = __DIR__.'/resource/cache/tmp';
-
         $this->container->expects($this->once())
             ->method('get')
             ->with('mautic.helper.core_parameters')

--- a/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
@@ -12,7 +12,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
-use Symfony\Component\Lock\Exception\LockAcquiringException;
 
 class ModeratedCommandTest extends TestCase
 {
@@ -235,7 +234,7 @@ class ModeratedCommandTest extends TestCase
     {
         $this->coreParametersHelper->expects($this->once())
             ->method('get')
-            ->willReturn(['dsn' => 'redis://localhost']);
+            ->willReturn(['dsn' => null]);
 
         $this->input->method('getOption')
             ->willReturnCallback(
@@ -252,7 +251,6 @@ class ModeratedCommandTest extends TestCase
             );
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectException(LockAcquiringException::class);
 
         $this->fakeModeratedCommand->run($this->input, $this->output);
     }

--- a/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
@@ -251,6 +251,7 @@ class ModeratedCommandTest extends TestCase
                 }
             );
 
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectException(LockAcquiringException::class);
 
         $this->fakeModeratedCommand->run($this->input, $this->output);

--- a/app/bundles/EmailBundle/Command/ProcessEmailQueueCommand.php
+++ b/app/bundles/EmailBundle/Command/ProcessEmailQueueCommand.php
@@ -30,7 +30,7 @@ class ProcessEmailQueueCommand extends ModeratedCommand
         CoreParametersHelper $parametersHelper,
         PathsHelper $pathsHelper
     ) {
-        parent::__construct($pathsHelper);
+        parent::__construct($pathsHelper, $parametersHelper);
 
         $this->swiftTransport   = $swiftTransport;
         $this->eventDispatcher  = $eventDispatcher;

--- a/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
+++ b/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
@@ -3,6 +3,7 @@
 namespace Mautic\LeadBundle\Command;
 
 use Mautic\CoreBundle\Command\ModeratedCommand;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Model\ListModel;
@@ -18,9 +19,9 @@ class UpdateLeadListsCommand extends ModeratedCommand
     private TranslatorInterface $translator;
     private ListModel $listModel;
 
-    public function __construct(ListModel $listModel, TranslatorInterface $translator, PathsHelper $pathsHelper)
+    public function __construct(ListModel $listModel, TranslatorInterface $translator, PathsHelper $pathsHelper, CoreParametersHelper $coreParametersHelper)
     {
-        parent::__construct($pathsHelper);
+        parent::__construct($pathsHelper, $coreParametersHelper);
 
         $this->listModel  = $listModel;
         $this->translator = $translator;

--- a/plugins/MauticCitrixBundle/Command/SyncCommand.php
+++ b/plugins/MauticCitrixBundle/Command/SyncCommand.php
@@ -3,6 +3,7 @@
 namespace MauticPlugin\MauticCitrixBundle\Command;
 
 use Mautic\CoreBundle\Command\ModeratedCommand;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use MauticPlugin\MauticCitrixBundle\Helper\CitrixHelper;
 use MauticPlugin\MauticCitrixBundle\Helper\CitrixProducts;
@@ -20,9 +21,9 @@ class SyncCommand extends ModeratedCommand
 {
     private CitrixModel $citrixModel;
 
-    public function __construct(CitrixModel $citrixModel, PathsHelper $pathsHelper)
+    public function __construct(CitrixModel $citrixModel, PathsHelper $pathsHelper, CoreParametersHelper $coreParametersHelper)
     {
-        parent::__construct($pathsHelper);
+        parent::__construct($pathsHelper, $coreParametersHelper);
 
         $this->citrixModel = $citrixModel;
     }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes/no
| New feature?                           | yes/no
| Deprecations?                          | yes/no
| BC breaks?                             | yes/no
| Automated tests included?              | yes/no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--f
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
Mautic4 for bring support for Lock component. Now it's easy to add any of supported lock systems to our commands. This PR bring support for redis 

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Setup Redis. On ddev you can zse https://github.com/mautic/mautic/pull/10347
3. Setup it to local.php 

```php
      'cache_adapter_redis'     => [
            'dsn'     => 'redis://redis',
        ],

```
4. Run `php bin/console m:s:r -x redis`
5. Should work like before

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10347"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

