### PR TITLE
Fix for #10517

### DIFF
--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -825,10 +825,14 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
                 case 'POST':
                 case 'PUT':
                 case 'PATCH':
+                    $payloadKey = \GuzzleHttp\RequestOptions::FORM_PARAMS;
+                    if (is_string($parameters)) {
+                        $payloadKey = \GuzzleHttp\RequestOptions::BODY;
+                    }
                     $result = $client->request($method, $url, [
-                        \GuzzleHttp\RequestOptions::FORM_PARAMS => $parameters,
-                        \GuzzleHttp\RequestOptions::HEADERS     => $headers,
-                        \GuzzleHttp\RequestOptions::TIMEOUT     => $timeout,
+                        $payloadKey                         => $parameters,
+                        \GuzzleHttp\RequestOptions::HEADERS => $headers,
+                        \GuzzleHttp\RequestOptions::TIMEOUT => $timeout,
                     ]);
                     break;
                 case 'DELETE':


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | ❌
| Related developer documentation PR URL | ❌
| Issue(s) addressed                     | Fixes #10517 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Some integrations such as Hubspot have an `'encode_parameters' => 'json'` setting, which triggers the parameters being sent in `POST` / `PUT` / `PATCH` requests to be `json_encode`-d: https://github.com/mautic/mautic/blob/5975231722cfde8bdad783b373c70ad20333db37/app/bundles/PluginBundle/Integration/AbstractIntegration.php#L760

That causes a problem when the result is passed to Guzzle's `request` method under key `\GuzzleHttp\RequestOptions::FORM_PARAMS`, because the payload is expected to be an array: https://github.com/mautic/mautic/blob/5975231722cfde8bdad783b373c70ad20333db37/app/bundles/PluginBundle/Integration/AbstractIntegration.php#L829 as per the documentation: https://docs.guzzlephp.org/en/stable/request-options.html#form-params

The above RP addresses this by passing the payload under `\GuzzleHttp\RequestOptions::BODY` instead, **if** the payload is a string, rather than an array.

Tested and working with HubSpot.
