### PR TITLE
fix: handle missing page-hit in point-action

### DIFF
--- a/app/bundles/PageBundle/Entity/HitRepository.php
+++ b/app/bundles/PageBundle/Entity/HitRepository.php
@@ -273,7 +273,7 @@ class HitRepository extends CommonRepository
         }
         $result = $sq->execute()->fetch();
 
-        if ($result == false) {
+        if (false == $result) {
             return $result;
         }
 

--- a/app/bundles/PageBundle/Entity/HitRepository.php
+++ b/app/bundles/PageBundle/Entity/HitRepository.php
@@ -273,6 +273,10 @@ class HitRepository extends CommonRepository
         }
         $result = $sq->execute()->fetch();
 
+        if ($result == false) {
+            return $result;
+        }
+
         return new \DateTime($result['latest_hit'], new \DateTimeZone('UTC'));
     }
 

--- a/app/bundles/PageBundle/Helper/PointActionHelper.php
+++ b/app/bundles/PageBundle/Helper/PointActionHelper.php
@@ -87,7 +87,6 @@ class PointActionHelper
         $latestHit = $hitRepository->getLatestHit(['leadId' => $lead->getId(), $urlWithSqlWC, 'second_to_last' => $eventDetails->getId()]);
 
         if (false != $latestHit) {
-
             if ($action['properties']['accumulative_time']) {
                 if (!isset($hitStats)) {
                     $hitStats = $hitRepository->getDwellTimesForUrl($urlWithSqlWC, ['leadId' => $lead->getId()]);
@@ -127,7 +126,6 @@ class PointActionHelper
                     $changePoints['returns_after'] = false;
                 }
             }
-
         }
 
         // return true only if all configured options are true

--- a/app/bundles/PageBundle/Helper/PointActionHelper.php
+++ b/app/bundles/PageBundle/Helper/PointActionHelper.php
@@ -86,44 +86,48 @@ class PointActionHelper
         $now       = new \DateTime();
         $latestHit = $hitRepository->getLatestHit(['leadId' => $lead->getId(), $urlWithSqlWC, 'second_to_last' => $eventDetails->getId()]);
 
-        if ($action['properties']['accumulative_time']) {
-            if (!isset($hitStats)) {
-                $hitStats = $hitRepository->getDwellTimesForUrl($urlWithSqlWC, ['leadId' => $lead->getId()]);
-            }
+        if (false != $latestHit) {
 
-            if (isset($hitStats['sum'])) {
-                if ($action['properties']['accumulative_time'] <= $hitStats['sum']) {
-                    $changePoints['accumulative_time'] = true;
+            if ($action['properties']['accumulative_time']) {
+                if (!isset($hitStats)) {
+                    $hitStats = $hitRepository->getDwellTimesForUrl($urlWithSqlWC, ['leadId' => $lead->getId()]);
+                }
+
+                if (isset($hitStats['sum'])) {
+                    if ($action['properties']['accumulative_time'] <= $hitStats['sum']) {
+                        $changePoints['accumulative_time'] = true;
+                    } else {
+                        $changePoints['accumulative_time'] = false;
+                    }
                 } else {
                     $changePoints['accumulative_time'] = false;
                 }
-            } else {
-                $changePoints['accumulative_time'] = false;
             }
-        }
-        if ($action['properties']['page_hits']) {
-            if (!isset($hitStats)) {
-                $hitStats = $hitRepository->getDwellTimesForUrl($urlWithSqlWC, ['leadId' => $lead->getId()]);
+            if ($action['properties']['page_hits']) {
+                if (!isset($hitStats)) {
+                    $hitStats = $hitRepository->getDwellTimesForUrl($urlWithSqlWC, ['leadId' => $lead->getId()]);
+                }
+                if (isset($hitStats['count']) && $hitStats['count'] >= $action['properties']['page_hits']) {
+                    $changePoints['page_hits'] = true;
+                } else {
+                    $changePoints['page_hits'] = false;
+                }
             }
-            if (isset($hitStats['count']) && $hitStats['count'] >= $action['properties']['page_hits']) {
-                $changePoints['page_hits'] = true;
-            } else {
-                $changePoints['page_hits'] = false;
+            if ($action['properties']['returns_within']) {
+                if ($now->getTimestamp() - $latestHit->getTimestamp() <= $action['properties']['returns_within']) {
+                    $changePoints['returns_within'] = true;
+                } else {
+                    $changePoints['returns_within'] = false;
+                }
             }
-        }
-        if ($action['properties']['returns_within']) {
-            if ($now->getTimestamp() - $latestHit->getTimestamp() <= $action['properties']['returns_within']) {
-                $changePoints['returns_within'] = true;
-            } else {
-                $changePoints['returns_within'] = false;
+            if ($action['properties']['returns_after']) {
+                if ($now->getTimestamp() - $latestHit->getTimestamp() >= $action['properties']['returns_after']) {
+                    $changePoints['returns_after'] = true;
+                } else {
+                    $changePoints['returns_after'] = false;
+                }
             }
-        }
-        if ($action['properties']['returns_after']) {
-            if ($now->getTimestamp() - $latestHit->getTimestamp() >= $action['properties']['returns_after']) {
-                $changePoints['returns_after'] = true;
-            } else {
-                $changePoints['returns_after'] = false;
-            }
+
         }
 
         // return true only if all configured options are true


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | Fixes #10316

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

This is a type of race condition. A page hit is getting recorded asyncrhonously of being referenced in another worker. To reproduce, make sure you are running w/ multiple fcgi backends, and record some events w/ mtc.js. You will see some 'crashes' (e.g. the sql returns false, but the code expects an array), or, the original issue submitter (not me) had some issue w/ getting 2 hits recorded instead of one

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
