### PR TITLE
Removed cascadeDetach() from Lead to Stage

### DIFF
--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -365,7 +365,6 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
         $builder->createManyToOne('stage', Stage::class)
             ->cascadePersist()
             ->cascadeMerge()
-            ->cascadeDetach()
             ->addJoinColumn('stage_id', 'id', true, false, 'SET NULL')
             ->build();
 

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -365,6 +365,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
         $builder->createManyToOne('stage', Stage::class)
             ->cascadePersist()
             ->cascadeMerge()
+            ->cascadeDetach() // < this should be removed
             ->addJoinColumn('stage_id', 'id', true, false, 'SET NULL')
             ->build();
 

--- a/app/bundles/StageBundle/Tests/Functional/LeadStageRelationshipTest.php
+++ b/app/bundles/StageBundle/Tests/Functional/LeadStageRelationshipTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Functional\Entity;
+
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\StageBundle\Entity\Stage;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class LeadStageRelationshipTest extends MauticMysqlTestCase
+{
+    public function testBatchEditApiDoesNotDuplicateStage(): void
+    {
+        // Step 1: Create a stage
+        $stage = new Stage();
+        $stage->setName('Test Stage');
+        $stage->setDescription('Stage for testing batch edit bug');
+        
+        // Step 2: Create two contacts and assign them to the same stage
+        $contact1 = new Lead();
+        $contact1->setFirstname('John');
+        $contact1->setLastname('Doe');
+        $contact1->setEmail('john.doe@test.com');
+        $contact1->setStage($stage);
+        
+        $contact2 = new Lead();
+        $contact2->setFirstname('Jane');
+        $contact2->setLastname('Smith');
+        $contact2->setEmail('jane.smith@test.com');
+        $contact2->setStage($stage);
+        
+        $this->em->persist($stage);
+        $this->em->persist($contact1);
+        $this->em->persist($contact2);
+        $this->em->flush();
+        
+        $contact1Id = $contact1->getId();
+        $contact2Id = $contact2->getId();
+        $originalStageId = $stage->getId();
+        
+        // Count stages before the batch edit
+        $stageRepository = $this->em->getRepository(Stage::class);
+        $stageCountBefore = count($stageRepository->findAll());
+        
+        $payload = [
+            ['id' => $contact1Id],
+            ['id' => $contact2Id]
+        ];
+        
+        $this->client->request(
+            Request::METHOD_PATCH,
+            '/api/contacts/batch/edit',
+            $payload
+        );
+        
+        $this->assertResponseIsSuccessful();
+        $this->em->clear();
+        
+        // Step 4: Check if stages were duplicated (this is the bug)
+        $stageCountAfter = count($stageRepository->findAll());
+        $allStages = $stageRepository->findAll();
+        
+        $this->assertSame(
+            $stageCountBefore,
+            $stageCountAfter,
+            sprintf(
+                'Stage duplication detected! Expected %d stages, found %d. Stages: %s',
+                $stageCountBefore,
+                $stageCountAfter,
+                implode(', ', array_map(fn($s) => sprintf('ID:%d Name:"%s"', $s->getId(), $s->getName()), $allStages))
+            )
+        );
+        
+        // Verify both contacts still reference the original stage (not duplicates)
+        $updatedContact1 = $this->em->find(Lead::class, $contact1Id);
+        $updatedContact2 = $this->em->find(Lead::class, $contact2Id);
+        
+        $this->assertNotNull($updatedContact1->getStage());
+        $this->assertNotNull($updatedContact2->getStage());
+        
+        // Both contacts should reference the same original stage
+        $this->assertSame(
+            $originalStageId,
+            $updatedContact1->getStage()->getId(),
+            'Contact 1 should reference the original stage, not a duplicate'
+        );
+        $this->assertSame(
+            $originalStageId,
+            $updatedContact2->getStage()->getId(),
+            'Contact 2 should reference the original stage, not a duplicate'
+        );
+        
+        // Most importantly: both contacts should reference the exact same stage
+        $this->assertSame(
+            $updatedContact1->getStage()->getId(),
+            $updatedContact2->getStage()->getId(),
+            'Both contacts should reference the same stage instance'
+        );
+    }
+}


### PR DESCRIPTION
Addresses #8951 and similar situations in which a copy of a Stage is generated by doctrine during API calls due to the associated Stage getting detached when a Lead is detached.
A single Lead is not the owner of a Stage so, besides being an easy solution, this seems appropriate. However, it is a global change of the configuration and could affect other places.

| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | ---
| Automated tests included?              | no
| Issue(s) addressed                     | Fixes #8951

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Follow steps in #8951 and see the issue not reproduced anymore
3. However - are there legitimate scenarios that this PR could break?

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10417"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

