### PR TITLE
fix: handle case where email is deleted after sending, user hits unsub

### DIFF
--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Tests\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Assert;
+
+final class PublicControllerTest extends MauticMysqlTestCase
+{
+    public function testUnsubscribeAfterEmailWasDeleted(): void
+    {
+        // TODO create segment email with unsubscribe link
+
+        // TODO delete semgent email
+
+        // TODO replace idHashHere with the actual email hash
+        $this->client->request('GET', '/email/unsubscribe/idHashHere');
+
+        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+
+        Assert::assertStringContainsString(
+            'will no longer recieve emails from us.',
+            $this->client->getResponse()->getContent()
+        );
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 4.0
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 


#### Description:


#### Steps to test this PR:
Send a segment email with an unsubscribe link.
Delete the email.
Click the unsubscribe link. You will get a 500 error. After this, you will get the generic preferences page.




<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10423"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

