### PR TITLE
Only run subsplit in the mautic org

### DIFF
--- a/.github/workflows/split-monorepo-in-multi-repo.yml
+++ b/.github/workflows/split-monorepo-in-multi-repo.yml
@@ -25,6 +25,7 @@ on:
 
 jobs:
     sync_commits:
+        if: github.repository_owner == 'mautic'
         runs-on: ubuntu-latest
         name: Sync commits
         steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,11 +6,13 @@ on:
       - '[0-9].*'
   pull_request:
   schedule:
-    # Run every day at 10 AM UTC to discover potential issues with dependencies like PHP updates etc.
-    - cron: '0 10 * * *'
+    # Run every day at 10:45 AM UTC to discover potential issues with dependencies like PHP updates etc.
+    - cron: '45 10 * * *'
 
 jobs:
   phpunit:
+    # We don't want the scheduled jobs to run on forks of Mautic
+    if: (github.event_name == 'schedule' && github.repository_owner == 'mautic') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
 
     strategy:
@@ -115,6 +117,8 @@ jobs:
         path: ./var/logs/*
 
   misc:
+    # We don't want the scheduled jobs to run on forks of Mautic
+    if: (github.event_name == 'schedule' && github.repository_owner == 'mautic') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
We're seeing the subsplit running on people's forks: https://github.com/woutersf/mautic/actions/workflows/split-monorepo-in-multi-repo.yml

Let's make sure we only run this in the Mautic organization

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10594"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

