### PR TITLE
Do not write to console when updating segments if quiet flag is specified

### DIFF
--- a/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
+++ b/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
@@ -20,10 +20,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdateLeadListsCommand extends ModeratedCommand
 {
-    /**
-     * @var bool
-     */
-    private $quiet;
 
     protected function configure()
     {
@@ -75,10 +71,9 @@ class UpdateLeadListsCommand extends ModeratedCommand
         $batch                 = $input->getOption('batch-limit');
         $max                   = $input->getOption('max-contacts');
         $enableTimeMeasurement = (bool) $input->getOption('timing');
-        $this->quiet           = $input->getOption('quiet');
-        $this->output          = ($this->quiet) ? new NullOutput() : $output;
+        $output         = ($input->getOption('quiet')) ? new NullOutput() : $output;
 
-        if (!$this->checkRunStatus($input, $this->output, $id)) {
+        if (!$this->checkRunStatus($input, $output, $id)) {
             return 0;
         }
 
@@ -91,15 +86,15 @@ class UpdateLeadListsCommand extends ModeratedCommand
 
             if (null !== $list) {
                 if ($list->isPublished()) {
-                    $this->output->writeln('<info>'.$translator->trans('mautic.lead.list.rebuild.rebuilding', ['%id%' => $id]).'</info>');
+                    $output->writeln('<info>'.$translator->trans('mautic.lead.list.rebuild.rebuilding', ['%id%' => $id]).'</info>');
                     $processed = 0;
                     try {
-                        $processed = $listModel->rebuildListLeads($list, $batch, $max, $this->output);
+                        $processed = $listModel->rebuildListLeads($list, $batch, $max, $output);
                     } catch (QueryException $e) {
                         $this->getContainer()->get('monolog.logger.mautic')->error('Query Builder Exception: '.$e->getMessage());
                     }
 
-                    $this->output->writeln(
+                    $output->writeln(
                         '<comment>'.$translator->trans('mautic.lead.list.rebuild.leads_affected', ['%leads%' => $processed]).'</comment>'
                     );
                 }
@@ -118,10 +113,10 @@ class UpdateLeadListsCommand extends ModeratedCommand
                 $l = reset($l);
 
                 if ($l->isPublished()) {
-                    $this->output->writeln('<info>'.$translator->trans('mautic.lead.list.rebuild.rebuilding', ['%id%' => $l->getId()]).'</info>');
+                    $output->writeln('<info>'.$translator->trans('mautic.lead.list.rebuild.rebuilding', ['%id%' => $l->getId()]).'</info>');
 
-                    $processed = $listModel->rebuildListLeads($l, $batch, $max, $this->output);
-                    $this->output->writeln(
+                    $processed = $listModel->rebuildListLeads($l, $batch, $max, $output);
+                    $output->writeln(
                         '<comment>'.$translator->trans('mautic.lead.list.rebuild.leads_affected', ['%leads%' => $processed]).'</comment>'."\n"
                     );
                 }
@@ -136,7 +131,7 @@ class UpdateLeadListsCommand extends ModeratedCommand
 
         if ($enableTimeMeasurement) {
             $totalTime = round(microtime(true) - $startTime, 2);
-            $this->output->writeln("Total time: {$totalTime} seconds");
+            $output->writeln("Total time: {$totalTime} seconds");
         }
 
         return 0;

--- a/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
+++ b/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
@@ -20,7 +20,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdateLeadListsCommand extends ModeratedCommand
 {
-
     protected function configure()
     {
         $this
@@ -71,7 +70,7 @@ class UpdateLeadListsCommand extends ModeratedCommand
         $batch                 = $input->getOption('batch-limit');
         $max                   = $input->getOption('max-contacts');
         $enableTimeMeasurement = (bool) $input->getOption('timing');
-        $output         = ($input->getOption('quiet')) ? new NullOutput() : $output;
+        $output                = ($input->getOption('quiet')) ? new NullOutput() : $output;
 
         if (!$this->checkRunStatus($input, $output, $id)) {
             return 0;


### PR DESCRIPTION
This is useful when the command is run from cron, because cron won't send
an email when nothing is written on the console, avoiding bothering the
administrator if no error was emitted.

Fixes: #10531.

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Issue(s) addressed                     | Fixes #10531 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

See description of bug #10531.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10533"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

