### PR TITLE
Add Gitpod.io integration

### DIFF
--- a/.ddev/commands/web/ddev-setup-mautic
+++ b/.ddev/commands/web/ddev-setup-mautic
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+source ./.ddev/mautic-setup.sh
+echo "ddev-managed" > ./.ddev/mautic-preference
+setup_mautic

--- a/.ddev/gitpod-setup-ddev.sh
+++ b/.ddev/gitpod-setup-ddev.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Set up ddev for use on gitpod
+
+set -eu -o pipefail
+
+MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Generate a config.gitpod.yaml that adds the gitpod
+# proxied ports so they're known to ddev.
+shortgpurl="${GITPOD_WORKSPACE_URL#'https://'}"
+
+cat <<CONFIGEND > ${MYDIR}/config.gitpod.yaml
+#ddev-gitpod-generated
+use_dns_when_possible: false
+# Throwaway ports, otherwise Gitpod throw an error 'port needs to be > 1024'
+router_http_port: "8888"
+router_https_port: "8889"
+additional_fqdns:
+- 8888-${shortgpurl}
+- 8025-${shortgpurl}
+- 8036-${shortgpurl}
+CONFIGEND
+
+# We need host.docker.internal inside the container,
+# So add it via docker-compose.host-docker-internal.yaml
+hostip=$(awk "\$2 == \"$HOSTNAME\" { print \$1; }" /etc/hosts)
+
+cat <<COMPOSEEND >${MYDIR}/docker-compose.host-docker-internal.yaml
+#ddev-gitpod-generated
+version: "3.6"
+services:
+  web:
+    extra_hosts:
+    - "host.docker.internal:${hostip}"
+    # This adds 8080 on the host (bound on all interfaces)
+    # It goes directly to the web container without
+    # ddev-nginx
+    ports:
+    - 8080:80
+COMPOSEEND
+
+# Misc housekeeping before start
+ddev config global --router-bind-all-interfaces
+
+yes | ddev start

--- a/.ddev/gitpod-setup-ddev.sh
+++ b/.ddev/gitpod-setup-ddev.sh
@@ -42,5 +42,7 @@ COMPOSEEND
 
 # Misc housekeeping before start
 ddev config global --router-bind-all-interfaces
+# Pass the GITPOD_WORKSPACE_URL env variable to the web container for our setup script
+ddev config global --web-environment="GITPOD_WORKSPACE_URL=${GITPOD_WORKSPACE_URL}"
 
 echo "yes" | ddev start

--- a/.ddev/gitpod-setup-ddev.sh
+++ b/.ddev/gitpod-setup-ddev.sh
@@ -43,4 +43,4 @@ COMPOSEEND
 # Misc housekeeping before start
 ddev config global --router-bind-all-interfaces
 
-yes | ddev start
+ddev start

--- a/.ddev/gitpod-setup-ddev.sh
+++ b/.ddev/gitpod-setup-ddev.sh
@@ -43,4 +43,4 @@ COMPOSEEND
 # Misc housekeeping before start
 ddev config global --router-bind-all-interfaces
 
-ddev start
+echo "yes" | ddev start

--- a/.ddev/gitpod-setup-ddev.sh
+++ b/.ddev/gitpod-setup-ddev.sh
@@ -43,6 +43,6 @@ COMPOSEEND
 # Misc housekeeping before start
 ddev config global --router-bind-all-interfaces
 # Pass the GITPOD_WORKSPACE_URL env variable to the web container for our setup script
-ddev config global --web-environment="GITPOD_WORKSPACE_URL=${GITPOD_WORKSPACE_URL}"
+ddev config global --web-environment="MAUTIC_URL=$(gp url 8080),PHPMYADMIN_URL=$(gp url 8036),MAILHOG_URL=$(gp url 8025)"
 
 echo "yes" | ddev start

