### PR TITLE
Update AssetsHelper to only check for current builder if Mautic is installed

### DIFF
--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/TemplatingPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/TemplatingPass.php
@@ -48,6 +48,7 @@ class TemplatingPass implements CompilerPassInterface
                 ->addMethodCall('setPathsHelper', [new Reference('mautic.helper.paths')])
                 ->addMethodCall('setAssetHelper', [new Reference('mautic.helper.assetgeneration')])
                 ->addMethodCall('setBuilderIntegrationsHelper', [new Reference('mautic.integrations.helper.builder_integrations')])
+                ->addMethodCall('setInstallService', [new Reference('mautic.install.service')])
                 ->addMethodCall('setSiteUrl', ['%mautic.site_url%'])
                 ->addMethodCall('setVersion', ['%mautic.secret_key%', MAUTIC_VERSION])
                 ->setPublic(true);


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | features
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | N/A
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #10371 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

Please see #10371 for more details - currently the UI installer is showing some errors because we try to check for the currently active builder before Mautic is installed. This tries to access the database which at that point hasn't been configured yet. This PR adds a check for whether Mautic has been installed or not, as we don't need this logic up until an actual builder has to be shown.

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. The UI installer shouldn't show an error on the first page anymore

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
