### PR TITLE
Add support for database cache provider + allow use multiple cache provider in code

### DIFF
--- a/app/bundles/CacheBundle/Cache/Adapter/DatabaseTagAwareAdapter.php
+++ b/app/bundles/CacheBundle/Cache/Adapter/DatabaseTagAwareAdapter.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2021 Mautic. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CacheBundle\Cache\Adapter;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+
+class DatabaseTagAwareAdapter extends TagAwareAdapter
+{
+    public function __construct(Connection $connection, array $servers, ?string $namespace, int $lifetime)
+    {
+        if (isset($servers['cache_lifetime'])) {
+            $lifetime = $servers['cache_lifetime'];
+        }
+
+        parent::__construct(
+            new \Symfony\Component\Cache\Adapter\PdoAdapter($connection, (string) $namespace, $lifetime),
+            new \Symfony\Component\Cache\Adapter\PdoAdapter($connection, (string) $namespace, $lifetime)
+        );
+    }
+}

--- a/app/bundles/CacheBundle/Cache/CacheProvider.php
+++ b/app/bundles/CacheBundle/Cache/CacheProvider.php
@@ -47,9 +47,9 @@ final class CacheProvider implements CacheProviderInterface
         $this->container            = $container;
     }
 
-    public function getCacheAdapter(): TagAwareAdapterInterface
+    public function getCacheAdapter(?string $cacheAdapter = null): TagAwareAdapterInterface
     {
-        $selectedAdapter = $this->coreParametersHelper->get('cache_adapter');
+        $selectedAdapter = $cacheAdapter ? $cacheAdapter : $this->coreParametersHelper->get('cache_adapter');
         if (!$selectedAdapter || !$this->container->has($selectedAdapter)) {
             throw new InvalidArgumentException('Requested cache adapter "'.$selectedAdapter.'" is not available');
         }
@@ -62,10 +62,10 @@ final class CacheProvider implements CacheProviderInterface
         return $adaptor;
     }
 
-    public function getSimpleCache(): Psr6Cache
+    public function getSimpleCache(?string $cacheAdapter = null): Psr6Cache
     {
         if (is_null($this->psr16)) {
-            $this->psr16 = new Psr6Cache($this->getCacheAdapter());
+            $this->psr16 = new Psr6Cache($this->getCacheAdapter($cacheAdapter));
         }
 
         return $this->psr16;

--- a/app/bundles/CacheBundle/Config/config.php
+++ b/app/bundles/CacheBundle/Config/config.php
@@ -66,6 +66,16 @@ return [
                 ],
                 'tag'       => 'mautic.cache.adapter',
             ],
+            'mautic.cache.adapter.db'      => [
+                'class'     => \Mautic\CacheBundle\Cache\Adapter\DatabaseTagAwareAdapter::class,
+                'arguments' => [
+                    'doctrine.dbal.default_connection',
+                    '%mautic.cache_adapter_db%',
+                    '%mautic.cache_prefix%',
+                    '%mautic.cache_lifetime%',
+                ],
+                'tag'       => 'mautic.cache.adapter',
+            ],
         ],
         'models'    => [],
         'validator' => [],
@@ -75,6 +85,9 @@ return [
         'cache_adapter'           => 'mautic.cache.adapter.filesystem',
         'cache_prefix'            => '',
         'cache_lifetime'          => 86400,
+        'cache_adapter_db'        => [
+            'timeout' => 86400,
+        ],
         'cache_adapter_memcached' => [
             'servers' => ['memcached://localhost'],
             'options' => [


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Cache component (https://developer.mautic.org/#cache-bundle) in Mautic support at the moment filesystem, memcached a redis mechanism. This PR add database cache adapter (https://symfony.com/doc/current/components/cache/adapters/pdo_doctrine_dbal_adapter.html)

Also this allow use multiple cache provider in your code.

```
$cache = $this->get('mautic.cache.provider');
$item = $cache->getItem('test_tagged_Item');
$item->set('yesa!!!');
```

and 

```
$cache = $this->get('mautic.cache.provider')->getCacheAdapter('mautic.cache.adapter.db');
$item = $cache->getItem('test_tagged_Item');
$item->set('yesa!!!');
```

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Load up [this PR](https://mautibox.com)
2. Apply PR 
3. Set to local.php 

```
     'cache_adapter'           => 'mautic.cache.adapter.db',
```

4. For test you can apply this PR https://github.com/mautic/mautic/pull/7785 and go to dashboard and change date 
5. Should work  like before
6. You can also check in database If data are cached in `cache_items` table

Or use code from  documentation https://developer.mautic.org/#cache-bundle

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
