### PR TITLE
Fix for pushing to integrations in campaign actions

### DIFF
--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\EntityManager;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\RequestOptions;
 use Mautic\CoreBundle\Entity\FormEntity;
 use Mautic\CoreBundle\Helper\CacheStorageHelper;
 use Mautic\CoreBundle\Helper\EncryptionHelper;
@@ -673,7 +674,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     /**
      * Make a basic call using cURL to get the data.
      *
-     * @param        $url
+     * @param string $url
      * @param array  $parameters
      * @param string $method
      * @param array  $settings   Set $settings['return_raw'] to receive a ResponseInterface
@@ -788,14 +789,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
             $options[CURLOPT_SSL_VERIFYPEER] = $settings['ssl_verifypeer'];
         }
 
-        /**
-         * Because so many integrations extend this class and mautic.http.client is not in the
-         * constructor at the time of writing, let's just create a new client here. In addition,
-         * we add some custom cURL options.
-         */
-        $client = new Client(['handler' => HandlerStack::create(new CurlHandler([
-            'options' => $options,
-        ]))]);
+        $client = $this->makeHttpClient($options);
 
         $parseHeaders = (isset($settings['headers'])) ? array_merge($headers, $settings['headers']) : $headers;
         // HTTP library requires that headers are in key => value pairs
