### PR TITLE
Change webhook_url column type to text

### DIFF
--- a/app/bundles/WebhookBundle/Entity/Webhook.php
+++ b/app/bundles/WebhookBundle/Entity/Webhook.php
@@ -124,7 +124,7 @@ class Webhook extends FormEntity
             ->cascadeDetach()
             ->build();
 
-        $builder->addNamedField('webhookUrl', Types::STRING, 'webhook_url');
+        $builder->addNamedField('webhookUrl', Types::TEXT, 'webhook_url');
         $builder->addField('secret', Types::STRING);
         $builder->addNullableField('eventsOrderbyDir', Types::STRING, 'events_orderby_dir');
     }

--- a/app/migrations/Version20210614151138.php
+++ b/app/migrations/Version20210614151138.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   <year> Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        https://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\SkipMigration;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+final class Version20210614151138 extends AbstractMauticMigration
+{
+    /**
+     * @throws SkipMigration
+     */
+    public function preUp(Schema $schema): void
+    {
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Please modify to your needs
+        $this->addSql("ALTER TABLE {$this->prefix}webhooks MODIFY webhook_url LONGTEXT NOT NULL");
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Roll back webhook_url to it's previous value: VARCHAR(191)
+        // Trimming long values of webhook_url to fit the VARCHAR(191)
+        $this->addSql("UPDATE {$this->prefix}webhooks SET webhook_url = left(webhook_url,191)");
+        $this->addSql("ALTER TABLE {$this->prefix}webhooks MODIFY webhook_url VARCHAR(191) DEFAULT '' ");
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
Our customer used webhook url longer like 191. It return 500 error

This PR change column type to text same like similar PR before https://github.com/mautic/mautic/pull/9542

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create webhook
3. Set URL longer like 191 characters
4. Check If works after PR properly

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
