### PR TITLE
WIP - getEmailPendingQuery performance improvements

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -168,47 +168,46 @@ class EmailRepository extends CommonRepository
         $minContactId = null,
         $maxContactId = null,
         $countWithMaxMin = false
-    ) {
+        ) {
+        
+        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        
         // Do not include leads in the do not contact table
-        $dncQb = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $dncQb->select('null')
-            ->from(MAUTIC_TABLE_PREFIX.'lead_donotcontact', 'dnc')
-            ->where(
-                $dncQb->expr()->andX(
-                    $dncQb->expr()->eq('dnc.lead_id', 'l.id'),
-                    $dncQb->expr()->eq('dnc.channel', $dncQb->expr()->literal('email'))
-                )
-            );
+        $dncExpr = $q->expr()->and(
+            $q->expr()->eq('dnc.lead_id', 'll.lead_id'),
+            $q->expr()->eq('dnc.channel', $q->expr()->literal('email'))
+        );
 
         // Do not include contacts where the message is pending in the message queue
-        $mqQb = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $mqQb->select('null')
-            ->from(MAUTIC_TABLE_PREFIX.'message_queue', 'mq')
-            ->where(
-                $mqQb->expr()->andX(
-                    $mqQb->expr()->eq('mq.lead_id', 'l.id'),
-                    $mqQb->expr()->neq('mq.status', $mqQb->expr()->literal(MessageQueue::STATUS_SENT)),
-                    $mqQb->expr()->eq('mq.channel', $mqQb->expr()->literal('email'))
-                )
-            );
+        $mqExpr = $q->expr()->and(
+            $q->expr()->eq('mq.lead_id', 'll.lead_id'),
+            $q->expr()->neq('mq.status', $q->expr()->literal(MessageQueue::STATUS_SENT)),
+            $q->expr()->eq('mq.channel', $q->expr()->literal('email'))
+        );
 
         // Do not include leads that have already been emailed
-        $statQb = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $statQb->select('null')
-            ->from(MAUTIC_TABLE_PREFIX.'email_stats', 'stat')
-            ->where(
-                $statQb->expr()->eq('stat.lead_id', 'l.id')
-            );
-
+        $statExpr = $q->expr()->eq('stat.lead_id', 'll.lead_id');
         if ($variantIds) {
             if (!in_array($emailId, $variantIds)) {
                 $variantIds[] = (int) $emailId;
             }
-            $statQb->andWhere($statQb->expr()->in('stat.email_id', $variantIds));
-            $mqQb->andWhere($mqQb->expr()->in('mq.channel_id', $variantIds));
+            $statExpr = $q->expr()->and(
+                $statExpr,
+                $q->expr()->in('stat.email_id', $variantIds)
+            );
+            $mqExpr = $q->expr()->and(
+                $mqExpr,
+                $q->expr()->in('mq.channel_id', $variantIds)
+            );
         } else {
-            $statQb->andWhere($statQb->expr()->eq('stat.email_id', (int) $emailId));
-            $mqQb->andWhere($mqQb->expr()->eq('mq.channel_id', (int) $emailId));
+            $statExpr = $q->expr()->and(
+                $statExpr,
+                $q->expr()->eq('stat.email_id', (int) $emailId)
+            );
+            $mqExpr = $q->expr()->and(
+                $mqExpr,
+                $q->expr()->eq('mq.channel_id', (int) $emailId)
+            );
         }
 
         // Only include those who belong to the associated lead lists
@@ -235,44 +234,44 @@ class EmailRepository extends CommonRepository
         }
 
         // Only include those in associated segments
-        $segmentQb = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $segmentQb->select('null')
-            ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'll')
-            ->where(
-                $segmentQb->expr()->andX(
-                    $segmentQb->expr()->eq('ll.lead_id', 'l.id'),
-                    $segmentQb->expr()->in('ll.leadlist_id', $listIds),
-                    $segmentQb->expr()->eq('ll.manually_removed', ':false')
-                )
-            );
+        $segmentExpr = $q->expr()->and(
+            $q->expr()->in('ll.leadlist_id', $listIds),
+            $q->expr()->eq('ll.manually_removed', ':false')
+        );
 
         // Main query