@@ -818,27 +812,24 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
             switch ($method) {
                 case 'GET':
                     $result = $client->get($url, [
-                        \GuzzleHttp\RequestOptions::HEADERS => $headers,
-                        \GuzzleHttp\RequestOptions::TIMEOUT => $timeout,
+                        RequestOptions::HEADERS => $headers,
+                        RequestOptions::TIMEOUT => $timeout,
                     ]);
                     break;
                 case 'POST':
                 case 'PUT':
                 case 'PATCH':
-                    $payloadKey = \GuzzleHttp\RequestOptions::FORM_PARAMS;
-                    if (is_string($parameters)) {
-                        $payloadKey = \GuzzleHttp\RequestOptions::BODY;
-                    }
-                    $result = $client->request($method, $url, [
-                        $payloadKey                         => $parameters,
-                        \GuzzleHttp\RequestOptions::HEADERS => $headers,
-                        \GuzzleHttp\RequestOptions::TIMEOUT => $timeout,
+                    $payloadKey = is_string($parameters) ? RequestOptions::BODY : RequestOptions::FORM_PARAMS;
+                    $result     = $client->request($method, $url, [
+                        $payloadKey             => $parameters,
+                        RequestOptions::HEADERS => $headers,
+                        RequestOptions::TIMEOUT => $timeout,
                     ]);
                     break;
                 case 'DELETE':
                     $result = $client->delete($url, [
-                        \GuzzleHttp\RequestOptions::HEADERS => $headers,
-                        \GuzzleHttp\RequestOptions::TIMEOUT => $timeout,
+                        RequestOptions::HEADERS => $headers,
+                        RequestOptions::TIMEOUT => $timeout,
                     ]);
                     break;
             }
@@ -2539,5 +2530,19 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     public function getLeadDoNotContactByDate($channel, $records, $object, $lead, $integrationData, $params = [])
     {
         return $records;
+    }
+
+    /**
+     * Because so many integrations extend this class and mautic.http.client is not in the
+     * constructor at the time of writing, let's just create a new client here. In addition,
+     * we add some custom cURL options.
+     * 
+     * @param mixed[] $options
+     */
+    protected function makeHttpClient(array $options): Client
+    {
+        return new Client(['handler' => HandlerStack::create(new CurlHandler([
+            'options' => $options,
+        ]))]);
     }
 }

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -2536,7 +2536,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
      * Because so many integrations extend this class and mautic.http.client is not in the
      * constructor at the time of writing, let's just create a new client here. In addition,
      * we add some custom cURL options.
-     * 
+     *
      * @param mixed[] $options
      */
     protected function makeHttpClient(array $options): Client

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -825,10 +825,14 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
                 case 'POST':
                 case 'PUT':
                 case 'PATCH':
+                    $payloadKey = \GuzzleHttp\RequestOptions::FORM_PARAMS;
+                    if (is_string($parameters)) {
+                        $payloadKey = \GuzzleHttp\RequestOptions::BODY;
+                    }
                     $result = $client->request($method, $url, [
-                        \GuzzleHttp\RequestOptions::FORM_PARAMS => $parameters,
-                        \GuzzleHttp\RequestOptions::HEADERS     => $headers,
-                        \GuzzleHttp\RequestOptions::TIMEOUT     => $timeout,
+                        $payloadKey                         => $parameters,
+                        \GuzzleHttp\RequestOptions::HEADERS => $headers,
+                        \GuzzleHttp\RequestOptions::TIMEOUT => $timeout,
                     ]);
                     break;
                 case 'DELETE':

--- a/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
+++ b/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2017 Mautic Contributors. All rights reserved
  * @author      Mautic, Inc.
@@ -11,12 +13,22 @@
 
 namespace Mautic\PluginBundle\Tests\Integration;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\RequestOptions;
 use Mautic\PluginBundle\Integration\AbstractIntegration;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\ResponseInterface;
 
 class AbstractIntegrationTest extends AbstractIntegrationTestCase
 {
-    public function testPopulatedLeadDataReturnsIntAndNotDncEntityForMauticContactIsContactableByEmail()
+    public function testPopulatedLeadDataReturnsIntAndNotDncEntityForMauticContactIsContactableByEmail(): void
     {
+        /**
+         * @var MockObject&AbstractIntegration
+         */
         $integration = $this->getMockBuilder(AbstractIntegration::class)
             ->setConstructorArgs([
                 $this->dispatcher,
@@ -36,14 +48,8 @@ class AbstractIntegrationTest extends AbstractIntegrationTestCase
                 $this->integrationEntityModel,
                 $this->doNotContact,
             ])
-            ->setMethodsExcept(['convertLeadFieldKey', 'getLeadDoNotContact', 'populateLeadData', 'setTranslator', 'setLeadModel'])
+            ->onlyMethods(['getName', 'getAuthenticationType', 'getAvailableLeadFields'])
             ->getMock();
-
-        $config = [
-            'leadFields' => [
-                'dnc' => 'mauticContactIsContactableByEmail',
-            ],
-        ];
 
         $integration->method('getAvailableLeadFields')
             ->willReturn(
@@ -55,13 +61,126 @@ class AbstractIntegrationTest extends AbstractIntegrationTestCase
                     ],
                 ]
             );
-        $matched = $integration->populateLeadData(['id' => 1], $config);
 
         $this->assertEquals(
-            [
-                'dnc' => 0,
-            ],
-            $matched
+            ['dnc' => 0],
+            $integration->populateLeadData(
+                ['id' => 1],
+                [
+                    'leadFields' => [
+                        'dnc' => 'mauticContactIsContactableByEmail',
+                    ],
+                ]
+            )
         );
+    }
+
+    /**
+     * @dataProvider requestProvider
+     */
+    public function testMakeRequest(string $uri, array $parameters, string $method, array $settings, object $assertRequest): void
+    {
+        /**
+         * @var MockObject&AbstractIntegration
+         */
+        $integration = $this->getMockBuilder(AbstractIntegration::class)
+            ->setConstructorArgs([
+                $this->dispatcher,
+                $this->cache,
+                $this->em,
+                $this->session,
+                $this->request,
+                $this->router,
+                $this->translator,
+                $this->logger,
+                $this->encryptionHelper,
+                $this->leadModel,
+                $this->companyModel,
+                $this->pathsHelper,
+                $this->notificationModel,
+                $this->fieldModel,
+                $this->integrationEntityModel,
+                $this->doNotContact,
+            ])
+            ->onlyMethods(['getName', 'getAuthenticationType', 'makeHttpClient'])
+            ->getMock();
+
+        $integration->method('makeHttpClient')
+            ->willReturn(
+                new class($assertRequest) extends Client {
+
+                    private object $assertRequest;
+
+                    public function __construct(object $assertRequest)
+                    {
+                        $this->assertRequest = $assertRequest;
+                    }
+
+                    public function request(string $method, $uri = '', array $options = []): ResponseInterface
+                    {
+                        $this->assertRequest->assert($method, $uri, $options);
+
+                        return new Response();
+                    }
+                }
+            );
+
+        $this->assertEquals([], $integration->makeRequest($uri, $parameters, $method, $settings));
+    }
+
+    public function requestProvider(): iterable
+    {
+        // Test with JSON.
+        yield [
+            'https://some.uri',
+            ['this will be' => 'encoded to json string'],
+            'POST',
+            [
+                'ignore_event_dispatch' => true,
+                'encode_parameters'     => 'json',
+            ],
+            new class {
+                /**
+                 * @param mixed[] $options
+                 */
+                function assert(string $method, string $uri = '', array $options = []) {
+                    Assert::assertSame('POST', $method);
+                    Assert::assertSame('https://some.uri', $uri);
+                    Assert::assertSame(
+                        [
+                            RequestOptions::BODY => '{"this will be":"encoded to json string"}',
+                            'headers'            => ['Content-Type' => 'application/json'],
+                            'timeout'            => 10,
+                        ],
+                        $options
+                    );
+                }
+            }
+        ];
+
+        // Test with form params.
+        yield [
+            'https://some.uri',
+            ['this will be' => 'encoded to form array'],
+            'POST',
+            ['ignore_event_dispatch' => true],
+            new class {
+                /**
+                 * @param mixed[] $options
+                 */
+                function assert(string $method, string $uri = '', array $options = []) {
+                    Assert::assertSame('POST', $method);
+                    Assert::assertSame('https://some.uri', $uri);
+                    Assert::assertSame(
+                        [
+                            RequestOptions::FORM_PARAMS => ['this will be' => 'encoded to form array'],
+                            'headers'            => [],
+                            'timeout'            => 10,
+                        ],
+                        $options
+                    );
+                }
+            }
+        ];
     }
 }

