### PR TITLE
Update split-monorepo-in-multi-repo.yml

### DIFF
--- a/.github/workflows/split-monorepo-in-multi-repo.yml
+++ b/.github/workflows/split-monorepo-in-multi-repo.yml
@@ -4,7 +4,7 @@ on:
     push:
         # Only trigger for specific branches or changes in specific paths.
         branches:
-            - '*'
+            - '[0-9].*'
         paths:
             - app/**
             - plugins/**


### PR DESCRIPTION
Changed the logic in `split-monorepo-in-multi-repo.yml` to trigger only on branches that start with a version number (e.g. 4.0, 4.x, 5.x) as we don't want to trigger subtree split on other branches.