### PR TITLE
Fix Amazon SES API transport multiple unsubscribe header using send immediately

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonApiTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/AmazonApiTransport.php
@@ -393,6 +393,11 @@ class AmazonApiTransport extends AbstractTokenArrayTransport implements \Swift_T
                 if (isset($tokenizedMessage['headers'])) {
                     $headers = $toSendMessage->getHeaders();
                     foreach ($tokenizedMessage['headers'] as $key => $value) {
+                        if ('List-Unsubscribe' === $key) {
+                            $listUnsubscribe = array_map('trim', explode(',', $value));
+                            $listUnsubscribe = array_filter($listUnsubscribe, fn ($el) => strpos($el, $mailData['hashId']));
+                            $value           = implode(',', $listUnsubscribe);
+                        }
                         $headers->addTextHeader($key, $value);
                     }
                 }

--- a/app/bundles/EmailBundle/Tests/Transport/AmazonApiTransportTest.php
+++ b/app/bundles/EmailBundle/Tests/Transport/AmazonApiTransportTest.php
@@ -167,6 +167,132 @@ class AmazonApiTransportTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, $sent);
     }
 
+    public function testGetAmazonMessageBatch()
+    {
+        $emailBody = <<< 'EOD'
+Hi {contactfield=firstname},
+lorem ipsum dolor.   
+     
+{signature}
+
+{unsubscribe_text}
+EOD;
+
+        $recipient1Email = 'johnny.cage@teleworm.us';
+        $recipient2Email = 'noob.saibot@teleworm.us';
+
+        $recipient1Metadata = [
+            'name'        => 'Johnny Cage',
+            'leadId'      => 1,
+            'emailId'     => 1,
+            'emailName'   => 'Test batch email',
+            'hashId'      => '5f86a61cc8084320276637',
+            'hashIdState' => true,
+            'source'      => [
+                'campaign.event',
+                23,
+            ],
+            'tokens' => [
+                '{dynamiccontent="Dynamic Content 1"}' => 'Default Dynamic Content',
+                '{unsubscribe_text}'                   => '<a href="https://mautic.local/email/unsubscribe/5f86a61cc8084320276637">Unsubscribe</a> to no longer receive emails from us.',
+                '{unsubscribe_url}'                    => 'https://mautic.local/email/unsubscribe/5f86a61cc8084320276637',
+                '{webview_text}'                       => '<a href="https://mautic.local/email/view/5f86a61cc8084320276637">Having trouble reading this email? Click here.</a>',
+                '{webview_url}'                        => 'https://mautic.local/email/view/5f86a61cc8084320276637',
+                '{signature}'                          => 'Best regards, Johnny Cage',
+                '{subject}'                            => 'Test batch email',
+                '{contactfield=firstname}'             => 'Johnny',
+                '{contactfield=lastname}'              => 'Cage',
+                '{ownerfield=email}'                   => '',
+                '{ownerfield=firstname}'               => '',
+                '{ownerfield=lastname}'                => '',
+                '{ownerfield=position}'                => '',
+                '{ownerfield=signature}'               => '',
+                '{tracking_pixel}'                     => 'https://mautic.local/email/5f86a61cc8084320276637.gif',
+            ],
+            'utmTags' => [
+                'utmSource'   => 'c_source',
+                'utmMedium'   => 'c_medium',
+                'utmCampaign' => 'c_name',
+                'utmContent'  => 'c_content',
+            ],
+        ];
+        $recipient2Metadata = [
+            'name'        => 'Noob Saibot',
+            'leadId'      => 2,
+            'emailId'     => 1,
+            'emailName'   => 'Test batch email',
+            'hashId'      => '6f86a61cc415555ecf6412',
+            'hashIdState' => true,
+            'source'      => [
+                'campaign.event',
+                23,
+            ],
+            'tokens' => [
+                '{dynamiccontent="Dynamic Content 1"}' => 'Default Dynamic Content',
+                '{unsubscribe_text}'                   => '<a href="https://mautic.local/email/unsubscribe/6f86a61cc415555ecf6412">Unsubscribe</a> to no longer receive emails from us.',
+                '{unsubscribe_url}'                    => 'https://mautic.local/email/unsubscribe/6f86a61cc415555ecf6412',
+                '{webview_text}'                       => '<a href="https://mautic.local/email/view/6f86a61cc415555ecf6412">Having trouble reading this email? Click here.</a>',
+                '{webview_url}'                        => 'https://mautic.local/email/view/6f86a61cc415555ecf6412',
+                '{signature}'                          => 'Best regards, Noob Saibot',
+                '{subject}'                            => 'Test batch email',
+                '{contactfield=firstname}'             => 'Noob',
+                '{contactfield=lastname}'              => 'Saibot',
+                '{ownerfield=email}'                   => '',
+                '{ownerfield=firstname}'               => '',
+                '{ownerfield=lastname}'                => '',
+                '{ownerfield=position}'                => '',
+                '{ownerfield=signature}'               => '',
+                '{tracking_pixel}'                     => 'https://mautic.local/email/6f86a61cc415555ecf6412.gif',
+            ],
+            'utmTags' => [
+                'utmSource'   => 'c_source',
+                'utmMedium'   => 'c_medium',
+                'utmCampaign' => 'c_name',
+                'utmContent'  => 'c_content',
+            ],
+        ];
+
+        $fromEmail = 'shang.tsung@teleworm.us';
+        $fromName  = 'Shang Tsung';
+        $subject   = 'Test batch email';
+
+        $msg = new MauticMessage($subject, $emailBody, 'text/html', 'utf-8');
+        $msg->addMetadata($recipient1Email, $recipient1Metadata);
+        $msg->addMetadata($recipient2Email, $recipient2Metadata);
+        $msg->setFrom($fromEmail, $fromName);
+        $msg->setTo([
+            $recipient1Email => $recipient1Metadata['name'],
+            $recipient2Email => $recipient2Metadata['name'],
+        ]);
+        $msg->setSubject($subject);
+        $msg->setBody($emailBody, 'text/html', 'utf-8');
+
+        // Mautic creates Unsubscribe-List header with for all message recipients, this should be filtered
+        $msg->getHeaders()->addTextHeader('List-Unsubscribe', '<mailto:return+unsubscribe_5f86a61cc8084320276637@teleworm.us>, <mailto:return+unsubscribe_6f86a61cc415555ecf6412@teleworm.us>, <http://mautic.local/email/unsubscribe/5f86a61cc8084320276637>,<http://mautic.local/email/unsubscribe/6f86a61cc415555ecf6412>');
+
+        $amazonMessages = iterator_to_array($this->amazonTransport->getAmazonMessage($msg));
+
+        $this->assertCount(2, $amazonMessages);
+        $this->assertEquals([
+            'ToAddresses'  => ['johnny.cage@teleworm.us'],
+        ], $amazonMessages[0]['Destination']);
+        $this->assertEquals([
+            'ToAddresses'  => ['noob.saibot@teleworm.us'],
+        ], $amazonMessages[1]['Destination']);
+
+        // Test replaced tokens
+        $this->assertStringContainsString('Hi Johnny', $amazonMessages[0]['Content']['Raw']['Data']);
+        $this->assertStringContainsString('Hi Noob', $amazonMessages[1]['Content']['Raw']['Data']);
+
+        // We want to ensure that the hashes of other leads will not be compromised when sending batch emails
+        $this->assertStringNotContainsString('6f86a61cc415555ecf6412', $amazonMessages[0]['Content']['Raw']['Data']);
+        $this->assertStringNotContainsString('5f86a61cc8084320276637', $amazonMessages[1]['Content']['Raw']['Data']);
+
+        // Persist filtered List-Unsubscribe header
+        $this->assertStringContainsString('List-Unsubscribe: <mailto:return+unsubscribe_5f86a61cc8084320276637@teleworm.us>,<http://mautic.local/email/unsubscribe/5f86a61cc8084320276637>', $amazonMessages[0]['Content']['Raw']['Data']);
+        $this->assertStringContainsString('List-Unsubscribe: <mailto:return+unsubscribe_6f86a61cc415555ecf6412@teleworm.us>,<http://mautic.local/email/unsubscribe/6f86a61cc415555ecf6412>', $amazonMessages[1]['Content']['Raw']['Data']);
+    }
+
     public function testprocessInvalidJsonRequest()
     {
         $payload = <<< 'PAYLOAD'


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | Y
| New feature/enhancement? (use the a.x branch)      | N
| Deprecations?                          | N
| BC breaks? (use the c.x branch)        | N
| Automated tests included?              | Y <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Marketing email messages sent immediately in batches through Amazon SES API generates multiple unsubscribe header. The `List-unsubscribe` header will contain unsubscribe URL's for all the contacts in batch.

#### Steps to reproduce issue:
1. Setup Mautic with `Amazon SES - API` email setting
2. Set `How should email be handled?` to `Send immediately`
3. Create and send email to segment with at least 2 contacts
4. Check the `List-Unsubscribe` header in received email. It should contain unsubscribe link* for all contacts in the batch.

![obraz](https://user-images.githubusercontent.com/8580942/138891386-05e9f107-b3fe-4721-afb6-6b280578f4d3.png)

\* If you have unsubscribe mailbox monitoring active then email address also will appear alongside with the links.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Repeat 1-3 steps to reproduce
2. `List-Unsubscribe` header should contain only data for the message recipient

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
