### PR TITLE
fixed mautic:unusedip:delete

### DIFF
--- a/app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php
+++ b/app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php
@@ -52,7 +52,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $em             = $this->getContainer()->get('doctrine')->getEntityManager();
+        $em             = $this->getContainer()->get('doctrine')->getManager();
         $ipAddressRepo  = $em->getRepository('MauticCoreBundle:IpAddress');
 
         try {


### PR DESCRIPTION
I closed the old PR, because I had problems with the branches:
https://github.com/mautic/mautic/pull/10536

It's still the same functionality and the same code, only based on the right

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | Yes
| New feature/enhancement? (use the a.x branch)      | No
| Deprecations?                          | No
| BC breaks? (use the c.x branch)        | No
| Issue(s) addressed                     | Fixes #10387  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
As mentioned in #10387 it was not possible to use `mautic:unusedip:delete` since Mautic 4.x. This PR fixes this Issue
#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Load up [this PR](https://mautibox.com)
2. Got to the CLI
3. execute the command `bin/console mautic:unusedip:delete`
4. There should be no exception thrown.
5. `n unused IP addresses have been deleted` should appear

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10589"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>
