### PR TITLE
Doctrine cache with APCu support

### DIFF
--- a/app/bundles/CoreBundle/Helper/CacheHelper.php
+++ b/app/bundles/CoreBundle/Helper/CacheHelper.php
@@ -97,6 +97,12 @@ class CacheHelper
             return;
         }
 
-        apcu_clear_cache();
+        if (function_exists('apc_clear_cache')) {
+            apc_clear_cache();
+        }
+
+        if (function_exists('apcu_clear_cache')) {
+            apcu_clear_cache();
+        }
     }
 }

--- a/app/config/config_prod.php
+++ b/app/config/config_prod.php
@@ -8,21 +8,37 @@ if (file_exists(__DIR__.'/security_local.php')) {
     $loader->import('security.php');
 }
 
-/*
-$container->loadFromExtension("framework", array(
-    "validation" => array(
-        "cache" => "apc"
-    )
-));
-
-$container->loadFromExtension("doctrine", array(
-    "orm" => array(
-        "metadata_cache_driver" => "apc",
-        "result_cache_driver"   => "apc",
-        "query_cache_driver"    => "apc"
-    )
-));
-*/
+if (function_exists('apcu_store')) {
+    // Validation caching does not work in Mautic currently - https://github.com/mautic/mautic/issues/6259
+    // $container->loadFromExtension('framework', array(
+    //     'validation' => array(
+    //         'cache' => 'apcu',
+    //     )
+    // ));
+    $container->loadFromExtension('doctrine', [
+        'orm' => [
+            'metadata_cache_driver' => 'apcu',
+            'query_cache_driver'    => 'apcu',
+            // You can use APCu for result caching if using a single node in production, otherwise Redis works well.
+            'result_cache_driver'   => 'apcu',
+        ],
+    ]);
+} elseif (function_exists('apc_store')) {
+    // Validation caching does not work in Mautic currently - https://github.com/mautic/mautic/issues/6259
+    // $container->loadFromExtension('framework', array(
+    //     'validation' => array(
+    //         'cache' => 'apc',
+    //     )
+    // ));
+    $container->loadFromExtension('doctrine', [
+        'orm' => [
+            'metadata_cache_driver' => 'apc',
+            'query_cache_driver'    => 'apc',
+            // You can use APC for result caching if using a single node in production, otherwise Redis works well.
+            'result_cache_driver'   => 'apc',
+        ],
+    ]);
+}
 
 $container->loadFromExtension('monolog', [
     'channels' => [


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | no
| Related developer documentation PR URL | no
| Issue(s) addressed                     | not addressed

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#step-5-work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "features" branch.
-->

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do.
-->
#### Description:

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

There were a few APC-specific functions that will not work in PHP 7 where APCu has supplanted those methods. In addition, when available APCu caching should be used for doctrine metadata, query and result caching (not results) for a bump in performance.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Test it with this script https://github.com/krakjoe/apcu/blob/master/apc.php , Mautic now use APCu cache for doctrine 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
