### PR TITLE
Fix accessibility of HTML Emails

### DIFF
--- a/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
@@ -326,7 +326,8 @@ class BuilderSubscriber implements EventSubscriberInterface
         $event->addToken('{signature}', EmojiHelper::toHtml($signatureText));
 
         $event->addToken('{subject}', EmojiHelper::toHtml($event->getSubject()));
-        $event->addToken('{lang}', $email->getLanguage());
+        $event->addToken('{lang}', $email instanceof Email ? $email->getLanguage() : $this->coreParametersHelper->get(
+            'locale'));
     }
 
     /**

--- a/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
@@ -280,7 +280,7 @@ class BuilderSubscriber implements EventSubscriberInterface
         }
 
         // Add the lang attribute to the <html/> tag if it's missing.
-        $locale = empty($event->getEmail()->getLanguage()) ? $event->getEmail()->getLanguage() : $this->coreParametersHelper->get('locale');
+        $locale = empty($event->getEmail()->getLanguage()) ? $this->coreParametersHelper->get('locale') : $event->getEmail()->getLanguage();
         preg_match_all("~<html.*lang\s*=\s*[\"']([^\"']+)[\"'][^>]*>~i", $content, $matches);
         if (empty($matches[1])) {
             $content = str_replace('<html', '<html lang="'.$locale.'"', $content);

--- a/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
@@ -280,7 +280,7 @@ class BuilderSubscriber implements EventSubscriberInterface
         }
 
         // Add the lang attribute to the <html/> tag if it's missing.
-        $locale = $event->getEmail()->getLanguage() ?? $this->coreParametersHelper->get('locale');
+        $locale = empty($event->getEmail()->getLanguage()) ? $event->getEmail()->getLanguage() : $this->coreParametersHelper->get('locale');
         preg_match_all("~<html.*lang\s*=\s*[\"']([^\"']+)[\"'][^>]*>~i", $content, $matches);
         if (empty($matches[1])) {
             $content = str_replace('<html', '<html lang="'.$locale.'"', $content);

--- a/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
@@ -45,7 +45,7 @@ class BuilderSubscriberTest extends \PHPUnit\Framework\TestCase
         });
 
         $email = new Email();
-        $email->setSubject("A unicorn spotted in Alaska");
+        $email->setSubject('A unicorn spotted in Alaska');
         $email->setLanguage($emailLocale);
 
         $emailSendEvent = new EmailSendEvent(null, ['email' => $email]);
@@ -60,52 +60,52 @@ class BuilderSubscriberTest extends \PHPUnit\Framework\TestCase
         yield [
             '<html><head></head></html>',
             '<html lang="en"><head><title>A unicorn spotted in Alaska</title></head></html>',
-            'en'
+            'en',
         ];
         yield [
             '<html><head></head></html>',
             '<html lang="es"><head><title>A unicorn spotted in Alaska</title></head></html>',
-            'es'
+            'es',
         ];
         yield [
             '<html><head></head></html>',
             '<html lang="default_locale"><head><title>A unicorn spotted in Alaska</title></head></html>',
-            null
+            null,
         ];
         yield [
             "<html>\n\n<head>\n</head>\n</html>",
             "<html lang=\"en\">\n\n<head>\n<title>A unicorn spotted in Alaska</title></head>\n</html>",
-            'en'
+            'en',
         ];
         yield [
             '<html lang="en"><head></head></html>',
             '<html lang="en"><head><title>A unicorn spotted in Alaska</title></head></html>',
-            'en'
+            'en',
         ];
         yield [
             '<html lang="en"><head></head></html>',
             '<html lang="en"><head><title>A unicorn spotted in Alaska</title></head></html>',
-            'es'
+            'es',
         ];
         yield [
             '<html lang="cs_CZ"><head></head></html>',
             '<html lang="cs_CZ"><head><title>A unicorn spotted in Alaska</title></head></html>',
-            'en'
+            'en',
         ];
         yield [
             '<html lang="en"><head><title>Existed Title</title></head></html>',
             '<html lang="en"><head><title>Existed Title</title></head></html>',
-            'en'
+            'en',
         ];
         yield [
             '<head><title>Existed Title</title></head>',
             '<head><title>Existed Title</title></head>',
-            'en'
+            'en',
         ];
         yield [
             '<html><body>xxx</body></html>',
             '<html lang="en"><head><title>A unicorn spotted in Alaska</title></head><body>xxx</body></html>',
-            'en'
+            'en',
         ];
     }
 }

--- a/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
@@ -55,6 +55,9 @@ class BuilderSubscriberTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expectedContent, $emailSendEvent->getContent());
     }
 
+    /**
+     * @return iterable<array<int,string>>
+     */
     public function fixEmailAccessibilityContent(): iterable
     {
         yield [
@@ -70,7 +73,7 @@ class BuilderSubscriberTest extends \PHPUnit\Framework\TestCase
         yield [
             '<html><head></head></html>',
             '<html lang="default_locale"><head><title>A unicorn spotted in Alaska</title></head></html>',
-            null,
+            '',
         ];
         yield [
             "<html>\n\n<head>\n</head>\n</html>",

--- a/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\EventListener;
+
+use Doctrine\ORM\EntityManager;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Event\EmailSendEvent;
+use Mautic\EmailBundle\EventListener\BuilderSubscriber;
+use Mautic\EmailBundle\Model\EmailModel;
+use Mautic\PageBundle\Model\RedirectModel;
+use Mautic\PageBundle\Model\TrackableModel;
+use function RectorPrefix20210720\Stringy\create;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class BuilderSubscriberTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider fixEmailAccessibilityContent
+     */
+    public function testFixEmailAccessibility(string $content, string $expectedContent)
+    {
+        $coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+        $emailModel           = $this->createMock(EmailModel::class);
+        $trackableModel       = $this->createMock(TrackableModel::class);
+        $redirectModel        = $this->createMock(RedirectModel::class);
+        $translator           = $this->createMock(\Symfony\Component\Translation\TranslatorInterface::class);
+        $entityManager        = $this->createMock(EntityManager::class);
+        $builderSubscriber    = new BuilderSubscriber(
+            $coreParametersHelper,
+            $emailModel,
+            $trackableModel,
+            $redirectModel,
+            $translator,
+            $entityManager
+        );
+
+        $email = new Email();
+        $email->setLanguage('en');
+        $emailSendEvent = new EmailSendEvent(null, ['email'=>$email]);
+        $emailSendEvent->setContent($content);
+        $builderSubscriber->fixEmailAccessibility($emailSendEvent);
+        $this->assertSame($emailSendEvent->getContent(), $expectedContent);
+    }
+
+    public function fixEmailAccessibilityContent(): iterable
+    {
+        yield ['<html><head></head></html>', '<html lang="en"><head><title>{subject}</title></head></html>'];
+        yield ['<html lang="en"><head></head></html>', '<html lang="en"><head><title>{subject}</title></head></html>'];
+        yield ['<html lang="en"><head><title>Existed Title</title></head></html>', '<html lang="en"><head><title>Existed Title</title></head></html>'];
+        yield ['<head><title>Existed Title</title></head>', '<head><title>Existed Title</title></head>'];
+        yield ['<html><body>xxx</body></html>', '<html lang="en"><body>xxx</body></html>'];
+    }
+}

--- a/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
@@ -19,8 +19,6 @@ use Mautic\EmailBundle\EventListener\BuilderSubscriber;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\PageBundle\Model\RedirectModel;
 use Mautic\PageBundle\Model\TrackableModel;
-use function RectorPrefix20210720\Stringy\create;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 class BuilderSubscriberTest extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features
| Bug fix?                               | kinda
| New feature?                           | not really
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | ✅ 
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
This PR add  automatically title tag and lang attribute of emails If not exists. This increase accessibility To be blind compliant. More https://www.htmlemailcheck.com/knowledge-base/optimizing-accessibility-html-emails/
 

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create email without `<title>` tag in the head
3. Send
4. Check source of email If `<title>` was added and. Also lang attribute was added to `<html>` tag

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10402"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

