### PR TITLE
Remove code for get contact from lead list lead table for graph

### DIFF
--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -1067,13 +1067,8 @@ class ListModel extends FormModel
 
         // added line everytime
         $chart->setDataset($this->translator->trans('mautic.lead.segments.contacts.added'), $this->segmentChartQueryFactory->getContactsAdded($query));
-
-        // Just if we have event log data
-        // Added in 2.15 , then we can' display just from data from date range with event logs
-        if ($query->isStatsFromEventLog()) {
-            $chart->setDataset($this->translator->trans('mautic.lead.segments.contacts.removed'), $this->segmentChartQueryFactory->getContactsRemoved($query));
-            $chart->setDataset($this->translator->trans('mautic.lead.segments.contacts.total'), $this->segmentChartQueryFactory->getContactsTotal($query, $this));
-        }
+        $chart->setDataset($this->translator->trans('mautic.lead.segments.contacts.removed'), $this->segmentChartQueryFactory->getContactsRemoved($query));
+        $chart->setDataset($this->translator->trans('mautic.lead.segments.contacts.total'), $this->segmentChartQueryFactory->getContactsTotal($query, $this));
 
         return $chart->render();
     }

--- a/app/bundles/LeadBundle/Segment/Stat/ChartQuery/SegmentContactsLineChartQuery.php
+++ b/app/bundles/LeadBundle/Segment/Stat/ChartQuery/SegmentContactsLineChartQuery.php
@@ -3,12 +3,10 @@
 namespace Mautic\LeadBundle\Segment\Stat\ChartQuery;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Mautic\CoreBundle\Helper\ArrayHelper;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\LeadBundle\Entity\LeadEventLog;
-use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\LeadBundle\Segment\Exception\SegmentNotFoundException;
 
 class SegmentContactsLineChartQuery extends ChartQuery

--- a/app/bundles/LeadBundle/Segment/Stat/ChartQuery/SegmentContactsLineChartQuery.php
+++ b/app/bundles/LeadBundle/Segment/Stat/ChartQuery/SegmentContactsLineChartQuery.php
@@ -16,18 +16,9 @@ class SegmentContactsLineChartQuery extends ChartQuery
      */
     private $segmentId;
 
-    /**
-     * @var bool|string
-     */
-    private $firstEventLog;
-
     private ?array $addedEventLogStats = null;
 
     private ?array $removedEventLogStats = null;
-
-    private ?array $addedLeadListStats = null;
-
-    private ?bool $statsFromEventLog = null;
 
     /**
      * @param string|null $unit
@@ -114,42 +105,6 @@ class SegmentContactsLineChartQuery extends ChartQuery
     }
 
     /**
-     * Get data about add from segment based on LeadListLead before upgrade to 2.15.
-     */
-    public function getDataFromLeadListLeads(): array
-    {
-        $q = $this->prepareTimeDataQuery('lead_lists_leads', 'date_added', $this->filters);
-        if ($this->firstEventLog) {
-            $q->andWhere($q->expr()->lt('t.date_added', $q->expr()->literal($this->firstEventLog)));
-        }
-        $q = $this->optimizeListLeadQuery($q);
-
-        return $this->loadAndBuildTimeData($q);
-    }
-
-    /**
-     * @return bool|string
-     */
-    private function getFirstDateAddedSegmentEventLog()
-    {
-        $subQuery = $this->connection->createQueryBuilder();
-        $subQuery->select('el.date_added - INTERVAL 10 SECOND')
-            ->from(MAUTIC_TABLE_PREFIX.'lead_event_log el FORCE INDEX ('.MAUTIC_TABLE_PREFIX.'IDX_SEARCH)')
-            ->where(
-                $subQuery->expr()->and(
-                    $subQuery->expr()->eq('el.object', $subQuery->expr()->literal('segment')),
-                    $subQuery->expr()->eq('el.bundle', $subQuery->expr()->literal('lead')),
-                    $subQuery->expr()->eq('el.object_id', $this->segmentId)
-                )
-            )
-            ->orderBy('el.date_added')
-            ->setFirstResult(0)
-            ->setMaxResults(1);
-
-        return $subQuery->executeQuery()->fetchOne();
-    }
-
-    /**
      * @return int
      */
     public function getSegmentId()
