### PR TITLE
Fix sync salesforce if company has name with html entity code of singlequote

### DIFF
--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -603,11 +603,11 @@ class SalesforceApi extends CrmApi
         // Remember that PHP uses \ as an escape. Therefore, to replace a single backslash with 2, must use 2 and 4
         $value = str_replace('\\', '\\\\', $value);
 
-        // Escape single quotes
-        $value = str_replace("'", "\'", $value);
-
         // Apply general formatting/cleanup
         $value = $this->integration->cleanPushData($value);
+
+        // Escape single quotes
+        $value = str_replace("'", "\'", $value);
 
         return $value;
     }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | X
| New feature/enhancement? (use the a.x branch)      | 
| Deprecations?                          | 
| BC breaks? (use the c.x branch)        | 
| Automated tests included?              | X
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #10534

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Fix the issue #10534 .

There was a problem on Salesforce sync when a company was saved on database with the html entity code of the single quote.
The problem was on decode of `escapeQueryValue` function on `SalesforceApi.php` file.
The function did these passages:
1) Replace single quote
2) Decode value
3) Strip tag

If value has an html entity code of string, the replace of single quote has no effect, the decode convert html entity code on a single quote, and the query that try to execute on Salesforce breaks because is malformed.

An example of query that try to execute in this case is `select Id, Description,PersonEmail,Email__c,Name,Keywords__c,Telefono_Alternativo__c,Website from Account where isDeleted = false and Name in ('Fondazione Test' Test')`.

To resolve this bug i move the replace of single quote at the end of function.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Load up [this PR](https://mautibox.com)
2.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
