### PR TITLE
Bring .github changes over to 4.0 (subtree split etc.)

### DIFF
--- a/.github/subtree-splitter-config.json
+++ b/.github/subtree-splitter-config.json
@@ -1,0 +1,174 @@
+{
+    "subtree-splits": [
+        {
+            "name": "core-lib",
+            "directory": "app",
+            "target": "git@github.com:mautic/core-lib.git"
+        },
+        {
+            "name": "GrapesJsBuilderBundle",
+            "directory": "plugins/GrapesJsBuilderBundle",
+            "target": "git@github.com:mautic/plugin-grapesjs-builder.git"
+        },
+        {
+            "name": "MauticCitrixBundle",
+            "directory": "plugins/MauticCitrixBundle",
+            "target": "git@github.com:mautic/plugin-citrix.git"
+        },
+        {
+            "name": "MauticClearbitBundle",
+            "directory": "plugins/MauticClearbitBundle",
+            "target": "git@github.com:mautic/plugin-clearbit.git"
+        },
+        {
+            "name": "MauticCloudStorageBundle",
+            "directory": "plugins/MauticCloudStorageBundle",
+            "target": "git@github.com:mautic/plugin-cloudstorage.git"
+        },
+        {
+            "name": "MauticCrmBundle",
+            "directory": "plugins/MauticCrmBundle",
+            "target": "git@github.com:mautic/plugin-crm.git"
+        },
+        {
+            "name": "MauticEmailMarketingBundle",
+            "directory": "plugins/MauticEmailMarketingBundle",
+            "target": "git@github.com:mautic/plugin-emailmarketing.git"
+        },
+        {
+            "name": "MauticFocusBundle",
+            "directory": "plugins/MauticFocusBundle",
+            "target": "git@github.com:mautic/plugin-focus.git"
+        },
+        {
+            "name": "MauticFullContactBundle",
+            "directory": "plugins/MauticFullContactBundle",
+            "target": "git@github.com:mautic/plugin-fullcontact.git"
+        },
+        {
+            "name": "MauticGmailBundle",
+            "directory": "plugins/MauticGmailBundle",
+            "target": "git@github.com:mautic/plugin-gmail.git"
+        },
+        {
+            "name": "MauticOutlookBundle",
+            "directory": "plugins/MauticOutlookBundle",
+            "target": "git@github.com:mautic/plugin-outlook.git"
+        },
+        {
+            "name": "MauticSocialBundle",
+            "directory": "plugins/MauticSocialBundle",
+            "target": "git@github.com:mautic/plugin-social.git"
+        },
+        {
+            "name": "MauticTagManagerBundle",
+            "directory": "plugins/MauticTagManagerBundle",
+            "target": "git@github.com:mautic/plugin-tagmanager.git"
+        },
+        {
+            "name": "MauticZapierBundle",
+            "directory": "plugins/MauticZapierBundle",
+            "target": "git@github.com:mautic/plugin-zapier.git"
+        },
+        {
+            "name": "theme-aurora",
+            "directory": "themes/aurora",
+            "target": "git@github.com:mautic/theme-aurora.git"
+        },
+        {
+            "name": "theme-blank",
+            "directory": "themes/blank",
+            "target": "git@github.com:mautic/theme-blank.git"
+        },
+        {
+            "name": "theme-brienz",
+            "directory": "themes/brienz",
+            "target": "git@github.com:mautic/theme-brienz.git"
+        },
+        {
+            "name": "theme-cards",
+            "directory": "themes/cards",
+            "target": "git@github.com:mautic/theme-cards.git"
+        },
+        {
+            "name": "theme-coffee",
+            "directory": "themes/coffee",
+            "target": "git@github.com:mautic/theme-coffee.git"
+        },
+        {
+            "name": "theme-confirmme",
+            "directory": "themes/confirmme",
+            "target": "git@github.com:mautic/theme-confirmme.git"
+        },
+        {
+            "name": "theme-fresh-center",
+            "directory": "themes/fresh-center",
+            "target": "git@github.com:mautic/theme-fresh-center.git"
+        },
+        {
+            "name": "theme-fresh-fixed",
+            "directory": "themes/fresh-fixed",
+            "target": "git@github.com:mautic/theme-fresh-fixed.git"
+        },
+        {
+            "name": "theme-fresh-left",
+            "directory": "themes/fresh-left",
+            "target": "git@github.com:mautic/theme-fresh-left.git"
+        },
+        {
+            "name": "theme-fresh-wide",
+            "directory": "themes/fresh-wide",
+            "target": "git@github.com:mautic/theme-fresh-wide.git"
+        },
+        {
+            "name": "theme-goldstar",
+            "directory": "themes/goldstar",
+            "target": "git@github.com:mautic/theme-goldstar.git"
+        },
+        {
+            "name": "theme-mauve",
+            "directory": "themes/Mauve",
+            "target": "git@github.com:mautic/theme-mauve.git"
+        },
+        {
+            "name": "theme-nature",
+            "directory": "themes/nature",
+            "target": "git@github.com:mautic/theme-nature.git"
+        },
+        {
+            "name": "theme-neopolitan",
+            "directory": "themes/neopolitan",
+            "target": "git@github.com:mautic/theme-neopolitan.git"
+        },
+        {
+            "name": "theme-oxygen",
+            "directory": "themes/oxygen",
+            "target": "git@github.com:mautic/theme-oxygen.git"
+        },
+        {
+            "name": "theme-paprika",
+            "directory": "themes/paprika",
+            "target": "git@github.com:mautic/theme-paprika.git"
+        },
+        {
+            "name": "theme-skyline",
+            "directory": "themes/sparse",
+            "target": "git@github.com:mautic/theme-sparse.git"
+        },
+        {
+            "name": "theme-sunday",
+            "directory": "themes/sunday",
+            "target": "git@github.com:mautic/theme-sunday.git"
+        },
+        {
+            "name": "theme-trulypersonal",
+            "directory": "themes/trulypersonal",
+            "target": "git@github.com:mautic/theme-trulypersonal.git"
+        },
+        {
+            "name": "theme-vibrant",
+            "directory": "themes/vibrant",
+            "target": "git@github.com:mautic/theme-vibrant.git"
+        }
+    ]
+}