@@ -180,35 +135,6 @@ class SegmentContactsLineChartQuery extends ChartQuery
     {
         $this->addedEventLogStats   = $this->getDataFromLeadEventLog('added');
         $this->removedEventLogStats = $this->getDataFromLeadEventLog('removed');
-    }
-
-    private function optimizeListLeadQuery(QueryBuilder $qb): QueryBuilder
-    {
-        if (
-            // Remove unwanted self join with lead_lists_leads table
-            false !== ($key = array_search(MAUTIC_TABLE_PREFIX.ListLead::TABLE_NAME, array_column($qb->getQueryPart('from'), 'table'))) &&
-            false !== ($joinKey = array_search(MAUTIC_TABLE_PREFIX.ListLead::TABLE_NAME, array_column($qb->getQueryPart('join')[$tableAlias = $qb->getQueryPart('from')[$key]['alias']], 'joinTable')))
-        ) {
-            $joinAlias = $qb->getQueryPart('join')[$tableAlias][$joinKey]['joinAlias'];
-            $qb->resetQueryPart('join');
-            $compositeExpression = $qb->getQueryPart('where');
-            $this->removeUnwantedWhereClause($compositeExpression, $joinAlias);
-        }
-
-        return $qb;
-    }
-
-    private function removeUnwantedWhereClause(CompositeExpression $compositeExpression, string $joinAlias): void
-    {
-        // CompositeExpression class has no way to remove members of it's 'parts' property, and we have
-        // to resort on Reflection here.
-        $compositeExpressionReflection      = new \ReflectionClass(CompositeExpression::class);
-        $compositeExpressionReflectionParts = $compositeExpressionReflection->getProperty('parts');
-        $compositeExpressionReflectionParts->setAccessible(true);
-        $parts    = $compositeExpressionReflectionParts->getValue($compositeExpression);
-        $newParts = array_filter($parts, fn ($val): bool => !str_starts_with($val, "$joinAlias."));
-        $compositeExpressionReflectionParts->setValue($compositeExpression, $newParts);
-        $compositeExpressionReflectionParts->setAccessible(false);
     }
 
     private function optimizeSearchInLeadEventLog(QueryBuilder $qb): QueryBuilder

--- a/app/bundles/LeadBundle/Segment/Stat/ChartQuery/SegmentContactsLineChartQuery.php
+++ b/app/bundles/LeadBundle/Segment/Stat/ChartQuery/SegmentContactsLineChartQuery.php
@@ -160,14 +160,6 @@ class SegmentContactsLineChartQuery extends ChartQuery
     }
 
     /**
-     * @return bool
-     */
-    public function isStatsFromEventLog()
-    {
-        return $this->statsFromEventLog;
-    }
-
-    /**
      * @return array
      */
     public function getAddedEventLogStats()
@@ -188,15 +180,8 @@ class SegmentContactsLineChartQuery extends ChartQuery
      */
     private function init(): void
     {
-        $this->firstEventLog        = $this->getFirstDateAddedSegmentEventLog();
-        $this->addedLeadListStats   = $this->getDataFromLeadListLeads();
         $this->addedEventLogStats   = $this->getDataFromLeadEventLog('added');
         $this->removedEventLogStats = $this->getDataFromLeadEventLog('removed');
-        $this->statsFromEventLog    = (
-            empty(array_filter($this->addedLeadListStats))
-            && (!empty(array_filter($this->addedEventLogStats))
-            || !empty(array_filter($this->removedEventLogStats)))
-        );
     }
 
     private function optimizeListLeadQuery(QueryBuilder $qb): QueryBuilder

--- a/app/bundles/LeadBundle/Segment/Stat/SegmentChartQueryFactory.php
+++ b/app/bundles/LeadBundle/Segment/Stat/SegmentChartQueryFactory.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\LeadBundle\Segment\Stat;
 
-use Mautic\CoreBundle\Helper\ArrayHelper;
 use Mautic\LeadBundle\Model\ListModel;
 use Mautic\LeadBundle\Segment\Stat\ChartQuery\SegmentContactsLineChartQuery;
 
