### PR TITLE
Update Codecov GH Action to v2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,7 @@ jobs:
 
     - name: Upload coverage report
       if: ${{ matrix.php-versions == '7.4' && matrix.db-types == 'mysql' }}
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         files: ./coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
Got an email from Codecov that they're deprecating their old bash uploader (v1) for enhanced security and more features in the future. Apparently they've started a brownout period where the bash uploader won't be available at several times. Let's migrate to v2 right away as we don't have any special/complex configuration.

https://about.codecov.io/blog/codecov-uploader-deprecation-plan/

![image](https://user-images.githubusercontent.com/17739158/137186032-68bf4b96-8f8c-45cf-b3da-d35df118a739.png)

@RCheesley let me know if you also want this for Mautic's 3.3 branch. We don't use Codecov's official GH Action there yet, but it's an easy thing to change