-        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
         if ($countOnly) {
-            $q->select('count(*) as count');
+            $q->select('count(distinct ll.lead_id) as count');
             if ($countWithMaxMin) {
-                $q->addSelect('MIN(l.id) as min_id, MAX(l.id) as max_id');
+                $q->addSelect('MIN(ll.lead_id) as min_id, MAX(ll.lead_id) as max_id');
             }
         } else {
-            $q->select('l.*');
+            $q->select('distinct l.*');
         }
 
-        $q->from(MAUTIC_TABLE_PREFIX.'leads', 'l')
-            ->andWhere(sprintf('EXISTS (%s)', $segmentQb->getSQL()))
-            ->andWhere(sprintf('NOT EXISTS (%s)', $dncQb->getSQL()))
-            ->andWhere(sprintf('NOT EXISTS (%s)', $statQb->getSQL()))
-            ->andWhere(sprintf('NOT EXISTS (%s)', $mqQb->getSQL()))
+        // Has an email
+        $leadExpr = $q->expr()->and(
+            $q->expr()->eq('l.id', 'll.lead_id'),
+            $q->expr()->isNotNull('l.email'),
+            $q->expr()->neq('l.email', $q->expr()->literal(''))
+        );
+
+        $segmentExpr = $q->expr()->and(
+            $q->expr()->isNull('stat.id'),
+            $q->expr()->isNull('dnc.id'),
+            $q->expr()->isNull('mq.id'),
+            $segmentExpr
+        );
+
+        $q->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'll')
+            ->innerJoin('ll', MAUTIC_TABLE_PREFIX.'leads', 'l USE INDEX(leads_id_email)', $leadExpr)
+            ->leftJoin('ll', MAUTIC_TABLE_PREFIX.'email_stats', 'stat', $statExpr)
+            ->leftJoin('ll', MAUTIC_TABLE_PREFIX.'lead_donotcontact', 'dnc', $dncExpr)
+            ->leftJoin('ll', MAUTIC_TABLE_PREFIX.'message_queue', 'mq', $mqExpr)
+            ->where($segmentExpr)
             ->setParameter('false', false, 'boolean');
 
         $q = $this->setMinMaxIds($q, 'l.id', $minContactId, $maxContactId);
-
-        // Has an email
-        $q->andWhere(
-            $q->expr()->andX(
-                $q->expr()->isNotNull('l.email'),
-                $q->expr()->neq('l.email', $q->expr()->literal(''))
-            )
-        );
 
         if (!empty($limit)) {
             $q->setFirstResult(0)

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -244,7 +244,8 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
             ->addLifecycleEvent('checkAttributionDate', 'prePersist')
             ->addLifecycleEvent('checkDateAdded', 'prePersist')
             ->addIndex(['date_added'], 'lead_date_added')
-            ->addIndex(['date_identified'], 'date_identified');
+            ->addIndex(['date_identified'], 'date_identified')
+            ->addIndex(['id', 'email'], 'leads_id_email');
 
         $builder->addBigIntIdField();
 

--- a/app/migrations/Version20211108171716.php
+++ b/app/migrations/Version20211108171716.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2021 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        https://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\SkipMigration;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+final class Version20211108171716 extends AbstractMauticMigration
+{
+    /**
+     * @throws SkipMigration
+     */
+    public function preUp(Schema $schema): void
+    {
+        $table = $schema->getTable($this->prefix.'leads');
+        if ($table->hasIndex('leads_id_email')) {
+            throw new SkipMigration('Schema includes this migration');
+        }
+
+        parent::preUp($schema);
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX '.$this->prefix.'leads_id_email ON '.$this->prefix.'leads (id, email)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX '.$this->prefix.'leads_id_email ON '.$this->prefix.'leads');
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [X]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR changes the getEmailPendingQuery method in a couple of ways to make the final query much faster with our dataset of 2M leads. This query is used both when accessing an email details, and multiple times while sending pending emails.
In our tests, performance of the query has improved 10X.

**Changes**
- Instead of using EXISTS subqueries to apply conditions, we use filters on INNER/LEFT joins (as appropriate) and then retrieve/count distinct instances.
- We inverted the whole query to start from lead_lists_leads and then join with leads, instead of querying FROM leads.
- We added an index to the leads table for the join to be faster. The index is explicitly suggested via "USE INDEX(leads_id_email)" since it was not being picked up by default.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
**WIP**
1. Manually create our added index: `CREATE INDEX leads_id_email ON leads (id, email)`
2. Test `getEmailPendingQuery `performance through the different functionalities where it's used (looking into an email detail / sending an email)

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10585"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