--- a/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
+++ b/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
@@ -77,7 +77,7 @@ class AbstractIntegrationTest extends AbstractIntegrationTestCase
 
     /**
      * @dataProvider requestProvider
-     * 
+     *
      * @param mixed[] $parameters
      * @param mixed[] $settings
      */

--- a/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
+++ b/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
@@ -77,6 +77,9 @@ class AbstractIntegrationTest extends AbstractIntegrationTestCase
 
     /**
      * @dataProvider requestProvider
+     * 
+     * @param mixed[] $parameters
+     * @param mixed[] $settings
      */
     public function testMakeRequest(string $uri, array $parameters, string $method, array $settings, object $assertRequest): void
     {
@@ -115,6 +118,9 @@ class AbstractIntegrationTest extends AbstractIntegrationTestCase
                         $this->assertRequest = $assertRequest;
                     }
 
+                    /**
+                     * @param mixed[] $options
+                     */
                     public function request(string $method, $uri = '', array $options = []): ResponseInterface
                     {
                         $this->assertRequest->assert($method, $uri, $options);
@@ -127,6 +133,9 @@ class AbstractIntegrationTest extends AbstractIntegrationTestCase
         $this->assertEquals([], $integration->makeRequest($uri, $parameters, $method, $settings));
     }
 
