### PR TITLE
Show form validation errors if an integration is published or if the …

### DIFF
--- a/app/bundles/IntegrationsBundle/Controller/ConfigController.php
+++ b/app/bundles/IntegrationsBundle/Controller/ConfigController.php
@@ -142,11 +142,10 @@ class ConfigController extends AbstractFormController
         $configEvent     = new ConfigSaveEvent($this->integrationConfiguration);
         $eventDispatcher->dispatch(IntegrationEvents::INTEGRATION_CONFIG_BEFORE_SAVE, $configEvent);
 
-        // Show the form if there are errors
-        if (!$this->form->isValid() && (!$this->integrationObject instanceof ConfigFormAuthorizeButtonInterface || $this->integrationObject->isAuthorized())) {
-            // Invalid form data
-            // Integration IS NOT instance of ConfigFormAuthorizeButtonInterface
-            // Integration IS instance of ConfigFormAuthorizeButtonInterface and IS authorized
+        // Show the form if there are errors and the plugin is published or the authorized button was clicked
+        $integrationDetailsPost = $this->request->request->get('integration_details', []);
+        $authorize              = !empty($integrationDetailsPost['in_auth']);
+        if (!$this->form->isValid() && ($this->integrationConfiguration->getIsPublished() || $authorize)) {
             return $this->showForm();
         }
 

--- a/app/bundles/IntegrationsBundle/Controller/ConfigController.php
+++ b/app/bundles/IntegrationsBundle/Controller/ConfigController.php
@@ -151,11 +151,10 @@ class ConfigController extends AbstractFormController
         $configEvent     = new ConfigSaveEvent($this->integrationConfiguration);
         $eventDispatcher->dispatch(IntegrationEvents::INTEGRATION_CONFIG_BEFORE_SAVE, $configEvent);
 
-        // Show the form if there are errors
-        if (!$this->form->isValid() && (!$this->integrationObject instanceof ConfigFormAuthorizeButtonInterface || $this->integrationObject->isAuthorized())) {
-            // Invalid form data
-            // Integration IS NOT instance of ConfigFormAuthorizeButtonInterface
-            // Integration IS instance of ConfigFormAuthorizeButtonInterface and IS authorized
+        // Show the form if there are errors and the plugin is published or the authorized button was clicked
+        $integrationDetailsPost = $this->request->request->get('integration_details', []);
+        $authorize              = !empty($integrationDetailsPost['in_auth']);
+        if (!$this->form->isValid() && ($this->integrationConfiguration->getIsPublished() || $authorize)) {
             return $this->showForm();
         }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | 
| Related user documentation PR URL |  
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
The problem with this is that form validation was ignored for integrations that are not already authorized but you can't authorize without API keys. This PR changes the behavior to instead show form validation errors if the plugin is published or if the authorize button was clicked which typically happens before publishing. 

Note: The mautic does not have an applicable plugin in the core. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
 

#### Other areas of Mautic that may be affected by the change:
1. Other integration configurations are potentially affected by this and why testing different plugins above should be done. Note that although some fields are marked with a required asterisk, the fields don't have coded constraints and thus will not return validation failures. Symfony forms have a "required" parameter on form fields but that only affects the UI where the validation must still be defined via constraints on the field. 

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
NA

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10539"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