@@ -17,7 +16,7 @@ class SegmentChartQueryFactory
 
     public function getContactsAdded(SegmentContactsLineChartQuery $query): array
     {
-        return ArrayHelper::sum($query->getAddedEventLogStats(), $query->getDataFromLeadListLeads());
+        return $query->getAddedEventLogStats();
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
@@ -2,8 +2,6 @@
 
 namespace Mautic\LeadBundle\Tests\Model;
 
-use DateTime;
-use DateTimeZone;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
@@ -111,17 +109,17 @@ class ListModelFunctionalTest extends MauticMysqlTestCase
 
         // Adding record in mautic_lead_lists_leads before 11 second from mautic_lead_event_log
         // using old code there should be double records means 2 but now it will show only 1 contact
-        $segmentModel->addLead($contacts[0], $segment, true, false, 1, new DateTime('-11 seconds', new DateTimeZone('UTC'))); // Emulating adding by a filter.
+        $segmentModel->addLead($contacts[0], $segment, true, false, 1, new \DateTime('-11 seconds', new \DateTimeZone('UTC'))); // Emulating adding by a filter.
 
         $data = $segmentModel->getSegmentContactsLineChartData(
             'd',
-            new DateTime('-2 days', new DateTimeZone('UTC')),
-            new DateTime('now', new DateTimeZone('UTC')),
+            new \DateTime('-2 days', new \DateTimeZone('UTC')),
+            new \DateTime('now', new \DateTimeZone('UTC')),
             null,
             ['leadlist_id' => ['value' => $segment->getId(), 'list_column_name' => 't.lead_id']]
         );
 
-        //using old code there should be only 1 label added but now there should be all 3 labels
+        // using old code there should be only 1 label added but now there should be all 3 labels
         Assert::assertSame('added', strtolower($data['datasets'][0]['label']));
         Assert::assertSame('removed', strtolower($data['datasets'][1]['label']));
         Assert::assertSame('total', strtolower($data['datasets'][2]['label']));
@@ -135,8 +133,8 @@ class ListModelFunctionalTest extends MauticMysqlTestCase
 
         $data = $segmentModel->getSegmentContactsLineChartData(
             'd',
-            new DateTime('-2 days', new DateTimeZone('UTC')),
-            new DateTime('now', new DateTimeZone('UTC')),
+            new \DateTime('-2 days', new \DateTimeZone('UTC')),
+            new \DateTime('now', new \DateTimeZone('UTC')),
             null,
             ['leadlist_id' => ['value' => $segment->getId(), 'list_column_name' => 't.lead_id']]
         );

--- a/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
@@ -82,9 +82,9 @@ class ListModelFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame('removed', strtolower($data['datasets'][1]['label']));
         Assert::assertSame('total', strtolower($data['datasets'][2]['label']));
 
-        Assert::assertSame(4, (int)end($data['datasets'][0]['data'])); // Added for today.
-        Assert::assertSame(0, (int)end($data['datasets'][1]['data'])); // Removed for today.
-        Assert::assertSame(4, (int)end($data['datasets'][2]['data'])); // Total for today.
+        Assert::assertSame(4, (int) end($data['datasets'][0]['data'])); // Added for today.
+        Assert::assertSame(0, (int) end($data['datasets'][1]['data'])); // Removed for today.
+        Assert::assertSame(4, (int) end($data['datasets'][2]['data'])); // Total for today.
 
         // To make this interesting, lets' remove some contacts to see what happens.
         $segmentModel->removeLead($contacts[1], $segment); // Emulating removing by a filter.
@@ -98,8 +98,8 @@ class ListModelFunctionalTest extends MauticMysqlTestCase
             ['leadlist_id' => ['value' => $segment->getId(), 'list_column_name' => 't.lead_id']]
         );
 