+    /**
+     * @return iterable<mixed[]>
+     */
     public function requestProvider(): iterable
     {
         // Test with JSON.
@@ -142,7 +151,7 @@ class AbstractIntegrationTest extends AbstractIntegrationTestCase
                 /**
                  * @param mixed[] $options
                  */
-                public function assert(string $method, string $uri = '', array $options = [])
+                public function assert(string $method, string $uri = '', array $options = []): void
                 {
                     Assert::assertSame('POST', $method);
                     Assert::assertSame('https://some.uri', $uri);
@@ -168,7 +177,7 @@ class AbstractIntegrationTest extends AbstractIntegrationTestCase
                 /**
                  * @param mixed[] $options
                  */
-                public function assert(string $method, string $uri = '', array $options = [])
+                public function assert(string $method, string $uri = '', array $options = []): void
                 {
                     Assert::assertSame('POST', $method);
                     Assert::assertSame('https://some.uri', $uri);

--- a/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
+++ b/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
@@ -108,7 +108,6 @@ class AbstractIntegrationTest extends AbstractIntegrationTestCase
         $integration->method('makeHttpClient')
             ->willReturn(
                 new class($assertRequest) extends Client {
-
                     private object $assertRequest;
 
                     public function __construct(object $assertRequest)
@@ -139,11 +138,12 @@ class AbstractIntegrationTest extends AbstractIntegrationTestCase
                 'ignore_event_dispatch' => true,
                 'encode_parameters'     => 'json',
             ],
-            new class {
+            new class() {
                 /**
                  * @param mixed[] $options
                  */
-                function assert(string $method, string $uri = '', array $options = []) {
+                public function assert(string $method, string $uri = '', array $options = [])
+                {
                     Assert::assertSame('POST', $method);
                     Assert::assertSame('https://some.uri', $uri);
                     Assert::assertSame(
@@ -155,7 +155,7 @@ class AbstractIntegrationTest extends AbstractIntegrationTestCase
                         $options
                     );
                 }
-            }
+            },
         ];
 
         // Test with form params.
@@ -164,23 +164,24 @@ class AbstractIntegrationTest extends AbstractIntegrationTestCase
             ['this will be' => 'encoded to form array'],
             'POST',
             ['ignore_event_dispatch' => true],
-            new class {
+            new class() {
                 /**
                  * @param mixed[] $options
                  */
-                function assert(string $method, string $uri = '', array $options = []) {
+                public function assert(string $method, string $uri = '', array $options = [])
+                {
                     Assert::assertSame('POST', $method);
                     Assert::assertSame('https://some.uri', $uri);
                     Assert::assertSame(
                         [
                             RequestOptions::FORM_PARAMS => ['this will be' => 'encoded to form array'],
-                            'headers'            => [],
-                            'timeout'            => 10,
+                            'headers'                   => [],
+                            'timeout'                   => 10,
                         ],
                         $options
                     );
                 }
-            }
+            },
         ];
     }
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✅ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | ❌
| Related developer documentation PR URL | ❌
| Issue(s) addressed                     | Fixes #10517 

### Description

Starting with Mautic 4.0 it is no longer possible to push lead activity to integrations communicating via JSON such as Hubspot (and most likely Salesforce as well).

To reproduce it, follow these steps:

1. Enable the Hubspot integration by switching the plugin on and setting an API key.
2. Enable the *Triggered action push contacts to integration* feature.
3. Create a segment containing some contacts.
4. Run `./bin/console mautic:segments:update` to add the contacts to the segment.
5. Create a campaign using the segment's contacts as source and add a *Push contact to integration* (Hubspot) action.
6. Run `./bin/console mautic:campaigns:rebuild` to rebuild the campaign.
7. Run `./bin/console mautic:campaigns:trigger` to trigger the campaign and *push* the contacts to Hubspot.

At this point you should see the following error in the terminal:

```
Triggering events for campaign 1
Triggering events for newly added contacts
1 total events(s) to be processed in batches of 100 contacts
 1/1 [============================] 100%PHP Warning:  http_build_query() expects parameter 1 to be array, string given in /var/www/localhost/public/vendor/guzzlehttp/guzzle/src/Client.php on line 359
```

This is **NOT** treated as a critical error, so the command will succeed, however, the contact(s) will **NOT** be pushed to Hubspot due to this bug.

After applying this PR, follow the same steps above to trigger push again. This time around you shouldn't see the PHP Warning in the terminal and the contact(s) should now be pushed to Hubspot.

### Developer Description

Some integrations such as Hubspot have an `'encode_parameters' => 'json'` setting, which triggers the parameters being sent in `POST` / `PUT` / `PATCH` requests to be `json_encode`-d: https://github.com/mautic/mautic/blob/5975231722cfde8bdad783b373c70ad20333db37/app/bundles/PluginBundle/Integration/AbstractIntegration.php#L760

That causes a problem when the result is passed to Guzzle's `request` method under key `\GuzzleHttp\RequestOptions::FORM_PARAMS`, because the payload is expected to be an array: https://github.com/mautic/mautic/blob/5975231722cfde8bdad783b373c70ad20333db37/app/bundles/PluginBundle/Integration/AbstractIntegration.php#L829 as per the documentation: https://docs.guzzlephp.org/en/stable/request-options.html#form-params

The above RP addresses this by passing the payload under `\GuzzleHttp\RequestOptions::BODY` instead, **if** the payload is a string, rather than an array.

Tested and working with HubSpot.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10674"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

