### PR TITLE
DDEV: update `install_source` for the stats server

### DIFF
--- a/.ddev/local.config.php.dist
+++ b/.ddev/local.config.php.dist
@@ -14,4 +14,5 @@ $parameters = [
     'db_password'           => 'db',
     'admin_email'           => 'mautic@ddev.local',
     'admin_password'        => 'mautic',
+    'install_source'        => 'DDEV'
 ];


### PR DESCRIPTION
This will help us distinguish DDEV-based installations (local development) from other Mautic installations in our statistics