-        Assert::assertSame(4, (int)end($data['datasets'][0]['data'])); // Added for today.
-        Assert::assertSame(2, (int)end($data['datasets'][1]['data'])); // Removed for today.
-        Assert::assertSame(2, (int)end($data['datasets'][2]['data'])); // Total for today.
+        Assert::assertSame(4, (int) end($data['datasets'][0]['data'])); // Added for today.
+        Assert::assertSame(2, (int) end($data['datasets'][1]['data'])); // Removed for today.
+        Assert::assertSame(2, (int) end($data['datasets'][2]['data'])); // Total for today.
     }
 }

--- a/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
@@ -78,9 +78,13 @@ class ListModelFunctionalTest extends MauticMysqlTestCase
             ['leadlist_id' => ['value' => $segment->getId(), 'list_column_name' => 't.lead_id']]
         );
 
-        Assert::assertSame(4, end($data['datasets'][0]['data'])); // Added for today.
-        Assert::assertSame(0, end($data['datasets'][1]['data'])); // Removed for today.
-        Assert::assertSame(4, end($data['datasets'][2]['data'])); // Total for today.
+        Assert::assertSame('added', strtolower($data['datasets'][0]['label']));
+        Assert::assertSame('removed', strtolower($data['datasets'][1]['label']));
+        Assert::assertSame('total', strtolower($data['datasets'][2]['label']));
+
+        Assert::assertSame(4, (int)end($data['datasets'][0]['data'])); // Added for today.
+        Assert::assertSame(0, (int)end($data['datasets'][1]['data'])); // Removed for today.
+        Assert::assertSame(4, (int)end($data['datasets'][2]['data'])); // Total for today.
 
         // To make this interesting, lets' remove some contacts to see what happens.
         $segmentModel->removeLead($contacts[1], $segment); // Emulating removing by a filter.
@@ -94,8 +98,8 @@ class ListModelFunctionalTest extends MauticMysqlTestCase
             ['leadlist_id' => ['value' => $segment->getId(), 'list_column_name' => 't.lead_id']]
         );
 
-        Assert::assertSame(4, end($data['datasets'][0]['data'])); // Added for today.
-        Assert::assertSame('2', end($data['datasets'][1]['data'])); // Removed for today.
-        Assert::assertSame(2, end($data['datasets'][2]['data'])); // Total for today.
+        Assert::assertSame(4, (int)end($data['datasets'][0]['data'])); // Added for today.
+        Assert::assertSame(2, (int)end($data['datasets'][1]['data'])); // Removed for today.
+        Assert::assertSame(2, (int)end($data['datasets'][2]['data'])); // Total for today.
     }
 }

--- a/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
@@ -2,6 +2,8 @@
 
 namespace Mautic\LeadBundle\Tests\Model;
 
+use DateTime;
+use DateTimeZone;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
@@ -33,19 +35,6 @@ class ListModelFunctionalTest extends MauticMysqlTestCase
             $lists,
             'Non-global lists should not be returned by the `getGlobalLists()` method.'
         );
-    }
-
-    private function createLeadList(User $user, string $name, bool $isGlobal): LeadList
-    {
-        $leadList = new LeadList();
-        $leadList->setName($name);
-        $leadList->setPublicName('Public'.$name);
-        $leadList->setAlias(mb_strtolower($name));
-        $leadList->setCreatedBy($user);
-        $leadList->setIsGlobal($isGlobal);
-        $this->em->persist($leadList);
-
-        return $leadList;
     }
 
     public function testSegmentLineChartData(): void