--- a/.ddev/mautic-setup.sh
+++ b/.ddev/mautic-setup.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 setup_mautic() {
-    if [ -z "${GITPOD_WORKSPACE}"]; then
-        MAUTIC_URL="$(gp url 8080)"
-        PHPMYADMIN_URL="$(gp url 8036)"
-        MAILHOG_URL="$(gp url 8025)"
-    else
+    if [ -z "${GITPOD_WORKSPACE_URL}" ]; then
         MAUTIC_URL="https://${DDEV_HOSTNAME}"
         PHPMYADMIN_URL="https://${DDEV_HOSTNAME}:8037"
         MAILHOG_URL="https://${DDEV_HOSTNAME}:8026"
+    else
+        MAUTIC_URL="$(gp url 8080)"
+        PHPMYADMIN_URL="$(gp url 8036)"
+        MAILHOG_URL="$(gp url 8025)"
     fi
 
     printf "Installing Mautic Composer dependencies...\n"

--- a/.ddev/mautic-setup.sh
+++ b/.ddev/mautic-setup.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 
 setup_mautic() {
+    if [ -z "${GITPOD_WORKSPACE}"]; then
+        MAUTIC_URL="$(gp url 8080)"
+        PHPMYADMIN_URL="$(gp url 8036)"
+        MAILHOG_URL="$(gp url 8025)"
+    else
+        MAUTIC_URL="https://${DDEV_HOSTNAME}"
+        PHPMYADMIN_URL="https://${DDEV_HOSTNAME}:8037"
+        MAILHOG_URL="https://${DDEV_HOSTNAME}:8026"
+    fi
+
     printf "Installing Mautic Composer dependencies...\n"
     composer install
 
@@ -8,7 +18,7 @@ setup_mautic() {
     cp ./.env.dist ./.env
 
     printf "Installing Mautic...\n"
-    php bin/console mautic:install https://${DDEV_HOSTNAME} \
+    php bin/console mautic:install "${MAUTIC_URL}" \
         --mailer_from_name="DDEV" --mailer_from_email="mautic@ddev.local" \
         --mailer_transport="smtp" --mailer_host="localhost" --mailer_port="1025"
     php bin/console cache:warmup --no-interaction --env=dev
@@ -19,9 +29,9 @@ setup_mautic() {
     tput setaf 2
     printf "All done! Here's some useful information:\n"
     printf "🔒 The default login is admin/mautic\n"
-    printf "🌐 To open the Mautic instance, go to https://${DDEV_HOSTNAME} in your browser.\n"
-    printf "🌐 To open PHPMyAdmin for managing the database, go to https://${DDEV_HOSTNAME}:8037 in your browser.\n"
-    printf "🌐 To open MailHog for seeing all emails that Mautic sent, go to https://${DDEV_HOSTNAME}:8026 in your browser.\n"
+    printf "🌐 To open the Mautic instance, go to ${MAUTIC_URL} in your browser.\n"
+    printf "🌐 To open PHPMyAdmin for managing the database, go to ${PHPMYADMIN_URL} in your browser.\n"
+    printf "🌐 To open MailHog for seeing all emails that Mautic sent, go to ${MAILHOG_URL} in your browser.\n"
     printf "🚀 Run \"ddev exec composer test\" to run PHPUnit tests.\n"
     printf "🚀 Run \"ddev exec bin/console COMMAND\" (like mautic:segments:update) to use the Mautic CLI. For an overview of all available CLI commands, go to https://mau.tc/cli\n"
     printf "🔴 If you want to stop the instance, simply run \"ddev stop\".\n"

--- a/.ddev/mautic-setup.sh
+++ b/.ddev/mautic-setup.sh
@@ -1,15 +1,9 @@
 #!/bin/bash
 
 setup_mautic() {
-    if [ -z "${GITPOD_WORKSPACE_URL}" ]; then
-        MAUTIC_URL="https://${DDEV_HOSTNAME}"
-        PHPMYADMIN_URL="https://${DDEV_HOSTNAME}:8037"
-        MAILHOG_URL="https://${DDEV_HOSTNAME}:8026"
-    else
-        MAUTIC_URL="$(gp url 8080)"
-        PHPMYADMIN_URL="$(gp url 8036)"
-        MAILHOG_URL="$(gp url 8025)"
-    fi
+    [ -z "${MAUTIC_URL}" ] && MAUTIC_URL="https://${DDEV_HOSTNAME}"
+    [ -z "${PHPMYADMIN_URL}" ] && PHPMYADMIN_URL="https://${DDEV_HOSTNAME}:8037"
+    [ -z "${MAILHOG_URL}" ] && MAILHOG_URL="https://${DDEV_HOSTNAME}:8026"
 
     printf "Installing Mautic Composer dependencies...\n"
     composer install

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /.ddev/docker-compose.host-docker-internal.yaml
 !.gitpod.Dockerfile
 !.gitpod.yml
+!.ddev/commands/web/dd
 .php_cs.cache
 /.env
 /composer.phar

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 !.ddev
 !.php-cs-fixer.php
 .ddev/mautic-preference
+/.ddev/docker-compose.host-docker-internal.yaml
+!.gitpod.Dockerfile
+!.gitpod.yml
 .php_cs.cache
 /.env
 /composer.phar

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,16 +1,5 @@
 FROM gitpod/workspace-full
 SHELL ["/bin/bash", "-c"]
 
-RUN sudo apt-get -qq update
-# Install required libraries for Projector + PhpStorm
-RUN sudo apt-get -qq install -y python3 python3-pip libxext6 libxrender1 libxtst6 libfreetype6 libxi6
-
-# Install Projector
-RUN pip3 install projector-installer
-# Install PhpStorm
-# Prevents projector install from asking for the license acceptance
-RUN mkdir -p ~/.projector/configs
-RUN projector install 'PhpStorm 2021.1' --no-auto-run
-
 # Install ddev
 RUN brew update && brew install drud/ddev/ddev && mkcert -install

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,16 @@
+FROM gitpod/workspace-full
+SHELL ["/bin/bash", "-c"]
+
+RUN sudo apt-get -qq update
+# Install required libraries for Projector + PhpStorm
+RUN sudo apt-get -qq install -y python3 python3-pip libxext6 libxrender1 libxtst6 libfreetype6 libxi6
+
+# Install Projector
+RUN pip3 install projector-installer
+# Install PhpStorm
+# Prevents projector install from asking for the license acceptance
+RUN mkdir -p ~/.projector/configs
+RUN projector install 'PhpStorm 2021.1' --no-auto-run
+
+# Install ddev
+RUN brew update && brew install drud/ddev/ddev && mkcert -install

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,7 @@ image:
 # when starting a workspace all docker images are ready
 tasks:
   - before: bash .ddev/gitpod-setup-ddev.sh
-    init: ddev composer install
+    init: ddev ddev-setup-mautic
     command: gp await-port 8080 && gp preview $(gp url 8080) 
 
 # VScode xdebug extension

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,44 +17,25 @@ vscode:
     - ziyasal.vscode-open-in-github
 
 ports:
-  # Used by projector
-  - port: 6942
-    onOpen: ignore
-    visibility: private
-  # Direct-connect ddev-webserver port that is the main port
+  # Main web port
   - port: 8080
     onOpen: ignore
     visibility: public
-  # Currently un-notified and unsupported mailhog http port
+  # mailhog http port
   - port: 8025
     onOpen: ignore
     visibility: private
-  # Currently un-notified and unsupported mailhog https port
-  - port: 8026
-    onOpen: ignore
-    visibility: private
-  # Currently un-notified and unsupported phpmyadmin http port
+  # phpmyadmin http port
   - port: 8036
-    onOpen: ignore
-    visibility: private
-  # Currently un-notified and unsupported phpmyadmin https port
-  - port: 8037
     onOpen: ignore
     visibility: private
   # router http port that we're ignoring.
   - port: 8888
     onOpen: ignore
     visibility: private
-  # router https port that we're ignoring.
-  - port: 8889
-    onOpen: ignore
-    visibility: private
   # xdebug port
   - port: 9000
     onOpen: ignore
-    visibility: private
-  # projector port
-  - port: 9999
     visibility: private
 
 github:
@@ -68,10 +49,10 @@ github:
     # enable for pull requests coming from forks (defaults to false)
     pullRequestsFromForks: true
     # add a check to pull requests (defaults to true)
-    addCheck: true
+    addCheck: false
     # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
-    addComment: true
+    addComment: false
     # add a "Review in Gitpod" button to the pull request's description (defaults to false)
     addBadge: true
     # add a label once the prebuild is ready to pull requests (defaults to false)
-    addLabel: true
+    addLabel: false

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,77 @@
+# Docker image
+image:
+  file: .gitpod.Dockerfile
+
+# ddev and composer are running as part of the prebuild
+# when starting a workspace all docker images are ready
+tasks:
+  - before: bash .ddev/gitpod-setup-ddev.sh
+    init: yes | ddev composer install
+    command: gp await-port 8080 && gp preview $(gp url 8080) 
+
+# VScode xdebug extension
+vscode:
+  extensions:
+    - felixfbecker.php-debug
+    - bmewburn.vscode-intelephense-client
+    - ziyasal.vscode-open-in-github
+
+ports:
+  # Used by projector
+  - port: 6942
+    onOpen: ignore
+    visibility: private
+  # Direct-connect ddev-webserver port that is the main port
+  - port: 8080
+    onOpen: ignore
+    visibility: public
+  # Currently un-notified and unsupported mailhog http port
+  - port: 8025
+    onOpen: ignore
+    visibility: private
+  # Currently un-notified and unsupported mailhog https port
+  - port: 8026
+    onOpen: ignore
+    visibility: private
+  # Currently un-notified and unsupported phpmyadmin http port
+  - port: 8036
+    onOpen: ignore
+    visibility: private
+  # Currently un-notified and unsupported phpmyadmin https port
+  - port: 8037
+    onOpen: ignore
+    visibility: private
+  # router http port that we're ignoring.
+  - port: 8888
+    onOpen: ignore
+    visibility: private
+  # router https port that we're ignoring.
+  - port: 8889
+    onOpen: ignore
+    visibility: private
+  # xdebug port
+  - port: 9000
+    onOpen: ignore
+    visibility: private
+  # projector port
+  - port: 9999
+    visibility: private
+
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: true
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: true
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,7 @@ image:
 # when starting a workspace all docker images are ready
 tasks:
   - before: bash .ddev/gitpod-setup-ddev.sh
-    init: yes | ddev composer install
+    init: ddev composer install
     command: gp await-port 8080 && gp preview $(gp url 8080) 
 
 # VScode xdebug extension

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -25,12 +25,24 @@ ports:
   - port: 8025
     onOpen: ignore
     visibility: private
+  # mailhog https port
+  - port: 8026
+    onOpen: ignore
+    visibility: private
   # phpmyadmin http port
   - port: 8036
     onOpen: ignore
     visibility: private
+  # phpmyadmin https port
+  - port: 8037
+    onOpen: ignore
+    visibility: private
   # router http port that we're ignoring.
   - port: 8888
+    onOpen: ignore
+    visibility: private
+  # router https port that we're ignoring.
+  - port: 8889
     onOpen: ignore
     visibility: private
   # xdebug port


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| New feature/enhancement? (use the 4.x branch)      | [x]
| Related user documentation PR URL      | _TBD_

#### Description:

Since we have ddev support it would be nice to also have a direct https://gitpod.io integration that creates a "managed" Mautic instance.

In this PR I have also create a custom ddev command which is a wrapper of the `.ddev/mautic-setup.sh` script. Saying that, I would suggest to also move the whole script `.ddev/mautic-setup.sh` into ddev commands.


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10500"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

