### PR TITLE
Removed composer v1 requirement in README (and hoping this will address the CodeCov issue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The GitHub version is recommended for both development and testing. The producti
 *Also note that source code outside of a [tagged release][tagged-release] should be considered ‘alpha’. It may contain bugs, cause unexpected results, data corruption or loss, and is not recommended for use in a production environment. Use at your own risk.*
 
 ### How to install Mautic
-You must already have [Composer v1][composer-v1] available on your computer because this is a development release and you'll need Composer to download the vendor packages. Note that Composer v2 is not yet supported.
+You must already have [Composer][composer] available on your computer because this is a development release and you'll need Composer to download the vendor packages.
 
 Also note that if you have DDEV installed, you can run 'ddev config' followed by 'ddev start'. This will kick off the Mautic first-run process which will automatically install dependencies and configure Mautic for use. ✨ 🚀 Read more [here][ddev-mautic]
 
@@ -154,7 +154,7 @@ This project follows the [all-contributors][all-contributors] specification. Con
 [t1-issues]: <https://github.com/mautic/mautic/issues?q=is%3Aissue+is%3Aopen+label%3AT1>
 [download-mautic]: <https://www.mautic.org/download>
 [tagged-release]: <https://github.com/mautic/mautic/releases>
-[composer-v1]: <http://getcomposer.org/>
+[composer]: <http://getcomposer.org/>
 [download-zip]: <https://github.com/mautic/mautic/archive/refs/heads/features.zip>
 [ddev-mautic]: <https://kb.mautic.org/knowledgebase/development/how-to-install-mautic-using-ddev>
 [troubleshooting]: <https://docs.mautic.org/en/troubleshooting>


### PR DESCRIPTION
We continue to have issues with CodeCov for PRs compared against the 4.0 branch. That's because one of the builds in https://codecov.io/gh/mautic/mautic/commit/2ba0eb796b9823d7ac391d406a6b67f51ce144ee/build ([1390283338](https://codecov.io/api/gh/mautic/mautic/download/build?path=v4/raw/2021-10-27/A11556F6B0D89FD9D7685F6BDFA35F23/2ba0eb796b9823d7ac391d406a6b67f51ce144ee/5b946894-1c26-4b60-9f27-9bb32756670c.txt)) references lines that don't match up with the branch's code and thus shows coverage that doesn't exist. Build [1390283027](https://codecov.io/api/gh/mautic/mautic/download/build?path=v4/raw/2021-10-27/A11556F6B0D89FD9D7685F6BDFA35F23/2ba0eb796b9823d7ac391d406a6b67f51ce144ee/1b48e65e-f1cc-445f-90e1-9197c3bf3aec.txt) lines match that of the branch's code. I'm not sure how or why this commit has two build reports uploaded near the same time that references different code bases but I'm hoping yet another PR merge will fix this. 

I'll assume it will also fail CodeCov project diff as it will be compared to  2ba0eb796b9823d7ac391d406a6b67f51ce144e with the bad build report but we still need to merge this. 

To have something legitimate, I removed the composer v1 requirement from the README as v2 works for M4. 