### PR TITLE
Remove generated assets and generate them on composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,17 +92,20 @@
     "post-install-cmd": [
       "@auto-scripts",
       "@remove-git-submodules"
+      "@generate-assets"      
     ],
     "post-update-cmd": [
       "@auto-scripts",
-      "@remove-git-submodules"
+      "@remove-git-submodules",
+      "@generate-assets"
     ],
     "test": "bin/phpunit -d memory_limit=1G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist",
     "phpstan": "php -d memory_limit=4G bin/phpstan analyse",
     "cs": "bin/php-cs-fixer fix -v --dry-run --diff",
     "fixcs": "bin/php-cs-fixer fix -v",
     "rector": "bin/rector process",
-    "remove-git-submodules": "find . -mindepth 2 -type d -name .git | xargs rm -rf"
+    "remove-git-submodules": "find . -mindepth 2 -type d -name .git | xargs rm -rf",
+    "generate-assets": "./bin/console mautic:assets:generate"
   },
   "config": {
     "bin-dir": "bin",


### PR DESCRIPTION

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [n]
| New feature/enhancement? (use the a.x branch)      | [y]
| Deprecations?                          | [n]
| BC breaks? (use the c.x branch)        | [n]
| Automated tests included?              | [n] <!-- All PRs must maintain or improve code coverage -->
| Issue(s) addressed                     | 

#### Description:

The fix above makes sure that https://github.com/mautic/mautic/pull/10647 is no longer needed everytime a release is made. We can also remove the generated assets from the github repo as the tarball that one can download has the newest assets and using composer install it will also generate the assets.

#### Steps to test this PR:

1. run composer install
2. check if the app.css & app.js file is being generated.
3. check if you can install mautic and if it works as expected


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10654"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

