### PR TITLE
Fixes 500 error in forms when render style is deactivated

### DIFF
--- a/app/bundles/FormBundle/Form/Type/FormType.php
+++ b/app/bundles/FormBundle/Form/Type/FormType.php
@@ -152,7 +152,6 @@ class FormType extends AbstractType
         $builder->add('renderStyle', YesNoButtonGroupType::class, [
             'label'      => 'mautic.form.form.renderstyle',
             'data'       => (null === $options['data']->getRenderStyle()) ? true : $options['data']->getRenderStyle(),
-            'empty_data' => true,
             'attr'       => [
                 'tooltip' => 'mautic.form.form.renderstyle.tooltip',
             ],


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅ 
| New feature/enhancement? (use the a.x branch)      |❌ 
| Deprecations?                          | ❌ 
| BC breaks? (use the c.x branch)        | ❌ 
| Automated tests included?              | ✅  <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | ❌  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #10453   <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

### How can we reproduce this issue?

1. Go to forms
2. Create a new Form
3. Deactivate "Render Style from Template"
4. Save the form

Bonus:(If it seemed to have saved errorless, open the form, activate, save and then deactivate the "Render Style from Template again and see wether you get an error or not")

Testing on my local, I removed that line, and everything worked fine.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10673"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

