### PR TITLE
 send raw html tokens using (rawhtml://) as a token prefix

### DIFF
--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -131,7 +131,11 @@ class EmailApiController extends CommonApiController
             $cleanTokens = [];
 
             foreach ($tokens as $token => $value) {
-                $value = InputHelper::clean($value);
+                if (stripos($value, 'rawhtml://') === 0) {
+                    $value = substr($value, 10);
+                } else {
+                    $value = InputHelper::clean($value);
+                }
                 if (!preg_match('/^{.*?}$/', $token)) {
                     $token = '{'.$token.'}';
                 }

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -131,7 +131,7 @@ class EmailApiController extends CommonApiController
             $cleanTokens = [];
 
             foreach ($tokens as $token => $value) {
-                if (stripos($value, 'rawhtml://') === 0) {
+                if (0 === stripos($value, 'rawhtml://')) {
                     $value = substr($value, 10);
                 } else {
                     $value = InputHelper::clean($value);


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 
| Bug fix?                               | no
| New feature?                           | yes
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     |  https://github.com/mautic/mautic/issues/5933



#### Description:

This PR is to enable mautic API to deal with HTML based tokens, issue mentioned here https://github.com/mautic/mautic/issues/5933, this PR also fixes a problem with the other related PR https://github.com/PurHur/mautic/pull/2/ since "rawhtml" has been used instead of "html" as a token prefix.

#### Steps to test this PR:
1. Load up this PR
2. Send a html token like this:
`
$params = [
   'tokens' => [
        'strong_name' => 'rawhtml://<b>Hello World!</b>'
    ],
];
$response = $emailApi->sendToContact($mailId, $contactId, $params);
`

