### PR TITLE
fix(LeadTimelineEvent): keys do not match the func args, strips keys

### DIFF
--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -244,7 +244,7 @@ class LeadTimelineEvent extends Event
             return [];
         }
 
-        $events = call_user_func_array('array_merge', $this->events);
+        $events = call_user_func_array('array_merge', array_values($this->events));
 
         foreach ($events as &$e) {
             if (!$e['timestamp'] instanceof \DateTime) {


### PR DESCRIPTION
Fix error when using PHP 8:
{"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): array_merge() does not accept unknown named parameters}

Not sure if this is the most elegant way to address the issue but this bug has broken the site functionality.

No new tests are needed. 


<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Fix error when using PHP 8:
{"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): array_merge() does not accept unknown named parameters}

#### Steps to test this PR:
1. Run Mautic with PHP 8.
1. Click on a contact.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10663"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

