### PR TITLE
Add support for default language in segment date string filter

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -1159,6 +1159,7 @@ return [
                 'class'     => \Mautic\LeadBundle\Segment\RelativeDate::class,
                 'arguments' => [
                     'translator',
+                    'mautic.helper.core_parameters'
                 ],
             ],
             'mautic.lead.model.lead_segment_filter_operator' => [

--- a/app/bundles/LeadBundle/Form/DataTransformer/FieldFilterTransformer.php
+++ b/app/bundles/LeadBundle/Form/DataTransformer/FieldFilterTransformer.php
@@ -31,13 +31,13 @@ class FieldFilterTransformer implements DataTransformerInterface
     public function __construct($translator, $default = [])
     {
         $this->relativeDateStrings = LeadListRepository::getRelativeDateTranslationKeys();
-        $defaultStrings = [];
+        $defaultStrings            = [];
         foreach ($this->relativeDateStrings as &$string) {
-            $defaultStrings[] = $translator->trans($string, [], null, 'en_US');;
-            $string = $translator->trans($string);
+            $defaultStrings[] = $translator->trans($string, [], null, 'en_US');
+            $string           = $translator->trans($string);
         }
         $this->relativeDateStrings = array_merge($this->relativeDateStrings, $defaultStrings);
-        $this->default = $default;
+        $this->default             = $default;
     }
 
     /**

--- a/app/bundles/LeadBundle/Form/DataTransformer/FieldFilterTransformer.php
+++ b/app/bundles/LeadBundle/Form/DataTransformer/FieldFilterTransformer.php
@@ -31,9 +31,12 @@ class FieldFilterTransformer implements DataTransformerInterface
     public function __construct($translator, $default = [])
     {
         $this->relativeDateStrings = LeadListRepository::getRelativeDateTranslationKeys();
+        $defaultStrings = [];
         foreach ($this->relativeDateStrings as &$string) {
+            $defaultStrings[] = $translator->trans($string, [], null, 'en_US');;
             $string = $translator->trans($string);
         }
+        $this->relativeDateStrings = array_merge($this->relativeDateStrings, $defaultStrings);
         $this->default = $default;
     }
 

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionFactory.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionFactory.php
@@ -65,8 +65,11 @@ class DateOptionFactory
     {
         $originalValue        = $leadSegmentFilterCrate->getFilter();
         $relativeDateStrings  = $this->relativeDate->getRelativeDateStrings();
+
         $dateOptionParameters = new DateOptionParameters($leadSegmentFilterCrate, $relativeDateStrings, $this->timezoneResolver);
+
         $timeframe            = $this->relativeDate->getParsedTimeFrame($leadSegmentFilterCrate->getFilter());
+
         if (!$timeframe) {
             return new DateDefault($this->dateDecorator, $originalValue);
         }

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionFactory.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionFactory.php
@@ -65,15 +65,11 @@ class DateOptionFactory
     {
         $originalValue        = $leadSegmentFilterCrate->getFilter();
         $relativeDateStrings  = $this->relativeDate->getRelativeDateStrings();
-
         $dateOptionParameters = new DateOptionParameters($leadSegmentFilterCrate, $relativeDateStrings, $this->timezoneResolver);
-
-        $timeframe = $dateOptionParameters->getTimeframe();
-
+        $timeframe = $this->relativeDate->getParsedTimeFrame($leadSegmentFilterCrate->getFilter());
         if (!$timeframe) {
             return new DateDefault($this->dateDecorator, $originalValue);
         }
-
         switch ($timeframe) {
             case 'birthday':
             case 'anniversary':

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionFactory.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionFactory.php
@@ -66,7 +66,7 @@ class DateOptionFactory
         $originalValue        = $leadSegmentFilterCrate->getFilter();
         $relativeDateStrings  = $this->relativeDate->getRelativeDateStrings();
         $dateOptionParameters = new DateOptionParameters($leadSegmentFilterCrate, $relativeDateStrings, $this->timezoneResolver);
-        $timeframe = $this->relativeDate->getParsedTimeFrame($leadSegmentFilterCrate->getFilter());
+        $timeframe            = $this->relativeDate->getParsedTimeFrame($leadSegmentFilterCrate->getFilter());
         if (!$timeframe) {
             return new DateDefault($this->dateDecorator, $originalValue);
         }

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionFactory.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionFactory.php
@@ -73,6 +73,7 @@ class DateOptionFactory
         if (!$timeframe) {
             return new DateDefault($this->dateDecorator, $originalValue);
         }
+
         switch ($timeframe) {
             case 'birthday':
             case 'anniversary':

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateAnniversary.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateAnniversary.php
@@ -74,7 +74,6 @@ class DateAnniversary implements FilterDecoratorInterface
     public function getParameterValue(ContactSegmentFilterCrate $contactSegmentFilterCrate)
     {
         $date           = $this->dateOptionParameters->getDefaultDate();
-        $filter         =  $contactSegmentFilterCrate->getFilter();
 
         $relativeFilter =  trim(str_replace(['anniversary', 'birthday'], '', $this->dateOptionParameters->getTimeframe()));
 

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateAnniversary.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateAnniversary.php
@@ -75,7 +75,8 @@ class DateAnniversary implements FilterDecoratorInterface
     {
         $date           = $this->dateOptionParameters->getDefaultDate();
         $filter         =  $contactSegmentFilterCrate->getFilter();
-        $relativeFilter =  trim(str_replace(['anniversary', 'birthday'], '', $filter));
+
+        $relativeFilter =  trim(str_replace(['anniversary', 'birthday'], '', $this->dateOptionParameters->getTimeframe()));
 
         if ($relativeFilter) {
             $date->modify($relativeFilter);

--- a/app/bundles/LeadBundle/Segment/RelativeDate.php
+++ b/app/bundles/LeadBundle/Segment/RelativeDate.php
@@ -26,28 +26,13 @@ class RelativeDate
     /**
      * @return array
      */
-    public function getRelativeDateStrings()
+    public function getRelativeDateStrings(string $locale = null)
     {
         $keys = $this->getRelativeDateTranslationKeys();
 
         $strings = [];
         foreach ($keys as $key) {
-            $strings[$key] = $this->translator->trans($key);
-        }
-
-        return $strings;
-    }
-
-    /**
-     * @return array
-     */
-    public function getDefaultRelativeDateStrings()
-    {
-        $keys = $this->getRelativeDateTranslationKeys();
-
-        $strings = [];
-        foreach ($keys as $key) {
-            $strings[$key] = $this->translator->trans($key, [], null, 'en_US');
+            $strings[$key] = $this->translator->trans($key, [], null, $locale);
         }
 
         return $strings;
@@ -55,8 +40,8 @@ class RelativeDate
 
     public function getParsedTimeFrame(string $filter): string
     {
-        $key = array_search($filter, $this->getRelativeDateStrings(), true);
-        $key = (false === $key) ? array_search($filter, $this->getDefaultRelativeDateStrings(), true) : $key;
+        $key = array_key($filter, $this->getRelativeDateStrings(), true);
+        $key = (false === $key) ? array_search($filter, $this->getRelativeDateStrings('en_US'), true) : $key;
         if (false === $key) {
             // Time frame does not match any option from $relativeDateStrings, so return original value
             return $filter;

--- a/app/bundles/LeadBundle/Segment/RelativeDate.php
+++ b/app/bundles/LeadBundle/Segment/RelativeDate.php
@@ -38,7 +38,7 @@ class RelativeDate
         return $strings;
     }
 
-    public function getParsedTimeFrame(string $filter): string
+    public function getParsedTimeFrame(string $filter = null): ?string
     {
         $key = array_search($filter, $this->getRelativeDateStrings(), true);
         $key = (false === $key) ? array_search($filter, $this->getRelativeDateStrings('en_US'), true) : $key;

--- a/app/bundles/LeadBundle/Segment/RelativeDate.php
+++ b/app/bundles/LeadBundle/Segment/RelativeDate.php
@@ -40,7 +40,7 @@ class RelativeDate
 
     public function getParsedTimeFrame(string $filter): string
     {
-        $key = array_key($filter, $this->getRelativeDateStrings(), true);
+        $key = array_search($filter, $this->getRelativeDateStrings(), true);
         $key = (false === $key) ? array_search($filter, $this->getRelativeDateStrings('en_US'), true) : $key;
         if (false === $key) {
             // Time frame does not match any option from $relativeDateStrings, so return original value

--- a/app/bundles/LeadBundle/Segment/RelativeDate.php
+++ b/app/bundles/LeadBundle/Segment/RelativeDate.php
@@ -41,6 +41,34 @@ class RelativeDate
     /**
      * @return array
      */
+    public function getDefaultRelativeDateStrings()
+    {
+        $keys = $this->getRelativeDateTranslationKeys();
+
+        $strings = [];
+        foreach ($keys as $key) {
+            $strings[$key] = $this->translator->trans($key, [], null, 'en_US');
+
+        }
+
+        return $strings;
+    }
+
+    public function getParsedTimeFrame(string $filter): string
+    {
+        $key = array_search($filter, $this->getRelativeDateStrings(), true);
+        $key = (false === $key) ? array_search($filter, $this->getDefaultRelativeDateStrings(), true) : $key;
+        if (false === $key) {
+            // Time frame does not match any option from $relativeDateStrings, so return original value
+            return $filter;
+        }
+
+        return str_replace('mautic.lead.list.', '', $key);
+    }
+
+    /**
+     * @return array
+     */
     private function getRelativeDateTranslationKeys()
     {
         return [

--- a/app/bundles/LeadBundle/Segment/RelativeDate.php
+++ b/app/bundles/LeadBundle/Segment/RelativeDate.php
@@ -48,7 +48,6 @@ class RelativeDate
         $strings = [];
         foreach ($keys as $key) {
             $strings[$key] = $this->translator->trans($key, [], null, 'en_US');
-
         }
 
         return $strings;

--- a/app/bundles/LeadBundle/Segment/RelativeDate.php
+++ b/app/bundles/LeadBundle/Segment/RelativeDate.php
@@ -11,16 +11,20 @@
 
 namespace Mautic\LeadBundle\Segment;
 
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class RelativeDate
 {
+    private CoreParametersHelper $coreParametersHelper;
+
     /** @var TranslatorInterface */
     private $translator;
 
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(TranslatorInterface $translator, CoreParametersHelper $coreParametersHelper)
     {
         $this->translator = $translator;
+        $this->coreParametersHelper = $coreParametersHelper;
     }
 
     /**
@@ -28,13 +32,15 @@ class RelativeDate
      */
     public function getRelativeDateStrings(string $locale = null)
     {
+        if ($locale === null) {
+            $locale = $this->coreParametersHelper->get('locale');
+        }
         $keys = $this->getRelativeDateTranslationKeys();
 
         $strings = [];
         foreach ($keys as $key) {
             $strings[$key] = $this->translator->trans($key, [], null, $locale);
         }
-
         return $strings;
     }
 

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/DateOptionFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/DateOptionFactoryTest.php
@@ -267,25 +267,36 @@ class DateOptionFactoryTest extends \PHPUnit\Framework\TestCase
         $relativeDate     = $this->createMock(RelativeDate::class);
         $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
+        $dates = [
+            'mautic.lead.list.month_last'  => 'last month',
+            'mautic.lead.list.month_next'  => 'next month',
+            'mautic.lead.list.month_this'  => 'this month',
+            'mautic.lead.list.today'       => 'today',
+            'mautic.lead.list.tomorrow'    => 'tomorrow',
+            'mautic.lead.list.yesterday'   => 'yesterday',
+            'mautic.lead.list.week_last'   => 'last week',
+            'mautic.lead.list.week_next'   => 'next week',
+            'mautic.lead.list.week_this'   => 'this week',
+            'mautic.lead.list.year_last'   => 'last year',
+            'mautic.lead.list.year_next'   => 'next year',
+            'mautic.lead.list.year_this'   => 'this year',
+            'mautic.lead.list.birthday'    => 'birthday',
+            'mautic.lead.list.anniversary' => 'anniversary',
+            'mautic.lead.list.day'         => 'day',
+            'mautic.lead.list.month'       => 'month',
+        ];
         $relativeDate->method('getRelativeDateStrings')
             ->willReturn(
-                [
-                    'mautic.lead.list.month_last'  => 'last month',
-                    'mautic.lead.list.month_next'  => 'next month',
-                    'mautic.lead.list.month_this'  => 'this month',
-                    'mautic.lead.list.today'       => 'today',
-                    'mautic.lead.list.tomorrow'    => 'tomorrow',
-                    'mautic.lead.list.yesterday'   => 'yesterday',
-                    'mautic.lead.list.week_last'   => 'last week',
-                    'mautic.lead.list.week_next'   => 'next week',
-                    'mautic.lead.list.week_this'   => 'this week',
-                    'mautic.lead.list.year_last'   => 'last year',
-                    'mautic.lead.list.year_next'   => 'next year',
-                    'mautic.lead.list.year_this'   => 'this year',
-                    'mautic.lead.list.birthday'    => 'birthday',
-                    'mautic.lead.list.anniversary' => 'anniversary',
-                ]
+                $dates
             );
+
+        $relativeDate->method('getParsedTimeFrame')
+            ->with($filterName)
+            ->willReturnCallback(function ($filter) use ($dates) {
+                $key = array_search($filter, $dates, true);
+
+                return false === $key ? $filter : str_replace('mautic.lead.list.', '', $key);
+            });
 
         $dateOptionFactory = new DateOptionFactory($dateDecorator, $relativeDate, $timezoneResolver);
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

If you are using different language in configuration. Then you are able to use just date strings from your language. This PR added support also for default en_US locale text strings. Without these default string it could cause some issue after add translations to transifex atc.

For example when we add new date filters strings https://github.com/mautic/mautic/pull/10542 and these translation does not exist in Transifex we are able to use just EN phrases. After update translations, just French phrases were allowed. 

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Load up [this PR](https://mautibox.com)
2. Switch Mautic to French
3. Create segment with date filter equal = today
4. Create segment with date filter equal = aujourd'hui (french translation of today)
5. Test both segment, should works
6. Before just segment with filter `aujourd'hui`

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
