### PR TITLE
PHPSTAN baseline + level 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
       "@remove-git-submodules"
     ],
     "test": "bin/phpunit -d memory_limit=1G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist",
-    "phpstan": "bin/phpstan analyse app/bundles app/migrations plugins",
+    "phpstan": "php -d memory_limit=4G bin/phpstan analyse",
     "cs": "bin/php-cs-fixer fix -v --dry-run --diff",
     "fixcs": "bin/php-cs-fixer fix -v",
     "rector": "bin/rector process",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,17 @@
+includes:
+	- phpstan-baseline.neon
+	- vendor/phpstan/phpstan/conf/bleedingEdge.neon
+
 parameters:
-	level: 1
+	level: 6
+	reportUnmatchedIgnoredErrors: false
+	parallel:
+		maximumNumberOfProcesses: 1
+		processTimeout: 1000.0
+	paths:
+		- app/bundles
+		- app/migrations
+		- plugins
 	excludes_analyse:
 		- *.html.php
 		- *.js.php


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [x] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR was sparked by an incident caused by the type casting having priority over null coalescing operator. It happened for the second time. It is easy to overlook this during development and code review. You can see the problem here:

https://phpstan.org/r/99fb1188-a6d8-46e1-a42d-01d3a262caa7

PHPSTAN can discover these bugs with level 4+ and bleeding edge. Now the question was how to turn this on only on the code changed in the new PRs because no one has resources to fix all the existing PHPSTAN problems. Luckily, PHPSAN has feature called [Baseline](https://phpstan.org/user-guide/baseline). This will dump all existing errors to a single file and it will ignore those errors. This way only the new errors will be reported.

Here is how the baseline file is generated:
```
$ bin/phpstan clear-result-cache && php -d memory_limit=4G bin/phpstan analyse --generate-baseline
Note: Using configuration file /var/www/html/phpstan.neon.
Result cache cleared from directory:
/tmp/phpstan
Note: Using configuration file /var/www/html/phpstan.neon.
 3056/3056 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
                                                                                                                        
 [OK] Baseline generated with 21344 errors.
```

This PR will cause troubles for the open PRs as those will fail if some problem will be found by PHPSTAN, but there will never be better time to merge this and **improve the code quality by automated checks with quick feedback loop** then now. It will also save time for code reviewers as many issues will be reported by this tool. I'm happy to assist and fix whatever PHPSTAN finds in open PRs.

#### Steps to test this PR:

No need to test. Just check the green CI checks.