### PR TITLE
Asset language as required 

### DIFF
--- a/app/bundles/AssetBundle/Form/Type/AssetType.php
+++ b/app/bundles/AssetBundle/Form/Type/AssetType.php
@@ -28,6 +28,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 class AssetType extends AbstractType
 {
@@ -155,7 +156,14 @@ class AssetType extends AbstractType
                 'class'   => 'form-control',
                 'tooltip' => 'mautic.asset.asset.form.language.help',
             ],
-            'required' => false,
+            'required'    => true,
+            'constraints' => [
+                new NotBlank(
+                    [
+                        'message' => 'mautic.core.value.required',
+                    ]
+                ),
+            ],
         ]);
 
         $builder->add('isPublished', YesNoButtonGroupType::class);


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
Same fix like https://github.com/mautic/mautic/pull/9403
If you reset language, then asset form return 500 error

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create assets and choose nothing in language field
3. Save and should return 500 error
4. With PR you must set language

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
