### PR TITLE
Fix Contact's Timeline and Timeline export

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -332,6 +332,7 @@ return [
                     'doctrine.orm.entity_manager',
                     'translator',
                     'router',
+                    'mautic.helper.core_parameters',
                 ],
                 'methodCalls' => [
                     'setModelFactory' => ['mautic.model.factory'],

--- a/app/bundles/LeadBundle/Controller/TimelineController.php
+++ b/app/bundles/LeadBundle/Controller/TimelineController.php
@@ -266,8 +266,7 @@ class TimelineController extends CommonController
                 }
             }
 
-            $items = $this->getEngagements($lead, $filters, $order, $loop + 1, 200);
-            ['events'] ?? [];
+            $items = $this->getEngagements($lead, $filters, $order, $loop + 1, 200)['events'] ?? [];
 
             $this->getDoctrine()->getManager()->clear();
 

--- a/app/bundles/LeadBundle/Controller/TimelineController.php
+++ b/app/bundles/LeadBundle/Controller/TimelineController.php
@@ -267,6 +267,7 @@ class TimelineController extends CommonController
             }
 
             $items = $this->getEngagements($lead, $filters, $order, $loop + 1, 200);
+            ['events'] ?? [];
 
             $this->getDoctrine()->getManager()->clear();
 

--- a/app/bundles/LeadBundle/Tests/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/LeadSubscriberTest.php
@@ -15,6 +15,7 @@ namespace Mautic\LeadBundle\Tests\EventListener;
 
 use DateTime;
 use Doctrine\ORM\EntityManager;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\CoreBundle\Tests\CommonMocks;
@@ -69,6 +70,11 @@ class LeadSubscriberTest extends CommonMocks
      */
     private $router;
 
+    /**
+     * @var CoreParametersHelper
+     */
+    private $coreParameterHelper;
+
     protected function setUp(): void
     {
         $this->ipLookupHelper      = $this->createMock(IpLookupHelper::class);
@@ -78,6 +84,7 @@ class LeadSubscriberTest extends CommonMocks
         $this->entityManager       = $this->createMock(EntityManager::class);
         $this->translator          = $this->createMock(TranslatorInterface::class);
         $this->router              = $this->createMock(RouterInterface::class);
+        $this->coreParameterHelper = $this->createMock(CoreParametersHelper::class);
     }
 
     public function testOnLeadPostSaveWillNotProcessTheSameLeadTwice()
@@ -131,7 +138,8 @@ class LeadSubscriberTest extends CommonMocks
             $this->dncReasonHelper,
             $this->entityManager,
             $this->translator,
-            $this->router
+            $this->router,
+            $this->coreParameterHelper
         );
 
         $leadEvent = $this->createMock(LeadEvent::class);
@@ -217,6 +225,7 @@ class LeadSubscriberTest extends CommonMocks
             $this->entityManager,
             $this->translator,
             $this->router,
+            $this->coreParameterHelper,
             true
         );
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅ 
| New feature/enhancement? (use the a.x branch)      | no
| Deprecations?                          | no
| BC breaks? (use the c.x branch)        | no
| Automated tests included?              | no
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

#### Description:

This PR solves 3 issues on contact timeline and timeline export:

1. **Fix loop iteration in Timeline:batchExportAction** : We had an error in a loop when exporting Contact timeline events, causing a lack of event exported.
2. **Update LeadBundle:LeadSubscriber event counters** : When calculating the total events in the timeline (or exported) the counter was incremented before actually adding the event to the timeline, this caused miscalculations sometimes.
3. **Update LeadBundle:LeadSubscriber annonimized IP** : When adding (or exporting) `lead.ipadded` events to the timeline on instances using the `anonymize_ip` configuration, we had an error trying to match masked and unmasked IPs. Now we apply the correct mask before comparison on those instances.

#### Steps to test this PR:
It is complicated to reproduce but if you have a lot of different events you'll see that when exporting the timeline, you don't have the same amount of raws in the csv file as the amount of events in the timeline.
This PR fixes it.