### PR TITLE
Fix Codecov on 4.0 branch

### DIFF
--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -1,6 +1,6 @@
 {
-  "version": "4.0.1",
-  "stability": "stable",
+  "version": "4.0.2-beta",
+  "stability": "beta",
   "minimum_php_version": "7.4.0",
   "maximum_php_version": "8.0.99",
   "show_php_version_warning_if_under": "7.4.0",


### PR DESCRIPTION
A problematic PR was merged recently (https://github.com/mautic/mautic/pull/10482) that is causing all new PRs to the `4.0` branch to fail on the code coverage report (you can specifically see files like `MailHelper.php` having decreased coverage).

The problematic PR probably had a wrong base commit (or a similar issue) and it might've been better to investigate the issue in that PR rather than merging it 😉 something for next time!

@RCheesley we can get back into a working state by simply merging this PR. We just need something to be merged so that the code coverage can recover itself, so I figured that simply bumping the version to 4.0.2-beta would be appropriate here (see the Files changed tab). After that, the following PRs will need to be updated so that they'll have correct code coverage reports:
- https://github.com/mautic/mautic/pull/10519
- https://github.com/mautic/mautic/pull/10509
- https://github.com/mautic/mautic/pull/10503
- https://github.com/mautic/mautic/pull/10497
- https://github.com/mautic/mautic/pull/10495
- https://github.com/mautic/mautic/pull/10489
- https://github.com/mautic/mautic/pull/10486