--- a/.github/workflows/split-monorepo-in-multi-repo.yml
+++ b/.github/workflows/split-monorepo-in-multi-repo.yml
@@ -1,0 +1,56 @@
+name: 'Packages Split 2'
+
+on:
+    push:
+        # Only trigger for specific branches or changes in specific paths.
+        branches:
+            - '[0-9].*'
+        paths:
+            - app/**
+            - plugins/**
+            - themes/**
+        # Tag push events should be ignored, they will be handled with the create event below.
+        tags-ignore:
+            - '*'
+    create:
+        tags:
+            - '*'
+        branches:
+            - '*'
+    delete:
+        tags:
+            - '*'
+        branches:
+            - '*'
+
+jobs:
+    sync_commits:
+        if: github.repository_owner == 'mautic'
+        runs-on: ubuntu-latest
+        name: Sync commits
+        steps:
+            -   uses: actions/checkout@v2
+                with:
+                    persist-credentials: false
+                    fetch-depth: 0
+
+            # Add a personal access token to the repository secrets. This will allow the splitter action to push the new commits
+            -   uses: frankdejonge/use-github-token@1.0.1
+                with:
+                    authentication: 'username:${{ secrets.ACCESS_TOKEN }}'
+                    user_name: 'Mautic CI'
+                    user_email: 'ci@mautic.org'
+
+            # Cache the splitsh executable to speedup future runs
+            -   name: Cache splitsh-lite
+                uses: actions/cache@v2
+                with:
+                    path: './splitsh'
+                    key: '${{ runner.os }}-splitsh-v101'
+
+            # Sync commits and tags for the configured subtree splits
+            -   name: subtree split
+                uses: acrobat/subtree-splitter@v1.0.0
+                with:
+                    config-path: .github/subtree-splitter-config.json # Reference the location where you saved your config file
+    

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,16 +3,16 @@ name: Mautic tests and validations
 on:
   push:
     branches:
-      - staging
-      - features
-      - '[0-9]+\.[0-9]+'
+      - '[0-9].*'
   pull_request:
   schedule:
-    # Run every day at 10 AM UTC to discover potential issues with dependencies like PHP updates etc.
-    - cron: '0 10 * * *'
+    # Run every day at 10:45 AM UTC to discover potential issues with dependencies like PHP updates etc.
+    - cron: '45 10 * * *'
 
 jobs:
   phpunit:
+    # We don't want the scheduled jobs to run on forks of Mautic
+    if: (github.event_name == 'schedule' && github.repository_owner == 'mautic') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
 
     strategy:
@@ -117,6 +117,8 @@ jobs:
         path: ./var/logs/*
 
   misc:
+    # We don't want the scheduled jobs to run on forks of Mautic
+    if: (github.event_name == 'schedule' && github.repository_owner == 'mautic') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
We fixed some things in the `4.x` branch yesterday and today, including the Git subtree split. These changes will need to be in the `4.0` branch as well. This PR does exactly that 😊 