### PR TITLE
Fix form field campaign condition with special character in value

### DIFF
--- a/app/bundles/FormBundle/Config/config.php
+++ b/app/bundles/FormBundle/Config/config.php
@@ -213,6 +213,7 @@ return [
                     'mautic.form.model.form',
                     'mautic.form.model.submission',
                     'mautic.campaign.executioner.realtime',
+                    'mautic.helper.form.field_helper',
                 ],
             ],
             'mautic.form.leadbundle.subscriber' => [

--- a/app/bundles/FormBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/CampaignSubscriber.php
@@ -15,10 +15,12 @@ use Mautic\CampaignBundle\CampaignEvents;
 use Mautic\CampaignBundle\Event\CampaignBuilderEvent;
 use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
 use Mautic\CampaignBundle\Executioner\RealTimeExecutioner;
+use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\FormBundle\Event\SubmissionEvent;
 use Mautic\FormBundle\Form\Type\CampaignEventFormFieldValueType;
 use Mautic\FormBundle\Form\Type\CampaignEventFormSubmitType;
 use Mautic\FormBundle\FormEvents;
+use Mautic\FormBundle\Helper\FormFieldHelper;
 use Mautic\FormBundle\Model\FormModel;
 use Mautic\FormBundle\Model\SubmissionModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -40,11 +42,17 @@ class CampaignSubscriber implements EventSubscriberInterface
      */
     private $realTimeExecutioner;
 
-    public function __construct(FormModel $formModel, SubmissionModel $formSubmissionModel, RealTimeExecutioner $realTimeExecutioner)
+    /**
+     * @var FormFieldHelper
+     */
+    private $formFieldHelper;
+
+    public function __construct(FormModel $formModel, SubmissionModel $formSubmissionModel, RealTimeExecutioner $realTimeExecutioner, FormFieldHelper $formFieldHelper)
     {
         $this->formModel           = $formModel;
         $this->formSubmissionModel = $formSubmissionModel;
         $this->realTimeExecutioner = $realTimeExecutioner;
+        $this->formFieldHelper     = $formFieldHelper;
     }
 
     /**
@@ -127,12 +135,15 @@ class CampaignSubscriber implements EventSubscriberInterface
 
         $field = $this->formModel->findFormFieldByAlias($form, $event->getConfig()['field']);
 
+        $filter = $this->formFieldHelper->getFieldFilter($field->getType());
+        $value  = InputHelper::_($event->getConfig()['value'], $filter);
+
         $result = $this->formSubmissionModel->getRepository()->compareValue(
             $lead->getId(),
             $form->getId(),
             $form->getAlias(),
             $event->getConfig()['field'],
-            $event->getConfig()['value'],
+            $value,
             $operators[$event->getConfig()['operator']]['expr'],
             $field ? $field->getType() : null
         );

--- a/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -24,7 +24,6 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
      */
     public function testComparingFormSubmissionValues(string $valueToCompare, string $submittedValue, bool $result): void
     {
-        $this->markTestSkipped('Testing if this test has some effect on other failing tests');
         $formPayload = [
             'name'     => 'Test Form',
             'formType' => 'campaign',

--- a/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -17,6 +17,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
 {
+    protected $useCleanupRollback = false;
+
     /**
      * @dataProvider valueProvider
      */
@@ -74,7 +76,7 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         $form['mauticform[email]']->setValue('testing@ampersand.select');
 
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
 
         // Create some necessary entities.
         $campaignEvent = new Event();
@@ -135,5 +137,16 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
             'unicorn',
             false,
         ];
+    }
+
+    protected function tearDown(): void
+    {
+        $tablePrefix = self::$container->getParameter('mautic.db_table_prefix');
+
+        parent::tearDown();
+
+        if ($this->connection->getSchemaManager()->tablesExist("{$tablePrefix}form_results_1_test_form")) {
+            $this->connection->executeQuery("DROP TABLE {$tablePrefix}form_results_1_test_form");
+        }
     }
 }

--- a/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -20,7 +20,7 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
     /**
      * @dataProvider valueProvider
      */
-    public function testComparingValueWithAmpersand(string $valueToCompare, string $submittedValue, bool $result): void
+    public function testComparingFormSubmissionValues(string $valueToCompare, string $submittedValue, bool $result): void
     {
         $formPayload = [
             'name'     => 'Test Form',
@@ -104,10 +104,13 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         $contact = $this->em->getRepository(Lead::class)->findOneBy(['email' => 'testing@ampersand.select']);
         $event   = new CampaignExecutionEvent(
             [
-                'lead'  => $contact,
-                'event' => $campaignEvent,
+                'lead'            => $contact,
+                'event'           => $campaignEvent,
+                'eventDetails'    => null,
+                'systemTriggered' => false,
+                'eventSettings'   => [],
             ],
-            false
+            null
         );
 
         /** @var EventDispatcherInterface $dispatcher */

--- a/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\FormBundle\Tests\Controller;
+
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\FormBundle\FormEvents;
+use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
+{
+    /**
+     * @dataProvider valueProvider
+     */
+    public function testComparingValueWithAmpersand(string $valueToCompare, string $submittedValue, bool $result): void
+    {
+        $formPayload = [
+            'name'     => 'Test Form',
+            'formType' => 'campaign',
+            'fields'   => [
+                [
+                    'label'      => 'Select A',
+                    'alias'      => 'select_a',
+                    'type'       => 'select',
+                    'properties' => [
+                        'list' => [
+                            'list' => [
+                                [
+                                    'label' => $valueToCompare,
+                                    'value' => $valueToCompare,
+                                ],
+                                [
+                                    'label' => $submittedValue,
+                                    'value' => $submittedValue,
+                                ],
+                            ],
+                        ],
+                        'multiple' => false,
+                    ],
+                ], [
+                    'label'     => 'Email',
+                    'alias'     => 'email',
+                    'type'      => 'email',
+                    'leadField' => 'email',
+                ], [
+                    'label' => 'Submit',
+                    'alias' => 'submit',
+                    'type'  => 'button',
+                ],
+            ],
+        ];
+
+        // Creating the form via API so it would create the submission table.
+        $this->client->request('POST', '/api/forms/new', $formPayload);
+        $clientResponse = $this->client->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $response = json_decode($clientResponse->getContent(), true);
+        $formId   = $response['form']['id'];
+
+        // Submitting the form.
+        $crawler    = $this->client->request(Request::METHOD_GET, "/form/{$formId}");
+        $saveButton = $crawler->selectButton('mauticform[submit]');
+        $form       = $saveButton->form();
+        $form['mauticform[select_a]']->setValue($submittedValue);
+        $form['mauticform[email]']->setValue('testing@ampersand.select');
+
+        $this->client->submit($form);
+        Assert::assertTrue($this->client->getResponse()->isOk());
+
+        // Create some necessary entities.
+        $campaignEvent = new Event();
+        $campaignEvent->setName('Test Event');
+        $campaignEvent->setType('form.field_value');
+        $campaignEvent->setEventType('condition');
+        $campaignEvent->setProperties(
+            [
+                'form'     => $formId,
+                'field'    => 'select_a',
+                'value'    => $valueToCompare,
+                'operator' => '=',
+            ]
+        );
+
+        $campaign = new Campaign();
+        $campaign->setName('Test Campaign');
+        $campaign->addEvent(1, $campaignEvent);
+
+        $campaignEvent->setCampaign($campaign);
+
+        $this->em->persist($campaignEvent);
+        $this->em->persist($campaign);
+        $this->em->flush();
+        $this->em->clear();
+
+        $contact = $this->em->getRepository(Lead::class)->findOneBy(['email' => 'testing@ampersand.select']);
+        $event   = new CampaignExecutionEvent(
+            [
+                'lead'  => $contact,
+                'event' => $campaignEvent,
+            ],
+            false
+        );
+
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = self::$container->get('event_dispatcher');
+
+        $dispatcher->dispatch(FormEvents::ON_CAMPAIGN_TRIGGER_CONDITION, $event);
+
+        Assert::assertSame('form', $event->getChannel());
+        Assert::assertSame($result, $event->getResult());
+    }
+
+    public function valueProvider(): iterable
+    {
+        yield [
+            'test & test',
+            'test & test',
+            true,
+        ];
+
+        yield [
+            'test & test',
+            'unicorn',
+            false,
+        ];
+    }
+}

--- a/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -24,6 +24,7 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
      */
     public function testComparingFormSubmissionValues(string $valueToCompare, string $submittedValue, bool $result): void
     {
+        $this->markTestSkipped('Testing if this test has some effect on other failing tests');
         $formPayload = [
             'name'     => 'Test Form',
             'formType' => 'campaign',

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -55,10 +55,11 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
+        $this->assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+
         // Ensure the contact 1 is a campaign 1 member now.
         $this->assertSame([['lead_id' => '1', 'manually_added' => '1', 'manually_removed' => '0']], $this->getMembersForCampaign(1));
 
-        $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
         $this->assertTrue(isset($response['success']), 'The response does not contain the `success` param.');
         $this->assertSame(1, $response['success']);
 

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -13,11 +13,10 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Tests\Controller;
 
-use Mautic\CampaignBundle\DataFixtures\ORM\CampaignData;
+use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
-use Mautic\LeadBundle\DataFixtures\ORM\LoadLeadData;
+use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 {
@@ -36,18 +35,19 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         ]);
     }
 
-    public function testToggleLeadCampaignAction()
+    public function testToggleLeadCampaignAction(): void
     {
-        $this->loadFixtures([CampaignData::class, LoadLeadData::class]);
+        $campaign = $this->createCampaign();
+        $contact  = $this->createContact('blabla@contact.email');
 
         // Ensure there is no member for campaign 1 yet.
-        $this->assertSame([], $this->getMembersForCampaign(1));
+        $this->assertSame([], $this->getMembersForCampaign($campaign->getId()));
 
         // Create the member now.
         $payload = [
             'action'         => 'lead:toggleLeadCampaign',
-            'leadId'         => 1,
-            'campaignId'     => 1,
+            'leadId'         => $contact->getId(),
+            'campaignId'     => $campaign->getId(),
             'campaignAction' => 'add',
         ];
 
@@ -58,7 +58,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertTrue($clientResponse->isOk(), $clientResponse->getContent());
 
         // Ensure the contact 1 is a campaign 1 member now.
-        $this->assertSame([['lead_id' => '1', 'manually_added' => '1', 'manually_removed' => '0']], $this->getMembersForCampaign(1));
+        $this->assertSame([['lead_id' => (string) $contact->getId(), 'manually_added' => '1', 'manually_removed' => '0']], $this->getMembersForCampaign(1));
 
         $this->assertTrue(isset($response['success']), 'The response does not contain the `success` param.');
         $this->assertSame(1, $response['success']);
@@ -66,8 +66,8 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         // Let's remove the member now.
         $payload = [
             'action'         => 'lead:toggleLeadCampaign',
-            'leadId'         => 1,
-            'campaignId'     => 1,
+            'leadId'         => $contact->getId(),
+            'campaignId'     => $campaign->getId(),
             'campaignAction' => 'remove',
         ];
 
@@ -76,9 +76,9 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
 
         // Ensure the contact 1 was removed as a member of campaign 1 member now.
-        $this->assertSame([['lead_id' => '1', 'manually_added' => '0', 'manually_removed' => '1']], $this->getMembersForCampaign(1));
+        $this->assertSame([['lead_id' => (string) $contact->getId(), 'manually_added' => '0', 'manually_removed' => '1']], $this->getMembersForCampaign(1));
 
-        $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertTrue($clientResponse->isOk(), $clientResponse->getContent());
         $this->assertTrue(isset($response['success']), 'The response does not contain the `success` param.');
         $this->assertSame(1, $response['success']);
     }
@@ -90,6 +90,55 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
             ->from(MAUTIC_TABLE_PREFIX.'campaign_leads', 'cl')
             ->where("cl.campaign_id = {$campaignId}")
             ->execute()
-            ->fetchAll();
+            ->fetchAllAssociative();
+    }
+
+    private function createContact(string $email): Lead
+    {
+        $lead = new Lead();
+        $lead->setEmail($email);
+
+        $this->em->persist($lead);
+        $this->em->flush();
+
+        return $lead;
+    }
+
+    private function createCampaign(): Campaign
+    {
+        $campaign = new Campaign();
+
+        $campaign->setName('Campaign A');
+        $campaign->setCanvasSettings(
+            [
+                'nodes' => [
+                    [
+                        'id'        => '148',
+                        'positionX' => '760',
+                        'positionY' => '155',
+                    ],
+                    [
+                        'id'        => 'lists',
+                        'positionX' => '860',
+                        'positionY' => '50',
+                    ],
+                ],
+                'connections' => [
+                    [
+                        'sourceId' => 'lists',
+                        'targetId' => '148',
+                        'anchors'  => [
+                            'source' => 'leadsource',
+                            'target' => 'top',
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->em->persist($campaign);
+        $this->em->flush();
+
+        return $campaign;
     }
 }

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -58,7 +58,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertTrue($clientResponse->isOk(), $clientResponse->getContent());
 
         // Ensure the contact 1 is a campaign 1 member now.
-        $this->assertSame([['lead_id' => (string) $contact->getId(), 'manually_added' => '1', 'manually_removed' => '0']], $this->getMembersForCampaign(1));
+        $this->assertSame([['lead_id' => (string) $contact->getId(), 'manually_added' => '1', 'manually_removed' => '0']], $this->getMembersForCampaign($campaign->getId()));
 
         $this->assertTrue(isset($response['success']), 'The response does not contain the `success` param.');
         $this->assertSame(1, $response['success']);
@@ -76,7 +76,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
 
         // Ensure the contact 1 was removed as a member of campaign 1 member now.
-        $this->assertSame([['lead_id' => (string) $contact->getId(), 'manually_added' => '0', 'manually_removed' => '1']], $this->getMembersForCampaign(1));
+        $this->assertSame([['lead_id' => (string) $contact->getId(), 'manually_added' => '0', 'manually_removed' => '1']], $this->getMembersForCampaign($campaign->getId()));
 
         $this->assertTrue($clientResponse->isOk(), $clientResponse->getContent());
         $this->assertTrue(isset($response['success']), 'The response does not contain the `success` param.');

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -224,7 +224,7 @@ class LeadControllerTest extends MauticMysqlTestCase
             [
                 'lead[firstname]' => 'John',
                 'lead[lastname]'  => 'Doe',
-                'lead[email]'     => 'john@doe.com',
+                'lead[email]'     => 'john_23657@doe.com',
                 'lead[companies]' => [$company->getId()],
                 'lead[points]'    => 20,
             ]
@@ -243,15 +243,15 @@ class LeadControllerTest extends MauticMysqlTestCase
         $contactRepository = $this->em->getRepository(Lead::class);
 
         /** @var AuditLog[] $auditLogs */
-        $auditLogs = $auditLogRepository->getAuditLogs($contactRepository->findOneBy(['email' => 'john@doe.com']));
+        $auditLogs = $auditLogRepository->getAuditLogs($contactRepository->findOneBy(['email' => 'john_23657@doe.com']));
 
-        Assert::assertTrue(isset($auditLogs[0]['details']['fields']), $clientResponse->getContent().PHP_EOL.json_encode($auditLogs, JSON_PRETTY_PRINT));
+        Assert::assertTrue(isset($auditLogs[0]['details']['fields']), json_encode($auditLogs, JSON_PRETTY_PRINT));
 
         Assert::assertSame(
             [
                 'firstname' => [null, 'John'],
                 'lastname'  => [null, 'Doe'],
-                'email'     => [null, 'john@doe.com'],
+                'email'     => [null, 'john_23657@doe.com'],
                 'points'    => [0, 20.0],
                 'company'   => ['', 'Doe Corp'],
             ],

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -244,28 +244,15 @@ class LeadControllerTest extends MauticMysqlTestCase
         /** @var AuditLog[] $auditLogs */
         $auditLogs = $auditLogRepository->getAuditLogs($contactRepository->findOneBy(['email' => 'john@doe.com']));
 
+        Assert::assertTrue(isset($auditLogs[0]['details']['fields']), $clientResponse->getContent().PHP_EOL.json_encode($auditLogs, JSON_PRETTY_PRINT));
+
         Assert::assertSame(
             [
-                'firstname' => [
-                    0 => null,
-                    1 => 'John',
-                ],
-                'lastname' => [
-                    0 => null,
-                    1 => 'Doe',
-                ],
-                'email' => [
-                    0 => null,
-                    1 => 'john@doe.com',
-                ],
-                'points' => [
-                    0 => 0,
-                    1 => 20.0,
-                ],
-                'company' => [
-                    0 => '',
-                    1 => 'Doe Corp',
-                ],
+                'firstname' => [null, 'John'],
+                'lastname'  => [null, 'Doe'],
+                'email'     => [null, 'john@doe.com'],
+                'points'    => [0, 20.0],
+                'company'   => ['', 'Doe Corp'],
             ],
             $auditLogs[0]['details']['fields']
         );

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -4,14 +4,12 @@ namespace Mautic\LeadBundle\Tests\Controller;
 
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CoreBundle\Entity\AuditLog;
-use Mautic\CoreBundle\Entity\AuditLogRepository;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\DataFixtures\ORM\LoadCategorizedLeadListData;
 use Mautic\LeadBundle\DataFixtures\ORM\LoadCategoryData;
 use Mautic\LeadBundle\DataFixtures\ORM\LoadLeadData;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
-use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Model\FieldModel;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
@@ -236,16 +234,13 @@ class LeadControllerTest extends MauticMysqlTestCase
 
         Assert::assertTrue($clientResponse->isOk(), $clientResponse->getContent());
 
-        /** @var AuditLogRepository $auditLogRepository */
-        $auditLogRepository = $this->em->getRepository(AuditLog::class);
+        /** @var Lead $contact */
+        $contact = $this->em->getRepository(Lead::class)->findOneBy(['email' => 'john_23657@doe.com']);
 
-        /** @var LeadRepository $contactRepository */
-        $contactRepository = $this->em->getRepository(Lead::class);
+        /** @var AuditLog $auditLog */
+        $auditLog = $this->em->getRepository(AuditLog::class)->findOneBy(['object' => 'lead', 'objectId' => $contact, 'userId' => 1]);
 
-        /** @var AuditLog[] $auditLogs */
-        $auditLogs = $auditLogRepository->getAuditLogs($contactRepository->findOneBy(['email' => 'john_23657@doe.com']));
-
-        Assert::assertTrue(isset($auditLogs[0]['details']['fields']), json_encode($auditLogs, JSON_PRETTY_PRINT));
+        Assert::assertTrue(isset($auditLog->getDetails()['fields']), json_encode($auditLog, JSON_PRETTY_PRINT));
 
         Assert::assertSame(
             [
@@ -255,7 +250,7 @@ class LeadControllerTest extends MauticMysqlTestCase
                 'points'    => [0, 20.0],
                 'company'   => ['', 'Doe Corp'],
             ],
-            $auditLogs[0]['details']['fields']
+            $auditLog->getDetails()['fields']
         );
     }
 

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -201,7 +201,7 @@ class LeadControllerTest extends MauticMysqlTestCase
                     'date_last_exited' => null,
                 ],
             ],
-            $this->getMembersForCampaign(1)
+            $this->getMembersForCampaign($campaign->getId())
         );
 
         $response = json_decode($clientResponse->getContent(), true);

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -230,6 +230,10 @@ class LeadControllerTest extends MauticMysqlTestCase
 
         $this->client->submit($form);
 
+        $clientResponse = $this->client->getResponse();
+
+        Assert::assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+
         /** @var AuditLogRepository $auditLogRepository */
         $auditLogRepository = $this->em->getRepository(AuditLog::class);
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 4.0
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:
Form field condition made wrong condition If value contain special character like `&`

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Crete campaign form with email field
3. Create select field with one value `test & test`
4. Then create campaign with source of this form
5. Then create condition form field value with you select field condition equal `test & test`
6. Submit form
7. Trigger campaign actions
7. See your contact was not passed by condition
8. After PR should go to true

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