@@ -106,7 +95,7 @@ class ListModelFunctionalTest extends MauticMysqlTestCase
     public function testSegmentLineChartDataWithoutFetchDataFromLeadListTable(): void
     {
         /** @var ListModel $segmentModel */
-        $segmentModel = $this->container->get('mautic.lead.model.list');
+        $segmentModel = self::$container->get('mautic.lead.model.list');
 
         /** @var LeadRepository $contactRepository */
         $contactRepository = $this->em->getRepository(Lead::class);
@@ -161,6 +150,7 @@ class ListModelFunctionalTest extends MauticMysqlTestCase
     {
         $leadList = new LeadList();
         $leadList->setName($name);
+        $leadList->setPublicName('Public'.$name);
         $leadList->setAlias(mb_strtolower($name));
         $leadList->setCreatedBy($user);
         $leadList->setIsGlobal($isGlobal);

--- a/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
@@ -102,4 +102,70 @@ class ListModelFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame(2, (int) end($data['datasets'][1]['data'])); // Removed for today.
         Assert::assertSame(2, (int) end($data['datasets'][2]['data'])); // Total for today.
     }
+
+    public function testSegmentLineChartDataWithoutFetchDataFromLeadListTable(): void
+    {
+        /** @var ListModel $segmentModel */
+        $segmentModel = $this->container->get('mautic.lead.model.list');
+
+        /** @var LeadRepository $contactRepository */
+        $contactRepository = $this->em->getRepository(Lead::class);
+
+        $segment = new LeadList();
+        $segment->setName('Segment A');
+
+        $segmentModel->saveEntity($segment);
+
+        $contacts = [new Lead()];
+
+        $contactRepository->saveEntities($contacts);
+
+        // Adding record in mautic_lead_lists_leads before 11 second from mautic_lead_event_log
+        // using old code there should be double records means 2 but now it will show only 1 contact
+        $segmentModel->addLead($contacts[0], $segment, true, false, 1, new DateTime('-11 seconds', new DateTimeZone('UTC'))); // Emulating adding by a filter.
+
+        $data = $segmentModel->getSegmentContactsLineChartData(
+            'd',
+            new DateTime('-2 days', new DateTimeZone('UTC')),
+            new DateTime('now', new DateTimeZone('UTC')),
+            null,
+            ['leadlist_id' => ['value' => $segment->getId(), 'list_column_name' => 't.lead_id']]
+        );
+
+        //using old code there should be only 1 label added but now there should be all 3 labels
+        Assert::assertSame('added', strtolower($data['datasets'][0]['label']));
+        Assert::assertSame('removed', strtolower($data['datasets'][1]['label']));
+        Assert::assertSame('total', strtolower($data['datasets'][2]['label']));
+
+        Assert::assertSame(1, (int) end($data['datasets'][0]['data'])); // Added for today.
+        Assert::assertSame(0, (int) end($data['datasets'][1]['data'])); // Removed for today.
+        Assert::assertSame(1, (int) end($data['datasets'][2]['data'])); // Total for today.
+
+        // To make this interesting, lets' remove some contacts to see what happens.
+        $segmentModel->removeLead($contacts[0], $segment, true);
+
+        $data = $segmentModel->getSegmentContactsLineChartData(
+            'd',
+            new DateTime('-2 days', new DateTimeZone('UTC')),
+            new DateTime('now', new DateTimeZone('UTC')),
+            null,
+            ['leadlist_id' => ['value' => $segment->getId(), 'list_column_name' => 't.lead_id']]
+        );
+
+        Assert::assertSame(1, (int) end($data['datasets'][0]['data'])); // Added for today.
+        Assert::assertSame(1, (int) end($data['datasets'][1]['data'])); // Removed for today.
+        Assert::assertSame(0, (int) end($data['datasets'][2]['data'])); // Total for today.
+    }
+
+    private function createLeadList(User $user, string $name, bool $isGlobal): LeadList
+    {
+        $leadList = new LeadList();
+        $leadList->setName($name);
+        $leadList->setAlias(mb_strtolower($name));
+        $leadList->setCreatedBy($user);
+        $leadList->setIsGlobal($isGlobal);
+        $this->em->persist($leadList);
+
+        return $leadList;
+    }
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

We found that some segment are showing double contact count in graph. And we was fetching contact from 2 following places :-

> mautic_lead_lists_leads
> mautic_lead_event_log

and we was showing sum of both in graph for added contacts so contacts count was showing double if contacts was found in mautic_lead_lists_leads table as per query date filter.

It was not reproducible every time because we fetched contact from mautic_lead_lists_leads only if contacts are added in mautic_lead_lists_leads before 10 second of first contact added in mautic_lead_event_log. So it is only reproducible when we are creating data in millions using data loader script.

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

1. Add 1 or 2 millions contacts
2. Create a segment for associate contacts
3. In segment detail page graph contact count should be actual instead of double.
4. In graph all three keys (Added, Removed, Total) should be exists every time.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10432"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

