### PR TITLE
Fix push branch trigger on 4.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,7 @@ name: Mautic tests and validations
 on:
   push:
     branches:
-      - staging
-      - features
-      - '[0-9]+\.[0-9]+'
+      - '[0-9].*'
   pull_request:
   schedule:
     # Run every day at 10 AM UTC to discover potential issues with dependencies like PHP updates etc.


### PR DESCRIPTION
The CI test workflow was configured to run on the following branches:
- staging
- features
- [MAJOR].[MINOR] - only numbers, so 4.0, 4.1, etc. - not 4.x

Because of this, our CI tests haven't run on the 4.x branch since August 31st 🤯 

This PR changes the trigger so that we trigger it on `[MAJOR].*`, so it will trigger on 4.0, 4.x, 5.0, 5.x, etc.